### PR TITLE
lib: add gitservice

### DIFF
--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -1,14 +1,8 @@
 package server
 
 import (
-	"compress/gzip"
-	"fmt"
 	"io"
-	"net/http"
-	"os"
 	"os/exec"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -16,141 +10,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/lib/gitservice"
 )
-
-var uploadPackArgs = []string{
-	// Partial clones/fetches
-	"-c", "uploadpack.allowFilter=true",
-
-	// Can fetch any object. Used in case of race between a resolve ref and a
-	// fetch of a commit. Safe to do, since this is only used internally.
-	"-c", "uploadpack.allowAnySHA1InWant=true",
-
-	"upload-pack",
-
-	"--stateless-rpc", "--strict",
-}
-
-// gitServiceHandler is a smart Git HTTP transfer protocol as documented at
-// https://www.git-scm.com/docs/http-protocol.
-//
-// This allows users to clone any git repo. We only support the smart
-// protocol. We aim to support modern git features such as protocol v2 to
-// minimize traffic.
-type gitServiceHandler struct {
-	// Dir is a funcion which takes a repository name and returns an absolute
-	// path to the GIT_DIR for it.
-	Dir func(string) string
-
-	// CommandHook if non-nil will run with the git upload command before we
-	// start the command.
-	//
-	// This allows the command to be modified before running. In practice
-	// sourcegraph.com will add a flowrated writer for Stdout to treat our
-	// internal networks more kindly.
-	CommandHook func(*exec.Cmd)
-
-	// Trace if non-nil is called at the start of serving a request. It will
-	// call the returned function when done executing. If the executation
-	// failed, it will pass in a non-nil error.
-	Trace func(svc, repo, protocol string) func(error)
-}
-
-func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Only support clones and fetches (git upload-pack). /info/refs sets the
-	// service field.
-	if svcQ := r.URL.Query().Get("service"); svcQ != "" && svcQ != "git-upload-pack" {
-		http.Error(w, "only support service git-upload-pack", http.StatusBadRequest)
-		return
-	}
-
-	var repo, svc string
-	for _, suffix := range []string{"/info/refs", "/git-upload-pack"} {
-		if strings.HasSuffix(r.URL.Path, suffix) {
-			svc = suffix
-			repo = strings.TrimSuffix(r.URL.Path, suffix)
-			repo = strings.TrimPrefix(repo, "/")
-			break
-		}
-	}
-
-	dir := s.Dir(repo)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		http.Error(w, "repository not found", http.StatusNotFound)
-		return
-	} else if err != nil {
-		http.Error(w, "failed to stat repo: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	body := r.Body
-	defer body.Close()
-
-	if r.Header.Get("Content-Encoding") == "gzip" {
-		gzipReader, err := gzip.NewReader(body)
-		if err != nil {
-			http.Error(w, "malformed payload: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		defer gzipReader.Close()
-
-		body = gzipReader
-	}
-
-	// err is set if we fail to run command or have an unexpected svc. It is
-	// captured for tracing.
-	var err error
-	if s.Trace != nil {
-		done := s.Trace(svc, repo, r.Header.Get("Git-Protocol"))
-		defer func() {
-			done(err)
-		}()
-	}
-
-	args := append([]string{}, uploadPackArgs...)
-	switch svc {
-	case "/info/refs":
-		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
-		_, _ = w.Write(packetWrite("# service=git-upload-pack\n"))
-		_, _ = w.Write([]byte("0000"))
-		args = append(args, "--advertise-refs")
-	case "/git-upload-pack":
-		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
-	default:
-		err = fmt.Errorf("unexpected subpath (want /info/refs or /git-upload-pack): %q", svc)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	args = append(args, dir)
-
-	env := os.Environ()
-	if protocol := r.Header.Get("Git-Protocol"); protocol != "" {
-		env = append(env, "GIT_PROTOCOL="+protocol)
-	}
-
-	cmd := exec.CommandContext(r.Context(), "git", args...)
-	cmd.Env = env
-	cmd.Stdout = w
-	cmd.Stdin = body
-
-	if s.CommandHook != nil {
-		s.CommandHook(cmd)
-	}
-
-	err = cmd.Run()
-	if err != nil {
-		err = fmt.Errorf("error running git service command args=%q: %w", args, err)
-		_, _ = w.Write([]byte("\n" + err.Error() + "\n"))
-	}
-}
-
-func packetWrite(str string) []byte {
-	s := strconv.FormatInt(int64(len(str)+4), 16)
-	if len(s)%4 != 0 {
-		s = strings.Repeat("0", 4-len(s)%4) + s
-	}
-	return []byte(s + str)
-}
 
 // flowrateWriter limits the write rate of w to 1 Gbps.
 //
@@ -171,8 +32,8 @@ func flowrateWriter(w io.Writer) io.Writer {
 	return flowrate.NewWriter(w, limit)
 }
 
-func (s *Server) gitServiceHandler() *gitServiceHandler {
-	return &gitServiceHandler{
+func (s *Server) gitServiceHandler() *gitservice.Handler {
+	return &gitservice.Handler{
 		Dir: func(d string) string {
 			return string(s.dir(api.RepoName(d)))
 		},

--- a/lib/gitservice/gitservice.go
+++ b/lib/gitservice/gitservice.go
@@ -1,0 +1,146 @@
+// package gitservice provides a smart Git HTTP transfer protocol handler.
+package gitservice
+
+import (
+	"compress/gzip"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var uploadPackArgs = []string{
+	// Partial clones/fetches
+	"-c", "uploadpack.allowFilter=true",
+
+	// Can fetch any object. Used in case of race between a resolve ref and a
+	// fetch of a commit. Safe to do, since this is only used internally.
+	"-c", "uploadpack.allowAnySHA1InWant=true",
+
+	"upload-pack",
+
+	"--stateless-rpc", "--strict",
+}
+
+// Handler is a smart Git HTTP transfer protocol as documented at
+// https://www.git-scm.com/docs/http-protocol.
+//
+// This allows users to clone any git repo. We only support the smart
+// protocol. We aim to support modern git features such as protocol v2 to
+// minimize traffic.
+type Handler struct {
+	// Dir is a funcion which takes a repository name and returns an absolute
+	// path to the GIT_DIR for it.
+	Dir func(string) string
+
+	// CommandHook if non-nil will run with the git upload command before we
+	// start the command.
+	//
+	// This allows the command to be modified before running. In practice
+	// sourcegraph.com will add a flowrated writer for Stdout to treat our
+	// internal networks more kindly.
+	CommandHook func(*exec.Cmd)
+
+	// Trace if non-nil is called at the start of serving a request. It will
+	// call the returned function when done executing. If the executation
+	// failed, it will pass in a non-nil error.
+	Trace func(svc, repo, protocol string) func(error)
+}
+
+func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only support clones and fetches (git upload-pack). /info/refs sets the
+	// service field.
+	if svcQ := r.URL.Query().Get("service"); svcQ != "" && svcQ != "git-upload-pack" {
+		http.Error(w, "only support service git-upload-pack", http.StatusBadRequest)
+		return
+	}
+
+	var repo, svc string
+	for _, suffix := range []string{"/info/refs", "/git-upload-pack"} {
+		if strings.HasSuffix(r.URL.Path, suffix) {
+			svc = suffix
+			repo = strings.TrimSuffix(r.URL.Path, suffix)
+			repo = strings.TrimPrefix(repo, "/")
+			break
+		}
+	}
+
+	dir := s.Dir(repo)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		http.Error(w, "repository not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, "failed to stat repo: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	body := r.Body
+	defer body.Close()
+
+	if r.Header.Get("Content-Encoding") == "gzip" {
+		gzipReader, err := gzip.NewReader(body)
+		if err != nil {
+			http.Error(w, "malformed payload: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		defer gzipReader.Close()
+
+		body = gzipReader
+	}
+
+	// err is set if we fail to run command or have an unexpected svc. It is
+	// captured for tracing.
+	var err error
+	if s.Trace != nil {
+		done := s.Trace(svc, repo, r.Header.Get("Git-Protocol"))
+		defer func() {
+			done(err)
+		}()
+	}
+
+	args := append([]string{}, uploadPackArgs...)
+	switch svc {
+	case "/info/refs":
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		_, _ = w.Write(packetWrite("# service=git-upload-pack\n"))
+		_, _ = w.Write([]byte("0000"))
+		args = append(args, "--advertise-refs")
+	case "/git-upload-pack":
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+	default:
+		err = fmt.Errorf("unexpected subpath (want /info/refs or /git-upload-pack): %q", svc)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	args = append(args, dir)
+
+	env := os.Environ()
+	if protocol := r.Header.Get("Git-Protocol"); protocol != "" {
+		env = append(env, "GIT_PROTOCOL="+protocol)
+	}
+
+	cmd := exec.CommandContext(r.Context(), "git", args...)
+	cmd.Env = env
+	cmd.Stdout = w
+	cmd.Stdin = body
+
+	if s.CommandHook != nil {
+		s.CommandHook(cmd)
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("error running git service command args=%q: %w", args, err)
+		_, _ = w.Write([]byte("\n" + err.Error() + "\n"))
+	}
+}
+
+func packetWrite(str string) []byte {
+	s := strconv.FormatInt(int64(len(str)+4), 16)
+	if len(s)%4 != 0 {
+		s = strings.Repeat("0", 4-len(s)%4) + s
+	}
+	return []byte(s + str)
+}

--- a/lib/gitservice/gitservice_test.go
+++ b/lib/gitservice/gitservice_test.go
@@ -1,4 +1,4 @@
-package server
+package gitservice_test
 
 import (
 	"bytes"
@@ -6,7 +6,10 @@ import (
 	"net/http/httptest"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/lib/gitservice"
 )
 
 // numTestCommits determines the number of files/commits/tags to create for
@@ -15,8 +18,8 @@ import (
 // this same behavior.
 const numTestCommits = 25
 
-func TestGitServiceHandler(t *testing.T) {
-	root := tmpDir(t)
+func TestHandler(t *testing.T) {
+	root := t.TempDir()
 	repo := filepath.Join(root, "testrepo")
 
 	// Setup a repo with a commit so we can add bad refs
@@ -29,7 +32,7 @@ func TestGitServiceHandler(t *testing.T) {
 		runCmd(t, repo, "git", "tag", fmt.Sprintf("v%d", i+1))
 	}
 
-	ts := httptest.NewServer(&gitServiceHandler{
+	ts := httptest.NewServer(&gitservice.Handler{
 		Dir: func(s string) string {
 			return filepath.Join(root, s, ".git")
 		},
@@ -38,7 +41,7 @@ func TestGitServiceHandler(t *testing.T) {
 
 	t.Run("404", func(t *testing.T) {
 		c := exec.Command("git", "clone", ts.URL+"/doesnotexist")
-		c.Dir = tmpDir(t)
+		c.Dir = t.TempDir()
 		b, err := c.CombinedOutput()
 		if !bytes.Contains(b, []byte("repository not found")) {
 			t.Fatal("expected clone to fail with repository not found", string(b), err)
@@ -48,7 +51,7 @@ func TestGitServiceHandler(t *testing.T) {
 	cloneURL := ts.URL + "/testrepo"
 
 	t.Run("clonev1", func(t *testing.T) {
-		runCmd(t, tmpDir(t), "git", "-c", "protocol.version=1", "clone", cloneURL)
+		runCmd(t, t.TempDir(), "git", "-c", "protocol.version=1", "clone", cloneURL)
 	})
 
 	cloneV2 := []struct {
@@ -69,7 +72,7 @@ func TestGitServiceHandler(t *testing.T) {
 			args = append(args, cloneURL)
 
 			c := exec.Command("git", args...)
-			c.Dir = tmpDir(t)
+			c.Dir = t.TempDir()
 			c.Env = []string{
 				"GIT_TRACE_PACKET=1",
 			}
@@ -85,4 +88,21 @@ func TestGitServiceHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func runCmd(t *testing.T, dir string, cmd string, arg ...string) string {
+	t.Helper()
+	c := exec.Command(cmd, arg...)
+	c.Dir = dir
+	c.Env = []string{
+		"GIT_COMMITTER_NAME=a",
+		"GIT_COMMITTER_EMAIL=a@a.com",
+		"GIT_AUTHOR_NAME=a",
+		"GIT_AUTHOR_EMAIL=a@a.com",
+	}
+	b, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %s\nOutput: %s", cmd, strings.Join(arg, " "), err, b)
+	}
+	return string(b)
 }


### PR DESCRIPTION
This is a service that was originally written for src-cli, but then copy
pasted into gitserver. It has evolved a bit and occasionally they have
been out of sync. So instead we are moving the service into a new
package for both gitserver and src-cli to use.