### PR TITLE
search frontend: fix predicate highlights for field aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Stricter validation of structural search queries. The `type:` parameter is not supported for structural searches and returns an appropriate alert. [#21487](https://github.com/sourcegraph/sourcegraph/pull/21487)
 - Batch changeset specs that are not attached to changesets will no longer prematurely expire before the batch specs that they are associated with. [#21678](https://github.com/sourcegraph/sourcegraph/pull/21678)
 - Code insights line chart no longer has a negative quadrant [#22018](https://github.com/sourcegraph/sourcegraph/pull/22018)
+- Correctly handle field aliases in the query (like `r:` versus `repo:`) when used with `contains` predicates. [#22105](https://github.com/sourcegraph/sourcegraph/pull/22105)
 
 ### Removed
 

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -49,6 +49,21 @@ export enum AliasedFilterType {
 }
 /* eslint-enable unicorn/prevent-abbreviations */
 
+export const ALIASES: Record<string, string> = {
+    r: 'repo',
+    g: 'repogroup',
+    f: 'file',
+    l: 'lang',
+    language: 'language',
+    since: 'after',
+    until: 'before',
+    m: 'message',
+    msg: 'message',
+    revision: 'rev',
+}
+
+export const resolveFieldAlias = (field: string): string => ALIASES[field] || field
+
 export const isFilterType = (filter: string): filter is FilterType => filter in FilterType
 export const isAliasedFilterType = (filter: string): boolean => filter in AliasedFilterType
 

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -35,6 +35,12 @@ describe('scanPredicate', () => {
     test('scan invalid nonalphanumeric name', () => {
         expect(scanPredicate('repo', 'contains.yo?inks(stuff)')).toMatchInlineSnapshot('invalid')
     })
+
+    test('resolve field aliases for predicates', () => {
+        expect(scanPredicate('r', 'contains.file(stuff)')).toMatchInlineSnapshot(
+            '{"path":["contains","file"],"parameters":"(stuff)"}'
+        )
+    })
 })
 
 describe('resolveAccess', () => {

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-template-curly-in-string */
-import { Completion } from './filters'
+import { Completion, resolveFieldAlias } from './filters'
 
 interface Access {
     name: string
@@ -115,6 +115,7 @@ export const scanPredicate = (field: string, value: string): Predicate | undefin
     }
     const name = match[0]
     const path = name.split('.')
+    field = resolveFieldAlias(field)
     const access = resolveAccess([field, ...path], PREDICATES)
     if (!access) {
         return undefined


### PR DESCRIPTION
Fixes #21880.

<img width="300" alt="Screen Shot 2021-06-15 at 3 36 42 PM" src="https://user-images.githubusercontent.com/888624/122132337-80feeb80-cdef-11eb-8fca-ade636a17be8.png">
