### PR TITLE
search: tracing for resolveRepositories and SearchRepositories

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -308,19 +308,14 @@ type resolveRepositoriesOpts struct {
 // resolveRepositories calls ResolveRepositories, caching the result for the common case
 // where opts.effectiveRepoFieldValues == nil.
 func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRepositoriesOpts) (resolved searchrepos.Resolved, err error) {
-	var repoRevs, missingRepoRevs []*search.RepositoryRevisions
-	var overLimit bool
 	if mockResolveRepositories != nil {
 		return mockResolveRepositories(opts.effectiveRepoFieldValues)
 	}
 
 	tr, ctx := trace.New(ctx, "graphql.resolveRepositories", fmt.Sprintf("opts: %+v", opts))
 	defer func() {
-		if err != nil {
-			tr.SetError(err)
-		} else {
-			tr.LazyPrintf("numRepoRevs: %d, numMissingRepoRevs: %d, overLimit: %v", len(repoRevs), len(missingRepoRevs), overLimit)
-		}
+		tr.SetError(err)
+		tr.LazyPrintf("%s", resolved.String())
 		tr.Finish()
 	}()
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -41,6 +41,10 @@ type Resolved struct {
 	OverLimit       bool
 }
 
+func (r *Resolved) String() string {
+	return fmt.Sprintf("Resolved{RepoRevs=%d, MissingRepoRevs=%d, OverLimit=%v, %#v}", len(r.RepoRevs), len(r.MissingRepoRevs), r.OverLimit, r.ExcludedRepos)
+}
+
 type Resolver struct {
 	DB               dbutil.DB
 	Zoekt            *searchbackend.Zoekt


### PR DESCRIPTION
resolveRepositories logging was accidently broken with the introduction
of the Resolved struct. Additionally we trace SearchRepositories.

Co-authored-by: @tsenart 