### PR TITLE
search signup CTAs: QA items

### DIFF
--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -46,30 +46,6 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
       className="nav align-items-center"
     >
       <li
-        className="nav-item"
-      >
-        <a
-          className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none"
-          href="/extensions"
-          onClick={[Function]}
-          onKeyPress={[Function]}
-          tabIndex={0}
-        >
-          <svg
-            className="mdi-icon icon-inline mr-1"
-            fill="currentColor"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-          >
-            <path
-              d="M22,13.5C22,15.26 20.7,16.72 19,16.96V20A2,2 0 0,1 17,22H13.2V21.7A2.7,2.7 0 0,0 10.5,19C9,19 7.8,20.21 7.8,21.7V22H4A2,2 0 0,1 2,20V16.2H2.3C3.79,16.2 5,15 5,13.5C5,12 3.79,10.8 2.3,10.8H2V7A2,2 0 0,1 4,5H7.04C7.28,3.3 8.74,2 10.5,2C12.26,2 13.72,3.3 13.96,5H17A2,2 0 0,1 19,7V10.04C20.7,10.28 22,11.74 22,13.5M17,15H18.5A1.5,1.5 0 0,0 20,13.5A1.5,1.5 0 0,0 18.5,12H17V7H12V5.5A1.5,1.5 0 0,0 10.5,4A1.5,1.5 0 0,0 9,5.5V7H4V9.12C5.76,9.8 7,11.5 7,13.5C7,15.5 5.75,17.2 4,17.88V20H6.12C6.8,18.25 8.5,17 10.5,17C12.5,17 14.2,18.25 14.88,20H17V15Z"
-            />
-          </svg>
-          Extend
-        </a>
-      </li>
-      <li
         aria-hidden="true"
         className="search-results-info-bar__divider"
       />
@@ -175,30 +151,6 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
     <ul
       className="nav align-items-center"
     >
-      <li
-        className="nav-item"
-      >
-        <a
-          className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none"
-          href="/extensions"
-          onClick={[Function]}
-          onKeyPress={[Function]}
-          tabIndex={0}
-        >
-          <svg
-            className="mdi-icon icon-inline mr-1"
-            fill="currentColor"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-          >
-            <path
-              d="M22,13.5C22,15.26 20.7,16.72 19,16.96V20A2,2 0 0,1 17,22H13.2V21.7A2.7,2.7 0 0,0 10.5,19C9,19 7.8,20.21 7.8,21.7V22H4A2,2 0 0,1 2,20V16.2H2.3C3.79,16.2 5,15 5,13.5C5,12 3.79,10.8 2.3,10.8H2V7A2,2 0 0,1 4,5H7.04C7.28,3.3 8.74,2 10.5,2C12.26,2 13.72,3.3 13.96,5H17A2,2 0 0,1 19,7V10.04C20.7,10.28 22,11.74 22,13.5M17,15H18.5A1.5,1.5 0 0,0 20,13.5A1.5,1.5 0 0,0 18.5,12H17V7H12V5.5A1.5,1.5 0 0,0 10.5,4A1.5,1.5 0 0,0 9,5.5V7H4V9.12C5.76,9.8 7,11.5 7,13.5C7,15.5 5.75,17.2 4,17.88V20H6.12C6.8,18.25 8.5,17 10.5,17C12.5,17 14.2,18.25 14.88,20H17V15Z"
-            />
-          </svg>
-          Extend
-        </a>
-      </li>
       <li
         aria-hidden="true"
         className="search-results-info-bar__divider"
@@ -333,60 +285,9 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
       className="nav align-items-center"
     >
       <li
-        className="nav-item"
-      >
-        <a
-          className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none"
-          href="/extensions"
-          onClick={[Function]}
-          onKeyPress={[Function]}
-          tabIndex={0}
-        >
-          <svg
-            className="mdi-icon icon-inline mr-1"
-            fill="currentColor"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-          >
-            <path
-              d="M22,13.5C22,15.26 20.7,16.72 19,16.96V20A2,2 0 0,1 17,22H13.2V21.7A2.7,2.7 0 0,0 10.5,19C9,19 7.8,20.21 7.8,21.7V22H4A2,2 0 0,1 2,20V16.2H2.3C3.79,16.2 5,15 5,13.5C5,12 3.79,10.8 2.3,10.8H2V7A2,2 0 0,1 4,5H7.04C7.28,3.3 8.74,2 10.5,2C12.26,2 13.72,3.3 13.96,5H17A2,2 0 0,1 19,7V10.04C20.7,10.28 22,11.74 22,13.5M17,15H18.5A1.5,1.5 0 0,0 20,13.5A1.5,1.5 0 0,0 18.5,12H17V7H12V5.5A1.5,1.5 0 0,0 10.5,4A1.5,1.5 0 0,0 9,5.5V7H4V9.12C5.76,9.8 7,11.5 7,13.5C7,15.5 5.75,17.2 4,17.88V20H6.12C6.8,18.25 8.5,17 10.5,17C12.5,17 14.2,18.25 14.88,20H17V15Z"
-            />
-          </svg>
-          Extend
-        </a>
-      </li>
-      <li
         aria-hidden="true"
         className="search-results-info-bar__divider"
       />
-      <li
-        className="nav-item"
-      >
-        <a
-          className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none create-code-monitor-button"
-          href="/code-monitoring/new?trigger-query=foo+type%3Adiff+patterntype%3Aliteral"
-          onClick={[Function]}
-          onKeyPress={[Function]}
-          tabIndex={0}
-        >
-          <svg
-            className="icon-inline mr-1"
-            fill="currentColor"
-            height="20"
-            viewBox="0 0 20 20"
-            width="20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
-              fillRule="evenodd"
-            />
-          </svg>
-          Monitor
-        </a>
-      </li>
       <li
         aria-hidden="true"
         className="search-results-info-bar__divider"
@@ -463,30 +364,6 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
     <ul
       className="nav align-items-center"
     >
-      <li
-        className="nav-item"
-      >
-        <a
-          className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none"
-          href="/extensions"
-          onClick={[Function]}
-          onKeyPress={[Function]}
-          tabIndex={0}
-        >
-          <svg
-            className="mdi-icon icon-inline mr-1"
-            fill="currentColor"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-          >
-            <path
-              d="M22,13.5C22,15.26 20.7,16.72 19,16.96V20A2,2 0 0,1 17,22H13.2V21.7A2.7,2.7 0 0,0 10.5,19C9,19 7.8,20.21 7.8,21.7V22H4A2,2 0 0,1 2,20V16.2H2.3C3.79,16.2 5,15 5,13.5C5,12 3.79,10.8 2.3,10.8H2V7A2,2 0 0,1 4,5H7.04C7.28,3.3 8.74,2 10.5,2C12.26,2 13.72,3.3 13.96,5H17A2,2 0 0,1 19,7V10.04C20.7,10.28 22,11.74 22,13.5M17,15H18.5A1.5,1.5 0 0,0 20,13.5A1.5,1.5 0 0,0 18.5,12H17V7H12V5.5A1.5,1.5 0 0,0 10.5,4A1.5,1.5 0 0,0 9,5.5V7H4V9.12C5.76,9.8 7,11.5 7,13.5C7,15.5 5.75,17.2 4,17.88V20H6.12C6.8,18.25 8.5,17 10.5,17C12.5,17 14.2,18.25 14.88,20H17V15Z"
-            />
-          </svg>
-          Extend
-        </a>
-      </li>
       <li
         aria-hidden="true"
         className="search-results-info-bar__divider"


### PR DESCRIPTION
Minor follow-ups to #22091 for #21093

- "Extend" button should only be shown to signed out users with the feature flag enabled (it was previously being shown to everyone)
- "Monitor" button should be shown to signed out users only when the feature flag is enabled (it was previously being shown to all signed out users)
- "Create insights" button should also contribute to the display of the vertical separator