### PR TITLE
internal/bg: Change log retention to round numbers

### DIFF
--- a/cmd/frontend/internal/bg/delete_old_event_logs_in_postgres.go
+++ b/cmd/frontend/internal/bg/delete_old_event_logs_in_postgres.go
@@ -13,7 +13,7 @@ func DeleteOldEventLogsInPostgres(ctx context.Context, db dbutil.DB) {
 	for {
 		_, err := db.ExecContext(
 			ctx,
-			`DELETE FROM event_logs WHERE "timestamp" < now() - interval '93' day`,
+			`DELETE FROM event_logs WHERE "timestamp" < now() - interval '90' day`,
 		)
 		if err != nil {
 			log15.Error("deleting expired rows from event_logs table", "error", err)
@@ -26,7 +26,7 @@ func DeleteOldSecurityEventLogsInPostgres(ctx context.Context, db dbutil.DB) {
 	for {
 		_, err := db.ExecContext(
 			ctx,
-			`DELETE FROM security_event_logs WHERE "timestamp" < now() - interval '186' day`,
+			`DELETE FROM security_event_logs WHERE "timestamp" < now() - interval '180' day`,
 		)
 		if err != nil {
 			log15.Error("deleting expired rows from security_event_logs table", "error", err)


### PR DESCRIPTION
In this commit we change the log retention of old event logs in
Postgres from 93 to 90 days.

And we change the log retention of old security event logs in Postgres
from 186 to 180 days.

90 and 180 being round numbers are easy to remember and
reference. Also 93 and 186 do not guarantee that they will be exactly
3 and 6 months depending on the time period in question. Example:

1. February
2. February but a leap year
3. July - August and December - January have back to back 31 days.

This is a follow up on #22025.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
