### PR TITLE
search frontend: functional experimental sign up page

### DIFF
--- a/client/web/src/auth/ExperimentalSignUpPage.module.scss
+++ b/client/web/src/auth/ExperimentalSignUpPage.module.scss
@@ -170,3 +170,8 @@
     margin-top: 1.5rem;
     margin-bottom: 2rem;
 }
+
+.back-icon {
+    margin-left: -0.25rem; // Negative margin so icon aligns with form taking internal padding into account.
+    margin-right: 0.25rem;
+}

--- a/client/web/src/auth/ExperimentalSignUpPage.story.tsx
+++ b/client/web/src/auth/ExperimentalSignUpPage.story.tsx
@@ -3,15 +3,53 @@ import React from 'react'
 import sinon from 'sinon'
 
 import { WebStory } from '../components/WebStory'
+import { SourcegraphContext } from '../jscontext'
 
 import { ExperimentalSignUpPage } from './ExperimentalSignUpPage'
 
 const { add } = storiesOf('web/auth/ExperimentalSignUpPage', module)
 
+const context: Pick<SourcegraphContext, 'authProviders'> = {
+    authProviders: [
+        {
+            serviceType: 'github',
+            displayName: 'GitHub.com',
+            isBuiltin: false,
+            authenticationURL: '/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F',
+        },
+        {
+            serviceType: 'gitlab',
+            displayName: 'GitLab.com',
+            isBuiltin: false,
+            authenticationURL: '/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F',
+        },
+    ],
+}
+
 add('default', () => (
     <WebStory>
         {({ isLightTheme }) => (
-            <ExperimentalSignUpPage isLightTheme={isLightTheme} source="test" onSignUp={sinon.stub()} />
+            <ExperimentalSignUpPage
+                isLightTheme={isLightTheme}
+                source="test"
+                onSignUp={sinon.stub()}
+                context={context}
+                useEmail={false}
+            />
+        )}
+    </WebStory>
+))
+
+add('email form', () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <ExperimentalSignUpPage
+                isLightTheme={isLightTheme}
+                source="test"
+                onSignUp={sinon.stub()}
+                context={context}
+                useEmail={true}
+            />
         )}
     </WebStory>
 ))

--- a/client/web/src/auth/ExperimentalSignUpPage.story.tsx
+++ b/client/web/src/auth/ExperimentalSignUpPage.story.tsx
@@ -31,10 +31,10 @@ add('default', () => (
         {({ isLightTheme }) => (
             <ExperimentalSignUpPage
                 isLightTheme={isLightTheme}
-                source="test"
+                source="Monitor"
                 onSignUp={sinon.stub()}
                 context={context}
-                useEmail={false}
+                showEmailForm={false}
             />
         )}
     </WebStory>
@@ -45,10 +45,24 @@ add('email form', () => (
         {({ isLightTheme }) => (
             <ExperimentalSignUpPage
                 isLightTheme={isLightTheme}
+                source="SearchCTA"
+                onSignUp={sinon.stub()}
+                context={context}
+                showEmailForm={true}
+            />
+        )}
+    </WebStory>
+))
+
+add('invalid source', () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <ExperimentalSignUpPage
+                isLightTheme={isLightTheme}
                 source="test"
                 onSignUp={sinon.stub()}
                 context={context}
-                useEmail={true}
+                showEmailForm={false}
             />
         )}
     </WebStory>

--- a/client/web/src/auth/ExperimentalSignUpPage.story.tsx
+++ b/client/web/src/auth/ExperimentalSignUpPage.story.tsx
@@ -2,6 +2,8 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import sinon from 'sinon'
 
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
 import { WebStory } from '../components/WebStory'
 import { SourcegraphContext } from '../jscontext'
 
@@ -35,6 +37,7 @@ add('default', () => (
                 onSignUp={sinon.stub()}
                 context={context}
                 showEmailForm={false}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
             />
         )}
     </WebStory>
@@ -49,6 +52,7 @@ add('email form', () => (
                 onSignUp={sinon.stub()}
                 context={context}
                 showEmailForm={true}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
             />
         )}
     </WebStory>
@@ -63,6 +67,7 @@ add('invalid source', () => (
                 onSignUp={sinon.stub()}
                 context={context}
                 showEmailForm={false}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
             />
         )}
     </WebStory>

--- a/client/web/src/auth/ExperimentalSignUpPage.tsx
+++ b/client/web/src/auth/ExperimentalSignUpPage.tsx
@@ -14,24 +14,37 @@ import { SignUpArguments, SignUpForm } from './SignUpForm'
 
 interface Props extends ThemeProps {
     source: string | null
-    useEmail: boolean
+    showEmailForm: boolean
     /** Called to perform the signup on the server. */
     onSignUp: (args: SignUpArguments) => Promise<void>
     context: Pick<SourcegraphContext, 'authProviders'>
 }
 
+const SourceToTitleMap = {
+    Context: 'Easily search the code you care about.',
+    Saved: 'Create a library of useful searches.',
+    Monitor: 'Monitor code for changes.',
+    Extend: 'Augment code and workflows via extensions.',
+    SearchCTA: 'Add your public (and soon private) repositories.',
+    Snippet: 'Easily search the code you care about.',
+}
+
+export const ShowEmailFormQueryParameter = 'showEmail'
+
 export const ExperimentalSignUpPage: React.FunctionComponent<Props> = ({
     isLightTheme,
-    context,
-    useEmail,
+    source,
+    showEmailForm,
     onSignUp,
+    context,
 }) => {
     const location = useLocation()
+
     const queryWithUseEmailToggled = new URLSearchParams(location.search)
-    if (useEmail) {
-        queryWithUseEmailToggled.delete('useEmail')
+    if (showEmailForm) {
+        queryWithUseEmailToggled.delete(ShowEmailFormQueryParameter)
     } else {
-        queryWithUseEmailToggled.append('useEmail', 'true')
+        queryWithUseEmailToggled.append(ShowEmailFormQueryParameter, 'true')
     }
 
     const assetsRoot = window.context?.assetsRoot || ''
@@ -47,6 +60,11 @@ export const ExperimentalSignUpPage: React.FunctionComponent<Props> = ({
         provider.authenticationURL?.startsWith('/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F')
     )
 
+    const title =
+        source && Object.keys(SourceToTitleMap).includes(source)
+            ? SourceToTitleMap[source as keyof typeof SourceToTitleMap]
+            : SourceToTitleMap.Context // Use Context as default
+
     return (
         <div className={styles.page}>
             <header>
@@ -61,7 +79,7 @@ export const ExperimentalSignUpPage: React.FunctionComponent<Props> = ({
                 </div>
 
                 <div className={styles.limitWidth}>
-                    <h2 className={styles.pageHeading}>Easily search the code you care about.</h2>
+                    <h2 className={styles.pageHeading}>{title}</h2>
                 </div>
             </header>
 
@@ -85,7 +103,7 @@ export const ExperimentalSignUpPage: React.FunctionComponent<Props> = ({
 
                 <div className={styles.signUpWrapper}>
                     <h2>Create a free account</h2>
-                    {!useEmail ? (
+                    {!showEmailForm ? (
                         <>
                             {githubProvider && (
                                 <a

--- a/client/web/src/auth/ExperimentalSignUpPage.tsx
+++ b/client/web/src/auth/ExperimentalSignUpPage.tsx
@@ -1,22 +1,51 @@
 import classNames from 'classnames'
+import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 import GithubIcon from 'mdi-react/GithubIcon'
 import React from 'react'
+import { Link, useLocation } from 'react-router-dom'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { BrandLogo } from '../components/branding/BrandLogo'
+import { SourcegraphContext } from '../jscontext'
 
 import styles from './ExperimentalSignUpPage.module.scss'
-import { SignUpArguments } from './SignUpForm'
+import { SignUpArguments, SignUpForm } from './SignUpForm'
 
 interface Props extends ThemeProps {
     source: string | null
+    useEmail: boolean
     /** Called to perform the signup on the server. */
     onSignUp: (args: SignUpArguments) => Promise<void>
+    context: Pick<SourcegraphContext, 'authProviders'>
 }
 
-export const ExperimentalSignUpPage: React.FunctionComponent<Props> = ({ isLightTheme }) => {
+export const ExperimentalSignUpPage: React.FunctionComponent<Props> = ({
+    isLightTheme,
+    context,
+    useEmail,
+    onSignUp,
+}) => {
+    const location = useLocation()
+    const queryWithUseEmailToggled = new URLSearchParams(location.search)
+    if (useEmail) {
+        queryWithUseEmailToggled.delete('useEmail')
+    } else {
+        queryWithUseEmailToggled.append('useEmail', 'true')
+    }
+
     const assetsRoot = window.context?.assetsRoot || ''
+
+    // Since this page is only intented for use on Sourcegraph.com, it's OK to hardcode
+    // GitHub and GitLab auth providers here as they are the only ones used on Sourcegraph.com.
+    // In the future if this page is intented for use in Sourcegraph Sever, this would need to be generisized
+    // for other auth providers such SAML, OpenID, Okta, Azure AD, etc.
+    const githubProvider = context.authProviders.find(provider =>
+        provider.authenticationURL?.startsWith('/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F')
+    )
+    const gitlabProvider = context.authProviders.find(provider =>
+        provider.authenticationURL?.startsWith('/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F')
+    )
 
     return (
         <div className={styles.page}>
@@ -56,27 +85,70 @@ export const ExperimentalSignUpPage: React.FunctionComponent<Props> = ({ isLight
 
                 <div className={styles.signUpWrapper}>
                     <h2>Create a free account</h2>
+                    {!useEmail ? (
+                        <>
+                            {githubProvider && (
+                                <a
+                                    href={githubProvider.authenticationURL}
+                                    className={classNames(styles.signUpButton, styles.githubButton)}
+                                >
+                                    <GithubIcon className="mr-3" /> Continue with GitHub
+                                </a>
+                            )}
+                            {gitlabProvider && (
+                                <a
+                                    href={gitlabProvider.authenticationURL}
+                                    className={classNames(styles.signUpButton, styles.gitlabButton)}
+                                >
+                                    <GitlabColorIcon className="mr-3" /> Continue with GitLab
+                                </a>
+                            )}
 
-                    <button type="button" className={classNames(styles.signUpButton, styles.githubButton)}>
-                        <GithubIcon className="mr-3" /> Continue with GitHub
-                    </button>
-                    <button type="button" className={classNames(styles.signUpButton, styles.gitlabButton)}>
-                        <GitlabColorIcon className="mr-3" /> Continue with GitLab
-                    </button>
+                            <div className="mb-4">
+                                Or,{' '}
+                                <Link to={`${location.pathname}?${queryWithUseEmailToggled.toString()}`}>
+                                    continue with email
+                                </Link>
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <small className="d-block mt-3">
+                                <Link
+                                    className="d-flex align-items-center"
+                                    to={`${location.pathname}?${queryWithUseEmailToggled.toString()}`}
+                                >
+                                    <ChevronLeftIcon className={classNames('icon-inline', styles.backIcon)} />
+                                    Go back
+                                </Link>
+                            </small>
 
-                    <div className="mb-4">
-                        Or, <a href="/">continue with email</a>
-                    </div>
+                            <SignUpForm
+                                onSignUp={onSignUp}
+                                context={{ authProviders: [], sourcegraphDotComMode: true }}
+                                buttonLabel="Sign up"
+                                experimental={true}
+                                className="my-3"
+                            />
+                        </>
+                    )}
 
                     <small className="text-muted">
-                        By registering, you agree to our <a href="/">Terms of Service</a> and{' '}
-                        <a href="/">Privacy Policy</a>.
+                        By registering, you agree to our{' '}
+                        <a href="https://about.sourcegraph.com/terms" target="_blank" rel="noopener">
+                            Terms of Service
+                        </a>{' '}
+                        and{' '}
+                        <a href="https://about.sourcegraph.com/privacy" target="_blank" rel="noopener">
+                            Privacy Policy
+                        </a>
+                        .
                     </small>
 
                     <hr className={styles.separator} />
 
                     <div>
-                        Already have an account? <a href="/">Log in</a>
+                        Already have an account? <Link to={`/sign-in${location.search}`}>Log in</Link>
                     </div>
                 </div>
             </div>

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -42,6 +42,9 @@ interface SignUpFormProps {
 
     buttonLabel?: string
     context: Pick<SourcegraphContext, 'authProviders' | 'sourcegraphDotComMode'>
+
+    // For use in ExperimentalSignUpPage. Modifies styling and removes terms of service section.
+    experimental?: boolean
 }
 
 const preventDefault = (event: React.FormEvent): void => event.preventDefault()
@@ -49,7 +52,13 @@ const preventDefault = (event: React.FormEvent): void => event.preventDefault()
 /**
  * The form for creating an account
  */
-export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({ onSignUp, buttonLabel, className, context }) => {
+export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
+    onSignUp,
+    buttonLabel,
+    className,
+    context,
+    experimental = false,
+}) => {
     const [loading, setLoading] = useState(false)
     const [requestedTrial, setRequestedTrial] = useState(false)
     const [error, setError] = useState<Error | null>(null)
@@ -130,12 +139,12 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({ onSignUp,
             {/* eslint-disable-next-line react/forbid-elements */}
             <form
                 className={classNames(
-                    'signin-signup-form',
-                    'signup-form',
+                    !experimental && 'signin-signup-form',
+                    !experimental && 'signup-form',
                     'test-signup-form',
-                    'rounded p-4',
+                    !experimental && 'rounded p-4',
                     'text-left',
-                    context.sourcegraphDotComMode || error ? 'mt-3' : 'mt-4',
+                    !experimental && (context.sourcegraphDotComMode || error) ? 'mt-3' : 'mt-4',
                     className
                 )}
                 onSubmit={handleSubmit}
@@ -282,7 +291,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({ onSignUp,
                     </>
                 )}
 
-                {signupTerms && (
+                {!experimental && signupTerms && (
                     <p className="mt-3 mb-0">
                         <small className="form-text text-muted">
                             By signing up, you agree to our {/* eslint-disable-next-line react/jsx-no-target-blank */}

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -43,7 +43,7 @@ interface SignUpFormProps {
     buttonLabel?: string
     context: Pick<SourcegraphContext, 'authProviders' | 'sourcegraphDotComMode'>
 
-    // For use in ExperimentalSignUpPage. Modifies styling and removes terms of service section.
+    // For use in ExperimentalSignUpPage. Modifies styling and removes terms of service and trial section.
     experimental?: boolean
 }
 
@@ -240,7 +240,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
                         <small className="form-text text-muted">At least 12 characters</small>
                     )}
                 </div>
-                {enterpriseTrial && (
+                {!experimental && enterpriseTrial && (
                     <div className="form-group">
                         <div className="form-check">
                             <label className="form-check-label">

--- a/client/web/src/auth/SignUpPage.test.tsx
+++ b/client/web/src/auth/SignUpPage.test.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { MemoryRouter } from 'react-router'
 import renderer from 'react-test-renderer'
 
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
 import { AuthenticatedUser } from '../auth'
 import { FeatureFlagName } from '../featureFlags/featureFlags'
 import { SourcegraphContext } from '../jscontext'
@@ -48,6 +50,7 @@ describe('SignUpPage', () => {
                                 authProviders,
                                 xhrHeaders: {},
                             }}
+                            telemetryService={NOOP_TELEMETRY_SERVICE}
                         />
                     </MemoryRouter>
                 )
@@ -70,6 +73,7 @@ describe('SignUpPage', () => {
                                 authProviders,
                                 xhrHeaders: {},
                             }}
+                            telemetryService={NOOP_TELEMETRY_SERVICE}
                         />
                     </MemoryRouter>
                 )
@@ -100,6 +104,7 @@ describe('SignUpPage', () => {
                                 authProviders,
                                 xhrHeaders: {},
                             }}
+                            telemetryService={NOOP_TELEMETRY_SERVICE}
                         />
                     </MemoryRouter>
                 )

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -73,7 +73,15 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
         })
 
     if (context.sourcegraphDotComMode && featureFlags.get('w0-signup-optimisation') && query.get('src')) {
-        return <ExperimentalSignUpPage source={query.get('src')} onSignUp={handleSignUp} isLightTheme={isLightTheme} />
+        return (
+            <ExperimentalSignUpPage
+                source={query.get('src')}
+                onSignUp={handleSignUp}
+                isLightTheme={isLightTheme}
+                useEmail={query.has('useEmail')}
+                context={context}
+            />
+        )
     }
 
     return (

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { Link, Redirect, useLocation } from 'react-router-dom'
 
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { AuthenticatedUser } from '../auth'
@@ -15,7 +16,7 @@ import { SourcegraphIcon } from './icons'
 import { getReturnTo } from './SignInSignUpCommon'
 import { SignUpArguments, SignUpForm } from './SignUpForm'
 
-interface SignUpPageProps extends ThemeProps {
+interface SignUpPageProps extends ThemeProps, TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<
         SourcegraphContext,
@@ -29,6 +30,7 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
     context,
     featureFlags,
     isLightTheme,
+    telemetryService,
 }) => {
     const location = useLocation()
     const query = new URLSearchParams(location.search)
@@ -80,6 +82,7 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
                 isLightTheme={isLightTheme}
                 showEmailForm={query.has(ShowEmailFormQueryParameter)}
                 context={context}
+                telemetryService={telemetryService}
             />
         )
     }

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -10,7 +10,7 @@ import { FlagSet } from '../featureFlags/featureFlags'
 import { SourcegraphContext } from '../jscontext'
 import { eventLogger } from '../tracking/eventLogger'
 
-import { ExperimentalSignUpPage } from './ExperimentalSignUpPage'
+import { ExperimentalSignUpPage, ShowEmailFormQueryParameter } from './ExperimentalSignUpPage'
 import { SourcegraphIcon } from './icons'
 import { getReturnTo } from './SignInSignUpCommon'
 import { SignUpArguments, SignUpForm } from './SignUpForm'
@@ -78,7 +78,7 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
                 source={query.get('src')}
                 onSignUp={handleSignUp}
                 isLightTheme={isLightTheme}
-                useEmail={query.has('useEmail')}
+                showEmailForm={query.has(ShowEmailFormQueryParameter)}
                 context={context}
             />
         )


### PR DESCRIPTION
Part of #21093. 

- The sign up page is now functional. Reuses the existing `SignUpForm` and hardcodes the GitHub and GitLab buttons. 
- The title changes based on the source (eg. `src=Monitor` shows the title as `Monitor code for changes.`)
- Events are logged when buttons (GitHub, GitLab, or Sign Up) are clicked. Event logged is `SignUpPLG<src>_2_ClickedSignup`, where `<src>` is the source passed via the `src` query parameter. Only valid sources will be logged.

Light mode:

![image](https://user-images.githubusercontent.com/206864/122276667-e0b1d100-ce99-11eb-82a5-296ae43d8761.png)

Dark mode:

![image](https://user-images.githubusercontent.com/206864/122276637-d8599600-ce99-11eb-9bd7-9193d6fcffdf.png)
