### PR TITLE
Add an upper bound for the search insight repositories resolve result

### DIFF
--- a/client/web/src/insights/core/backend/requests/fetch-repositories-by-search.ts
+++ b/client/web/src/insights/core/backend/requests/fetch-repositories-by-search.ts
@@ -27,6 +27,8 @@ export function fetchRepositoriesBySearch(searchQuery: string): Observable<strin
     ).pipe(
         map(dataOrThrowErrors),
         map(result => result.search?.results?.repositories ?? []),
-        map(result => result.map(repo => repo.name))
+        // Get only the first 10 repositories to avoid DDoS from the live preview in
+        // insight creation UI or at insights page.
+        map(result => result.map(repo => repo.name).slice(0, 10))
     )
 }


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/22159

This PR adds an upper bound for the 1-click creation flow on repositories search-resolve step to avoid possible DDoS by insight live preview or insight extension fetching at insights page. 