### PR TITLE
docker-images: have codeintel-db's build script just call postgres-12.6's

### DIFF
--- a/docker-images/codeintel-db/build.sh
+++ b/docker-images/codeintel-db/build.sh
@@ -4,4 +4,4 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # This image is identical to our "sourcegraph/postgres-12.6" image.
-IMAGE="${IMAGE:-sourcegraph/codeintel-db}"../postgres-12.6/build.sh
+IMAGE="${IMAGE:-sourcegraph/codeintel-db}" ../postgres-12.6/build.sh

--- a/docker-images/codeintel-db/build.sh
+++ b/docker-images/codeintel-db/build.sh
@@ -3,9 +3,5 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# This merely re-tags the image to match our official versioning scheme. The
-# actual image currently lives here: https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/codeintel-db/build.sh
-#
-# TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/postgres-12.6:95244_2021-05-06_2c1f77e@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778
-docker tag index.docker.io/sourcegraph/postgres-12.6:95244_2021-05-06_2c1f77e@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778 "$IMAGE"
+# This image is identical to our "sourcegraph/postgres-12.6" image.
+IMAGE="${IMAGE:-sourcegraph/codeintel-db}"../postgres-12.6/build.sh


### PR DESCRIPTION
This is a debt item that I am fixing now - this way we don't have to update codeintel-db's image separately if we update the base postgres one. 