### PR TITLE
Change "New" badge from "Product research" to "Repositories"

### DIFF
--- a/client/web/src/user/settings/sidebaritems.ts
+++ b/client/web/src/user/settings/sidebaritems.ts
@@ -45,11 +45,11 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = [
         label: 'Repositories',
         to: '/repositories',
         condition: userExternalServicesEnabled,
+        status: 'new',
     },
     {
         label: 'Product research',
         to: '/product-research',
         condition: () => window.context.productResearchPageEnabled,
-        status: 'new',
     },
 ]


### PR DESCRIPTION
Fix #21913, by removing the _New_ badge on "Product research", and adding it to "Repositories".

<img width="248" alt="CleanShot 2021-06-14 at 16 39 31@2x" src="https://user-images.githubusercontent.com/17293/121910436-21410b80-cd2f-11eb-855f-3d10bf8cea34.png">
