### PR TITLE
search frontend: update Monaco colors

### DIFF
--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -9,169 +9,134 @@ import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 const SOURCEGRAPH_LIGHT = 'sourcegraph-light'
-const SOURCEGRAPH_LIGHT_REDESIGN = 'sourcegraph-light-redesign'
-
 const SOURCEGRAPH_DARK = 'sourcegraph-dark'
-const SOURCEGRAPH_DARK_REDESIGN = 'sourcegraph-dark-redesign'
+
+// 🚨 WARNING!!!
+// Monaco does not support CSS variables/custom properties, all colors must be in hex codes.
+// See https://github.com/microsoft/monaco-editor/issues/2427
+// When updating these colors, always add the name of the color variable from CSS so
+// we can look up uses later when updating color palettes.
 
 const darkColors: monaco.editor.IColors = {
-    background: '#0E121B',
-    'editor.background': '#0E121B',
-    'textLink.activeBackground': '#2a3a51',
-    'editor.foreground': '#f2f4f8',
-    'editorCursor.foreground': '#ffffff',
-    'editorSuggestWidget.background': '#1c2736',
-    'editorSuggestWidget.foreground': '#F2F4F8',
-    'editorSuggestWidget.highlightForeground': '#569cd6',
-    'editorSuggestWidget.selectedBackground': '#2a3a51',
-    'list.hoverBackground': '#2a3a51',
-    'editorSuggestWidget.border': '#2b3750',
-    'editorHoverWidget.background': '#1c2736',
-    'editorHoverWidget.foreground': '#F2F4F8',
-    'editorHoverWidget.border': '#2b3750',
-    'editor.hoverHighlightBackground': '#495057',
+    background: '#181b26', // --color-bg-1
+    'editor.background': '#181b26', // --color-bg-1
+    'textLink.activeBackground': '#1d212f', // --color-bg-2
+    'editor.foreground': '#dbe2f0', // --search-query-text-color
+    'editorCursor.foreground': '#dbe2f0', // --search-query-text-color
+    'editorSuggestWidget.background': '#181b26', // --color-bg-1
+    'editorSuggestWidget.foreground': '#dbe2f0', // --search-query-text-color
+    'editorSuggestWidget.highlightForeground': '#4393e7', // --search-filter-keyword-color
+    'editorSuggestWidget.selectedBackground': '#1d212f', // --color-bg-2
+    'list.hoverBackground': '#1d212f', // --color-bg-2
+    'editorSuggestWidget.border': '#262b38', // --border-color
+    'editorHoverWidget.background': '#181b26', // --color-bg-1
+    'editorHoverWidget.foreground': '#dbe2f0', // --search-query-text-color
+    'editorHoverWidget.border': '#262b38', // --border-color
+    'editor.hoverHighlightBackground': '#1d212f', // --color-bg-2
 }
 
 const darkRules: monaco.editor.ITokenThemeRule[] = [
     // Sourcegraph base language tokens
-    { token: 'identifier', foreground: '#f2f4f8' },
-    { token: 'field', foreground: '#569cd6' },
-    { token: 'keyword', foreground: '#da77f2' },
-    { token: 'openingParen', foreground: '#da77f2' },
-    { token: 'closingParen', foreground: '#da77f2' },
-    { token: 'comment', foreground: '#ffa94d' },
+    { token: 'identifier', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'field', foreground: '#4393e7' }, // --search-filter-keyword-color
+    { token: 'keyword', foreground: '#d68cf3' }, // --search-keyword-color
+    { token: 'openingParen', foreground: '#d68cf3' }, // --search-keyword-color
+    { token: 'closingParen', foreground: '#d68cf3' }, // --search-keyword-color
+    { token: 'comment', foreground: '#ffa94d' }, // --oc-orange-4
     // Sourcegraph decorated language tokens
-    { token: 'metaRepoRevisionSeparator', foreground: '#569cd9' },
-    { token: 'metaContextPrefix', foreground: '#da77f2' },
-    { token: 'metaPredicateNameAccess', foreground: '#da77f2' },
-    { token: 'metaPredicateDot', foreground: '#f2f4f8' },
-    { token: 'metaPredicateParenthesis', foreground: '#f08d58' },
+    { token: 'metaRepoRevisionSeparator', foreground: '#4393e7' }, // --search-filter-keyword-color
+    { token: 'metaContextPrefix', foreground: '#d68cf3' }, // --search-keyword-color
+    { token: 'metaPredicateNameAccess', foreground: '#d68cf3' }, // --search-keyword-color
+    { token: 'metaPredicateDot', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'metaPredicateParenthesis', foreground: '#ffa94d' }, // --oc-orange-4
     // Regexp pattern highlighting
-    { token: 'metaRegexpDelimited', foreground: '#ff6b6b' },
-    { token: 'metaRegexpAssertion', foreground: '#ff6b6b' },
-    { token: 'metaRegexpLazyQuantifier', foreground: '#ff6b6b' },
-    { token: 'metaRegexpEscapedCharacter', foreground: '#ffa8a8' },
-    { token: 'metaRegexpCharacterSet', foreground: '#da77f2' },
-    { token: 'metaRegexpCharacterClass', foreground: '#da77f2' },
-    { token: 'metaRegexpCharacterClassMember', foreground: '#f2f4f8' },
-    { token: 'metaRegexpCharacterClassRange', foreground: '#f2f4f8' },
-    { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#da77f2' },
-    { token: 'metaRegexpRangeQuantifier', foreground: '#3bc9db' },
-    { token: 'metaRegexpAlternative', foreground: '#3bc9db' },
+    { token: 'metaRegexpDelimited', foreground: '#ff6b6b' }, // --oc-red-5
+    { token: 'metaRegexpAssertion', foreground: '#ff6b6b' }, // --oc-red-5
+    { token: 'metaRegexpLazyQuantifier', foreground: '#ff6b6b' }, // --oc-red-5
+    { token: 'metaRegexpEscapedCharacter', foreground: '#ffa8a8' }, // --oc-red-3
+    { token: 'metaRegexpCharacterSet', foreground: '#d68cf3' }, // --search-keyword-color
+    { token: 'metaRegexpCharacterClass', foreground: '#da77f2' }, // --oc-grape-4
+    { token: 'metaRegexpCharacterClassMember', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'metaRegexpCharacterClassRange', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#d68cf3' }, // --search-keyword-color
+    { token: 'metaRegexpRangeQuantifier', foreground: '#3bc9db' }, // --oc-cyan-4
+    { token: 'metaRegexpAlternative', foreground: '#3bc9db' }, // --oc-cyan-4
     // Structural pattern highlighting
-    { token: 'metaStructuralHole', foreground: '#ff6b6b' },
-    { token: 'metaStructuralRegexpHole', foreground: '#ff6b6b' },
-    { token: 'metaStructuralVariable', foreground: '#f2f4f8' },
-    { token: 'metaStructuralRegexpSeparator', foreground: '#ffa94d' },
+    { token: 'metaStructuralHole', foreground: '#ff6b6b' }, // --oc-red-5
+    { token: 'metaStructuralRegexpHole', foreground: '#ff6b6b' }, // --oc-red-5
+    { token: 'metaStructuralVariable', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'metaStructuralRegexpSeparator', foreground: '#ffa94d' }, // --oc-orange-4
     // Revision highlighting
-    { token: 'metaRevisionSeparator', foreground: '#ffa94d' },
-    { token: 'metaRevisionIncludeGlobMarker', foreground: '#ff6b6b' },
-    { token: 'metaRevisionExcludeGlobMarker', foreground: '#ff6b6b' },
-    { token: 'metaRevisionCommitHash', foreground: '#f2f4f8' },
-    { token: 'metaRevisionLabel', foreground: '#f2f4f8' },
-    { token: 'metaRevisionReferencePath', foreground: '#f2f4f8' },
-    { token: 'metaRevisionWildcard', foreground: '#3bc9db' },
+    { token: 'metaRevisionSeparator', foreground: '#ffa94d' }, // --oc-orange-4
+    { token: 'metaRevisionIncludeGlobMarker', foreground: '#ff6b6b' }, // --oc-red-5
+    { token: 'metaRevisionExcludeGlobMarker', foreground: '#ff6b6b' }, // --oc-red-5
+    { token: 'metaRevisionCommitHash', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'metaRevisionLabel', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'metaRevisionReferencePath', foreground: '#dbe2f0' }, // --search-query-text-color
+    { token: 'metaRevisionWildcard', foreground: '#3bc9db' }, // --oc-cyan-4
     // Path-like highlighting
-    { token: 'metaPathSeparator', foreground: '#868e96' },
+    { token: 'metaPathSeparator', foreground: '#868e96' }, // --oc-gray-6
 ]
 
 const lightColors: monaco.editor.IColors = {
-    background: '#ffffff',
-    'editor.background': '#ffffff',
-    'editor.foreground': '#2b3750',
-    'editorCursor.foreground': '#2b3750',
-    'editorSuggestWidget.background': '#ffffff',
-    'editorSuggestWidget.foreground': '#2b3750',
-    'editorSuggestWidget.border': '#cad2e2',
-    'editorSuggestWidget.highlightForeground': '#268bd2',
-    'editorSuggestWidget.selectedBackground': '#f2f4f8',
-    'list.hoverBackground': '#f2f4f8',
-    'editorHoverWidget.background': '#ffffff',
-    'editorHoverWidget.foreground': '#2b3750',
-    'editorHoverWidget.border': '#cad2e2',
-    'editor.hoverHighlightBackground': '#dee2e6',
+    background: '#ffffff', // --color-bg-1
+    'editor.background': '#ffffff', // --color-bg-1
+    'editor.foreground': '#14171f', // --search-query-text-color
+    'editorCursor.foreground': '#14171f', // --search-query-text-color
+    'editorSuggestWidget.background': '#ffffff', // --color-bg-1
+    'editorSuggestWidget.foreground': '#14171f', // --search-query-text-color
+    'editorSuggestWidget.border': '#e6ebf2', // --border-color
+    'editorSuggestWidget.highlightForeground': '#0b70db', // --search-filter-keyword-color
+    'editorSuggestWidget.selectedBackground': '#e6ebf2', // --color-bg-2
+    'list.hoverBackground': '#e6ebf2', // --color-bg-2
+    'editorHoverWidget.background': '#ffffff', // --color-bg-1
+    'editorHoverWidget.foreground': '#14171f', // --search-query-text-color
+    'editorHoverWidget.border': '#e6ebf2', // --border-color
+    'editor.hoverHighlightBackground': '#e6ebf2', // --color-bg-2
 }
 
 const lightRules: monaco.editor.ITokenThemeRule[] = [
     // Sourcegraph base language tokens
-    { token: 'identifier', foreground: '#2b3750' },
-    { token: 'field', foreground: '#268bd2' },
-    { token: 'keyword', foreground: '#ae3ec9' },
-    { token: 'openingParen', foreground: '#ae3ec9' },
-    { token: 'closingParen', foreground: '#ae3ec9' },
-    { token: 'comment', foreground: '#d9480f' },
+    { token: 'identifier', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'field', foreground: '#0b70db' }, // --search-filter-keyword-color
+    { token: 'keyword', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'openingParen', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'closingParen', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'comment', foreground: '#d9480f' }, // --oc-orange-9
     // Sourcegraph decorated language tokens
-    { token: 'metaRepoRevisionSeparator', foreground: '#268bd2' },
-    { token: 'metaContextPrefix', foreground: '#ae3ec9' },
-    { token: 'metaPredicateNameAccess', foreground: '#ae3ec9' },
-    { token: 'metaPredicateDot', foreground: '#2b3750' },
-    { token: 'metaPredicateParenthesis', foreground: '#d6550f' },
+    { token: 'metaRepoRevisionSeparator', foreground: '#0b70db' }, // --search-filter-keyword-color
+    { token: 'metaContextPrefix', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'metaPredicateNameAccess', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'metaPredicateDot', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'metaPredicateParenthesis', foreground: '#d9480f' }, // --oc-orange-9
     // Regexp pattern highlighting
-    { token: 'metaRegexpDelimited', foreground: '#c92a2a' },
-    { token: 'metaRegexpAssertion', foreground: '#c92a2a' },
-    { token: 'metaRegexpLazyQuantifier', foreground: '#c92a2a' },
-    { token: 'metaRegexpEscapedCharacter', foreground: '#af5200' },
-    { token: 'metaRegexpCharacterSet', foreground: '#ae3ec9' },
-    { token: 'metaRegexpCharacterClass', foreground: '#ae3ec9' },
-    { token: 'metaRegexpCharacterClassMember', foreground: '#2b3750' },
-    { token: 'metaRegexpCharacterClassRange', foreground: '#2b3750' },
-    { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#ae3ec9' },
-    { token: 'metaRegexpRangeQuantifier', foreground: '#1098ad' },
-    { token: 'metaRegexpAlternative', foreground: '#1098ad' },
+    { token: 'metaRegexpDelimited', foreground: '#c92a2a' }, // --oc-red-9
+    { token: 'metaRegexpAssertion', foreground: '#c92a2a' }, // --oc-red-9
+    { token: 'metaRegexpLazyQuantifier', foreground: '#c92a2a' }, // --oc-red-9
+    { token: 'metaRegexpEscapedCharacter', foreground: '#d9480f' }, // --oc-orange-9
+    { token: 'metaRegexpCharacterSet', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'metaRegexpCharacterClass', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'metaRegexpCharacterClassMember', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'metaRegexpCharacterClassRange', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#a305e1' }, // --search-keyword-color
+    { token: 'metaRegexpRangeQuantifier', foreground: '#1098ad' }, // --oc-cyan-7
+    { token: 'metaRegexpAlternative', foreground: '#1098ad' }, // --oc-cyan-7
     // Structural pattern highlighting
-    { token: 'metaStructuralHole', foreground: '#c92a2a' },
-    { token: 'metaStructuralRegexpHole', foreground: '#c92a2a' },
-    { token: 'metaStructuralVariable', foreground: '#2b3750' },
-    { token: 'metaStructuralRegexpSeparator', foreground: '#d9480f' },
+    { token: 'metaStructuralHole', foreground: '#c92a2a' }, // --oc-red-9
+    { token: 'metaStructuralRegexpHole', foreground: '#c92a2a' }, // --oc-red-9
+    { token: 'metaStructuralVariable', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'metaStructuralRegexpSeparator', foreground: '#d9480f' }, // --oc-orange-9
     // Revision highlighting
-    { token: 'metaRevisionSeparator', foreground: '#d9480f' },
-    { token: 'metaRevisionIncludeGlobMarker', foreground: '#c92a2a' },
-    { token: 'metaRevisionExcludeGlobMarker', foreground: '#c92a2a' },
-    { token: 'metaRevisionCommitHash', foreground: '#2b3750' },
-    { token: 'metaRevisionLabel', foreground: '#2b3750' },
-    { token: 'metaRevisionReferencePath', foreground: '#2b3750' },
-    { token: 'metaRevisionWildcard', foreground: '#1098ad' },
+    { token: 'metaRevisionSeparator', foreground: '#d9480f' }, // --oc-orange-9
+    { token: 'metaRevisionIncludeGlobMarker', foreground: '#c92a2a' }, // --oc-red-9
+    { token: 'metaRevisionExcludeGlobMarker', foreground: '#c92a2a' }, // --oc-red-9
+    { token: 'metaRevisionCommitHash', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'metaRevisionLabel', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'metaRevisionReferencePath', foreground: '#14171f' }, // --search-query-text-color
+    { token: 'metaRevisionWildcard', foreground: '#1098ad' }, // --oc-cyan-7
     // Path-like highlighting
-    { token: 'metaPathSeparator', foreground: '#868e96' },
+    { token: 'metaPathSeparator', foreground: '#868e96' }, // --oc-gray-6
 ]
-
-monaco.editor.defineTheme(SOURCEGRAPH_DARK_REDESIGN, {
-    base: 'vs-dark',
-    inherit: true,
-    colors: {
-        ...darkColors,
-        background: '#181b26',
-        'editor.background': '#181b26',
-        'editorSuggestWidget.border': '#343a4d',
-        'editorHoverWidget.border': '#343a4d',
-    },
-    rules: [
-        ...darkRules,
-        // Sourcegraph base language tokens
-        { token: 'identifier', foreground: '#f9fafb' },
-        { token: 'field', foreground: '#4393e7' },
-        { token: 'keyword', foreground: '#d68cf3' },
-        { token: 'openingParen', foreground: '#d68cf3' },
-        { token: 'closingParen', foreground: '#d68cf3' },
-        // Sourcegraph decorated language tokens
-        { token: 'metaRepoRevisionSeparator', foreground: '#569cd9' },
-        { token: 'metaContextPrefix', foreground: '#d68cf3' },
-        { token: 'metaPredicateNameAccess', foreground: '#d68cf3' },
-        { token: 'metaPredicateDot', foreground: '#f9fafb' },
-        // Regexp pattern highlighting
-        { token: 'metaRegexpCharacterSet', foreground: '#d68cf3' },
-        { token: 'metaRegexpCharacterClass', foreground: '#d68cf3' },
-        { token: 'metaRegexpCharacterClassMember', foreground: '#f9fafb' },
-        { token: 'metaRegexpCharacterClassRange', foreground: '#f9fafb' },
-        { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#d68cf3' },
-        // Structural pattern highlighting
-        { token: 'metaStructuralVariable', foreground: '#f9fafb' },
-        // Revision highlighting
-        { token: 'metaRevisionCommitHash', foreground: '#f9fafb' },
-        { token: 'metaRevisionLabel', foreground: '#f9fafb' },
-        { token: 'metaRevisionReferencePath', foreground: '#f9fafb' },
-    ],
-})
 
 monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
     base: 'vs-dark',
@@ -185,47 +150,6 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
     inherit: true,
     colors: lightColors,
     rules: lightRules,
-})
-
-monaco.editor.defineTheme(SOURCEGRAPH_LIGHT_REDESIGN, {
-    base: 'vs',
-    inherit: true,
-    colors: {
-        ...lightColors,
-        'editor.foreground': '#14171f',
-        'editorCursor.foreground': '#14171f',
-        'editorSuggestWidget.foreground': '#14171f',
-        'editorSuggestWidget.border': '#dbe2f0',
-        'editorHoverWidget.foreground': '#14171f',
-        'editorHoverWidget.border': '#dbe2f0',
-        'editor.hoverHighlightBackground': '#343a4d',
-    },
-    rules: [
-        ...lightRules,
-        // Sourcegraph base language tokens
-        { token: 'identifier', foreground: '#14171f' },
-        { token: 'field', foreground: '#0b70db' },
-        { token: 'keyword', foreground: '#a305e1' },
-        { token: 'openingParen', foreground: '#a305e1' },
-        { token: 'closingParen', foreground: '#a305e1' },
-        // Sourcegraph decorated language tokens
-        { token: 'metaRepoRevisionSeparator', foreground: '#0b70db' },
-        { token: 'metaContextPrefix', foreground: '#a305e1' },
-        { token: 'metaPredicateNameAccess', foreground: '#a305e1' },
-        { token: 'metaPredicateDot', foreground: '#14171f' },
-        // Regexp pattern highlighting
-        { token: 'metaRegexpCharacterSet', foreground: '#a305e1' },
-        { token: 'metaRegexpCharacterClass', foreground: '#a305e1' },
-        { token: 'metaRegexpCharacterClassMember', foreground: '#14171f' },
-        { token: 'metaRegexpCharacterClassRange', foreground: '#14171f' },
-        { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#a305e1' },
-        // Structural pattern highlighting
-        { token: 'metaStructuralVariable', foreground: '#14171f' },
-        // Revision highlighting
-        { token: 'metaRevisionCommitHash', foreground: '#14171f' },
-        { token: 'metaRevisionLabel', foreground: '#14171f' },
-        { token: 'metaRevisionReferencePath', foreground: '#14171f' },
-    ],
 })
 
 interface Props extends ThemeProps {
@@ -258,9 +182,6 @@ interface Props extends ThemeProps {
 
     /** Keyboard shortcut to focus the Monaco editor. */
     keyboardShortcutForFocus?: KeyboardShortcut
-
-    /** Whether to use the redesign theme */
-    isRedesignEnabled?: boolean
 }
 
 interface State {}
@@ -280,7 +201,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         const editor = monaco.editor.create(element, {
             value: this.props.value,
             language: this.props.language,
-            theme: this.getTheme(this.props.isLightTheme, this.props.isRedesignEnabled),
+            theme: this.getTheme(this.props.isLightTheme),
             ...this.props.options,
         })
         if (this.props.onEditorCreated) {
@@ -300,7 +221,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         this.subscriptions.add(
             this.componentUpdates
                 .pipe(
-                    map(({ isLightTheme, isRedesignEnabled }) => this.getTheme(isLightTheme, isRedesignEnabled)),
+                    map(({ isLightTheme }) => this.getTheme(isLightTheme)),
                     distinctUntilChanged()
                 )
                 .subscribe(theme => monaco.editor.setTheme(theme))
@@ -347,14 +268,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         }
     }
 
-    private getTheme = (isLightTheme: boolean, isRedesignEnabled?: boolean): string =>
-        isRedesignEnabled
-            ? isLightTheme
-                ? SOURCEGRAPH_LIGHT_REDESIGN
-                : SOURCEGRAPH_DARK_REDESIGN
-            : isLightTheme
-            ? SOURCEGRAPH_LIGHT
-            : SOURCEGRAPH_DARK
+    private getTheme = (isLightTheme: boolean): string => (isLightTheme ? SOURCEGRAPH_LIGHT : SOURCEGRAPH_DARK)
 }
 
 if (!window.MonacoEnvironment) {

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -11,7 +11,6 @@ import { SearchSuggestion } from '@sourcegraph/shared/src/search/suggestions'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { hasProperty } from '@sourcegraph/shared/src/util/types'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { CaseSensitivityProps, PatternTypeProps, SearchContextProps } from '..'
 import { MonacoEditor } from '../../components/MonacoEditor'
@@ -181,8 +180,6 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
         (query: string) => fetchSuggestions(appendContextFilter(query, selectedSearchContextSpec, versionContext)),
         [selectedSearchContextSpec, versionContext]
     )
-
-    const [isRedesignEnabled] = useRedesignToggle()
 
     // Register themes and code intelligence providers. The providers are passed
     // a ReplaySubject of search queries to avoid registering new providers on
@@ -387,7 +384,6 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
                 options={options}
                 border={false}
                 keyboardShortcutForFocus={KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR}
-                isRedesignEnabled={isRedesignEnabled}
                 className="test-query-input monaco-query-input"
             />
         </div>


### PR DESCRIPTION
- Fix incorrect hover color in light mode (fixes #21981)
- Remove redesign themes and merge new redesign colors into the default theme (part of #20847)
- Added comments with the CSS variable names for all the colors. Some colors without a corresponding CSS variable have been modified to match a close-enough color. Some colors have been modified to match a more fitting semantic color (eg. borders updated to use `--border-color`)

## Light mode

![image](https://user-images.githubusercontent.com/206864/121602681-8aa5df00-c9fc-11eb-96b5-840831c2875c.png)
![image](https://user-images.githubusercontent.com/206864/121602714-95607400-c9fc-11eb-8b65-39b73b21d643.png)

## Dark mode

![image](https://user-images.githubusercontent.com/206864/121602801-ae692500-c9fc-11eb-9f02-58bbada8e97c.png)
![image](https://user-images.githubusercontent.com/206864/121602755-a315f980-c9fc-11eb-9e78-52887b4b1477.png)
