### PR TITLE
Replace triggerarea color with icon-muted

### DIFF
--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -128,7 +128,6 @@ $theme-colors-redesign: (
     --code-line-highlight-color: var(--color-bg-2);
     --diff-add-bg: #eeffec;
     --diff-remove-bg: #ffecec;
-    --triggerarea-checklist-checkbox-color: var(--gray-05);
 }
 
 .theme-dark.theme-redesign {
@@ -176,7 +175,6 @@ $theme-colors-redesign: (
     --code-line-highlight-color: var(--body-bg);
     --diff-add-bg: #224035;
     --diff-remove-bg: #3e1d1d;
-    --triggerarea-checklist-checkbox-color: var(--gray-07);
 
     // TODO: Remove from use, replace with the variables referenced here.
     // Issue: https://github.com/sourcegraph/sourcegraph/issues/19973

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -45,7 +45,7 @@
         &-checkbox {
             font-size: 0.65rem;
             margin-right: 0.5rem;
-            color: var(--triggerarea-checklist-checkbox-color);
+            color: var(--icon-muted);
 
             &--unchecked {
                 // Make unchecked icon smaller so it doesn't look like a radio button.


### PR DESCRIPTION
These are the same, `icon-muted` is preferred as a more-semantic option