### PR TITLE
API docs: LSIF protocol: add searchKey

### DIFF
--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -172,8 +172,6 @@ type Documentation struct {
 	// to include the full project path (e.g. `github.com/gorilla/mux` or `com.JodaOrg.JodaTime`)
 	// instead of the shortened name (`mux` or `JodaTime`).
 	//
-	// within the context of a project (there may be multiple projects in a workspace.)
-	//
 	// Clients are encouraged to treat matches towards the left of the string with higher relevance
 	// than matches towards the end of the string. For example, it is typically the case that search
 	// keys will start with the project/package/library/etc name, followed by namespaces, then a

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -188,6 +188,7 @@ type Documentation struct {
 	//   a much more subtle location (see `identifier` docs), as it is a truly unique path to the
 	//   documentation and can be a final way for users to disambiguate if all other options fail.
 	//
+	// An empty string indicates this documentationResult should not be indexed by a search engine.
 	SearchKey string `json:"searchKey"`
 
 	// Tags about the type of content this documentation contains.

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -166,7 +166,12 @@ type Documentation struct {
 	// For example, in Go this may look like `mux.Router` or `mux.Router.ServeHTTP`. It should be
 	// of a format that makes sense to users of the language being documented.
 	//
-	// Search keys do not have to be unique, although they are encouraged to be generally unique
+	// Search keys do not have to be unique. For symbols, search keys are encouraged (but not
+	// required) to be unique within the scope of e.g. a project by prefixing the project name/path
+	// (there may be multiple projects in a workspace). For projects themselves, it is encouraged
+	// to include the full project path (e.g. `github.com/gorilla/mux` or `com.JodaOrg.JodaTime`)
+	// instead of the shortened name (`mux` or `JodaTime`).
+	//
 	// within the context of a project (there may be multiple projects in a workspace.)
 	//
 	// Clients are encouraged to treat matches towards the left of the string with higher relevance

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -166,11 +166,21 @@ type Documentation struct {
 	// For example, in Go this may look like `mux.Router` or `mux.Router.ServeHTTP`. It should be
 	// of a format that makes sense to users of the language being documented.
 	//
-	// Search keys do not have to be unique. For symbols, search keys are encouraged (but not
-	// required) to be unique within the scope of e.g. a project by prefixing the project name/path
-	// (there may be multiple projects in a workspace). For projects themselves, it is encouraged
-	// to include the full project path (e.g. `github.com/gorilla/mux` or `com.JodaOrg.JodaTime`)
-	// instead of the shortened name (`mux` or `JodaTime`).
+	// Search keys are not required to be unique. It is desirable for them to be generally unique
+	// within the scope of the workspace itself, or a project within the workspace (if the
+	// documentation is for something in a project.) However, it is not desirable for it to be unique
+	// globally across workspaces (you can think of the searchKey as always being prefixed with the
+	// workspace URI.)
+	//
+	// If a search key is describing a project within the workspace itself, it is encouraged for it
+	// to be unique within the context of the workspace. Sometimes this means using a full project
+	// path/name (e.g. `github.com/gorilla/mux/router` or `com.JodaOrg.JodaTime`) is required - while
+	// in other contexts the shortened name (`router` or `JodaTime`) may be sufficient.
+	//
+	// If a search key is describing a symbol within a project, a shortened project path/name prefix
+	// is usually sufficient: using `router.New` over `github.com/gorilla/mux/router.New` or
+	// `JodaTime.Time.now` over `com.JodaOrg.JodaTime.Time.now` is preferred. Clients will display
+	// enough additional information to disambiguiate between any conflicts (see below.)
 	//
 	// Clients are encouraged to treat matches towards the left of the string with higher relevance
 	// than matches towards the end of the string. For example, it is typically the case that search

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -175,7 +175,12 @@ type Documentation struct {
 	// Clients are encouraged to treat matches towards the left of the string with higher relevance
 	// than matches towards the end of the string. For example, it is typically the case that search
 	// keys will start with the project/package/library/etc name, followed by namespaces, then a
-	// specific symbol.
+	// specific symbol. For example, if a user searches for `gorilla/mux.Error` the desired ranking
+	// for three theoretical semi-conflicting results would be:
+	//
+	// * github.com/gorilla/mux.Error (near exact match)
+	// * github.com/gorilla/router.Error (`mux` not matching on left, result ranked lower)
+	// * github.com/sourcegraph/mux.Error (`gorilla` not matching on left, result ranked lower)
 	//
 	// Clients are encouraged to use smart case sensitivity by default: if the user is searching for
 	// a mixed-case query, the search should be case-sensitive (and otherwise not.)

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -161,6 +161,34 @@ type Documentation struct {
 	// its children should be e.g. displayed on their own dedicated page.
 	NewPage bool `json:"newPage"`
 
+	// SearchKey is a key which can be used to implement search for a specific documentationResult.
+	// For example, in Go this may look like `mux.Router` or `mux.Router.ServeHTTP`. It should be
+	// of a format that makes sense to users of the language being documented.
+	//
+	// Search keys do not have to be unique, although they are encouraged to be generally unique
+	// within the context of a project (there may be multiple projects in a workspace.)
+	//
+	// Clients are encouraged to treat matches towards the left of the string with higher relevance
+	// than matches towards the end of the string. For example, it is typically the case that search
+	// keys will start with the project/package/library/etc name, followed by namespaces, then a
+	// specific symbol.
+	//
+	// Clients are encouraged to use smart case sensitivity by default: if the user is searching for
+	// a mixed-case query, the search should be case-sensitive (and otherwise not.)
+	//
+	// Since search keys may not be unique, clients are encouraged to display alongside the search
+	// key other information about the documentation that will disambiguate identical keys. The
+	// following in specific is encouraged:
+	//
+	// * Always display the `label` string, which provides e.g. a one-line function signature.
+	// * Optionally display the `detail` string (e.g. when considering a specific result), as it
+	//   contains detailed information that can help disambiguate.
+	// * Always display the path identifier to the documentationResult _somewhere_, even if it is
+	//   a much more subtle location (see `identifier` docs), as it is a truly unique path to the
+	//   documentation and can be a final way for users to disambiguate if all other options fail.
+	//
+	SearchKey string `json:"searchKey"`
+
 	// Tags about the type of content this documentation contains.
 	Tags []DocumentationTag `json:"tags"`
 }

--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -116,9 +116,10 @@ func NewDocumentationResult(id uint64, result Documentation) DocumentationResult
 // This enables validators to ensure the indexer knows how to emit both label and detail strings
 // properly, and just chose to emit none specifically.
 //
-// If this documentationResult is for the project root, the identifier should be an empty string.
-// Similarly, if there is no project root documentation (e.g. it would just be an index page for
-// documentation below the project root), an empty label and detail string should be attached.
+// If this documentationResult is for the project root, the identifier and searchKey should be an
+// empty string. Similarly, if there is no project root documentation (e.g. it would just be an
+// index page for documentation below the project root), an empty label and detail string should be
+// attached.
 //
 type Documentation struct {
 	// A human readable identifier for this documentationResult, uniquely identifying it within the


### PR DESCRIPTION
Search integration is a long term (not immediate) goal of API docs, and unlikely to be implemented any time soon.

However, while I am looking into solidifying our LSIF data format more concretely (because dealing with backwards compatibility and/or losing all data are both annoying options), it becomes clear to me that we do not have sufficient information today to do nice, global and repository-local, search integration in the future.

This is a quick attempt at ensuring we do have that data in the future, and I believe would let us implement:

1. Global fuzzy search across API docs/symbols
2. Repository-local fuzzy search across API docs/symbols
3. File and directory-specific fuzzy search across API docs/symbols

The first two have straightforward data implementation paths. The third point would require correlating documentation to the specific files/directories it was describing, which is not trivial (documentation may not align with files/directories at all!) but could be done by following the `documentationResult->resultSet->definition->document` information trail and effectively correlating documentation with files/directories through that path.

The one thing this does _not_ address is the fact that API docs currently only indexes top-level symbols (e.g. it doesn't index vars inside functions); this might be something that we would eventually want if we used API docs as the source of data for "quickly jump to a symbol in a repository" in Sourcegraph. We could eventually support that, but as that adds much more data and scaling concerns I am keen to defer that problem.

Helps https://github.com/sourcegraph/sourcegraph/issues/21938

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>