### PR TITLE
Clarify that branches must be unique

### DIFF
--- a/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -73,7 +73,7 @@ This batch spec will produce up to 4 changesets in the `github.com/sourcegraph/s
 1. a changeset with the changes in `monitoring`
 1. a changeset with the changes in the other directories.
 
-Since code hosts and git don't allow creating multiple, _different_ changesets on the same branch, it is **required** to specify the `branch` that will be used for the additional changesets. That `branch` will overwrite the default branch specified in `changesetTemplate`.
+Since code hosts and git don't allow creating multiple, _different_ changesets on the same branch, it is **required** to specify a unique `branch` for each `directory` that will be used for the additional changesets. That `branch` will overwrite the default branch specified in `changesetTemplate`.
 
 In case no changes have been made in a `directory` specified in a `group`, no additional changeset will be produced.
 


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

To clarify that each `branch` as an argument to `directory` in `transformChanges` must be unique. 
