### PR TITLE
batches: correctly pluralise when asking to close changesets

### DIFF
--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
@@ -1,4 +1,4 @@
-import { boolean } from '@storybook/addon-knobs'
+import { boolean, number } from '@storybook/addon-knobs'
 import { useState } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
@@ -17,6 +17,7 @@ const { add } = storiesOf('web/batches/close/BatchChangeCloseAlert', module)
 
 add('Has open changesets', () => {
     const [closeChangesets, setCloseChangesets] = useState(false)
+    const totalCount = number('totalCount', 10)
     return (
         <EnterpriseWebStory>
             {props => (
@@ -24,7 +25,7 @@ add('Has open changesets', () => {
                     {...props}
                     batchChangeID="change123"
                     batchChangeURL="/users/john/batch-changes/change123"
-                    totalCount={10}
+                    totalCount={totalCount}
                     closeChangesets={closeChangesets}
                     setCloseChangesets={setCloseChangesets}
                     viewerCanAdminister={boolean('viewerCanAdminister', true)}

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { isErrorLike, asError } from '@sourcegraph/shared/src/util/errors'
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { ErrorAlert } from '../../../components/alerts'
 import { Scalars } from '../../../graphql-operations'
@@ -73,7 +74,13 @@ export const BatchChangeCloseAlert: React.FunctionComponent<BatchChangeCloseAler
                                     disabled={isClosing === true || !viewerCanAdminister}
                                 />
                                 <label className="form-check-label" htmlFor="closeChangesets">
-                                    Also close all {totalCount} open changesets on code hosts.
+                                    Also close {pluralize('the', totalCount, 'all')} {totalCount}{' '}
+                                    {pluralize(
+                                        'open changeset on the code host',
+                                        totalCount,
+                                        'open changesets on the code hosts'
+                                    )}
+                                    .
                                 </label>
                             </div>
                         </>


### PR DESCRIPTION
This actually required a bit more rewording than just a single `pluralize()` call. I've updated the storybook to allow the total number of changesets to be changed; opening https://5f0f381c0e50750022dc6bf7-jawrqfbzzn.chromatic.com/?path=/story/web-batches-close-batchchangeclosealert--has-open-changesets and changing the `totalCount` knob is probably the best way to test this.