### PR TITLE
search: resolve field aliases for predicates

### DIFF
--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -75,3 +75,25 @@ var allFields = map[string]struct{}{
 	"revision":              empty,
 	FieldSelect:             empty,
 }
+
+var aliases = map[string]string{
+	"r":        FieldRepo,
+	"g":        FieldRepoGroup,
+	"f":        FieldFile,
+	"l":        FieldLang,
+	"language": FieldLang,
+	"since":    FieldAfter,
+	"until":    FieldBefore,
+	"m":        FieldMessage,
+	"msg":      FieldMessage,
+	"revision": FieldRev,
+}
+
+// resolveFieldAlias resolves an aliased field like `r:` to its canonical name
+// like `repo:`.
+func resolveFieldAlias(field string) string {
+	if canonical, ok := aliases[field]; ok {
+		return canonical
+	}
+	return field
+}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -404,7 +404,7 @@ loop:
 // ScanPredicate scans for a predicate that exists in the predicate
 // registry. It takes the current field as context.
 func ScanPredicate(field string, buf []byte) (string, int, bool) {
-	fieldRegistry, ok := DefaultPredicateRegistry[field]
+	fieldRegistry, ok := DefaultPredicateRegistry[resolveFieldAlias(field)]
 	if !ok {
 		// This field has no registered predicates
 		return "", 0, false

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -229,6 +229,11 @@ func TestScanPredicate(t *testing.T) {
 		Result:       `{"Kind":2,"Operands":[{"value":"abc","negated":false},{"value":"contains(file:test)","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`,
 		ResultLabels: "HeuristicDanglingParens,Regexp",
 	}).Equal(t, test(`abc contains(file:test)`))
+
+	autogold.Want("Resolve field aliases for predicates", value{
+		Result:       `{"field":"r","value":"contains.file(sup)","negated":false}`,
+		ResultLabels: "IsPredicate",
+	}).Equal(t, test(`r:contains.file(sup)`))
 }
 
 func TestScanField(t *testing.T) {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -9,20 +9,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
-// SubstituteAliases substitutes field name aliases for their canonical names.
+// SubstituteAliases substitutes field name aliases for their canonical names,
+// and substitutes `content:` for pattern nodes.
 func SubstituteAliases(searchType SearchType) func(nodes []Node) []Node {
-	aliases := map[string]string{
-		"r":        FieldRepo,
-		"g":        FieldRepoGroup,
-		"f":        FieldFile,
-		"l":        FieldLang,
-		"language": FieldLang,
-		"since":    FieldAfter,
-		"until":    FieldBefore,
-		"m":        FieldMessage,
-		"msg":      FieldMessage,
-		"revision": FieldRev,
-	}
 	mapper := func(nodes []Node) []Node {
 		return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 			if field == "content" {
@@ -33,9 +22,7 @@ func SubstituteAliases(searchType SearchType) func(nodes []Node) []Node {
 				}
 				return Pattern{Value: value, Negated: negated, Annotation: annotation}
 			}
-			if canonical, ok := aliases[field]; ok {
-				field = canonical
-			}
+			field = resolveFieldAlias(field)
 			return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
 		})
 	}


### PR DESCRIPTION
Part of #21880. Field aliases were always resolved after parsing. Since predicate detection is mixed into parsing, we previously misses resolving aliases there.  This fixes it.

Changelog entry to come after fixing frontend too.