### PR TITLE
search: replace repoSet with repoBranches

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -37,7 +37,8 @@ type repoLister interface {
 
 func (r *repositoryTextSearchIndexResolver) resolve(ctx context.Context) (*zoekt.RepoListEntry, error) {
 	r.once.Do(func() {
-		repoList, err := r.client.List(ctx, zoektquery.NewRepoSet(r.repo.Name()))
+		q := &zoektquery.RepoBranches{Set: map[string][]string{r.repo.Name(): {"HEAD"}}}
+		repoList, err := r.client.List(ctx, q)
 		if err != nil {
 			r.err = err
 			return


### PR DESCRIPTION
there is only one place where we use repoSet and we can easily replace
it with repoBranches. This way we can remove repoSets from Zoekt
entirely and simplify the code base.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
