### PR TITLE
batches: 3.29 release chores

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
@@ -1,0 +1,12 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+
+import { BatchChangesChangelogAlert } from './BatchChangesChangelogAlert'
+
+const { add } = storiesOf('web/batches/BatchChangesChangelogAlert', module).addDecorator(story => (
+    <div className="p-3 container web-content">{story()}</div>
+))
+
+add('Changelog', () => <EnterpriseWebStory>{() => <BatchChangesChangelogAlert />}</EnterpriseWebStory>)

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -1,0 +1,33 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { DismissibleAlert } from '@sourcegraph/web/src/components/DismissibleAlert'
+
+import styles from './BatchChangesListIntro.module.scss'
+
+export const BatchChangesChangelogAlert: React.FunctionComponent = () => (
+    <DismissibleAlert
+        className={styles.batchChangesListIntroAlert}
+        partialStorageKey="batch-changes-list-intro-changelog-3.29"
+    >
+        <div className={classNames(styles.batchChangesListIntroCard, 'card h-100 p-2')}>
+            <div className="card-body">
+                <h4>New Batch Changes features in version 3.29</h4>
+                <ul className="mb-0 pl-3">
+                    <li>New bulk operations have been added to retry or merge multiple changesets at once. &#x2705;</li>
+                    <li>
+                        <a target="_blank" rel="noopener noreferrer" href="https://github.com/sourcegraph/src-cli">
+                            <code>src</code>
+                        </a>{' '}
+                        can now cache the result of each step when executing a batch spec, rather than only caching the
+                        final result. &#x1f680;
+                    </li>
+                    <li>
+                        Changeset specs on batch changes that have been previewed but not applied now expire
+                        consistently after one week. &#x1f5d3;&#xfe0f;
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </DismissibleAlert>
+)

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -2,8 +2,8 @@ import classNames from 'classnames'
 import React from 'react'
 
 import { SourcegraphIcon } from '../../../auth/icons'
-import { DismissibleAlert } from '../../../components/DismissibleAlert'
 
+import { BatchChangesChangelogAlert } from './BatchChangesChangelogAlert'
 import styles from './BatchChangesListIntro.module.scss'
 
 export interface BatchChangesListIntroProps {
@@ -33,58 +33,6 @@ export const BatchChangesListIntro: React.FunctionComponent<BatchChangesListIntr
         </div>
     )
 }
-
-const BatchChangesChangelogAlert: React.FunctionComponent = () => (
-    <DismissibleAlert
-        className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-3.28"
-    >
-        <div className={classNames(styles.batchChangesListIntroCard, 'card h-100 p-2')}>
-            <div className="card-body">
-                <h4>New Batch Changes features in version 3.28</h4>
-                <ul className="mb-0 pl-3">
-                    <li>
-                        Commenting on changesets{' '}
-                        <a
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href="https://docs.sourcegraph.com/batch_changes/how-tos/bulk_operations_on_changesets"
-                        >
-                            is now supported
-                        </a>
-                        .
-                    </li>
-                </ul>
-                <ul className="mb-0 pl-3">
-                    <li>
-                        Steps in batch specs can be run conditionally using{' '}
-                        <a
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href="https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#steps-if"
-                        >
-                            the `if:` property
-                        </a>
-                        .
-                    </li>
-                </ul>
-                <ul className="mb-0 pl-3">
-                    <li>
-                        User and site credentials can be encrypted in the database by adding a key to{' '}
-                        <a
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href="https://docs.sourcegraph.com/admin/config/encryption"
-                        >
-                            the `batchChangesCredentialKey` property
-                        </a>{' '}
-                        of `encryption.keys` in the site configuration.
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </DismissibleAlert>
-)
 
 const BatchChangesUnlicensedAlert: React.FunctionComponent = () => (
     <div className={classNames(styles.batchChangesListIntroAlert, 'h-100')}>

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.28.1"
+const MinimumVersion = "3.29.0"


### PR DESCRIPTION
I'll release a new src-cli tomorrow morning when I merge this.

I refactored the changelog component into its own file, because I have to hunt for it every month, and it would be a lot easier if I could just fuzzy find the file based on the word `changelog`. I also added a storybook, because now I can request feedback using that.

The final, shocking change is that I added emoji to each changelog entry. :astonished: 