### PR TITLE
extsvc: Support fetching granted OAuth scopes for GitLab

### DIFF
--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -293,7 +293,7 @@ func (c *Client) ValidateToken(ctx context.Context) error {
 }
 
 func (c *Client) GetAuthenticatedUserOAuthScopes(ctx context.Context) ([]string, error) {
-	// The oauth token info path is not standard so we need to build it manually
+	// The oauth token info path is non standard so we need to build it manually
 	// without the default `/api/v4` prefix
 	u, _ := url.Parse(c.baseURL.String())
 	u.Path = "oauth/token/info"

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -210,8 +210,15 @@ func isGitLabDotComURL(baseURL *url.URL) bool {
 	return hostname == "gitlab.com" || hostname == "www.gitlab.com"
 }
 
+// do is the default method for making API requests and will prepare the correct
+// base path.
 func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) (responseHeader http.Header, responseCode int, err error) {
 	req.URL = c.baseURL.ResolveReference(req.URL)
+	return c.doWithBaseURL(ctx, req, result)
+}
+
+// doWithBaseURL will not amend the request URL.
+func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result interface{}) (responseHeader http.Header, responseCode int, err error) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	if c.Auth != nil {
 		if err := c.Auth.Authenticate(req); err != nil {
@@ -283,6 +290,26 @@ func (c *Client) ValidateToken(ctx context.Context) error {
 	v := struct{}{}
 	_, _, err = c.do(ctx, req, &v)
 	return err
+}
+
+func (c *Client) GetAuthenticatedUserOAuthScopes(ctx context.Context) ([]string, error) {
+	// The oauth token info path is not standard so we need to build it manually
+	// without the default `/api/v4` prefix
+	u, _ := url.Parse(c.baseURL.String())
+	u.Path = "oauth/token/info"
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	v := struct {
+		Scopes []string `json:"scopes,omitempty"`
+	}{}
+	_, _, err = c.doWithBaseURL(ctx, req, &v)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting oauth scopes")
+	}
+	return v.Scopes, nil
 }
 
 type HTTPError struct {

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -1,0 +1,52 @@
+package gitlab
+
+import (
+	"context"
+	"flag"
+	"net/url"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+)
+
+func TestGetAuthenticatedUserOAuthScopes(t *testing.T) {
+	provider := createTestProvider(t)
+	// We expect the GitLab token stored in 1Password under gitlab@sourcegraph.com
+	token := os.Getenv("GITLAB_TOKEN")
+	client := provider.GetOAuthClient(token)
+	ctx := context.Background()
+	have, err := client.GetAuthenticatedUserOAuthScopes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"read_user", "read_api", "api"}
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func createTestProvider(t *testing.T) *ClientProvider {
+	t.Helper()
+	fac, cleanup := httptestutil.NewRecorderFactory(t, update(t.Name()), t.Name())
+	t.Cleanup(cleanup)
+	doer, err := fac.Doer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseURL, _ := url.Parse("https://gitlab.com/")
+	provider := NewClientProvider(baseURL, doer)
+	return provider
+}
+
+var updateRegex = flag.String("update", "", "Update testdata of tests matching the given regex")
+
+func update(name string) bool {
+	if updateRegex == nil || *updateRegex == "" {
+		return false
+	}
+	return regexp.MustCompile(*updateRegex).MatchString(name)
+}

--- a/internal/extsvc/gitlab/testdata/vcr/TestGetAuthenticatedUserOAuthScopes.yaml
+++ b/internal/extsvc/gitlab/testdata/vcr/TestGetAuthenticatedUserOAuthScopes.yaml
@@ -1,0 +1,59 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/oauth/token/info
+    method: GET
+  response:
+    body: '{"resource_owner_id":7799956,"scope":["read_user","read_api","api"],"expires_in":null,"application":{"uid":"a2148736697e8d87a22ccf0d29fd29f60f40538fcfd26f75326c89f9389c3e43"},"created_at":1623838922,"scopes":["read_user","read_api","api"],"expires_in_seconds":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 66036a7d6edf3ea5-CPT
+      Cf-Request-Id:
+      - 0ab600e26500003ea554263000000001
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 10:39:44 GMT
+      Etag:
+      - W/"6e32fb070d83fd277a1927005e85d785"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-04-lb-gprd
+      Gitlab-Sv:
+      - web-16-sv-gprd
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 01F8A6FJQXHV232VDNN60VM2RJ
+      X-Runtime:
+      - "0.019830"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -277,7 +277,7 @@ func TestGrantedScopes(t *testing.T) {
 		return want, nil
 	}
 
-	svc := &types.ExternalService{Kind: extsvc.KindGitHub, Config: `{"token": "abc"}`}
+	svc := &types.ExternalService{Kind: extsvc.KindGitHub, Config: `{"token": "abc"}`, NamespaceUserID: 123}
 	// Run twice to use cache
 	for i := 0; i < 2; i++ {
 		have, err := GrantedScopes(ctx, cache, svc)


### PR DESCRIPTION
Update our GrantedScopes method to also support GitLab.

Additionally, added our first VCR based test for our GitLab client which will
make it easier to add these kinds of tests in the future.