### PR TITLE
internal/search: order results by repository priority (star count).

### DIFF
--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -35,6 +35,10 @@ func (r *CommitMatch) ResultCount() int {
 	return 1
 }
 
+func (r *CommitMatch) Priority() float64 {
+	return 0
+}
+
 func (r *CommitMatch) Limit(limit int) int {
 	if len(r.Body.Highlights) == 0 {
 		return limit - 1 // just counting the commit

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -37,17 +37,19 @@ func (f *File) URL() *url.URL {
 // FileMatch represents either:
 // - A collection of symbol results (len(Symbols) > 0)
 // - A collection of text content results (len(LineMatches) > 0)
-// - A result repsenting the whole file (len(Symbols) == 0 && len(LineMatches) == 0)
+// - A result representing the whole file (len(Symbols) == 0 && len(LineMatches) == 0)
 type FileMatch struct {
 	File
 
 	LineMatches []*LineMatch
 	Symbols     []*SymbolMatch `json:"-"`
 
-	LimitHit bool
+	LimitHit           bool
+	RepositoryPriority float64
 }
 
 func (fm *FileMatch) searchResultMarker() {}
+func (fm *FileMatch) Priority() float64   { return fm.RepositoryPriority }
 
 func (fm *FileMatch) ResultCount() int {
 	rc := len(fm.Symbols)

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -15,6 +15,8 @@ type Match interface {
 	// Key returns a key which uniquely identifies this match.
 	Key() Key
 
+	Priority() float64
+
 	// ensure only types in this package can be a Match.
 	searchResultMarker()
 }

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -16,6 +16,8 @@ type RepoMatch struct {
 	Rev string
 }
 
+func (r *RepoMatch) Priority() float64 { return 0 }
+
 func (r RepoMatch) RepoName() types.RepoName {
 	return types.RepoName{
 		Name: r.Name,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -454,9 +454,10 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 						symbols = zoektFileMatchToSymbolResults(repo, inputRev, &file)
 					}
 					fm := result.FileMatch{
-						LineMatches: lines,
-						LimitHit:    fileLimitHit,
-						Symbols:     symbols,
+						RepositoryPriority: file.RepositoryPriority,
+						LineMatches:        lines,
+						LimitHit:           fileLimitHit,
+						Symbols:            symbols,
 						File: result.File{
 							InputRev: &inputRev,
 							CommitID: api.CommitID(file.Version),


### PR DESCRIPTION
This should make result pages more stable and useful.

This requires sourcegraph/zoekt#89 for Zoekt results to include repo priorities.
