### PR TITLE
ci: add sourcegraph/alpine to images built on each commit

### DIFF
--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -45,6 +45,7 @@ var SourcegraphDockerImages = []string{
 	"executor",
 
 	// Images under docker-images/
+	"alpine",
 	"cadvisor",
 	"indexed-searcher",
 	"postgres-11.4",


### PR DESCRIPTION
All of our other `docker-images/` are built on each commit. This makes sourcegraph/alpine's built process consistent with everything else.