### PR TITLE
upgrade libxml2 for CVEs

### DIFF
--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -27,3 +27,8 @@ RUN apk add --no-cache bind-tools
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates mailcap tini curl
+
+# Manually upgrade upgrade libxml2 packages due CVE's
+# See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517 and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3518
+# hadolint ignore=DL3018
+RUN apk add --upgrade --no-cache libxml2

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -28,7 +28,9 @@ RUN apk add --no-cache bind-tools
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates mailcap tini curl
 
-# Manually upgrade upgrade libxml2 packages due CVE's
+# Manually upgrade to remediate the following CVE's
 # See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517 and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3518
 # hadolint ignore=DL3018
-RUN apk add --upgrade --no-cache libxml2
+RUN apk -U upgrade
+
+

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -28,9 +28,7 @@ RUN apk add --no-cache bind-tools
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates mailcap tini curl
 
-# Manually upgrade to remediate the following CVE's
+# Manually upgrade upgrade libxml2 packages due CVE's
 # See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517 and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3518
 # hadolint ignore=DL3018
-RUN apk -U upgrade
-
-
+RUN apk add --upgrade --no-cache libxml2


### PR DESCRIPTION
This PR manually upgrades the libxml2 to remediate the two CVEs below:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3518

Found as part of https://github.com/sourcegraph/security-issues/issues/151