### PR TITLE
gitlab: 'api' scope is required to clone private repos

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -98,10 +98,21 @@ func newOAuthFlowHandler(db dbutil.DB, serviceType string) http.Handler {
 	return mux
 }
 
+// serviceType -> scopes
+var extraScopes = map[string][]string{
+	// We need `repo` scopes for reading private repos
+	extsvc.TypeGitHub: {"repo"},
+	// We need full api scope for cloning private repos
+	extsvc.TypeGitLab: {"api"},
+}
+
 func getExtraScopes(ctx context.Context, db dbutil.DB, serviceType string) ([]string, error) {
-	// On Sourcegraph Cloud and for GitHub, check if the user is allowed to add
-	// private code and if so, ask the code host for additional scopes
-	if !envvar.SourcegraphDotComMode() || (serviceType != extsvc.TypeGitHub) {
+	// Extra scopes are only needed on Sourcegraph.com
+	if !envvar.SourcegraphDotComMode() {
+		return nil, nil
+	}
+	scopes, ok := extraScopes[serviceType]
+	if !ok {
 		return nil, nil
 	}
 
@@ -112,13 +123,7 @@ func getExtraScopes(ctx context.Context, db dbutil.DB, serviceType string) ([]st
 	if mode != conf.ExternalServiceModeAll {
 		return nil, nil
 	}
-
-	switch serviceType {
-	case extsvc.TypeGitHub:
-		return []string{"repo"}, nil
-	default:
-		return nil, errors.Errorf("unknown service type: %q", serviceType)
-	}
+	return scopes, nil
 }
 
 // withOAuthExternalHTTPClient updates client such that the

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -102,7 +102,7 @@ func newOAuthFlowHandler(db dbutil.DB, serviceType string) http.Handler {
 var extraScopes = map[string][]string{
 	// We need `repo` scopes for reading private repos
 	extsvc.TypeGitHub: {"repo"},
-	// We need full api scope for cloning private repos
+	// We need full `api` scope for cloning private repos
 	extsvc.TypeGitLab: {"api"},
 }
 

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -164,7 +164,7 @@ func githubCloneURL(repo *github.Repository, cfg *schema.GitHubConnection) (stri
 	return u.String(), nil
 }
 
-// authenticatedRemoteURL returns the GitLab projects's Git remote URL with the
+// authenticatedRemoteURL returns the GitLab project's Git remote URL with the
 // configured GitLab personal access token inserted in the URL userinfo.
 func gitlabCloneURL(repo *gitlab.Project, cfg *schema.GitLabConnection) string {
 	if cfg.GitURLType == "ssh" {
@@ -178,8 +178,11 @@ func gitlabCloneURL(repo *gitlab.Project, cfg *schema.GitLabConnection) string {
 		log15.Warn("Error adding authentication to GitLab repository Git remote URL.", "url", repo.HTTPURLToRepo, "error", err)
 		return repo.HTTPURLToRepo
 	}
-	// Any username works; "git" is not special.
-	u.User = url.UserPassword("git", cfg.Token)
+	username := "git"
+	if cfg.TokenType == "oauth" {
+		username = "oauth2"
+	}
+	u.User = url.UserPassword(username, cfg.Token)
 	return u.String()
 }
 

--- a/internal/repos/clone_url_test.go
+++ b/internal/repos/clone_url_test.go
@@ -208,17 +208,21 @@ func TestGitLabCloneURLs(t *testing.T) {
 	tests := []struct {
 		Token      string
 		GitURLType string
+		TokenType  string
 		Want       string
 	}{
-		{"", "", "https://gitlab.com/gitlab-org/gitaly.git"},
-		{"abcd", "", "https://git:abcd@gitlab.com/gitlab-org/gitaly.git"},
-		{"abcd", "ssh", "git@gitlab.com:gitlab-org/gitaly.git"},
+		{Want: "https://gitlab.com/gitlab-org/gitaly.git"},
+		{Token: "abcd", Want: "https://git:abcd@gitlab.com/gitlab-org/gitaly.git"},
+		{Token: "abcd", TokenType: "oauth", Want: "https://oauth2:abcd@gitlab.com/gitlab-org/gitaly.git"},
+		{Token: "abcd", GitURLType: "ssh", Want: "git@gitlab.com:gitlab-org/gitaly.git"},
+		{Token: "abcd", GitURLType: "ssh", Want: "git@gitlab.com:gitlab-org/gitaly.git"},
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Token(%q) / URLType(%q)", test.Token, test.GitURLType), func(t *testing.T) {
 			cfg := schema.GitLabConnection{
 				Token:      test.Token,
+				TokenType:  test.TokenType,
 				GitURLType: test.GitURLType,
 			}
 


### PR DESCRIPTION
We need to request addition `api` scope in order to clone private repos on GitLab

Part of: https://sourcegraph.atlassian.net/browse/COREAPP-75