### PR TITLE
Use `withAuthenticatedUser` for insight router 

### DIFF
--- a/client/web/src/insights/InsightsRouter.tsx
+++ b/client/web/src/insights/InsightsRouter.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { RouteComponentProps, Switch, Route } from 'react-router'
 
 import { AuthenticatedUser } from '../auth'
+import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
 import { HeroPage } from '../components/HeroPage'
 import { lazyComponent } from '../util/lazyComponent'
 
@@ -30,13 +31,13 @@ export interface InsightsRouterProps
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
      * */
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations' | 'username'> | null
+    authenticatedUser: AuthenticatedUser
 }
 
 /**
  * Main Insight routing component. Main entry point to code insights UI.
  */
-export const InsightsRouter: React.FunctionComponent<InsightsRouterProps> = props => {
+export const InsightsRouter = withAuthenticatedUser<InsightsRouterProps>(props => {
     const { match, ...outerProps } = props
 
     return (
@@ -70,4 +71,4 @@ export const InsightsRouter: React.FunctionComponent<InsightsRouterProps> = prop
             <Route component={NotFoundPage} key="hardcoded-key" />
         </Switch>
     )
-}
+})

--- a/client/web/src/insights/pages/creation/CreationRoutes.tsx
+++ b/client/web/src/insights/pages/creation/CreationRoutes.tsx
@@ -24,7 +24,7 @@ interface CreationRoutesProps extends TelemetryProps, PlatformContextProps<'upda
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
      * */
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations' | 'username'> | null
+    authenticatedUser: AuthenticatedUser
 }
 
 /**

--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames'
 import React, { useCallback, useContext, useEffect } from 'react'
-import { Redirect } from 'react-router'
 import { useHistory } from 'react-router-dom'
 
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -34,7 +33,7 @@ export interface LangStatsInsightCreationPageProps
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organization dashboard (public)
      * */
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations'> | null
+    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations'>
 }
 
 export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsightCreationPageProps> = props => {
@@ -102,10 +101,6 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
 
     const handleChange = (event: FormChangeEvent<LangStatsCreationFormFields>): void => {
         setInitialFormValues(event.values)
-    }
-
-    if (authenticatedUser === null) {
-        return <Redirect to="/" />
     }
 
     const {

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames'
 import React, { useCallback, useContext, useEffect } from 'react'
-import { Redirect } from 'react-router'
 import { useHistory, useLocation } from 'react-router-dom'
 
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -33,7 +32,7 @@ export interface SearchInsightCreationPageProps
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
      * */
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations'> | null
+    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations'>
 }
 
 /** Displays create insight page with creation form. */
@@ -54,8 +53,6 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
         'insights.search-insight-creation',
         undefined
     )
-
-    console.log('render')
 
     // Query param insight values have a higher priority that local storage values
     const initialFormValues = queryParameterInsight ?? localStorageFormValues
@@ -116,11 +113,6 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
         setInitialFormValues(undefined)
         history.push('/insights')
     }, [history, setInitialFormValues, telemetryService])
-
-    // TODO [VK] Move this logic to high order component to simplify logic here
-    if (authenticatedUser === null) {
-        return <Redirect to="/" />
-    }
 
     const {
         organizations: { nodes: orgs },

--- a/client/web/src/insights/pages/edit/EditInsightPage.tsx
+++ b/client/web/src/insights/pages/edit/EditInsightPage.tsx
@@ -1,7 +1,6 @@
 import classnames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useContext, useMemo, useState } from 'react'
-import { Redirect } from 'react-router'
 import { useHistory, Link } from 'react-router-dom'
 
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -29,7 +28,7 @@ export interface EditInsightPageProps extends SettingsCascadeProps, PlatformCont
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
      * */
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations' | 'username'> | null
+    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations' | 'username'>
 }
 
 interface ParsedInsightInfo {
@@ -152,11 +151,6 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
                 }
             />
         )
-    }
-
-    // TODO [VK] Move this logic to high order component to simplify logic here
-    if (authenticatedUser === null) {
-        return <Redirect to="/" />
     }
 
     const {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21073

A few pages within the insight routes area require an authUser object. But naturally we can have authUser with null value (logged out user) 

To avoid manually check into insights pages this PR adds one root check with `withAuthenticatedUser` hoc