### PR TITLE
Fix Safari RegExp support 

### DIFF
--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
@@ -2,5 +2,5 @@
  * Returns whether the query specifies a count. Search queries break when count is specified twice.
  */
 export function queryHasCountFilter(query: string): boolean {
-    return /\bcount:\d+\b(?!(\s*)["'])/gi.test(query)
+    return /\bcount:\d+\b/gi.test(query)
 }

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count-filter.ts
@@ -2,5 +2,5 @@
  * Returns whether the query specifies a count. Search queries break when count is specified twice.
  */
 export function queryHasCountFilter(query: string): boolean {
-    return /(?<!\s["'])count:(\s*)\d+\b(?!(\s*)["'])/gi.test(query)
+    return /\bcount:\d+\b(?!(\s*)["'])/gi.test(query)
 }

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
@@ -13,6 +13,7 @@ describe('queryHasCount()', () => {
 
     // Return these tests when Safari will support look behind group in regexp
     // or when we have separate query parsers package
+    // See https://github.com/sourcegraph/sourcegraph/issues/22092
     it.skip('returns false when count is escaped', () => {
         assert.strictEqual(queryHasCountFilter('"count:100" lang:ts'), false)
     })

--- a/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/query-has-count.test.ts
@@ -4,18 +4,20 @@ import { queryHasCountFilter } from './query-has-count-filter'
 
 describe('queryHasCount()', () => {
     it('returns true when count is specified', () => {
-        assert.strictEqual(queryHasCountFilter('const count: 1000'), true)
+        assert.strictEqual(queryHasCountFilter('const count:1000'), true)
     })
 
     it('returns false when count is not specified', () => {
         assert.strictEqual(queryHasCountFilter('const'), false)
     })
 
-    it('returns false when count is escaped', () => {
+    // Return these tests when Safari will support look behind group in regexp
+    // or when we have separate query parsers package
+    it.skip('returns false when count is escaped', () => {
         assert.strictEqual(queryHasCountFilter('"count:100" lang:ts'), false)
     })
 
-    it('returns false when count is escaped by single quotes', () => {
+    it.skip('returns false when count is escaped by single quotes', () => {
         assert.strictEqual(queryHasCountFilter("'count:100' lang:ts"), false)
     })
 })


### PR DESCRIPTION
For cathing `count:` filter in insight creation UI query input we use follow regexp 

```js
/(?<!\s["'])count:(\s*)\d+\b(?!(\s*)["'])/gi
```

But Safari doesn't support look behind groups in regexp that leads us to a syntax error that completely breaks the app with `invalid group specifier name` error


**Reminder**: as soon this PR is merged we have to update the search-based insight extension according to these PR changes. 

**Knowing issues** 

Due to the fact that we have to come up with a similar solution in search based insight extension we can't use query parsers from sourcegraph/sourcegraph repo here and therefore can't support count filter quoted case 

**Example**: `testquery "count:99"` in this example, our regexp still treat the search term "count:99" as a count filter which is not 
