### PR TITLE
Use single suggest `RepositoryField` instead of multi suggest`RepositoriesField` for lang stats creation UI. 

### DIFF
--- a/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
+++ b/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
@@ -8,135 +8,126 @@ import React, {
     forwardRef,
     useImperativeHandle,
     Ref,
-    InputHTMLAttributes,
 } from 'react'
 
 import { FlexTextArea } from './components/flex-textarea/FlexTextArea'
 import { SuggestionsPanel } from './components/suggestion-panel/SuggestionPanel'
 import { useRepoSuggestions } from './hooks/use-repo-suggestions'
 import styles from './RepositoriesField.module.scss'
+import { RepositoryFieldProps } from './types'
 import { getSuggestionsSearchTerm } from './utils/get-suggestions-search-term'
 
-interface RepositoriesFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
-    /**
-     * String value for the input - repo, repo, ....
-     */
-    value: string
-
-    /**
-     * Change handler runs when user changed input value or picked element
-     * from the suggestion panel.
-     */
-    onChange: (value: string) => void
-}
-
 /**
- * Renders repository input with suggestion panel.
+ * Renders multi repositories input with suggestions.
  */
-export const RepositoriesField = forwardRef(
-    (props: RepositoriesFieldProps, reference: Ref<HTMLInputElement | null>) => {
-        const { value, onChange, onBlur, ...otherProps } = props
+export const RepositoriesField = forwardRef((props: RepositoryFieldProps, reference: Ref<HTMLInputElement | null>) => {
+    const { value, onChange, onBlur, ...otherProps } = props
 
-        const inputReference = useRef<HTMLInputElement>(null)
+    const inputReference = useRef<HTMLInputElement>(null)
 
-        const [caretPosition, setCaretPosition] = useState<number | null>(null)
-        const [panel, setPanel] = useState(false)
+    const [caretPosition, setCaretPosition] = useState<number | null>(null)
+    const [panel, setPanel] = useState(false)
 
-        const { repositories, value: search, index: searchTermIndex } = getSuggestionsSearchTerm({
-            value,
-            caretPosition,
-        })
-        const { searchValue, suggestions } = useRepoSuggestions({
-            excludedItems: repositories,
-            search,
-            disable: !panel,
-        })
+    const { repositories, value: search, index: searchTermIndex } = getSuggestionsSearchTerm({
+        value,
+        caretPosition,
+    })
+    const { searchValue, suggestions } = useRepoSuggestions({
+        excludedItems: repositories,
+        search,
+        disable: !panel,
+    })
 
-        // Support top level reference prop
-        useImperativeHandle(reference, () => inputReference.current)
+    // Support top level reference prop
+    useImperativeHandle(reference, () => inputReference.current)
 
-        const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
-            onChange(event.target.value)
-            setCaretPosition(event.target.selectionStart)
-            setPanel(true)
-        }
+    const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
+        onChange(event.target.value)
+        setCaretPosition(event.target.selectionStart)
+        setPanel(true)
+    }
 
-        const handleSelect = (selectValue: string): void => {
-            const separatorString = ', '
+    const handleSelect = (selectValue: string): void => {
+        const separatorString = ', '
 
-            if (searchTermIndex !== null) {
-                const newRepositoriesSerializedValue = [
+        if (searchTermIndex !== null) {
+            const newRepositoriesSerializedValue =
+                [
                     ...repositories.slice(0, searchTermIndex),
                     selectValue,
                     ...repositories.slice(searchTermIndex + 1),
-                ].join(separatorString)
+                ].join(separatorString) + separatorString
 
-                onChange(newRepositoriesSerializedValue)
-                setPanel(false)
+            onChange(newRepositoriesSerializedValue)
+            setPanel(false)
 
-                /**
-                 * Setting the value ('setValue' above) triggers the reset selection of the input
-                 * if the user selects a value from suggestion panel for some sub-string of
-                 * the input value we need to preserve the selection at the end of the sub-string
-                 * and avoid resetting and putting the selection at the end of input string.
-                 */
-                setTimeout(() => {
-                    if (!inputReference.current) {
-                        return
-                    }
+            /**
+             * Setting the value ('setValue' above) triggers the reset selection of the input
+             * if the user selects a value from suggestion panel for some sub-string of
+             * the input value we need to preserve the selection at the end of the sub-string
+             * and avoid resetting and putting the selection at the end of input string.
+             */
+            setTimeout(() => {
+                if (!inputReference.current) {
+                    return
+                }
 
-                    const endOfSelectedItem = [...repositories.slice(0, searchTermIndex), selectValue].join(
-                        separatorString
-                    ).length
+                const isLastItemEdited = searchTermIndex === repositories.length - 1
+                const endOfSelectedItem = [...repositories.slice(0, searchTermIndex), selectValue].join(separatorString)
+                    .length
 
-                    inputReference.current.setSelectionRange(endOfSelectedItem, endOfSelectedItem)
-                }, 0)
-            }
+                const nextCaretPosition = isLastItemEdited
+                    ? // Put cursor at the end the input value
+                      newRepositoriesSerializedValue.length
+                    : endOfSelectedItem
+
+                inputReference.current.setSelectionRange(nextCaretPosition, nextCaretPosition)
+            }, 0)
         }
-
-        const trackInputCursorChange = (event: MouseEvent | KeyboardEvent | FocusEvent): void => {
-            const target = event.target as HTMLInputElement
-
-            if (caretPosition !== target.selectionStart) {
-                /**
-                 * After the moment when user selected the value from the suggestion panel we closed
-                 * this panel by setPanel(false) but if the user is changing the cursor position we
-                 * need to re-open suggestion panel for the new suggestions.
-                 */
-                setPanel(true)
-                setCaretPosition(target.selectionStart)
-            }
-        }
-
-        const handleInputFocus = (event: FocusEvent): void => {
-            setPanel(true)
-            trackInputCursorChange(event)
-        }
-
-        const handleInputBlur = (event: FocusEvent<HTMLInputElement>): void => {
-            onBlur?.(event)
-        }
-
-        return (
-            <Combobox openOnFocus={true} onSelect={handleSelect} className={styles.combobox}>
-                <ComboboxInput
-                    {...otherProps}
-                    as={FlexTextArea}
-                    ref={inputReference}
-                    autocomplete={false}
-                    value={value}
-                    onChange={handleInputChange}
-                    onFocus={handleInputFocus}
-                    onBlur={handleInputBlur}
-                    onClick={trackInputCursorChange}
-                />
-
-                {panel && (
-                    <ComboboxPopover className={styles.comboboxPopover}>
-                        <SuggestionsPanel value={searchValue} suggestions={suggestions} />
-                    </ComboboxPopover>
-                )}
-            </Combobox>
-        )
     }
-)
+
+    const trackInputCursorChange = (event: MouseEvent | KeyboardEvent | FocusEvent): void => {
+        const target = event.target as HTMLInputElement
+
+        if (caretPosition !== target.selectionStart) {
+            /**
+             * After the moment when user selected the value from the suggestion panel we closed
+             * this panel by setPanel(false) but if the user is changing the cursor position we
+             * need to re-open suggestion panel for the new suggestions.
+             */
+            setPanel(true)
+            setCaretPosition(target.selectionStart)
+        }
+    }
+
+    const handleInputFocus = (event: FocusEvent): void => {
+        setPanel(true)
+        trackInputCursorChange(event)
+    }
+
+    const handleInputBlur = (event: FocusEvent<HTMLInputElement>): void => {
+        onBlur?.(event)
+    }
+
+    return (
+        <Combobox openOnFocus={true} onSelect={handleSelect} className={styles.combobox}>
+            <ComboboxInput
+                {...otherProps}
+                as={FlexTextArea}
+                ref={inputReference}
+                autocomplete={false}
+                value={value}
+                onChange={handleInputChange}
+                onFocus={handleInputFocus}
+                onBlur={handleInputBlur}
+                onClick={trackInputCursorChange}
+            />
+
+            {panel && (
+                <ComboboxPopover className={styles.comboboxPopover}>
+                    <SuggestionsPanel value={searchValue} suggestions={suggestions} />
+                </ComboboxPopover>
+            )}
+        </Combobox>
+    )
+})

--- a/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
+++ b/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
@@ -62,7 +62,7 @@ export const RepositoriesField = forwardRef((props: RepositoryFieldProps, refere
             setPanel(false)
 
             /**
-             * Setting the value ('setValue' above) triggers the reset selection of the input
+             * Setting the value ('onChange' above) triggers the reset selection of the input
              * if the user selects a value from suggestion panel for some sub-string of
              * the input value we need to preserve the selection at the end of the sub-string
              * and avoid resetting and putting the selection at the end of input string.

--- a/client/web/src/insights/components/form/repositories-field/RepositoryField.tsx
+++ b/client/web/src/insights/components/form/repositories-field/RepositoryField.tsx
@@ -1,0 +1,47 @@
+import { Combobox, ComboboxInput, ComboboxPopover } from '@reach/combobox'
+import React, { ChangeEvent, forwardRef, Ref, useImperativeHandle, useRef } from 'react'
+
+import { getSanitizedRepositories } from '../../../pages/creation/search-insight/utils/insight-sanitizer'
+
+import { FlexTextArea } from './components/flex-textarea/FlexTextArea'
+import { SuggestionsPanel } from './components/suggestion-panel/SuggestionPanel'
+import { useRepoSuggestions } from './hooks/use-repo-suggestions'
+import styles from './RepositoriesField.module.scss'
+import { RepositoryFieldProps } from './types'
+
+/**
+ * Renders single repository field with suggestions.
+ */
+export const RepositoryField = forwardRef((props: RepositoryFieldProps, reference: Ref<HTMLInputElement | null>) => {
+    const { value, onChange, onBlur, ...otherProps } = props
+
+    const inputReference = useRef<HTMLInputElement>(null)
+
+    const { searchValue, suggestions } = useRepoSuggestions({
+        excludedItems: [value],
+        search: getSanitizedRepositories(value)[0],
+    })
+
+    // Support top level reference prop
+    useImperativeHandle(reference, () => inputReference.current)
+
+    const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
+        onChange(event.target.value)
+    }
+
+    return (
+        <Combobox openOnFocus={true} onSelect={onChange} className={styles.combobox}>
+            <ComboboxInput
+                {...otherProps}
+                as={FlexTextArea}
+                ref={inputReference}
+                value={value}
+                onChange={handleInputChange}
+            />
+
+            <ComboboxPopover className={styles.comboboxPopover}>
+                <SuggestionsPanel value={searchValue} suggestions={suggestions} />
+            </ComboboxPopover>
+        </Combobox>
+    )
+})

--- a/client/web/src/insights/components/form/repositories-field/types.ts
+++ b/client/web/src/insights/components/form/repositories-field/types.ts
@@ -1,0 +1,17 @@
+import { InputHTMLAttributes } from 'react'
+
+/**
+ * Common props for multi and single repository field with suggestions.
+ */
+export interface RepositoryFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
+    /**
+     * String value for the input - repo, repo, ....
+     */
+    value: string
+
+    /**
+     * Change handler runs when user changed input value or picked element
+     * from the suggestion panel.
+     */
+    onChange: (value: string) => void
+}

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -6,7 +6,7 @@ import { LoaderButton } from '../../../../../../components/LoaderButton'
 import { FormInput } from '../../../../../components/form/form-input/FormInput'
 import { useFieldAPI } from '../../../../../components/form/hooks/useField'
 import { FORM_ERROR, SubmissionErrors } from '../../../../../components/form/hooks/useForm'
-import { RepositoriesField } from '../../../../../components/form/repositories-field/RepositoriesField'
+import { RepositoryField } from '../../../../../components/form/repositories-field/RepositoryField'
 import {
     getVisibilityValue,
     Organization,
@@ -65,7 +65,7 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
             onReset={onFormReset}
         >
             <FormInput
-                as={RepositoriesField}
+                as={RepositoryField}
                 required={true}
                 autoFocus={true}
                 title="Repository"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22042

### Background
This PR adds a separate repository field component with suggestions for lang stats insight creation UI. Previously we used multiple repo suggestions for both search-based and lang stats insights, this worked for us because we have a comprehensive validation for the repo field, and by that we didn't allow users to type multiple repositories in lang stats insights creation UI. But to avoid the complexity of supporting use cases for single and multiple repo suggestion fields we have to split this logic (UX may be different from single to multi repo suggests like adding a trailing comma right after a suggestion was selected).

Now we just split these two use cases (sing and multiple repo field) into two separate components `RepositoriesField` and `RepositoryField`. 

