### PR TITLE
add repo metadata to streaming results

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -24,7 +24,7 @@ func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {
 		if r.gitCommitResolver != nil {
 			return
 		}
-		repoResolver := NewRepositoryResolver(r.db, r.RepoName.ToRepo())
+		repoResolver := NewRepositoryResolver(r.db, r.Repo.ToRepo())
 		r.gitCommitResolver = toGitCommitResolver(repoResolver, r.db, r.CommitMatch.Commit.ID, &r.CommitMatch.Commit)
 	})
 	return r.gitCommitResolver

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -21,6 +21,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/actor"

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1018,7 +1018,7 @@ func TestSearchContext(t *testing.T) {
 
 func commitResult(repo, commit string) *result.CommitMatch {
 	return &result.CommitMatch{
-		RepoName: types.RepoName{Name: api.RepoName(repo)},
+		Repo: types.RepoName{Name: api.RepoName(repo)},
 		Commit: git.Commit{
 			ID: api.CommitID(commit),
 		},
@@ -1028,7 +1028,7 @@ func commitResult(repo, commit string) *result.CommitMatch {
 func diffResult(repo, commit string) *result.CommitMatch {
 	return &result.CommitMatch{
 		DiffPreview: &result.HighlightedString{},
-		RepoName:    types.RepoName{Name: api.RepoName(repo)},
+		Repo:        types.RepoName{Name: api.RepoName(repo)},
 		Commit: git.Commit{
 			ID: api.CommitID(commit),
 		},

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -47,10 +47,10 @@ func newExternalHTTPHandler(db dbutil.DB, schema *graphql.Schema, gitHubWebhook 
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		apiHandler = hooks.PostAuthMiddleware(apiHandler)
 	}
+	apiHandler = featureflag.Middleware(database.FeatureFlags(db), apiHandler)
 	apiHandler = authMiddlewares.API(apiHandler) // 🚨 SECURITY: auth middleware
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication (except those with the
 	// X-Requested-With header). Doing so would open it up to CSRF attacks.
-	apiHandler = featureflag.Middleware(database.FeatureFlags(db), apiHandler)
 	apiHandler = session.CookieMiddlewareWithCSRFSafety(apiHandler, corsAllowHeader, isTrustedOrigin) // API accepts cookies with special header
 	apiHandler = internalhttpapi.AccessTokenAuthMiddleware(db, apiHandler)                            // API accepts access tokens
 	apiHandler = gziphandler.GzipHandler(apiHandler)
@@ -64,6 +64,7 @@ func newExternalHTTPHandler(db dbutil.DB, schema *graphql.Schema, gitHubWebhook 
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		appHandler = hooks.PostAuthMiddleware(appHandler)
 	}
+	appHandler = featureflag.Middleware(database.FeatureFlags(db), appHandler)
 	appHandler = handlerutil.CSRFMiddleware(appHandler, func() bool {
 		return globals.ExternalURL().Scheme == "https"
 	}) // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -32,6 +34,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // StreamHandler is an http handler which streams back search results.
@@ -151,6 +154,8 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = matchesBuf.Append(m)
 	}
 
+	repoCache := make(map[api.RepoID]*types.Repo, 10)
+
 	flushTicker := time.NewTicker(h.flushTickerInternal)
 	defer flushTicker.Stop()
 
@@ -179,13 +184,19 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		progress.Update(event)
 		filters.Update(event)
 
+		// Ensure that, for each result in the event, we have a copy of the full repo metadata.
+		if err := updateRepoCache(ctx, h.db, repoCache, event); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		for _, match := range event.Results {
 			if display <= 0 {
 				break
 			}
 
 			display = match.Limit(display)
-			matchesAppend(fromMatch(match))
+			matchesAppend(fromMatch(match, repoCache))
 		}
 
 		// Instantly send results if we have not sent any yet.
@@ -273,6 +284,47 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log15.Warn("streaming: slow search request", searchlogs.MapToLog15Ctx(ev.Fields())...)
 		}
 	}
+}
+
+// updateRepoCache requests repo metadata for each repo referenced by results in the event. It only makes a database request if there
+// are new repos that do not already exist in the cache.
+func updateRepoCache(ctx context.Context, db dbutil.DB, repoCache map[api.RepoID]*types.Repo, event streaming.SearchEvent) error {
+	uncachedIDs := make(map[api.RepoID]struct{}, 10)
+	for _, r := range event.Results {
+		var id api.RepoID
+		switch v := r.(type) {
+		case *result.FileMatch:
+			id = v.Repo.ID
+		case *result.RepoMatch:
+			id = v.ID
+		case *result.CommitMatch:
+			id = v.RepoName.ID
+		default:
+			return fmt.Errorf("unknown match type %T", r)
+		}
+
+		if _, ok := repoCache[id]; !ok {
+			uncachedIDs[id] = struct{}{}
+		}
+	}
+
+	if len(uncachedIDs) == 0 {
+		return nil
+	}
+
+	uncachedIDSlice := make([]api.RepoID, 0, len(uncachedIDs))
+	for id := range uncachedIDs {
+		uncachedIDSlice = append(uncachedIDSlice, id)
+	}
+
+	repos, err := database.Repos(db).GetReposSetByIDs(ctx, uncachedIDSlice...)
+	if err != nil {
+		return err
+	}
+	for id, repo := range repos {
+		repoCache[id] = repo
+	}
+	return nil
 }
 
 // startSearch will start a search. It returns the events channel which
@@ -377,20 +429,20 @@ func fromStrPtr(s *string) string {
 	return *s
 }
 
-func fromMatch(match result.Match) streamhttp.EventMatch {
+func fromMatch(match result.Match, repoCache map[api.RepoID]*types.Repo) streamhttp.EventMatch {
 	switch v := match.(type) {
 	case *result.FileMatch:
-		return fromFileMatch(v)
+		return fromFileMatch(v, repoCache)
 	case *result.RepoMatch:
-		return fromRepository(v)
+		return fromRepository(v, repoCache)
 	case *result.CommitMatch:
-		return fromCommit(v)
+		return fromCommit(v, repoCache)
 	default:
 		panic(fmt.Sprintf("unknown match type %T", v))
 	}
 }
 
-func fromFileMatch(fm *result.FileMatch) streamhttp.EventMatch {
+func fromFileMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Repo) streamhttp.EventMatch {
 	if syms := fm.Symbols; len(syms) > 0 {
 		return fromSymbolMatch(fm)
 	}
@@ -409,10 +461,16 @@ func fromFileMatch(fm *result.FileMatch) streamhttp.EventMatch {
 		branches = []string{*fm.InputRev}
 	}
 
+	var stars int
+	if r, ok := repoCache[fm.Repo.ID]; ok {
+		stars = r.Stars
+	}
+
 	return &streamhttp.EventFileMatch{
 		Type:        streamhttp.FileMatchType,
 		Path:        fm.Path,
 		Repository:  string(fm.Repo.Name),
+		RepoStars:   stars,
 		Branches:    branches,
 		Version:     string(fm.CommitID),
 		LineMatches: lineMatches,
@@ -451,20 +509,29 @@ func fromSymbolMatch(fm *result.FileMatch) *streamhttp.EventSymbolMatch {
 	}
 }
 
-func fromRepository(rm *result.RepoMatch) *streamhttp.EventRepoMatch {
+func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Repo) *streamhttp.EventRepoMatch {
 	var branches []string
 	if rev := rm.Rev; rev != "" {
 		branches = []string{rev}
 	}
 
-	return &streamhttp.EventRepoMatch{
+	repoEvent := &streamhttp.EventRepoMatch{
 		Type:       streamhttp.RepoMatchType,
 		Repository: string(rm.Name),
 		Branches:   branches,
 	}
+
+	if r, ok := repoCache[rm.ID]; ok {
+		repoEvent.Stars = r.Stars
+		repoEvent.Description = r.Description
+		repoEvent.Fork = r.Fork
+		repoEvent.Archived = r.Archived
+	}
+
+	return repoEvent
 }
 
-func fromCommit(commit *result.CommitMatch) *streamhttp.EventCommitMatch {
+func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Repo) *streamhttp.EventCommitMatch {
 	content := commit.Body.Value
 
 	highlights := commit.Body.Highlights
@@ -473,12 +540,18 @@ func fromCommit(commit *result.CommitMatch) *streamhttp.EventCommitMatch {
 		ranges[i] = [3]int32{h.Line, h.Character, h.Length}
 	}
 
+	var stars int
+	if r, ok := repoCache[commit.RepoName.ID]; ok {
+		stars = r.Stars
+	}
+
 	return &streamhttp.EventCommitMatch{
 		Type:       streamhttp.CommitMatchType,
 		Label:      commit.Label(),
 		URL:        commit.URL().String(),
 		Detail:     commit.Detail(),
 		Repository: string(commit.RepoName.Name),
+		RepoStars:  stars,
 		Content:    content,
 		Ranges:     ranges,
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -522,7 +522,7 @@ func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Repo) 
 	}
 
 	if r, ok := repoCache[rm.ID]; ok {
-		repoEvent.Stars = r.Stars
+		repoEvent.RepoStars = r.Stars
 		repoEvent.Description = r.Description
 		repoEvent.Fork = r.Fork
 		repoEvent.Archived = r.Archived

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -94,7 +94,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	events, inputs, results := h.startSearch(ctx, args)
 	flags := featureflag.FromContext(ctx)
 	if flags.GetBoolOr("repoMetadata", false) {
-		events = batchedEvents(events, 50*time.Millisecond)
+		events = batchEvents(events, 50*time.Millisecond)
 	}
 
 	traceURL := ""
@@ -631,9 +631,9 @@ func GuessSource(r *http.Request) trace.SourceType {
 	return trace.SourceOther
 }
 
-// batchedEvents takes an event stream and merges events htat come through close in time into a single event.
+// batchEvents takes an event stream and merges events htat come through close in time into a single event.
 // This makes downstream database and network operations more efficient by enabling batch reads.
-func batchedEvents(source <-chan streaming.SearchEvent, delay time.Duration) <-chan streaming.SearchEvent {
+func batchEvents(source <-chan streaming.SearchEvent, delay time.Duration) <-chan streaming.SearchEvent {
 	results := make(chan streaming.SearchEvent)
 	go func() {
 		defer close(results)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -45,7 +45,7 @@ func StreamHandler(db dbutil.DB) http.Handler {
 		newSearchResolver:   defaultNewSearchResolver,
 		flushTickerInternal: 100 * time.Millisecond,
 		pingTickerInterval:  5 * time.Second,
-		repoMetadataCache:   repos.NewMetadataCache(1000),
+		repoMetadataCache:   repos.NewMetadataCache(5000),
 	}
 }
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -631,7 +631,7 @@ func GuessSource(r *http.Request) trace.SourceType {
 	return trace.SourceOther
 }
 
-// batchEvents takes an event stream and merges events htat come through close in time into a single event.
+// batchEvents takes an event stream and merges events that come through close in time into a single event.
 // This makes downstream database and network operations more efficient by enabling batch reads.
 func batchEvents(source <-chan streaming.SearchEvent, delay time.Duration) <-chan streaming.SearchEvent {
 	results := make(chan streaming.SearchEvent)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -195,8 +195,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if featureflag.FromContext(ctx).GetBoolOr("repoMetadata", false) {
 			repoList, err = getReposForResults(ctx, h.db, h.repoMetadataCache, event.Results)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
+				log15.Error("streaming: failed to retrieve repo metadata: %s", err)
 			}
 		}
 

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	api2 "github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -22,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming/api"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -124,6 +126,16 @@ func TestDisplayLimit(t *testing.T) {
 		t.Run(fmt.Sprintf("q=%s;displayLimit=%d", c.queryString, c.displayLimit), func(t *testing.T) {
 			mock := &mockSearchResolver{
 				done: make(chan struct{}),
+			}
+
+			database.Mocks.Repos.GetByIDs = func(ctx context.Context, ids ...api2.RepoID) (_ []*types.Repo, err error) {
+				res := make([]*types.Repo, 0, len(ids))
+				for _, id := range ids {
+					res = append(res, &types.Repo{
+						ID: id,
+					})
+				}
+				return res, nil
 			}
 
 			ts := httptest.NewServer(&streamHandler{

--- a/internal/search/repos/metadata_cache.go
+++ b/internal/search/repos/metadata_cache.go
@@ -1,0 +1,93 @@
+package repos
+
+import (
+	"context"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type MetadataCache struct {
+	lru *lru.TwoQueueCache
+}
+
+type cacheEntry struct {
+	repo       *types.Repo
+	validUntil time.Time
+}
+
+// Get returns a cached *types.Repo for an id if it exists in the cache
+// and hasn't expired.
+func (c *MetadataCache) Get(id api.RepoID) (*types.Repo, bool) {
+	ci, ok := c.lru.Get(id)
+	if !ok {
+		return nil, false
+	}
+	ce := ci.(cacheEntry)
+
+	// Evict the entry if it has expired
+	if time.Now().After(ce.validUntil) {
+		c.lru.Remove(id)
+		return nil, false
+	}
+
+	return ce.repo, true
+}
+
+func (c *MetadataCache) Add(id api.RepoID, repo *types.Repo) {
+	e := cacheEntry{
+		repo:       repo,
+		validUntil: time.Now().Add(10 * time.Minute),
+	}
+	c.lru.Add(id, e)
+}
+
+func (c *MetadataCache) GetReposForEvent(ctx context.Context, db dbutil.DB, event streaming.SearchEvent) (map[api.RepoID]*types.Repo, error) {
+	res := make(map[api.RepoID]*types.Repo, 10)
+	uncachedIDs := make(map[api.RepoID]struct{})
+	for _, match := range event.Results {
+		id := match.RepoName().ID
+		if repo, ok := c.Get(id); ok {
+			res[id] = repo
+		} else {
+			uncachedIDs[id] = struct{}{}
+		}
+	}
+
+	// All repos referenced in the event were populated from the cache,
+	// so no need to hit the database
+	if len(uncachedIDs) == 0 {
+		return res, nil
+	}
+
+	uncachedIDSlice := make([]api.RepoID, 0, len(uncachedIDs))
+	for id := range uncachedIDs {
+		uncachedIDSlice = append(uncachedIDSlice, id)
+	}
+
+	// Retrieve all repo metadata that doesn't exist in the cache
+	repos, err := database.Repos(db).GetByIDs(ctx, uncachedIDSlice...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update the cache and the result
+	for _, repo := range repos {
+		c.Add(repo.ID, repo)
+		res[repo.ID] = repo
+	}
+	return res, nil
+}
+
+func NewMetadataCache(size int) MetadataCache {
+	l, _ := lru.New2Q(size)
+	return MetadataCache{
+		lru: l,
+	}
+}

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -13,7 +13,7 @@ import (
 
 type CommitMatch struct {
 	Commit         git.Commit
-	RepoName       types.RepoName
+	Repo           types.RepoName
 	Refs           []string
 	SourceRefs     []string
 	MessagePreview *HighlightedString
@@ -35,6 +35,10 @@ func (r *CommitMatch) ResultCount() int {
 	return 1
 }
 
+func (r *CommitMatch) RepoName() types.RepoName {
+	return r.Repo
+}
+
 func (r *CommitMatch) Limit(limit int) int {
 	if len(r.Body.Highlights) == 0 {
 		return limit - 1 // just counting the commit
@@ -49,8 +53,8 @@ func (r *CommitMatch) Select(path filter.SelectPath) Match {
 	switch path.Type {
 	case filter.Repository:
 		return &RepoMatch{
-			Name: r.RepoName.Name,
-			ID:   r.RepoName.ID,
+			Name: r.Repo.Name,
+			ID:   r.Repo.ID,
 		}
 	case filter.Commit:
 		if len(path.Fields) > 0 && path.Fields[0] == "diff" {
@@ -78,7 +82,7 @@ func (r *CommitMatch) Key() Key {
 	}
 	return Key{
 		TypeRank: typeRank,
-		Repo:     r.RepoName.Name,
+		Repo:     r.Repo.Name,
 		Commit:   r.Commit.ID,
 	}
 }
@@ -86,8 +90,8 @@ func (r *CommitMatch) Key() Key {
 func (r *CommitMatch) Label() string {
 	message := r.Commit.Message.Subject()
 	author := r.Commit.Author.Name
-	repoName := displayRepoName(string(r.RepoName.Name))
-	repoURL := (&RepoMatch{Name: r.RepoName.Name, ID: r.RepoName.ID}).URL().String()
+	repoName := displayRepoName(string(r.Repo.Name))
+	repoURL := (&RepoMatch{Name: r.Repo.Name, ID: r.Repo.ID}).URL().String()
 	commitURL := r.URL().String()
 
 	return fmt.Sprintf("[%s](%s) › [%s](%s): [%s](%s)", repoName, repoURL, author, commitURL, message, commitURL)
@@ -100,7 +104,7 @@ func (r *CommitMatch) Detail() string {
 }
 
 func (r *CommitMatch) URL() *url.URL {
-	u := (&RepoMatch{Name: r.RepoName.Name, ID: r.RepoName.ID}).URL()
+	u := (&RepoMatch{Name: r.Repo.Name, ID: r.Repo.ID}).URL()
 	u.Path = u.Path + "/-/commit/" + string(r.Commit.ID)
 	return u
 }

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -13,7 +13,7 @@ import (
 func TestDeduper(t *testing.T) {
 	commit := func(repo, id string) *CommitMatch {
 		return &CommitMatch{
-			RepoName: types.RepoName{
+			Repo: types.RepoName{
 				Name: api.RepoName(repo),
 			},
 			Commit: git.Commit{
@@ -24,7 +24,7 @@ func TestDeduper(t *testing.T) {
 
 	diff := func(repo, id string) *CommitMatch {
 		return &CommitMatch{
-			RepoName: types.RepoName{
+			Repo: types.RepoName{
 				Name: api.RepoName(repo),
 			},
 			Commit: git.Commit{

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -47,6 +47,10 @@ type FileMatch struct {
 	LimitHit bool
 }
 
+func (fm *FileMatch) RepoName() types.RepoName {
+	return fm.File.Repo
+}
+
 func (fm *FileMatch) searchResultMarker() {}
 
 func (fm *FileMatch) ResultCount() int {

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -3,6 +3,7 @@ package result
 import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // Match is *FileMatch | *RepoMatch | *CommitMatch. We have a private method
@@ -11,6 +12,7 @@ type Match interface {
 	ResultCount() int
 	Limit(int) int
 	Select(filter.SelectPath) Match
+	RepoName() types.RepoName
 
 	// Key returns a key which uniquely identifies this match.
 	Key() Key

--- a/internal/search/run/commit.go
+++ b/internal/search/run/commit.go
@@ -289,7 +289,7 @@ func logCommitSearchResultsToMatches(op *search.CommitParameters, repoName types
 				Value:      matchBody,
 				Highlights: matchHighlights,
 			},
-			RepoName: repoName,
+			Repo: repoName,
 		}
 	}
 

--- a/internal/search/run/commit_test.go
+++ b/internal/search/run/commit_test.go
@@ -73,7 +73,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 
 	want := []*result.CommitMatch{{
 		Commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
-		RepoName:    types.RepoName{ID: 1, Name: "repo"},
+		Repo:        types.RepoName{ID: 1, Name: "repo"},
 		DiffPreview: &result.HighlightedString{Value: "x", Highlights: []result.HighlightedRange{}},
 		Body:        result.HighlightedString{Value: "```diff\nx```", Highlights: []result.HighlightedRange{}},
 	}}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -19,6 +19,7 @@ type EventFileMatch struct {
 
 	Path       string   `json:"name"`
 	Repository string   `json:"repository"`
+	RepoStars  int      `json:"repoStars"`
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
@@ -39,8 +40,12 @@ type EventRepoMatch struct {
 	// Type is always RepoMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
-	Repository string   `json:"repository"`
-	Branches   []string `json:"branches,omitempty"`
+	Repository  string   `json:"repository"`
+	Branches    []string `json:"branches,omitempty"`
+	Stars       int      `json:"stars"`
+	Description string   `json:"description"`
+	Fork        bool     `json:"fork"`
+	Archived    bool     `json:"archived"`
 }
 
 func (e *EventRepoMatch) eventMatch() {}
@@ -52,6 +57,7 @@ type EventSymbolMatch struct {
 
 	Path       string   `json:"name"`
 	Repository string   `json:"repository"`
+	RepoStars  int      `json:"repoStars"`
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
@@ -79,6 +85,7 @@ type EventCommitMatch struct {
 	URL        string `json:"url"`
 	Detail     string `json:"detail"`
 	Repository string `json:"repository"`
+	RepoStars  int    `json:"repoStars"`
 	Content    string `json:"content"`
 	// [line, character, length]
 	Ranges [][3]int32 `json:"ranges"`

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -44,8 +44,8 @@ type EventRepoMatch struct {
 	Branches    []string `json:"branches,omitempty"`
 	RepoStars   int      `json:"repoStars,omitempty"`
 	Description string   `json:"description,omitempty"`
-	Fork        bool     `json:"fork"`
-	Archived    bool     `json:"archived"`
+	Fork        bool     `json:"fork,omitempty"`
+	Archived    bool     `json:"archived,omitempty"`
 }
 
 func (e *EventRepoMatch) eventMatch() {}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -19,7 +19,7 @@ type EventFileMatch struct {
 
 	Path       string   `json:"name"`
 	Repository string   `json:"repository"`
-	RepoStars  int      `json:"repoStars"`
+	RepoStars  int      `json:"repoStars,omitempty"`
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
@@ -42,8 +42,8 @@ type EventRepoMatch struct {
 
 	Repository  string   `json:"repository"`
 	Branches    []string `json:"branches,omitempty"`
-	RepoStars   int      `json:"repoStars"`
-	Description string   `json:"description"`
+	RepoStars   int      `json:"repoStars,omitempty"`
+	Description string   `json:"description,omitempty"`
 	Fork        bool     `json:"fork"`
 	Archived    bool     `json:"archived"`
 }
@@ -57,7 +57,7 @@ type EventSymbolMatch struct {
 
 	Path       string   `json:"name"`
 	Repository string   `json:"repository"`
-	RepoStars  int      `json:"repoStars"`
+	RepoStars  int      `json:"repoStars,omitempty"`
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
@@ -85,7 +85,7 @@ type EventCommitMatch struct {
 	URL        string `json:"url"`
 	Detail     string `json:"detail"`
 	Repository string `json:"repository"`
-	RepoStars  int    `json:"repoStars"`
+	RepoStars  int    `json:"repoStars,omitempty"`
 	Content    string `json:"content"`
 	// [line, character, length]
 	Ranges [][3]int32 `json:"ranges"`

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -42,7 +42,7 @@ type EventRepoMatch struct {
 
 	Repository  string   `json:"repository"`
 	Branches    []string `json:"branches,omitempty"`
-	Stars       int      `json:"stars"`
+	RepoStars   int      `json:"repoStars"`
 	Description string   `json:"description"`
 	Fork        bool     `json:"fork"`
 	Archived    bool     `json:"archived"`


### PR DESCRIPTION
This PR adds streaming metadata to streaming results. It is an updated and re-opened #22032, which was reverted because it caused performance degration on sourcegraph.com.

In order to fix the performance issues seen on sourcegraph.com, two changes were made:
- Events are batched together every 50 milliseconds, skipping the first event to maintain a low time-to-first-result. 
- A repo metadata cache is added to cache repo metadata for the most popular repos on sourcegraph.com

Because the conditions of sourcegraph.com are difficult to reproduce locally, I put this behind a temporary feature flag so I can test on the scale of sourcegraph.com for only my user. Additionally, this gives me the chance to dogfood backend feature flags a bit to work out some kinks. It revealed an issue that feature flag middleware wasn't being run on the app handler, only the API handler, so feature flags were not available for streaming search. That's fixed by b6eaa4e