### PR TITLE
Instantiate backend.Repos where required

### DIFF
--- a/cmd/frontend/backend/go_importers_test.go
+++ b/cmd/frontend/backend/go_importers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -57,7 +58,7 @@ func TestCountGoImporters(t *testing.T) {
 		}, nil
 	}
 
-	count, err := CountGoImporters(ctx, wantRepoName)
+	count, err := CountGoImporters(ctx, &dbtesting.MockDB{}, wantRepoName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +69,7 @@ func TestCountGoImporters(t *testing.T) {
 
 func TestListGoPackagesInRepoImprecise(t *testing.T) {
 	t.Run("disabled on non-Sourcegraph.com", func(t *testing.T) {
-		if _, err := listGoPackagesInRepoImprecise(context.Background(), "a"); err == nil || !strings.Contains(err.Error(), "only supported on Sourcegraph.com") {
+		if _, err := listGoPackagesInRepoImprecise(context.Background(), &dbtesting.MockDB{}, "a"); err == nil || !strings.Contains(err.Error(), "only supported on Sourcegraph.com") {
 			t.Error("want listGoPackagesInRepoImprecise to only be supported on Sourcegraph.com")
 		}
 	})

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -40,11 +40,6 @@ func (e ErrRepoSeeOther) Error() string {
 	return fmt.Sprintf("repo not found at this location, but might exist at %s", e.RedirectURL)
 }
 
-// var Repos = &repos{
-// 	store: database.GlobalRepos,
-// 	cache: dbcache.NewDefaultRepoLister(database.GlobalRepos),
-// }
-
 func NewRepos(db dbutil.DB) *Repos {
 	rstore := database.Repos(db)
 	return &Repos{

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestReposService_Get(t *testing.T) {
-	var s repos
+	var s Repos
 	ctx := testContext()
 
 	wantRepo := &types.Repo{ID: 1, Name: "github.com/u/r"}
@@ -46,7 +46,7 @@ func TestReposService_Get(t *testing.T) {
 }
 
 func TestReposService_List(t *testing.T) {
-	var s repos
+	var s Repos
 	ctx := testContext()
 
 	wantRepos := []*types.Repo{
@@ -69,7 +69,7 @@ func TestReposService_List(t *testing.T) {
 }
 
 func TestRepos_Add(t *testing.T) {
-	var s repos
+	var s Repos
 	ctx := testContext()
 
 	const repoName = "my/repo"
@@ -109,7 +109,7 @@ func (oid gitObjectInfo) OID() git.OID {
 }
 
 func TestReposGetInventory(t *testing.T) {
-	var s repos
+	var s Repos
 	ctx := testContext()
 
 	const (

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -19,7 +19,7 @@ import (
 // * Empty repository: git.RevisionNotFoundError
 // * The user does not have permission: errcode.IsNotFound
 // * Other unexpected errors.
-func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (commitID api.CommitID, err error) {
+func (s *Repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (commitID api.CommitID, err error) {
 	if Mocks.Repos.ResolveRev != nil {
 		return Mocks.Repos.ResolveRev(ctx, repo, rev)
 	}
@@ -30,7 +30,7 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 	return git.ResolveRevision(ctx, repo.Name, rev, git.ResolveRevisionOptions{})
 }
 
-func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *git.Commit, err error) {
+func (s *Repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *git.Commit, err error) {
 	if Mocks.Repos.GetCommit != nil {
 		return Mocks.Repos.GetCommit(ctx, repo, commitID)
 	}

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -38,7 +39,7 @@ func TestRepos_ResolveRev_noRevSpecified_getsDefaultBranch(t *testing.T) {
 	defer git.ResetMocks()
 
 	// (no rev/branch specified)
-	commitID, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, "")
+	commitID, err := NewRepos(&dbtesting.MockDB{}).ResolveRev(ctx, &types.Repo{Name: "a"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +78,7 @@ func TestRepos_ResolveRev_noCommitIDSpecified_resolvesRev(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commitID, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, "b")
+	commitID, err := NewRepos(&dbtesting.MockDB{}).ResolveRev(ctx, &types.Repo{Name: "a"}, "b")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +117,7 @@ func TestRepos_ResolveRev_commitIDSpecified_resolvesCommitID(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commitID, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
+	commitID, err := NewRepos(&dbtesting.MockDB{}).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +156,7 @@ func TestRepos_ResolveRev_commitIDSpecified_failsToResolve(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	_, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
+	_, err := NewRepos(&dbtesting.MockDB{}).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
 	if !reflect.DeepEqual(err, want) {
 		t.Fatalf("got err %v, want %v", err, want)
 	}
@@ -189,7 +190,7 @@ func TestRepos_GetCommit_repoupdaterError(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commit, err := Repos.GetCommit(ctx, &types.Repo{Name: "a"}, want)
+	commit, err := NewRepos(&dbtesting.MockDB{}).GetCommit(ctx, &types.Repo{Name: "a"}, want)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -242,7 +242,7 @@ func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	inventory, err := backend.Repos.GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +260,7 @@ func (r *GitCommitResolver) LanguageStatistics(ctx context.Context) ([]*language
 		return nil, err
 	}
 
-	inventory, err := backend.Repos.GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -569,7 +569,7 @@ func (r *schemaResolver) RepositoryRedirect(ctx context.Context, args *struct {
 		return nil, errors.New("neither name nor cloneURL given")
 	}
 
-	repo, err := backend.Repos.GetByName(ctx, name)
+	repo, err := backend.NewRepos(r.db).GetByName(ctx, name)
 	if err != nil {
 		if err, ok := err.(backend.ErrRepoSeeOther); ok {
 			return &repositoryRedirect{redirect: &RedirectResolver{url: err.RedirectURL}}, nil

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -420,7 +420,6 @@ type schemaResolver struct {
 
 // newSchemaResolver will return a new schemaResolver using repoupdater.DefaultClient.
 func newSchemaResolver(db dbutil.DB) *schemaResolver {
-
 	r := &schemaResolver{
 		db:                db,
 		repoupdaterClient: repoupdater.DefaultClient,

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -158,7 +158,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			if opt2.LimitOffset != nil {
 				opt2.LimitOffset.Limit++
 			}
-			repos, err := backend.Repos.List(ctx, opt2)
+			repos, err := backend.NewRepos(r.db).List(ctx, opt2)
 			if err != nil {
 				r.err = err
 				return

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -220,13 +220,15 @@ func (r *RepositoryResolver) Language(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	commitID, err := backend.NewRepos(r.db).ResolveRev(ctx, repo, "")
+	repos := backend.NewRepos(r.db)
+
+	commitID, err := repos.ResolveRev(ctx, repo, "")
 	if err != nil {
 		// Comment: Should we return a nil error?
 		return "", err
 	}
 
-	inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, commitID, false)
+	inventory, err := repos.GetInventory(ctx, repo, commitID, false)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -152,7 +152,7 @@ func (r *RepositoryResolver) Commit(ctx context.Context, args *RepositoryCommitA
 		return nil, err
 	}
 
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, args.Rev)
+	commitID, err := backend.NewRepos(r.db).ResolveRev(ctx, repo, args.Rev)
 	if err != nil {
 		if gitserver.IsRevisionNotFound(err) {
 			return nil, nil
@@ -220,13 +220,13 @@ func (r *RepositoryResolver) Language(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, "")
+	commitID, err := backend.NewRepos(r.db).ResolveRev(ctx, repo, "")
 	if err != nil {
 		// Comment: Should we return a nil error?
 		return "", err
 	}
 
-	inventory, err := backend.Repos.GetInventory(ctx, repo, commitID, false)
+	inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, commitID, false)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -223,7 +223,7 @@ func (r *schemaResolver) CheckMirrorRepositoryConnection(ctx context.Context, ar
 		if err != nil {
 			return nil, err
 		}
-		repo, err = backend.Repos.Get(ctx, repoID)
+		repo, err = backend.NewRepos(r.db).Get(ctx, repoID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -406,7 +406,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 	repositoryResolver := &searchrepos.Resolver{
 		DB:               r.db,
 		Zoekt:            r.zoekt,
-		DefaultReposFunc: backend.Repos.ListDefault,
+		DefaultReposFunc: backend.NewRepos(r.db).ListDefault,
 	}
 
 	return repositoryResolver.Resolve(ctx, options)

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -113,7 +113,7 @@ func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Opt
 	repositoryResolver := &searchrepos.Resolver{
 		DB:               r.db,
 		Zoekt:            r.zoekt,
-		DefaultReposFunc: backend.Repos.ListDefault,
+		DefaultReposFunc: backend.NewRepos(r.db).ListDefault,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -26,7 +26,7 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 	}
 
 	// List at most 10 repositories as default suggestions.
-	repos, err := backend.Repos.List(ctx, database.ReposListOptions{
+	repos, err := backend.NewRepos(r.db).List(ctx, database.ReposListOptions{
 		OrderBy: database.RepoListOrderBy{
 			{
 				Field:      database.RepoListStars,

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -23,7 +24,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 		return nil, err
 	}
 
-	langs, err := searchResultsStatsLanguages(ctx, srr.Matches)
+	langs, err := searchResultsStatsLanguages(ctx, srs.srs.db, srr.Matches)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +48,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsRe
 	return srs.srs, srs.srsErr
 }
 
-func searchResultsStatsLanguages(ctx context.Context, matches []result.Match) ([]inventory.Lang, error) {
+func searchResultsStatsLanguages(ctx context.Context, db dbutil.DB, matches []result.Match) ([]inventory.Lang, error) {
 	// Batch our operations by repo-commit.
 	type repoCommit struct {
 		repo     api.RepoID
@@ -126,7 +127,7 @@ func searchResultsStatsLanguages(ctx context.Context, matches []result.Match) ([
 					run.Error(err)
 					return
 				}
-				inv, err := backend.Repos.GetInventory(ctx, repoName.ToRepo(), api.CommitID(oid.String()), true)
+				inv, err := backend.NewRepos(db).GetInventory(ctx, repoName.ToRepo(), api.CommitID(oid.String()), true)
 				if err != nil {
 					run.Error(err)
 					return

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -108,7 +109,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 				return test.getFiles, nil
 			}
 
-			langs, err := searchResultsStatsLanguages(context.Background(), test.results)
+			langs, err := searchResultsStatsLanguages(context.Background(), &dbtesting.MockDB{}, test.results)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -336,27 +336,29 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return nil, nil
 		}
 
+		repos := backend.NewRepos(r.db)
+
 		// Only care about the first found repository.
-		repos, err := backend.NewRepos(r.db).List(ctx, database.ReposListOptions{
+		rs, err := repos.List(ctx, database.ReposListOptions{
 			IncludePatterns: validValues,
 			LimitOffset: &database.LimitOffset{
 				Limit: 1,
 			},
 		})
-		if err != nil || len(repos) == 0 {
+		if err != nil || len(rs) == 0 {
 			return nil, err
 		}
-		repo := repos[0]
+		repo := rs[0]
 
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		commitID, err := backend.NewRepos(r.db).ResolveRev(ctx, repo, "")
+		commitID, err := repos.ResolveRev(ctx, repo, "")
 		if err != nil {
 			return nil, err
 		}
 
-		inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, commitID, false)
+		inventory, err := repos.GetInventory(ctx, repo, commitID, false)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -337,7 +337,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		}
 
 		// Only care about the first found repository.
-		repos, err := backend.Repos.List(ctx, database.ReposListOptions{
+		repos, err := backend.NewRepos(r.db).List(ctx, database.ReposListOptions{
 			IncludePatterns: validValues,
 			LimitOffset: &database.LimitOffset{
 				Limit: 1,
@@ -351,12 +351,12 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		commitID, err := backend.Repos.ResolveRev(ctx, repo, "")
+		commitID, err := backend.NewRepos(r.db).ResolveRev(ctx, repo, "")
 		if err != nil {
 			return nil, err
 		}
 
-		inventory, err := backend.Repos.GetInventory(ctx, repo, commitID, false)
+		inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, commitID, false)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -49,7 +49,7 @@ func NewHandler(db dbutil.DB) http.Handler {
 	})))
 
 	if envvar.SourcegraphDotComMode() {
-		r.Get(router.GoSymbolURL).Handler(trace.Route(errorutil.Handler(serveGoSymbolURL)))
+		r.Get(router.GoSymbolURL).Handler(trace.Route(errorutil.Handler(serveGoSymbolURL(db))))
 	}
 
 	r.Get(router.UI).Handler(ui.Router())
@@ -73,7 +73,7 @@ func NewHandler(db dbutil.DB) http.Handler {
 	r.Get(router.LatestPing).Handler(trace.Route(http.HandlerFunc(latestPingHandler(db))))
 
 	r.Get(router.GDDORefs).Handler(trace.Route(errorutil.Handler(serveGDDORefs)))
-	r.Get(router.Editor).Handler(trace.Route(errorutil.Handler(serveEditor)))
+	r.Get(router.Editor).Handler(trace.Route(errorutil.Handler(serveEditor(db))))
 
 	r.Get(router.DebugHeaders).Handler(trace.Route(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Header.Del("Cookie")

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -37,7 +37,7 @@ func NewHandler(db dbutil.DB) http.Handler {
 	r.Get(router.Favicon).Handler(trace.Route(http.HandlerFunc(favicon)))
 	r.Get(router.OpenSearch).Handler(trace.Route(http.HandlerFunc(openSearch)))
 
-	r.Get(router.RepoBadge).Handler(trace.Route(errorutil.Handler(serveRepoBadge)))
+	r.Get(router.RepoBadge).Handler(trace.Route(errorutil.Handler(serveRepoBadge(db))))
 
 	// Redirects
 	r.Get(router.OldToolsRedirect).Handler(trace.Route(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/app/badge.go
+++ b/cmd/frontend/internal/app/badge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )
 
 // TODO(slimsag): once https://github.com/badges/shields/pull/828 is merged,
@@ -19,7 +20,7 @@ import (
 
 // NOTE: Keep in sync with services/backend/httpapi/repo_shield.go
 func badgeValue(r *http.Request) (int, error) {
-	totalRefs, err := backend.CountGoImporters(r.Context(), routevar.ToRepo(mux.Vars(r)))
+	totalRefs, err := backend.CountGoImporters(r.Context(), dbconn.Global, routevar.ToRepo(mux.Vars(r)))
 	if err != nil {
 		return 0, errors.Wrap(err, "Defs.TotalRefs")
 	}

--- a/cmd/frontend/internal/app/badge.go
+++ b/cmd/frontend/internal/app/badge.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // TODO(slimsag): once https://github.com/badges/shields/pull/828 is merged,
@@ -19,8 +19,8 @@ import (
 // duplication kludge.
 
 // NOTE: Keep in sync with services/backend/httpapi/repo_shield.go
-func badgeValue(r *http.Request) (int, error) {
-	totalRefs, err := backend.CountGoImporters(r.Context(), dbconn.Global, routevar.ToRepo(mux.Vars(r)))
+func badgeValue(db dbutil.DB, r *http.Request) (int, error) {
+	totalRefs, err := backend.CountGoImporters(r.Context(), db, routevar.ToRepo(mux.Vars(r)))
 	if err != nil {
 		return 0, errors.Wrap(err, "Defs.TotalRefs")
 	}
@@ -41,26 +41,28 @@ func badgeValueFmt(totalRefs int) string {
 	return " " + desc
 }
 
-func serveRepoBadge(w http.ResponseWriter, r *http.Request) error {
-	value, err := badgeValue(r)
-	if err != nil {
-		return err
-	}
+func serveRepoBadge(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		value, err := badgeValue(db, r)
+		if err != nil {
+			return err
+		}
 
-	v := url.Values{}
-	v.Set("logo", "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3Ny4wNzUgNzcuNyI+PHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQ3LjMyMyA3Ny43Yy0zLjU5NCAwLTYuNzktMi4zOTYtNy43ODctNS45OWwtMTcuMTcyLTYxLjdjLS45OTgtNC4zOTMgMS41OTgtOC43ODYgNS45OS05Ljc4NCA0LjE5My0xIDguMzg3IDEuMzk3IDkuNTg0IDUuMzlsMTYuOTczIDYxLjdjMS4xOTggNC4zOTQtMS4zOTcgOC43ODYtNS41OSA5Ljk4NC0uNi4yLTEuMzk3LjQtMS45OTcuNHoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNMTcuMzcyIDcwLjcxYy00LjM5MyAwLTcuOTg3LTMuNTkzLTcuOTg3LTcuOTg1IDAtMS45OTcuOC0zLjk5NCAxLjk5Ny01LjM5Mkw1NC4xMTIgOS40MWMyLjk5NS0zLjM5MyA3Ljk4Ni0zLjU5MyAxMS4zOC0uNTk4czMuNTk1IDcuOTg3LjYgMTEuMzhsLTQyLjczIDQ3LjcyM2MtMS41OTcgMS43OTgtMy43OTQgMi43OTYtNS45OSAyLjc5NnoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNNjkuMDg3IDU2LjczNGMtLjc5OCAwLTEuNTk3LS4yLTIuNTk2LS40TDUuNTkgMzYuMzY4QzEuNCAzNC45Ny0uOTk3IDMwLjM3Ny40IDI2LjE4NGMxLjM5Ny00LjE5MyA1Ljk5LTYuNTkgMTAuMTgzLTUuMTlsNjAuOSAxOS45NjZjNC4xOTMgMS4zOTcgNi41OSA1Ljk5IDUuMTkgMTAuMTg0LS45OTYgMy4zOTQtMy45OSA1LjU5LTcuNTg2IDUuNTl6Ii8+PC9zdmc+")
+		v := url.Values{}
+		v.Set("logo", "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3Ny4wNzUgNzcuNyI+PHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQ3LjMyMyA3Ny43Yy0zLjU5NCAwLTYuNzktMi4zOTYtNy43ODctNS45OWwtMTcuMTcyLTYxLjdjLS45OTgtNC4zOTMgMS41OTgtOC43ODYgNS45OS05Ljc4NCA0LjE5My0xIDguMzg3IDEuMzk3IDkuNTg0IDUuMzlsMTYuOTczIDYxLjdjMS4xOTggNC4zOTQtMS4zOTcgOC43ODYtNS41OSA5Ljk4NC0uNi4yLTEuMzk3LjQtMS45OTcuNHoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNMTcuMzcyIDcwLjcxYy00LjM5MyAwLTcuOTg3LTMuNTkzLTcuOTg3LTcuOTg1IDAtMS45OTcuOC0zLjk5NCAxLjk5Ny01LjM5Mkw1NC4xMTIgOS40MWMyLjk5NS0zLjM5MyA3Ljk4Ni0zLjU5MyAxMS4zOC0uNTk4czMuNTk1IDcuOTg3LjYgMTEuMzhsLTQyLjczIDQ3LjcyM2MtMS41OTcgMS43OTgtMy43OTQgMi43OTYtNS45OSAyLjc5NnoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNNjkuMDg3IDU2LjczNGMtLjc5OCAwLTEuNTk3LS4yLTIuNTk2LS40TDUuNTkgMzYuMzY4QzEuNCAzNC45Ny0uOTk3IDMwLjM3Ny40IDI2LjE4NGMxLjM5Ny00LjE5MyA1Ljk5LTYuNTkgMTAuMTgzLTUuMTlsNjAuOSAxOS45NjZjNC4xOTMgMS4zOTcgNi41OSA1Ljk5IDUuMTkgMTAuMTg0LS45OTYgMy4zOTQtMy45OSA1LjU5LTcuNTg2IDUuNTl6Ii8+PC9zdmc+")
 
-	// Allow users to pick the style of badge.
-	if val := r.URL.Query().Get("style"); val != "" {
-		v.Set("style", val)
-	}
+		// Allow users to pick the style of badge.
+		if val := r.URL.Query().Get("style"); val != "" {
+			v.Set("style", val)
+		}
 
-	u := &url.URL{
-		Scheme:   "https",
-		Host:     "img.shields.io",
-		Path:     "/badge/used by-" + badgeValueFmt(value) + "-brightgreen.svg",
-		RawQuery: v.Encode(),
+		u := &url.URL{
+			Scheme:   "https",
+			Host:     "img.shields.io",
+			Path:     "/badge/used by-" + badgeValueFmt(value) + "-brightgreen.svg",
+			RawQuery: v.Encode(),
+		}
+		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
+		return nil
 	}
-	http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
-	return nil
 }

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -25,7 +25,10 @@ func editorRev(ctx context.Context, db dbutil.DB, repoName api.RepoName, rev str
 	if rev == "HEAD" {
 		return "", nil // Detached head state
 	}
-	repo, err := backend.NewRepos(db).GetByName(ctx, repoName)
+
+	repos := backend.NewRepos(db)
+
+	repo, err := repos.GetByName(ctx, repoName)
 	if err != nil {
 		// We weren't able to fetch the repo. This means it either doesn't
 		// exist (unlikely) or that the user is not logged in (most likely). In
@@ -37,11 +40,11 @@ func editorRev(ctx context.Context, db dbutil.DB, repoName api.RepoName, rev str
 	// If we are on the default branch we want to return a clean URL without a
 	// branch. If we fail its best to return the full URL and allow the
 	// front-end to inform them of anything that is wrong.
-	defaultBranchCommitID, err := backend.NewRepos(db).ResolveRev(ctx, repo, "")
+	defaultBranchCommitID, err := repos.ResolveRev(ctx, repo, "")
 	if err != nil {
 		return "@" + rev, nil
 	}
-	branchCommitID, err := backend.NewRepos(db).ResolveRev(ctx, repo, rev)
+	branchCommitID, err := repos.ResolveRev(ctx, repo, rev)
 	if err != nil {
 		return "@" + rev, nil
 	}

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -48,7 +49,7 @@ func TestEditorRev(t *testing.T) {
 		{strings.Repeat("d", 40), "@" + strings.Repeat("d", 40), true}, // default revision, explicit
 	}
 	for _, c := range cases {
-		got, err := editorRev(ctx, repoName, c.inputRev, c.beExplicit)
+		got, err := editorRev(ctx, &dbtesting.MockDB{}, repoName, c.inputRev, c.beExplicit)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -314,7 +315,7 @@ func TestEditorRedirect(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			editorRequest, parseErr := parseEditorRequest(c.q)
+			editorRequest, parseErr := parseEditorRequest(&dbtesting.MockDB{}, c.q)
 			if errStr(parseErr) != c.wantParseErr {
 				t.Fatalf("got parseErr %q want %q", parseErr, c.wantParseErr)
 			}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -161,7 +162,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 	if _, ok := mux.Vars(r)["Repo"]; ok {
 		// Common repo pages (blob, tree, etc).
 		var err error
-		common.Repo, common.CommitID, err = handlerutil.GetRepoAndRev(r.Context(), mux.Vars(r))
+		common.Repo, common.CommitID, err = handlerutil.GetRepoAndRev(r.Context(), dbconn.Global, mux.Vars(r))
 		isRepoEmptyError := routevar.ToRepoRev(mux.Vars(r)).Rev == "" && gitserver.IsRevisionNotFound(errors.Cause(err)) // should reply with HTTP 200
 		if err != nil && !isRepoEmptyError {
 			if e, ok := err.(*handlerutil.URLMovedError); ok {

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -274,7 +274,7 @@ func initRouter(db dbutil.DB, router *mux.Router) {
 		router.Get(routeLegacyOldRouteDefLanding).Handler(http.HandlerFunc(serveOldRouteDefLanding))
 		router.Get(routeLegacyDefRedirectToDefLanding).Handler(http.HandlerFunc(serveDefRedirectToDefLanding))
 		router.Get(routeLegacyDefLanding).Handler(handler(serveDefLanding))
-		router.Get(routeLegacyRepoLanding).Handler(handler(serveRepoLanding))
+		router.Get(routeLegacyRepoLanding).Handler(handler(serveRepoLanding(db)))
 	}
 
 	// search

--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -9,16 +9,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // GetRepo gets the repo (from the reposSvc) specified in the URL's
 // Repo route param. Callers should ideally check for a return error of type
 // URLMovedError and handle this scenario by warning or redirecting the user.
-func GetRepo(ctx context.Context, vars map[string]string) (*types.Repo, error) {
+func GetRepo(ctx context.Context, db dbutil.DB, vars map[string]string) (*types.Repo, error) {
 	origRepo := routevar.ToRepo(vars)
 
-	repo, err := backend.Repos.GetByName(ctx, origRepo)
+	repo, err := backend.NewRepos(db).GetByName(ctx, origRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -31,13 +32,13 @@ func GetRepo(ctx context.Context, vars map[string]string) (*types.Repo, error) {
 }
 
 // getRepoRev resolves the repository and commit specified in the route vars.
-func getRepoRev(ctx context.Context, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
+func getRepoRev(ctx context.Context, db dbutil.DB, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
 	repoRev := routevar.ToRepoRev(vars)
-	repo, err := backend.Repos.Get(ctx, repoID)
+	repo, err := backend.NewRepos(db).Get(ctx, repoID)
 	if err != nil {
 		return repoID, "", err
 	}
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, repoRev.Rev)
+	commitID, err := backend.NewRepos(db).ResolveRev(ctx, repo, repoRev.Rev)
 	if err != nil {
 		return repoID, "", err
 	}
@@ -48,13 +49,13 @@ func getRepoRev(ctx context.Context, vars map[string]string, repoID api.RepoID) 
 // GetRepoAndRev returns the repo object and the commit ID for a repository. It may
 // also return custom error URLMovedError to allow special handling of this case,
 // such as for example redirecting the user.
-func GetRepoAndRev(ctx context.Context, vars map[string]string) (*types.Repo, api.CommitID, error) {
-	repo, err := GetRepo(ctx, vars)
+func GetRepoAndRev(ctx context.Context, db dbutil.DB, vars map[string]string) (*types.Repo, api.CommitID, error) {
+	repo, err := GetRepo(ctx, db, vars)
 	if err != nil {
 		return repo, "", err
 	}
 
-	_, commitID, err := getRepoRev(ctx, vars, repo.ID)
+	_, commitID, err := getRepoRev(ctx, db, vars, repo.ID)
 	return repo, commitID, err
 }
 

--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -33,12 +33,14 @@ func GetRepo(ctx context.Context, db dbutil.DB, vars map[string]string) (*types.
 
 // getRepoRev resolves the repository and commit specified in the route vars.
 func getRepoRev(ctx context.Context, db dbutil.DB, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
+	repos := backend.NewRepos(db)
+
 	repoRev := routevar.ToRepoRev(vars)
-	repo, err := backend.NewRepos(db).Get(ctx, repoID)
+	repo, err := repos.Get(ctx, repoID)
 	if err != nil {
 		return repoID, "", err
 	}
-	commitID, err := backend.NewRepos(db).ResolveRev(ctx, repo, repoRev.Rev)
+	commitID, err := repos.ResolveRev(ctx, repo, repoRev.Rev)
 	if err != nil {
 		return repoID, "", err
 	}

--- a/cmd/frontend/internal/handlerutil/repo_test.go
+++ b/cmd/frontend/internal/handlerutil/repo_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -18,7 +19,7 @@ func TestGetRepo(t *testing.T) {
 			backend.Mocks.Repos = backend.MockRepos{}
 		})
 
-		_, err := GetRepo(context.Background(), map[string]string{"Repo": "repo1"})
+		_, err := GetRepo(context.Background(), &dbtesting.MockDB{}, map[string]string{"Repo": "repo1"})
 		if _, ok := err.(*URLMovedError); !ok {
 			t.Fatalf("err: want type *URLMovedError but got %T", err)
 		}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -54,7 +54,7 @@ func NewHandler(db dbutil.DB, m *mux.Router, schema *graphql.Schema, githubWebho
 	// Set handlers for the installed routes.
 	m.Get(apirouter.RepoShield).Handler(trace.Route(handler(serveRepoShield)))
 
-	m.Get(apirouter.RepoRefresh).Handler(trace.Route(handler(serveRepoRefresh)))
+	m.Get(apirouter.RepoRefresh).Handler(trace.Route(handler(serveRepoRefresh(db))))
 
 	gh := webhooks.GitHubWebhook{
 		ExternalServices: database.ExternalServices(db),
@@ -115,12 +115,12 @@ func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, new
 	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.Route(handler(servePhabricatorRepoCreate(db))))
 	reposList := &reposListServer{
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
-		Repos:                 backend.Repos,
+		Repos:                 backend.NewRepos(db),
 		Indexers:              search.Indexers(),
 	}
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(reposList.serveIndex)))
 	m.Get(apirouter.ReposListEnabled).Handler(trace.Route(handler(serveReposListEnabled)))
-	m.Get(apirouter.ReposGetByName).Handler(trace.Route(handler(serveReposGetByName)))
+	m.Get(apirouter.ReposGetByName).Handler(trace.Route(handler(serveReposGetByName(db))))
 	m.Get(apirouter.SettingsGetForSubject).Handler(trace.Route(handler(serveSettingsGetForSubject(db))))
 	m.Get(apirouter.SavedQueriesListAll).Handler(trace.Route(handler(serveSavedQueriesListAll(db))))
 	m.Get(apirouter.SavedQueriesGetInfo).Handler(trace.Route(handler(serveSavedQueriesGetInfo(db))))

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -52,7 +52,7 @@ func NewHandler(db dbutil.DB, m *mux.Router, schema *graphql.Schema, githubWebho
 	})
 
 	// Set handlers for the installed routes.
-	m.Get(apirouter.RepoShield).Handler(trace.Route(handler(serveRepoShield)))
+	m.Get(apirouter.RepoShield).Handler(trace.Route(handler(serveRepoShield(db))))
 
 	m.Get(apirouter.RepoRefresh).Handler(trace.Route(handler(serveRepoRefresh(db))))
 

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -32,19 +32,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func serveReposGetByName(w http.ResponseWriter, r *http.Request) error {
-	repoName := api.RepoName(mux.Vars(r)["RepoName"])
-	repo, err := backend.Repos.GetByName(r.Context(), repoName)
-	if err != nil {
-		return err
+func serveReposGetByName(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		repoName := api.RepoName(mux.Vars(r)["RepoName"])
+		repo, err := backend.NewRepos(db).GetByName(r.Context(), repoName)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(repo)
+		if err != nil {
+			return err
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+		return nil
 	}
-	data, err := json.Marshal(repo)
-	if err != nil {
-		return err
-	}
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(data)
-	return nil
 }
 
 func servePhabricatorRepoCreate(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {

--- a/cmd/frontend/internal/httpapi/repo_refresh.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh.go
@@ -6,17 +6,20 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 )
 
-func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
+func serveRepoRefresh(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		ctx := r.Context()
 
-	repo, err := handlerutil.GetRepo(ctx, mux.Vars(r))
-	if err != nil {
+		repo, err := handlerutil.GetRepo(ctx, db, mux.Vars(r))
+		if err != nil {
+			return err
+		}
+
+		_, err = repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.Name)
 		return err
 	}
-
-	_, err = repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.Name)
-	return err
 }

--- a/cmd/frontend/internal/httpapi/repo_shield.go
+++ b/cmd/frontend/internal/httpapi/repo_shield.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )
 
 // NOTE: Keep in sync with services/backend/httpapi/repo_shield.go
 func badgeValue(r *http.Request) (int, error) {
-	totalRefs, err := backend.CountGoImporters(r.Context(), routevar.ToRepo(mux.Vars(r)))
+	totalRefs, err := backend.CountGoImporters(r.Context(), dbconn.Global, routevar.ToRepo(mux.Vars(r)))
 	if err != nil {
 		return 0, errors.Wrap(err, "Defs.TotalRefs")
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/iface.go
@@ -8,9 +8,10 @@ import (
 )
 
 type DBStore interface {
+	basestore.ShareableStore
+
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
-	Handle() *basestore.TransactableHandle
 
 	GetUploadByID(ctx context.Context, uploadID int) (dbstore.Upload, bool, error)
 	InsertUpload(ctx context.Context, upload dbstore.Upload) (int, error)

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/iface.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 )
 
 type DBStore interface {
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
+	Handle() *basestore.TransactableHandle
 
 	GetUploadByID(ctx context.Context, uploadID int) (dbstore.Upload, bool, error)
 	InsertUpload(ctx context.Context, upload dbstore.Upload) (int, error)

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
@@ -4,9 +4,10 @@ package httpapi
 
 import (
 	"context"
+	"sync"
+
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"sync"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
@@ -388,7 +388,9 @@ func ensureRepoAndCommitExist(ctx context.Context, db dbutil.DB, w http.Response
 	// This function won't be able to see all repositories without bypassing authz.
 	ctx = actor.WithInternalActor(ctx)
 
-	repo, err := backend.NewRepos(db).GetByName(ctx, api.RepoName(repoName))
+	repos := backend.NewRepos(db)
+
+	repo, err := repos.GetByName(ctx, api.RepoName(repoName))
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
@@ -399,7 +401,7 @@ func ensureRepoAndCommitExist(ctx context.Context, db dbutil.DB, w http.Response
 		return nil, false
 	}
 
-	if _, err := backend.NewRepos(db).ResolveRev(ctx, repo, commit); err != nil {
+	if _, err := repos.ResolveRev(ctx, repo, commit); err != nil {
 		if gitserver.IsRevisionNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
 			return nil, false

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -69,7 +70,7 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 		// 🚨 SECURITY: It is critical to ensure if repository and commit exists after
 		// the above authz check. Otherwise, it is possible to use this endpoint to
 		// brute-force existence of repositories.
-		repo, ok := ensureRepoAndCommitExist(ctx, w, repoName, commit)
+		repo, ok := ensureRepoAndCommitExist(ctx, h.dbStore.Handle().DB(), w, repoName, commit)
 		if !ok {
 			return
 		}
@@ -383,11 +384,11 @@ func inferIndexer(r *http.Request) (string, error) {
 // 🚨 SECURITY: It is critical to call this function after necessary authz check
 // because this function would bypass authz to for testing if the repository and
 // commit exists in Sourcegraph.
-func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool) {
+func ensureRepoAndCommitExist(ctx context.Context, db dbutil.DB, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool) {
 	// This function won't be able to see all repositories without bypassing authz.
 	ctx = actor.WithInternalActor(ctx)
 
-	repo, err := backend.Repos.GetByName(ctx, api.RepoName(repoName))
+	repo, err := backend.NewRepos(db).GetByName(ctx, api.RepoName(repoName))
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
@@ -398,7 +399,7 @@ func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoNa
 		return nil, false
 	}
 
-	if _, err := backend.Repos.ResolveRev(ctx, repo, commit); err != nil {
+	if _, err := backend.NewRepos(db).ResolveRev(ctx, repo, commit); err != nil {
 		if gitserver.IsRevisionNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
 			return nil, false

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"flag"
 	"io"
 	"net/http"
@@ -20,6 +21,8 @@ import (
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	uploadstoremocks "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore/mocks"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -40,6 +43,7 @@ func TestHandleEnqueueSinglePayload(t *testing.T) {
 	mockUploadStore := uploadstoremocks.NewMockStore()
 
 	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
+	mockDBStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	mockDBStore.InsertUploadFunc.SetDefaultReturn(42, nil)
 
@@ -122,6 +126,7 @@ func TestHandleEnqueueSinglePayloadNoIndexerName(t *testing.T) {
 	mockUploadStore := uploadstoremocks.NewMockStore()
 
 	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
+	mockDBStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	mockDBStore.InsertUploadFunc.SetDefaultReturn(42, nil)
 
@@ -189,6 +194,7 @@ func TestHandleEnqueueMultipartSetup(t *testing.T) {
 	mockUploadStore := uploadstoremocks.NewMockStore()
 
 	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
+	mockDBStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	mockDBStore.InsertUploadFunc.SetDefaultReturn(42, nil)
 
@@ -254,6 +260,7 @@ func TestHandleEnqueueMultipartUpload(t *testing.T) {
 	}
 
 	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
+	mockDBStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(upload, true, nil)
 
@@ -328,6 +335,7 @@ func TestHandleEnqueueMultipartFinalize(t *testing.T) {
 		UploadedParts: []int{0, 1, 2, 3, 4},
 	}
 	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
+	mockDBStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(upload, true, nil)
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -203,7 +203,7 @@ func (r *CachedLocationResolver) cachedPath(ctx context.Context, id api.RepoID, 
 // repo that has since been deleted. This method must be called only when constructing a resolver to
 // populate the cache.
 func (r *CachedLocationResolver) resolveRepository(ctx context.Context, id api.RepoID) (*gql.RepositoryResolver, error) {
-	repo, err := backend.Repos.Get(ctx, id)
+	repo, err := backend.NewRepos(r.db).Get(ctx, id)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return nil, nil

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -192,12 +192,14 @@ const CloneInProgressDelay = time.Minute
 // If the repo is currently cloning, then we'll requeue the upload to be tried again later. This will not
 // increase the reset count of the record (so this doesn't count against the upload as a legitimate attempt).
 func requeueIfCloning(ctx context.Context, workerStore dbworkerstore.Store, upload store.Upload) (requeued bool, _ error) {
-	repo, err := backend.NewRepos(workerStore.Handle().DB()).Get(ctx, api.RepoID(upload.RepositoryID))
+	repos := backend.NewRepos(workerStore.Handle().DB())
+
+	repo, err := repos.Get(ctx, api.RepoID(upload.RepositoryID))
 	if err != nil {
 		return false, errors.Wrap(err, "Repos.Get")
 	}
 
-	if _, err := backend.NewRepos(workerStore.Handle().DB()).ResolveRev(ctx, repo, upload.Commit); err != nil {
+	if _, err := repos.ResolveRev(ctx, repo, upload.Commit); err != nil {
 		if !vcs.IsCloneInProgress(err) {
 			return false, errors.Wrap(err, "Repos.ResolveRev")
 		}

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -192,12 +192,12 @@ const CloneInProgressDelay = time.Minute
 // If the repo is currently cloning, then we'll requeue the upload to be tried again later. This will not
 // increase the reset count of the record (so this doesn't count against the upload as a legitimate attempt).
 func requeueIfCloning(ctx context.Context, workerStore dbworkerstore.Store, upload store.Upload) (requeued bool, _ error) {
-	repo, err := backend.Repos.Get(ctx, api.RepoID(upload.RepositoryID))
+	repo, err := backend.NewRepos(workerStore.Handle().DB()).Get(ctx, api.RepoID(upload.RepositoryID))
 	if err != nil {
 		return false, errors.Wrap(err, "Repos.Get")
 	}
 
-	if _, err := backend.Repos.ResolveRev(ctx, repo, upload.Commit); err != nil {
+	if _, err := backend.NewRepos(workerStore.Handle().DB()).ResolveRev(ctx, repo, upload.Commit); err != nil {
 		if !vcs.IsCloneInProgress(err) {
 			return false, errors.Wrap(err, "Repos.ResolveRev")
 		}

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	uploadstoremocks "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore/mocks"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/bloomfilter"
@@ -37,6 +40,8 @@ func TestHandle(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockUploadStore := uploadstoremocks.NewMockStore()
 	gitserverClient := NewMockGitserverClient()
+
+	mockWorkerStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
 
 	// Set default transaction behavior
 	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
@@ -163,6 +168,8 @@ func TestHandleError(t *testing.T) {
 	mockUploadStore := uploadstoremocks.NewMockStore()
 	gitserverClient := NewMockGitserverClient()
 
+	mockWorkerStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
+
 	// Set default transaction behavior
 	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
@@ -230,6 +237,8 @@ func TestHandleCloneInProgress(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockUploadStore := uploadstoremocks.NewMockStore()
 	gitserverClient := NewMockGitserverClient()
+
+	mockWorkerStore.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(&dbtesting.MockDB{}, sql.TxOptions{}))
 
 	handler := &handler{
 		uploadStore:     mockUploadStore,


### PR DESCRIPTION
This removes the need for a global backend.Repos that uses dbconn.Global.

TODO: We don't share the cache anymore.
