### PR TITLE
extensibility: fix blob status bar color regression

### DIFF
--- a/client/web/src/components/diff/FileDiffHunks.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.tsx
@@ -230,7 +230,7 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
             {extensionInfo && (
                 <StatusBar
                     getStatusBarItems={getStatusBarItems}
-                    className="border-bottom border-top-0"
+                    className="file-diff-node__status-bar border-bottom border-top-0"
                     extensionsController={extensionInfo.extensionsController}
                     location={location}
                 />

--- a/client/web/src/components/diff/FileDiffNode.scss
+++ b/client/web/src/components/diff/FileDiffNode.scss
@@ -11,6 +11,11 @@
         }
     }
 
+    &__status-bar {
+        background-color: var(--code-bg);
+        height: 2rem;
+    }
+
     &__header {
         display: flex;
         align-items: center;

--- a/client/web/src/components/diff/FileDiffNode.tsx
+++ b/client/web/src/components/diff/FileDiffNode.tsx
@@ -26,15 +26,6 @@ export interface FileDiffNodeProps extends ThemeProps {
     location: H.Location
     history: H.History
 
-    // extensionInfo?: {
-    //     /** The base repository and revision. */
-    //     base: RepoSpec & RevisionSpec & ResolvedRevisionSpec & { repoID: Scalars['ID'] }
-
-    //     /** The head repository and revision. */
-    //     head: RepoSpec & RevisionSpec & ResolvedRevisionSpec & { repoID: Scalars['ID'] }
-
-    //     hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
-    // } & ExtensionsControllerProps
     extensionInfo?: ExtensionInfo<{
         observeViewerId?: (uri: string) => Observable<ViewerId | undefined>
     }>

--- a/client/web/src/extensions/components/StatusBar.scss
+++ b/client/web/src/extensions/components/StatusBar.scss
@@ -1,19 +1,11 @@
 .status-bar {
     background-color: var(--color-bg-2);
     height: 1.5rem;
-    .theme-redesign & {
-        background-color: var(--code-bg);
-        height: 2rem;
-    }
 
     &__items {
         overflow-x: auto;
         white-space: nowrap;
-        margin: 0 0.5rem;
-
-        .theme-redesign & {
-            margin: 0;
-        }
+        margin: 0;
 
         scrollbar-width: none;
         &::-webkit-scrollbar {


### PR DESCRIPTION
Move out diff-specific styles from 9a4bc257ba8356da6f3b914375a18482205bfa95 that changed the blob status bar's appearance as well. cc @sourcegraph/frontend-platform to ensure that this PR doesn't cause diff page regressions.

#### Before
![Screenshot from 2021-06-11 15-42-28](https://user-images.githubusercontent.com/37420160/121741351-64e80b00-cacc-11eb-86a4-64b156c0beaa.png)

#### After 
![Screenshot from 2021-06-11 15-48-08](https://user-images.githubusercontent.com/37420160/121741377-729d9080-cacc-11eb-8391-8ef86d51777e.png)
