### PR TITLE
extensibility: refresh diff status bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Backend Code Insights displays data points for a fixed 6 months period in 2 week intervals, and will carry observations forward that are missing. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
 - Backend Code Insights now aggregate over 26 weeks instead of 6 months. [#22527](https://github.com/sourcegraph/sourcegraph/pull/22527)
 - Search queries now disallow specifying `rev:` without `repo:`. Note that to search across potentially multiple revisions, a query like `repo:.* rev:<revision>` remains valid. [#22705](https://github.com/sourcegraph/sourcegraph/pull/22705)
+- The extensions status bar on diff pages has been redesigned and now shows information for both the base and head commits. [#22123](https://github.com/sourcegraph/sourcegraph/pull/22123/files)
 
 ### Fixed
 

--- a/client/web/src/components/diff/FileDiffHunks.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import * as H from 'history'
 import React, { useCallback, useMemo, useState, useEffect } from 'react'
 import { combineLatest, from, NEVER, Observable, of, ReplaySubject, Subscription } from 'rxjs'
-import { filter, first, map, switchMap, tap } from 'rxjs/operators'
+import { distinctUntilKeyChanged, filter, first, map, switchMap, tap } from 'rxjs/operators'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 
 import { findPositionsFromEvents } from '@sourcegraph/codeintellify'
@@ -16,6 +16,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { StatusBar } from '../../extensions/components/StatusBar'
 import { FileDiffFields } from '../../graphql-operations'
+import { DiffMode } from '../../repo/commit/RepositoryCommitPage'
 import { diffDomFunctions } from '../../repo/compare/dom-functions'
 
 import { DiffHunk } from './DiffHunk'
@@ -53,7 +54,7 @@ export interface FileHunksProps extends ThemeProps {
     history: H.History
     /** Reflect selected line in url */
     persistLines?: boolean
-    diffMode: string
+    diffMode: DiffMode
 }
 
 /** Displays hunks in a unified file diff. */
@@ -124,43 +125,36 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                         headViewerIds,
                         from(extensionInfo.extensionsController.extHostAPI),
                     ])
-                })
+                }),
+                map(([baseViewerId, headViewerId, extensionHostAPI]) => ({
+                    baseViewerId,
+                    headViewerId,
+                    extensionHostAPI,
+                }))
             ),
         [extensionInfoChanges]
     )
 
-    // Listen for and merge status bar items from extensions for <StatusBar>
-    const getStatusBarItems = useCallback(
+    const getHeadStatusBarItems = useCallback(
         () =>
             baseAndHeadViewerIds.pipe(
-                switchMap(([baseViewerId, headViewerId, extensionHostAPI]) =>
-                    combineLatest([
-                        baseViewerId
-                            ? wrapRemoteObservable(extensionHostAPI.getStatusBarItems(baseViewerId))
-                            : of(null),
-                        headViewerId
-                            ? wrapRemoteObservable(extensionHostAPI.getStatusBarItems(headViewerId))
-                            : of(null),
-                    ])
+                distinctUntilKeyChanged('headViewerId'),
+                switchMap(({ headViewerId, extensionHostAPI }) =>
+                    headViewerId ? wrapRemoteObservable(extensionHostAPI.getStatusBarItems(headViewerId)) : of(null)
                 ),
-                map(([baseStatusBarItems, headStatusBarItems]) => {
-                    if (baseStatusBarItems && headStatusBarItems) {
-                        return [
-                            ...baseStatusBarItems.map(({ text, key, ...rest }) => ({
-                                text: `base: ${text}`,
-                                key: `base-${key}`,
-                                ...rest,
-                            })),
-                            ...headStatusBarItems.map(({ text, key, ...rest }) => ({
-                                text: `head: ${text}`,
-                                key: `head-${key}`,
-                                ...rest,
-                            })),
-                        ]
-                    }
+                map(statusBarItems => statusBarItems || [])
+            ),
+        [baseAndHeadViewerIds]
+    )
 
-                    return headStatusBarItems || baseStatusBarItems || []
-                })
+    const getBaseStatusBarItems = useCallback(
+        () =>
+            baseAndHeadViewerIds.pipe(
+                distinctUntilKeyChanged('baseViewerId'),
+                switchMap(({ baseViewerId, extensionHostAPI }) =>
+                    baseViewerId ? wrapRemoteObservable(extensionHostAPI.getStatusBarItems(baseViewerId)) : of(null)
+                ),
+                map(statusBarItems => statusBarItems || [])
             ),
         [baseAndHeadViewerIds]
     )
@@ -170,7 +164,7 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
         useMemo(
             () =>
                 baseAndHeadViewerIds.pipe(
-                    switchMap(([baseViewerId, headViewerId, extensionHostAPI]) =>
+                    switchMap(({ baseViewerId, headViewerId, extensionHostAPI }) =>
                         combineLatest([
                             baseViewerId
                                 ? wrapRemoteObservable(extensionHostAPI.getTextDecorations(baseViewerId))
@@ -225,15 +219,36 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
         return () => subscription.unsubscribe()
     }, [codeElements, extensionInfoChanges])
 
+    const isSplitMode = diffMode === 'split'
+
     return (
         <div className="file-diff-node__body">
             {extensionInfo && (
-                <StatusBar
-                    getStatusBarItems={getStatusBarItems}
-                    className="file-diff-node__status-bar border-bottom border-top-0"
-                    extensionsController={extensionInfo.extensionsController}
-                    location={location}
-                />
+                <div className={classNames('d-flex w-100')}>
+                    {/* Always render base status bar even though it isn't displayed in unified mode
+                    in order to prevent overloading the extension host with messages (`api.getStatusBarItems`) on
+                    mode switch, which noticeably decreases status bar performance. */}
+                    <StatusBar
+                        getStatusBarItems={getBaseStatusBarItems}
+                        className={classNames(
+                            isSplitMode ? 'flex-1 w-50' : 'd-none',
+                            'file-diff-node__status-bar border-bottom border-top-0'
+                        )}
+                        extensionsController={extensionInfo.extensionsController}
+                        location={location}
+                        badgeText={isSplitMode ? 'BASE' : undefined}
+                    />
+                    <StatusBar
+                        getStatusBarItems={getHeadStatusBarItems}
+                        className={classNames(
+                            isSplitMode && 'w-50',
+                            'flex-1 file-diff-node__status-bar border-bottom border-top-0'
+                        )}
+                        extensionsController={extensionInfo.extensionsController}
+                        location={location}
+                        badgeText={isSplitMode ? 'HEAD' : undefined}
+                    />
+                </div>
             )}
             <div className={`file-diff-hunks ${className}`} ref={nextBlobElement}>
                 {hunks.length === 0 ? (
@@ -242,12 +257,12 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                     <div className="file-diff-hunks__container" ref={nextCodeElement}>
                         <table
                             className={classNames('file-diff-hunks__table file-diff-hunks__table', {
-                                'diff-hunk--split': diffMode === 'split',
+                                'diff-hunk--split': isSplitMode,
                             })}
                         >
                             {lineNumbers && (
                                 <colgroup>
-                                    {diffMode === 'split' ? (
+                                    {isSplitMode ? (
                                         <>
                                             <col width="40" />
                                             <col />
@@ -264,8 +279,8 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                                 </colgroup>
                             )}
                             <tbody>
-                                {hunks.map((hunk, index) =>
-                                    diffMode === 'split' ? (
+                                {hunks.map(hunk =>
+                                    isSplitMode ? (
                                         <DiffSplitHunk
                                             fileDiffAnchor={fileDiffAnchor}
                                             isLightTheme={isLightTheme}

--- a/client/web/src/components/diff/FileDiffHunks.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.tsx
@@ -224,19 +224,19 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
     return (
         <div className="file-diff-node__body">
             {extensionInfo && (
-                <div className={classNames('d-flex w-100')}>
+                <div className={classNames('w-100', isSplitMode && 'd-flex ')}>
                     {/* Always render base status bar even though it isn't displayed in unified mode
                     in order to prevent overloading the extension host with messages (`api.getStatusBarItems`) on
                     mode switch, which noticeably decreases status bar performance. */}
                     <StatusBar
                         getStatusBarItems={getBaseStatusBarItems}
                         className={classNames(
-                            isSplitMode ? 'flex-1 w-50' : 'd-none',
+                            isSplitMode && 'flex-1 w-50',
                             'file-diff-node__status-bar border-bottom border-top-0'
                         )}
                         extensionsController={extensionInfo.extensionsController}
                         location={location}
-                        badgeText={isSplitMode ? 'BASE' : undefined}
+                        badgeText="BASE"
                     />
                     <StatusBar
                         getStatusBarItems={getHeadStatusBarItems}
@@ -246,7 +246,7 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                         )}
                         extensionsController={extensionInfo.extensionsController}
                         location={location}
-                        badgeText={isSplitMode ? 'HEAD' : undefined}
+                        badgeText="HEAD"
                     />
                 </div>
             )}

--- a/client/web/src/components/diff/FileDiffHunks.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.tsx
@@ -234,6 +234,7 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                             isSplitMode && 'flex-1 w-50',
                             'file-diff-node__status-bar border-bottom border-top-0'
                         )}
+                        statusBarItemClassName="mx-0"
                         extensionsController={extensionInfo.extensionsController}
                         location={location}
                         badgeText="BASE"
@@ -244,6 +245,7 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                             isSplitMode && 'w-50',
                             'flex-1 file-diff-node__status-bar border-bottom border-top-0'
                         )}
+                        statusBarItemClassName="mx-0"
                         extensionsController={extensionInfo.extensionsController}
                         location={location}
                         badgeText="HEAD"

--- a/client/web/src/extensions/components/StatusBar.scss
+++ b/client/web/src/extensions/components/StatusBar.scss
@@ -53,11 +53,11 @@
 
         &--noop {
             cursor: default;
+            color: var(--body-color);
         }
     }
 
     &__text {
         padding-top: 0.0625rem; // 1px
-        color: var(--body-color);
     }
 }

--- a/client/web/src/extensions/components/StatusBar.scss
+++ b/client/web/src/extensions/components/StatusBar.scss
@@ -51,13 +51,6 @@
             padding-right: 0.5rem !important;
         }
 
-        &--interactive {
-            &:hover {
-                background-color: var(--color-bg-2);
-                color: var(--link-hover-color);
-            }
-        }
-
         &--noop {
             cursor: default;
         }

--- a/client/web/src/extensions/components/StatusBar.scss
+++ b/client/web/src/extensions/components/StatusBar.scss
@@ -1,6 +1,15 @@
 .status-bar {
     background-color: var(--color-bg-2);
     height: 1.5rem;
+    // Define `width` and `display` in this class, instead of with utility classes,
+    // to allow consumers to override them with utility classes
+    width: 100%;
+    display: flex;
+
+    .theme-redesign & {
+        background-color: var(--code-bg);
+        height: 2rem;
+    }
 
     &__items {
         overflow-x: auto;

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -36,6 +36,9 @@ interface StatusBarProps extends ExtensionsControllerProps<'extHostAPI' | 'execu
 
     /** Whether to hide the status bar while extensions are loading. */
     hideWhileInitializing?: boolean
+
+    /** If specified, this text will be displayed in a badge left of the status bar items */
+    badgeText?: string
 }
 
 export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
@@ -46,6 +49,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
     location,
     statusBarRef,
     hideWhileInitializing,
+    badgeText,
 }) => {
     const statusBarItems = useObservable(useMemo(() => getStatusBarItems(), [getStatusBarItems]))
 
@@ -87,7 +91,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
     return (
         <div
             className={classNames(
-                'status-bar w-100 border-top d-flex',
+                'status-bar border-top',
                 'percy-hide', // TODO: Fix flaky status bar in Percy tests: https://github.com/sourcegraph/sourcegraph/issues/20751
                 className
             )}
@@ -113,6 +117,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                     </button>
                 )}
                 <div className="status-bar__items d-flex align-items-center px-2" ref={carouselReference}>
+                    {badgeText && <p className="badge badge-secondary m-0">{badgeText}</p>}
                     {!!statusBarItems && statusBarItems !== 'loading' && statusBarItems.length > 0
                         ? statusBarItems.map(statusBarItem => (
                               <StatusBarItem

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -23,6 +23,7 @@ import { useCarousel } from '../../components/useCarousel'
 interface StatusBarProps extends ExtensionsControllerProps<'extHostAPI' | 'executeCommand'> {
     getStatusBarItems: () => Observable<StatusBarItemWithKey[] | 'loading'>
     className?: string
+    statusBarItemClassName?: string
     /**
      * Used to determine when to restart timer to show "Install extensions"
      * message when there are no status bar items. Only necessary when status bar
@@ -44,6 +45,7 @@ interface StatusBarProps extends ExtensionsControllerProps<'extHostAPI' | 'execu
 export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
     getStatusBarItems,
     className,
+    statusBarItemClassName,
     extensionsController,
     uri,
     location,
@@ -125,6 +127,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                                   statusBarItem={statusBarItem}
                                   extensionsController={extensionsController}
                                   location={location}
+                                  className={statusBarItemClassName}
                               />
                           ))
                         : hasEnoughTimePassed && (
@@ -159,7 +162,7 @@ const StatusBarItem: React.FunctionComponent<
         component?: JSX.Element
         location: H.Location
     } & ExtensionsControllerProps<'extHostAPI' | 'executeCommand'>
-> = ({ statusBarItem, className = 'status-bar', component, extensionsController, location }) => {
+> = ({ statusBarItem, className, component, extensionsController, location }) => {
     const [commandState, setCommandState] = useState<'loading' | null>(null)
 
     const command = useMemo(() => statusBarItem.command, [statusBarItem.command])
@@ -191,8 +194,9 @@ const StatusBarItem: React.FunctionComponent<
     return (
         <ButtonLink
             className={classNames(
-                `${className}__item h-100 d-flex align-items-center px-1 text-decoration-none`,
-                noop && `${className}__item--noop`
+                'status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none',
+                noop && 'status-bar__item--noop',
+                className
             )}
             data-tooltip={statusBarItem.tooltip}
             onSelect={handleCommand}
@@ -201,7 +205,7 @@ const StatusBarItem: React.FunctionComponent<
             disabled={commandState === 'loading'}
         >
             {component || (
-                <small className={classNames(`${className}__text`, commandState === 'loading' && 'text-muted')}>
+                <small className={classNames('status-bar__text', commandState === 'loading' && 'text-muted')}>
                     {statusBarItem.text}
                 </small>
             )}

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -188,13 +188,10 @@ const StatusBarItem: React.FunctionComponent<
 
     const noop = !command
 
-    const interactive = Boolean(command || statusBarItem.tooltip)
-
     return (
         <ButtonLink
             className={classNames(
                 `${className}__item h-100 d-flex align-items-center px-1 text-decoration-none`,
-                interactive && `${className}__item--interactive`,
                 noop && `${className}__item--noop`
             )}
             data-tooltip={statusBarItem.tooltip}

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -194,8 +194,8 @@ const StatusBarItem: React.FunctionComponent<
     return (
         <ButtonLink
             className={classNames(
-                'status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none',
-                noop && 'status-bar__item--noop',
+                'status-bar__item h-100 d-flex align-items-center px-1',
+                noop && 'status-bar__item--noop text-decoration-none',
                 className
             )}
             data-tooltip={statusBarItem.tooltip}

--- a/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
+++ b/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`StatusBar renders correctly 1`] = `
         class="status-bar__items d-flex align-items-center px-2"
       >
         <a
-          class="status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none status-bar__item--noop"
+          class="status-bar__item h-100 d-flex align-items-center px-1 status-bar__item--noop text-decoration-none"
           href=""
           role="button"
           tabindex="-1"
@@ -23,7 +23,7 @@ exports[`StatusBar renders correctly 1`] = `
         </a>
         <a
           aria-label="Code owners: @felixbecker, @beyang"
-          class="status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none status-bar__item--noop"
+          class="status-bar__item h-100 d-flex align-items-center px-1 status-bar__item--noop text-decoration-none"
           data-tooltip="Code owners: @felixbecker, @beyang"
           href=""
           role="button"

--- a/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
+++ b/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`StatusBar renders correctly 1`] = `
 <body>
   <div>
     <div
-      class="status-bar w-100 border-top d-flex percy-hide"
+      class="status-bar border-top percy-hide"
     >
       <div
         class="status-bar__items d-flex align-items-center px-2"
@@ -23,7 +23,7 @@ exports[`StatusBar renders correctly 1`] = `
         </a>
         <a
           aria-label="Code owners: @felixbecker, @beyang"
-          class="status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none status-bar__item--interactive status-bar__item--noop"
+          class="status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none status-bar__item--noop"
           data-tooltip="Code owners: @felixbecker, @beyang"
           href=""
           role="button"

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -112,5 +112,6 @@
         border-radius: var(--border-radius);
         border: 1px solid var(--border-color);
         background-color: var(--body-bg);
+        color: var(--body-color);
     }
 }


### PR DESCRIPTION
Closes #21716. 

![Screenshot from 2021-06-16 08-36-24](https://user-images.githubusercontent.com/37420160/122220068-fdd8a680-ce7d-11eb-8455-113c1ca0c560.png)
![Screenshot from 2021-06-16 08-36-59](https://user-images.githubusercontent.com/37420160/122220115-0a5cff00-ce7e-11eb-92ef-e8a7f217bb60.png)

Only show head status bar in unified mode, show both in split mode. Remove hover styles. @AlicjaSuska should we have a different text color/underline on hover?

<details>
<summary>Split status bars scroll when overflowing</summary>
<img src="https://user-images.githubusercontent.com/37420160/122220662-8a836480-ce7e-11eb-8196-1b48679d3615.gif" />
</details>

<details>
<summary>No more full height background on hover</summary>
<img src="https://user-images.githubusercontent.com/37420160/122220587-750e3a80-ce7e-11eb-838e-43882bac025c.gif" />
</details>

<details>
<summary>Toggle between split and unified mode</summary>
<img src="https://user-images.githubusercontent.com/37420160/122220736-9cfd9e00-ce7e-11eb-96ed-631485a5c8ed.gif" />
</details>

TODO (based on latest information):
- [ ] Show base and head status bars on unified mode on separate lines