### PR TITLE
web: fix useScrollToLocationHash on hashes containing ":", ".", etc.

### DIFF
--- a/client/web/src/components/useScrollToLocationHash.ts
+++ b/client/web/src/components/useScrollToLocationHash.ts
@@ -25,8 +25,8 @@ export const useScrollToLocationHash = (location: H.Location): void => {
         if (location.hash) {
             const idOrName = location.hash.slice(1)
             if (idOrName !== scrolledTo) {
-                // eslint-disable-next-line unicorn/prefer-query-selector
                 const element =
+                    // eslint-disable-next-line unicorn/prefer-query-selector
                     tryCatch(() => document.getElementById(idOrName)) ||
                     document.getElementsByName(idOrName).item(0)
                 if (element) {

--- a/client/web/src/components/useScrollToLocationHash.ts
+++ b/client/web/src/components/useScrollToLocationHash.ts
@@ -27,8 +27,7 @@ export const useScrollToLocationHash = (location: H.Location): void => {
             if (idOrName !== scrolledTo) {
                 const element =
                     // eslint-disable-next-line unicorn/prefer-query-selector
-                    tryCatch(() => document.getElementById(idOrName)) ||
-                    document.getElementsByName(idOrName).item(0)
+                    tryCatch(() => document.getElementById(idOrName)) || document.getElementsByName(idOrName).item(0)
                 if (element) {
                     element.scrollIntoView()
                     setScrolledTo(idOrName)

--- a/client/web/src/components/useScrollToLocationHash.ts
+++ b/client/web/src/components/useScrollToLocationHash.ts
@@ -26,7 +26,7 @@ export const useScrollToLocationHash = (location: H.Location): void => {
             const idOrName = location.hash.slice(1)
             if (idOrName !== scrolledTo) {
                 const element =
-                    tryCatch(() => document.getElementById(`${idOrName}`)) ||
+                    tryCatch(() => document.getElementById(idOrName)) ||
                     document.getElementsByName(idOrName).item(0)
                 if (element) {
                     element.scrollIntoView()

--- a/client/web/src/components/useScrollToLocationHash.ts
+++ b/client/web/src/components/useScrollToLocationHash.ts
@@ -25,6 +25,7 @@ export const useScrollToLocationHash = (location: H.Location): void => {
         if (location.hash) {
             const idOrName = location.hash.slice(1)
             if (idOrName !== scrolledTo) {
+                // eslint-disable-next-line unicorn/prefer-query-selector
                 const element =
                     tryCatch(() => document.getElementById(idOrName)) ||
                     document.getElementsByName(idOrName).item(0)

--- a/client/web/src/components/useScrollToLocationHash.ts
+++ b/client/web/src/components/useScrollToLocationHash.ts
@@ -26,7 +26,7 @@ export const useScrollToLocationHash = (location: H.Location): void => {
             const idOrName = location.hash.slice(1)
             if (idOrName !== scrolledTo) {
                 const element =
-                    tryCatch(() => document.querySelector(`#${idOrName}`)) ||
+                    tryCatch(() => document.getElementById(`${idOrName}`)) ||
                     document.getElementsByName(idOrName).item(0)
                 if (element) {
                     element.scrollIntoView()


### PR DESCRIPTION
URL hashes may contain punctuation characters like `:`, `.`, `;`, etc. and
I intend to use them in API docs to make URL hashes nicer, e.g. `#type:Router:Serve`
instead of `#typeRouterServe`.

This code previously used a CSS selector to match the relevant element by ID,
but not all element IDs/URL hashes are valid CSS selectors: any containing
punctuation are not.

This fixes it, by using `getElementById` which is better / more correct than
composing a CSS selector for an ID anyway.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>