### PR TITLE
update syntax highlighter with new alpine base

### DIFF
--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull docker.io/sourcegraph/syntect_server:137d7de@sha256:36e5f85519052bc660345753cdb4774ea38f81b3b3ba65eec184ac53a3ad1c7b
-docker tag docker.io/sourcegraph/syntect_server:137d7de@sha256:36e5f85519052bc660345753cdb4774ea38f81b3b3ba65eec184ac53a3ad1c7b "$IMAGE"
+docker pull docker.io/sourcegraph/syntect_server:f68be78@sha256:1d2ac738eec37f8a3ac4da3d73350a4f9be6a2d730074f07ce42dd9dd978b5fc
+docker tag docker.io/sourcegraph/syntect_server:f68be78@sha256:1d2ac738eec37f8a3ac4da3d73350a4f9be6a2d730074f07ce42dd9dd978b5fc "$IMAGE"


### PR DESCRIPTION
 This remediates the following CVEs

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3518

Found as part of sourcegraph/security-issues#151

Syntext image build in https://github.com/sourcegraph/syntect_server/pull/39

