### PR TITLE
Add fix for count filter in data series query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added support for Terraform syntax highlighting. [#22040](https://github.com/sourcegraph/sourcegraph/pull/22040)
 - A new bulk operation to merge many changesets at once has been added to Batch Changes. [#21959](https://github.com/sourcegraph/sourcegraph/pull/21959)
 - Pings include aggregated usage for the Code Insights creation UI, organization visible insight count per insight type, and insight step size in days. [#21671](https://github.com/sourcegraph/sourcegraph/pull/21671)
+- Search-based insight creation UI now supports `count:` filter in data series query input. [#22049](https://github.com/sourcegraph/sourcegraph/pull/22049)
 
 ### Changed
 

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/get-search-insight-content.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/get-search-insight-content.ts
@@ -4,9 +4,11 @@ import { defer } from 'rxjs'
 import { retry } from 'rxjs/operators'
 import type { LineChartContent } from 'sourcegraph'
 
-import { EMPTY_DATA_POINT_VALUE } from '../../../../views/ChartViewContent/charts/line/constants'
-import { fetchRawSearchInsightResults, fetchSearchInsightCommits } from '../requests/fetch-search-insight'
-import { SearchInsightSettings } from '../types'
+import { EMPTY_DATA_POINT_VALUE } from '../../../../../views/ChartViewContent/charts/line/constants'
+import { fetchRawSearchInsightResults, fetchSearchInsightCommits } from '../../requests/fetch-search-insight'
+import { SearchInsightSettings } from '../../types'
+
+import { queryHasCountFilter } from './query-has-count-filter'
 
 interface RepoCommit {
     date: Date
@@ -60,7 +62,7 @@ export async function getSearchInsightContent(insight: SearchInsightSettings): P
             date,
             repo,
             commit,
-            query: `repo:^${escapeRegExp(repo)}$@${commit} ${query} count:99999`,
+            query: `repo:^${escapeRegExp(repo)}$@${commit} ${getQueryWithCount(query)}`,
         }))
     )
 
@@ -186,4 +188,11 @@ function getDaysToQuery(step: Duration): Date[] {
     }
 
     return dates
+}
+
+function getQueryWithCount(query: string): string {
+    return queryHasCountFilter(query)
+        ? query
+        : // Increase the number to the maximum value to get all the data we can have
+          `${query} count:99999`
 }

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
@@ -1,0 +1,17 @@
+const COUNT_PREFIX = 'count:'
+
+/**
+ * Returns whether the query specifies a count. Search queries break when count is specified twice.
+ */
+export function queryHasCountFilter(query: string): boolean {
+    return query
+        .split(' ')
+        .map(part => part.trim())
+        .some(part => {
+            if (!part.startsWith(COUNT_PREFIX)) {
+                return false
+            }
+
+            return part.slice(COUNT_PREFIX.length).length > 0
+        })
+}

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
@@ -1,17 +1,6 @@
-const COUNT_PREFIX = 'count:'
-
 /**
  * Returns whether the query specifies a count. Search queries break when count is specified twice.
  */
 export function queryHasCountFilter(query: string): boolean {
-    return query
-        .split(' ')
-        .map(part => part.trim())
-        .some(part => {
-            if (!part.startsWith(COUNT_PREFIX)) {
-                return false
-            }
-
-            return part.slice(COUNT_PREFIX.length).length > 0
-        })
+    return /(?<!\s["'])count:(\s*)\d+\b(?!(\s*)["'])/gi.test(query)
 }

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
@@ -1,0 +1,17 @@
+import * as assert from 'assert'
+
+import { queryHasCountFilter } from './query-has-count-filter'
+
+describe('queryHasCount()', () => {
+    it('returns true when count is specified', () => {
+        assert.strictEqual(queryHasCountFilter('const count:1000'), true)
+    })
+
+    it('returns false when count is not specified', () => {
+        assert.strictEqual(queryHasCountFilter('const'), false)
+    })
+
+    it('returns false when count is escaped', () => {
+        assert.strictEqual(queryHasCountFilter('"count:100" lang:ts'), false)
+    })
+})

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
@@ -4,7 +4,7 @@ import { queryHasCountFilter } from './query-has-count-filter'
 
 describe('queryHasCount()', () => {
     it('returns true when count is specified', () => {
-        assert.strictEqual(queryHasCountFilter('const count:1000'), true)
+        assert.strictEqual(queryHasCountFilter('const count: 1000'), true)
     })
 
     it('returns false when count is not specified', () => {
@@ -13,5 +13,9 @@ describe('queryHasCount()', () => {
 
     it('returns false when count is escaped', () => {
         assert.strictEqual(queryHasCountFilter('"count:100" lang:ts'), false)
+    })
+
+    it('returns false when count is escaped by single quotes', () => {
+        assert.strictEqual(queryHasCountFilter("'count:100' lang:ts"), false)
     })
 })

--- a/client/web/src/insights/core/backend/insights-api.ts
+++ b/client/web/src/insights/core/backend/insights-api.ts
@@ -3,7 +3,7 @@ import { of, throwError } from 'rxjs'
 import { getCombinedViews, getInsightCombinedViews } from './api/get-combined-views'
 import { getLangStatsInsightContent } from './api/get-lang-stats-insight-content'
 import { getRepositorySuggestions } from './api/get-repository-suggestions'
-import { getSearchInsightContent } from './api/get-search-insight-content'
+import { getSearchInsightContent } from './api/get-search-insight-content/get-search-insight-content'
 import { getSubjectSettings, updateSubjectSettings } from './api/subject-settings'
 import { ApiService } from './types'
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21955

Adds fix for count filter in an insight search query for live preview chart. 

### Background
We're usually adding `count: 9999` as the default filter to series query search-insight data for the live preview chart just to be sure we will collect and fetch all data that we have. 

But if the user specified the count filter themself we should use the user value instead of the `9999` value. This PR adds a fix for it. 

Important to note this fix only for the live preview chart of search-based insight creation UI. 
We have a separate PR that fixes that problem in search-based extension. https://github.com/sourcegraph/sourcegraph-search-insights/pull/9

