### PR TITLE
internal/repos: Set owner tag for sync metrics

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -245,6 +245,10 @@ func Main(enterpriseInit EnterpriseInit) {
 	var gps *repos.GitolitePhabricatorMetadataSyncer
 	if !envvar.SourcegraphDotComMode() {
 		gps = repos.NewGitolitePhabricatorMetadataSyncer(store)
+
+		// WARNING: This enables the streaming inserter which allows it to sync private repos. If
+		// this is ever enabled for sourcegraph.com, we want to be sure we are not unintentionally
+		// syncing private repos.
 		syncer.SubsetSynced = make(chan repos.Diff)
 	}
 

--- a/internal/repos/metrics.go
+++ b/internal/repos/metrics.go
@@ -33,7 +33,7 @@ var (
 	syncStarted = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_syncer_start_sync",
 		Help: "A sync was started",
-	}, []string{tagFamily})
+	}, []string{tagFamily, tagOwner})
 
 	syncedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_syncer_synced_repos_total",

--- a/internal/repos/metrics.go
+++ b/internal/repos/metrics.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	tagFamily  = "family"
+	tagOwner   = "owner"
 	tagID      = "id"
 	tagState   = "state"
 	tagSuccess = "success"
@@ -42,7 +43,7 @@ var (
 	syncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_syncer_sync_errors_total",
 		Help: "Total number of sync errors",
-	}, []string{tagFamily})
+	}, []string{tagFamily, tagOwner})
 
 	syncDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "src_repoupdater_syncer_sync_duration_seconds",

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -506,11 +506,9 @@ func (s *Syncer) insertIfNew(ctx context.Context, store *Store, sourcedRepo *typ
 	ctx, save := s.observe(ctx, "Syncer.InsertIfNew", string(sourcedRepo.Name))
 	defer save(&diff, &owner, &err)
 
-	// Note on why we set the publicOnly argument to false while invoking syncRepo:
-	// 1. insertIfNew is only invoked from makeNewRepoInserter
-	// 2. makeNewRepoInserter is only invoked if repo is not owned by the user
-	// 3. This implies that this repo is being synced by the site owner
-	// 4. TODO: Add clarification why the above means publicOnly = false.
+	// insertIfNew is only used for streaming inserter, which is currently only enabled on customer
+	// instances. Therefore we set publicOnly to false because customer instances do not have any
+	// limitation for private code.
 	diff, err = s.syncRepo(ctx, store, true, false, sourcedRepo)
 	return err
 }

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -41,6 +41,7 @@ type Syncer struct {
 	// TODO: The name of this channel does not make it easy to understand its use case. This is
 	// triggered by an adhoc sync when a user tries to search a repo we don't have cloned on
 	// sourcegraph.com yet.
+	// https://sourcegraph.atlassian.net/browse/COREAPP-128
 	SubsetSynced chan Diff
 
 	// Logger if non-nil is logged to.

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -151,7 +151,6 @@ func (s *Syncer) TriggerExternalServiceSync(ctx context.Context, id int64) error
 type ownerType string
 
 const (
-	// TODO: Verify if empty string does not tag the metric.
 	ownerUndefined ownerType = ""
 	ownerSite      ownerType = "site"
 	ownerUser      ownerType = "user"

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -164,7 +164,6 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 		unauthorized     bool
 		accountSuspended bool
 		forbidden        bool
-		isUserOwned      bool
 	)
 
 	if s.Logger != nil {
@@ -190,7 +189,6 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 
 	if svc.NamespaceUserID > 0 {
 		owner = ownerUser
-		isUserOwned = true
 	} else {
 		owner = ownerSite
 	}
@@ -254,9 +252,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 	// Unless our site config explicitly allows private code or the user has the
 	// "AllowUserExternalServicePrivate" tag, user added external services should
 	// only sync public code.
-	//
-	// TODO: How does this flag indicate the conditions mentioned in the comment above hold true?
-	if isUserOwned {
+	if owner == ownerUser {
 		if mode, err := database.UsersWith(tx).UserAllowedExternalServices(ctx, svc.NamespaceUserID); err != nil {
 			return errors.Wrap(err, "checking if user can add private code")
 		} else if mode != conf.ExternalServiceModeAll {

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -39,8 +39,7 @@ type Syncer struct {
 	// SubsetSynced is non-nil)
 	//
 	// TODO: The name of this channel does not make it easy to understand its use case. This is
-	// triggered by an adhoc sync when a user tries to search a repo we don't have cloned on
-	// sourcegraph.com yet.
+	// triggered by the streaming inserter.
 	// https://sourcegraph.atlassian.net/browse/COREAPP-128
 	SubsetSynced chan Diff
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -868,7 +868,12 @@ func (s *Syncer) observe(ctx context.Context, family, title string) (context.Con
 	tr, ctx := trace.New(ctx, family, title)
 
 	return ctx, func(d *Diff, owner *externalServiceOwnerType, err *error) {
-		syncStarted.WithLabelValues(family, string(*owner)).Inc()
+		var ownerTag string
+		if owner != nil {
+			ownerTag = string(*owner)
+		}
+
+		syncStarted.WithLabelValues(family, ownerTag).Inc()
 
 		now := s.Now()
 		took := s.Now().Sub(began).Seconds()
@@ -902,7 +907,7 @@ func (s *Syncer) observe(ctx context.Context, family, title string) (context.Con
 
 		if !success {
 			tr.SetError(*err)
-			syncErrors.WithLabelValues(family, string(*owner)).Add(1)
+			syncErrors.WithLabelValues(family, ownerTag).Add(1)
 		}
 
 		tr.Finish()

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -148,12 +148,12 @@ func (s *Syncer) TriggerExternalServiceSync(ctx context.Context, id int64) error
 	return s.Store.EnqueueSingleSyncJob(ctx, id)
 }
 
-type ownerType string
+type externalServiceOwnerType string
 
 const (
-	ownerUndefined ownerType = ""
-	ownerSite      ownerType = "site"
-	ownerUser      ownerType = "user"
+	ownerUndefined externalServiceOwnerType = ""
+	ownerSite      externalServiceOwnerType = "site"
+	ownerUser      externalServiceOwnerType = "user"
 )
 
 // SyncExternalService syncs repos using the supplied external service.
@@ -500,7 +500,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, store *Store, sourcedRepo *types.
 
 // insertIfNew is a specialization of SyncRepo. It will insert sourcedRepo
 // if there are no related repositories, otherwise does nothing.
-func (s *Syncer) insertIfNew(ctx context.Context, store *Store, sourcedRepo *types.Repo, owner ownerType) (err error) {
+func (s *Syncer) insertIfNew(ctx context.Context, store *Store, sourcedRepo *types.Repo, owner externalServiceOwnerType) (err error) {
 	var diff Diff
 
 	ctx, save := s.observe(ctx, "Syncer.InsertIfNew", string(sourcedRepo.Name))
@@ -836,7 +836,7 @@ func (s *Syncer) sourced(ctx context.Context, svc *types.ExternalService, onSour
 
 // makeNewRepoInserter returns a function that will insert repos.
 // If publicOnly is set it will never insert a private repo.
-func (s *Syncer) makeNewRepoInserter(ctx context.Context, store *Store, owner ownerType) (func(*types.Repo) error, error) {
+func (s *Syncer) makeNewRepoInserter(ctx context.Context, store *Store, owner externalServiceOwnerType) (func(*types.Repo) error, error) {
 	// insertIfNew requires querying the store for related repositories, and
 	// will do nothing if `insertOnly` is set and there are any related repositories. Most
 	// repositories will already have related repos, so to avoid that cost we
@@ -863,11 +863,11 @@ func (s *Syncer) makeNewRepoInserter(ctx context.Context, store *Store, owner ow
 	}, nil
 }
 
-func (s *Syncer) observe(ctx context.Context, family, title string) (context.Context, func(*Diff, *ownerType, *error)) {
+func (s *Syncer) observe(ctx context.Context, family, title string) (context.Context, func(*Diff, *externalServiceOwnerType, *error)) {
 	began := s.Now()
 	tr, ctx := trace.New(ctx, family, title)
 
-	return ctx, func(d *Diff, owner *ownerType, err *error) {
+	return ctx, func(d *Diff, owner *externalServiceOwnerType, err *error) {
 		syncStarted.WithLabelValues(family, string(*owner)).Inc()
 
 		now := s.Now()

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -482,7 +482,8 @@ func calcSyncInterval(now time.Time, lastSync time.Time, minSyncInterval time.Du
 func (s *Syncer) SyncRepo(ctx context.Context, store *Store, sourcedRepo *types.Repo) (err error) {
 	var diff Diff
 
-	owner := ownerUndefined
+	// SyncRepo is only used for site level external services on sourcegraph.com
+	owner := ownerSite
 
 	ctx, save := s.observe(ctx, "Syncer.SyncRepo", string(sourcedRepo.Name))
 	defer save(&diff, &owner, &err)

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -872,7 +872,7 @@ func (s *Syncer) observe(ctx context.Context, family, title string) (context.Con
 	tr, ctx := trace.New(ctx, family, title)
 
 	return ctx, func(d *Diff, owner ownerType, err *error) {
-		syncStarted.WithLabelValues(family).Inc()
+		syncStarted.WithLabelValues(family, string(owner)).Inc()
 
 		now := s.Now()
 		took := s.Now().Sub(began).Seconds()


### PR DESCRIPTION
Working local dev links to affected metrics along with screenshots:

[src_repoupdater_syncer_start_sync](https://sourcegraph.test:3443/-/debug/grafana/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max%20by%20(owner,%20family)%20(rate(src_repoupdater_syncer_start_sync%5B10m%5D))%22,%22datasource%22:%22Prometheus%22,%22exemplar%22:true,%22requestId%22:%22Q-3275e72c-6ee8-463c-b199-3eb376027962-0A%22,%22instant%22:true,%22range%22:true%7D%5D)

![image](https://user-images.githubusercontent.com/2682729/122808122-0c91e400-d2ea-11eb-947f-4b4b48afb6fc.png)

[src_repoupdater_syncer_sync_errors_total](https://sourcegraph.test:3443/-/debug/grafana/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max%20by%20(family,%20owner)%20(rate(src_repoupdater_syncer_sync_errors_total%5B5m%5D))%22,%22datasource%22:%22Prometheus%22,%22exemplar%22:true,%22requestId%22:%22Q-c91fd597-01a6-4ee5-bd2f-51b7e76ac0a2-0A%22%7D%5D)

![image](https://user-images.githubusercontent.com/2682729/122808238-4105a000-d2ea-11eb-8fc1-82c8abd09c76.png)


COREAPP-126 #done.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
