### PR TITLE
Clarify staging for caddy2

### DIFF
--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -161,7 +161,9 @@ Sourcegraph's [Docker Compose deployment](../admin/install/docker-compose/index.
 - HTTPS with automatically provisioned Let's Encrypt certificates
 - HTTPS with custom certificates that you provide
 
-Usage instructions are provided via [the `caddy` service's inline comments inside the `docker-compose.yaml` definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/3.14/docker-compose/docker-compose.yaml#L3:L58). Detailed steps are found below. 
+Usage instructions are provided via [the `caddy` service's inline comments inside the `docker-compose.yaml` definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/3.14/docker-compose/docker-compose.yaml#L3:L58). Detailed steps are found below.
+
+**Important:** When setting up caddy's automatic Lets Encypt TLS certification for HTTPS we strongly recommended to test with the staging configuration first, however TLS certs provided by Lets Encrypt staging will not be verifiable, and the production env variable must be uncommented for functional HTTPS.
 
 ### HTTPS with Custom Certificates in Docker Compose
 
@@ -176,18 +178,18 @@ In https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-c
 2. In Volumes section of the compose file comment out the following line 
 
 ```
-# - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
+- '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
 ```        
       
 
 3. In Volumes section of the compose file uncomment the following line: 
 ```
- - '../caddy/builtins/https.custom-cert.Caddyfile:/etc/caddy/Caddyfile' 
+- '../caddy/builtins/https.custom-cert.Caddyfile:/etc/caddy/Caddyfile' 
 ``` 
 
 4. In Volumes section of the compose file uncomment and update the following line with your custom cert path: 
 ```
- - '/LOCAL/CERT/PATH.pem:/sourcegraph.pem'
+- '/LOCAL/CERT/PATH.pem:/sourcegraph.pem'
 ```
 
 5. In Volumes section of the compose file uncomment and update the following line with your custom cert path: 


### PR DESCRIPTION
Clarify that staging setting for lets encrypt won't provide a valid cert. Additionally fix some minor formating errors in custom cert instructions



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
