### PR TITLE
limit event matches before fetching repo metadata

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -189,14 +189,18 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		progress.Update(event)
 		filters.Update(event)
 
-		repoMetadata := h.getEventRepoMetadata(ctx, event)
-
-		for _, match := range event.Results {
+		// Truncate the event to the match limit before fetching repo metadata
+		for i, match := range event.Results {
 			if display <= 0 {
+				event.Results = event.Results[:i]
 				break
 			}
 
 			display = match.Limit(display)
+		}
+
+		repoMetadata := h.getEventRepoMetadata(ctx, event)
+		for _, match := range event.Results {
 			matchesAppend(fromMatch(match, repoMetadata))
 		}
 


### PR DESCRIPTION
With the initial implementation, we'd batch events, then fetch metadata
for all results in the batch before limiting the batch. For queries with
very large result sets that return quickly, this means we're doing extra
work by fetching metadata for many results that won't actually be
returned. This can cause a significant delay. This commit changes it so
we limit first, then fetch metadata.

Note that the effect of this is only visible behind a feature flag, so this is not
affecting users. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
