### PR TITLE
gitlab: On prem instance should request `api` scope by default

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -123,7 +123,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockGitLabCom.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "read_user read_api"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "read_user api"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {
@@ -156,7 +156,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockPrivateGitLab.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "read_user read_api"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "read_user api"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {
@@ -189,7 +189,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockGitLabCom.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "read_user read_api"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "read_user api"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -75,8 +75,12 @@ func getStateConfig() gologin.CookieConfig {
 }
 
 func requestedScopes(extraScopes []string) []string {
-	scopes := []string{"read_user", "read_api"}
-	if !envvar.SourcegraphDotComMode() {
+	scopes := []string{"read_user"}
+	if envvar.SourcegraphDotComMode() {
+		// By default, request `read_api`. User's who are allowed to add private code
+		// will request full `api` access via extraScopes.
+		scopes = append(scopes, "read_api")
+	} else {
 		scopes = append(scopes, "api")
 	}
 	// Append extra scopes and ensure there are no duplicates

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dghubble/gologin"
 	"golang.org/x/oauth2"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -75,7 +76,9 @@ func getStateConfig() gologin.CookieConfig {
 
 func requestedScopes(extraScopes []string) []string {
 	scopes := []string{"read_user", "read_api"}
-
+	if !envvar.SourcegraphDotComMode() {
+		scopes = append(scopes, "api")
+	}
 	// Append extra scopes and ensure there are no duplicates
 	for _, s := range extraScopes {
 		var found bool


### PR DESCRIPTION
This is consistent with what we do for GitHub and should be safe as we don't
support user added code on private instances yet.