### PR TITLE
analytics: generate a cohort ID based on user's first week and log it automatically with all events

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -14,11 +14,11 @@ export const FIRST_SOURCE_URL_KEY = 'sourcegraphSourceUrl'
 export class EventLogger implements TelemetryService {
     private hasStrippedQueryParameters = false
 
-    private anonymousUserID?: string
+    private anonymousUserID = ''
     private cohortID?: string
     private firstSourceURL?: string
 
-    private readonly CookieSettings: CookieAttributes = {
+    private readonly cookieSettings: CookieAttributes = {
         // 365 days expiry, but renewed on activity.
         expires: 365,
         // Enforce HTTPS
@@ -40,6 +40,8 @@ export class EventLogger implements TelemetryService {
                 console.debug('%cBrowser extension detected, sync completed', 'color: #aaa')
             }
         })
+
+        this.initializeLogParameters()
     }
 
     /**
@@ -85,29 +87,9 @@ export class EventLogger implements TelemetryService {
      * Get the anonymous identifier for this user (used to allow site admins
      * on a Sourcegraph instance to see a count of unique users on a daily,
      * weekly, and monthly basis).
-     * If the user doesn't have an anonymours ID yet, it generates one as well
-     * as a cohort ID based on the week the user's first visit.
      */
     public getAnonymousUserID(): string {
-        let anonymousUserID =
-            this.anonymousUserID || cookies.get(ANONYMOUS_USER_ID_KEY) || localStorage.getItem(ANONYMOUS_USER_ID_KEY)
-        if (!anonymousUserID) {
-            anonymousUserID = uuid.v4()
-            this.generateCohortID()
-        }
-        // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
-        // Always set to renew expiry and migrate from localStorage
-        cookies.set(ANONYMOUS_USER_ID_KEY, anonymousUserID, this.CookieSettings)
-        localStorage.removeItem(ANONYMOUS_USER_ID_KEY)
-        this.anonymousUserID = anonymousUserID
-        return anonymousUserID
-    }
-
-    /** Generates a cohort ID for the user, which is the Monday of the week they first visited, in YYYY-MM-DD */
-    private generateCohortID(): void {
-        const cohortID = getPreviousMonday(new Date())
-        cookies.set(COHORT_ID_KEY, cohortID, this.CookieSettings)
-        this.cohortID = cohortID
+        return this.anonymousUserID
     }
 
     /**
@@ -115,9 +97,7 @@ export class EventLogger implements TelemetryService {
      * Users that have visited before the introduction of cohort IDs will not have one.
      */
     public getCohortID(): string | undefined {
-        const cohortId = this.cohortID || cookies.get(COHORT_ID_KEY)
-        this.cohortID = cohortId
-        return cohortId
+        return this.cohortID
     }
 
     public getFirstSourceURL(): string {
@@ -127,20 +107,41 @@ export class EventLogger implements TelemetryService {
 
         // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
         // Always set to renew expiry and migrate from localStorage
-        cookies.set(FIRST_SOURCE_URL_KEY, redactedURL, {
-            // 365 days expiry, but renewed on activity.
-            expires: 365,
-            // Enforce HTTPS
-            secure: true,
-            // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
-            sameSite: 'Strict',
-            // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
-            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
-            domain: location.hostname,
-        })
+        cookies.set(FIRST_SOURCE_URL_KEY, redactedURL, this.cookieSettings)
 
         this.firstSourceURL = firstSourceURL
         return firstSourceURL
+    }
+
+    /**
+     * Gets the anonymous user ID and cohort ID of the user from cookies.
+     * If user doesn't have an anonymous user ID yet, a new one is generated, along with
+     * a cohort ID of the week the user first visited.
+     *
+     * If the user already has an anonymous user ID before the introduction of cohort IDs,
+     * the user will not haved a cohort ID.
+     *
+     * If user had an anonymous user ID in localStorage, it will be migrated to cookies.
+     */
+    private initializeLogParameters(): void {
+        let anonymousUserID = cookies.get(ANONYMOUS_USER_ID_KEY) || localStorage.getItem(ANONYMOUS_USER_ID_KEY)
+        let cohortID = cookies.get(COHORT_ID_KEY)
+
+        if (!anonymousUserID) {
+            anonymousUserID = uuid.v4()
+            cohortID = getPreviousMonday(new Date())
+        }
+
+        // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
+        // Always set to renew expiry and migrate from localStorage
+        cookies.set(ANONYMOUS_USER_ID_KEY, anonymousUserID, this.cookieSettings)
+        localStorage.removeItem(ANONYMOUS_USER_ID_KEY)
+        if (cohortID) {
+            cookies.set(COHORT_ID_KEY, cohortID, this.cookieSettings)
+        }
+
+        this.anonymousUserID = anonymousUserID
+        this.cohortID = cohortID
     }
 }
 

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -1,20 +1,34 @@
-import cookies from 'js-cookie'
+import cookies, { CookieAttributes } from 'js-cookie'
 import * as uuid from 'uuid'
 
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { browserExtensionMessageReceived, handleQueryEvents, pageViewQueryParameters } from './analyticsUtils'
 import { serverAdmin } from './services/serverAdminWrapper'
-import { redactSensitiveInfoFromURL } from './util'
+import { getPreviousMonday, redactSensitiveInfoFromURL } from './util'
 
 export const ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
+export const COHORT_ID_KEY = 'sourcegraphCohortId'
 export const FIRST_SOURCE_URL_KEY = 'sourcegraphSourceUrl'
 
 export class EventLogger implements TelemetryService {
     private hasStrippedQueryParameters = false
 
-    private anonymousUserId?: string
+    private anonymousUserID?: string
+    private cohortID?: string
     private firstSourceURL?: string
+
+    private readonly CookieSettings: CookieAttributes = {
+        // 365 days expiry, but renewed on activity.
+        expires: 365,
+        // Enforce HTTPS
+        secure: true,
+        // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
+        sameSite: 'Strict',
+        // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
+        domain: location.hostname,
+    }
 
     constructor() {
         // EventLogger is never teared down
@@ -71,29 +85,39 @@ export class EventLogger implements TelemetryService {
      * Get the anonymous identifier for this user (used to allow site admins
      * on a Sourcegraph instance to see a count of unique users on a daily,
      * weekly, and monthly basis).
+     * If the user doesn't have an anonymours ID yet, it generates one as well
+     * as a cohort ID based on the week the user's first visit.
      */
     public getAnonymousUserID(): string {
-        let anonymousUserId =
-            this.anonymousUserId || cookies.get(ANONYMOUS_USER_ID_KEY) || localStorage.getItem(ANONYMOUS_USER_ID_KEY)
-        if (!anonymousUserId) {
-            anonymousUserId = uuid.v4()
+        let anonymousUserID =
+            this.anonymousUserID || cookies.get(ANONYMOUS_USER_ID_KEY) || localStorage.getItem(ANONYMOUS_USER_ID_KEY)
+        if (!anonymousUserID) {
+            anonymousUserID = uuid.v4()
+            this.generateCohortID()
         }
         // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
         // Always set to renew expiry and migrate from localStorage
-        cookies.set(ANONYMOUS_USER_ID_KEY, anonymousUserId, {
-            // 365 days expiry, but renewed on activity.
-            expires: 365,
-            // Enforce HTTPS
-            secure: true,
-            // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
-            sameSite: 'Strict',
-            // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
-            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
-            domain: location.hostname,
-        })
+        cookies.set(ANONYMOUS_USER_ID_KEY, anonymousUserID, this.CookieSettings)
         localStorage.removeItem(ANONYMOUS_USER_ID_KEY)
-        this.anonymousUserId = anonymousUserId
-        return anonymousUserId
+        this.anonymousUserID = anonymousUserID
+        return anonymousUserID
+    }
+
+    /** Generates a cohort ID for the user, which is the Monday of the week they first visited, in YYYY-MM-DD */
+    private generateCohortID(): void {
+        const cohortID = getPreviousMonday(new Date())
+        cookies.set(COHORT_ID_KEY, cohortID, this.CookieSettings)
+        this.cohortID = cohortID
+    }
+
+    /**
+     * The cohort ID is generated when the anonymous user ID is generated.
+     * Users that have visited before the introduction of cohort IDs will not have one.
+     */
+    public getCohortID(): string | undefined {
+        const cohortId = this.cohortID || cookies.get(COHORT_ID_KEY)
+        this.cohortID = cohortId
+        return cohortId
     }
 
     public getFirstSourceURL(): string {

--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -44,7 +44,7 @@ describe('tracking/util', () => {
     })
 
     describe(`${getPreviousMonday.name}()`, () => {
-        it('gets the corrent day if it is a Monday', () => {
+        it('gets the current day if it is a Monday', () => {
             const date = new Date(2021, 5, 14) // June 14, 2021 is a Monday
             const monday = getPreviousMonday(date)
             expect(monday).toBe('2021-06-14')

--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -1,4 +1,4 @@
-import { redactSensitiveInfoFromURL } from './util'
+import { getPreviousMonday, redactSensitiveInfoFromURL } from './util'
 
 describe('tracking/util', () => {
     describe(`${redactSensitiveInfoFromURL.name}()`, () => {
@@ -40,6 +40,32 @@ describe('tracking/util', () => {
                     'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/test?utm_source=test&utm_campaign=test'
                 )
             ).toEqual('https://sourcegraph.com/redacted?utm_source=test&utm_campaign=test')
+        })
+    })
+
+    describe(`${getPreviousMonday.name}()`, () => {
+        it('gets the corrent day if it is a Monday', () => {
+            const date = new Date(2021, 5, 14) // June 14, 2021 is a Monday
+            const monday = getPreviousMonday(date)
+            expect(monday).toBe('2021-06-14')
+        })
+
+        it('gets the previous Monday if it is not a Monday', () => {
+            const date = new Date(2021, 5, 13) // June 13, 2021 is a Sunday
+            const monday = getPreviousMonday(date)
+            expect(monday).toBe('2021-06-07')
+        })
+
+        it('gets the previous Monday if it is in a different month', () => {
+            const date = new Date(2021, 5, 3) // June 3, 2021 is a Thursday
+            const monday = getPreviousMonday(date)
+            expect(monday).toBe('2021-05-31')
+        })
+
+        it('gets the previous Monday if it is in a different year', () => {
+            const date = new Date(2021, 0, 2) // Jan 2, 2021 is a Saturday
+            const monday = getPreviousMonday(date)
+            expect(monday).toBe('2020-12-28')
         })
     })
 })

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -1,4 +1,4 @@
-import { padStart } from 'lodash'
+import { formatISO, startOfWeek } from 'date-fns'
 
 /**
  * Strip provided URL parameters and update window history
@@ -43,16 +43,5 @@ export function redactSensitiveInfoFromURL(url: string): string {
  * started using the site on the same week.
  */
 export function getPreviousMonday(date: Date): string {
-    const previousMonday = new Date(date)
-
-    while (previousMonday.getDay() !== 1 /* Monday */) {
-        previousMonday.setDate(previousMonday.getDate() - 1)
-    }
-
-    const year = previousMonday.getFullYear()
-    const month = padStart((previousMonday.getMonth() + 1).toString(), 2, '0') // Months in JS are 0-indexed
-    const dayOfMonth = padStart(previousMonday.getDate().toString(), 2, '0')
-
-    const isoString = `${year}-${month}-${dayOfMonth}`
-    return isoString
+    return formatISO(startOfWeek(date, { weekStartsOn: 1 }), { representation: 'date' })
 }

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -1,3 +1,5 @@
+import { padStart } from 'lodash'
+
 /**
  * Strip provided URL parameters and update window history
  */
@@ -33,4 +35,24 @@ export function redactSensitiveInfoFromURL(url: string): string {
     }
 
     return sourceURL.href
+}
+
+/**
+ * Returns the Monday at or before the supplied date, in YYYY-MM-DD format.
+ * This is used to generate cohort IDs for users who
+ * started using the site on the same week.
+ */
+export function getPreviousMonday(date: Date): string {
+    const previousMonday = new Date(date)
+
+    while (previousMonday.getDay() !== 1 /* Monday */) {
+        previousMonday.setDate(previousMonday.getDate() - 1)
+    }
+
+    const year = previousMonday.getFullYear()
+    const month = padStart((previousMonday.getMonth() + 1).toString(), 2, '0') // Months in JS are 0-indexed
+    const dayOfMonth = padStart(previousMonday.getDate().toString(), 2, '0')
+
+    const isoString = `${year}-${month}-${dayOfMonth}`
+    return isoString
 }

--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -155,7 +155,7 @@ export function logEvent(event: string, eventProperties?: unknown): void {
         {
             event,
             userCookieID: eventLogger.getAnonymousUserID(),
-            cohortID: eventLogger.getCohortID() || null, // Must be called AFTER eventLogger.getAnonymousUserID()
+            cohortID: eventLogger.getCohortID() || null,
             firstSourceURL: eventLogger.getFirstSourceURL(),
             url: window.location.href,
             source: EventSource.WEB,

--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -133,6 +133,7 @@ export function logEvent(event: string, eventProperties?: unknown): void {
             mutation LogEvent(
                 $event: String!
                 $userCookieID: String!
+                $cohortID: String
                 $firstSourceURL: String!
                 $url: String!
                 $source: EventSource!
@@ -141,6 +142,7 @@ export function logEvent(event: string, eventProperties?: unknown): void {
                 logEvent(
                     event: $event
                     userCookieID: $userCookieID
+                    cohortID: $cohortID
                     firstSourceURL: $firstSourceURL
                     url: $url
                     source: $source
@@ -153,6 +155,7 @@ export function logEvent(event: string, eventProperties?: unknown): void {
         {
             event,
             userCookieID: eventLogger.getAnonymousUserID(),
+            cohortID: eventLogger.getCohortID() || null, // Must be called AFTER eventLogger.getAnonymousUserID()
             firstSourceURL: eventLogger.getFirstSourceURL(),
             url: window.location.href,
             source: EventSource.WEB,


### PR DESCRIPTION
Cohort ID is generated at the same time the Anonymous User ID is generated and is the date of the Monday of the week the user first visited. Just like the Anonymous User ID, the cohort ID is saved in a cookie and is logged with every call to `logEvent`.

Users that already have an Anonymous User ID before this PR is merged won't have a Cohort ID.