### PR TITLE
precise-code-intel-tester: do not make unnamed GraphQL requests

### DIFF
--- a/internal/cmd/precise-code-intel-tester/query.go
+++ b/internal/cmd/precise-code-intel-tester/query.go
@@ -172,7 +172,7 @@ func queryDefinitions(ctx context.Context, location Location) (locations []Locat
 	}
 
 	payload := QueryResponse{}
-	if err := util.QueryGraphQL(ctx, endpoint, token, query, variables, &payload); err != nil {
+	if err := util.QueryGraphQL(ctx, endpoint, "CodeIntelTesterDefinitions", token, query, variables, &payload); err != nil {
 		return nil, err
 	}
 
@@ -246,7 +246,7 @@ func queryReferences(ctx context.Context, location Location) (locations []Locati
 		}
 
 		payload := QueryResponse{}
-		if err := util.QueryGraphQL(ctx, endpoint, token, query, variables, &payload); err != nil {
+		if err := util.QueryGraphQL(ctx, endpoint, "CodeIntelTesterReferences", token, query, variables, &payload); err != nil {
 			return nil, err
 		}
 

--- a/internal/cmd/precise-code-intel-tester/upload.go
+++ b/internal/cmd/precise-code-intel-tester/upload.go
@@ -278,7 +278,7 @@ func uploadStates(ctx context.Context, ids, names []string) (stateByUpload map[s
 			} `json:"codeIntelligenceCommitGraph"`
 		} `json:"data"`
 	}{}
-	if err := util.QueryGraphQL(ctx, endpoint, token, query, nil, &payload); err != nil {
+	if err := util.QueryGraphQL(ctx, endpoint, "CodeIntelTesterUploadStates", token, query, nil, &payload); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
Prior to this change, `precise-code-intel-tester` would make unnamed GraphQL
requests which were impossible to identify in Grafana - and also spam the logs
with unnamed GraphQL request logs:

```
10:06:38                  frontend | logging complete query for unnamed GraphQL request above name=unknown user=slimsag source=other:
10:06:38                  frontend | QUERY
10:06:38                  frontend | -----
10:06:38                  frontend | {
10:06:38                  frontend | 	r0: repository(name: "github.com/sourcegraph-testing/tidb") {
10:06:38                  frontend | 		codeIntelligenceCommitGraph {
10:06:38                  frontend | 			stale
10:06:38                  frontend | 		}
10:06:38                  frontend | 	}
10:06:38                  frontend | }
10:06:38                  frontend | VARIABLES
10:06:38                  frontend | ---------
10:06:38                  frontend | map[]
```

Every GraphQL request that comes from software Sourcegraph writes should include a `?QueryName` to identify the type of request being made: it helps monitoring, it eliminates log verbosity.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
