### PR TITLE
Add async repo resolve step for 1 click code insight creation flow

### DIFF
--- a/client/web/src/insights/core/backend/api/get-resolved-search-repositories.ts
+++ b/client/web/src/insights/core/backend/api/get-resolved-search-repositories.ts
@@ -1,0 +1,9 @@
+import { fetchRepositoriesBySearch } from '../requests/fetch-repositories-by-search'
+
+/**
+ * Get list of resolved repositories from the search API.
+ *
+ * @param query - search query
+ */
+export const getResolvedSearchRepositories = (query: string): Promise<string[]> =>
+    fetchRepositoriesBySearch(query).toPromise()

--- a/client/web/src/insights/core/backend/insights-api.ts
+++ b/client/web/src/insights/core/backend/insights-api.ts
@@ -3,6 +3,7 @@ import { of, throwError } from 'rxjs'
 import { getCombinedViews, getInsightCombinedViews } from './api/get-combined-views'
 import { getLangStatsInsightContent } from './api/get-lang-stats-insight-content'
 import { getRepositorySuggestions } from './api/get-repository-suggestions'
+import { getResolvedSearchRepositories } from './api/get-resolved-search-repositories'
 import { getSearchInsightContent } from './api/get-search-insight-content/get-search-insight-content'
 import { getSubjectSettings, updateSubjectSettings } from './api/subject-settings'
 import { ApiService } from './types'
@@ -20,6 +21,7 @@ export const createInsightAPI = (): ApiService => ({
     getSearchInsightContent,
     getLangStatsInsightContent,
     getRepositorySuggestions,
+    getResolvedSearchRepositories,
 })
 
 /**
@@ -34,5 +36,7 @@ export const createMockInsightAPI = (overrideRequests: Partial<ApiService>): Api
     getSearchInsightContent: () => Promise.reject(new Error('Implement getSubjectSettings handler first')),
     getLangStatsInsightContent: () => Promise.reject(new Error('Implement getLangStatsInsightContent handler first')),
     getRepositorySuggestions: () => Promise.reject(new Error('Implement getRepositorySuggestions handler first')),
+    getResolvedSearchRepositories: () =>
+        Promise.reject(new Error('Implement getResolvedSearchRepositories handler first')),
     ...overrideRequests,
 })

--- a/client/web/src/insights/core/backend/requests/fetch-repositories-by-search.ts
+++ b/client/web/src/insights/core/backend/requests/fetch-repositories-by-search.ts
@@ -1,0 +1,32 @@
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
+
+import { requestGraphQL } from '../../../../backend/graphql'
+import { SearchRepositoriesResult } from '../../../../graphql-operations'
+
+/**
+ * Resolve repositories from the search query.
+ * Used for generate repositories field value in 1 click insight creation scenario.
+ */
+export function fetchRepositoriesBySearch(searchQuery: string): Observable<string[]> {
+    return requestGraphQL<SearchRepositoriesResult>(
+        gql`
+            query SearchRepositories($query: String) {
+                search(query: $query) {
+                    results {
+                        repositories {
+                            name
+                        }
+                    }
+                }
+            }
+        `,
+        { query: searchQuery }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(result => result.search?.results?.repositories ?? []),
+        map(result => result.map(repo => repo.name))
+    )
+}

--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -62,4 +62,5 @@ export interface ApiService {
     getSearchInsightContent: (insight: SearchInsightSettings) => Promise<sourcegraph.LineChartContent<any, string>>
     getLangStatsInsightContent: (insight: LangStatsInsightsSettings) => Promise<sourcegraph.PieChartContent<any>>
     getRepositorySuggestions: (query: string) => Promise<RepositorySuggestion[]>
+    getResolvedSearchRepositories: (query: string) => Promise<string[]>
 }

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -2,6 +2,7 @@ import classnames from 'classnames'
 import React, { useCallback, useContext, useEffect } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -129,7 +130,10 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
 
             {hasQueryInsight && urlQueryInsightValues === undefined && (
                 // loading state for 1 click creation insight values resolve operation
-                <span>Loading...</span>
+                <div>
+                    {' '}
+                    <LoadingSpinner className="icon-inline" /> Resolving search query
+                </div>
             )}
 
             {hasQueryInsight && isErrorLike(urlQueryInsightValues) && <ErrorAlert error={urlQueryInsightValues} />}
@@ -138,32 +142,31 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
                 // If we have query in URL we should be sure that we have initial values
                 // from URL query based insight. If we don't have query in URl we can render
                 // page without resolving URL query based insight values.
-                !hasQueryInsight ||
-                    (hasQueryInsight && !isErrorLike(urlQueryInsightValues) && urlQueryInsightValues && (
-                        <>
-                            <div className="mb-5">
-                                <h2>Create new code insight</h2>
+                (!hasQueryInsight || hasUrlQueryInsightValues) && (
+                    <>
+                        <div className="mb-5">
+                            <h2>Create new code insight</h2>
 
-                                <p className="text-muted">
-                                    Search-based code insights analyze your code based on any search query.{' '}
-                                    <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
-                                        Learn more.
-                                    </a>
-                                </p>
-                            </div>
+                            <p className="text-muted">
+                                Search-based code insights analyze your code based on any search query.{' '}
+                                <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                                    Learn more.
+                                </a>
+                            </p>
+                        </div>
 
-                            <SearchInsightCreationContent
-                                className="pb-5"
-                                dataTestId="search-insight-create-page-content"
-                                settings={settingsCascade.final}
-                                initialValue={initialFormValues}
-                                organizations={orgs}
-                                onSubmit={handleSubmit}
-                                onCancel={handleCancel}
-                                onChange={handleChange}
-                            />
-                        </>
-                    ))
+                        <SearchInsightCreationContent
+                            className="pb-5"
+                            dataTestId="search-insight-create-page-content"
+                            settings={settingsCascade.final}
+                            initialValue={initialFormValues}
+                            organizations={orgs}
+                            onSubmit={handleSubmit}
+                            onCancel={handleCancel}
+                            onChange={handleChange}
+                        />
+                    </>
+                )
             }
         </Page>
     )

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-initial-values.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-initial-values.ts
@@ -1,0 +1,43 @@
+import { useLocation } from 'react-router-dom'
+
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
+
+import { CreateInsightFormFields } from '../types'
+
+import { useURLQueryInsight } from './use-url-query-insight/use-url-query-insight'
+
+export interface UseInitialValuesResult {
+    initialValues: CreateInsightFormFields | undefined
+    loading: boolean
+    setLocalStorageFormValues: (values: CreateInsightFormFields | undefined) => void
+}
+
+export function useSearchInsightInitialValues(): UseInitialValuesResult {
+    const { search } = useLocation()
+
+    // Search insight creation UI form can take value from query param in order
+    // to support 1-click insight creation from search result page.
+    const { hasQueryInsight, data: urlQueryInsightValues } = useURLQueryInsight(search)
+
+    // Creation UI saves all form values in local storage to be able restore these
+    // values if page was fully refreshed or user came back from other page.
+    const [localStorageFormValues, setLocalStorageFormValues] = useLocalStorage<CreateInsightFormFields | undefined>(
+        'insights.search-insight-creation',
+        undefined
+    )
+
+    if (hasQueryInsight) {
+        return {
+            initialValues: !isErrorLike(urlQueryInsightValues) ? urlQueryInsightValues : undefined,
+            loading: urlQueryInsightValues === undefined,
+            setLocalStorageFormValues,
+        }
+    }
+
+    return {
+        initialValues: localStorageFormValues,
+        loading: false,
+        setLocalStorageFormValues,
+    }
+}

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
@@ -4,7 +4,10 @@ describe('getInsightDataFromQuery', () => {
     it('should return null with empty query params', () => {
         const result = getInsightDataFromQuery('')
 
-        expect(result).toBeNull()
+        expect(result).toStrictEqual({
+            repositories: [],
+            seriesQuery: '',
+        })
     })
 
     describe('should return correct insight values ', () => {
@@ -14,7 +17,7 @@ describe('getInsightDataFromQuery', () => {
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repositories: 'github.com/sourcegraph/sourcegraph',
+                repositories: ['^github\\.com/sourcegraph/sourcegraph$'],
                 seriesQuery: 'context:global test patterntype:literal',
             })
         })
@@ -26,7 +29,7 @@ describe('getInsightDataFromQuery', () => {
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repositories: 'github.com/sourcegraph/sourcegraph, github.com/sourcegraph/about',
+                repositories: ['^github\\.com/sourcegraph/sourcegraph$', '^github\\.com/sourcegraph/about'],
                 seriesQuery: 'context:global test patterntype:literal',
             })
         })
@@ -38,7 +41,7 @@ describe('getInsightDataFromQuery', () => {
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repositories: 'github.com/sourcegraph/sourcegraph, github.com/sourcegraph/about',
+                repositories: ['^github\\.com/sourcegraph/sourcegraph$|^github\\.com/sourcegraph/about'],
                 seriesQuery: 'context:global test patterntype:literal',
             })
         })
@@ -50,7 +53,7 @@ describe('getInsightDataFromQuery', () => {
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repositories: 'github.com/sourcegraph/sourcegraph',
+                repositories: ['^github\\.com/sourcegraph/sourcegraph$'],
                 seriesQuery: 'context:global "repo: " patterntype:literal',
             })
         })

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -89,7 +89,7 @@ export interface UseURLQueryInsightResult {
  */
 export function useURLQueryInsight(queryParameters: string): UseURLQueryInsightResult {
     const { getResolvedSearchRepositories } = useContext(InsightsApiContext)
-    const [insight, setInsight] = useState<CreateInsightFormFields | ErrorLike | undefined>()
+    const [insightFormFields, setInsightFormFields] = useState<CreateInsightFormFields | ErrorLike | undefined>()
 
     const query = new URLSearchParams(queryParameters).get('query')
 
@@ -105,15 +105,15 @@ export function useURLQueryInsight(queryParameters: string): UseURLQueryInsightR
         // all indexed repositories.
         if (repositories.length > 0) {
             getResolvedSearchRepositories(query)
-                .then(repositories => setInsight(createInsightFormFields(seriesQuery, repositories)))
-                .catch(error => setInsight(asError(error)))
+                .then(repositories => setInsightFormFields(createInsightFormFields(seriesQuery, repositories)))
+                .catch(error => setInsightFormFields(asError(error)))
         } else {
-            setInsight(createInsightFormFields(seriesQuery, repositories))
+            setInsightFormFields(createInsightFormFields(seriesQuery, repositories))
         }
     }, [getResolvedSearchRepositories, query])
 
     return {
         hasQueryInsight: query !== null,
-        data: query !== null ? insight : undefined,
+        data: query !== null ? insightFormFields : undefined,
     }
 }

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -1,46 +1,36 @@
-import { memoize } from 'lodash'
+import { useContext, useEffect, useState } from 'react'
 
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'
+import { ErrorLike, asError } from '@sourcegraph/shared/src/util/errors'
 import { dedupeWhitespace } from '@sourcegraph/shared/src/util/strings'
 
+import { InsightsApiContext } from '../../../../../core/backend/api-provider'
 import { createDefaultEditSeries } from '../../components/search-insight-creation-content/hooks/use-editable-series'
 import { INITIAL_INSIGHT_VALUES } from '../../components/search-insight-creation-content/initial-insight-values'
 import { CreateInsightFormFields } from '../../types'
 
-/**
- * Generate repositories string value without special reg exp
- * characters and extra whitespaces.
- */
-const getSanitizedRepositoriesString = (repositories: string[]): string =>
-    repositories
-        .map(repo =>
-            repo
-                // Remove special regexp characters like ^\$
-                .replace(/(\^)|(\$)|(\\)/gi, '')
-                // Remove whitespaces at the start and end
-                .trim()
-        )
-        .join(', ')
-
 export interface InsightData {
-    repositories: string
+    repositories: string[]
     seriesQuery: string
 }
 
 /**
  * Return serialized value of repositories and query from the URL query params.
  *
- * @param query -- query param with possible value for the creation UI
+ * @param searchQuery -- query param with possible value for the creation UI
  *
  * Exported for testing only.
  */
-export function getInsightDataFromQuery(query: string | null): InsightData | null {
-    const sequence = scanSearchQuery(query ?? '')
+export function getInsightDataFromQuery(searchQuery: string): InsightData {
+    const sequence = scanSearchQuery(searchQuery ?? '')
 
-    if (!query || sequence.type === 'error') {
-        return null
+    if (!searchQuery || sequence.type === 'error') {
+        return {
+            seriesQuery: '',
+            repositories: [],
+        }
     }
 
     const tokens = Array.isArray(sequence.term) ? sequence.term : [sequence.term]
@@ -52,9 +42,7 @@ export function getInsightDataFromQuery(query: string | null): InsightData | nul
             const repoValue = token.value?.value
 
             if (repoValue) {
-                // Split repo value in order to support case with multiple repo values
-                // in repo: filter. Example repo:^github\.com/org/repo-1$ | ^github\.com/org/repo-2$
-                repositories.push(...repoValue.split('|'))
+                repositories.push(repoValue)
             }
         }
     }
@@ -66,22 +54,11 @@ export function getInsightDataFromQuery(query: string | null): InsightData | nul
 
     return {
         seriesQuery: dedupeWhitespace(humanReadableQueryString),
-        repositories: getSanitizedRepositoriesString(repositories),
+        repositories,
     }
 }
 
-/**
- * Returns initial values for the search insight from query param 'insight-query'.
- */
-export const getUrlQueryInsight = memoize((queryParameters: string): CreateInsightFormFields | null => {
-    const queryParametersString = new URLSearchParams(queryParameters).get('query')
-
-    const insightData = getInsightDataFromQuery(queryParametersString)
-
-    if (insightData === null) {
-        return null
-    }
-
+function createInsightFormFields(seriesQuery: string, repositories: string[] = []): CreateInsightFormFields {
     return {
         ...INITIAL_INSIGHT_VALUES,
         series: [
@@ -89,9 +66,54 @@ export const getUrlQueryInsight = memoize((queryParameters: string): CreateInsig
                 edit: true,
                 valid: true,
                 name: 'Search series #1',
-                query: insightData.seriesQuery,
+                query: seriesQuery ?? '',
             }),
         ],
-        repositories: insightData.repositories,
+        repositories: repositories.join(', '),
     }
-})
+}
+
+export interface UseURLQueryInsightResult {
+    /**
+     * Insight data. undefined in case if we are in a loading state or
+     * URL doesn't have query param.
+     * */
+    data: CreateInsightFormFields | ErrorLike | undefined
+
+    /** Whether the search query  param is presented in URL. */
+    hasQueryInsight: boolean
+}
+
+/**
+ * Returns initial values for the search insight from query param.
+ */
+export function useURLQueryInsight(queryParameters: string): UseURLQueryInsightResult {
+    const { getResolvedSearchRepositories } = useContext(InsightsApiContext)
+    const [insight, setInsight] = useState<CreateInsightFormFields | ErrorLike | undefined>()
+
+    const query = new URLSearchParams(queryParameters).get('query')
+
+    useEffect(() => {
+        if (query === null) {
+            return
+        }
+
+        const { seriesQuery, repositories } = getInsightDataFromQuery(query)
+
+        // If search query doesn't have repo we should run async repositories resolve
+        // step to avoid case then run search with query without repo: filter we get
+        // all indexed repositories.
+        if (repositories.length > 0) {
+            getResolvedSearchRepositories(query)
+                .then(repositories => setInsight(createInsightFormFields(seriesQuery, repositories)))
+                .catch(error => setInsight(asError(error)))
+        } else {
+            setInsight(createInsightFormFields(seriesQuery, repositories))
+        }
+    }, [getResolvedSearchRepositories, query])
+
+    return {
+        hasQueryInsight: query !== null,
+        data: query !== null ? insight : undefined,
+    }
+}


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/22005

In 1 click creation UI flow we're getting query value from URL query param and trying to break down this query into insight parts - series query and repositories. Before this PR we did FE processing for repositories value with FE query parsers and extract repository names from `repo:` filter value 

But this FE logic about extraction isn't reliable in many cases 

```
repo:^github.com/sourcegraph/sourcegraph-
repo:^github.com/sourcegraph/.*\.js$
repo:^github.com/sourcegraph/sourcegraph-(sourcegraph|about)$
```

In order to support all possible cases, this PR adds a search resolver via search API and uses search results instead of runtime regexp processed values from URL.
