### PR TITLE
search: remove alert for overLimit for type:repo search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1315,9 +1315,6 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 	if len(resolved.RepoRevs) == 0 {
 		return nil, r.errorForNoResolvedRepos(ctx)
 	}
-	if resolved.OverLimit {
-		return nil, r.errorForOverRepoLimit(ctx)
-	}
 	return &resolved, nil
 }
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -193,7 +193,7 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 			return Resolved{}, err
 		}
 	}
-	overLimit := len(repos) >= limit
+	overLimit := len(repos) > limit
 	repoRevs := make([]*search.RepositoryRevisions, 0, len(repos))
 	var missingRepoRevs []*search.RepositoryRevisions
 	tr.LazyPrintf("Associate/validate revs - start")


### PR DESCRIPTION
We set overLimit to true whenever len(repos)>=limit. However, for a
global type:repo query we always have len(repos) = limit+1, which is why
we always show an alert.

Here we remove the alert from defaultRepositories and adjust the
condition at the same time. This means we will never show an alert for
type:repo search. We should think about whether we should send a
signal to the user that the results are possibly incomplete (aka '+'
sign)

The best thing would be to follow an earlier proposal by Rijnard to map
type:repo to repo: queries.

Co-authored-by: Tomás Senart <tomas@sourcegraph.com>