### PR TITLE
Improve repo pages after redesign

### DIFF
--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.scss
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.scss
@@ -5,6 +5,7 @@
         row-gap: 1rem;
         column-gap: 1rem;
         align-items: center;
+        margin-bottom: 1rem;
         @media (--sm-breakpoint-down) {
             row-gap: 0.5rem;
             column-gap: 0.5rem;

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
@@ -9,7 +9,7 @@ import { UploadConnection } from './backend'
 import { CodeIntelUploadsPage } from './CodeIntelUploadsPage'
 
 const { add } = storiesOf('web/codeintel/list/CodeIntelUploadPage', module)
-    .addDecorator(story => <div className="p-3 container web-content">{story()}</div>)
+    .addDecorator(story => <div className="p-3 container">{story()}</div>)
     .addParameters({
         chromatic: {
             viewports: [320, 576, 978, 1440],
@@ -19,6 +19,12 @@ const { add } = storiesOf('web/codeintel/list/CodeIntelUploadPage', module)
 add('SiteAdminPage', () => (
     <EnterpriseWebStory>
         {props => <CodeIntelUploadsPage {...props} now={now} fetchLsifUploads={fetchLsifUploads} />}
+    </EnterpriseWebStory>
+))
+
+add('Empty', () => (
+    <EnterpriseWebStory>
+        {props => <CodeIntelUploadsPage {...props} now={now} fetchLsifUploads={fetchEmptyLsifUploads} />}
     </EnterpriseWebStory>
 ))
 
@@ -106,11 +112,11 @@ const fetch = (
             isLatestForRepo: false,
             ...upload,
         })),
-        totalCount: 10,
+        totalCount: uploads.length > 0 ? uploads.length + 5 : 0,
         pageInfo: {
             __typename: 'PageInfo',
-            endCursor: 'fakenextpage',
-            hasNextPage: true,
+            endCursor: uploads.length > 0 ? 'fakenextpage' : null,
+            hasNextPage: uploads.length > 0,
         },
     })
 
@@ -166,5 +172,7 @@ const fetchLsifUploads = fetch(
         associatedIndex: null,
     }
 )
+
+const fetchEmptyLsifUploads = fetch()
 
 const now = () => new Date('2020-06-15T15:25:00+00:00')

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
@@ -150,7 +150,7 @@ export const CodeIntelUploadsPage: FunctionComponent<CodeIntelUploadsPageProps> 
     )
 }
 
-const EmptyLSIFUploadsElement: React.FunctionComponent<{}> = () => (
+const EmptyLSIFUploadsElement: React.FunctionComponent = () => (
     <p className="text-muted text-center w-100 mb-0 mt-1">
         <MapSearchIcon className="mb-2" />
         <br />

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
@@ -1,10 +1,11 @@
+import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
 import { RouteComponentProps } from 'react-router'
 import { of } from 'rxjs'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { PageHeader } from '@sourcegraph/wildcard'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import {
     FilteredConnection,
@@ -103,56 +104,64 @@ export const CodeIntelUploadsPage: FunctionComponent<CodeIntelUploadsPageProps> 
     )
 
     return (
-        <div className="code-intel-uploads web-content">
+        <div className="code-intel-uploads">
             <PageTitle title="Precise code intelligence uploads" />
             <PageHeader
-                path={[{ text: 'Precise code intelligence upload' }]}
+                headingElement="h2"
+                path={[{ text: 'Precise code intelligence uploads' }]}
                 description={
                     <>
-                        <p>
-                            Enable precise code intelligence by{' '}
-                            <a
-                                href="https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence"
-                                target="_blank"
-                                rel="noreferrer noopener"
-                            >
-                                uploading LSIF data
-                            </a>
-                            .
-                        </p>
-                        <p>
-                            Current uploads provide code intelligence for the latest commit on the default branch and
-                            are used in cross-repository <em>Find References</em> requests. Non-current uploads may
-                            still provide code intelligence for historic and branch commits.
-                        </p>
+                        Current uploads provide code intelligence for the latest commit on the default branch and are
+                        used in cross-repository <em>Find References</em> requests. Non-current uploads may still
+                        provide code intelligence for historic and branch commits.
                     </>
                 }
+                className="mb-3"
             />
 
-            {repo && commitGraphMetadata && (
-                <CommitGraphMetadata
-                    stale={commitGraphMetadata.stale}
-                    updatedAt={commitGraphMetadata.updatedAt}
-                    now={now}
-                />
-            )}
+            <Container>
+                {repo && commitGraphMetadata && (
+                    <CommitGraphMetadata
+                        stale={commitGraphMetadata.stale}
+                        updatedAt={commitGraphMetadata.updatedAt}
+                        now={now}
+                    />
+                )}
 
-            <div className="list-group position-relative">
-                <FilteredConnection<LsifUploadFields, Omit<CodeIntelUploadNodeProps, 'node'>>
-                    listComponent="div"
-                    listClassName="codeintel-uploads__grid mb-3"
-                    noun="upload"
-                    pluralNoun="uploads"
-                    nodeComponent={CodeIntelUploadNode}
-                    nodeComponentProps={{ now }}
-                    queryConnection={queryUploads}
-                    history={props.history}
-                    location={props.location}
-                    cursorPaging={true}
-                    filters={filters}
-                    defaultFilter="current"
-                />
-            </div>
+                <div className="list-group position-relative">
+                    <FilteredConnection<LsifUploadFields, Omit<CodeIntelUploadNodeProps, 'node'>>
+                        listComponent="div"
+                        listClassName="codeintel-uploads__grid"
+                        noun="upload"
+                        pluralNoun="uploads"
+                        nodeComponent={CodeIntelUploadNode}
+                        nodeComponentProps={{ now }}
+                        queryConnection={queryUploads}
+                        history={props.history}
+                        location={props.location}
+                        cursorPaging={true}
+                        filters={filters}
+                        defaultFilter="current"
+                        emptyElement={<EmptyLSIFUploadsElement />}
+                    />
+                </div>
+            </Container>
         </div>
     )
 }
+
+const EmptyLSIFUploadsElement: React.FunctionComponent<{}> = () => (
+    <p className="text-muted text-center w-100 mb-0 mt-1">
+        <MapSearchIcon className="mb-2" />
+        <br />
+        No uploads yet. Enable precise code intelligence by{' '}
+        <a
+            href="https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence"
+            target="_blank"
+            rel="noreferrer noopener"
+        >
+            uploading LSIF data
+        </a>
+        .
+    </p>
+)

--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../components/PageTitle'
 import { Timestamp } from '../../../components/time/Timestamp'
@@ -33,45 +34,61 @@ export const RepoSettingsPermissionsPage: React.FunctionComponent<RepoSettingsPe
     }
 
     return (
-        <div className="repo-settings-permissions-page w-100">
+        <>
             <PageTitle title="Permissions" />
-            <h2>Permissions</h2>
-            {!repo.isPrivate ? (
-                <div className="alert alert-info">
-                    Access to this repository is not restricted, all Sourcegraph users have access.
-                </div>
-            ) : !permissionsInfo ? (
-                <div className="alert alert-info">
-                    This repository is queued to sync permissions, only site admins will have access to it until syncing
-                    is finished.
-                </div>
-            ) : (
-                <div>
-                    <table className="table">
-                        <tbody>
-                            <tr>
-                                <th>Last complete sync</th>
-                                <td>
-                                    {permissionsInfo.syncedAt ? <Timestamp date={permissionsInfo.syncedAt} /> : 'Never'}
-                                </td>
-                                <td className="text-muted">Updated by repository permissions syncing</td>
-                            </tr>
-                            <tr>
-                                <th>Last incremental sync</th>
-                                <td>
-                                    <Timestamp date={permissionsInfo.updatedAt} />
-                                </td>
-                                <td className="text-muted">Updated by user permissions syncing</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <ScheduleRepositoryPermissionsSyncActionContainer repo={repo} history={history} />
-                </div>
-            )}
-            <a href="/help/admin/repo/permissions#background-permissions-syncing">
-                Learn more about background permissions syncing.
-            </a>
-        </div>
+            <PageHeader
+                path={[{ text: 'Permissions' }]}
+                headingElement="h2"
+                className="mb-3"
+                description={
+                    <>
+                        Learn more about{' '}
+                        <a href="/help/admin/repo/permissions#background-permissions-syncing">
+                            background permissions syncing
+                        </a>
+                        .
+                    </>
+                }
+            />
+            <Container className="repo-settings-permissions-page">
+                {!repo.isPrivate ? (
+                    <div className="alert alert-info mb-0">
+                        Access to this repository is not restricted, all Sourcegraph users have access.
+                    </div>
+                ) : !permissionsInfo ? (
+                    <div className="alert alert-info mb-0">
+                        This repository is queued to sync permissions, only site admins will have access to it until
+                        syncing is finished.
+                    </div>
+                ) : (
+                    <div>
+                        <table className="table">
+                            <tbody>
+                                <tr>
+                                    <th>Last complete sync</th>
+                                    <td>
+                                        {permissionsInfo.syncedAt ? (
+                                            <Timestamp date={permissionsInfo.syncedAt} />
+                                        ) : (
+                                            'Never'
+                                        )}
+                                    </td>
+                                    <td className="text-muted">Updated by repository permissions syncing</td>
+                                </tr>
+                                <tr>
+                                    <th>Last incremental sync</th>
+                                    <td>
+                                        <Timestamp date={permissionsInfo.updatedAt} />
+                                    </td>
+                                    <td className="text-muted">Updated by user permissions syncing</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <ScheduleRepositoryPermissionsSyncActionContainer repo={repo} history={history} />
+                    </div>
+                )}
+            </Container>
+        </>
     )
 }
 

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -383,7 +383,7 @@ describe('Repository', () => {
 
             await driver.page.goto(driver.sourcegraphBaseUrl + '/' + repositoryName)
 
-            await driver.page.waitForSelector('h2.tree-page__title')
+            await driver.page.waitForSelector('header.test-tree-page-title')
 
             // Assert that the directory listing displays properly
             await driver.page.waitForSelector('.test-tree-entries')
@@ -416,8 +416,8 @@ describe('Repository', () => {
             await driver.page.waitForSelector('.test-repo-header-repo-link')
             await driver.page.click('.test-repo-header-repo-link')
 
-            await driver.page.waitForSelector('h2.tree-page__title')
-            await assertSelectorHasText('h2.tree-page__title', ' ' + shortRepositoryName)
+            await driver.page.waitForSelector('header.test-tree-page-title')
+            await assertSelectorHasText('header.test-tree-page-title', shortRepositoryName)
             await driver.assertWindowLocation(repositorySourcegraphUrl)
 
             await driver.findElementWithText(clickedCommit, { selector: '.git-commit-node__oid', action: 'click' })
@@ -521,8 +521,8 @@ describe('Repository', () => {
 
             await driver.page.goto(driver.sourcegraphBaseUrl + repositorySourcegraphUrl)
 
-            await driver.page.waitForSelector('h2.tree-page__title')
-            await assertSelectorHasText('h2.tree-page__title', ` ${shortRepositoryName}`)
+            await driver.page.waitForSelector('header.test-tree-page-title')
+            await assertSelectorHasText('header.test-tree-page-title', shortRepositoryName)
             await assertSelectorHasText('.test-tree-entry-file', 'readme.md')
 
             await driver.page.waitForSelector('#monaco-query-input .view-lines')
@@ -558,8 +558,8 @@ describe('Repository', () => {
 
             await driver.page.goto(driver.sourcegraphBaseUrl + repositorySourcegraphUrl)
 
-            await driver.page.waitForSelector('h2.tree-page__title')
-            await assertSelectorHasText('h2.tree-page__title', ' my org/repo with spaces')
+            await driver.page.waitForSelector('header.test-tree-page-title')
+            await assertSelectorHasText('header.test-tree-page-title', 'my org/repo with spaces')
             await assertSelectorHasText('.test-tree-entry-file', 'readme.md')
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -52,7 +52,7 @@
         // Add border to repo revision container content
         // but enable variable margin-bottom (by setting it on child div)
         // without having to repeat border styles.
-        .theme-redesign & > div:first-of-type {
+        > div:first-of-type {
             border: 1px solid var(--border-color);
             border-top-left-radius: 0.1875rem;
             border-top-right-radius: 0.1875rem;
@@ -65,11 +65,7 @@
     }
 
     &__divider {
-        margin-right: 0.25rem;
-
-        .theme-redesign & {
-            margin-left: 0.375rem;
-            margin-right: 0.375rem;
-        }
+        margin-left: 0.375rem;
+        margin-right: 0.375rem;
     }
 }

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -6,10 +6,7 @@
     padding-top: 0.5rem;
     tab-size: 4;
     display: flex;
-
-    .theme-redesign & {
-        background-color: var(--code-bg);
-    }
+    background-color: var(--code-bg);
 
     &__code {
         flex: 1;
@@ -88,38 +85,32 @@
     // Unfortunately, <StatusBar> can overlap with <Blob>'s scrollbar, so calculate <StatusBar>'s
     // `right` and `maxWidth` at runtime.
     &__container {
-        .theme-redesign & {
-            position: relative;
+        position: relative;
 
-            --blob-status-bar-height: 2rem;
-            // Used to calculate status bar `bottom` along with scrollbar width.
-            --blob-status-bar-vertical-gap: 1rem;
-            // Used to calculate status bar `right` along with scrollbar width.
-            --blob-status-bar-horizontal-gap: 0.5rem;
-        }
+        --blob-status-bar-height: 2rem;
+        // Used to calculate status bar `bottom` along with scrollbar width.
+        --blob-status-bar-vertical-gap: 1rem;
+        // Used to calculate status bar `right` along with scrollbar width.
+        --blob-status-bar-horizontal-gap: 0.5rem;
     }
 
     // Add this class to <StatusBar>
     &__body {
-        position: static;
+        // Make the status bar "float" slightly above the bottom of the code view.
+        position: absolute;
+        bottom: var(--blob-status-bar-vertical-gap);
 
-        .theme-redesign & {
-            // Make the status bar "float" slightly above the bottom of the code view.
-            position: absolute;
-            bottom: var(--blob-status-bar-vertical-gap);
+        // Override default bootstrap `.w-100`, ensure that the status bar "sticks" to the right side.
+        width: auto !important;
+        // Default `right`, should be added with scrollbar width at runtime.
+        right: var(--blob-status-bar-horizontal-gap);
+        // `maxWidth` will also be subtracted by scrollbar width at runtime
+        max-width: calc(100% - (2 * var(--blob-status-bar-horizontal-gap)));
 
-            // Override default bootstrap `.w-100`, ensure that the status bar "sticks" to the right side.
-            width: auto !important;
-            // Default `right`, should be added with scrollbar width at runtime.
-            right: var(--blob-status-bar-horizontal-gap);
-            // `maxWidth` will also be subtracted by scrollbar width at runtime
-            max-width: calc(100% - (2 * var(--blob-status-bar-horizontal-gap)));
-
-            // Misc. style
-            height: var(--blob-status-bar-height);
-            border-radius: var(--border-radius);
-            border: 1px solid var(--border-color);
-            background-color: var(--body-bg);
-        }
+        // Misc. style
+        height: var(--blob-status-bar-height);
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border-color);
+        background-color: var(--body-bg);
     }
 }

--- a/client/web/src/repo/blob/BlobPage.scss
+++ b/client/web/src/repo/blob/BlobPage.scss
@@ -6,6 +6,7 @@
     flex-direction: column;
 
     &__placeholder {
+        background-color: var(--code-bg);
         flex: 1 1 50%;
     }
 

--- a/client/web/src/repo/blob/RenderedFile.scss
+++ b/client/web/src/repo/blob/RenderedFile.scss
@@ -2,6 +2,7 @@
     overflow: auto;
     padding: 1rem 1.5rem;
     flex: 1;
+    background-color: var(--code-bg);
 
     &__container {
         max-width: 50rem;

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.scss
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.scss
@@ -3,6 +3,7 @@
 .repo-settings-index-page {
     &__refs {
         list-style-type: none;
+        padding-left: 0;
     }
     &__ref {
         display: flex;
@@ -11,6 +12,12 @@
         border: 1px solid var(--border-color);
         border-radius: 0.125rem;
         margin: 0.5rem 0;
+        &:first-of-type {
+            margin-top: 0;
+        }
+        &:last-of-type {
+            margin-bottom: 0;
+        }
         padding: 0.5rem 0.75rem;
         &-icon {
             margin-right: 0.25rem;

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -12,6 +12,7 @@ import { gql } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { createAggregateError } from '@sourcegraph/shared/src/util/errors'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { ErrorAlert } from '../../components/alerts'
@@ -156,88 +157,98 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <div className="repo-settings-index-page">
+            <>
                 <PageTitle title="Index settings" />
-                <h2>Indexing</h2>
-                {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && (
-                    <ErrorAlert prefix="Error getting repository index status" error={this.state.error} />
-                )}
-                {!this.state.error &&
-                    !this.state.loading &&
-                    (this.state.textSearchIndex ? (
-                        <>
-                            <p>Index branches to enhance search performance at scale.</p>
-                            {this.state.textSearchIndex.refs && (
-                                <ul className="repo-settings-index-page__refs">
-                                    {this.state.textSearchIndex.refs.map((reference, index) => (
-                                        <TextSearchIndexedReference
-                                            key={index}
-                                            repo={this.props.repo}
-                                            indexedRef={reference}
-                                        />
-                                    ))}
-                                </ul>
-                            )}
-                            {this.state.textSearchIndex.status && (
-                                <>
-                                    <h3>Statistics</h3>
-                                    <table className="table repo-settings-index-page__stats">
-                                        <tbody>
-                                            <tr>
-                                                <th>Last updated</th>
-                                                <td>
-                                                    <Timestamp date={this.state.textSearchIndex.status.updatedAt} />
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>Content size</th>
-                                                <td>
-                                                    {prettyBytes(this.state.textSearchIndex.status.contentByteSize)} (
-                                                    {this.state.textSearchIndex.status.contentFilesCount}{' '}
-                                                    {pluralize(
-                                                        'file',
-                                                        this.state.textSearchIndex.status.contentFilesCount
-                                                    )}
-                                                    )
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>Index size</th>
-                                                <td>
-                                                    {prettyBytes(this.state.textSearchIndex.status.indexByteSize)} (
-                                                    {this.state.textSearchIndex.status.indexShardsCount}{' '}
-                                                    {pluralize(
-                                                        'shard',
-                                                        this.state.textSearchIndex.status.indexShardsCount
-                                                    )}
-                                                    )
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>New lines count</th>
-                                                <td>
-                                                    {this.state.textSearchIndex.status.newLinesCount.toLocaleString()}{' '}
-                                                    (default branch:{' '}
-                                                    {this.state.textSearchIndex.status.defaultBranchNewLinesCount.toLocaleString()}
-                                                    ) (other branches:{' '}
-                                                    {this.state.textSearchIndex.status.otherBranchesNewLinesCount.toLocaleString()}
-                                                    )
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </>
-                            )}
-                        </>
-                    ) : (
-                        <div className="alert alert-info">
-                            This Sourcegraph site has not enabled indexed search. See{' '}
-                            <Link to="/help/admin/search">search documentation</Link> for information on how to enable
-                            it.
-                        </div>
-                    ))}
-            </div>
+                <PageHeader
+                    path={[{ text: 'Indexing' }]}
+                    headingElement="h2"
+                    className="mb-3"
+                    description={
+                        !this.state.error && !this.state.loading && this.state.textSearchIndex ? (
+                            <>Index branches to enhance search performance at scale.</>
+                        ) : undefined
+                    }
+                />
+                <Container className="repo-settings-index-page">
+                    {this.state.loading && <LoadingSpinner className="icon-inline" />}
+                    {this.state.error && (
+                        <ErrorAlert prefix="Error getting repository index status" error={this.state.error} />
+                    )}
+                    {!this.state.error &&
+                        !this.state.loading &&
+                        (this.state.textSearchIndex ? (
+                            <>
+                                {this.state.textSearchIndex.refs && (
+                                    <ul className="repo-settings-index-page__refs">
+                                        {this.state.textSearchIndex.refs.map((reference, index) => (
+                                            <TextSearchIndexedReference
+                                                key={index}
+                                                repo={this.props.repo}
+                                                indexedRef={reference}
+                                            />
+                                        ))}
+                                    </ul>
+                                )}
+                                {this.state.textSearchIndex.status && (
+                                    <>
+                                        <h3>Statistics</h3>
+                                        <table className="table repo-settings-index-page__stats mb-0">
+                                            <tbody>
+                                                <tr>
+                                                    <th>Last updated</th>
+                                                    <td>
+                                                        <Timestamp date={this.state.textSearchIndex.status.updatedAt} />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Content size</th>
+                                                    <td>
+                                                        {prettyBytes(this.state.textSearchIndex.status.contentByteSize)}{' '}
+                                                        ({this.state.textSearchIndex.status.contentFilesCount}{' '}
+                                                        {pluralize(
+                                                            'file',
+                                                            this.state.textSearchIndex.status.contentFilesCount
+                                                        )}
+                                                        )
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Index size</th>
+                                                    <td>
+                                                        {prettyBytes(this.state.textSearchIndex.status.indexByteSize)} (
+                                                        {this.state.textSearchIndex.status.indexShardsCount}{' '}
+                                                        {pluralize(
+                                                            'shard',
+                                                            this.state.textSearchIndex.status.indexShardsCount
+                                                        )}
+                                                        )
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <th>New lines count</th>
+                                                    <td>
+                                                        {this.state.textSearchIndex.status.newLinesCount.toLocaleString()}{' '}
+                                                        (default branch:{' '}
+                                                        {this.state.textSearchIndex.status.defaultBranchNewLinesCount.toLocaleString()}
+                                                        ) (other branches:{' '}
+                                                        {this.state.textSearchIndex.status.otherBranchesNewLinesCount.toLocaleString()}
+                                                        )
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </>
+                                )}
+                            </>
+                        ) : (
+                            <div className="alert alert-info mb-0">
+                                This Sourcegraph site has not enabled indexed search. See{' '}
+                                <Link to="/help/admin/search">search documentation</Link> for information on how to
+                                enable it.
+                            </div>
+                        ))}
+                </Container>
+            </>
         )
     }
 }

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -1,5 +1,4 @@
 import * as H from 'history'
-import CheckIcon from 'mdi-react/CheckIcon'
 import LockIcon from 'mdi-react/LockIcon'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -10,6 +9,7 @@ import { catchError, switchMap, tap } from 'rxjs/operators'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { asError } from '@sourcegraph/shared/src/util/errors'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../components/alerts'
 import { FeedbackText } from '../../components/FeedbackText'
@@ -210,17 +210,17 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
                             <ErrorAlert className="action-container__alert" error={this.state.errorDescription} />
                         )}
                         {this.state.loading && (
-                            <div className="alert alert-primary action-container__alert">
+                            <div className="alert alert-primary action-container__alert mb-0">
                                 <LoadingSpinner className="icon-inline" /> Checking connection...
                             </div>
                         )}
                         {this.state.result &&
                             (this.state.result.error === null ? (
-                                <div className="alert alert-success action-container__alert">
-                                    <CheckIcon className="icon-inline" /> The remote repository is reachable.
+                                <div className="alert alert-success action-container__alert mb-0">
+                                    The remote repository is reachable.
                                 </div>
                             ) : (
-                                <div className="alert alert-danger action-container__alert">
+                                <div className="alert alert-danger action-container__alert mb-0">
                                     <p>The remote repository is unreachable. Logs follow.</p>
                                     <div>
                                         <pre className="check-mirror-repository-connection-action-container__log">
@@ -231,6 +231,7 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
                             ))}
                     </>
                 }
+                className="mb-0"
             />
         )
     }
@@ -294,74 +295,79 @@ export class RepoSettingsMirrorPage extends React.PureComponent<
 
     public render(): JSX.Element | null {
         return (
-            <div className="repo-settings-mirror-page">
+            <>
                 <PageTitle title="Mirror settings" />
-                <h2>Mirroring and cloning</h2>
-                {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <ErrorAlert error={this.state.error} />}
-                <div className="form-group">
-                    <label>
-                        Remote repository URL{' '}
-                        <small className="text-info">
-                            <LockIcon className="icon-inline" /> Only visible to site admins
-                        </small>
-                    </label>
-                    <input
-                        className="form-control"
-                        value={this.props.repo.mirrorInfo.remoteURL || '(unknown)'}
-                        readOnly={true}
-                    />
-                    {this.state.repo.viewerCanAdminister && (
-                        <small className="form-text text-muted">
-                            Configure repository mirroring in{' '}
-                            <Link to="/site-admin/external-services">external services</Link>.
-                        </small>
-                    )}
-                </div>
-                <UpdateMirrorRepositoryActionContainer
-                    repo={this.state.repo}
-                    onDidUpdateRepository={this.onDidUpdateRepository}
-                    disabled={typeof this.state.reachable === 'boolean' && !this.state.reachable}
-                    disabledReason={
-                        typeof this.state.reachable === 'boolean' && !this.state.reachable ? 'Not reachable' : undefined
-                    }
-                    history={this.props.history}
-                />
-                <CheckMirrorRepositoryConnectionActionContainer
-                    repo={this.state.repo}
-                    onDidUpdateReachability={this.onDidUpdateReachability}
-                    history={this.props.history}
-                />
-                {typeof this.state.reachable === 'boolean' && !this.state.reachable && (
-                    <div className="alert alert-info repo-settings-mirror-page__troubleshooting">
-                        Problems cloning or updating this repository?
-                        <ul className="repo-settings-mirror-page__steps">
-                            <li className="repo-settings-mirror-page__step">
-                                Inspect the <strong>Check connection</strong> error log output to see why the remote
-                                repository is not reachable.
-                            </li>
-                            <li className="repo-settings-mirror-page__step">
-                                <code>
-                                    <strong>No ECDSA host key is known ... Host key verification failed?</strong>
-                                </code>{' '}
-                                See{' '}
-                                <Link to="/help/admin/repo/auth#ssh-authentication-config-keys-known-hosts">
-                                    SSH repository authentication documentation
-                                </Link>{' '}
-                                for how to provide an SSH <code>known_hosts</code> file with the remote host's SSH host
-                                key.
-                            </li>
-                            <li className="repo-settings-mirror-page__step">
-                                Consult <Link to="/help/admin/repo/add">Sourcegraph repositories documentation</Link>{' '}
-                                for resolving other authentication issues (such as HTTPS certificates and SSH keys).
-                            </li>
-                            <li className="repo-settings-mirror-page__step">
-                                <FeedbackText headerText="Questions?" />
-                            </li>
-                        </ul>
+                <PageHeader path={[{ text: 'Mirroring and cloning' }]} headingElement="h2" className="mb-3" />
+                <Container className="repo-settings-mirror-page">
+                    {this.state.loading && <LoadingSpinner className="icon-inline" />}
+                    {this.state.error && <ErrorAlert error={this.state.error} />}
+                    <div className="form-group">
+                        <label>
+                            Remote repository URL{' '}
+                            <small className="text-info">
+                                <LockIcon className="icon-inline" /> Only visible to site admins
+                            </small>
+                        </label>
+                        <input
+                            className="form-control"
+                            value={this.props.repo.mirrorInfo.remoteURL || '(unknown)'}
+                            readOnly={true}
+                        />
+                        {this.state.repo.viewerCanAdminister && (
+                            <small className="form-text text-muted">
+                                Configure repository mirroring in{' '}
+                                <Link to="/site-admin/external-services">external services</Link>.
+                            </small>
+                        )}
                     </div>
-                )}
-            </div>
+                    <UpdateMirrorRepositoryActionContainer
+                        repo={this.state.repo}
+                        onDidUpdateRepository={this.onDidUpdateRepository}
+                        disabled={typeof this.state.reachable === 'boolean' && !this.state.reachable}
+                        disabledReason={
+                            typeof this.state.reachable === 'boolean' && !this.state.reachable
+                                ? 'Not reachable'
+                                : undefined
+                        }
+                        history={this.props.history}
+                    />
+                    <CheckMirrorRepositoryConnectionActionContainer
+                        repo={this.state.repo}
+                        onDidUpdateReachability={this.onDidUpdateReachability}
+                        history={this.props.history}
+                    />
+                    {typeof this.state.reachable === 'boolean' && !this.state.reachable && (
+                        <div className="alert alert-info repo-settings-mirror-page__troubleshooting">
+                            Problems cloning or updating this repository?
+                            <ul className="repo-settings-mirror-page__steps">
+                                <li className="repo-settings-mirror-page__step">
+                                    Inspect the <strong>Check connection</strong> error log output to see why the remote
+                                    repository is not reachable.
+                                </li>
+                                <li className="repo-settings-mirror-page__step">
+                                    <code>
+                                        <strong>No ECDSA host key is known ... Host key verification failed?</strong>
+                                    </code>{' '}
+                                    See{' '}
+                                    <Link to="/help/admin/repo/auth#ssh-authentication-config-keys-known-hosts">
+                                        SSH repository authentication documentation
+                                    </Link>{' '}
+                                    for how to provide an SSH <code>known_hosts</code> file with the remote host's SSH
+                                    host key.
+                                </li>
+                                <li className="repo-settings-mirror-page__step">
+                                    Consult{' '}
+                                    <Link to="/help/admin/repo/add">Sourcegraph repositories documentation</Link> for
+                                    resolving other authentication issues (such as HTTPS certificates and SSH keys).
+                                </li>
+                                <li className="repo-settings-mirror-page__step">
+                                    <FeedbackText headerText="Questions?" />
+                                </li>
+                            </ul>
+                        </div>
+                    )}
+                </Container>
+            </>
         )
     }
 

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -6,6 +6,7 @@ import { switchMap } from 'rxjs/operators'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError } from '@sourcegraph/shared/src/util/errors'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../components/alerts'
 import { ExternalServiceCard } from '../../components/externalServices/ExternalServiceCard'
@@ -64,51 +65,53 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
     public render(): JSX.Element | null {
         const services = this.state.repo.externalServices.nodes
         return (
-            <div className="repo-settings-options-page">
+            <>
                 <PageTitle title="Repository settings" />
-                <h2>Settings</h2>
-                {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <ErrorAlert error={this.state.error} />}
-                {services.length > 0 && (
-                    <div className="mb-4">
-                        {services.map(service => (
-                            <div className="mb-3" key={service.id}>
-                                <ExternalServiceCard
-                                    {...defaultExternalServices[service.kind]}
-                                    kind={service.kind}
-                                    title={service.displayName}
-                                    shortDescription="Update this external service configuration to manage repository mirroring."
-                                    to={`/site-admin/external-services/${service.id}`}
-                                />
-                            </div>
-                        ))}
-                        {services.length > 1 && (
-                            <p>
-                                This repository is mirrored by multiple external services. To change access, disable, or
-                                remove this repository, the configuration must be updated on all external services.
-                            </p>
-                        )}
-                    </div>
-                )}
-                <Form>
-                    <div className="form-group">
-                        <label htmlFor="repo-settings-options-page__name">Repository name</label>
-                        <input
-                            id="repo-settings-options-page__name"
-                            type="text"
-                            className="form-control"
-                            readOnly={true}
-                            disabled={true}
-                            value={this.state.repo.name}
-                            required={true}
-                            spellCheck={false}
-                            autoCapitalize="off"
-                            autoCorrect="off"
-                            aria-describedby="repo-settings-options-page__name-help"
-                        />
-                    </div>
-                </Form>
-            </div>
+                <PageHeader path={[{ text: 'Settings' }]} headingElement="h2" className="mb-3" />
+                <Container className="repo-settings-options-page">
+                    {this.state.loading && <LoadingSpinner className="icon-inline" />}
+                    {this.state.error && <ErrorAlert error={this.state.error} />}
+                    {services.length > 0 && (
+                        <div className="mb-3">
+                            {services.map(service => (
+                                <div className="mb-3" key={service.id}>
+                                    <ExternalServiceCard
+                                        {...defaultExternalServices[service.kind]}
+                                        kind={service.kind}
+                                        title={service.displayName}
+                                        shortDescription="Update this external service configuration to manage repository mirroring."
+                                        to={`/site-admin/external-services/${service.id}`}
+                                    />
+                                </div>
+                            ))}
+                            {services.length > 1 && (
+                                <p>
+                                    This repository is mirrored by multiple external services. To change access,
+                                    disable, or remove this repository, the configuration must be updated on all
+                                    external services.
+                                </p>
+                            )}
+                        </div>
+                    )}
+                    <Form>
+                        <div className="form-group mb-0">
+                            <label htmlFor="repo-settings-options-page__name">Repository name</label>
+                            <input
+                                id="repo-settings-options-page__name"
+                                type="text"
+                                className="form-control"
+                                readOnly={true}
+                                disabled={true}
+                                value={this.state.repo.name}
+                                required={true}
+                                spellCheck={false}
+                                autoCapitalize="off"
+                                autoCorrect="off"
+                            />
+                        </div>
+                    </Form>
+                </Container>
+            </>
         )
     }
 }

--- a/client/web/src/repo/settings/RepoSettingsSidebar.tsx
+++ b/client/web/src/repo/settings/RepoSettingsSidebar.tsx
@@ -1,14 +1,7 @@
-import ConsoleIcon from 'mdi-react/ConsoleIcon'
 import * as React from 'react'
-import { Link, RouteComponentProps } from 'react-router-dom'
+import { RouteComponentProps } from 'react-router-dom'
 
-import {
-    SIDEBAR_BUTTON_CLASS,
-    SidebarGroupItems,
-    SidebarGroupHeader,
-    SidebarGroup,
-    SidebarNavItem,
-} from '../../components/Sidebar'
+import { SidebarGroupItems, SidebarGroupHeader, SidebarGroup, SidebarNavItem } from '../../components/Sidebar'
 import { SettingsAreaRepositoryFields } from '../../graphql-operations'
 import { NavGroupDescriptor } from '../../util/contributions'
 
@@ -49,10 +42,5 @@ export const RepoSettingsSidebar: React.FunctionComponent<Props> = ({
                     </SidebarGroup>
                 )
         )}
-
-        <Link to="/api/console" className={SIDEBAR_BUTTON_CLASS}>
-            <ConsoleIcon className="icon-inline" />
-            API console
-        </Link>
     </div>
 )

--- a/client/web/src/repo/tree/TreeEntriesSection.tsx
+++ b/client/web/src/repo/tree/TreeEntriesSection.tsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames'
 import { identity } from 'lodash'
+import FileDocumentOutlineIcon from 'mdi-react/FileDocumentOutlineIcon'
+import FolderOutlineIcon from 'mdi-react/FolderOutlineIcon'
 import React from 'react'
 
 import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
@@ -40,6 +42,8 @@ const TreeEntry: React.FunctionComponent<{
             )}
         >
             <span>
+                {isDirectory && <FolderOutlineIcon className="icon-inline mr-1" />}
+                {!isDirectory && <FileDocumentOutlineIcon className="icon-inline mr-1" />}
                 {name}
                 {isDirectory && '/'}
             </span>

--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -3,6 +3,10 @@
 @import './TreeEntriesSection';
 
 .tree-page {
+    // For the other sub-pages in the RepoArea, we use a child selector to add the
+    // border and radius to the sub-page containers. Since we use the Container
+    // component here, we already have a pair of borders and had duplicate borders
+    // without it. This should be removed once we can get rid of that child selector.
     border: none !important;
     border-radius: 0 !important;
     padding-bottom: 2rem !important;

--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -4,12 +4,16 @@
 
 .tree-page {
     overflow-y: auto;
-    padding: 1rem 2rem;
     flex: 1;
+    background-color: var(--code-bg);
 
-    .theme-redesign & {
-        background-color: var(--code-bg);
-        margin-bottom: 2rem;
+    // We need to increase specificity here, because the child selector from where
+    // this is set has higher specificity than this plain one.
+    // stylelint-disable-next-line selector-max-id
+    &__container:not(#\9) {
+        border: none;
+        border-radius: 0;
+        padding-bottom: 2rem;
     }
 
     &__title {
@@ -19,12 +23,7 @@
     }
 
     &__section {
-        margin-bottom: 1.75rem;
         width: 100%;
-
-        &-header {
-            margin-bottom: 0.125rem;
-        }
 
         max-width: map-get($grid-breakpoints, xl);
 

--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -3,17 +3,14 @@
 @import './TreeEntriesSection';
 
 .tree-page {
-    overflow-y: auto;
-    flex: 1;
-    background-color: var(--code-bg);
+    border: none !important;
+    border-radius: 0 !important;
+    padding-bottom: 2rem !important;
 
-    // We need to increase specificity here, because the child selector from where
-    // this is set has higher specificity than this plain one.
-    // stylelint-disable-next-line selector-max-id
-    &__container:not(#\9) {
-        border: none;
-        border-radius: 0;
-        padding-bottom: 2rem;
+    &__container {
+        overflow-y: auto;
+        flex: 1;
+        background-color: var(--code-bg);
     }
 
     &__title {

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -352,8 +352,8 @@ export const TreePage: React.FunctionComponent<Props> = ({
         </div>
     )
     return (
-        <div className="tree-page__container">
-            <Container className="tree-page">
+        <div className="tree-page">
+            <Container className="tree-page__container">
                 <PageTitle title={getPageTitle()} />
                 {treeOrError === undefined ? (
                     <div>

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -35,6 +35,7 @@ import { memoizeObservable } from '@sourcegraph/shared/src/util/memoizeObservabl
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 import { encodeURIPathComponent, toPrettyBlobURL, toURIWithPath } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { getFileDecorations } from '../../backend/features'
 import { queryGraphQL } from '../../backend/graphql'
@@ -321,8 +322,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
         <>No commits in this tree.</>
     ) : (
         <div className="test-tree-page-no-recent-commits">
-            No commits in this tree in the past year.
-            <br />
+            <p className="mb-2">No commits in this tree in the past year.</p>
             <button
                 type="button"
                 className="btn btn-secondary btn-sm test-tree-page-show-all-commits"
@@ -336,12 +336,15 @@ export const TreePage: React.FunctionComponent<Props> = ({
     const TotalCountSummary: React.FunctionComponent<{ totalCount: number }> = ({ totalCount }) => (
         <div className="mt-2">
             {showOlderCommits ? (
-                <>{totalCount} total commits in this tree.</>
+                <>
+                    {totalCount} total {pluralize('commit', totalCount)} in this tree.
+                </>
             ) : (
                 <>
-                    {totalCount} {pluralize('commit', totalCount)} in this tree in the past year.
-                    <br />
-                    <button type="button" className="btn btn-secondary btn-sm mt-1" onClick={onShowOlderCommitsClicked}>
+                    <p className="mb-2">
+                        {totalCount} {pluralize('commit', totalCount)} in this tree in the past year.
+                    </p>
+                    <button type="button" className="btn btn-secondary btn-sm" onClick={onShowOlderCommitsClicked}>
                         Show all commits
                     </button>
                 </>
@@ -349,143 +352,151 @@ export const TreePage: React.FunctionComponent<Props> = ({
         </div>
     )
     return (
-        <div className="tree-page">
-            <PageTitle title={getPageTitle()} />
-            {treeOrError === undefined ? (
-                <div>
-                    <LoadingSpinner className="icon-inline tree-page__entries-loader" /> Loading files and directories
-                </div>
-            ) : isErrorLike(treeOrError) ? (
-                // If the tree is actually a blob, be helpful and redirect to the blob page.
-                // We don't have error names on GraphQL errors.
-                /not a directory/i.test(treeOrError.message) ? (
-                    <Redirect to={toPrettyBlobURL({ repoName: repo.name, revision, commitID, filePath })} />
-                ) : (
-                    <ErrorAlert error={treeOrError} />
-                )
-            ) : (
-                <>
-                    <header className="mb-3">
-                        {treeOrError.isRoot ? (
-                            <>
-                                <h2 className="tree-page__title">
-                                    <SourceRepositoryIcon className="icon-inline" /> {displayRepoName(repo.name)}
-                                </h2>
-                                {repo.description && <p>{repo.description}</p>}
-                                <div className="btn-group mb-3">
-                                    {enableAPIDocs && (
-                                        <Link className="btn btn-secondary" to={`${treeOrError.url}/-/docs`}>
-                                            <BookOpenVariantIcon className="icon-inline" /> API docs
-                                        </Link>
-                                    )}
-                                    <Link className="btn btn-secondary" to={`${treeOrError.url}/-/commits`}>
-                                        <SourceCommitIcon className="icon-inline" /> Commits
-                                    </Link>
-                                    <Link
-                                        className="btn btn-secondary"
-                                        to={`/${encodeURIPathComponent(repo.name)}/-/branches`}
-                                    >
-                                        <SourceBranchIcon className="icon-inline" /> Branches
-                                    </Link>
-                                    <Link
-                                        className="btn btn-secondary"
-                                        to={`/${encodeURIPathComponent(repo.name)}/-/tags`}
-                                    >
-                                        <TagIcon className="icon-inline" /> Tags
-                                    </Link>
-                                    <Link
-                                        className="btn btn-secondary"
-                                        to={
-                                            revision
-                                                ? `/${encodeURIPathComponent(
-                                                      repo.name
-                                                  )}/-/compare/...${encodeURIComponent(revision)}`
-                                                : `/${encodeURIPathComponent(repo.name)}/-/compare`
-                                        }
-                                    >
-                                        <HistoryIcon className="icon-inline" /> Compare
-                                    </Link>
-                                    <Link
-                                        className="btn btn-secondary"
-                                        to={`/${encodeURIPathComponent(repo.name)}/-/stats/contributors`}
-                                    >
-                                        <UserIcon className="icon-inline" /> Contributors
-                                    </Link>
-                                    {repo.viewerCanAdminister && (
-                                        <Link
-                                            className="btn btn-secondary"
-                                            to={`/${encodeURIPathComponent(repo.name)}/-/settings`}
-                                        >
-                                            <SettingsIcon className="icon-inline" /> Settings
-                                        </Link>
-                                    )}
-                                </div>
-                            </>
-                        ) : (
-                            <h2 className="tree-page__title">
-                                <FolderIcon className="icon-inline" /> {filePath}
-                            </h2>
-                        )}
-                    </header>
-                    {views && (
-                        <InsightsViewGrid
-                            {...props}
-                            className="tree-page__section"
-                            views={views}
-                            patternType={patternType}
-                            settingsCascade={settingsCascade}
-                            caseSensitive={caseSensitive}
-                        />
-                    )}
-                    <section className="tree-page__section test-tree-entries">
-                        <h3 className="tree-page__section-header">Files and directories</h3>
-                        <TreeEntriesSection
-                            parentPath={filePath}
-                            entries={treeOrError.entries}
-                            fileDecorationsByPath={fileDecorationsByPath}
-                            isLightTheme={props.isLightTheme}
-                        />
-                    </section>
-                    <ActionsContainer {...props} menu={ContributableMenu.DirectoryPage} empty={null}>
-                        {items => (
-                            <section className="tree-page__section">
-                                <h3 className="tree-page__section-header">Actions</h3>
-                                {items.map(item => (
-                                    <ActionItem
-                                        {...props}
-                                        key={item.action.id}
-                                        {...item}
-                                        className="btn btn-secondary mr-1 mb-1"
-                                    />
-                                ))}
-                            </section>
-                        )}
-                    </ActionsContainer>
-
-                    <div className="tree-page__section">
-                        <h3 className="tree-page__section-header">Changes</h3>
-                        <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact'>>
-                            location={props.location}
-                            className="mt-2 tree-page__section--commits"
-                            listClassName="list-group list-group-flush"
-                            noun="commit in this tree"
-                            pluralNoun="commits in this tree"
-                            queryConnection={queryCommits}
-                            nodeComponent={GitCommitNode}
-                            nodeComponentProps={{
-                                className: 'list-group-item',
-                                compact: true,
-                            }}
-                            updateOnChange={`${repo.name}:${revision}:${filePath}:${String(showOlderCommits)}`}
-                            defaultFirst={7}
-                            useURLQuery={false}
-                            hideSearch={true}
-                            emptyElement={emptyElement}
-                            totalCountSummaryComponent={TotalCountSummary}
-                        />
+        <div className="tree-page__container">
+            <Container className="tree-page">
+                <PageTitle title={getPageTitle()} />
+                {treeOrError === undefined ? (
+                    <div>
+                        <LoadingSpinner className="icon-inline tree-page__entries-loader" /> Loading files and
+                        directories
                     </div>
-                </>
-            )}
+                ) : isErrorLike(treeOrError) ? (
+                    // If the tree is actually a blob, be helpful and redirect to the blob page.
+                    // We don't have error names on GraphQL errors.
+                    /not a directory/i.test(treeOrError.message) ? (
+                        <Redirect to={toPrettyBlobURL({ repoName: repo.name, revision, commitID, filePath })} />
+                    ) : (
+                        <ErrorAlert error={treeOrError} />
+                    )
+                ) : (
+                    <>
+                        <header className="mb-3">
+                            {treeOrError.isRoot ? (
+                                <>
+                                    <PageHeader
+                                        path={[{ icon: SourceRepositoryIcon, text: displayRepoName(repo.name) }]}
+                                        className="mb-3 test-tree-page-title"
+                                    />
+                                    {repo.description && <p>{repo.description}</p>}
+                                    <div className="btn-group">
+                                        {enableAPIDocs && (
+                                            <Link
+                                                className="btn btn-outline-secondary"
+                                                to={`${treeOrError.url}/-/docs`}
+                                            >
+                                                <BookOpenVariantIcon className="icon-inline" /> API docs
+                                            </Link>
+                                        )}
+                                        <Link className="btn btn-outline-secondary" to={`${treeOrError.url}/-/commits`}>
+                                            <SourceCommitIcon className="icon-inline" /> Commits
+                                        </Link>
+                                        <Link
+                                            className="btn btn-outline-secondary"
+                                            to={`/${encodeURIPathComponent(repo.name)}/-/branches`}
+                                        >
+                                            <SourceBranchIcon className="icon-inline" /> Branches
+                                        </Link>
+                                        <Link
+                                            className="btn btn-outline-secondary"
+                                            to={`/${encodeURIPathComponent(repo.name)}/-/tags`}
+                                        >
+                                            <TagIcon className="icon-inline" /> Tags
+                                        </Link>
+                                        <Link
+                                            className="btn btn-outline-secondary"
+                                            to={
+                                                revision
+                                                    ? `/${encodeURIPathComponent(
+                                                          repo.name
+                                                      )}/-/compare/...${encodeURIComponent(revision)}`
+                                                    : `/${encodeURIPathComponent(repo.name)}/-/compare`
+                                            }
+                                        >
+                                            <HistoryIcon className="icon-inline" /> Compare
+                                        </Link>
+                                        <Link
+                                            className="btn btn-outline-secondary"
+                                            to={`/${encodeURIPathComponent(repo.name)}/-/stats/contributors`}
+                                        >
+                                            <UserIcon className="icon-inline" /> Contributors
+                                        </Link>
+                                        {repo.viewerCanAdminister && (
+                                            <Link
+                                                className="btn btn-outline-secondary"
+                                                to={`/${encodeURIPathComponent(repo.name)}/-/settings`}
+                                            >
+                                                <SettingsIcon className="icon-inline" /> Settings
+                                            </Link>
+                                        )}
+                                    </div>
+                                </>
+                            ) : (
+                                <PageHeader
+                                    path={[{ icon: FolderIcon, text: filePath }]}
+                                    className="mb-3 test-tree-page-title"
+                                />
+                            )}
+                        </header>
+                        {views && (
+                            <InsightsViewGrid
+                                {...props}
+                                className="tree-page__section mb-3"
+                                views={views}
+                                patternType={patternType}
+                                settingsCascade={settingsCascade}
+                                caseSensitive={caseSensitive}
+                            />
+                        )}
+                        <section className="tree-page__section test-tree-entries mb-3">
+                            <h2>Files and directories</h2>
+                            <TreeEntriesSection
+                                parentPath={filePath}
+                                entries={treeOrError.entries}
+                                fileDecorationsByPath={fileDecorationsByPath}
+                                isLightTheme={props.isLightTheme}
+                            />
+                        </section>
+                        <ActionsContainer {...props} menu={ContributableMenu.DirectoryPage} empty={null}>
+                            {items => (
+                                <section className="tree-page__section">
+                                    <h2>Actions</h2>
+                                    {items.map(item => (
+                                        <ActionItem
+                                            {...props}
+                                            key={item.action.id}
+                                            {...item}
+                                            className="btn btn-secondary mr-1 mb-1"
+                                        />
+                                    ))}
+                                </section>
+                            )}
+                        </ActionsContainer>
+
+                        <div className="tree-page__section">
+                            <h2>Changes</h2>
+                            <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact'>>
+                                location={props.location}
+                                className="mt-2 tree-page__section--commits"
+                                listClassName="list-group list-group-flush"
+                                noun="commit in this tree"
+                                pluralNoun="commits in this tree"
+                                queryConnection={queryCommits}
+                                nodeComponent={GitCommitNode}
+                                nodeComponentProps={{
+                                    className: 'list-group-item',
+                                    compact: true,
+                                }}
+                                updateOnChange={`${repo.name}:${revision}:${filePath}:${String(showOlderCommits)}`}
+                                defaultFirst={7}
+                                useURLQuery={false}
+                                hideSearch={true}
+                                emptyElement={emptyElement}
+                                totalCountSummaryComponent={TotalCountSummary}
+                            />
+                        </div>
+                    </>
+                )}
+            </Container>
         </div>
     )
 }

--- a/client/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
+++ b/client/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
@@ -11,6 +11,17 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z"
+          />
+        </svg>
         src/
       </span>
       <div
@@ -38,6 +49,17 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z"
+          />
+        </svg>
         testdata/
       </span>
       <div
@@ -65,6 +87,17 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M6,2A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6M6,4H13V9H18V20H6V4M8,12V14H16V12H8M8,16V18H13V16H8Z"
+          />
+        </svg>
         .editorconfig
       </span>
     </div>
@@ -78,6 +111,17 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M6,2A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6M6,4H13V9H18V20H6V4M8,12V14H16V12H8M8,16V18H13V16H8Z"
+          />
+        </svg>
         .eslintrc.json
       </span>
     </div>
@@ -96,6 +140,17 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z"
+          />
+        </svg>
         testutils/
       </span>
       <div
@@ -123,6 +178,17 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z"
+          />
+        </svg>
         typings/
       </span>
       <div
@@ -150,6 +216,17 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M6,2A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6M6,4H13V9H18V20H6V4M8,12V14H16V12H8M8,16V18H13V16H8Z"
+          />
+        </svg>
         errors.ts
       </span>
     </div>
@@ -163,6 +240,17 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M6,2A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6M6,4H13V9H18V20H6V4M8,12V14H16V12H8M8,16V18H13V16H8Z"
+          />
+        </svg>
         helpers.ts
       </span>
     </div>
@@ -181,6 +269,17 @@ exports[`TreeEntriesSection should render only direct children 1`] = `
       class="d-flex align-items-center justify-content-between test-file-decorable-name overflow-hidden"
     >
       <span>
+        <svg
+          class="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z"
+          />
+        </svg>
         ref/
       </span>
       <div


### PR DESCRIPTION
This PR reworks the landing page for repos a bit and adds containers to the repo settings pages. It's not meant to be the entire overhaul for these pages, but gives them a bit of a fresher and more polished look, until someone finds the time to properly address the design changes that are planned for this page.

I've split up all the changes in separate commits, so it's easiest to **review commit by commit**, I think. Also, hide whitespace changes is your friend :)

| **Before** | **After** | 
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19534377/121546546-a95fa200-ca0b-11eb-88ec-5ea27c5bf60b.png) | Now has correct border radius at bottom corners, too. Was not rounded before ![image](https://user-images.githubusercontent.com/19534377/121546066-4ec64600-ca0b-11eb-98bf-6b0425797f9b.png) |
| ![image](https://user-images.githubusercontent.com/19534377/121546584-afee1980-ca0b-11eb-984e-e0d424bd8bdd.png) | ![image](https://user-images.githubusercontent.com/19534377/121546085-538afa00-ca0b-11eb-9bf0-43dfe7dddfb4.png) |
| ![image](https://user-images.githubusercontent.com/19534377/121546619-b9778180-ca0b-11eb-86c7-014339a9c438.png) | ![image](https://user-images.githubusercontent.com/19534377/121546114-584fae00-ca0b-11eb-9ea2-84443c889117.png) |
| ![image](https://user-images.githubusercontent.com/19534377/121546875-ef1c6a80-ca0b-11eb-818c-b4f848081889.png) | ![image](https://user-images.githubusercontent.com/19534377/121546646-be3c3580-ca0b-11eb-8027-31181f17cac2.png) |
| ![image](https://user-images.githubusercontent.com/19534377/121546661-c1cfbc80-ca0b-11eb-8566-70d263f80649.png) | ![image](https://user-images.githubusercontent.com/19534377/121546158-5f76bc00-ca0b-11eb-805c-bfc274403785.png) |
| ![image](https://user-images.githubusercontent.com/19534377/121546674-c5fbda00-ca0b-11eb-9278-ed04f3ce13f0.png) | ![image](https://user-images.githubusercontent.com/19534377/121546182-630a4300-ca0b-11eb-8b35-66b35d314aef.png) |
| **Rendered markdown background color** ![image](https://user-images.githubusercontent.com/19534377/121608405-2ada2300-ca52-11eb-92f9-50b6b8683d27.png) | ![image](https://user-images.githubusercontent.com/19534377/121608366-14cc6280-ca52-11eb-8d4f-1a1cda7502eb.png) |

