### PR TITLE
Fuzzy finder: don't force URL to use git SHA revision

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -508,7 +508,14 @@ export function encodeRepoRevision({ repoName, revision }: RepoSpec & Partial<Re
 }
 
 export function toPrettyBlobURL(
-    target: RepoFile & Partial<UIPositionSpec> & Partial<ViewStateSpec> & Partial<UIRangeSpec> & Partial<RenderModeSpec>
+    target: RepoSpec &
+        Partial<RevisionSpec> &
+        Partial<ResolvedRevisionSpec> &
+        FileSpec &
+        Partial<UIPositionSpec> &
+        Partial<ViewStateSpec> &
+        Partial<UIRangeSpec> &
+        Partial<RenderModeSpec>
 ): string {
     const searchParameters = addLineRangeQueryParameter(
         addRenderModeQueryParameter(new URLSearchParams(), target),

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -9,6 +9,7 @@ import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 import { CaseInsensitiveFuzzySearch } from '../../fuzzyFinder/CaseInsensitiveFuzzySearch'
 import { FuzzySearch, FuzzySearchResult, SearchIndexing, SearchValue } from '../../fuzzyFinder/FuzzySearch'
 import { WordSensitiveFuzzySearch } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
+import { parseBrowserRepoURL } from '../../util/url'
 
 import { FuzzyFinderProps, Indexing, FuzzyFSM } from './FuzzyFinder'
 import styles from './FuzzyModal.module.scss'
@@ -269,15 +270,17 @@ function renderFiles(
     search: FuzzySearch,
     indexing?: SearchIndexing
 ): RenderedFuzzyResult {
+    const { revision } = parseBrowserRepoURL(location.pathname + location.search + location.hash)
+    const revisionUrlPart = revision ? `@${revision}` : ''
     const indexedFileCount = indexing ? indexing.indexedFileCount : ''
-    const cacheKey = `${state.query}-${state.maxResults}${indexedFileCount}`
+    const cacheKey = `${state.query}-${state.maxResults}${indexedFileCount}-${revisionUrlPart}`
     let fuzzyResult = lastFuzzySearchResult.get(cacheKey)
     if (!fuzzyResult) {
         const start = window.performance.now()
         fuzzyResult = search.search({
             query: state.query,
             maxResults: state.maxResults,
-            createUrl: filename => `/${props.repoName}@${props.commitID}/-/blob/${filename}`,
+            createUrl: filename => `/${props.repoName}${revisionUrlPart}/-/blob/${filename}`,
             onClick: () => props.onClose(),
         })
         fuzzyResult.elapsedMilliseconds = window.performance.now() - start

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -274,7 +274,7 @@ function renderFiles(
     // Parse the URL here instead of accepting it as a React prop because the
     // URL can change based on shortcuts like `y` that won't trigger a re-render
     // in React. By parsing the URL here, we avoid the risk of rendering links to a revision that
-    // doesn't match the active revision in the
+    // doesn't match the active revision in the browser's address bar.
     const repoUrl = parseBrowserRepoURL(location.pathname + location.search + location.hash)
     const indexedFileCount = indexing ? indexing.indexedFileCount : ''
     const cacheKey = `${state.query}-${state.maxResults}${indexedFileCount}-${repoUrl.revision || ''}`


### PR DESCRIPTION
Previously, the fuzzy finder always used URLs that pointed to the exact
active git SHA (example: `@cfd12491d0f2675ac630e06a3a040b94f3946f70`).
This behavior caused two problems:

- when using the fuzzy finder, your URL can't point to a branch name
  like `@main`. You have to manually edit the URL if you want it to
  point to a non-SHA URL.
- if you activated the fuzzy finder in a non-SHA URL
  (like `@main`) then you always re-downloaded the filenames the next
  time you activated the fuzzy finder (because your URL changed to a SHA
      URL like `@cfd12491d0f2675ac630e06a3a040b94f3946f70`).

This commit updates the fuzzy finder to use the revision (`@main`)
URL, if it's available. This change fixes both problems above.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
