### PR TITLE
Revert "add repo metadata to streaming events"

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
-	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -34,7 +32,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // StreamHandler is an http handler which streams back search results.
@@ -154,8 +151,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = matchesBuf.Append(m)
 	}
 
-	repoCache := make(map[api.RepoID]*types.Repo, 10)
-
 	flushTicker := time.NewTicker(h.flushTickerInternal)
 	defer flushTicker.Stop()
 
@@ -184,19 +179,13 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		progress.Update(event)
 		filters.Update(event)
 
-		// Ensure that, for each result in the event, we have a copy of the full repo metadata.
-		if err := updateRepoCache(ctx, h.db, repoCache, event); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
 		for _, match := range event.Results {
 			if display <= 0 {
 				break
 			}
 
 			display = match.Limit(display)
-			matchesAppend(fromMatch(match, repoCache))
+			matchesAppend(fromMatch(match))
 		}
 
 		// Instantly send results if we have not sent any yet.
@@ -284,47 +273,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log15.Warn("streaming: slow search request", searchlogs.MapToLog15Ctx(ev.Fields())...)
 		}
 	}
-}
-
-// updateRepoCache requests repo metadata for each repo referenced by results in the event. It only makes a database request if there
-// are new repos that do not already exist in the cache.
-func updateRepoCache(ctx context.Context, db dbutil.DB, repoCache map[api.RepoID]*types.Repo, event streaming.SearchEvent) error {
-	uncachedIDs := make(map[api.RepoID]struct{}, 10)
-	for _, r := range event.Results {
-		var id api.RepoID
-		switch v := r.(type) {
-		case *result.FileMatch:
-			id = v.Repo.ID
-		case *result.RepoMatch:
-			id = v.ID
-		case *result.CommitMatch:
-			id = v.RepoName.ID
-		default:
-			return fmt.Errorf("unknown match type %T", r)
-		}
-
-		if _, ok := repoCache[id]; !ok {
-			uncachedIDs[id] = struct{}{}
-		}
-	}
-
-	if len(uncachedIDs) == 0 {
-		return nil
-	}
-
-	uncachedIDSlice := make([]api.RepoID, 0, len(uncachedIDs))
-	for id := range uncachedIDs {
-		uncachedIDSlice = append(uncachedIDSlice, id)
-	}
-
-	repos, err := database.Repos(db).GetReposSetByIDs(ctx, uncachedIDSlice...)
-	if err != nil {
-		return err
-	}
-	for id, repo := range repos {
-		repoCache[id] = repo
-	}
-	return nil
 }
 
 // startSearch will start a search. It returns the events channel which
@@ -429,20 +377,20 @@ func fromStrPtr(s *string) string {
 	return *s
 }
 
-func fromMatch(match result.Match, repoCache map[api.RepoID]*types.Repo) streamhttp.EventMatch {
+func fromMatch(match result.Match) streamhttp.EventMatch {
 	switch v := match.(type) {
 	case *result.FileMatch:
-		return fromFileMatch(v, repoCache)
+		return fromFileMatch(v)
 	case *result.RepoMatch:
-		return fromRepository(v, repoCache)
+		return fromRepository(v)
 	case *result.CommitMatch:
-		return fromCommit(v, repoCache)
+		return fromCommit(v)
 	default:
 		panic(fmt.Sprintf("unknown match type %T", v))
 	}
 }
 
-func fromFileMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Repo) streamhttp.EventMatch {
+func fromFileMatch(fm *result.FileMatch) streamhttp.EventMatch {
 	if syms := fm.Symbols; len(syms) > 0 {
 		return fromSymbolMatch(fm)
 	}
@@ -461,16 +409,10 @@ func fromFileMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Repo) s
 		branches = []string{*fm.InputRev}
 	}
 
-	var stars int
-	if r, ok := repoCache[fm.Repo.ID]; ok {
-		stars = r.Stars
-	}
-
 	return &streamhttp.EventFileMatch{
 		Type:        streamhttp.FileMatchType,
 		Path:        fm.Path,
 		Repository:  string(fm.Repo.Name),
-		RepoStars:   stars,
 		Branches:    branches,
 		Version:     string(fm.CommitID),
 		LineMatches: lineMatches,
@@ -509,29 +451,20 @@ func fromSymbolMatch(fm *result.FileMatch) *streamhttp.EventSymbolMatch {
 	}
 }
 
-func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Repo) *streamhttp.EventRepoMatch {
+func fromRepository(rm *result.RepoMatch) *streamhttp.EventRepoMatch {
 	var branches []string
 	if rev := rm.Rev; rev != "" {
 		branches = []string{rev}
 	}
 
-	repoEvent := &streamhttp.EventRepoMatch{
+	return &streamhttp.EventRepoMatch{
 		Type:       streamhttp.RepoMatchType,
 		Repository: string(rm.Name),
 		Branches:   branches,
 	}
-
-	if r, ok := repoCache[rm.ID]; ok {
-		repoEvent.RepoStars = r.Stars
-		repoEvent.Description = r.Description
-		repoEvent.Fork = r.Fork
-		repoEvent.Archived = r.Archived
-	}
-
-	return repoEvent
 }
 
-func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Repo) *streamhttp.EventCommitMatch {
+func fromCommit(commit *result.CommitMatch) *streamhttp.EventCommitMatch {
 	content := commit.Body.Value
 
 	highlights := commit.Body.Highlights
@@ -540,18 +473,12 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Repo
 		ranges[i] = [3]int32{h.Line, h.Character, h.Length}
 	}
 
-	var stars int
-	if r, ok := repoCache[commit.RepoName.ID]; ok {
-		stars = r.Stars
-	}
-
 	return &streamhttp.EventCommitMatch{
 		Type:       streamhttp.CommitMatchType,
 		Label:      commit.Label(),
 		URL:        commit.URL().String(),
 		Detail:     commit.Detail(),
 		Repository: string(commit.RepoName.Name),
-		RepoStars:  stars,
 		Content:    content,
 		Ranges:     ranges,
 	}

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	api2 "github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -23,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming/api"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -126,16 +124,6 @@ func TestDisplayLimit(t *testing.T) {
 		t.Run(fmt.Sprintf("q=%s;displayLimit=%d", c.queryString, c.displayLimit), func(t *testing.T) {
 			mock := &mockSearchResolver{
 				done: make(chan struct{}),
-			}
-
-			database.Mocks.Repos.GetByIDs = func(ctx context.Context, ids ...api2.RepoID) (_ []*types.Repo, err error) {
-				res := make([]*types.Repo, 0, len(ids))
-				for _, id := range ids {
-					res = append(res, &types.Repo{
-						ID: id,
-					})
-				}
-				return res, nil
 			}
 
 			ts := httptest.NewServer(&streamHandler{

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -19,7 +19,6 @@ type EventFileMatch struct {
 
 	Path       string   `json:"name"`
 	Repository string   `json:"repository"`
-	RepoStars  int      `json:"repoStars"`
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
@@ -40,12 +39,8 @@ type EventRepoMatch struct {
 	// Type is always RepoMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
-	Repository  string   `json:"repository"`
-	Branches    []string `json:"branches,omitempty"`
-	RepoStars   int      `json:"repoStars"`
-	Description string   `json:"description"`
-	Fork        bool     `json:"fork"`
-	Archived    bool     `json:"archived"`
+	Repository string   `json:"repository"`
+	Branches   []string `json:"branches,omitempty"`
 }
 
 func (e *EventRepoMatch) eventMatch() {}
@@ -57,7 +52,6 @@ type EventSymbolMatch struct {
 
 	Path       string   `json:"name"`
 	Repository string   `json:"repository"`
-	RepoStars  int      `json:"repoStars"`
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
@@ -85,7 +79,6 @@ type EventCommitMatch struct {
 	URL        string `json:"url"`
 	Detail     string `json:"detail"`
 	Repository string `json:"repository"`
-	RepoStars  int    `json:"repoStars"`
 	Content    string `json:"content"`
 	// [line, character, length]
 	Ranges [][3]int32 `json:"ranges"`


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#22032

This had a significantly different performance profile on sourcegraph.com than locally, and tracing revealed this to be quite inefficient. Reverting until we can work through some perf and design questions

cc @stefanhengl @tsenart 