### PR TITLE
docs: remove extension troubleshooting prereqs

### DIFF
--- a/doc/admin/how-to/troubleshoot-sg-extension.md
+++ b/doc/admin/how-to/troubleshoot-sg-extension.md
@@ -2,10 +2,6 @@
 
 This guide gives specific instructions for troubleshooting [extensions](https://docs.sourcegraph.com/extensions) developed by Sourcegraph.
 
-## Prerequisites
-
-* This document assumes that you already have the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension) installed
-
 ## FAQs
 
 #### How do I know if a Sourcegraph extension is running?


### PR DESCRIPTION
The new extension troubleshooting docs are great! We should remove the prerequisites section though since none of the issues mentioned on this page require the browser extension to be installed.