### PR TITLE
codeintel: Do not store self-references in lsif_references table

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -395,7 +395,7 @@ WITH overlapping_dumps AS (
 	-- below. If we don't do this then we run into a pretty high
 	-- deadlock rate during upload processing as multiple workers
 	-- issue commands for the same set of records, but upload locks
-	-- records indeterministically.
+	-- records nondeterministically.
 	ORDER BY id FOR UPDATE
 ),
 updated AS (

--- a/lib/codeintel/lsif/conversion/group_test.go
+++ b/lib/codeintel/lsif/conversion/group_test.go
@@ -188,6 +188,22 @@ func TestGroupBundleData(t *testing.T) {
 				},
 				PackageInformationID: 0,
 			},
+			4005: {
+				Moniker: reader.Moniker{
+					Kind:       "export",
+					Scheme:     "scheme E",
+					Identifier: "ident E",
+				},
+				PackageInformationID: 5003,
+			},
+			4006: {
+				Moniker: reader.Moniker{
+					Kind:       "import",
+					Scheme:     "scheme E",
+					Identifier: "ident E",
+				},
+				PackageInformationID: 5003,
+			},
 		},
 		PackageInformationData: map[int]PackageInformation{
 			5001: {
@@ -197,6 +213,10 @@ func TestGroupBundleData(t *testing.T) {
 			5002: {
 				Name:    "pkg B",
 				Version: "1.2.3",
+			},
+			5003: {
+				Name:    "pkg C",
+				Version: "3.2.1",
 			},
 		},
 		DiagnosticResults: map[int][]Diagnostic{
@@ -247,8 +267,8 @@ func TestGroupBundleData(t *testing.T) {
 				},
 			},
 		},
-		ImportedMonikers: datastructures.IDSetWith(4001),
-		ExportedMonikers: datastructures.IDSetWith(4003),
+		ImportedMonikers: datastructures.IDSetWith(4001, 4006),
+		ExportedMonikers: datastructures.IDSetWith(4003, 4005),
 		Contains: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 			1001: datastructures.IDSetWith(2001, 2002, 2003),
 			1002: datastructures.IDSetWith(2004, 2005, 2006),
@@ -278,7 +298,11 @@ func TestGroupBundleData(t *testing.T) {
 
 	expectedPackages := []semantic.Package{
 		{Scheme: "scheme C", Name: "pkg B", Version: "1.2.3"},
+		{Scheme: "scheme E", Name: "pkg C", Version: "3.2.1"},
 	}
+	sort.Slice(actualBundleData.Packages, func(i, j int) bool {
+		return actualBundleData.Packages[i].Scheme < actualBundleData.Packages[j].Scheme
+	})
 	if diff := cmp.Diff(expectedPackages, actualBundleData.Packages); diff != "" {
 		t.Errorf("unexpected packages (-want +got):\n%s", diff)
 	}
@@ -293,6 +317,9 @@ func TestGroupBundleData(t *testing.T) {
 			Filter:  expectedFilter,
 		},
 	}
+	sort.Slice(actualBundleData.PackageReferences, func(i, j int) bool {
+		return actualBundleData.PackageReferences[i].Scheme < actualBundleData.PackageReferences[j].Scheme
+	})
 	if diff := cmp.Diff(expectedPackageReferences, actualBundleData.PackageReferences); diff != "" {
 		t.Errorf("unexpected package references (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
In the future we'll want to avoid deleting indexes that are referenced by another visible index. This will be made more difficult if an index can import a symbol from itself (common in a lot of index formats).

This stops adding a reference to the same index inside of the lsif_references table by checking whether or not there will be an entry inserted in the lsif_packages table with the same scheme, name, and version. This may also clean up some conditions in the query path in the future (we no longer have to explicitly de-list our own index when paging references).

Behavior should be identical, but should save some space on useless entries being inserted into the frontend db. We'll need a second pass in th future to clean up existing data that is self-referential.

Partial effort towards #19120.