### PR TITLE
remove fileMatchesToMatches

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -431,7 +431,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 				return
 			}
 
-			matches := make([]*result.FileMatch, 0, len(files))
+			matches := make([]result.Match, 0, len(files))
 			for _, file := range files {
 				fileLimitHit := false
 				mu.Lock()
@@ -469,7 +469,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 			}
 
 			c.Send(streaming.SearchEvent{
-				Results: fileMatchesToMatches(matches),
+				Results: matches,
 				Stats: streaming.Stats{
 					IsLimitHit: limitHit,
 				},
@@ -497,15 +497,6 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 		return nil
 	}
 	return nil
-}
-
-func fileMatchesToMatches(fms []*result.FileMatch) []result.Match {
-	matches := make([]result.Match, 0, len(fms))
-	for _, fm := range fms {
-		newFm := fm
-		matches = append(matches, newFm)
-	}
-	return matches
 }
 
 // getRepos is a wrapper around p.Get. It returns an error if the promise


### PR DESCRIPTION
It was only being used in one place, and could be removed by just
constructing a slice of matches directly.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
