### PR TITLE
sg(fixup_migration): Add sg migration fixup

### DIFF
--- a/dev/sg/go.mod
+++ b/dev/sg/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cockroachdb/errors v1.8.4
+	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/rjeczalik/notify v0.9.2

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -123,6 +123,17 @@ var (
 		UsageFunc:  printMigrationSquashUsage,
 	}
 
+	migrationFixupFlagSet          = flag.NewFlagSet("sg migration fixup", flag.ExitOnError)
+	migrationFixupDatabaseNameFlag = migrationFixupFlagSet.String("db", defaultDatabase.Name, "The target database instance")
+	migrationFixupCommand          = &ffcli.Command{
+		Name:       "fixup",
+		ShortUsage: fmt.Sprintf("sg migration fixup [-db=%s]", defaultDatabase.Name),
+		ShortHelp:  "Find and fix any conflicting migration names from rebasing on main",
+		FlagSet:    migrationFixupFlagSet,
+		Exec:       migrationFixupExec,
+		UsageFunc:  printMigrationFixupUsage,
+	}
+
 	migrationFlagSet = flag.NewFlagSet("sg migration", flag.ExitOnError)
 	migrationCommand = &ffcli.Command{
 		Name:       "migration",
@@ -138,6 +149,7 @@ var (
 			migrationUpCommand,
 			migrationDownCommand,
 			migrationSquashCommand,
+			migrationFixupCommand,
 		},
 	}
 )
@@ -532,6 +544,24 @@ func printRunUsage(c *ffcli.Command) string {
 	return out.String()
 }
 
+func migrationFixupExec(ctx context.Context, args []string) (err error) {
+	if len(args) != 0 {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		return flag.ErrHelp
+	}
+
+	var (
+		databaseName = *migrationSquashDatabaseNameFlag
+		database, ok = databaseByName(databaseName)
+	)
+	if !ok {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(\n", databaseName))
+		return flag.ErrHelp
+	}
+
+	return fixupMigrations(database, "main", "HEAD")
+}
+
 func printTestUsage(c *ffcli.Command) string {
 	var out strings.Builder
 
@@ -677,6 +707,21 @@ func printMigrationSquashUsage(c *ffcli.Command) string {
 
 	fmt.Fprintf(&out, "USAGE\n")
 	fmt.Fprintf(&out, "  sg migration squash [-db=%s] <current-release>\n", defaultDatabase.Name)
+	fmt.Fprintf(&out, "\n")
+	fmt.Fprintf(&out, "AVAILABLE DATABASES\n")
+
+	for _, name := range databaseNames() {
+		fmt.Fprintf(&out, "  %s\n", name)
+	}
+
+	return out.String()
+}
+
+func printMigrationFixupUsage(c *ffcli.Command) string {
+	var out strings.Builder
+
+	fmt.Fprintf(&out, "USAGE\n")
+	fmt.Fprintf(&out, "  sg migration fixup [-db=%s]\n", defaultDatabase.Name)
 	fmt.Fprintf(&out, "\n")
 	fmt.Fprintf(&out, "AVAILABLE DATABASES\n")
 

--- a/dev/sg/migration_test.go
+++ b/dev/sg/migration_test.go
@@ -98,7 +98,7 @@ func TestTrunkHasConflictingMigration(t *testing.T) {
 	conflicts, _, _ := findConflictingMigrations(trunk, branch)
 	expected := []migrationConflict{
 		{
-			ID:     2,
+			ID:    2,
 			Main:  trunk[2],
 			Local: branch[2],
 		},

--- a/dev/sg/migration_test.go
+++ b/dev/sg/migration_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSameMigrations(t *testing.T) {
+	branch := map[int]migration{
+		1: {
+			ID:   1,
+			Name: "first",
+		},
+	}
+
+	if conflicts, _ := findConflictingMigrations(branch, branch); len(conflicts) > 0 {
+		t.Errorf("Failed when comparing exacly the same migrations: %+v", branch)
+	}
+}
+
+func TestBranchHasExtraMigration(t *testing.T) {
+	trunk := map[int]migration{
+		1: {
+			ID:   1,
+			Name: "first",
+		},
+	}
+
+	branch := map[int]migration{
+		1: {
+			ID:   1,
+			Name: "first",
+		},
+		2: {
+			ID:   2,
+			Name: "second",
+		},
+	}
+
+	if conflicts, _ := findConflictingMigrations(trunk, branch); len(conflicts) > 0 {
+		t.Errorf("Failed when comparing exacly the same migrations: %+v", branch)
+	}
+}
+
+func TestTrunkHasExtraMigration(t *testing.T) {
+	trunk := map[int]migration{
+		1: {
+			ID:   1,
+			Name: "first",
+		},
+		2: {
+			ID:   2,
+			Name: "second",
+		},
+	}
+
+	branch := map[int]migration{
+		1: {
+			ID:   1,
+			Name: "first",
+		},
+	}
+
+	_, err := findConflictingMigrations(trunk, branch)
+	if err == nil {
+		t.Errorf("Error should have been set because you were missing a rebase")
+	}
+}
+
+func TestTrunkHasConflictingMigration(t *testing.T) {
+	trunk := map[int]migration{
+		1: {
+			ID:   1,
+			Name: "first",
+		},
+		2: {
+			ID:   2,
+			Name: "trunk second",
+		},
+	}
+
+	branch := map[int]migration{
+		1: {
+			ID:   1,
+			Name: "first",
+		},
+		2: {
+			ID:   2,
+			Name: "branch second",
+		},
+	}
+
+	conflicts, _ := findConflictingMigrations(trunk, branch)
+	expected := []migrationConflict{
+		{
+			ID:     2,
+			Trunk:  trunk[2],
+			Branch: branch[2],
+		},
+	}
+
+	if diff := cmp.Diff(conflicts, expected); diff != "" {
+		t.Errorf("Not conflicts expected: %s", diff)
+	}
+}

--- a/dev/sg/migration_test.go
+++ b/dev/sg/migration_test.go
@@ -14,7 +14,7 @@ func TestSameMigrations(t *testing.T) {
 		},
 	}
 
-	if conflicts, _ := findConflictingMigrations(branch, branch); len(conflicts) > 0 {
+	if conflicts, _, _ := findConflictingMigrations(branch, branch); len(conflicts) > 0 {
 		t.Errorf("Failed when comparing exacly the same migrations: %+v", branch)
 	}
 }
@@ -38,7 +38,7 @@ func TestBranchHasExtraMigration(t *testing.T) {
 		},
 	}
 
-	if conflicts, _ := findConflictingMigrations(trunk, branch); len(conflicts) > 0 {
+	if conflicts, _, _ := findConflictingMigrations(trunk, branch); len(conflicts) > 0 {
 		t.Errorf("Failed when comparing exacly the same migrations: %+v", branch)
 	}
 }
@@ -62,9 +62,13 @@ func TestTrunkHasExtraMigration(t *testing.T) {
 		},
 	}
 
-	_, err := findConflictingMigrations(trunk, branch)
-	if err == nil {
-		t.Errorf("Error should have been set because you were missing a rebase")
+	_, missing, err := findConflictingMigrations(trunk, branch)
+	if err != nil {
+		t.Errorf("Should not error for missing a migration.")
+	}
+
+	if len(missing) != 1 || missing[0].Name != "second" {
+		t.Errorf("Should have returned only 'second' was missing, instead +%v", missing)
 	}
 }
 
@@ -91,12 +95,12 @@ func TestTrunkHasConflictingMigration(t *testing.T) {
 		},
 	}
 
-	conflicts, _ := findConflictingMigrations(trunk, branch)
+	conflicts, _, _ := findConflictingMigrations(trunk, branch)
 	expected := []migrationConflict{
 		{
 			ID:     2,
-			Trunk:  trunk[2],
-			Branch: branch[2],
+			Main:  trunk[2],
+			Local: branch[2],
 		},
 	}
 


### PR DESCRIPTION
Good case

```
➜ go build && ./sg migration fixup

💡 Checking for conflicting migrations...
   ✅ ... No conflicting migrations
```

Fixup case
```
[➜ go build && ./sg migration fixup

💡 Checking for conflicting migrations...
   Database: frontend

   Changing migration: 1528395833 feature_flag_events
   ✅ 1528395833_feature_flag_events_dup.up.sql -> 1528395834_feature_flag_events_dup.up.sql
   ✅ 1528395833_feature_flag_events_dup.down.sql -> 1528395834_feature_flag_events_dup.down.sql
```