### PR TITLE
Make sure react keys are unique

### DIFF
--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -114,7 +114,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
 
     const getGitHubUpdateAuthBanner = (needsUpdate: boolean): JSX.Element | null =>
         needsUpdate ? (
-            <div className="alert alert-info mb-4" role="alert" key="add-repos">
+            <div className="alert alert-info mb-4" role="alert" key="update-github">
                 Update your GitHub code host connection to search private code with Sourcegraph.
             </div>
         ) : null


### PR DESCRIPTION

### Description

Fixes React's `Each child in a list should have a unique "key" prop.` warning on the "Code host connections" page.