### PR TITLE
dev/gqltest: Fix TestAccesstoken by removing trailing \n

### DIFF
--- a/dev/gqltest/access_token_test.go
+++ b/dev/gqltest/access_token_test.go
@@ -29,7 +29,7 @@ func TestAccessToken(t *testing.T) {
 	t.Run("use an invalid token gets 401", func(t *testing.T) {
 		_, err := client.CurrentUserID("a bad token")
 		gotErr := fmt.Sprintf("%v", errors.Cause(err))
-		wantErr := "401: Invalid access token.\n"
+		wantErr := "401: Invalid access token."
 		if gotErr != wantErr {
 			t.Fatalf("err: want %q but got %q", wantErr, gotErr)
 		}


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
