### PR TITLE
codeintel: Add RefDescriptions to gitserver client

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -103,21 +103,21 @@ func (c *Client) CommitGraph(ctx context.Context, repositoryID int, opts CommitG
 	}})
 	defer endObservation(1, observation.Args{})
 
-	commands := []string{"log", "--pretty=%H %P", "--topo-order"}
+	args := []string{"log", "--pretty=%H %P", "--topo-order"}
 	if opts.AllRefs {
-		commands = append(commands, "--all")
+		args = append(args, "--all")
 	}
 	if opts.Commit != "" {
-		commands = append(commands, opts.Commit)
+		args = append(args, opts.Commit)
 	}
 	if opts.Since != nil {
-		commands = append(commands, fmt.Sprintf("--since=%s", opts.Since.Format(time.RFC3339)))
+		args = append(args, fmt.Sprintf("--since=%s", opts.Since.Format(time.RFC3339)))
 	}
 	if opts.Limit > 0 {
-		commands = append(commands, fmt.Sprintf("-%d", opts.Limit))
+		args = append(args, fmt.Sprintf("-%d", opts.Limit))
 	}
 
-	out, err := c.execResolveRevGitCommand(ctx, repositoryID, opts.Commit, commands...)
+	out, err := c.execResolveRevGitCommand(ctx, repositoryID, opts.Commit, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -130,22 +130,22 @@ func (c *Client) CommitGraph(ctx context.Context, repositoryID int, opts CommitG
 // is listed but has no ancestors then its parent slice is empty, but is still present in
 // the map and the ordering. If the ordering is to be correct, the git log output must be
 // formatted with --topo-order.
-func ParseCommitGraph(pair []string) *CommitGraph {
+func ParseCommitGraph(lines []string) *CommitGraph {
 	// Process lines backwards so that we see all parents before children.
-	// We get a topological ordering by simply scraping the keys off in
-	// this order.
+	// We get a topological ordering by simply scraping the keys off in this
+	// order.
 
-	n := len(pair) - 1
-	for i := 0; i < len(pair)/2; i++ {
-		pair[i], pair[n-i] = pair[n-i], pair[i]
+	n := len(lines) - 1
+	for i := 0; i < len(lines)/2; i++ {
+		lines[i], lines[n-i] = lines[n-i], lines[i]
 	}
 
-	graph := make(map[string][]string, len(pair))
-	order := make([]string, 0, len(pair))
+	graph := make(map[string][]string, len(lines))
+	order := make([]string, 0, len(lines))
 
 	var prefix []string
-	for _, pair := range pair {
-		line := strings.TrimSpace(pair)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
@@ -172,6 +172,103 @@ func ParseCommitGraph(pair []string) *CommitGraph {
 		graph: graph,
 		order: append(prefix, order...),
 	}
+}
+
+// RefDescription describes a commit at the head of a branch or tag.
+type RefDescription struct {
+	Commit          string
+	Name            string
+	Type            RefType
+	IsDefaultBranch bool
+	CreatedDate     time.Time
+}
+
+type RefType int
+
+const (
+	RefTypeUnknown RefType = iota
+	RefTypeBranch
+	RefTypeTag
+)
+
+var refPrefixes = map[string]RefType{
+	"refs/heads/": RefTypeBranch,
+	"refs/tags/":  RefTypeTag,
+}
+
+// RefDescriptions returns a slice of objects describing the head of all branches
+// and tags of the given repository.
+func (c *Client) RefDescriptions(ctx context.Context, repositoryID int) (_ []RefDescription, err error) {
+	ctx, endObservation := c.operations.refDescriptions.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("repositoryID", repositoryID),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	args := []string{"for-each-ref", "--format=%(objectname):%(refname):%(HEAD):%(creatordate:iso8601-strict)"}
+	for prefix := range refPrefixes {
+		args = append(args, prefix)
+	}
+
+	out, err := c.execGitCommand(ctx, repositoryID, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseRefDescriptions(strings.Split(out, "\n"))
+}
+
+// parseRefDescriptions converts the output of the for-each-ref command in the RefDescriptions
+// method to a slice of RefDescription objects. Each line should conform to the format string
+// `%(objectname):%(refname):%(HEAD):%(creatordate)`, where:
+//
+// - %(objectname) is the 40-character revhash
+// - %(refname) is the name of the tag or branch (prefixed with refs/heads/ or ref/tags/)
+// - %(HEAD) is `*` if the branch is the default branch (and whitesace otherwise)
+// - %(creatordate) is the ISO-formatted date the object was created
+func parseRefDescriptions(lines []string) ([]RefDescription, error) {
+	refDescriptions := make([]RefDescription, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 4)
+		if len(parts) != 4 {
+			return nil, fmt.Errorf(`unexpected output from git for-each-ref "%s"`, line)
+		}
+
+		commit := parts[0]
+		isDefaultBranch := parts[2] == "*"
+
+		var name string
+		var refType RefType
+		for prefix, typ := range refPrefixes {
+			if strings.HasPrefix(parts[1], prefix) {
+				name = parts[1][len(prefix):]
+				refType = typ
+				break
+			}
+		}
+		if refType == RefTypeUnknown {
+			return nil, fmt.Errorf(`unexpected output from git for-each-ref "%s"`, line)
+		}
+
+		createdDate, err := time.Parse(time.RFC3339, parts[3])
+		if err != nil {
+			return nil, err
+		}
+
+		refDescriptions = append(refDescriptions, RefDescription{
+			Commit:          commit,
+			Name:            name,
+			Type:            refType,
+			IsDefaultBranch: isDefaultBranch,
+			CreatedDate:     createdDate,
+		})
+	}
+
+	return refDescriptions, nil
 }
 
 // RawContents returns the contents of a file in a particular commit of a repository.

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -256,7 +256,7 @@ func parseRefDescriptions(lines []string) ([]RefDescription, error) {
 
 		createdDate, err := time.Parse(time.RFC3339, parts[3])
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf(`unexpected output from git for-each-ref (bad date format) "%s"`, line)
 		}
 
 		refDescriptions = append(refDescriptions, RefDescription{

--- a/enterprise/internal/codeintel/gitserver/client_test.go
+++ b/enterprise/internal/codeintel/gitserver/client_test.go
@@ -2,6 +2,7 @@ package gitserver
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -113,5 +114,96 @@ func TestParseCommitGraphPartial(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedOrder, graph.Order()); diff != "" {
 		t.Errorf("unexpected commit order (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseRefDescriptions(t *testing.T) {
+	refDescriptions, err := parseRefDescriptions([]string{
+		"66a7ac584740245fc523da443a3f540a52f8af72:refs/heads/bl/symbols: :2021-01-18T16:46:51-08:00",
+		"58537c06cf7ba8a562a3f5208fb7a8efbc971d0e:refs/heads/bl/symbols-2: :2021-02-24T06:21:20-08:00",
+		"a40716031ae97ee7c5cdf1dec913567a4a7c50c8:refs/heads/ef/wtf: :2021-02-10T10:50:08-06:00",
+		"e2e283fdaf6ea4a419cdbad142bbfd4b730080f8:refs/heads/garo/go-and-typescript-lsif-indexing: :2020-04-29T16:45:46+00:00",
+		"c485d92c3d2065041bf29b3fe0b55ffac7e66b2a:refs/heads/garo/index-specific-files: :2021-03-01T13:09:42-08:00",
+		"ce30aee6cc56f39d0ac6fee03c4c151c08a8cd2e:refs/heads/master:*:2021-06-16T11:51:09-07:00",
+		"ec5cfc8ab33370c698273b1a097af73ea289c92b:refs/heads/nsc/bump-go-version: :2021-03-12T22:33:17+00:00",
+		"22b2c4f734f62060cae69da856fe3854defdcc87:refs/heads/nsc/markupcontent: :2021-05-03T23:50:02+01:00",
+		"9df3358a18792fa9dbd40d506f2e0ad23fc11ee8:refs/heads/nsc/random: :2021-02-10T16:29:06+00:00",
+		"a02b85b63345a1406d7a19727f7a5472c976e053:refs/heads/sg/document-symbols: :2021-04-08T15:33:03-07:00",
+		"234b0a484519129b251164ecb0674ec27d154d2f:refs/heads/symbols: :2021-01-01T22:51:55-08:00",
+		"c165bfff52e9d4f87891bba497e3b70fea144d89:refs/tags/v0.10.0: :2020-08-04T08:23:30-05:00",
+		"f73ee8ed601efea74f3b734eeb073307e1615606:refs/tags/v0.5.1: :2020-04-16T16:06:21-04:00",
+		"6057f7ed8d331c82030c713b650fc8fd2c0c2347:refs/tags/v0.5.2: :2020-04-16T16:20:26-04:00",
+		"7886287b8758d1baf19cf7b8253856128369a2a7:refs/tags/v0.5.3: :2020-04-16T16:55:58-04:00",
+		"b69f89473bbcc04dc52cafaf6baa504e34791f5a:refs/tags/v0.6.0: :2020-04-20T12:10:49-04:00",
+		"172b7fcf8b8c49b37b231693433586c2bfd1619e:refs/tags/v0.7.0: :2020-04-20T12:37:36-04:00",
+		"5bc35c78fb5fb388891ca944cd12d85fd6dede95:refs/tags/v0.8.0: :2020-05-05T12:53:18-05:00",
+		"14faa49ef098df9488536ca3c9b26d79e6bec4d6:refs/tags/v0.9.0: :2020-07-14T14:26:40-05:00",
+		"0a82af8b6914d8c81326eee5f3a7e1d1106547f1:refs/tags/v1.0.0: :2020-08-19T19:33:39-05:00",
+		"262defb72b96261a7d56b000d438c5c7ec6d0f3e:refs/tags/v1.1.0: :2020-08-21T14:15:44-05:00",
+		"806b96eb544e7e632a617c26402eccee6d67faed:refs/tags/v1.1.1: :2020-08-21T16:02:35-05:00",
+		"5d8865d6feacb4fce3313cade2c61dc29c6271e6:refs/tags/v1.1.2: :2020-08-22T13:45:26-05:00",
+		"8c45a5635cf0a4968cc8c9dac2d61c388b53251e:refs/tags/v1.1.3: :2020-08-25T10:10:46-05:00",
+		"fc212da31ce157ef0795e934381509c5a50654f6:refs/tags/v1.1.4: :2020-08-26T14:02:47-05:00",
+		"4fd8b2c3522df32ffc8be983d42c3a504cc75fbc:refs/tags/v1.2.0: :2020-09-07T09:52:43-05:00",
+		"9741f54aa0f14be1103b00c89406393ea4d8a08a:refs/tags/v1.3.0: :2021-02-10T23:21:31+00:00",
+		"b358977103d2d66e2a3fc5f8081075c2834c4936:refs/tags/v1.3.1: :2021-02-24T20:16:45+00:00",
+		"2882ad236da4b649b4c1259d815bf1a378e3b92f:refs/tags/v1.4.0: :2021-05-13T10:41:02-05:00",
+		"340b84452286c18000afad9b140a32212a82840a:refs/tags/v1.5.0: :2021-05-20T18:41:41-05:00",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error parsing ref descriptions: %s", err)
+	}
+
+	mustParseDate := func(s string) time.Time {
+		date, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("unexpected error parsing date string: %s", err)
+		}
+
+		return date
+	}
+
+	makeBranch := func(commit, name, createdDate string, isDefaultBranch bool) RefDescription {
+		return RefDescription{Commit: commit, Name: name, Type: RefTypeBranch, IsDefaultBranch: isDefaultBranch, CreatedDate: mustParseDate(createdDate)}
+	}
+
+	makeTag := func(commit, name, createdDate string) RefDescription {
+		return RefDescription{Commit: commit, Name: name, Type: RefTypeTag, IsDefaultBranch: false, CreatedDate: mustParseDate(createdDate)}
+	}
+
+	expectedRefDescriptions := []RefDescription{
+		makeBranch("66a7ac584740245fc523da443a3f540a52f8af72", "bl/symbols", "2021-01-18T16:46:51-08:00", false),
+		makeBranch("58537c06cf7ba8a562a3f5208fb7a8efbc971d0e", "bl/symbols-2", "2021-02-24T06:21:20-08:00", false),
+		makeBranch("a40716031ae97ee7c5cdf1dec913567a4a7c50c8", "ef/wtf", "2021-02-10T10:50:08-06:00", false),
+		makeBranch("e2e283fdaf6ea4a419cdbad142bbfd4b730080f8", "garo/go-and-typescript-lsif-indexing", "2020-04-29T16:45:46+00:00", false),
+		makeBranch("c485d92c3d2065041bf29b3fe0b55ffac7e66b2a", "garo/index-specific-files", "2021-03-01T13:09:42-08:00", false),
+		makeBranch("ce30aee6cc56f39d0ac6fee03c4c151c08a8cd2e", "master", "2021-06-16T11:51:09-07:00", true),
+		makeBranch("ec5cfc8ab33370c698273b1a097af73ea289c92b", "nsc/bump-go-version", "2021-03-12T22:33:17+00:00", false),
+		makeBranch("22b2c4f734f62060cae69da856fe3854defdcc87", "nsc/markupcontent", "2021-05-03T23:50:02+01:00", false),
+		makeBranch("9df3358a18792fa9dbd40d506f2e0ad23fc11ee8", "nsc/random", "2021-02-10T16:29:06+00:00", false),
+		makeBranch("a02b85b63345a1406d7a19727f7a5472c976e053", "sg/document-symbols", "2021-04-08T15:33:03-07:00", false),
+		makeBranch("234b0a484519129b251164ecb0674ec27d154d2f", "symbols", "2021-01-01T22:51:55-08:00", false),
+		makeTag("c165bfff52e9d4f87891bba497e3b70fea144d89", "v0.10.0", "2020-08-04T08:23:30-05:00"),
+		makeTag("f73ee8ed601efea74f3b734eeb073307e1615606", "v0.5.1", "2020-04-16T16:06:21-04:00"),
+		makeTag("6057f7ed8d331c82030c713b650fc8fd2c0c2347", "v0.5.2", "2020-04-16T16:20:26-04:00"),
+		makeTag("7886287b8758d1baf19cf7b8253856128369a2a7", "v0.5.3", "2020-04-16T16:55:58-04:00"),
+		makeTag("b69f89473bbcc04dc52cafaf6baa504e34791f5a", "v0.6.0", "2020-04-20T12:10:49-04:00"),
+		makeTag("172b7fcf8b8c49b37b231693433586c2bfd1619e", "v0.7.0", "2020-04-20T12:37:36-04:00"),
+		makeTag("5bc35c78fb5fb388891ca944cd12d85fd6dede95", "v0.8.0", "2020-05-05T12:53:18-05:00"),
+		makeTag("14faa49ef098df9488536ca3c9b26d79e6bec4d6", "v0.9.0", "2020-07-14T14:26:40-05:00"),
+		makeTag("0a82af8b6914d8c81326eee5f3a7e1d1106547f1", "v1.0.0", "2020-08-19T19:33:39-05:00"),
+		makeTag("262defb72b96261a7d56b000d438c5c7ec6d0f3e", "v1.1.0", "2020-08-21T14:15:44-05:00"),
+		makeTag("806b96eb544e7e632a617c26402eccee6d67faed", "v1.1.1", "2020-08-21T16:02:35-05:00"),
+		makeTag("5d8865d6feacb4fce3313cade2c61dc29c6271e6", "v1.1.2", "2020-08-22T13:45:26-05:00"),
+		makeTag("8c45a5635cf0a4968cc8c9dac2d61c388b53251e", "v1.1.3", "2020-08-25T10:10:46-05:00"),
+		makeTag("fc212da31ce157ef0795e934381509c5a50654f6", "v1.1.4", "2020-08-26T14:02:47-05:00"),
+		makeTag("4fd8b2c3522df32ffc8be983d42c3a504cc75fbc", "v1.2.0", "2020-09-07T09:52:43-05:00"),
+		makeTag("9741f54aa0f14be1103b00c89406393ea4d8a08a", "v1.3.0", "2021-02-10T23:21:31+00:00"),
+		makeTag("b358977103d2d66e2a3fc5f8081075c2834c4936", "v1.3.1", "2021-02-24T20:16:45+00:00"),
+		makeTag("2882ad236da4b649b4c1259d815bf1a378e3b92f", "v1.4.0", "2021-05-13T10:41:02-05:00"),
+		makeTag("340b84452286c18000afad9b140a32212a82840a", "v1.5.0", "2021-05-20T18:41:41-05:00"),
+	}
+	if diff := cmp.Diff(expectedRefDescriptions, refDescriptions); diff != "" {
+		t.Errorf("unexpected ref descriptions (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -11,13 +11,14 @@ import (
 
 type operations struct {
 	commitDate        *observation.Operation
+	commitExists      *observation.Operation
 	commitGraph       *observation.Operation
 	directoryChildren *observation.Operation
 	fileExists        *observation.Operation
-	commitExists      *observation.Operation
 	head              *observation.Operation
 	listFiles         *observation.Operation
 	rawContents       *observation.Operation
+	refDescriptions   *observation.Operation
 	resolveRevision   *observation.Operation
 }
 
@@ -48,13 +49,14 @@ func newOperations(observationContext *observation.Context) *operations {
 
 	return &operations{
 		commitDate:        op("CommitDate"),
+		commitExists:      op("CommitExists"),
 		commitGraph:       op("CommitGraph"),
 		directoryChildren: op("DirectoryChildren"),
 		fileExists:        op("FileExists"),
-		commitExists:      op("CommitExists"),
 		head:              op("Head"),
 		listFiles:         op("ListFiles"),
 		rawContents:       op("RawContents"),
+		refDescriptions:   op("RefDescriptions"),
 		resolveRevision:   op("ResolveRevision"),
 	}
 }


### PR DESCRIPTION
Add a method to the codeintel gitserver client that will return the tip commit on every remote branch and tag for a repository. We will use this instead of _only_ using HEAD to determine what indexes should be "protected" from eviction due to age.

Eventually, this will be called from the commit graph updater, which will also probably throw out a bunch of old tags and branches based on some configuration parameter (max age for branches so stale branches are not around forever).

Partial effort towards #19120.