### PR TITLE
Fix Code Insight line chart with negative value for chart Y axis 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Stricter validation of structural search queries. The `type:` parameter is not supported for structural searches and returns an appropriate alert. [#21487](https://github.com/sourcegraph/sourcegraph/pull/21487)
 - Batch changeset specs that are not attached to changesets will no longer prematurely expire before the batch specs that they are associated with. [#21678](https://github.com/sourcegraph/sourcegraph/pull/21678)
+- Code insights line chart no longer has a negative quadrant [#22018](https://github.com/sourcegraph/sourcegraph/pull/22018)
 
 ### Removed
 

--- a/client/web/src/views/ChartViewContent/ChartViewContent.story.tsx
+++ b/client/web/src/views/ChartViewContent/ChartViewContent.story.tsx
@@ -19,7 +19,7 @@ const commonProps = {
 }
 
 const { add } = storiesOf('web/ChartViewContent', module).addDecorator(story => (
-    <WebStory>{() => <div style={{ width: '32rem', height: '16rem' }}>{story()}</div>}</WebStory>
+    <WebStory>{() => <div style={{ width: '32rem', height: '20rem' }}>{story()}</div>}</WebStory>
 ))
 
 add('Line chart', () => (
@@ -28,10 +28,10 @@ add('Line chart', () => (
         content={{
             chart: 'line',
             data: [
-                { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: 110, b: 150 },
-                { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, a: 145, b: 260 },
-                { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 94, b: 200 },
-                { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 134, b: 190 },
+                { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: 0, b: 150 },
+                { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, a: 20, b: 260 },
+                { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 56, b: 200 },
+                { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 98, b: 190 },
                 { x: 1588965700286, a: 123, b: 170 },
             ],
             series: [

--- a/client/web/src/views/ChartViewContent/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/views/ChartViewContent/charts/line/components/LineChartContent.tsx
@@ -26,7 +26,7 @@ import { TooltipContent } from './TooltipContent'
 // Chart configuration
 const WIDTH_PER_TICK = 70
 const HEIGHT_PER_TICK = 40
-const MARGIN = { top: 10, left: 30, bottom: 20, right: 20 }
+const MARGIN = { top: 10, left: 30, bottom: 26, right: 20 }
 const SCALES_CONFIG = {
     x: {
         type: 'time' as const,
@@ -268,6 +268,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                     numTicks={numberOfTicksX}
                                     tickLabelProps={getTickXProps}
                                     tickComponent={Tick}
+                                    tickLength={8}
                                     axisClassName="line-chart__axis"
                                     axisLineClassName="line-chart__axis-line"
                                     tickClassName="line-chart__axis-tick"

--- a/client/web/src/views/ChartViewContent/charts/line/helpers/get-range-with-padding.ts
+++ b/client/web/src/views/ChartViewContent/charts/line/helpers/get-range-with-padding.ts
@@ -12,5 +12,6 @@ export function getRangeWithPadding(range: [number, number], paddingCoefficient:
     const [min, max] = range
     const increment = ((max - min) * paddingCoefficient) / 2
 
-    return [min - increment, max + increment]
+    // Minimal value for insight line chart can't be less than 0
+    return [Math.max(min - increment, 0), max + increment]
 }

--- a/client/web/src/views/ChartViewContent/charts/line/helpers/use-scales.ts
+++ b/client/web/src/views/ChartViewContent/charts/line/helpers/use-scales.ts
@@ -9,6 +9,8 @@ import { Accessors } from '../types'
 import { getMinAndMax } from './get-min-max'
 import { getRangeWithPadding } from './get-range-with-padding'
 
+const LINE_VERTICAL_PADDING = 0.15
+
 interface UseScalesProps<Datum> {
     /**
      * D3 scales configuration
@@ -54,7 +56,7 @@ export function useScales<Datum>(props: UseScalesProps<Datum>): UseScalesOutput 
             ...config,
             y: {
                 ...config.y,
-                domain: getRangeWithPadding(getMinAndMax(data, accessors), 0.3),
+                domain: getRangeWithPadding(getMinAndMax(data, accessors), LINE_VERTICAL_PADDING),
             },
         }),
         [accessors, data, config]


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/20046

This PR simply adds a constraint on the negative part of the Y-axis.

**Before** 

<img width="564" alt="image" src="https://user-images.githubusercontent.com/18492575/121710294-23faf100-cae2-11eb-9b21-0f066743c004.png">

**After** 

<img width="565" alt="image" src="https://user-images.githubusercontent.com/18492575/121709907-b3ec6b00-cae1-11eb-8825-d4cdadea6501.png">
