### PR TITLE
web: update file explorer expand button styles

### DIFF
--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -296,7 +296,7 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
     const resolvedRevisionOrError = props.resolvedRevisionOrError
 
     return (
-        <div className="repo-revision-container">
+        <div className="repo-revision-container pl-3">
             <Switch>
                 {props.routes.map(
                     ({ path, render, exact, condition = () => true }) =>

--- a/client/web/src/repo/RepoRevisionSidebar.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.scss
@@ -1,7 +1,8 @@
 @import './RepoRevisionSidebarSymbols';
 
-.repo-revision-container {
+.repo-revision-sidebar {
     &__tabpanels {
+        margin-top: 0.25rem;
         height: calc(100% - 2rem);
     }
 
@@ -10,22 +11,20 @@
     }
 
     &__toggle {
-        color: var(--link-color);
-        background-color: var(--color-bg-2);
-        border-radius: 0;
-        isolation: isolate;
-        width: 2.5rem;
-        height: 2.5rem;
-        margin-right: -1.25rem;
         display: flex;
         justify-content: center;
+        left: 0;
+        width: 2rem;
+        height: 2rem;
         z-index: 1;
-        .theme-redesign & {
-            border-bottom-right-radius: var(--border-radius);
-            color: var(--body-color);
-            &:hover {
-                background-color: var(--color-bg-3);
-            }
+        isolation: isolate;
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+        color: var(--icon-color);
+        background-color: var(--body-bg);
+
+        &:hover {
+            background-color: var(--color-bg-3);
         }
     }
 }

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -2,7 +2,7 @@ import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@reach/tabs'
 import classnames from 'classnames'
 import * as H from 'history'
 import ChevronDoubleLeftIcon from 'mdi-react/ChevronDoubleLeftIcon'
-import FileTreeIcon from 'mdi-react/FileTreeIcon'
+import ChevronDoubleRightIcon from 'mdi-react/ChevronDoubleRightIcon'
 import React, { useCallback } from 'react'
 import { Button } from 'reactstrap'
 
@@ -45,11 +45,11 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
         return (
             <button
                 type="button"
-                className="position-absolute btn btn-icon btn-link border-right border-bottom repo-revision-container__toggle"
+                className="position-absolute btn btn-icon border-top border-bottom border-right mt-4 repo-revision-sidebar__toggle"
                 onClick={handleSidebarToggle}
                 data-tooltip="Show sidebar"
             >
-                <FileTreeIcon className="icon-inline" />
+                <ChevronDoubleRightIcon className="icon-inline" />
             </button>
         )
     }
@@ -62,11 +62,11 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
             element={
                 <div className={classnames('d-flex w-100', !isRedesignEnabled && 'bg-2 border-right')}>
                     <Tabs
-                        className="w-100 test-repo-revision-sidebar"
+                        className="w-100 test-repo-revision-sidebar mr-3"
                         defaultIndex={tabIndex}
                         onChange={handleTabsChange}
                     >
-                        <div className={classnames('tablist-wrapper d-flex flex-1', isRedesignEnabled && 'mx-3')}>
+                        <div className="tablist-wrapper d-flex flex-1">
                             <TabList>
                                 <Tab data-tab-content="files">
                                     <span className="tablist-wrapper--tab-label">Files</span>
@@ -82,16 +82,10 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
                                 data-tooltip="Collapse panel"
                                 data-placement="right"
                             >
-                                <ChevronDoubleLeftIcon className="icon-inline repo-revision-container__close-icon" />
+                                <ChevronDoubleLeftIcon className="icon-inline repo-revision-sidebar__close-icon" />
                             </Button>
                         </div>
-                        <div
-                            aria-hidden={true}
-                            className={classnames(
-                                'd-flex repo-revision-container__tabpanels explorer',
-                                isRedesignEnabled && 'px-3'
-                            )}
-                        >
+                        <div aria-hidden={true} className="d-flex repo-revision-sidebar__tabpanels explorer">
                             <TabPanels className="w-100 overflow-auto">
                                 <TabPanel tabIndex={-1}>
                                     {tabIndex === 0 && (

--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -41,7 +41,7 @@ export const Directory: React.FunctionComponent<TreeChildProps> = (props: TreeCh
                         <a
                             // needed because of dynamic styling
                             // eslint-disable-next-line react/forbid-dom-props
-                            style={treePadding(props.depth, true)}
+                            style={treePadding(props.depth, true, true)}
                             className="tree__row-icon test-tree-noop-link"
                             href={props.entryInfo.url}
                             onClick={props.noopRowClick}
@@ -83,7 +83,7 @@ export const Directory: React.FunctionComponent<TreeChildProps> = (props: TreeCh
                     className="tree__row-alert alert alert-warning"
                     // needed because of dynamic styling
                     // eslint-disable-next-line react/forbid-dom-props
-                    style={treePadding(props.depth, true)}
+                    style={treePadding(props.depth, true, true)}
                 >
                     Too many entries. Use search to find a specific file.
                 </div>

--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom'
 import { FileDecoration } from 'sourcegraph'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { FileDecorator } from './FileDecorator'
 import { TreeLayerProps } from './TreeLayer'
@@ -29,70 +28,66 @@ interface TreeChildProps extends TreeLayerProps {
  *
  * @param props
  */
-export const Directory: React.FunctionComponent<TreeChildProps> = (props: TreeChildProps): JSX.Element => {
-    const [isRedesignEnable] = useRedesignToggle()
-
-    return (
-        <tr key={props.entryInfo.path} className={props.className} onClick={props.handleTreeClick}>
-            <td className="tree__cell test-sidebar-file-decorable">
-                <div
-                    className="tree__row-contents tree__row-contents-new"
-                    data-tree-is-directory="true"
-                    data-tree-path={props.entryInfo.path}
-                >
-                    <div className="tree__row-contents-text flex-1 justify-between">
-                        <div className="d-flex">
-                            <a
-                                // needed because of dynamic styling
-                                // eslint-disable-next-line react/forbid-dom-props
-                                style={treePadding(props.depth, true, isRedesignEnable)}
-                                className="tree__row-icon test-tree-noop-link"
-                                href={props.entryInfo.url}
-                                onClick={props.noopRowClick}
-                                tabIndex={-1}
-                            >
-                                {props.isExpanded ? (
-                                    <ChevronDownIcon className="icon-inline" />
-                                ) : (
-                                    <ChevronRightIcon className="icon-inline" />
-                                )}
-                            </a>
-                            <Link
-                                to={props.entryInfo.url}
-                                onClick={props.linkRowClick}
-                                className="tree__row-label test-file-decorable-name"
-                                draggable={false}
-                                title={props.entryInfo.path}
-                                tabIndex={-1}
-                            >
-                                {props.entryInfo.name}
-                            </Link>
-                        </div>
-                        <FileDecorator
-                            // If component is not specified, or it is 'sidebar', render it.
-                            fileDecorations={props.fileDecorations?.filter(decoration => decoration?.where !== 'page')}
-                            className="mr-3"
-                            isLightTheme={props.isLightTheme}
-                            isActive={props.isActive}
-                        />
+export const Directory: React.FunctionComponent<TreeChildProps> = (props: TreeChildProps): JSX.Element => (
+    <tr key={props.entryInfo.path} className={props.className} onClick={props.handleTreeClick}>
+        <td className="tree__cell test-sidebar-file-decorable">
+            <div
+                className="tree__row-contents tree__row-contents-new"
+                data-tree-is-directory="true"
+                data-tree-path={props.entryInfo.path}
+            >
+                <div className="tree__row-contents-text flex-1 justify-between">
+                    <div className="d-flex">
+                        <a
+                            // needed because of dynamic styling
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={treePadding(props.depth, true)}
+                            className="tree__row-icon test-tree-noop-link"
+                            href={props.entryInfo.url}
+                            onClick={props.noopRowClick}
+                            tabIndex={-1}
+                        >
+                            {props.isExpanded ? (
+                                <ChevronDownIcon className="icon-inline" />
+                            ) : (
+                                <ChevronRightIcon className="icon-inline" />
+                            )}
+                        </a>
+                        <Link
+                            to={props.entryInfo.url}
+                            onClick={props.linkRowClick}
+                            className="tree__row-label test-file-decorable-name"
+                            draggable={false}
+                            title={props.entryInfo.path}
+                            tabIndex={-1}
+                        >
+                            {props.entryInfo.name}
+                        </Link>
                     </div>
-                    {props.loading && (
-                        <div className="tree__row-loader">
-                            <LoadingSpinner className="icon-inline tree-page__entries-loader" />
-                        </div>
-                    )}
+                    <FileDecorator
+                        // If component is not specified, or it is 'sidebar', render it.
+                        fileDecorations={props.fileDecorations?.filter(decoration => decoration?.where !== 'page')}
+                        className="mr-3"
+                        isLightTheme={props.isLightTheme}
+                        isActive={props.isActive}
+                    />
                 </div>
-                {props.index === props.maxEntries - 1 && (
-                    <div
-                        className="tree__row-alert alert alert-warning"
-                        // needed because of dynamic styling
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={treePadding(props.depth, true, isRedesignEnable)}
-                    >
-                        Too many entries. Use search to find a specific file.
+                {props.loading && (
+                    <div className="tree__row-loader">
+                        <LoadingSpinner className="icon-inline tree-page__entries-loader" />
                     </div>
                 )}
-            </td>
-        </tr>
-    )
-}
+            </div>
+            {props.index === props.maxEntries - 1 && (
+                <div
+                    className="tree__row-alert alert alert-warning"
+                    // needed because of dynamic styling
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={treePadding(props.depth, true)}
+                >
+                    Too many entries. Use search to find a specific file.
+                </div>
+            )}
+        </td>
+    </tr>
+)

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -44,8 +44,8 @@ export function scrollIntoView(element: Element, scrollRoot: Element): void {
 export const getDomElement = (path: string): Element | null =>
     document.querySelector(`[data-tree-path='${path.replace(/'/g, "\\'")}']`)
 
-export const treePadding = (depth: number, isTree: boolean, isRedesignEnabled = false): React.CSSProperties => ({
-    marginLeft: `${depth * 12 + (isTree ? 0 : 12) + (isRedesignEnabled ? 0 : 12)}px`,
+export const treePadding = (depth: number, isTree: boolean): React.CSSProperties => ({
+    marginLeft: `${depth * 12 + (isTree ? 0 : 12)}px`,
     paddingRight: '1rem',
 })
 

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -44,8 +44,8 @@ export function scrollIntoView(element: Element, scrollRoot: Element): void {
 export const getDomElement = (path: string): Element | null =>
     document.querySelector(`[data-tree-path='${path.replace(/'/g, "\\'")}']`)
 
-export const treePadding = (depth: number, isTree: boolean): React.CSSProperties => ({
-    marginLeft: `${depth * 12 + (isTree ? 0 : 12)}px`,
+export const treePadding = (depth: number, isTree: boolean, isDirectory = false): React.CSSProperties => ({
+    marginLeft: `${depth * 12 + (isTree ? 0 : 12) + (isDirectory ? 0 : 8)}px`,
     paddingRight: '1rem',
 })
 


### PR DESCRIPTION
## Changes

- Updated file explorer toggle button styles to be consistent with the collapse button.
- Added top offset to the sidebar content according to [the mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=954%3A8290).
- Fixed tree padding util.

## Screenshots

### File explorer expand button

#### Before

<img width="415" alt="Screenshot 2021-06-17 at 10 38 03" src="https://user-images.githubusercontent.com/3846380/122352907-1cc06100-cf82-11eb-916b-301a2b8decc4.png">

#### After

<img width="427" alt="Screenshot 2021-06-17 at 10 25 39" src="https://user-images.githubusercontent.com/3846380/122351623-e209f900-cf80-11eb-8015-918b2b865d46.png">

### File explorer sidebar

#### Before

<img width="671" alt="Screenshot 2021-06-17 at 10 38 31" src="https://user-images.githubusercontent.com/3846380/122352918-21851500-cf82-11eb-9ba1-a3bafa960b62.png">

#### After

<img width="767" alt="Screenshot 2021-06-17 at 10 41 44" src="https://user-images.githubusercontent.com/3846380/122353356-8e001400-cf82-11eb-99ca-9419703c832c.png">

### File tree padding

#### Before

<img width="305" alt="Screenshot 2021-06-17 at 10 32 17" src="https://user-images.githubusercontent.com/3846380/122352213-7bd1a600-cf81-11eb-9c6d-e71475dfdb0f.png">

#### After

<img width="303" alt="Screenshot 2021-06-17 at 10 36 43" src="https://user-images.githubusercontent.com/3846380/122352613-da971f80-cf81-11eb-80b9-df35422f7dae.png">

Closes #21637.
Closes #22136.