### PR TITLE
storybook: fix dark mode toggle

### DIFF
--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -1,9 +1,9 @@
-import React, { useLayoutEffect, useState } from 'react'
+import React from 'react'
 import { MemoryRouter, MemoryRouterProps } from 'react-router'
-import { useDarkMode } from 'storybook-dark-mode'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useStyles } from '@sourcegraph/storybook/src/hooks/useStyles'
+import { useTheme } from '@sourcegraph/storybook/src/hooks/useTheme'
 
 import brandedStyles from '../global-styles/index.scss'
 
@@ -22,21 +22,8 @@ export const BrandedStory: React.FunctionComponent<
         styles?: string
     }
 > = ({ children: Children, styles = brandedStyles, ...memoryRouterProps }) => {
-    const isDarkMode = useDarkMode()
-    const [isLightTheme, setIsLightTheme] = useState(!isDarkMode)
+    const isLightTheme = useTheme()
     useStyles(styles)
-
-    useLayoutEffect(() => {
-        setIsLightTheme(!isDarkMode)
-    }, [isDarkMode])
-
-    useLayoutEffect(() => {
-        const listener = ((event: CustomEvent<boolean>): void => {
-            setIsLightTheme(event.detail)
-        }) as EventListener
-        document.body.addEventListener('chromatic-light-theme-toggled', listener)
-        return () => document.body.removeEventListener('chromatic-light-theme-toggled', listener)
-    }, [])
 
     return (
         <MemoryRouter {...memoryRouterProps}>

--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -22,8 +22,13 @@ export const BrandedStory: React.FunctionComponent<
         styles?: string
     }
 > = ({ children: Children, styles = brandedStyles, ...memoryRouterProps }) => {
-    const [isLightTheme, setIsLightTheme] = useState(!useDarkMode())
+    const isDarkMode = useDarkMode()
+    const [isLightTheme, setIsLightTheme] = useState(!isDarkMode)
     useStyles(styles)
+
+    useLayoutEffect(() => {
+        setIsLightTheme(!isDarkMode)
+    }, [isDarkMode])
 
     useLayoutEffect(() => {
         const listener = ((event: CustomEvent<boolean>): void => {

--- a/client/storybook/src/hooks/useTheme.ts
+++ b/client/storybook/src/hooks/useTheme.ts
@@ -1,0 +1,31 @@
+import { useLayoutEffect, useState } from 'react'
+import { useDarkMode } from 'storybook-dark-mode'
+
+/**
+ * Gets current theme and updates value when theme changes
+ *
+ * @returns isLightTheme: boolean that is true if the light theme is enabled
+ */
+export const useTheme = (): boolean => {
+    const isDarkMode = useDarkMode()
+    const [isLightTheme, setIsLightTheme] = useState(!isDarkMode)
+
+    // This is required for reacting to theme changes in local Storybook
+    // via the toolbar button added by storybook-dark-mode
+    useLayoutEffect(() => {
+        setIsLightTheme(!isDarkMode)
+    }, [isDarkMode])
+
+    // This is required for Chromatic to react to theme changes when
+    // taking screenshots. See `create-chromatic-story.tsx` where
+    // this event is dispatched.
+    useLayoutEffect(() => {
+        const listener = ((event: CustomEvent<boolean>): void => {
+            setIsLightTheme(event.detail)
+        }) as EventListener
+        document.body.addEventListener('chromatic-light-theme-toggled', listener)
+        return () => document.body.removeEventListener('chromatic-light-theme-toggled', listener)
+    }, [])
+
+    return isLightTheme
+}

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -26,10 +26,15 @@ export const WebStory: React.FunctionComponent<
         webStyles?: string
     }
 > = ({ children, webStyles = _webStyles, ...memoryRouterProps }) => {
-    const [isLightTheme, setIsLightTheme] = useState(!useDarkMode())
+    const isDarkMode = useDarkMode()
+    const [isLightTheme, setIsLightTheme] = useState(!isDarkMode)
     const breadcrumbSetters = useBreadcrumbs()
     const Children = useMemo(() => withRouter(children), [children])
     useStyles(webStyles)
+
+    useLayoutEffect(() => {
+        setIsLightTheme(!isDarkMode)
+    }, [isDarkMode])
 
     useLayoutEffect(() => {
         const listener = ((event: CustomEvent<boolean>): void => {

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -1,11 +1,11 @@
-import React, { useLayoutEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { MemoryRouter, MemoryRouterProps, RouteComponentProps, withRouter } from 'react-router'
-import { useDarkMode } from 'storybook-dark-mode'
 
 import { Tooltip } from '@sourcegraph/branded/src/components/tooltip/Tooltip'
 import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useStyles } from '@sourcegraph/storybook/src/hooks/useStyles'
+import { useTheme } from '@sourcegraph/storybook/src/hooks/useTheme'
 
 import _webStyles from '../SourcegraphWebApp.scss'
 
@@ -26,23 +26,10 @@ export const WebStory: React.FunctionComponent<
         webStyles?: string
     }
 > = ({ children, webStyles = _webStyles, ...memoryRouterProps }) => {
-    const isDarkMode = useDarkMode()
-    const [isLightTheme, setIsLightTheme] = useState(!isDarkMode)
+    const isLightTheme = useTheme()
     const breadcrumbSetters = useBreadcrumbs()
     const Children = useMemo(() => withRouter(children), [children])
     useStyles(webStyles)
-
-    useLayoutEffect(() => {
-        setIsLightTheme(!isDarkMode)
-    }, [isDarkMode])
-
-    useLayoutEffect(() => {
-        const listener = ((event: CustomEvent<boolean>): void => {
-            setIsLightTheme(event.detail)
-        }) as EventListener
-        document.body.addEventListener('chromatic-light-theme-toggled', listener)
-        return () => document.body.removeEventListener('chromatic-light-theme-toggled', listener)
-    }, [])
 
     return (
         <MemoryRouter {...memoryRouterProps}>


### PR DESCRIPTION
Previous work to make dark mode reactive in Chromatic broke the dark mode toggle when running storybook locally. This should bring that back again.