### PR TITLE
search snippets: rename settings button, update schema description, and log click event

### DIFF
--- a/client/web/src/search/results/sidebar/FilterLink.test.tsx
+++ b/client/web/src/search/results/sidebar/FilterLink.test.tsx
@@ -8,7 +8,7 @@ import { Filter } from '@sourcegraph/shared/src/search/stream'
 
 import { SearchScope } from '../../../schema/settings.schema'
 
-import { getDynamicFilterLinks, getRepoFilterLinks, getSearchScopeLinks } from './FilterLink'
+import { getDynamicFilterLinks, getRepoFilterLinks, getSearchSnippetLinks } from './FilterLink'
 
 describe('FilterLink', () => {
     const repoFilter1: Filter = {
@@ -108,7 +108,7 @@ describe('FilterLink', () => {
         ]
         const onFilterChosen = sinon.stub()
 
-        const links = getSearchScopeLinks({ subjects: [], final: { 'search.scopes': scopes } }, onFilterChosen)
+        const links = getSearchSnippetLinks({ subjects: [], final: { 'search.scopes': scopes } }, onFilterChosen)
         expect(links.length).toBe(2)
         expect(mount(<>{links}</>)).toMatchSnapshot()
     })
@@ -116,7 +116,7 @@ describe('FilterLink', () => {
     it('should have no snippet links if no snippets present', () => {
         const onFilterChosen = sinon.stub()
 
-        const links = getSearchScopeLinks({ subjects: [], final: {} }, onFilterChosen)
+        const links = getSearchSnippetLinks({ subjects: [], final: {} }, onFilterChosen)
         expect(links.length).toBe(0)
     })
 

--- a/client/web/src/search/results/sidebar/FilterLink.tsx
+++ b/client/web/src/search/results/sidebar/FilterLink.tsx
@@ -96,7 +96,7 @@ export const getDynamicFilterLinks = (
             <FilterLink {...filter} key={`${filter.label}-${filter.value}`} onFilterChosen={onFilterChosen} />
         ))
 
-export const getSearchScopeLinks = (
+export const getSearchSnippetLinks = (
     settingsCascade: SettingsCascadeProps['settingsCascade'],
     onFilterChosen: (value: string) => void
 ): React.ReactElement[] => {

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -11,7 +11,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { CaseSensitivityProps, PatternTypeProps, SearchContextProps } from '../..'
 import { submitSearch, toggleSearchFilter } from '../../helpers'
 
-import { getDynamicFilterLinks, getRepoFilterLinks, getSearchScopeLinks } from './FilterLink'
+import { getDynamicFilterLinks, getRepoFilterLinks, getSearchSnippetLinks } from './FilterLink'
 import { getQuickLinks } from './QuickLink'
 import styles from './SearchSidebar.module.scss'
 import { SearchSidebarSection } from './SearchSidebarSection'
@@ -34,15 +34,29 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
 
     const onFilterClicked = useCallback(
         (value: string) => {
+            const newQuery = toggleSearchFilter(props.query, value)
+            submitSearch({ ...props, query: newQuery, source: 'filter', history })
+        },
+        [history, props]
+    )
+
+    const onDynamicFilterClicked = useCallback(
+        (value: string) => {
             props.telemetryService.log('DynamicFilterClicked', {
                 search_filter: { value },
             })
 
-            const newQuery = toggleSearchFilter(props.query, value)
-
-            submitSearch({ ...props, query: newQuery, source: 'filter', history })
+            onFilterClicked(value)
         },
-        [history, props]
+        [onFilterClicked, props.telemetryService]
+    )
+
+    const onSnippetClicked = useCallback(
+        (value: string) => {
+            props.telemetryService.log('SearchSnippetClicked')
+            onFilterClicked(value)
+        },
+        [onFilterClicked, props.telemetryService]
     )
 
     return (
@@ -52,13 +66,13 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     {getSearchTypeLinks(props)}
                 </SearchSidebarSection>
                 <SearchSidebarSection className={styles.searchSidebarItem} header="Dynamic filters">
-                    {getDynamicFilterLinks(props.filters, onFilterClicked)}
+                    {getDynamicFilterLinks(props.filters, onDynamicFilterClicked)}
                 </SearchSidebarSection>
                 <SearchSidebarSection className={styles.searchSidebarItem} header="Repositories" showSearch={true}>
-                    {getRepoFilterLinks(props.filters, onFilterClicked)}
+                    {getRepoFilterLinks(props.filters, onDynamicFilterClicked)}
                 </SearchSidebarSection>
                 <SearchSidebarSection className={styles.searchSidebarItem} header="Search snippets">
-                    {getSearchScopeLinks(props.settingsCascade, onFilterClicked)}
+                    {getSearchSnippetLinks(props.settingsCascade, onSnippetClicked)}
                 </SearchSidebarSection>
                 <SearchSidebarSection className={styles.searchSidebarItem} header="Quicklinks">
                     {getQuickLinks(props.settingsCascade)}

--- a/client/web/src/site-admin/configHelpers.ts
+++ b/client/web/src/site-admin/configHelpers.ts
@@ -44,6 +44,6 @@ export const settingsActions: EditorAction[] = [
         label: 'Search: show # before/after lines',
         run: setSearchContextLines,
     },
-    { id: 'sourcegraph.settings.searchScopes', label: 'Add search scope', run: addSearchScopeToSettings },
+    { id: 'sourcegraph.settings.searchScopes', label: 'Add search snippet', run: addSearchScopeToSettings },
     { id: 'sourcegraph.settings.quickLinks', label: 'Add quick link', run: addQuickLinkToSettings },
 ]

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1302,7 +1302,7 @@ type Settings struct {
 	SearchRepositoryGroups map[string][]interface{} `json:"search.repositoryGroups,omitempty"`
 	// SearchSavedQueries description: DEPRECATED: Saved search queries
 	SearchSavedQueries []*SearchSavedQueries `json:"search.savedQueries,omitempty"`
-	// SearchScopes description: Predefined search scopes
+	// SearchScopes description: Predefined search snippets that can be appended to any search (also known as search scopes)
 	SearchScopes []*SearchScope `json:"search.scopes,omitempty"`
 	// SearchUppercase description: REMOVED. Previously, when active, any uppercase characters in the pattern will make the entire query case-sensitive.
 	SearchUppercase *bool `json:"search.uppercase,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -219,7 +219,7 @@
       }
     },
     "search.scopes": {
-      "description": "Predefined search scopes",
+      "description": "Predefined search snippets that can be appended to any search (also known as search scopes)",
       "type": "array",
       "items": {
         "$ref": "#/definitions/SearchScope"


### PR DESCRIPTION
- Rename settings button from "Add search scope" to "Add search snippet". From https://github.com/sourcegraph/sourcegraph/pull/22091#discussion_r654557408
- Update schema description of `search.scopes` to read "Predefined search snippets that can be appended to any search (also known as search scopes)". The setting is still called `search.scopes` for backwards compatibility.
- Log event `SearchSnippetClicked` when a snippet is clicked in the sidebar. This event will not have a filter value for privacy reasons, since snippets are user-defined. Closes #21682

![image](https://user-images.githubusercontent.com/206864/122594893-812ffe80-d01c-11eb-8ff2-d7dbb6aeef0f.png)
