### PR TITLE
extensibility: fix browser extension discoverability alerts

### DIFF
--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -127,7 +127,8 @@ export const UserNavItem: React.FunctionComponent<UserNavItemProps> = props => {
                 <div className="position-relative">
                     <div
                         className={classNames('align-items-center d-flex', {
-                            'user-nav-item__avatar-background': isExtensionAlertAnimating,
+                            // Temporarily remove user avatar flash animation for redesign
+                            // 'user-nav-item__avatar-background': isExtensionAlertAnimating,
                         })}
                     >
                         <UserAvatar

--- a/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
@@ -588,6 +588,7 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
           >
             <div
               class="user-avatar icon-inline user-nav-item__avatar"
+              id="target-user-avatar"
             >
               a
             </div>
@@ -1373,6 +1374,7 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
           >
             <div
               class="user-avatar icon-inline user-nav-item__avatar"
+              id="target-user-avatar"
             >
               a
             </div>
@@ -2168,6 +2170,7 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
           >
             <div
               class="user-avatar icon-inline user-nav-item__avatar"
+              id="target-user-avatar"
             >
               a
             </div>
@@ -2934,6 +2937,7 @@ exports[`NavLinks authed self-hosted /search 1`] = `
           >
             <div
               class="user-avatar icon-inline user-nav-item__avatar"
+              id="target-user-avatar"
             >
               a
             </div>

--- a/client/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
@@ -132,6 +132,7 @@ exports[`UserNavItem simple 1`] = `
                           >
                             <div
                               className="user-avatar icon-inline user-nav-item__avatar"
+                              id="target-user-avatar"
                             >
                               ad
                             </div>

--- a/client/web/src/user/UserAvatar.tsx
+++ b/client/web/src/user/UserAvatar.tsx
@@ -66,7 +66,11 @@ export const UserAvatar: React.FunctionComponent<Props> = ({
             return initials[0]
         }
 
-        return <div className={classNames('user-avatar', className)}>{getInitials(name)}</div>
+        return (
+            <div id={targetID} className={classNames('user-avatar', className)}>
+                {getInitials(name)}
+            </div>
+        )
     }
 
     return <AccountCircleIcon className={classNames('user-avatar', className)} id={targetID} {...otherProps} />


### PR DESCRIPTION
Fix #22168.

This PR doesn't update the flash animation for the redesign, but at least dismissing the alert doesn't completely break the webapp anymore, and we still display the tooltip for discoverability.

![workingBextTooltip](https://user-images.githubusercontent.com/37420160/122427252-f50bd180-cf5e-11eb-8ab2-f08e8d75621a.gif)
