### PR TITLE
Fix repo page scrolling

### DIFF
--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -9,10 +9,11 @@
     // without it. This should be removed once we can get rid of that child selector.
     border: none !important;
     border-radius: 0 !important;
-    padding-bottom: 2rem !important;
+    height: 100%;
 
     &__container {
         overflow-y: auto;
+        height: 100%;
         flex: 1;
         background-color: var(--code-bg);
     }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/22110

Seems like the scrolling was clearly intended (there was an `overflow-y: auto`), but it was ineffective because the container was not set to `height: 100%`. Also removed the padding to fix #21511 which would have otherwise been visible again.