### PR TITLE
gitserver: use t.TempDir() instead of own helper

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -125,7 +125,7 @@ func TestCleanupInactive(t *testing.T) {
 // relevant internal magic numbers and transformations change.
 func TestGitGCAuto(t *testing.T) {
 	// Create a test repository with detectable garbage that GC can prune.
-	root := tmpDir(t)
+	root := t.TempDir()
 	repo := filepath.Join(root, "garbage-repo")
 	defer os.RemoveAll(root)
 	runCmd(t, root, "git", "init", repo)
@@ -326,7 +326,7 @@ func TestCleanupExpired(t *testing.T) {
 }
 
 func TestCleanupOldLocks(t *testing.T) {
-	root := tmpDir(t)
+	root := t.TempDir()
 
 	// Only recent lock files should remain.
 	mkFiles(t, root,
@@ -394,7 +394,7 @@ func TestCleanupOldLocks(t *testing.T) {
 }
 
 func TestSetupAndClearTmp(t *testing.T) {
-	root := tmpDir(t)
+	root := t.TempDir()
 
 	s := &Server{ReposDir: root}
 
@@ -456,7 +456,7 @@ func TestSetupAndClearTmp(t *testing.T) {
 }
 
 func TestSetupAndClearTmp_Empty(t *testing.T) {
-	root := tmpDir(t)
+	root := t.TempDir()
 
 	s := &Server{ReposDir: root}
 
@@ -470,7 +470,7 @@ func TestSetupAndClearTmp_Empty(t *testing.T) {
 }
 
 func TestRemoveRepoDirectory(t *testing.T) {
-	root := tmpDir(t)
+	root := t.TempDir()
 
 	mkFiles(t, root,
 		"github.com/foo/baz/.git/HEAD",
@@ -553,7 +553,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 }
 
 func TestRemoveRepoDirectory_Empty(t *testing.T) {
-	root := tmpDir(t)
+	root := t.TempDir()
 
 	mkFiles(t, root,
 		"github.com/foo/baz/.git/HEAD",
@@ -631,16 +631,6 @@ func (f *fakeDiskSizer) BytesFreeOnDisk(mountPoint string) (uint64, error) {
 
 func (f *fakeDiskSizer) DiskSizeBytes(mountPoint string) (uint64, error) {
 	return f.diskSize, nil
-}
-
-func tmpDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("", filepath.Base(t.Name()))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	return dir
 }
 
 func mkFiles(t *testing.T, root string, paths ...string) {

--- a/cmd/gitserver/server/gitservice_test.go
+++ b/cmd/gitserver/server/gitservice_test.go
@@ -16,7 +16,7 @@ import (
 const numTestCommits = 25
 
 func TestGitServiceHandler(t *testing.T) {
-	root := tmpDir(t)
+	root := t.TempDir()
 	repo := filepath.Join(root, "testrepo")
 
 	// Setup a repo with a commit so we can add bad refs
@@ -38,7 +38,7 @@ func TestGitServiceHandler(t *testing.T) {
 
 	t.Run("404", func(t *testing.T) {
 		c := exec.Command("git", "clone", ts.URL+"/doesnotexist")
-		c.Dir = tmpDir(t)
+		c.Dir = t.TempDir()
 		b, err := c.CombinedOutput()
 		if !bytes.Contains(b, []byte("repository not found")) {
 			t.Fatal("expected clone to fail with repository not found", string(b), err)
@@ -48,7 +48,7 @@ func TestGitServiceHandler(t *testing.T) {
 	cloneURL := ts.URL + "/testrepo"
 
 	t.Run("clonev1", func(t *testing.T) {
-		runCmd(t, tmpDir(t), "git", "-c", "protocol.version=1", "clone", cloneURL)
+		runCmd(t, t.TempDir(), "git", "-c", "protocol.version=1", "clone", cloneURL)
 	})
 
 	cloneV2 := []struct {
@@ -69,7 +69,7 @@ func TestGitServiceHandler(t *testing.T) {
 			args = append(args, cloneURL)
 
 			c := exec.Command("git", args...)
-			c.Dir = tmpDir(t)
+			c.Dir = t.TempDir()
 			c.Env = []string{
 				"GIT_TRACE_PACKET=1",
 			}

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -482,7 +482,7 @@ func makeTestServer(ctx context.Context, repoDir, remote string, db dbutil.DB) *
 
 func TestCloneRepo(t *testing.T) {
 	ctx := context.Background()
-	remote := tmpDir(t)
+	remote := t.TempDir()
 	repoName := api.RepoName("example.com/foo/bar")
 	db := dbtesting.GetDB(t)
 
@@ -523,7 +523,7 @@ func TestCloneRepo(t *testing.T) {
 	// Add a bad tag
 	cmd("git", "tag", "HEAD")
 
-	reposDir := tmpDir(t)
+	reposDir := t.TempDir()
 	s := makeTestServer(ctx, reposDir, remote, db)
 
 	_, err := s.cloneRepo(ctx, repoName, nil)
@@ -579,7 +579,7 @@ func TestCloneRepo(t *testing.T) {
 
 func TestHandleRepoUpdate(t *testing.T) {
 	ctx := context.Background()
-	remote := tmpDir(t)
+	remote := t.TempDir()
 	repoName := api.RepoName("example.com/foo/bar")
 	db := dbtesting.GetDB(t)
 
@@ -601,7 +601,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 	// Add a bad tag
 	cmd("git", "tag", "HEAD")
 
-	reposDir := tmpDir(t)
+	reposDir := t.TempDir()
 
 	s := makeTestServer(ctx, reposDir, remote, db)
 	s.ctx = context.Background()
@@ -667,7 +667,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 }
 
 func TestRemoveBadRefs(t *testing.T) {
-	dir := tmpDir(t)
+	dir := t.TempDir()
 	gitDir := GitDir(filepath.Join(dir, ".git"))
 
 	cmd := func(name string, arg ...string) string {
@@ -713,8 +713,8 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 
 	t.Run("with no remote HEAD file", func(t *testing.T) {
 		var (
-			remote   = tmpDir(t)
-			reposDir = tmpDir(t)
+			remote   = t.TempDir()
+			reposDir = t.TempDir()
 			cmd      = func(name string, arg ...string) string {
 				t.Helper()
 				return runCmd(t, remote, name, arg...)
@@ -731,8 +731,8 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 	})
 	t.Run("with an empty remote HEAD file", func(t *testing.T) {
 		var (
-			remote   = tmpDir(t)
-			reposDir = tmpDir(t)
+			remote   = t.TempDir()
+			reposDir = t.TempDir()
 			cmd      = func(name string, arg ...string) string {
 				t.Helper()
 				return runCmd(t, remote, name, arg...)
@@ -749,8 +749,8 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 	})
 	t.Run("with no local HEAD file", func(t *testing.T) {
 		var (
-			remote   = tmpDir(t)
-			reposDir = tmpDir(t)
+			remote   = t.TempDir()
+			reposDir = t.TempDir()
 			cmd      = func(name string, arg ...string) string {
 				t.Helper()
 				return runCmd(t, remote, name, arg...)
@@ -787,8 +787,8 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 	})
 	t.Run("with an empty local HEAD file", func(t *testing.T) {
 		var (
-			remote   = tmpDir(t)
-			reposDir = tmpDir(t)
+			remote   = t.TempDir()
+			reposDir = t.TempDir()
 			cmd      = func(name string, arg ...string) string {
 				t.Helper()
 				return runCmd(t, remote, name, arg...)
@@ -887,7 +887,7 @@ func TestHostnameMatch(t *testing.T) {
 func TestSyncRepoState(t *testing.T) {
 	ctx := context.Background()
 	db := dbtesting.GetDB(t)
-	remoteDir := tmpDir(t)
+	remoteDir := t.TempDir()
 
 	cmd := func(name string, arg ...string) string {
 		t.Helper()
@@ -900,7 +900,7 @@ func TestSyncRepoState(t *testing.T) {
 	cmd("git", "add", "hello.txt")
 	cmd("git", "commit", "-m", "hello")
 
-	reposDir := tmpDir(t)
+	reposDir := t.TempDir()
 	repoName := api.RepoName("example.com/foo/bar")
 	hostname := "test"
 


### PR DESCRIPTION
This is a somewhat recent addition to the stdlib.

Removed tmpDir function and ran

```
ruplacer --go 'tmpDir\(t\)' 't.TempDir()'
```