### PR TITLE
sg: inherit environment for runGitCmd

### DIFF
--- a/dev/sg/util.go
+++ b/dev/sg/util.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
@@ -10,12 +11,11 @@ import (
 
 func runGitCmd(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
-	cmd.Env = []string{
+	cmd.Env = append(os.Environ(),
 		// Don't use the system wide git config.
 		"GIT_CONFIG_NOSYSTEM=1",
 		// And also not any other, because they can mess up output, change defaults, .. which can do unexpected things.
-		"GIT_CONFIG=/dev/null",
-	}
+		"GIT_CONFIG=/dev/null")
 
 	return runCommandInRoot(cmd)
 }


### PR DESCRIPTION
This allows it to inherit SSH_AUTH_SOCK. If we find this breaks
something, we should probably use an allowlist.
