### PR TITLE
Surface PAT permissions faster

### DIFF
--- a/doc/batch_changes/explanations/permissions_in_batch_changes.md
+++ b/doc/batch_changes/explanations/permissions_in_batch_changes.md
@@ -53,9 +53,9 @@ For instructions on adding and managing your code host access tokens, please ref
 
 See these code host specific pages for which permissions and scopes the tokens require:
 
-- [GitHub](../../../admin/external_service/github.md#github-api-token-and-access)
-- [GitLab](../../../admin/external_service/gitlab.md#access-token-scopes)
-- [Bitbucket Server](../../../admin/external_service/gitlab.md#access-token-permissions)
+- [GitHub](../../../admin/external_service/github.md#github-api-token-and-access) (requires `repo`, `read:org`, `user:email`, and `read:discussion`scope)
+- [GitLab](../../../admin/external_service/gitlab.md#access-token-scopes) (requires `api`, `read_repository`, and `write_repository` scope)
+- [Bitbucket Server](../../../admin/external_service/bitbucket_server.md#access-token-permissions) (requires write permissions on the project and repository level)
 
 ### Site admins
 


### PR DESCRIPTION
This PR corrects a bad link for the bitbucket server, and adds a quick reference for scopes needed on code host PAT without hoping between docs



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
