### PR TITLE
LSIF: protocol: new documentationResult identifier approach

### DIFF
--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -26,8 +26,9 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, d
         repoName: props.repo.name,
         revision: props.revision || '',
     }
-    const hash = node.pathID.slice(props.pagePathID.length + '/'.length).replace(/\//g, '-')
-    const thisPage = toDocumentationURL({ ...repoRevision, pathID: props.pagePathID }) + (hash ? '#' + hash : '')
+    const hashIndex = node.pathID.indexOf('#')
+    const hash = hashIndex ? node.pathID.slice(hashIndex + '#'.length) : ''
+    const thisPage = toDocumentationURL({ ...repoRevision, pathID: node.pathID })
 
     return (
         <div className="documentation-index-node">

--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -15,9 +15,21 @@ interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec {
 
     history: H.History
     location: H.Location
+
+    /** The documentation node to render */
     node: GQLDocumentationNode
+
+    /** How far deep we are in the tree of documentation nodes */
     depth: number
+
+    /** The pathID of the page containing this documentation node */
     pagePathID: string
+
+    /** If true, render subpage index only */
+    subpagesOnly: boolean
+
+    /** If true, render content index only */
+    contentOnly: boolean
 }
 
 export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, depth, ...props }) => {
@@ -27,33 +39,72 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, d
         revision: props.revision || '',
     }
     const hashIndex = node.pathID.indexOf('#')
-    const hash = hashIndex ? node.pathID.slice(hashIndex + '#'.length) : ''
-    const thisPage = toDocumentationURL({ ...repoRevision, pathID: node.pathID })
+    const hash = hashIndex !== -1 ? node.pathID.slice(hashIndex + '#'.length) : ''
+    const path = node.pathID.slice('/'.length, hashIndex)
+    const thisPage = toDocumentationURL({ ...repoRevision, pathID: path + '#' + hash })
+
+    if (props.subpagesOnly) {
+        return (
+            <div className="documentation-index-node">
+                <ul className="pl-3">
+                    {node.children?.map((child, index) =>
+                        child.pathID ? (
+                            <div key={`${depth}-${index}`} className="text-nowrap">
+                                <Link to={toDocumentationURL({ ...repoRevision, pathID: child.pathID })}>
+                                    {child.pathID.slice('/'.length) + '/'}
+                                </Link>
+                            </div>
+                        ) : null
+                    )}
+                </ul>
+            </div>
+        )
+    }
+    if (props.contentOnly) {
+        return (
+            <div className="documentation-index-node">
+                <Link id={'index-' + hash} to={thisPage} className="text-nowrap">
+                    {node.label.value}
+                </Link>
+                <ul className="pl-3">
+                    {node.children?.map((child, index) =>
+                        child.pathID ? null : (
+                            <DocumentationIndexNode
+                                key={`${depth}-${index}`}
+                                {...props}
+                                node={child.node!}
+                                depth={depth + 1}
+                                subpagesOnly={false}
+                                contentOnly={true}
+                            />
+                        )
+                    )}
+                </ul>
+            </div>
+        )
+    }
 
     return (
         <div className="documentation-index-node">
-            <Link id={'index-' + hash} to={thisPage} className="text-nowrap">
-                {node.label.value}
+            <Link id="index-subpages" to={thisPage} className="text-nowrap">
+                Subpages
             </Link>
-
-            <ul className="pl-3">
-                {node.children?.map((child, index) =>
-                    child.pathID ? (
-                        <li key={`${depth}-${index}`}>
-                            <Link to={toDocumentationURL({ ...repoRevision, pathID: child.pathID })}>
-                                {child.pathID}
-                            </Link>
-                        </li>
-                    ) : (
-                        <DocumentationIndexNode
-                            key={`${depth}-${index}`}
-                            {...props}
-                            node={child.node!}
-                            depth={depth + 1}
-                        />
-                    )
-                )}
-            </ul>
+            <DocumentationIndexNode
+                key={`${depth}-subpages`}
+                {...props}
+                node={node}
+                depth={depth + 1}
+                subpagesOnly={true}
+                contentOnly={false}
+            />
+            <DocumentationIndexNode
+                key={`${depth}-content`}
+                {...props}
+                node={node}
+                depth={depth + 1}
+                subpagesOnly={false}
+                contentOnly={true}
+            />
         </div>
     )
 }

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -60,8 +60,10 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
         revision: props.revision || '',
     }
     const hashIndex = node.pathID.indexOf('#')
-    const hash = hashIndex ? node.pathID.slice(hashIndex + '#'.length) : ''
-    const thisPage = toDocumentationURL({ ...repoRevision, pathID: node.pathID })
+    const hash = hashIndex !== -1 ? node.pathID.slice(hashIndex + '#'.length) : ''
+    const path = node.pathID.slice('/'.length, hashIndex)
+    const thisPage = toDocumentationURL({ ...repoRevision, pathID: path + '#' + hash })
+
     useBreadcrumb(
         useMemo(
             () =>

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -59,8 +59,9 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
         repoName: props.repo.name,
         revision: props.revision || '',
     }
-    const hash = node.pathID.slice(props.pagePathID.length + '/'.length).replace(/\//g, '-')
-    const thisPage = toDocumentationURL({ ...repoRevision, pathID: props.pagePathID }) + (hash ? '#' + hash : '')
+    const hashIndex = node.pathID.indexOf('#')
+    const hash = hashIndex ? node.pathID.slice(hashIndex + '#'.length) : ''
+    const thisPage = toDocumentationURL({ ...repoRevision, pathID: node.pathID })
     useBreadcrumb(
         useMemo(
             () =>

--- a/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
@@ -80,7 +80,14 @@ export const RepositoryDocumentationSidebar: React.FunctionComponent<Props> = ({
                         </Button>
                     </div>
                     <div aria-hidden={true} className="d-flex explorer overflow-auto px-3">
-                        <DocumentationIndexNode {...props} node={props.node} pagePathID={props.pagePathID} depth={0} />
+                        <DocumentationIndexNode
+                            {...props}
+                            node={props.node}
+                            pagePathID={props.pagePathID}
+                            depth={0}
+                            subpagesOnly={false}
+                            contentOnly={false}
+                        />
                     </div>
                 </div>
             }

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -143,6 +143,7 @@ type QueueAutoIndexJobArgs struct {
 type GitTreeLSIFDataResolver interface {
 	Diagnostics(ctx context.Context, args *LSIFDiagnosticsArgs) (DiagnosticConnectionResolver, error)
 	DocumentationPage(ctx context.Context, args *LSIFDocumentationPageArgs) (DocumentationPageResolver, error)
+	DocumentationPathInfo(ctx context.Context, args *LSIFDocumentationPathInfoArgs) (JSONValue, error)
 }
 
 type CodeIntelligenceCommitGraphResolver interface {

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -231,6 +231,33 @@ interface TreeEntryLSIFData {
     may choose to create new pages if an API surface exceeds some threshold size.
     """
     documentationPage(pathID: String!): DocumentationPage!
+
+    """
+    Returns the documentation pth info corresponding to the given path ID, where the empty string "/"
+    refers to the current tree entry and can be used to walk all documentation below this tree entry.
+
+    Currently this method is only supported on the root tree entry of a repository.
+
+    See @documentationPage for information about what a pathID refers to.
+
+    This method is optimal for e.g. walking the entire documentation path structure of a repository,
+    whereas documentationPage would require you to fetch the content for all pages you walk (not true
+    of path info.)
+
+    If maxDepth is specified, pages will be recursively returned up to that depth. Default max depth
+    is one (immediate child pages only.)
+
+    If ignoreIndex is true, empty index pages (pages whose only purpose is to describe pages below
+    them) will not qualify as a page in relation to the maxDepth property: index pages will be
+    recursively followed and included until a page with actual content is found, and only then will
+    the depth be considered to increment. Default is false.
+
+    This returns a JSON value because GraphQL has terrible support for recursive data structures: https://github.com/graphql/graphql-spec/issues/91
+
+    The exact structure of the return value is documented here:
+    https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+type+DocumentationPathInfoResult+struct&patternType=literal&case=yes
+    """
+    documentationPathInfo(pathID: String!, maxDepth: Int, ignoreIndex: Boolean): JSONValue!
 }
 
 """
@@ -334,6 +361,33 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
     may choose to create new pages if an API surface exceeds some threshold size.
     """
     documentationPage(pathID: String!): DocumentationPage!
+
+    """
+    Returns the documentation pth info corresponding to the given path ID, where the empty string "/"
+    refers to the current tree entry and can be used to walk all documentation below this tree entry.
+
+    Currently this method is only supported on the root tree entry of a repository.
+
+    See @documentationPage for information about what a pathID refers to.
+
+    This method is optimal for e.g. walking the entire documentation path structure of a repository,
+    whereas documentationPage would require you to fetch the content for all pages you walk (not true
+    of path info.)
+
+    If maxDepth is specified, pages will be recursively returned up to that depth. Default max depth
+    is one (immediate child pages only.)
+
+    If ignoreIndex is true, empty index pages (pages whose only purpose is to describe pages below
+    them) will not qualify as a page in relation to the maxDepth property: index pages will be
+    recursively followed and included until a page with actual content is found, and only then will
+    the depth be considered to increment. Default is false.
+
+    This returns a JSON value because GraphQL has terrible support for recursive data structures: https://github.com/graphql/graphql-spec/issues/91
+
+    The exact structure of the return value is documented here:
+    https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+type+DocumentationPathInfoResult+struct&patternType=literal&case=yes
+    """
+    documentationPathInfo(pathID: String!, maxDepth: Int, ignoreIndex: Boolean): JSONValue!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel_documentation.go
+++ b/cmd/frontend/graphqlbackend/codeintel_documentation.go
@@ -7,3 +7,9 @@ type LSIFDocumentationPageArgs struct {
 type DocumentationPageResolver interface {
 	Tree() JSONValue
 }
+
+type LSIFDocumentationPathInfoArgs struct {
+	PathID      string
+	MaxDepth    *int32
+	IgnoreIndex *bool
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"encoding/json"
+	"math"
 
 	"github.com/cockroachdb/errors"
 
@@ -30,4 +31,75 @@ type DocumentationPageResolver struct {
 
 func (r *DocumentationPageResolver) Tree() gql.JSONValue {
 	return r.tree
+}
+
+func (r *QueryResolver) DocumentationPathInfo(ctx context.Context, args *gql.LSIFDocumentationPathInfoArgs) (gql.JSONValue, error) {
+	var maxDepth int = 1
+	if args.MaxDepth != nil {
+		maxDepth = int(*args.MaxDepth)
+		if maxDepth < 0 {
+			maxDepth = int(math.MaxInt32)
+		}
+	}
+	ignoreIndex := false
+	if args.IgnoreIndex != nil {
+		ignoreIndex = *args.IgnoreIndex
+	}
+
+	var get func(pathID string, depth int) (*DocumentationPathInfoResult, error)
+	get = func(pathID string, depth int) (*DocumentationPathInfoResult, error) {
+		pathInfo, err := r.resolver.DocumentationPathInfo(ctx, pathID)
+		if err != nil {
+			return nil, err
+		}
+		if pathInfo == nil {
+			return nil, nil
+		}
+		var children []DocumentationPathInfoResult
+		if depth < maxDepth {
+			if !ignoreIndex || ignoreIndex && !pathInfo.IsIndex {
+				depth++
+			}
+			for _, childPathID := range pathInfo.Children {
+				child, err := get(childPathID, depth)
+				if err != nil {
+					return nil, err
+				}
+				children = append(children, *child)
+			}
+		}
+		return &DocumentationPathInfoResult{
+			PathID:   pathInfo.PathID,
+			IsIndex:  pathInfo.IsIndex,
+			Children: children,
+		}, nil
+	}
+
+	result, err := get(args.PathID, 0)
+	if err != nil {
+		return gql.JSONValue{}, err
+	}
+	if result == nil {
+		return gql.JSONValue{}, errors.New("page not found")
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return gql.JSONValue{}, err
+	}
+	return gql.JSONValue{Value: string(data)}, nil
+}
+
+// DocumentationPathInfoResult describes a single documentation page path, what is located there
+// and what pages are below it.
+type DocumentationPathInfoResult struct {
+	// The pathID for this page/entry.
+	PathID string `json:"pathID"`
+
+	// IsIndex tells if the page at this path is an empty index page whose only purpose is to describe
+	// all the pages below it.
+	IsIndex bool `json:"isIndex"`
+
+	// Children is a list of the children page paths immediately below this one.
+	Children []DocumentationPathInfoResult `json:"children,omitempty"`
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -53,6 +53,7 @@ type LSIFStore interface {
 	BulkMonikerResults(ctx context.Context, tableName string, ids []int, args []semantic.MonikerData, limit, offset int) (_ []lsifstore.Location, _ int, err error)
 	PackageInformation(ctx context.Context, bundleID int, path string, packageInformationID string) (semantic.PackageInformationData, bool, error)
 	DocumentationPage(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPageData, error)
+	DocumentationPathInfo(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPathInfoData, error)
 }
 
 type IndexEnqueuer interface {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4724,6 +4724,9 @@ type MockLSIFStore struct {
 	// DocumentationPageFunc is an instance of a mock function object
 	// controlling the behavior of the method DocumentationPage.
 	DocumentationPageFunc *LSIFStoreDocumentationPageFunc
+	// DocumentationPathInfoFunc is an instance of a mock function object
+	// controlling the behavior of the method DocumentationPathInfo.
+	DocumentationPathInfoFunc *LSIFStoreDocumentationPathInfoFunc
 	// ExistsFunc is an instance of a mock function object controlling the
 	// behavior of the method Exists.
 	ExistsFunc *LSIFStoreExistsFunc
@@ -4765,6 +4768,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 		},
 		DocumentationPageFunc: &LSIFStoreDocumentationPageFunc{
 			defaultHook: func(context.Context, int, string) (*semantic.DocumentationPageData, error) {
+				return nil, nil
+			},
+		},
+		DocumentationPathInfoFunc: &LSIFStoreDocumentationPathInfoFunc{
+			defaultHook: func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error) {
 				return nil, nil
 			},
 		},
@@ -4816,6 +4824,9 @@ func NewMockLSIFStoreFrom(i LSIFStore) *MockLSIFStore {
 		},
 		DocumentationPageFunc: &LSIFStoreDocumentationPageFunc{
 			defaultHook: i.DocumentationPage,
+		},
+		DocumentationPathInfoFunc: &LSIFStoreDocumentationPathInfoFunc{
+			defaultHook: i.DocumentationPathInfo,
 		},
 		ExistsFunc: &LSIFStoreExistsFunc{
 			defaultHook: i.Exists,
@@ -5320,6 +5331,120 @@ func (c LSIFStoreDocumentationPageFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LSIFStoreDocumentationPageFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LSIFStoreDocumentationPathInfoFunc describes the behavior when the
+// DocumentationPathInfo method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreDocumentationPathInfoFunc struct {
+	defaultHook func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error)
+	hooks       []func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error)
+	history     []LSIFStoreDocumentationPathInfoFuncCall
+	mutex       sync.Mutex
+}
+
+// DocumentationPathInfo delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) DocumentationPathInfo(v0 context.Context, v1 int, v2 string) (*semantic.DocumentationPathInfoData, error) {
+	r0, r1 := m.DocumentationPathInfoFunc.nextHook()(v0, v1, v2)
+	m.DocumentationPathInfoFunc.appendCall(LSIFStoreDocumentationPathInfoFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// DocumentationPathInfo method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreDocumentationPathInfoFunc) SetDefaultHook(hook func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DocumentationPathInfo method of the parent MockLSIFStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LSIFStoreDocumentationPathInfoFunc) PushHook(hook func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *LSIFStoreDocumentationPathInfoFunc) SetDefaultReturn(r0 *semantic.DocumentationPathInfoData, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *LSIFStoreDocumentationPathInfoFunc) PushReturn(r0 *semantic.DocumentationPathInfoData, r1 error) {
+	f.PushHook(func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error) {
+		return r0, r1
+	})
+}
+
+func (f *LSIFStoreDocumentationPathInfoFunc) nextHook() func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreDocumentationPathInfoFunc) appendCall(r0 LSIFStoreDocumentationPathInfoFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreDocumentationPathInfoFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreDocumentationPathInfoFunc) History() []LSIFStoreDocumentationPathInfoFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreDocumentationPathInfoFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreDocumentationPathInfoFuncCall is an object that describes an
+// invocation of method DocumentationPathInfo on an instance of
+// MockLSIFStore.
+type LSIFStoreDocumentationPathInfoFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *semantic.DocumentationPathInfoData
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreDocumentationPathInfoFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreDocumentationPathInfoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
@@ -25,6 +25,9 @@ type MockQueryResolver struct {
 	// DocumentationPageFunc is an instance of a mock function object
 	// controlling the behavior of the method DocumentationPage.
 	DocumentationPageFunc *QueryResolverDocumentationPageFunc
+	// DocumentationPathInfoFunc is an instance of a mock function object
+	// controlling the behavior of the method DocumentationPathInfo.
+	DocumentationPathInfoFunc *QueryResolverDocumentationPathInfoFunc
 	// HoverFunc is an instance of a mock function object controlling the
 	// behavior of the method Hover.
 	HoverFunc *QueryResolverHoverFunc
@@ -52,6 +55,11 @@ func NewMockQueryResolver() *MockQueryResolver {
 		},
 		DocumentationPageFunc: &QueryResolverDocumentationPageFunc{
 			defaultHook: func(context.Context, string) (*semantic.DocumentationPageData, error) {
+				return nil, nil
+			},
+		},
+		DocumentationPathInfoFunc: &QueryResolverDocumentationPathInfoFunc{
+			defaultHook: func(context.Context, string) (*semantic.DocumentationPathInfoData, error) {
 				return nil, nil
 			},
 		},
@@ -86,6 +94,9 @@ func NewMockQueryResolverFrom(i resolvers.QueryResolver) *MockQueryResolver {
 		},
 		DocumentationPageFunc: &QueryResolverDocumentationPageFunc{
 			defaultHook: i.DocumentationPage,
+		},
+		DocumentationPathInfoFunc: &QueryResolverDocumentationPathInfoFunc{
+			defaultHook: i.DocumentationPathInfo,
 		},
 		HoverFunc: &QueryResolverHoverFunc{
 			defaultHook: i.Hover,
@@ -431,6 +442,118 @@ func (c QueryResolverDocumentationPageFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c QueryResolverDocumentationPageFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// QueryResolverDocumentationPathInfoFunc describes the behavior when the
+// DocumentationPathInfo method of the parent MockQueryResolver instance is
+// invoked.
+type QueryResolverDocumentationPathInfoFunc struct {
+	defaultHook func(context.Context, string) (*semantic.DocumentationPathInfoData, error)
+	hooks       []func(context.Context, string) (*semantic.DocumentationPathInfoData, error)
+	history     []QueryResolverDocumentationPathInfoFuncCall
+	mutex       sync.Mutex
+}
+
+// DocumentationPathInfo delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockQueryResolver) DocumentationPathInfo(v0 context.Context, v1 string) (*semantic.DocumentationPathInfoData, error) {
+	r0, r1 := m.DocumentationPathInfoFunc.nextHook()(v0, v1)
+	m.DocumentationPathInfoFunc.appendCall(QueryResolverDocumentationPathInfoFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// DocumentationPathInfo method of the parent MockQueryResolver instance is
+// invoked and the hook queue is empty.
+func (f *QueryResolverDocumentationPathInfoFunc) SetDefaultHook(hook func(context.Context, string) (*semantic.DocumentationPathInfoData, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DocumentationPathInfo method of the parent MockQueryResolver instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *QueryResolverDocumentationPathInfoFunc) PushHook(hook func(context.Context, string) (*semantic.DocumentationPathInfoData, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *QueryResolverDocumentationPathInfoFunc) SetDefaultReturn(r0 *semantic.DocumentationPathInfoData, r1 error) {
+	f.SetDefaultHook(func(context.Context, string) (*semantic.DocumentationPathInfoData, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *QueryResolverDocumentationPathInfoFunc) PushReturn(r0 *semantic.DocumentationPathInfoData, r1 error) {
+	f.PushHook(func(context.Context, string) (*semantic.DocumentationPathInfoData, error) {
+		return r0, r1
+	})
+}
+
+func (f *QueryResolverDocumentationPathInfoFunc) nextHook() func(context.Context, string) (*semantic.DocumentationPathInfoData, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *QueryResolverDocumentationPathInfoFunc) appendCall(r0 QueryResolverDocumentationPathInfoFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of QueryResolverDocumentationPathInfoFuncCall
+// objects describing the invocations of this function.
+func (f *QueryResolverDocumentationPathInfoFunc) History() []QueryResolverDocumentationPathInfoFuncCall {
+	f.mutex.Lock()
+	history := make([]QueryResolverDocumentationPathInfoFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// QueryResolverDocumentationPathInfoFuncCall is an object that describes an
+// invocation of method DocumentationPathInfo on an instance of
+// MockQueryResolver.
+type QueryResolverDocumentationPathInfoFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *semantic.DocumentationPathInfoData
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c QueryResolverDocumentationPathInfoFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c QueryResolverDocumentationPathInfoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -15,13 +15,14 @@ import (
 )
 
 type operations struct {
-	queryResolver     *observation.Operation
-	definitions       *observation.Operation
-	diagnostics       *observation.Operation
-	hover             *observation.Operation
-	ranges            *observation.Operation
-	references        *observation.Operation
-	documentationPage *observation.Operation
+	queryResolver         *observation.Operation
+	definitions           *observation.Operation
+	diagnostics           *observation.Operation
+	hover                 *observation.Operation
+	ranges                *observation.Operation
+	references            *observation.Operation
+	documentationPage     *observation.Operation
+	documentationPathInfo *observation.Operation
 
 	findClosestDumps *observation.Operation
 }
@@ -52,13 +53,14 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		queryResolver:     op("QueryResolver"),
-		definitions:       op("Definitions"),
-		diagnostics:       op("Diagnostics"),
-		hover:             op("Hover"),
-		ranges:            op("Ranges"),
-		references:        op("References"),
-		documentationPage: op("DocumentationPage"),
+		queryResolver:         op("QueryResolver"),
+		definitions:           op("Definitions"),
+		diagnostics:           op("Diagnostics"),
+		hover:                 op("Hover"),
+		ranges:                op("Ranges"),
+		references:            op("References"),
+		documentationPage:     op("DocumentationPage"),
+		documentationPathInfo: op("DocumentationPathInfo"),
 
 		findClosestDumps: subOp("findClosestDumps"),
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -47,6 +47,7 @@ type QueryResolver interface {
 	Hover(ctx context.Context, line, character int) (string, lsifstore.Range, bool, error)
 	Diagnostics(ctx context.Context, limit int) ([]AdjustedDiagnostic, int, error)
 	DocumentationPage(ctx context.Context, pathID string) (*semantic.DocumentationPageData, error)
+	DocumentationPathInfo(ctx context.Context, pathID string) (*semantic.DocumentationPathInfoData, error)
 }
 
 type queryResolver struct {

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -268,6 +268,9 @@ func writeData(ctx context.Context, lsifStore LSIFStore, id int, groupedBundleDa
 	if err := tx.WriteDocumentationPages(ctx, id, groupedBundleData.DocumentationPages); err != nil {
 		return errors.Wrap(err, "store.WriteDocumentationPages")
 	}
+	if err := tx.WriteDocumentationPathInfo(ctx, id, groupedBundleData.DocumentationPathInfo); err != nil {
+		return errors.Wrap(err, "store.WriteDocumentationPathInfo")
+	}
 
 	return nil
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/iface.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/iface.go
@@ -55,6 +55,7 @@ type LSIFStore interface {
 	WriteDefinitions(ctx context.Context, bundleID int, monikerLocations chan semantic.MonikerLocations) error
 	WriteReferences(ctx context.Context, bundleID int, monikerLocations chan semantic.MonikerLocations) error
 	WriteDocumentationPages(ctx context.Context, bundleID int, documentation chan *semantic.DocumentationPageData) error
+	WriteDocumentationPathInfo(ctx context.Context, bundleID int, documentation chan *semantic.DocumentationPathInfoData) error
 }
 
 type LSIFStoreShim struct {

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
@@ -1753,6 +1753,10 @@ type MockLSIFStore struct {
 	// WriteDocumentationPagesFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteDocumentationPages.
 	WriteDocumentationPagesFunc *LSIFStoreWriteDocumentationPagesFunc
+	// WriteDocumentationPathInfoFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// WriteDocumentationPathInfo.
+	WriteDocumentationPathInfoFunc *LSIFStoreWriteDocumentationPathInfoFunc
 	// WriteDocumentsFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteDocuments.
 	WriteDocumentsFunc *LSIFStoreWriteDocumentsFunc
@@ -1788,6 +1792,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 		},
 		WriteDocumentationPagesFunc: &LSIFStoreWriteDocumentationPagesFunc{
 			defaultHook: func(context.Context, int, chan *semantic.DocumentationPageData) error {
+				return nil
+			},
+		},
+		WriteDocumentationPathInfoFunc: &LSIFStoreWriteDocumentationPathInfoFunc{
+			defaultHook: func(context.Context, int, chan *semantic.DocumentationPathInfoData) error {
 				return nil
 			},
 		},
@@ -1829,6 +1838,9 @@ func NewMockLSIFStoreFrom(i LSIFStore) *MockLSIFStore {
 		},
 		WriteDocumentationPagesFunc: &LSIFStoreWriteDocumentationPagesFunc{
 			defaultHook: i.WriteDocumentationPages,
+		},
+		WriteDocumentationPathInfoFunc: &LSIFStoreWriteDocumentationPathInfoFunc{
+			defaultHook: i.WriteDocumentationPathInfo,
 		},
 		WriteDocumentsFunc: &LSIFStoreWriteDocumentsFunc{
 			defaultHook: i.WriteDocuments,
@@ -2270,6 +2282,118 @@ func (c LSIFStoreWriteDocumentationPagesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LSIFStoreWriteDocumentationPagesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// LSIFStoreWriteDocumentationPathInfoFunc describes the behavior when the
+// WriteDocumentationPathInfo method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreWriteDocumentationPathInfoFunc struct {
+	defaultHook func(context.Context, int, chan *semantic.DocumentationPathInfoData) error
+	hooks       []func(context.Context, int, chan *semantic.DocumentationPathInfoData) error
+	history     []LSIFStoreWriteDocumentationPathInfoFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteDocumentationPathInfo delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) WriteDocumentationPathInfo(v0 context.Context, v1 int, v2 chan *semantic.DocumentationPathInfoData) error {
+	r0 := m.WriteDocumentationPathInfoFunc.nextHook()(v0, v1, v2)
+	m.WriteDocumentationPathInfoFunc.appendCall(LSIFStoreWriteDocumentationPathInfoFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// WriteDocumentationPathInfo method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreWriteDocumentationPathInfoFunc) SetDefaultHook(hook func(context.Context, int, chan *semantic.DocumentationPathInfoData) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteDocumentationPathInfo method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreWriteDocumentationPathInfoFunc) PushHook(hook func(context.Context, int, chan *semantic.DocumentationPathInfoData) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *LSIFStoreWriteDocumentationPathInfoFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, chan *semantic.DocumentationPathInfoData) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *LSIFStoreWriteDocumentationPathInfoFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, chan *semantic.DocumentationPathInfoData) error {
+		return r0
+	})
+}
+
+func (f *LSIFStoreWriteDocumentationPathInfoFunc) nextHook() func(context.Context, int, chan *semantic.DocumentationPathInfoData) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreWriteDocumentationPathInfoFunc) appendCall(r0 LSIFStoreWriteDocumentationPathInfoFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreWriteDocumentationPathInfoFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreWriteDocumentationPathInfoFunc) History() []LSIFStoreWriteDocumentationPathInfoFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreWriteDocumentationPathInfoFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreWriteDocumentationPathInfoFuncCall is an object that describes
+// an invocation of method WriteDocumentationPathInfo on an instance of
+// MockLSIFStore.
+type LSIFStoreWriteDocumentationPathInfoFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 chan *semantic.DocumentationPathInfoData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreWriteDocumentationPathInfoFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreWriteDocumentationPathInfoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -73,7 +73,7 @@ func (s *Store) scanFirstDocumentationPageData(rows *sql.Rows, queryErr error) (
 
 // DocumentationPathInfo returns info describing what is at the given pathID.
 func (s *Store) DocumentationPathInfo(ctx context.Context, bundleID int, pathID string) (_ *semantic.DocumentationPathInfoData, err error) {
-	ctx, _, endObservation := s.operations.documentationPage.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, _, endObservation := s.operations.documentationPathInfo.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("pathID", pathID),
 	}})

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -8,24 +8,26 @@ import (
 )
 
 type operations struct {
-	bulkMonikerResults      *observation.Operation
-	clear                   *observation.Operation
-	definitions             *observation.Operation
-	diagnostics             *observation.Operation
-	exists                  *observation.Operation
-	hover                   *observation.Operation
-	monikerResults          *observation.Operation
-	monikersByPosition      *observation.Operation
-	packageInformation      *observation.Operation
-	ranges                  *observation.Operation
-	references              *observation.Operation
-	documentationPage       *observation.Operation
-	writeDefinitions        *observation.Operation
-	writeDocuments          *observation.Operation
-	writeMeta               *observation.Operation
-	writeReferences         *observation.Operation
-	writeResultChunks       *observation.Operation
-	writeDocumentationPages *observation.Operation
+	bulkMonikerResults         *observation.Operation
+	clear                      *observation.Operation
+	definitions                *observation.Operation
+	diagnostics                *observation.Operation
+	exists                     *observation.Operation
+	hover                      *observation.Operation
+	monikerResults             *observation.Operation
+	monikersByPosition         *observation.Operation
+	packageInformation         *observation.Operation
+	ranges                     *observation.Operation
+	references                 *observation.Operation
+	documentationPage          *observation.Operation
+	documentationPathInfo      *observation.Operation
+	writeDefinitions           *observation.Operation
+	writeDocuments             *observation.Operation
+	writeMeta                  *observation.Operation
+	writeReferences            *observation.Operation
+	writeResultChunks          *observation.Operation
+	writeDocumentationPages    *observation.Operation
+	writeDocumentationPathInfo *observation.Operation
 
 	locations           *observation.Operation
 	locationsWithinFile *observation.Operation
@@ -57,24 +59,25 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		bulkMonikerResults:      op("BulkMonikerResults"),
-		clear:                   op("Clear"),
-		definitions:             op("Definitions"),
-		diagnostics:             op("Diagnostics"),
-		exists:                  op("Exists"),
-		hover:                   op("Hover"),
-		monikerResults:          op("MonikerResults"),
-		monikersByPosition:      op("MonikersByPosition"),
-		packageInformation:      op("PackageInformation"),
-		ranges:                  op("Ranges"),
-		references:              op("References"),
-		documentationPage:       op("DocumentationPage"),
-		writeDefinitions:        op("WriteDefinitions"),
-		writeDocuments:          op("WriteDocuments"),
-		writeMeta:               op("WriteMeta"),
-		writeReferences:         op("WriteReferences"),
-		writeResultChunks:       op("WriteResultChunks"),
-		writeDocumentationPages: op("WriteDocumentationPages"),
+		bulkMonikerResults:         op("BulkMonikerResults"),
+		clear:                      op("Clear"),
+		definitions:                op("Definitions"),
+		diagnostics:                op("Diagnostics"),
+		exists:                     op("Exists"),
+		hover:                      op("Hover"),
+		monikerResults:             op("MonikerResults"),
+		monikersByPosition:         op("MonikersByPosition"),
+		packageInformation:         op("PackageInformation"),
+		ranges:                     op("Ranges"),
+		references:                 op("References"),
+		documentationPage:          op("DocumentationPage"),
+		writeDefinitions:           op("WriteDefinitions"),
+		writeDocuments:             op("WriteDocuments"),
+		writeMeta:                  op("WriteMeta"),
+		writeReferences:            op("WriteReferences"),
+		writeResultChunks:          op("WriteResultChunks"),
+		writeDocumentationPages:    op("WriteDocumentationPages"),
+		writeDocumentationPathInfo: op("WriteDocumentationPathInfo"),
 
 		locations:           subOp("locations"),
 		locationsWithinFile: subOp("locationsWithinFile"),

--- a/enterprise/internal/codeintel/stores/lsifstore/serializer_documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/serializer_documentation.go
@@ -10,6 +10,7 @@ func init() {
 	gob.Register(&semantic.DocumentationPageData{})
 	gob.Register(&semantic.DocumentationNode{})
 	gob.Register(semantic.DocumentationNodeChild{})
+	gob.Register(&semantic.DocumentationPathInfoData{})
 }
 
 // MarshalDocumentationPageData transforms documentation page data into a string of bytes writable to disk.
@@ -21,4 +22,15 @@ func (s *Serializer) MarshalDocumentationPageData(documentationPage *semantic.Do
 func (s *Serializer) UnmarshalDocumentationPageData(data []byte) (documentationPage *semantic.DocumentationPageData, err error) {
 	err = s.decode(data, &documentationPage)
 	return documentationPage, err
+}
+
+// MarshalDocumentationPathInfoData transforms documentation path info data into a string of bytes writable to disk.
+func (s *Serializer) MarshalDocumentationPathInfoData(documentationPathInfo *semantic.DocumentationPathInfoData) ([]byte, error) {
+	return s.encode(&documentationPathInfo)
+}
+
+// UnmarshalDocumentationPathInfoData is the inverse of MarshalDocumentationPathInfoData.
+func (s *Serializer) UnmarshalDocumentationPathInfoData(data []byte) (documentationPathInfo *semantic.DocumentationPathInfoData, err error) {
+	err = s.decode(data, &documentationPathInfo)
+	return documentationPathInfo, err
 }

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -82,6 +82,26 @@ Associates documentation pathIDs to their documentation page hierarchy chunk.
 
 **path_id**: The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.
 
+# Table "public.lsif_data_documentation_path_info"
+```
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ dump_id | integer |           | not null | 
+ path_id | text    |           | not null | 
+ data    | bytea   |           |          | 
+Indexes:
+    "lsif_data_documentation_path_info_pkey" PRIMARY KEY, btree (dump_id, path_id)
+
+```
+
+Associates documentation page pathIDs to information about what is at that pathID, its immediate children, etc.
+
+**data**: A gob-encoded payload conforming to a `type DocumentationPathInoData struct` pointer (lib/codeintel/semantic/types.go)
+
+**dump_id**: The identifier of the associated dump in the lsif_uploads table (state=completed).
+
+**path_id**: The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.
+
 # Table "public.lsif_data_documents"
 ```
      Column      |  Type   | Collation | Nullable | Default 

--- a/lib/codeintel/lsif/conversion/correlate.go
+++ b/lib/codeintel/lsif/conversion/correlate.go
@@ -21,6 +21,8 @@ import (
 
 // Correlate reads LSIF data from the given reader and returns a correlation state object with
 // the same data canonicalized and pruned for storage.
+//
+// If getChildren == nil, no pruning of irrelevant data is performed.
 func Correlate(ctx context.Context, r io.Reader, root string, getChildren pathexistence.GetChildrenFunc) (*semantic.GroupedBundleDataChans, error) {
 	// Read raw upload stream and return a correlation state
 	state, err := correlateFromReader(ctx, r, root)
@@ -31,9 +33,11 @@ func Correlate(ctx context.Context, r io.Reader, root string, getChildren pathex
 	// Remove duplicate elements, collapse linked elements
 	canonicalize(state)
 
-	// Remove elements we don't need to store
-	if err := prune(ctx, state, root, getChildren); err != nil {
-		return nil, err
+	if getChildren != nil {
+		// Remove elements we don't need to store
+		if err := prune(ctx, state, root, getChildren); err != nil {
+			return nil, err
+		}
 	}
 
 	// Convert data to the format we send to the writer

--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -32,7 +32,7 @@ func groupBundleData(ctx context.Context, state *State) (*semantic.GroupedBundle
 	resultChunks := serializeResultChunks(ctx, state, numResultChunks)
 	definitionRows := gatherMonikersLocations(ctx, state, state.DefinitionData, func(r Range) int { return r.DefinitionResultID })
 	referenceRows := gatherMonikersLocations(ctx, state, state.ReferenceData, func(r Range) int { return r.ReferenceResultID })
-	documentationPagesRows := collectDocumentationPages(ctx, state)
+	documentationPagesRows, documentationPathInfoRows := collectDocumentationPages(ctx, state)
 	packages := gatherPackages(state)
 	packageReferences, err := gatherPackageReferences(state, packages)
 	if err != nil {
@@ -40,14 +40,15 @@ func groupBundleData(ctx context.Context, state *State) (*semantic.GroupedBundle
 	}
 
 	return &semantic.GroupedBundleDataChans{
-		Meta:               meta,
-		Documents:          documents,
-		ResultChunks:       resultChunks,
-		Definitions:        definitionRows,
-		References:         referenceRows,
-		DocumentationPages: documentationPagesRows,
-		Packages:           packages,
-		PackageReferences:  packageReferences,
+		Meta:                  meta,
+		Documents:             documents,
+		ResultChunks:          resultChunks,
+		Definitions:           definitionRows,
+		References:            referenceRows,
+		DocumentationPages:    documentationPagesRows,
+		DocumentationPathInfo: documentationPathInfoRows,
+		Packages:              packages,
+		PackageReferences:     packageReferences,
 	}, nil
 }
 
@@ -248,7 +249,6 @@ func (s sortableDocumentIDRangeIDs) Less(i, j int) bool {
 
 	if cmp := iRange.Start.Line - jRange.Start.Line; cmp != 0 {
 		return cmp < 0
-
 	}
 
 	return iRange.Start.Character-jRange.Start.Character < 0

--- a/lib/codeintel/lsif/conversion/group_documentation.go
+++ b/lib/codeintel/lsif/conversion/group_documentation.go
@@ -102,7 +102,6 @@ type pageCollector struct {
 }
 
 func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.DocumentationPageData) (remainingPages []*pageCollector) {
-	var remainingPagesMu sync.RWMutex
 	var walk func(parent *semantic.DocumentationNode, documentationResult int, pathID string)
 	walk = func(parent *semantic.DocumentationNode, documentationResult int, pathID string) {
 		labelID := p.state.DocumentationStringLabel[documentationResult]
@@ -137,7 +136,6 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 					PathID: this.PathID,
 				})
 				if p.walkedPages.add(this.PathID) {
-					remainingPagesMu.Lock()
 					remainingPages = append(remainingPages, &pageCollector{
 						isChildPage:                 true,
 						parentPathID:                parent.PathID,
@@ -146,7 +144,6 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 						dupChecker:                  p.dupChecker,
 						walkedPages:                 p.walkedPages,
 					})
-					remainingPagesMu.Unlock()
 				}
 				return
 			} else {
@@ -172,28 +169,28 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 	}
 	walk(nil, p.startingDocumentationResult, p.parentPathID)
 	if p.isChildPage {
-		remainingPagesMu.RLock()
-		defer remainingPagesMu.RUnlock()
 		return remainingPages
 	}
 
 	// We are the root project page! Collect all the remaining pages.
+	var (
+		remainingWorkMu sync.RWMutex
+		remainingWork   = remainingPages
+	)
 	wg := &sync.WaitGroup{}
-	remainingPagesMu.RLock()
-	wg.Add(len(remainingPages))
-	remainingPagesMu.RUnlock()
+	wg.Add(len(remainingWork))
 	for i := 0; i <= p.numWorkers; i++ {
 		go func() {
 			for {
 				// Get a remaining page to process.
-				remainingPagesMu.Lock()
-				if len(remainingPages) == 0 { // HERE
-					remainingPagesMu.Unlock()
+				remainingWorkMu.Lock()
+				if len(remainingWork) == 0 {
+					remainingWorkMu.Unlock()
 					return // no more work
 				}
-				work := remainingPages[0]
-				remainingPages = remainingPages[1:]
-				remainingPagesMu.Unlock()
+				work := remainingWork[0]
+				remainingWork = remainingWork[1:]
+				remainingWorkMu.Unlock()
 
 				// Perform work.
 				newRemainingPages := work.collect(ctx, ch)
@@ -201,9 +198,9 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 				// Add new work, if needed.
 				if len(newRemainingPages) > 0 {
 					wg.Add(len(newRemainingPages))
-					remainingPagesMu.Lock()
-					remainingPages = append(remainingPages, newRemainingPages...)
-					remainingPagesMu.Unlock()
+					remainingWorkMu.Lock()
+					remainingWork = append(remainingWork, newRemainingPages...)
+					remainingWorkMu.Unlock()
 				}
 				wg.Done()
 			}

--- a/lib/codeintel/lsif/conversion/group_documentation.go
+++ b/lib/codeintel/lsif/conversion/group_documentation.go
@@ -115,8 +115,8 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 						dupChecker:                  p.dupChecker,
 						walkedPages:                 p.walkedPages,
 					})
-					return
 				}
+				return
 			} else {
 				parent.Children = append(parent.Children, semantic.DocumentationNodeChild{
 					Node: this,

--- a/lib/codeintel/lsif/conversion/group_documentation.go
+++ b/lib/codeintel/lsif/conversion/group_documentation.go
@@ -101,6 +101,7 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 					parentPathID:                parent.PathID,
 					state:                       p.state,
 					startingDocumentationResult: documentationResult,
+					dupChecker:                  p.dupChecker,
 				})
 			} else {
 				parent.Children = append(parent.Children, semantic.DocumentationNodeChild{

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -226,6 +226,9 @@ const (
 	// The documentation describes e.g. a test function or concept related to testing.
 	TagTest Tag = "test"
 
+	// The documentation describes e.g. a benchmark function or concept related to benchmarking.
+	TagBenchmark Tag = "benchmark"
+
 	// The documentation describes e.g. an example function or example code.
 	TagExample Tag = "example"
 

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -117,10 +117,10 @@ func NewDocumentationResult(id uint64, result Documentation) DocumentationResult
 // properly, and just chose to emit none specifically.
 //
 // If this documentationResult is for the project root, the identifier and searchKey should be an
-// empty string. Similarly, if there is no project root documentation (e.g. it would just be an
-// index page for documentation below the project root), an empty label and detail string should be
-// attached.
+// empty string.
 //
+// If a pages' only purpose is to connect other pages below it (i.e. it is an index page), it
+// should have empty label and detail strings attached.
 type Documentation struct {
 	// A human readable identifier for this documentationResult, uniquely identifying it within the
 	// scope of the parent page (or an empty string, if this is the root documentationResult.)
@@ -216,11 +216,9 @@ type Documentation struct {
 type DocumentationTag string
 
 const (
-	// The documentation describes a concept that is exported externally.
-	DocumentationExported DocumentationTag = "exported"
-
-	// The documentation describes a concept that is unexported / internal.
-	DocumentationUnexported DocumentationTag = "unexported"
+	// The documentation describes a concept that is private/unexported, not a public/exported
+	// concept.
+	DocumentationPrivate DocumentationTag = "private"
 
 	// The documentation describes a concept that is deprecated.
 	DocumentationDeprecated DocumentationTag = "deprecated"

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -210,18 +210,62 @@ type Documentation struct {
 	SearchKey string `json:"searchKey"`
 
 	// Tags about the type of content this documentation contains.
-	Tags []DocumentationTag `json:"tags"`
+	Tags []Tag `json:"tags"`
 }
 
-type DocumentationTag string
+type Tag string
 
 const (
 	// The documentation describes a concept that is private/unexported, not a public/exported
 	// concept.
-	DocumentationPrivate DocumentationTag = "private"
+	TagPrivate Tag = "private"
 
 	// The documentation describes a concept that is deprecated.
-	DocumentationDeprecated DocumentationTag = "deprecated"
+	TagDeprecated Tag = "deprecated"
+
+	// The documentation describes e.g. a test function or concept related to testing.
+	TagTest Tag = "test"
+
+	// The documentation describes e.g. an example function or example code.
+	TagExample Tag = "example"
+
+	// The documentation describes license information.
+	TagLicense Tag = "license"
+
+	// The documentation describes owner information.
+	TagOwner Tag = "owner"
+
+	// The documentation describes package/library registry information, e.g. where a package is
+	// available for download.
+	TagRegistryInfo Tag = "owner"
+
+	// Tags derived from SymbolKind
+	TagFile          Tag = "file"
+	TagModule        Tag = "module"
+	TagNamespace     Tag = "namespace"
+	TagPackage       Tag = "package"
+	TagClass         Tag = "class"
+	TagMethod        Tag = "method"
+	TagProperty      Tag = "property"
+	TagField         Tag = "field"
+	TagConstructor   Tag = "constructor"
+	TagEnum          Tag = "enum"
+	TagInterface     Tag = "interface"
+	TagFunction      Tag = "function"
+	TagVariable      Tag = "variable"
+	TagConstant      Tag = "constant"
+	TagString        Tag = "string"
+	TagNumber        Tag = "number"
+	TagBoolean       Tag = "boolean"
+	TagArray         Tag = "array"
+	TagObject        Tag = "object"
+	TagKey           Tag = "key"
+	TagNull          Tag = "null"
+	TagEnumNumber    Tag = "enumNumber"
+	TagStruct        Tag = "struct"
+	TagEvent         Tag = "event"
+	TagOperator      Tag = "operator"
+	TagTypeParameter Tag = "typeParameter"
 )
 
 // A "documentationString" edge connects a "documentationResult" vertex to its label or detail

--- a/lib/codeintel/semantic/types.go
+++ b/lib/codeintel/semantic/types.go
@@ -157,6 +157,20 @@ type DocumentationPageData struct {
 	Tree *DocumentationNode
 }
 
+// DocumentationPathInfoData describes a single documentation path, what is located there and what
+// pages are below it.
+type DocumentationPathInfoData struct {
+	// The pathID for this entry.
+	PathID string `json:"pathID"`
+
+	// IsIndex tells if the page at this path is an empty index page whose only purpose is to describe
+	// all the pages below it.
+	IsIndex bool `json:"isIndex"`
+
+	// Children is a list of the children page paths immediately below this one.
+	Children []string `json:"children,omitempty"`
+}
+
 // Package pairs a package name and the dump that provides it.
 type Package struct {
 	Scheme  string
@@ -176,14 +190,15 @@ type PackageReference struct {
 // and parallelizing the work, while the Maps version can be modified for e.g. local development
 // via the REPL or patching for incremental indexing.
 type GroupedBundleDataChans struct {
-	Meta               MetaData
-	Documents          chan KeyedDocumentData
-	ResultChunks       chan IndexedResultChunkData
-	Definitions        chan MonikerLocations
-	References         chan MonikerLocations
-	Packages           []Package
-	PackageReferences  []PackageReference
-	DocumentationPages chan *DocumentationPageData
+	Meta                  MetaData
+	Documents             chan KeyedDocumentData
+	ResultChunks          chan IndexedResultChunkData
+	Definitions           chan MonikerLocations
+	References            chan MonikerLocations
+	Packages              []Package
+	PackageReferences     []PackageReference
+	DocumentationPages    chan *DocumentationPageData
+	DocumentationPathInfo chan *DocumentationPathInfoData
 }
 
 type GroupedBundleDataMaps struct {

--- a/migrations/codeintel/1000000016_apidocs_clean.down.sql
+++ b/migrations/codeintel/1000000016_apidocs_clean.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+COMMIT;

--- a/migrations/codeintel/1000000016_apidocs_clean.up.sql
+++ b/migrations/codeintel/1000000016_apidocs_clean.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+-- PR #22080 landed a number of backwards-incompatible API docs data changes and given how early
+-- stages API docs is, we don't care to maintain backwards compat with the old data and choose to
+-- instead start from scratch with indexing again (not many repos have been indexed with API docs,
+-- anyway.)
+TRUNCATE lsif_data_documentation_pages;
+
+COMMIT;

--- a/migrations/codeintel/1000000017_lsif_documentation_path_info.down.sql
+++ b/migrations/codeintel/1000000017_lsif_documentation_path_info.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS lsif_data_documentation_path_info;
+
+COMMIT;

--- a/migrations/codeintel/1000000017_lsif_documentation_path_info.up.sql
+++ b/migrations/codeintel/1000000017_lsif_documentation_path_info.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS lsif_data_documentation_path_info (
+    dump_id integer NOT NULL,
+    path_id TEXT,
+    data bytea
+);
+
+ALTER TABLE lsif_data_documentation_path_info ADD PRIMARY KEY (dump_id, path_id);
+
+COMMENT ON TABLE lsif_data_documentation_path_info IS 'Associates documentation page pathIDs to information about what is at that pathID, its immediate children, etc.';
+COMMENT ON COLUMN lsif_data_documentation_path_info.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';
+COMMENT ON COLUMN lsif_data_documentation_path_info.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';
+COMMENT ON COLUMN lsif_data_documentation_path_info.data IS 'A gob-encoded payload conforming to a `type DocumentationPathInoData struct` pointer (lib/codeintel/semantic/types.go)';
+
+COMMIT;


### PR DESCRIPTION
Today, a URL for a Go symbol in API docs is e.g.:

```
/cmd-frontend-auth#typemocksCreateUserAndSave
```

But as a Go developer, I would rather have the URL be:

```
/cmd/frontend/auth#mocks.CreateUserAndSave
```

The package path `cmd-frontend-auth` -> `/cmd/frontend/auth` is easily solved in the lsif-go indexer.

The URL hash `typemocksCreateUserAndSave`, however, is the joined _slugs_ `["type", "mocks", "CreateUserAndSave"]` from each hierarchial `documentationResult`, meaning:

* We can't get rid of "type" (we have no idea what that is)
* We don't know if it's right to join slugs with a `.` (that is right for Go, but perhaps for C++ you need `::` or `->` or something contextual even.)

With this change, once we get to a page level the URL hash can effectively be chosen by the language indexer. It can emit `mocks.CreateUserAndSave` knowing that is a good unique identifier within that page and with the context of what those mean in Go.

---

Today, the code dealing with the `documentationResult` graph starting at the root of the project have a few awkward choices to make:

1. Should we respect the `slug` of the root documentation result?
1. What should the `slug` of the root documentation result be?
2. What should the `label` of the root documentation result be?
3. What should the content of the root documentation result be?

This adds guidelines for each of these questions, and reduces complexity in some ways (such as never needing to respect the `slug` of the root documentation result, because it is now always `""`.)

Fixes https://github.com/sourcegraph/sourcegraph/issues/21928
Fixes https://github.com/sourcegraph/sourcegraph/issues/22132

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
