### PR TITLE
Fix code monitor feature tour positioning

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -127,7 +127,10 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
     const [hasSeenSearchContextsFeatureTour] = useLocalStorage(HAS_SEEN_SEARCH_CONTEXTS_FEATURE_TOUR_KEY, false)
     const tour = useFeatureTour(
         'create-code-monitor-feature-tour',
-        !!showCreateCodeMonitoringButton && canCreateMonitorFromQuery && hasSeenSearchContextsFeatureTour,
+        !!showCreateCodeMonitoringButton &&
+            canCreateMonitorFromQuery &&
+            hasSeenSearchContextsFeatureTour &&
+            props.resultsFound,
         getFeatureTourElement,
         HAS_SEEN_CODE_MONITOR_FEATURE_TOUR_KEY,
         getTourOptions({


### PR DESCRIPTION
Wait for search results to show up before displaying the code monitor feature tour. Context: https://sourcegraph.slack.com/archives/CHEKCRWKV/p1623908148342400