### PR TITLE
Update outdated repo-updater related comments 

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -326,10 +326,10 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		repo = list[0]
 	}
 
-	// If we are sourcegraph.com we don't sync our site level code hosts in the background
-	// since there are too many repos. Instead we use an incremental approach where we check
-	// for changes everytime a user browses a repo. RepoLookup is the signal
-	// we rely on to check metadata.
+	// If we are sourcegraph.com we don't sync our "cloud_default" code hosts in the background
+	// since there are too many repos. Instead we use an incremental approach where we check for
+	// changes everytime a user browses a repo. RepoLookup is the signal we rely on to check
+	// metadata.
 
 	codehost := extsvc.CodeHostOf(args.Repo, extsvc.PublicCodeHosts...)
 	if s.SourcegraphDotComMode && codehost != nil {

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -15,6 +15,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -202,7 +203,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 			}
 			return nil
 		}
-	} else if s.SubsetSynced != nil {
+	} else if !envvar.SourcegraphDotComMode() {
 		// This is a site admin owned external service so we should stream inserts ASAP.
 		// It should insert outside of our transaction so that repos are visible to the rest of our
 		// system immediately.

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -15,7 +15,6 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -203,10 +202,10 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 			}
 			return nil
 		}
-	} else if !envvar.SourcegraphDotComMode() {
-		// This is a site admin owned external service so we should stream inserts ASAP.
-		// It should insert outside of our transaction so that repos are visible to the rest of our
-		// system immediately.
+	} else if s.SubsetSynced != nil {
+		// This is a site level external service. We have a channel to handle streaming inserts,
+		// therefore we should create an inserter. Note that it inserts outside of our transaction
+		// so that repos are visible to the rest of our system immediately.
 		onSourced, err = s.makeNewRepoInserter(ctx, s.Store, isUserOwned)
 		if err != nil {
 			return errors.Wrap(err, "syncer.sync.streaming")


### PR DESCRIPTION
This PR makes two minor changes:

- cmd/repo-updater: Update outdated comment in func repoLookup

- internal/repos: Clarify comment on why we check SubsetSynced != nil


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
