### PR TITLE
Fix global alert style for GitHub private code notification

### DIFF
--- a/client/web/src/global/GlobalAlert.tsx
+++ b/client/web/src/global/GlobalAlert.tsx
@@ -1,6 +1,3 @@
-import ErrorIcon from 'mdi-react/ErrorIcon'
-import InformationIcon from 'mdi-react/InformationIcon'
-import WarningIcon from 'mdi-react/WarningIcon'
 import React from 'react'
 
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
@@ -17,13 +14,7 @@ export const GlobalAlert: React.FunctionComponent<{ alert: GQL.IAlert; className
     alert,
     className: commonClassName,
 }) => {
-    const Icon = alertIconForType(alert.type)
-    const content = (
-        <>
-            <Icon className="redesign-d-none icon-inline mr-2 flex-shrink-0" />
-            <Markdown dangerousInnerHTML={renderMarkdown(alert.message)} />
-        </>
-    )
+    const content = <Markdown dangerousInnerHTML={renderMarkdown(alert.message)} />
     const className = `${commonClassName} alert alert-${alertClassForType(alert.type)} d-flex`
     if (alert.isDismissibleWithKey) {
         return (
@@ -33,19 +24,6 @@ export const GlobalAlert: React.FunctionComponent<{ alert: GQL.IAlert; className
         )
     }
     return <div className={className}>{content}</div>
-}
-
-function alertIconForType(type: AlertType): React.ComponentType<{ className?: string }> {
-    switch (type) {
-        case AlertType.INFO:
-            return InformationIcon
-        case AlertType.WARNING:
-            return WarningIcon
-        case AlertType.ERROR:
-            return ErrorIcon
-        default:
-            return WarningIcon
-    }
 }
 
 function alertClassForType(type: AlertType): string {

--- a/client/web/src/site/GitHubCodeHostScopeAlert/GitHubScopeAlert.tsx
+++ b/client/web/src/site/GitHubCodeHostScopeAlert/GitHubScopeAlert.tsx
@@ -1,4 +1,3 @@
-import InfoIcon from 'mdi-react/InfoCircleIcon'
 import React, { FunctionComponent } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -20,25 +19,20 @@ export const GITHUB_SCOPE_ALERT_KEY = 'GitHubPrivateScopeAlert'
 export const GitHubScopeAlert: FunctionComponent<Props> = ({ authenticatedUser }) => {
     const { scopes } = useGitHubScopeContext()
 
-    const shouldTryToDisplayAlert = (): boolean => {
-        if (!authenticatedUser || scopes === null) {
-            return false
-        }
-
-        return githubRepoScopeRequired(authenticatedUser.tags, scopes)
+    if (!authenticatedUser || scopes === null) {
+        return null
     }
 
-    return shouldTryToDisplayAlert() ? (
-        <DismissibleAlert
-            partialStorageKey={GITHUB_SCOPE_ALERT_KEY}
-            className="alert alert-info d-flex align-items-center"
-        >
-            <InfoIcon className="redesign-d-none icon-inline mr-2 flex-shrink-0" />
-            Update your&nbsp;
-            <Link className="site-alert__link" to="/user/settings/code-hosts">
-                <span className="underline">GitHub code host connection</span>
-            </Link>
-            &nbsp;to search private code with Sourcegraph.
+    if (!githubRepoScopeRequired(authenticatedUser.tags, scopes)) {
+        return null
+    }
+
+    return (
+        <DismissibleAlert partialStorageKey={GITHUB_SCOPE_ALERT_KEY} className="alert-info global-alerts__alert">
+            <span>
+                Update your <Link to="/user/settings/code-hosts">GitHub code host connection</Link> to search private
+                code with Sourcegraph.
+            </span>
         </DismissibleAlert>
-    ) : null
+    )
 }


### PR DESCRIPTION
The github private code banner didn't use the global alert styles, and had margin that pushed down the navbar. This PR fixes it.

### Before 
![image](https://user-images.githubusercontent.com/19534377/121613894-ce7d0080-ca5d-11eb-8b2d-7f9550ad3664.png)

### After 
![image](https://user-images.githubusercontent.com/19534377/121614020-11d76f00-ca5e-11eb-9aaf-40b8745ba4b6.png)

.. and with a few other surrounding alerts
![image](https://user-images.githubusercontent.com/19534377/121613954-eeacbf80-ca5d-11eb-85db-4cb1e856fbc1.png)
