### PR TITLE
insights: #22079 fixing incorrect settings deserialization for code insights telemetry

### DIFF
--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -372,7 +372,7 @@ func FilterSettingJson(settingJson string, prefix string) (map[string]json.RawMe
 		return map[string]json.RawMessage{}, err
 	}
 
-	for key, _ := range raw {
+	for key := range raw {
 		if !strings.HasPrefix(key, prefix) {
 			delete(raw, key)
 		}

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -372,13 +372,14 @@ func FilterSettingJson(settingJson string, prefix string) (map[string]json.RawMe
 		return map[string]json.RawMessage{}, err
 	}
 
-	for key := range raw {
-		if !strings.HasPrefix(key, prefix) {
-			delete(raw, key)
+	filtered := make(map[string]json.RawMessage)
+	for key, val := range raw {
+		if strings.HasPrefix(key, prefix) {
+			filtered[key] = val
 		}
 	}
 
-	return raw, nil
+	return filtered, nil
 }
 
 func GetSearchInsights(ctx context.Context, db dbutil.DB, filter SettingFilter) ([]SearchInsight, error) {

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -125,14 +123,14 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db dbutil.DB) (*types.C
 	// also less important. So, in the case of any errors here we will not fail the entire ping for code insights.
 	timeIntervals, err := GetTimeStepCounts(ctx, db)
 	if err != nil {
-		log15.Error(fmt.Sprintf("code-insights/GetTimeStepCounts: %v", err))
+		log15.Error("code-insights/GetTimeStepCounts", "error", err)
 		return nil, nil
 	}
 	stats.InsightTimeIntervals = timeIntervals
 
 	orgVisible, err := GetOrgInsightCounts(ctx, db)
 	if err != nil {
-		log15.Error(fmt.Sprintf("code-insights/GetOrgInsightCounts: %v", err))
+		log15.Error("code-insights/GetOrgInsightCounts", "error", err)
 		return nil, nil
 	}
 	stats.InsightOrgVisible = orgVisible
@@ -404,7 +402,7 @@ func GetSearchInsights(ctx context.Context, db dbutil.DB, filter SettingFilter) 
 			temp.ID = id
 			if err := json.Unmarshal(body, &temp); err != nil {
 				// We would prefer to report some metrics if at all possible, so skip any deserialization errors
-				log15.Error(errors.Wrapf(err, "parsing error in setting body for setting key: %\n", id).Error())
+				log15.Error("parsing error in setting body", "id", id, "error", err)
 				continue
 			}
 			results = append(results, temp)
@@ -436,7 +434,7 @@ func GetLangStatsInsights(ctx context.Context, db dbutil.DB, filter SettingFilte
 			temp.ID = id
 			if err := json.Unmarshal(body, &temp); err != nil {
 				// We would prefer to report some metrics if at all possible, so skip any deserialization errors
-				log15.Error(errors.Wrapf(err, "parsing error in setting body for setting key: %v\n", id).Error())
+				log15.Error("parsing error in setting body", "id", id, "error", err)
 				continue
 			}
 			results = append(results, temp)

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -183,6 +183,9 @@ func TestGetSearchInsights(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := db.Exec(`INSERT INTO orgs(id, name) VALUES (1, 'first-org'), (2, 'second-org');`)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = db.Exec(`
 
@@ -262,6 +265,9 @@ func TestGetLangStatsInsights(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := db.Exec(`INSERT INTO orgs(id, name) VALUES (1, 'first-org'), (2, 'second-org');`)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = db.Exec(`
 

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -155,15 +155,12 @@ func TestWithCreationPings(t *testing.T) {
 }
 
 func TestFilterSettingJson(t *testing.T) {
-
 	var want map[string]json.RawMessage
-
 	if err := jsonc.Unmarshal(insightAloneSettingStr, &want); err != nil {
 		t.Fatal(err)
 	}
 
 	input := insightInlineSettingStr
-
 	got, err := FilterSettingJson(input, "searchInsights.")
 	if err != nil {
 		t.Fatal(err)
@@ -181,7 +178,6 @@ func TestFilterSettingJson(t *testing.T) {
 func TestGetSearchInsights(t *testing.T) {
 	db := dbtesting.GetDB(t)
 	ctx := context.Background()
-
 	_, err := db.Exec(`INSERT INTO orgs(id, name) VALUES (1, 'first-org'), (2, 'second-org');`)
 	if err != nil {
 		t.Fatal(err)
@@ -199,7 +195,6 @@ func TestGetSearchInsights(t *testing.T) {
 	}
 
 	step := 2
-
 	want := []SearchInsight{
 		{
 			ID:           "searchInsights.insight.global.first",
@@ -240,20 +235,18 @@ func TestGetSearchInsights(t *testing.T) {
 	}
 
 	got, err := GetSearchInsights(ctx, db, All)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Sorting the slices so that we can reliably compare them
 	sort.Slice(got, func(i, j int) bool {
 		return got[i].ID < got[j].ID
 	})
-
 	sort.Slice(want, func(i, j int) bool {
 		return want[i].ID < want[j].ID
 
 	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("unexpected insights diff: %v", cmp.Diff(want, got))
@@ -263,7 +256,6 @@ func TestGetSearchInsights(t *testing.T) {
 func TestGetLangStatsInsights(t *testing.T) {
 	db := dbtesting.GetDB(t)
 	ctx := context.Background()
-
 	_, err := db.Exec(`INSERT INTO orgs(id, name) VALUES (1, 'first-org'), (2, 'second-org');`)
 	if err != nil {
 		t.Fatal(err)
@@ -274,7 +266,6 @@ func TestGetLangStatsInsights(t *testing.T) {
 			INSERT INTO settings (id, org_id, contents, created_at, user_id, author_user_id)
 			VALUES  (1, 1, $1, CURRENT_TIMESTAMP, NULL, NULL)`,
 		langStatsInsightSettingStr)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +280,6 @@ func TestGetLangStatsInsights(t *testing.T) {
 	}
 
 	got, err := GetLangStatsInsights(ctx, db, All)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -2,9 +2,14 @@ package usagestats
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -148,3 +153,222 @@ func TestWithCreationPings(t *testing.T) {
 		t.Fatal(fmt.Sprintf("want: %v got: %v", want, got))
 	}
 }
+
+func TestFilterSettingJson(t *testing.T) {
+
+	var want map[string]json.RawMessage
+
+	if err := jsonc.Unmarshal(insightAloneSettingStr, &want); err != nil {
+		t.Fatal(err)
+	}
+
+	input := insightInlineSettingStr
+
+	got, err := FilterSettingJson(input, "searchInsights.")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected json map diff:%v", diff)
+	}
+
+	for key, val := range got {
+		t.Logf("k: %v val: %v", key, val)
+	}
+}
+
+func TestGetSearchInsights(t *testing.T) {
+	db := dbtesting.GetDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(`INSERT INTO orgs(id, name) VALUES (1, 'first-org'), (2, 'second-org');`)
+
+	_, err = db.Exec(`
+
+			INSERT INTO settings (id, org_id, contents, created_at, user_id, author_user_id)
+			VALUES  (1, 1, $1, CURRENT_TIMESTAMP, NULL, NULL),
+					(2, 2, $2, CURRENT_TIMESTAMP, NULL, NULL);`,
+		insightSettingMulti, insightSettingSimple)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	step := 2
+
+	want := []SearchInsight{
+		{
+			ID:           "searchInsights.insight.global.first",
+			Title:        "my insight",
+			Repositories: []string{"github.com/sourcegraph/sourcegraph"},
+			Series: []TimeSeries{{
+				Name:   "Redis",
+				Stroke: "var(--oc-red-7)",
+				Query:  "redis",
+			}},
+			Step:       Interval{Weeks: &step},
+			Visibility: "",
+		},
+		{
+			ID:           "searchInsights.insight.global.second",
+			Title:        "my insight",
+			Repositories: []string{"github.com/sourcegraph/sourcegraph"},
+			Series: []TimeSeries{{
+				Name:   "Redis",
+				Stroke: "var(--oc-red-7)",
+				Query:  "redis",
+			}},
+			Step:       Interval{Weeks: &step},
+			Visibility: "",
+		},
+		{
+			ID:           "searchInsights.insight.global.simple",
+			Title:        "my insight",
+			Repositories: []string{"github.com/sourcegraph/sourcegraph"},
+			Series: []TimeSeries{{
+				Name:   "Redis",
+				Stroke: "var(--oc-red-7)",
+				Query:  "redis",
+			}},
+			Step:       Interval{Weeks: &step},
+			Visibility: "",
+		},
+	}
+
+	got, err := GetSearchInsights(ctx, db, All)
+
+	// Sorting the slices so that we can reliably compare them
+	sort.Slice(got, func(i, j int) bool {
+		return got[i].ID < got[j].ID
+	})
+
+	sort.Slice(want, func(i, j int) bool {
+		return want[i].ID < want[j].ID
+
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("unexpected insights diff: %v", cmp.Diff(want, got))
+	}
+}
+
+func TestGetLangStatsInsights(t *testing.T) {
+	db := dbtesting.GetDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(`INSERT INTO orgs(id, name) VALUES (1, 'first-org'), (2, 'second-org');`)
+
+	_, err = db.Exec(`
+
+			INSERT INTO settings (id, org_id, contents, created_at, user_id, author_user_id)
+			VALUES  (1, 1, $1, CURRENT_TIMESTAMP, NULL, NULL)`,
+		langStatsInsightSettingStr)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []LangStatsInsight{
+		{
+			ID:             "codeStatsInsights.insight.global.lang1",
+			Title:          "my insight",
+			Repository:     "github.com/sourcegraph/sourcegraph",
+			OtherThreshold: float32(0),
+		},
+	}
+
+	got, err := GetLangStatsInsights(ctx, db, All)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("unexpected insights diff: %v", cmp.Diff(want, got))
+	}
+}
+
+const insightSettingSimple = `{"searchInsights.insight.global.simple": {
+    "title": "my insight",
+    "repositories": ["github.com/sourcegraph/sourcegraph"],
+    "series": [
+      {
+        "name": "Redis",
+        "query": "redis",
+        "stroke": "var(--oc-red-7)"
+      }
+    ],
+    "step": {
+      "weeks": 2
+    }
+  }}`
+
+const insightSettingMulti = `{"searchInsights.insight.global.first": {
+    "title": "my insight",
+    "repositories": ["github.com/sourcegraph/sourcegraph"],
+    "series": [
+      {
+        "name": "Redis",
+        "query": "redis",
+        "stroke": "var(--oc-red-7)"
+      }
+    ],
+    "step": {
+      "weeks": 2
+    }
+  },
+"searchInsights.insight.global.second": {
+    "title": "my insight",
+    "repositories": ["github.com/sourcegraph/sourcegraph"],
+    "series": [
+      {
+        "name": "Redis",
+        "query": "redis",
+        "stroke": "var(--oc-red-7)"
+      }
+    ],
+    "step": {
+      "weeks": 2
+    }
+  }}`
+
+const insightAloneSettingStr = `{"searchInsights.insight.global.myinsight": {
+    "title": "my insight",
+    "repositories": ["github.com/sourcegraph/sourcegraph"],
+    "series": [
+      {
+        "name": "Redis",
+        "query": "redis",
+        "stroke": "var(--oc-red-7)"
+      }
+    ],
+    "step": {
+      "weeks": 2
+    }
+  }}`
+
+const insightInlineSettingStr = `{"searchInsights.insight.global.myinsight": {
+    "title": "my insight",
+    "repositories": ["github.com/sourcegraph/sourcegraph"],
+    "series": [
+      {
+        "name": "Redis",
+        "query": "redis",
+        "stroke": "var(--oc-red-7)"
+      }
+    ],
+    "step": {
+      "weeks": 2
+    }
+  },
+  "codecov.insight.pie": true}`
+
+const langStatsInsightSettingStr = `{"codeStatsInsights.insight.global.lang1": {
+    "title": "my insight",
+    "repository": "github.com/sourcegraph/sourcegraph",
+  }}`


### PR DESCRIPTION
Closes #22079 

Settings that are loaded for code insights telemetry are deserialized incorrectly causing code insights pings to fail. This PR fixes the deserialization to occur on the correct JSON object by filtering on the JSON keys, as well as absorb errors that occur during this telemetry so that valid telemetry can still serialize.
