### PR TITLE
code monitoring: prep for experimental getting started page

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -33,14 +33,6 @@ export const CodeMonitorList: React.FunctionComponent<Required<CodeMonitoringPag
         [authenticatedUser, fetchUserCodeMonitors]
     )
 
-    const setAllFilter = useCallback<React.MouseEventHandler>(() => {
-        setMonitorListFilter('all')
-    }, [])
-
-    const setUserFilter = useCallback<React.MouseEventHandler>(() => {
-        setMonitorListFilter('user')
-    }, [])
-
     return (
         <>
             <div className="row mb-5">
@@ -51,7 +43,7 @@ export const CodeMonitorList: React.FunctionComponent<Required<CodeMonitoringPag
                         className={classnames('btn text-left', {
                             'btn-primary': monitorListFilter === 'all',
                         })}
-                        onClick={setAllFilter}
+                        onClick={() => setMonitorListFilter('all')}
                     >
                         All
                     </button>
@@ -60,7 +52,7 @@ export const CodeMonitorList: React.FunctionComponent<Required<CodeMonitoringPag
                         className={classnames('btn text-left', {
                             'btn-primary': monitorListFilter === 'user',
                         })}
-                        onClick={setUserFilter}
+                        onClick={() => setMonitorListFilter('user')}
                     >
                         Your code monitors
                     </button>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -1,0 +1,108 @@
+import classnames from 'classnames'
+import React, { useCallback, useState } from 'react'
+import { useHistory, useLocation } from 'react-router'
+
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { Container } from '@sourcegraph/wildcard'
+
+import { FilteredConnection } from '../../components/FilteredConnection'
+import { CodeMonitorFields, ListUserCodeMonitorsResult, ListUserCodeMonitorsVariables } from '../../graphql-operations'
+
+import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
+import { CodeMonitoringPageProps } from './CodeMonitoringPage'
+
+type CodeMonitorFilter = 'all' | 'user'
+
+export const CodeMonitorList: React.FunctionComponent<Required<CodeMonitoringPageProps>> = ({
+    authenticatedUser,
+    settingsCascade,
+    fetchUserCodeMonitors,
+    toggleCodeMonitorEnabled,
+}) => {
+    const location = useLocation()
+    const history = useHistory()
+    const [monitorListFilter, setMonitorListFilter] = useState<CodeMonitorFilter>('all')
+
+    const queryConnection = useCallback(
+        (args: Partial<ListUserCodeMonitorsVariables>) =>
+            fetchUserCodeMonitors({
+                id: authenticatedUser.id,
+                first: args.first ?? null,
+                after: args.after ?? null,
+            }),
+        [authenticatedUser, fetchUserCodeMonitors]
+    )
+
+    const setAllFilter = useCallback<React.MouseEventHandler>(() => {
+        setMonitorListFilter('all')
+    }, [])
+
+    const setUserFilter = useCallback<React.MouseEventHandler>(() => {
+        setMonitorListFilter('user')
+    }, [])
+
+    return (
+        <>
+            <div className="row mb-5">
+                <div className="d-flex flex-column col-2 mr-2">
+                    <h3>Filters</h3>
+                    <button
+                        type="button"
+                        className={classnames('btn text-left', {
+                            'btn-primary': monitorListFilter === 'all',
+                        })}
+                        onClick={setAllFilter}
+                    >
+                        All
+                    </button>
+                    <button
+                        type="button"
+                        className={classnames('btn text-left', {
+                            'btn-primary': monitorListFilter === 'user',
+                        })}
+                        onClick={setUserFilter}
+                    >
+                        Your code monitors
+                    </button>
+                </div>
+                <div className="d-flex flex-column w-100 col">
+                    <h3 className="mb-2">
+                        {`${monitorListFilter === 'all' ? 'All code monitors' : 'Your code monitors'}`}
+                    </h3>
+                    <Container>
+                        <FilteredConnection<
+                            CodeMonitorFields,
+                            Omit<CodeMonitorNodeProps, 'node'>,
+                            (ListUserCodeMonitorsResult['node'] & { __typename: 'User' })['monitors']
+                        >
+                            location={location}
+                            history={history}
+                            defaultFirst={10}
+                            queryConnection={queryConnection}
+                            hideSearch={true}
+                            nodeComponent={CodeMonitorNode}
+                            nodeComponentProps={{
+                                authenticatedUser,
+                                location,
+                                showCodeMonitoringTestEmailButton:
+                                    (!isErrorLike(settingsCascade.final) &&
+                                        settingsCascade.final?.experimentalFeatures
+                                            ?.showCodeMonitoringTestEmailButton) ||
+                                    false,
+                                toggleCodeMonitorEnabled,
+                            }}
+                            noun="code monitor"
+                            pluralNoun="code monitors"
+                            noSummaryIfAllNodesVisible={true}
+                            cursorPaging={true}
+                            className="filtered-connection__centered-summary"
+                        />
+                    </Container>
+                </div>
+            </div>
+            <div className="mt-5">
+                We want to hear your feedback! <a href="mailto:feedback@sourcegraph.com">Share your thoughts</a>
+            </div>
+        </>
+    )
+}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+
+import { Link } from '@sourcegraph/shared/src/components/Link'
+
+export const CodeMonitoringGettingStarted: React.FunctionComponent<{}> = () => (
+    <div className="mt-5">
+        <div className="d-flex flex-column mb-5">
+            <h2>Get started with code monitoring</h2>
+            <p className="text-muted code-monitoring-page__start-subheading mb-4">
+                Watch your code for changes and trigger actions to get notifications, send webhooks, and more.{' '}
+                <a href="https://docs.sourcegraph.com/code_monitoring">Learn more.</a>
+            </p>
+            <Link to="/code-monitoring/new" className="code-monitoring-page__start-button btn btn-primary">
+                Create your first code monitor →
+            </Link>
+        </div>
+        <div className="code-monitoring-page__start-points container">
+            <h3 className="mb-3">Starting points for your first monitor</h3>
+            <div className="row no-gutters code-monitoring-page__start-points-panel-container mb-3">
+                <div className="col-6">
+                    <div className="card">
+                        <div className="card-body p-3">
+                            <h3>Watch for AWS secrets in commits</h3>
+                            <p className="text-muted">
+                                Use a search query to watch for new search results, and choose how to receive
+                                notifications in response.
+                            </p>
+                            <a
+                                href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points#watch-for-potential-secrets"
+                                className="btn btn-secondary"
+                            >
+                                View in docs →
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div className="col-6">
+                    <div className="card">
+                        <div className="card-body p-3">
+                            <h3>Watch for new consumers of deprecated methods</h3>
+                            <p className="text-muted">
+                                Keep an eye on commits with new consumers of deprecated methods to keep your code base
+                                up-to-date.
+                            </p>
+                            <a
+                                href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points#watch-for-consumers-of-deprecated-endpoints"
+                                className="btn btn-secondary"
+                            >
+                                View in docs →
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <a className="link" href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points">
+                Find more starting points in the docs
+            </a>
+        </div>
+        <div className="code-monitoring-page__learn-more container mt-5">
+            <h3 className="mb-3">Learn more about code monitoring</h3>
+            <div className="row">
+                <div className="col-4">
+                    <div>
+                        <h4>Core concepts</h4>
+                        <p className="text-muted">
+                            Craft searches that will monitor your code and trigger actions.{' '}
+                            <a
+                                href="https://docs.sourcegraph.com/code_monitoring/explanations/core_concepts"
+                                className="link"
+                            >
+                                Read the docs
+                            </a>
+                        </p>
+                    </div>
+                </div>
+                <div className="col-4">
+                    <div>
+                        <h4>Starting points and ideas</h4>
+                        <p className="text-muted">
+                            Find specific examples of useful code monitors to keep on top of security and consistency
+                            concerns.{' '}
+                            <a
+                                href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points"
+                                className="link"
+                            >
+                                Explore starting points
+                            </a>
+                        </p>
+                    </div>
+                </div>
+                <div className="col-4">
+                    <div>
+                        <h4>Questions and feedback</h4>
+                        <p className="text-muted">
+                            We want to hear your feedback.{' '}
+                            <a href="mailto:feedback@sourcegraph.com" className="link">
+                                Share your thoughts
+                            </a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+)

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme'
-import * as H from 'history'
 import * as React from 'react'
+import { MemoryRouter } from 'react-router'
 import { of } from 'rxjs'
 import sinon from 'sinon'
 
@@ -16,15 +16,8 @@ jest.mock('../../tracking/eventLogger', () => ({
     eventLogger: { logViewEvent: () => undefined },
 }))
 
-const history = H.createBrowserHistory({})
-history.replace({ pathname: '/code-monitoring' })
 const additionalProps = {
-    history,
-    location: history.location,
     authenticatedUser: { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser,
-    breadcrumbs: [{ depth: 0, breadcrumb: null }],
-    setBreadcrumb: sinon.spy(),
-    useBreadcrumb: sinon.spy(),
     fetchUserCodeMonitors: ({ id, first, after }: ListUserCodeMonitorsVariables) =>
         of({
             nodes: mockCodeMonitorNodes,
@@ -53,23 +46,37 @@ const generateMockFetchMonitors = (count: number) => ({ id, first, after }: List
 describe('CodeMonitoringListPage', () => {
     test('Code monitoring page with less than 10 results', () => {
         expect(
-            mount(<CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(3)} />)
+            mount(
+                <MemoryRouter initialEntries={['/code-monitoring']}>
+                    <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(3)} />
+                </MemoryRouter>
+            )
         ).toMatchSnapshot()
     })
     test('Code monitoring page with 10 results', () => {
         expect(
-            mount(<CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(10)} />)
+            mount(
+                <MemoryRouter initialEntries={['/code-monitoring']}>
+                    <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(10)} />
+                </MemoryRouter>
+            )
         ).toMatchSnapshot()
     })
     test('Code monitoring page with more than 10 results', () => {
         expect(
-            mount(<CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(12)} />)
+            mount(
+                <MemoryRouter initialEntries={['/code-monitoring']}>
+                    <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(12)} />
+                </MemoryRouter>
+            )
         ).toMatchSnapshot()
     })
 
     test('Clicking enabled toggle calls toggleCodeMonitorEnabled', () => {
         const component = mount(
-            <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
+            <MemoryRouter initialEntries={['/code-monitoring']}>
+                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
+            </MemoryRouter>
         )
         const toggle = component.find('.test-toggle-monitor-enabled')
         toggle.simulate('click')

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,7 +1,5 @@
-import classnames from 'classnames'
-import * as H from 'history'
 import PlusIcon from 'mdi-react/PlusIcon'
-import React, { useCallback, useMemo, useState, useEffect } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import { catchError, map, startWith } from 'rxjs/operators'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
@@ -9,13 +7,11 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { Container, PageHeader } from '@sourcegraph/wildcard'
+import { PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
-import { FilteredConnection } from '../../components/FilteredConnection'
 import { PageTitle } from '../../components/PageTitle'
-import { CodeMonitorFields, ListUserCodeMonitorsResult, ListUserCodeMonitorsVariables } from '../../graphql-operations'
 import { Settings } from '../../schema/settings.schema'
 import { eventLogger } from '../../tracking/eventLogger'
 
@@ -23,38 +19,22 @@ import {
     fetchUserCodeMonitors as _fetchUserCodeMonitors,
     toggleCodeMonitorEnabled as _toggleCodeMonitorEnabled,
 } from './backend'
-import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
+import { CodeMonitoringGettingStarted } from './CodeMonitoringGettingStarted'
+import { CodeMonitorList } from './CodeMonitorList'
 
 export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings> {
     authenticatedUser: AuthenticatedUser
-    location: H.Location
-    history: H.History
-
     fetchUserCodeMonitors?: typeof _fetchUserCodeMonitors
     toggleCodeMonitorEnabled?: typeof _toggleCodeMonitorEnabled
 }
 
-type CodeMonitorFilter = 'all' | 'user'
-
 export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = ({
-    history,
-    location,
     settingsCascade,
     authenticatedUser,
     fetchUserCodeMonitors = _fetchUserCodeMonitors,
     toggleCodeMonitorEnabled = _toggleCodeMonitorEnabled,
 }) => {
     useEffect(() => eventLogger.logViewEvent('CodeMonitoringPage'), [])
-
-    const queryConnection = useCallback(
-        (args: Partial<ListUserCodeMonitorsVariables>) =>
-            fetchUserCodeMonitors({
-                id: authenticatedUser.id,
-                first: args.first ?? null,
-                after: args.after ?? null,
-            }),
-        [authenticatedUser, fetchUserCodeMonitors]
-    )
 
     const LOADING = 'loading' as const
 
@@ -73,16 +53,6 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
             [authenticatedUser.id, fetchUserCodeMonitors]
         )
     )
-
-    const [monitorListFilter, setMonitorListFilter] = useState<CodeMonitorFilter>('all')
-
-    const setAllFilter = useCallback<React.MouseEventHandler>(() => {
-        setMonitorListFilter('all')
-    }, [])
-
-    const setUserFilter = useCallback<React.MouseEventHandler>(() => {
-        setMonitorListFilter('user')
-    }, [])
 
     return (
         <div className="code-monitoring-page">
@@ -117,107 +87,9 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                 className="mb-3"
             />
             {userHasCodeMonitors === 'loading' && <LoadingSpinner />}
-            {!userHasCodeMonitors && (
-                <div className="mt-5">
-                    <div className="d-flex flex-column mb-5">
-                        <h2>Get started with code monitoring</h2>
-                        <p className="text-muted code-monitoring-page__start-subheading mb-4">
-                            Watch your code for changes and trigger actions to get notifications, send webhooks, and
-                            more. <a href="https://docs.sourcegraph.com/code_monitoring">Learn more.</a>
-                        </p>
-                        <Link to="/code-monitoring/new" className="code-monitoring-page__start-button btn btn-primary">
-                            Create your first code monitor →
-                        </Link>
-                    </div>
-                    <div className="code-monitoring-page__start-points container">
-                        <h3 className="mb-3">Starting points for your first monitor</h3>
-                        <div className="row no-gutters code-monitoring-page__start-points-panel-container mb-3">
-                            <div className="col-6">
-                                <div className="card">
-                                    <div className="card-body p-3">
-                                        <h3>Watch for AWS secrets in commits</h3>
-                                        <p className="text-muted">
-                                            Use a search query to watch for new search results, and choose how to
-                                            receive notifications in response.
-                                        </p>
-                                        <a
-                                            href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points#watch-for-potential-secrets"
-                                            className="btn btn-secondary"
-                                        >
-                                            View in docs →
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="col-6">
-                                <div className="card">
-                                    <div className="card-body p-3">
-                                        <h3>Watch for new consumers of deprecated methods</h3>
-                                        <p className="text-muted">
-                                            Keep an eye on commits with new consumers of deprecated methods to keep your
-                                            code base up-to-date.
-                                        </p>
-                                        <a
-                                            href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points#watch-for-consumers-of-deprecated-endpoints"
-                                            className="btn btn-secondary"
-                                        >
-                                            View in docs →
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <a className="link" href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points">
-                            Find more starting points in the docs
-                        </a>
-                    </div>
-                    <div className="code-monitoring-page__learn-more container mt-5">
-                        <h3 className="mb-3">Learn more about code monitoring</h3>
-                        <div className="row">
-                            <div className="col-4">
-                                <div>
-                                    <h4>Core concepts</h4>
-                                    <p className="text-muted">
-                                        Craft searches that will monitor your code and trigger actions.{' '}
-                                        <a
-                                            href="https://docs.sourcegraph.com/code_monitoring/explanations/core_concepts"
-                                            className="link"
-                                        >
-                                            Read the docs
-                                        </a>
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="col-4">
-                                <div>
-                                    <h4>Starting points and ideas</h4>
-                                    <p className="text-muted">
-                                        Find specific examples of useful code monitors to keep on top of security and
-                                        consistency concerns.{' '}
-                                        <a
-                                            href="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points"
-                                            className="link"
-                                        >
-                                            Explore starting points
-                                        </a>
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="col-4">
-                                <div>
-                                    <h4>Questions and feedback</h4>
-                                    <p className="text-muted">
-                                        We want to hear your feedback.{' '}
-                                        <a href="mailto:feedback@sourcegraph.com" className="link">
-                                            Share your thoughts
-                                        </a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            )}
+
+            {!userHasCodeMonitors && <CodeMonitoringGettingStarted />}
+
             {userHasCodeMonitors && userHasCodeMonitors !== 'loading' && !isErrorLike(userHasCodeMonitors) && (
                 <>
                     <div className="d-flex flex-column">
@@ -232,67 +104,12 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                                 </div>
                             </div>
                         </div>
-                        <div className="row mb-5">
-                            <div className="d-flex flex-column col-2 mr-2">
-                                <h3>Filters</h3>
-                                <button
-                                    type="button"
-                                    className={classnames('btn text-left', {
-                                        'btn-primary': monitorListFilter === 'all',
-                                    })}
-                                    onClick={setAllFilter}
-                                >
-                                    All
-                                </button>
-                                <button
-                                    type="button"
-                                    className={classnames('btn text-left', {
-                                        'btn-primary': monitorListFilter === 'user',
-                                    })}
-                                    onClick={setUserFilter}
-                                >
-                                    Your code monitors
-                                </button>
-                            </div>
-                            <div className="d-flex flex-column w-100 col">
-                                <h3 className="mb-2">
-                                    {`${monitorListFilter === 'all' ? 'All code monitors' : 'Your code monitors'}`}
-                                </h3>
-                                <Container>
-                                    <FilteredConnection<
-                                        CodeMonitorFields,
-                                        Omit<CodeMonitorNodeProps, 'node'>,
-                                        (ListUserCodeMonitorsResult['node'] & { __typename: 'User' })['monitors']
-                                    >
-                                        location={location}
-                                        history={history}
-                                        defaultFirst={10}
-                                        queryConnection={queryConnection}
-                                        hideSearch={true}
-                                        nodeComponent={CodeMonitorNode}
-                                        nodeComponentProps={{
-                                            authenticatedUser,
-                                            location,
-                                            showCodeMonitoringTestEmailButton:
-                                                (!isErrorLike(settingsCascade.final) &&
-                                                    settingsCascade.final?.experimentalFeatures
-                                                        ?.showCodeMonitoringTestEmailButton) ||
-                                                false,
-                                            toggleCodeMonitorEnabled,
-                                        }}
-                                        noun="code monitor"
-                                        pluralNoun="code monitors"
-                                        noSummaryIfAllNodesVisible={true}
-                                        cursorPaging={true}
-                                        className="filtered-connection__centered-summary"
-                                    />
-                                </Container>
-                            </div>
-                        </div>
-                        <div className="mt-5">
-                            We want to hear your feedback!{' '}
-                            <a href="mailto:feedback@sourcegraph.com">Share your thoughts</a>
-                        </div>
+                        <CodeMonitorList
+                            settingsCascade={settingsCascade}
+                            authenticatedUser={authenticatedUser}
+                            fetchUserCodeMonitors={fetchUserCodeMonitors}
+                            toggleCodeMonitorEnabled={toggleCodeMonitorEnabled}
+                        />
                     </div>
                 </>
             )}

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -1,5150 +1,5201 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
-<CodeMonitoringPage
-  authenticatedUser={
-    Object {
-      "email": "alice@alice.com",
-      "id": "foobar",
-      "username": "alice",
-    }
-  }
-  breadcrumbs={
+<MemoryRouter
+  initialEntries={
     Array [
-      Object {
-        "breadcrumb": null,
-        "depth": 0,
-      },
+      "/code-monitoring",
     ]
   }
-  fetchUserCodeMonitors={[Function]}
-  history="[History]"
-  location="[Location path=/code-monitoring]"
-  setBreadcrumb={[Function]}
-  settingsCascade={
-    Object {
-      "final": Object {},
-      "subjects": Array [],
-    }
-  }
-  toggleCodeMonitorEnabled={[Function]}
-  useBreadcrumb={[Function]}
 >
-  <div
-    className="code-monitoring-page"
+  <Router
+    history="[History]"
   >
-    <PageTitle
-      title="Code Monitoring"
-    />
-    <PageHeader
-      actions={
-        <AnchorLink
-          className="btn btn-primary"
-          to="/code-monitoring/new"
-        >
-          <Memo(PlusIcon)
-            className="icon-inline"
-          />
-          Create
-        </AnchorLink>
+    <CodeMonitoringPage
+      authenticatedUser={
+        Object {
+          "email": "alice@alice.com",
+          "id": "foobar",
+          "username": "alice",
+        }
       }
-      className="mb-3"
-      description={
-        <React.Fragment>
-          Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
-          <a
-            href="https://docs.sourcegraph.com/code_monitoring"
-          >
-            Learn more.
-          </a>
-        </React.Fragment>
+      fetchUserCodeMonitors={[Function]}
+      settingsCascade={
+        Object {
+          "final": Object {},
+          "subjects": Array [],
+        }
       }
-      path={
-        Array [
-          Object {
-            "icon": [Function],
-            "text": "Code monitoring",
-          },
-        ]
-      }
+      toggleCodeMonitorEnabled={[Function]}
     >
-      <header
-        className="container mb-3"
+      <div
+        className="code-monitoring-page"
       >
-        <div>
-          <h1
-            className="heading"
-          >
-            <LinkOrSpan
-              className="path"
-            >
-              <span
-                className="path"
-              >
-                <CodeMonitoringLogo
-                  className="pathIcon"
-                >
-                  <svg
-                    className="pathIcon"
-                    fill="currentColor"
-                    height="20"
-                    viewBox="0 0 20 20"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      clipRule="evenodd"
-                      d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </CodeMonitoringLogo>
-                <span
-                  className="pathText"
-                >
-                  Code monitoring
-                </span>
-              </span>
-            </LinkOrSpan>
-          </h1>
-          <p
-            className="description"
-          >
-            Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
-            <a
-              href="https://docs.sourcegraph.com/code_monitoring"
-            >
-              Learn more.
-            </a>
-          </p>
-        </div>
-        <div
-          className="actions"
-        >
-          <AnchorLink
-            className="btn btn-primary"
-            to="/code-monitoring/new"
-          >
-            <a
+        <PageTitle
+          title="Code Monitoring"
+        />
+        <PageHeader
+          actions={
+            <AnchorLink
               className="btn btn-primary"
-              href="/code-monitoring/new"
+              to="/code-monitoring/new"
             >
               <Memo(PlusIcon)
                 className="icon-inline"
               />
               Create
-            </a>
-          </AnchorLink>
-        </div>
-      </header>
-    </PageHeader>
-    <div
-      className="d-flex flex-column"
-    >
-      <div
-        className="code-monitoring-page-tabs mb-4"
-      >
+            </AnchorLink>
+          }
+          className="mb-3"
+          description={
+            <React.Fragment>
+              Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
+              <a
+                href="https://docs.sourcegraph.com/code_monitoring"
+              >
+                Learn more.
+              </a>
+            </React.Fragment>
+          }
+          path={
+            Array [
+              Object {
+                "icon": [Function],
+                "text": "Code monitoring",
+              },
+            ]
+          }
+        >
+          <header
+            className="container mb-3"
+          >
+            <div>
+              <h1
+                className="heading"
+              >
+                <LinkOrSpan
+                  className="path"
+                >
+                  <span
+                    className="path"
+                  >
+                    <CodeMonitoringLogo
+                      className="pathIcon"
+                    >
+                      <svg
+                        className="pathIcon"
+                        fill="currentColor"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                    </CodeMonitoringLogo>
+                    <span
+                      className="pathText"
+                    >
+                      Code monitoring
+                    </span>
+                  </span>
+                </LinkOrSpan>
+              </h1>
+              <p
+                className="description"
+              >
+                Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
+                <a
+                  href="https://docs.sourcegraph.com/code_monitoring"
+                >
+                  Learn more.
+                </a>
+              </p>
+            </div>
+            <div
+              className="actions"
+            >
+              <AnchorLink
+                className="btn btn-primary"
+                to="/code-monitoring/new"
+              >
+                <a
+                  className="btn btn-primary"
+                  href="/code-monitoring/new"
+                >
+                  <Memo(PlusIcon)
+                    className="icon-inline"
+                  />
+                  Create
+                </a>
+              </AnchorLink>
+            </div>
+          </header>
+        </PageHeader>
         <div
-          className="nav nav-tabs"
+          className="d-flex flex-column"
         >
           <div
-            className="nav-item"
+            className="code-monitoring-page-tabs mb-4"
           >
             <div
-              className="nav-link active"
+              className="nav nav-tabs"
             >
-              <span
-                className="text-content"
-                data-tab-content="Code monitors"
-              >
-                Code monitors
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="row mb-5"
-      >
-        <div
-          className="d-flex flex-column col-2 mr-2"
-        >
-          <h3>
-            Filters
-          </h3>
-          <button
-            className="btn text-left btn-primary"
-            onClick={[Function]}
-            type="button"
-          >
-            All
-          </button>
-          <button
-            className="btn text-left"
-            onClick={[Function]}
-            type="button"
-          >
-            Your code monitors
-          </button>
-        </div>
-        <div
-          className="d-flex flex-column w-100 col"
-        >
-          <h3
-            className="mb-2"
-          >
-            All code monitors
-          </h3>
-          <Container>
-            <div
-              className="container"
-            >
-              <FilteredConnection
-                className="filtered-connection__centered-summary"
-                cursorPaging={true}
-                defaultFirst={10}
-                hideSearch={true}
-                history="[History]"
-                location="[Location path=/code-monitoring]"
-                noSummaryIfAllNodesVisible={true}
-                nodeComponent={[Function]}
-                nodeComponentProps={
-                  Object {
-                    "authenticatedUser": Object {
-                      "email": "alice@alice.com",
-                      "id": "foobar",
-                      "username": "alice",
-                    },
-                    "location": "[Location path=/code-monitoring]",
-                    "showCodeMonitoringTestEmailButton": false,
-                    "toggleCodeMonitorEnabled": [Function],
-                  }
-                }
-                noun="code monitor"
-                pluralNoun="code monitors"
-                queryConnection={[Function]}
-                useURLQuery={true}
+              <div
+                className="nav-item"
               >
                 <div
-                  className="filtered-connection test-filtered-connection filtered-connection--noncompact filtered-connection__centered-summary"
+                  className="nav-link active"
                 >
-                  <ConnectionNodes
-                    connection={
-                      Object {
-                        "nodes": Array [
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Test code monitor",
-                            "enabled": true,
-                            "id": "foo0",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Second test code monitor",
-                            "enabled": true,
-                            "id": "foo1",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Third test code monitor",
-                            "enabled": true,
-                            "id": "foo2",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-3",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-3 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-3",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fourth test code monitor",
-                            "enabled": true,
-                            "id": "foo3",
-                            "trigger": Object {
-                              "id": "test-3",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-4",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-4 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-4",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fifth test code monitor",
-                            "enabled": true,
-                            "id": "foo4",
-                            "trigger": Object {
-                              "id": "test-4",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-5",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-5 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-5",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Sixth test code monitor",
-                            "enabled": true,
-                            "id": "foo5",
-                            "trigger": Object {
-                              "id": "test-5",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-6",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-6 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-6",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Seventh test code monitor",
-                            "enabled": true,
-                            "id": "foo6",
-                            "trigger": Object {
-                              "id": "test-6",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-7",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-7 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-7",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Eighth test code monitor",
-                            "enabled": true,
-                            "id": "foo7",
-                            "trigger": Object {
-                              "id": "test-7",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-9",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-9 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-9",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Ninth test code monitor",
-                            "enabled": true,
-                            "id": "foo9",
-                            "trigger": Object {
-                              "id": "test-9",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Tenth test code monitor",
-                            "enabled": true,
-                            "id": "foo10",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          },
-                        ],
-                        "pageInfo": Object {
-                          "endCursor": "foo10",
-                          "hasNextPage": false,
-                        },
-                        "totalCount": 10,
-                      }
-                    }
-                    connectionQuery=""
-                    first={10}
-                    loading={false}
-                    location="[Location path=/code-monitoring]"
-                    noSummaryIfAllNodesVisible={true}
-                    nodeComponent={[Function]}
-                    nodeComponentProps={
-                      Object {
-                        "authenticatedUser": Object {
-                          "email": "alice@alice.com",
-                          "id": "foobar",
-                          "username": "alice",
-                        },
-                        "location": "[Location path=/code-monitoring]",
-                        "showCodeMonitoringTestEmailButton": false,
-                        "toggleCodeMonitorEnabled": [Function],
-                      }
-                    }
-                    noun="code monitor"
-                    onShowMore={[Function]}
-                    pluralNoun="code monitors"
-                    query=""
+                  <span
+                    className="text-content"
+                    data-tab-content="Code monitors"
                   >
-                    <div
-                      className="filtered-connection__summary-container"
-                    />
-                    <ul
-                      className="filtered-connection__nodes"
-                      data-testid="nodes"
-                    >
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo0"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Test code monitor",
-                            "enabled": true,
-                            "id": "foo0",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo0"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo0"
-                                  >
-                                    Test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo0"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo0"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo1"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Second test code monitor",
-                            "enabled": true,
-                            "id": "foo1",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo1"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo1"
-                                  >
-                                    Second test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo1"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo1"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo2"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Third test code monitor",
-                            "enabled": true,
-                            "id": "foo2",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo2"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo2"
-                                  >
-                                    Third test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo2"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo2"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo3"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-3",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-3 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-3",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fourth test code monitor",
-                            "enabled": true,
-                            "id": "foo3",
-                            "trigger": Object {
-                              "id": "test-3",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo3"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo3"
-                                  >
-                                    Fourth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo3"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo3"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo4"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-4",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-4 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-4",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fifth test code monitor",
-                            "enabled": true,
-                            "id": "foo4",
-                            "trigger": Object {
-                              "id": "test-4",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo4"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo4"
-                                  >
-                                    Fifth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo4"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo4"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo5"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-5",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-5 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-5",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Sixth test code monitor",
-                            "enabled": true,
-                            "id": "foo5",
-                            "trigger": Object {
-                              "id": "test-5",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo5"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo5"
-                                  >
-                                    Sixth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo5"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo5"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo6"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-6",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-6 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-6",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Seventh test code monitor",
-                            "enabled": true,
-                            "id": "foo6",
-                            "trigger": Object {
-                              "id": "test-6",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo6"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo6"
-                                  >
-                                    Seventh test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo6"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo6"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo7"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-7",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-7 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-7",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Eighth test code monitor",
-                            "enabled": true,
-                            "id": "foo7",
-                            "trigger": Object {
-                              "id": "test-7",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo7"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo7"
-                                  >
-                                    Eighth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo7"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo7"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo9"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-9",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-9 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-9",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Ninth test code monitor",
-                            "enabled": true,
-                            "id": "foo9",
-                            "trigger": Object {
-                              "id": "test-9",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo9"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo9"
-                                  >
-                                    Ninth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo9"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo9"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo10"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Tenth test code monitor",
-                            "enabled": true,
-                            "id": "foo10",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo10"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo10"
-                                  >
-                                    Tenth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo10"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo10"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                    </ul>
-                    <div
-                      className="filtered-connection__summary-container"
-                    >
-                      <ConnectionNodesSummary
-                        connection={
-                          Object {
-                            "nodes": Array [
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-0",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-0 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-0",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Test code monitor",
-                                "enabled": true,
-                                "id": "foo0",
-                                "trigger": Object {
-                                  "id": "test-0",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-1",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-1 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-1",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Second test code monitor",
-                                "enabled": true,
-                                "id": "foo1",
-                                "trigger": Object {
-                                  "id": "test-1",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-2",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-2 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-2",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Third test code monitor",
-                                "enabled": true,
-                                "id": "foo2",
-                                "trigger": Object {
-                                  "id": "test-2",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-3",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-3 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-3",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Fourth test code monitor",
-                                "enabled": true,
-                                "id": "foo3",
-                                "trigger": Object {
-                                  "id": "test-3",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-4",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-4 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-4",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Fifth test code monitor",
-                                "enabled": true,
-                                "id": "foo4",
-                                "trigger": Object {
-                                  "id": "test-4",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-5",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-5 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-5",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Sixth test code monitor",
-                                "enabled": true,
-                                "id": "foo5",
-                                "trigger": Object {
-                                  "id": "test-5",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-6",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-6 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-6",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Seventh test code monitor",
-                                "enabled": true,
-                                "id": "foo6",
-                                "trigger": Object {
-                                  "id": "test-6",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-7",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-7 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-7",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Eighth test code monitor",
-                                "enabled": true,
-                                "id": "foo7",
-                                "trigger": Object {
-                                  "id": "test-7",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-9",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-9 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-9",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Ninth test code monitor",
-                                "enabled": true,
-                                "id": "foo9",
-                                "trigger": Object {
-                                  "id": "test-9",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-0",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-0 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-0",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Tenth test code monitor",
-                                "enabled": true,
-                                "id": "foo10",
-                                "trigger": Object {
-                                  "id": "test-0",
-                                  "query": "test",
-                                },
-                              },
-                            ],
-                            "pageInfo": Object {
-                              "endCursor": "foo10",
-                              "hasNextPage": false,
-                            },
-                            "totalCount": 10,
-                          }
-                        }
-                        connectionQuery=""
-                        hasNextPage={false}
-                        noSummaryIfAllNodesVisible={true}
-                        noun="code monitor"
-                        pluralNoun="code monitors"
-                        totalCount={10}
-                      />
-                    </div>
-                  </ConnectionNodes>
+                    Code monitors
+                  </span>
                 </div>
-              </FilteredConnection>
+              </div>
             </div>
-          </Container>
+          </div>
+          <CodeMonitorList
+            authenticatedUser={
+              Object {
+                "email": "alice@alice.com",
+                "id": "foobar",
+                "username": "alice",
+              }
+            }
+            fetchUserCodeMonitors={[Function]}
+            settingsCascade={
+              Object {
+                "final": Object {},
+                "subjects": Array [],
+              }
+            }
+            toggleCodeMonitorEnabled={[Function]}
+          >
+            <div
+              className="row mb-5"
+            >
+              <div
+                className="d-flex flex-column col-2 mr-2"
+              >
+                <h3>
+                  Filters
+                </h3>
+                <button
+                  className="btn text-left btn-primary"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  All
+                </button>
+                <button
+                  className="btn text-left"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Your code monitors
+                </button>
+              </div>
+              <div
+                className="d-flex flex-column w-100 col"
+              >
+                <h3
+                  className="mb-2"
+                >
+                  All code monitors
+                </h3>
+                <Container>
+                  <div
+                    className="container"
+                  >
+                    <FilteredConnection
+                      className="filtered-connection__centered-summary"
+                      cursorPaging={true}
+                      defaultFirst={10}
+                      hideSearch={true}
+                      history="[History]"
+                      location="[Location path=/code-monitoring]"
+                      noSummaryIfAllNodesVisible={true}
+                      nodeComponent={[Function]}
+                      nodeComponentProps={
+                        Object {
+                          "authenticatedUser": Object {
+                            "email": "alice@alice.com",
+                            "id": "foobar",
+                            "username": "alice",
+                          },
+                          "location": "[Location path=/code-monitoring]",
+                          "showCodeMonitoringTestEmailButton": false,
+                          "toggleCodeMonitorEnabled": [Function],
+                        }
+                      }
+                      noun="code monitor"
+                      pluralNoun="code monitors"
+                      queryConnection={[Function]}
+                      useURLQuery={true}
+                    >
+                      <div
+                        className="filtered-connection test-filtered-connection filtered-connection--noncompact filtered-connection__centered-summary"
+                      >
+                        <ConnectionNodes
+                          connection={
+                            Object {
+                              "nodes": Array [
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Test code monitor",
+                                  "enabled": true,
+                                  "id": "foo0",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Second test code monitor",
+                                  "enabled": true,
+                                  "id": "foo1",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Third test code monitor",
+                                  "enabled": true,
+                                  "id": "foo2",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-3",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-3 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-3",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fourth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo3",
+                                  "trigger": Object {
+                                    "id": "test-3",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-4",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-4 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-4",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fifth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo4",
+                                  "trigger": Object {
+                                    "id": "test-4",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-5",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-5 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-5",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Sixth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo5",
+                                  "trigger": Object {
+                                    "id": "test-5",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-6",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-6 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-6",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Seventh test code monitor",
+                                  "enabled": true,
+                                  "id": "foo6",
+                                  "trigger": Object {
+                                    "id": "test-6",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-7",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-7 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-7",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Eighth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo7",
+                                  "trigger": Object {
+                                    "id": "test-7",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-9",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-9 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-9",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Ninth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo9",
+                                  "trigger": Object {
+                                    "id": "test-9",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Tenth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo10",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                },
+                              ],
+                              "pageInfo": Object {
+                                "endCursor": "foo10",
+                                "hasNextPage": false,
+                              },
+                              "totalCount": 10,
+                            }
+                          }
+                          connectionQuery=""
+                          first={10}
+                          loading={false}
+                          location="[Location path=/code-monitoring]"
+                          noSummaryIfAllNodesVisible={true}
+                          nodeComponent={[Function]}
+                          nodeComponentProps={
+                            Object {
+                              "authenticatedUser": Object {
+                                "email": "alice@alice.com",
+                                "id": "foobar",
+                                "username": "alice",
+                              },
+                              "location": "[Location path=/code-monitoring]",
+                              "showCodeMonitoringTestEmailButton": false,
+                              "toggleCodeMonitorEnabled": [Function],
+                            }
+                          }
+                          noun="code monitor"
+                          onShowMore={[Function]}
+                          pluralNoun="code monitors"
+                          query=""
+                        >
+                          <div
+                            className="filtered-connection__summary-container"
+                          />
+                          <ul
+                            className="filtered-connection__nodes"
+                            data-testid="nodes"
+                          >
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo0"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Test code monitor",
+                                  "enabled": true,
+                                  "id": "foo0",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo0"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo0"
+                                        >
+                                          Test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo0"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo0"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo1"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Second test code monitor",
+                                  "enabled": true,
+                                  "id": "foo1",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo1"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo1"
+                                        >
+                                          Second test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo1"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo1"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo2"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Third test code monitor",
+                                  "enabled": true,
+                                  "id": "foo2",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo2"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo2"
+                                        >
+                                          Third test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo2"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo2"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo3"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-3",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-3 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-3",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fourth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo3",
+                                  "trigger": Object {
+                                    "id": "test-3",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo3"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo3"
+                                        >
+                                          Fourth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo3"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo3"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo4"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-4",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-4 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-4",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fifth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo4",
+                                  "trigger": Object {
+                                    "id": "test-4",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo4"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo4"
+                                        >
+                                          Fifth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo4"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo4"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo5"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-5",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-5 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-5",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Sixth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo5",
+                                  "trigger": Object {
+                                    "id": "test-5",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo5"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo5"
+                                        >
+                                          Sixth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo5"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo5"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo6"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-6",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-6 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-6",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Seventh test code monitor",
+                                  "enabled": true,
+                                  "id": "foo6",
+                                  "trigger": Object {
+                                    "id": "test-6",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo6"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo6"
+                                        >
+                                          Seventh test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo6"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo6"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo7"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-7",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-7 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-7",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Eighth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo7",
+                                  "trigger": Object {
+                                    "id": "test-7",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo7"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo7"
+                                        >
+                                          Eighth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo7"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo7"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo9"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-9",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-9 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-9",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Ninth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo9",
+                                  "trigger": Object {
+                                    "id": "test-9",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo9"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo9"
+                                        >
+                                          Ninth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo9"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo9"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo10"
+                              location="[Location path=/code-monitoring]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Tenth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo10",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo10"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo10"
+                                        >
+                                          Tenth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo10"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo10"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                          </ul>
+                          <div
+                            className="filtered-connection__summary-container"
+                          >
+                            <ConnectionNodesSummary
+                              connection={
+                                Object {
+                                  "nodes": Array [
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-0",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-0 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-0",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Test code monitor",
+                                      "enabled": true,
+                                      "id": "foo0",
+                                      "trigger": Object {
+                                        "id": "test-0",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-1",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-1 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-1",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Second test code monitor",
+                                      "enabled": true,
+                                      "id": "foo1",
+                                      "trigger": Object {
+                                        "id": "test-1",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-2",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-2 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-2",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Third test code monitor",
+                                      "enabled": true,
+                                      "id": "foo2",
+                                      "trigger": Object {
+                                        "id": "test-2",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-3",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-3 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-3",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Fourth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo3",
+                                      "trigger": Object {
+                                        "id": "test-3",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-4",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-4 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-4",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Fifth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo4",
+                                      "trigger": Object {
+                                        "id": "test-4",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-5",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-5 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-5",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Sixth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo5",
+                                      "trigger": Object {
+                                        "id": "test-5",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-6",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-6 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-6",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Seventh test code monitor",
+                                      "enabled": true,
+                                      "id": "foo6",
+                                      "trigger": Object {
+                                        "id": "test-6",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-7",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-7 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-7",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Eighth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo7",
+                                      "trigger": Object {
+                                        "id": "test-7",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-9",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-9 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-9",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Ninth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo9",
+                                      "trigger": Object {
+                                        "id": "test-9",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-0",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-0 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-0",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Tenth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo10",
+                                      "trigger": Object {
+                                        "id": "test-0",
+                                        "query": "test",
+                                      },
+                                    },
+                                  ],
+                                  "pageInfo": Object {
+                                    "endCursor": "foo10",
+                                    "hasNextPage": false,
+                                  },
+                                  "totalCount": 10,
+                                }
+                              }
+                              connectionQuery=""
+                              hasNextPage={false}
+                              noSummaryIfAllNodesVisible={true}
+                              noun="code monitor"
+                              pluralNoun="code monitors"
+                              totalCount={10}
+                            />
+                          </div>
+                        </ConnectionNodes>
+                      </div>
+                    </FilteredConnection>
+                  </div>
+                </Container>
+              </div>
+            </div>
+            <div
+              className="mt-5"
+            >
+              We want to hear your feedback! 
+              <a
+                href="mailto:feedback@sourcegraph.com"
+              >
+                Share your thoughts
+              </a>
+            </div>
+          </CodeMonitorList>
         </div>
       </div>
-      <div
-        className="mt-5"
-      >
-        We want to hear your feedback!
-         
-        <a
-          href="mailto:feedback@sourcegraph.com"
-        >
-          Share your thoughts
-        </a>
-      </div>
-    </div>
-  </div>
-</CodeMonitoringPage>
+    </CodeMonitoringPage>
+  </Router>
+</MemoryRouter>
 `;
 
 exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1`] = `
-<CodeMonitoringPage
-  authenticatedUser={
-    Object {
-      "email": "alice@alice.com",
-      "id": "foobar",
-      "username": "alice",
-    }
-  }
-  breadcrumbs={
+<MemoryRouter
+  initialEntries={
     Array [
-      Object {
-        "breadcrumb": null,
-        "depth": 0,
-      },
+      "/code-monitoring",
     ]
   }
-  fetchUserCodeMonitors={[Function]}
-  history="[History]"
-  location="[Location path=/code-monitoring]"
-  setBreadcrumb={[Function]}
-  settingsCascade={
-    Object {
-      "final": Object {},
-      "subjects": Array [],
-    }
-  }
-  toggleCodeMonitorEnabled={[Function]}
-  useBreadcrumb={[Function]}
 >
-  <div
-    className="code-monitoring-page"
+  <Router
+    history="[History]"
   >
-    <PageTitle
-      title="Code Monitoring"
-    />
-    <PageHeader
-      actions={
-        <AnchorLink
-          className="btn btn-primary"
-          to="/code-monitoring/new"
-        >
-          <Memo(PlusIcon)
-            className="icon-inline"
-          />
-          Create
-        </AnchorLink>
+    <CodeMonitoringPage
+      authenticatedUser={
+        Object {
+          "email": "alice@alice.com",
+          "id": "foobar",
+          "username": "alice",
+        }
       }
-      className="mb-3"
-      description={
-        <React.Fragment>
-          Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
-          <a
-            href="https://docs.sourcegraph.com/code_monitoring"
-          >
-            Learn more.
-          </a>
-        </React.Fragment>
+      fetchUserCodeMonitors={[Function]}
+      settingsCascade={
+        Object {
+          "final": Object {},
+          "subjects": Array [],
+        }
       }
-      path={
-        Array [
-          Object {
-            "icon": [Function],
-            "text": "Code monitoring",
-          },
-        ]
-      }
+      toggleCodeMonitorEnabled={[Function]}
     >
-      <header
-        className="container mb-3"
+      <div
+        className="code-monitoring-page"
       >
-        <div>
-          <h1
-            className="heading"
-          >
-            <LinkOrSpan
-              className="path"
-            >
-              <span
-                className="path"
-              >
-                <CodeMonitoringLogo
-                  className="pathIcon"
-                >
-                  <svg
-                    className="pathIcon"
-                    fill="currentColor"
-                    height="20"
-                    viewBox="0 0 20 20"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      clipRule="evenodd"
-                      d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </CodeMonitoringLogo>
-                <span
-                  className="pathText"
-                >
-                  Code monitoring
-                </span>
-              </span>
-            </LinkOrSpan>
-          </h1>
-          <p
-            className="description"
-          >
-            Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
-            <a
-              href="https://docs.sourcegraph.com/code_monitoring"
-            >
-              Learn more.
-            </a>
-          </p>
-        </div>
-        <div
-          className="actions"
-        >
-          <AnchorLink
-            className="btn btn-primary"
-            to="/code-monitoring/new"
-          >
-            <a
+        <PageTitle
+          title="Code Monitoring"
+        />
+        <PageHeader
+          actions={
+            <AnchorLink
               className="btn btn-primary"
-              href="/code-monitoring/new"
+              to="/code-monitoring/new"
             >
               <Memo(PlusIcon)
                 className="icon-inline"
               />
               Create
-            </a>
-          </AnchorLink>
-        </div>
-      </header>
-    </PageHeader>
-    <div
-      className="d-flex flex-column"
-    >
-      <div
-        className="code-monitoring-page-tabs mb-4"
-      >
+            </AnchorLink>
+          }
+          className="mb-3"
+          description={
+            <React.Fragment>
+              Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
+              <a
+                href="https://docs.sourcegraph.com/code_monitoring"
+              >
+                Learn more.
+              </a>
+            </React.Fragment>
+          }
+          path={
+            Array [
+              Object {
+                "icon": [Function],
+                "text": "Code monitoring",
+              },
+            ]
+          }
+        >
+          <header
+            className="container mb-3"
+          >
+            <div>
+              <h1
+                className="heading"
+              >
+                <LinkOrSpan
+                  className="path"
+                >
+                  <span
+                    className="path"
+                  >
+                    <CodeMonitoringLogo
+                      className="pathIcon"
+                    >
+                      <svg
+                        className="pathIcon"
+                        fill="currentColor"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                    </CodeMonitoringLogo>
+                    <span
+                      className="pathText"
+                    >
+                      Code monitoring
+                    </span>
+                  </span>
+                </LinkOrSpan>
+              </h1>
+              <p
+                className="description"
+              >
+                Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
+                <a
+                  href="https://docs.sourcegraph.com/code_monitoring"
+                >
+                  Learn more.
+                </a>
+              </p>
+            </div>
+            <div
+              className="actions"
+            >
+              <AnchorLink
+                className="btn btn-primary"
+                to="/code-monitoring/new"
+              >
+                <a
+                  className="btn btn-primary"
+                  href="/code-monitoring/new"
+                >
+                  <Memo(PlusIcon)
+                    className="icon-inline"
+                  />
+                  Create
+                </a>
+              </AnchorLink>
+            </div>
+          </header>
+        </PageHeader>
         <div
-          className="nav nav-tabs"
+          className="d-flex flex-column"
         >
           <div
-            className="nav-item"
+            className="code-monitoring-page-tabs mb-4"
           >
             <div
-              className="nav-link active"
+              className="nav nav-tabs"
             >
-              <span
-                className="text-content"
-                data-tab-content="Code monitors"
-              >
-                Code monitors
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="row mb-5"
-      >
-        <div
-          className="d-flex flex-column col-2 mr-2"
-        >
-          <h3>
-            Filters
-          </h3>
-          <button
-            className="btn text-left btn-primary"
-            onClick={[Function]}
-            type="button"
-          >
-            All
-          </button>
-          <button
-            className="btn text-left"
-            onClick={[Function]}
-            type="button"
-          >
-            Your code monitors
-          </button>
-        </div>
-        <div
-          className="d-flex flex-column w-100 col"
-        >
-          <h3
-            className="mb-2"
-          >
-            All code monitors
-          </h3>
-          <Container>
-            <div
-              className="container"
-            >
-              <FilteredConnection
-                className="filtered-connection__centered-summary"
-                cursorPaging={true}
-                defaultFirst={10}
-                hideSearch={true}
-                history="[History]"
-                location="[Location path=/code-monitoring]"
-                noSummaryIfAllNodesVisible={true}
-                nodeComponent={[Function]}
-                nodeComponentProps={
-                  Object {
-                    "authenticatedUser": Object {
-                      "email": "alice@alice.com",
-                      "id": "foobar",
-                      "username": "alice",
-                    },
-                    "location": "[Location path=/code-monitoring]",
-                    "showCodeMonitoringTestEmailButton": false,
-                    "toggleCodeMonitorEnabled": [Function],
-                  }
-                }
-                noun="code monitor"
-                pluralNoun="code monitors"
-                queryConnection={[Function]}
-                useURLQuery={true}
+              <div
+                className="nav-item"
               >
                 <div
-                  className="filtered-connection test-filtered-connection filtered-connection--noncompact filtered-connection__centered-summary"
+                  className="nav-link active"
                 >
-                  <ConnectionNodes
-                    connection={
-                      Object {
-                        "nodes": Array [
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Test code monitor",
-                            "enabled": true,
-                            "id": "foo0",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Second test code monitor",
-                            "enabled": true,
-                            "id": "foo1",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Third test code monitor",
-                            "enabled": true,
-                            "id": "foo2",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          },
-                        ],
-                        "pageInfo": Object {
-                          "endCursor": "foo3",
-                          "hasNextPage": false,
-                        },
-                        "totalCount": 3,
-                      }
-                    }
-                    connectionQuery=""
-                    first={10}
-                    loading={false}
-                    location="[Location path=/code-monitoring]"
-                    noSummaryIfAllNodesVisible={true}
-                    nodeComponent={[Function]}
-                    nodeComponentProps={
-                      Object {
-                        "authenticatedUser": Object {
-                          "email": "alice@alice.com",
-                          "id": "foobar",
-                          "username": "alice",
-                        },
-                        "location": "[Location path=/code-monitoring]",
-                        "showCodeMonitoringTestEmailButton": false,
-                        "toggleCodeMonitorEnabled": [Function],
-                      }
-                    }
-                    noun="code monitor"
-                    onShowMore={[Function]}
-                    pluralNoun="code monitors"
-                    query=""
+                  <span
+                    className="text-content"
+                    data-tab-content="Code monitors"
                   >
-                    <div
-                      className="filtered-connection__summary-container"
-                    />
-                    <ul
-                      className="filtered-connection__nodes"
-                      data-testid="nodes"
-                    >
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo0"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Test code monitor",
-                            "enabled": true,
-                            "id": "foo0",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo0"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo0"
-                                  >
-                                    Test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo0"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo0"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo1"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Second test code monitor",
-                            "enabled": true,
-                            "id": "foo1",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo1"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo1"
-                                  >
-                                    Second test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo1"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo1"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo2"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Third test code monitor",
-                            "enabled": true,
-                            "id": "foo2",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo2"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo2"
-                                  >
-                                    Third test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo2"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo2"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                    </ul>
-                    <div
-                      className="filtered-connection__summary-container"
-                    >
-                      <ConnectionNodesSummary
-                        connection={
-                          Object {
-                            "nodes": Array [
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-0",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-0 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-0",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Test code monitor",
-                                "enabled": true,
-                                "id": "foo0",
-                                "trigger": Object {
-                                  "id": "test-0",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-1",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-1 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-1",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Second test code monitor",
-                                "enabled": true,
-                                "id": "foo1",
-                                "trigger": Object {
-                                  "id": "test-1",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-2",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-2 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-2",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Third test code monitor",
-                                "enabled": true,
-                                "id": "foo2",
-                                "trigger": Object {
-                                  "id": "test-2",
-                                  "query": "test",
-                                },
-                              },
-                            ],
-                            "pageInfo": Object {
-                              "endCursor": "foo3",
-                              "hasNextPage": false,
-                            },
-                            "totalCount": 3,
-                          }
-                        }
-                        connectionQuery=""
-                        hasNextPage={false}
-                        noSummaryIfAllNodesVisible={true}
-                        noun="code monitor"
-                        pluralNoun="code monitors"
-                        totalCount={3}
-                      />
-                    </div>
-                  </ConnectionNodes>
+                    Code monitors
+                  </span>
                 </div>
-              </FilteredConnection>
+              </div>
             </div>
-          </Container>
+          </div>
+          <CodeMonitorList
+            authenticatedUser={
+              Object {
+                "email": "alice@alice.com",
+                "id": "foobar",
+                "username": "alice",
+              }
+            }
+            fetchUserCodeMonitors={[Function]}
+            settingsCascade={
+              Object {
+                "final": Object {},
+                "subjects": Array [],
+              }
+            }
+            toggleCodeMonitorEnabled={[Function]}
+          >
+            <div
+              className="row mb-5"
+            >
+              <div
+                className="d-flex flex-column col-2 mr-2"
+              >
+                <h3>
+                  Filters
+                </h3>
+                <button
+                  className="btn text-left btn-primary"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  All
+                </button>
+                <button
+                  className="btn text-left"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Your code monitors
+                </button>
+              </div>
+              <div
+                className="d-flex flex-column w-100 col"
+              >
+                <h3
+                  className="mb-2"
+                >
+                  All code monitors
+                </h3>
+                <Container>
+                  <div
+                    className="container"
+                  >
+                    <FilteredConnection
+                      className="filtered-connection__centered-summary"
+                      cursorPaging={true}
+                      defaultFirst={10}
+                      hideSearch={true}
+                      history="[History]"
+                      location="[Location path=/code-monitoring?visible=3]"
+                      noSummaryIfAllNodesVisible={true}
+                      nodeComponent={[Function]}
+                      nodeComponentProps={
+                        Object {
+                          "authenticatedUser": Object {
+                            "email": "alice@alice.com",
+                            "id": "foobar",
+                            "username": "alice",
+                          },
+                          "location": "[Location path=/code-monitoring?visible=3]",
+                          "showCodeMonitoringTestEmailButton": false,
+                          "toggleCodeMonitorEnabled": [Function],
+                        }
+                      }
+                      noun="code monitor"
+                      pluralNoun="code monitors"
+                      queryConnection={[Function]}
+                      useURLQuery={true}
+                    >
+                      <div
+                        className="filtered-connection test-filtered-connection filtered-connection--noncompact filtered-connection__centered-summary"
+                      >
+                        <ConnectionNodes
+                          connection={
+                            Object {
+                              "nodes": Array [
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Test code monitor",
+                                  "enabled": true,
+                                  "id": "foo0",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Second test code monitor",
+                                  "enabled": true,
+                                  "id": "foo1",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Third test code monitor",
+                                  "enabled": true,
+                                  "id": "foo2",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                },
+                              ],
+                              "pageInfo": Object {
+                                "endCursor": "foo3",
+                                "hasNextPage": false,
+                              },
+                              "totalCount": 3,
+                            }
+                          }
+                          connectionQuery=""
+                          first={10}
+                          loading={false}
+                          location="[Location path=/code-monitoring?visible=3]"
+                          noSummaryIfAllNodesVisible={true}
+                          nodeComponent={[Function]}
+                          nodeComponentProps={
+                            Object {
+                              "authenticatedUser": Object {
+                                "email": "alice@alice.com",
+                                "id": "foobar",
+                                "username": "alice",
+                              },
+                              "location": "[Location path=/code-monitoring?visible=3]",
+                              "showCodeMonitoringTestEmailButton": false,
+                              "toggleCodeMonitorEnabled": [Function],
+                            }
+                          }
+                          noun="code monitor"
+                          onShowMore={[Function]}
+                          pluralNoun="code monitors"
+                          query=""
+                        >
+                          <div
+                            className="filtered-connection__summary-container"
+                          />
+                          <ul
+                            className="filtered-connection__nodes"
+                            data-testid="nodes"
+                          >
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo0"
+                              location="[Location path=/code-monitoring?visible=3]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Test code monitor",
+                                  "enabled": true,
+                                  "id": "foo0",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo0"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo0"
+                                        >
+                                          Test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo0"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo0"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo1"
+                              location="[Location path=/code-monitoring?visible=3]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Second test code monitor",
+                                  "enabled": true,
+                                  "id": "foo1",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo1"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo1"
+                                        >
+                                          Second test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo1"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo1"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo2"
+                              location="[Location path=/code-monitoring?visible=3]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Third test code monitor",
+                                  "enabled": true,
+                                  "id": "foo2",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo2"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo2"
+                                        >
+                                          Third test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo2"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo2"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                          </ul>
+                          <div
+                            className="filtered-connection__summary-container"
+                          >
+                            <ConnectionNodesSummary
+                              connection={
+                                Object {
+                                  "nodes": Array [
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-0",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-0 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-0",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Test code monitor",
+                                      "enabled": true,
+                                      "id": "foo0",
+                                      "trigger": Object {
+                                        "id": "test-0",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-1",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-1 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-1",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Second test code monitor",
+                                      "enabled": true,
+                                      "id": "foo1",
+                                      "trigger": Object {
+                                        "id": "test-1",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-2",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-2 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-2",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Third test code monitor",
+                                      "enabled": true,
+                                      "id": "foo2",
+                                      "trigger": Object {
+                                        "id": "test-2",
+                                        "query": "test",
+                                      },
+                                    },
+                                  ],
+                                  "pageInfo": Object {
+                                    "endCursor": "foo3",
+                                    "hasNextPage": false,
+                                  },
+                                  "totalCount": 3,
+                                }
+                              }
+                              connectionQuery=""
+                              hasNextPage={false}
+                              noSummaryIfAllNodesVisible={true}
+                              noun="code monitor"
+                              pluralNoun="code monitors"
+                              totalCount={3}
+                            />
+                          </div>
+                        </ConnectionNodes>
+                      </div>
+                    </FilteredConnection>
+                  </div>
+                </Container>
+              </div>
+            </div>
+            <div
+              className="mt-5"
+            >
+              We want to hear your feedback! 
+              <a
+                href="mailto:feedback@sourcegraph.com"
+              >
+                Share your thoughts
+              </a>
+            </div>
+          </CodeMonitorList>
         </div>
       </div>
-      <div
-        className="mt-5"
-      >
-        We want to hear your feedback!
-         
-        <a
-          href="mailto:feedback@sourcegraph.com"
-        >
-          Share your thoughts
-        </a>
-      </div>
-    </div>
-  </div>
-</CodeMonitoringPage>
+    </CodeMonitoringPage>
+  </Router>
+</MemoryRouter>
 `;
 
 exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1`] = `
-<CodeMonitoringPage
-  authenticatedUser={
-    Object {
-      "email": "alice@alice.com",
-      "id": "foobar",
-      "username": "alice",
-    }
-  }
-  breadcrumbs={
+<MemoryRouter
+  initialEntries={
     Array [
-      Object {
-        "breadcrumb": null,
-        "depth": 0,
-      },
+      "/code-monitoring",
     ]
   }
-  fetchUserCodeMonitors={[Function]}
-  history="[History]"
-  location="[Location path=/code-monitoring]"
-  setBreadcrumb={[Function]}
-  settingsCascade={
-    Object {
-      "final": Object {},
-      "subjects": Array [],
-    }
-  }
-  toggleCodeMonitorEnabled={[Function]}
-  useBreadcrumb={[Function]}
 >
-  <div
-    className="code-monitoring-page"
+  <Router
+    history="[History]"
   >
-    <PageTitle
-      title="Code Monitoring"
-    />
-    <PageHeader
-      actions={
-        <AnchorLink
-          className="btn btn-primary"
-          to="/code-monitoring/new"
-        >
-          <Memo(PlusIcon)
-            className="icon-inline"
-          />
-          Create
-        </AnchorLink>
+    <CodeMonitoringPage
+      authenticatedUser={
+        Object {
+          "email": "alice@alice.com",
+          "id": "foobar",
+          "username": "alice",
+        }
       }
-      className="mb-3"
-      description={
-        <React.Fragment>
-          Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
-          <a
-            href="https://docs.sourcegraph.com/code_monitoring"
-          >
-            Learn more.
-          </a>
-        </React.Fragment>
+      fetchUserCodeMonitors={[Function]}
+      settingsCascade={
+        Object {
+          "final": Object {},
+          "subjects": Array [],
+        }
       }
-      path={
-        Array [
-          Object {
-            "icon": [Function],
-            "text": "Code monitoring",
-          },
-        ]
-      }
+      toggleCodeMonitorEnabled={[Function]}
     >
-      <header
-        className="container mb-3"
+      <div
+        className="code-monitoring-page"
       >
-        <div>
-          <h1
-            className="heading"
-          >
-            <LinkOrSpan
-              className="path"
-            >
-              <span
-                className="path"
-              >
-                <CodeMonitoringLogo
-                  className="pathIcon"
-                >
-                  <svg
-                    className="pathIcon"
-                    fill="currentColor"
-                    height="20"
-                    viewBox="0 0 20 20"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      clipRule="evenodd"
-                      d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </CodeMonitoringLogo>
-                <span
-                  className="pathText"
-                >
-                  Code monitoring
-                </span>
-              </span>
-            </LinkOrSpan>
-          </h1>
-          <p
-            className="description"
-          >
-            Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
-            <a
-              href="https://docs.sourcegraph.com/code_monitoring"
-            >
-              Learn more.
-            </a>
-          </p>
-        </div>
-        <div
-          className="actions"
-        >
-          <AnchorLink
-            className="btn btn-primary"
-            to="/code-monitoring/new"
-          >
-            <a
+        <PageTitle
+          title="Code Monitoring"
+        />
+        <PageHeader
+          actions={
+            <AnchorLink
               className="btn btn-primary"
-              href="/code-monitoring/new"
+              to="/code-monitoring/new"
             >
               <Memo(PlusIcon)
                 className="icon-inline"
               />
               Create
-            </a>
-          </AnchorLink>
-        </div>
-      </header>
-    </PageHeader>
-    <div
-      className="d-flex flex-column"
-    >
-      <div
-        className="code-monitoring-page-tabs mb-4"
-      >
+            </AnchorLink>
+          }
+          className="mb-3"
+          description={
+            <React.Fragment>
+              Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
+              <a
+                href="https://docs.sourcegraph.com/code_monitoring"
+              >
+                Learn more.
+              </a>
+            </React.Fragment>
+          }
+          path={
+            Array [
+              Object {
+                "icon": [Function],
+                "text": "Code monitoring",
+              },
+            ]
+          }
+        >
+          <header
+            className="container mb-3"
+          >
+            <div>
+              <h1
+                className="heading"
+              >
+                <LinkOrSpan
+                  className="path"
+                >
+                  <span
+                    className="path"
+                  >
+                    <CodeMonitoringLogo
+                      className="pathIcon"
+                    >
+                      <svg
+                        className="pathIcon"
+                        fill="currentColor"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                    </CodeMonitoringLogo>
+                    <span
+                      className="pathText"
+                    >
+                      Code monitoring
+                    </span>
+                  </span>
+                </LinkOrSpan>
+              </h1>
+              <p
+                className="description"
+              >
+                Watch your code for changes and trigger actions to get notifications, send webhooks, and more. 
+                <a
+                  href="https://docs.sourcegraph.com/code_monitoring"
+                >
+                  Learn more.
+                </a>
+              </p>
+            </div>
+            <div
+              className="actions"
+            >
+              <AnchorLink
+                className="btn btn-primary"
+                to="/code-monitoring/new"
+              >
+                <a
+                  className="btn btn-primary"
+                  href="/code-monitoring/new"
+                >
+                  <Memo(PlusIcon)
+                    className="icon-inline"
+                  />
+                  Create
+                </a>
+              </AnchorLink>
+            </div>
+          </header>
+        </PageHeader>
         <div
-          className="nav nav-tabs"
+          className="d-flex flex-column"
         >
           <div
-            className="nav-item"
+            className="code-monitoring-page-tabs mb-4"
           >
             <div
-              className="nav-link active"
+              className="nav nav-tabs"
             >
-              <span
-                className="text-content"
-                data-tab-content="Code monitors"
-              >
-                Code monitors
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="row mb-5"
-      >
-        <div
-          className="d-flex flex-column col-2 mr-2"
-        >
-          <h3>
-            Filters
-          </h3>
-          <button
-            className="btn text-left btn-primary"
-            onClick={[Function]}
-            type="button"
-          >
-            All
-          </button>
-          <button
-            className="btn text-left"
-            onClick={[Function]}
-            type="button"
-          >
-            Your code monitors
-          </button>
-        </div>
-        <div
-          className="d-flex flex-column w-100 col"
-        >
-          <h3
-            className="mb-2"
-          >
-            All code monitors
-          </h3>
-          <Container>
-            <div
-              className="container"
-            >
-              <FilteredConnection
-                className="filtered-connection__centered-summary"
-                cursorPaging={true}
-                defaultFirst={10}
-                hideSearch={true}
-                history="[History]"
-                location="[Location path=/code-monitoring]"
-                noSummaryIfAllNodesVisible={true}
-                nodeComponent={[Function]}
-                nodeComponentProps={
-                  Object {
-                    "authenticatedUser": Object {
-                      "email": "alice@alice.com",
-                      "id": "foobar",
-                      "username": "alice",
-                    },
-                    "location": "[Location path=/code-monitoring]",
-                    "showCodeMonitoringTestEmailButton": false,
-                    "toggleCodeMonitorEnabled": [Function],
-                  }
-                }
-                noun="code monitor"
-                pluralNoun="code monitors"
-                queryConnection={[Function]}
-                useURLQuery={true}
+              <div
+                className="nav-item"
               >
                 <div
-                  className="filtered-connection test-filtered-connection filtered-connection--noncompact filtered-connection__centered-summary"
+                  className="nav-link active"
                 >
-                  <ConnectionNodes
-                    connection={
-                      Object {
-                        "nodes": Array [
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Test code monitor",
-                            "enabled": true,
-                            "id": "foo0",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Second test code monitor",
-                            "enabled": true,
-                            "id": "foo1",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Third test code monitor",
-                            "enabled": true,
-                            "id": "foo2",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-3",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-3 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-3",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fourth test code monitor",
-                            "enabled": true,
-                            "id": "foo3",
-                            "trigger": Object {
-                              "id": "test-3",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-4",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-4 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-4",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fifth test code monitor",
-                            "enabled": true,
-                            "id": "foo4",
-                            "trigger": Object {
-                              "id": "test-4",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-5",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-5 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-5",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Sixth test code monitor",
-                            "enabled": true,
-                            "id": "foo5",
-                            "trigger": Object {
-                              "id": "test-5",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-6",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-6 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-6",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Seventh test code monitor",
-                            "enabled": true,
-                            "id": "foo6",
-                            "trigger": Object {
-                              "id": "test-6",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-7",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-7 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-7",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Eighth test code monitor",
-                            "enabled": true,
-                            "id": "foo7",
-                            "trigger": Object {
-                              "id": "test-7",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-9",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-9 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-9",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Ninth test code monitor",
-                            "enabled": true,
-                            "id": "foo9",
-                            "trigger": Object {
-                              "id": "test-9",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Tenth test code monitor",
-                            "enabled": true,
-                            "id": "foo10",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Eleventh test code monitor",
-                            "enabled": true,
-                            "id": "foo11",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          },
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Twelfth test code monitor",
-                            "enabled": true,
-                            "id": "foo12",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          },
-                        ],
-                        "pageInfo": Object {
-                          "endCursor": "foo12",
-                          "hasNextPage": true,
-                        },
-                        "totalCount": 12,
-                      }
-                    }
-                    connectionQuery=""
-                    first={10}
-                    loading={false}
-                    location="[Location path=/code-monitoring]"
-                    noSummaryIfAllNodesVisible={true}
-                    nodeComponent={[Function]}
-                    nodeComponentProps={
-                      Object {
-                        "authenticatedUser": Object {
-                          "email": "alice@alice.com",
-                          "id": "foobar",
-                          "username": "alice",
-                        },
-                        "location": "[Location path=/code-monitoring]",
-                        "showCodeMonitoringTestEmailButton": false,
-                        "toggleCodeMonitorEnabled": [Function],
-                      }
-                    }
-                    noun="code monitor"
-                    onShowMore={[Function]}
-                    pluralNoun="code monitors"
-                    query=""
+                  <span
+                    className="text-content"
+                    data-tab-content="Code monitors"
                   >
-                    <div
-                      className="filtered-connection__summary-container"
-                    />
-                    <ul
-                      className="filtered-connection__nodes"
-                      data-testid="nodes"
-                    >
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo0"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Test code monitor",
-                            "enabled": true,
-                            "id": "foo0",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo0"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo0"
-                                  >
-                                    Test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo0"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo0"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo1"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Second test code monitor",
-                            "enabled": true,
-                            "id": "foo1",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo1"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo1"
-                                  >
-                                    Second test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo1"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo1"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo2"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Third test code monitor",
-                            "enabled": true,
-                            "id": "foo2",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo2"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo2"
-                                  >
-                                    Third test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo2"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo2"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo3"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-3",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-3 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-3",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fourth test code monitor",
-                            "enabled": true,
-                            "id": "foo3",
-                            "trigger": Object {
-                              "id": "test-3",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo3"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo3"
-                                  >
-                                    Fourth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo3"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo3"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo4"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-4",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-4 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-4",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Fifth test code monitor",
-                            "enabled": true,
-                            "id": "foo4",
-                            "trigger": Object {
-                              "id": "test-4",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo4"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo4"
-                                  >
-                                    Fifth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo4"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo4"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo5"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-5",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-5 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-5",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Sixth test code monitor",
-                            "enabled": true,
-                            "id": "foo5",
-                            "trigger": Object {
-                              "id": "test-5",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo5"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo5"
-                                  >
-                                    Sixth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo5"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo5"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo6"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-6",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-6 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-6",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Seventh test code monitor",
-                            "enabled": true,
-                            "id": "foo6",
-                            "trigger": Object {
-                              "id": "test-6",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo6"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo6"
-                                  >
-                                    Seventh test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo6"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo6"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo7"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-7",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-7 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-7",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Eighth test code monitor",
-                            "enabled": true,
-                            "id": "foo7",
-                            "trigger": Object {
-                              "id": "test-7",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo7"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo7"
-                                  >
-                                    Eighth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo7"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo7"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo9"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-9",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-9 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-9",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Ninth test code monitor",
-                            "enabled": true,
-                            "id": "foo9",
-                            "trigger": Object {
-                              "id": "test-9",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo9"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo9"
-                                  >
-                                    Ninth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo9"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo9"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo10"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-0",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-0 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-0",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Tenth test code monitor",
-                            "enabled": true,
-                            "id": "foo10",
-                            "trigger": Object {
-                              "id": "test-0",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo10"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo10"
-                                  >
-                                    Tenth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo10"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo10"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo11"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-1",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-1 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-1",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Eleventh test code monitor",
-                            "enabled": true,
-                            "id": "foo11",
-                            "trigger": Object {
-                              "id": "test-1",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo11"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo11"
-                                  >
-                                    Eleventh test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo11"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo11"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                      <CodeMonitorNode
-                        authenticatedUser={
-                          Object {
-                            "email": "alice@alice.com",
-                            "id": "foobar",
-                            "username": "alice",
-                          }
-                        }
-                        key="foo12"
-                        location="[Location path=/code-monitoring]"
-                        node={
-                          Object {
-                            "actions": Object {
-                              "enabled": true,
-                              "id": "test-2",
-                              "nodes": Array [
-                                Object {
-                                  "enabled": true,
-                                  "id": "test-action-2 ",
-                                  "recipients": Object {
-                                    "nodes": Array [
-                                      Object {
-                                        "id": "baz-2",
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                            "description": "Twelfth test code monitor",
-                            "enabled": true,
-                            "id": "foo12",
-                            "trigger": Object {
-                              "id": "test-2",
-                              "query": "test",
-                            },
-                          }
-                        }
-                        showCodeMonitoringTestEmailButton={false}
-                        toggleCodeMonitorEnabled={[Function]}
-                      >
-                        <div
-                          className="code-monitoring-node"
-                        >
-                          <div
-                            className="d-flex justify-content-between align-items-center"
-                          >
-                            <div
-                              className="d-flex flex-column"
-                            >
-                              <div
-                                className="font-weight-bold"
-                              >
-                                <AnchorLink
-                                  to="/code-monitoring/foo12"
-                                >
-                                  <a
-                                    href="/code-monitoring/foo12"
-                                  >
-                                    Twelfth test code monitor
-                                  </a>
-                                </AnchorLink>
-                              </div>
-                              <div
-                                className="d-flex text-muted"
-                              >
-                                New search result → Sends email notifications
-                                 
-                              </div>
-                            </div>
-                            <div
-                              className="d-flex"
-                            >
-                              <div
-                                className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
-                              >
-                                <Toggle
-                                  className="mr-3"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  value={true}
-                                >
-                                  <button
-                                    aria-checked={true}
-                                    className="toggle mr-3"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    role="switch"
-                                    type="button"
-                                    value={1}
-                                  >
-                                    <span
-                                      className="toggle__bar toggle__bar--on"
-                                    />
-                                    <span
-                                      className="toggle__knob toggle__knob--on"
-                                    />
-                                  </button>
-                                </Toggle>
-                              </div>
-                              <AnchorLink
-                                className="btn btn-link code-monitoring-node__edit-button"
-                                to="/code-monitoring/foo12"
-                              >
-                                <a
-                                  className="btn btn-link code-monitoring-node__edit-button"
-                                  href="/code-monitoring/foo12"
-                                >
-                                  Edit
-                                </a>
-                              </AnchorLink>
-                            </div>
-                          </div>
-                        </div>
-                      </CodeMonitorNode>
-                    </ul>
-                    <div
-                      className="filtered-connection__summary-container"
-                    >
-                      <ConnectionNodesSummary
-                        connection={
-                          Object {
-                            "nodes": Array [
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-0",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-0 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-0",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Test code monitor",
-                                "enabled": true,
-                                "id": "foo0",
-                                "trigger": Object {
-                                  "id": "test-0",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-1",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-1 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-1",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Second test code monitor",
-                                "enabled": true,
-                                "id": "foo1",
-                                "trigger": Object {
-                                  "id": "test-1",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-2",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-2 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-2",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Third test code monitor",
-                                "enabled": true,
-                                "id": "foo2",
-                                "trigger": Object {
-                                  "id": "test-2",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-3",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-3 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-3",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Fourth test code monitor",
-                                "enabled": true,
-                                "id": "foo3",
-                                "trigger": Object {
-                                  "id": "test-3",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-4",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-4 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-4",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Fifth test code monitor",
-                                "enabled": true,
-                                "id": "foo4",
-                                "trigger": Object {
-                                  "id": "test-4",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-5",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-5 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-5",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Sixth test code monitor",
-                                "enabled": true,
-                                "id": "foo5",
-                                "trigger": Object {
-                                  "id": "test-5",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-6",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-6 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-6",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Seventh test code monitor",
-                                "enabled": true,
-                                "id": "foo6",
-                                "trigger": Object {
-                                  "id": "test-6",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-7",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-7 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-7",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Eighth test code monitor",
-                                "enabled": true,
-                                "id": "foo7",
-                                "trigger": Object {
-                                  "id": "test-7",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-9",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-9 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-9",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Ninth test code monitor",
-                                "enabled": true,
-                                "id": "foo9",
-                                "trigger": Object {
-                                  "id": "test-9",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-0",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-0 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-0",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Tenth test code monitor",
-                                "enabled": true,
-                                "id": "foo10",
-                                "trigger": Object {
-                                  "id": "test-0",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-1",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-1 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-1",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Eleventh test code monitor",
-                                "enabled": true,
-                                "id": "foo11",
-                                "trigger": Object {
-                                  "id": "test-1",
-                                  "query": "test",
-                                },
-                              },
-                              Object {
-                                "actions": Object {
-                                  "enabled": true,
-                                  "id": "test-2",
-                                  "nodes": Array [
-                                    Object {
-                                      "enabled": true,
-                                      "id": "test-action-2 ",
-                                      "recipients": Object {
-                                        "nodes": Array [
-                                          Object {
-                                            "id": "baz-2",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  ],
-                                },
-                                "description": "Twelfth test code monitor",
-                                "enabled": true,
-                                "id": "foo12",
-                                "trigger": Object {
-                                  "id": "test-2",
-                                  "query": "test",
-                                },
-                              },
-                            ],
-                            "pageInfo": Object {
-                              "endCursor": "foo12",
-                              "hasNextPage": true,
-                            },
-                            "totalCount": 12,
-                          }
-                        }
-                        connectionQuery=""
-                        hasNextPage={true}
-                        noSummaryIfAllNodesVisible={true}
-                        noun="code monitor"
-                        pluralNoun="code monitors"
-                        totalCount={12}
-                      >
-                        <p
-                          className="filtered-connection__summary"
-                          data-testid="summary"
-                        >
-                          <small>
-                            <span>
-                              12
-                               
-                              code monitors
-                               
-                              total
-                            </span>
-                             
-                          </small>
-                        </p>
-                      </ConnectionNodesSummary>
-                      <button
-                        className="btn btn-sm filtered-connection__show-more btn-link"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        Show more
-                      </button>
-                    </div>
-                  </ConnectionNodes>
+                    Code monitors
+                  </span>
                 </div>
-              </FilteredConnection>
+              </div>
             </div>
-          </Container>
+          </div>
+          <CodeMonitorList
+            authenticatedUser={
+              Object {
+                "email": "alice@alice.com",
+                "id": "foobar",
+                "username": "alice",
+              }
+            }
+            fetchUserCodeMonitors={[Function]}
+            settingsCascade={
+              Object {
+                "final": Object {},
+                "subjects": Array [],
+              }
+            }
+            toggleCodeMonitorEnabled={[Function]}
+          >
+            <div
+              className="row mb-5"
+            >
+              <div
+                className="d-flex flex-column col-2 mr-2"
+              >
+                <h3>
+                  Filters
+                </h3>
+                <button
+                  className="btn text-left btn-primary"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  All
+                </button>
+                <button
+                  className="btn text-left"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Your code monitors
+                </button>
+              </div>
+              <div
+                className="d-flex flex-column w-100 col"
+              >
+                <h3
+                  className="mb-2"
+                >
+                  All code monitors
+                </h3>
+                <Container>
+                  <div
+                    className="container"
+                  >
+                    <FilteredConnection
+                      className="filtered-connection__centered-summary"
+                      cursorPaging={true}
+                      defaultFirst={10}
+                      hideSearch={true}
+                      history="[History]"
+                      location="[Location path=/code-monitoring?visible=12]"
+                      noSummaryIfAllNodesVisible={true}
+                      nodeComponent={[Function]}
+                      nodeComponentProps={
+                        Object {
+                          "authenticatedUser": Object {
+                            "email": "alice@alice.com",
+                            "id": "foobar",
+                            "username": "alice",
+                          },
+                          "location": "[Location path=/code-monitoring?visible=12]",
+                          "showCodeMonitoringTestEmailButton": false,
+                          "toggleCodeMonitorEnabled": [Function],
+                        }
+                      }
+                      noun="code monitor"
+                      pluralNoun="code monitors"
+                      queryConnection={[Function]}
+                      useURLQuery={true}
+                    >
+                      <div
+                        className="filtered-connection test-filtered-connection filtered-connection--noncompact filtered-connection__centered-summary"
+                      >
+                        <ConnectionNodes
+                          connection={
+                            Object {
+                              "nodes": Array [
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Test code monitor",
+                                  "enabled": true,
+                                  "id": "foo0",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Second test code monitor",
+                                  "enabled": true,
+                                  "id": "foo1",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Third test code monitor",
+                                  "enabled": true,
+                                  "id": "foo2",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-3",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-3 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-3",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fourth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo3",
+                                  "trigger": Object {
+                                    "id": "test-3",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-4",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-4 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-4",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fifth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo4",
+                                  "trigger": Object {
+                                    "id": "test-4",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-5",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-5 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-5",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Sixth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo5",
+                                  "trigger": Object {
+                                    "id": "test-5",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-6",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-6 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-6",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Seventh test code monitor",
+                                  "enabled": true,
+                                  "id": "foo6",
+                                  "trigger": Object {
+                                    "id": "test-6",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-7",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-7 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-7",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Eighth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo7",
+                                  "trigger": Object {
+                                    "id": "test-7",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-9",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-9 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-9",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Ninth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo9",
+                                  "trigger": Object {
+                                    "id": "test-9",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Tenth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo10",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Eleventh test code monitor",
+                                  "enabled": true,
+                                  "id": "foo11",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                },
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Twelfth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo12",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                },
+                              ],
+                              "pageInfo": Object {
+                                "endCursor": "foo12",
+                                "hasNextPage": true,
+                              },
+                              "totalCount": 12,
+                            }
+                          }
+                          connectionQuery=""
+                          first={10}
+                          loading={false}
+                          location="[Location path=/code-monitoring?visible=12]"
+                          noSummaryIfAllNodesVisible={true}
+                          nodeComponent={[Function]}
+                          nodeComponentProps={
+                            Object {
+                              "authenticatedUser": Object {
+                                "email": "alice@alice.com",
+                                "id": "foobar",
+                                "username": "alice",
+                              },
+                              "location": "[Location path=/code-monitoring?visible=12]",
+                              "showCodeMonitoringTestEmailButton": false,
+                              "toggleCodeMonitorEnabled": [Function],
+                            }
+                          }
+                          noun="code monitor"
+                          onShowMore={[Function]}
+                          pluralNoun="code monitors"
+                          query=""
+                        >
+                          <div
+                            className="filtered-connection__summary-container"
+                          />
+                          <ul
+                            className="filtered-connection__nodes"
+                            data-testid="nodes"
+                          >
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo0"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Test code monitor",
+                                  "enabled": true,
+                                  "id": "foo0",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo0"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo0"
+                                        >
+                                          Test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo0"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo0"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo1"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Second test code monitor",
+                                  "enabled": true,
+                                  "id": "foo1",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo1"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo1"
+                                        >
+                                          Second test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo1"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo1"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo2"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Third test code monitor",
+                                  "enabled": true,
+                                  "id": "foo2",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo2"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo2"
+                                        >
+                                          Third test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo2"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo2"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo3"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-3",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-3 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-3",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fourth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo3",
+                                  "trigger": Object {
+                                    "id": "test-3",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo3"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo3"
+                                        >
+                                          Fourth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo3"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo3"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo4"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-4",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-4 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-4",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Fifth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo4",
+                                  "trigger": Object {
+                                    "id": "test-4",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo4"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo4"
+                                        >
+                                          Fifth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo4"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo4"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo5"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-5",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-5 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-5",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Sixth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo5",
+                                  "trigger": Object {
+                                    "id": "test-5",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo5"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo5"
+                                        >
+                                          Sixth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo5"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo5"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo6"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-6",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-6 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-6",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Seventh test code monitor",
+                                  "enabled": true,
+                                  "id": "foo6",
+                                  "trigger": Object {
+                                    "id": "test-6",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo6"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo6"
+                                        >
+                                          Seventh test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo6"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo6"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo7"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-7",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-7 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-7",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Eighth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo7",
+                                  "trigger": Object {
+                                    "id": "test-7",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo7"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo7"
+                                        >
+                                          Eighth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo7"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo7"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo9"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-9",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-9 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-9",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Ninth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo9",
+                                  "trigger": Object {
+                                    "id": "test-9",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo9"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo9"
+                                        >
+                                          Ninth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo9"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo9"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo10"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-0",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-0 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-0",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Tenth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo10",
+                                  "trigger": Object {
+                                    "id": "test-0",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo10"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo10"
+                                        >
+                                          Tenth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo10"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo10"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo11"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-1",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-1 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-1",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Eleventh test code monitor",
+                                  "enabled": true,
+                                  "id": "foo11",
+                                  "trigger": Object {
+                                    "id": "test-1",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo11"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo11"
+                                        >
+                                          Eleventh test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo11"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo11"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                            <CodeMonitorNode
+                              authenticatedUser={
+                                Object {
+                                  "email": "alice@alice.com",
+                                  "id": "foobar",
+                                  "username": "alice",
+                                }
+                              }
+                              key="foo12"
+                              location="[Location path=/code-monitoring?visible=12]"
+                              node={
+                                Object {
+                                  "actions": Object {
+                                    "enabled": true,
+                                    "id": "test-2",
+                                    "nodes": Array [
+                                      Object {
+                                        "enabled": true,
+                                        "id": "test-action-2 ",
+                                        "recipients": Object {
+                                          "nodes": Array [
+                                            Object {
+                                              "id": "baz-2",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  "description": "Twelfth test code monitor",
+                                  "enabled": true,
+                                  "id": "foo12",
+                                  "trigger": Object {
+                                    "id": "test-2",
+                                    "query": "test",
+                                  },
+                                }
+                              }
+                              showCodeMonitoringTestEmailButton={false}
+                              toggleCodeMonitorEnabled={[Function]}
+                            >
+                              <div
+                                className="code-monitoring-node"
+                              >
+                                <div
+                                  className="d-flex justify-content-between align-items-center"
+                                >
+                                  <div
+                                    className="d-flex flex-column"
+                                  >
+                                    <div
+                                      className="font-weight-bold"
+                                    >
+                                      <AnchorLink
+                                        to="/code-monitoring/foo12"
+                                      >
+                                        <a
+                                          href="/code-monitoring/foo12"
+                                        >
+                                          Twelfth test code monitor
+                                        </a>
+                                      </AnchorLink>
+                                    </div>
+                                    <div
+                                      className="d-flex text-muted"
+                                    >
+                                      New search result → Sends email notifications
+                                       
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="d-flex"
+                                  >
+                                    <div
+                                      className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                                    >
+                                      <Toggle
+                                        className="mr-3"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        value={true}
+                                      >
+                                        <button
+                                          aria-checked={true}
+                                          className="toggle mr-3"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="switch"
+                                          type="button"
+                                          value={1}
+                                        >
+                                          <span
+                                            className="toggle__bar toggle__bar--on"
+                                          />
+                                          <span
+                                            className="toggle__knob toggle__knob--on"
+                                          />
+                                        </button>
+                                      </Toggle>
+                                    </div>
+                                    <AnchorLink
+                                      className="btn btn-link code-monitoring-node__edit-button"
+                                      to="/code-monitoring/foo12"
+                                    >
+                                      <a
+                                        className="btn btn-link code-monitoring-node__edit-button"
+                                        href="/code-monitoring/foo12"
+                                      >
+                                        Edit
+                                      </a>
+                                    </AnchorLink>
+                                  </div>
+                                </div>
+                              </div>
+                            </CodeMonitorNode>
+                          </ul>
+                          <div
+                            className="filtered-connection__summary-container"
+                          >
+                            <ConnectionNodesSummary
+                              connection={
+                                Object {
+                                  "nodes": Array [
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-0",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-0 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-0",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Test code monitor",
+                                      "enabled": true,
+                                      "id": "foo0",
+                                      "trigger": Object {
+                                        "id": "test-0",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-1",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-1 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-1",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Second test code monitor",
+                                      "enabled": true,
+                                      "id": "foo1",
+                                      "trigger": Object {
+                                        "id": "test-1",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-2",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-2 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-2",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Third test code monitor",
+                                      "enabled": true,
+                                      "id": "foo2",
+                                      "trigger": Object {
+                                        "id": "test-2",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-3",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-3 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-3",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Fourth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo3",
+                                      "trigger": Object {
+                                        "id": "test-3",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-4",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-4 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-4",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Fifth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo4",
+                                      "trigger": Object {
+                                        "id": "test-4",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-5",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-5 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-5",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Sixth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo5",
+                                      "trigger": Object {
+                                        "id": "test-5",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-6",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-6 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-6",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Seventh test code monitor",
+                                      "enabled": true,
+                                      "id": "foo6",
+                                      "trigger": Object {
+                                        "id": "test-6",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-7",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-7 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-7",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Eighth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo7",
+                                      "trigger": Object {
+                                        "id": "test-7",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-9",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-9 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-9",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Ninth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo9",
+                                      "trigger": Object {
+                                        "id": "test-9",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-0",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-0 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-0",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Tenth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo10",
+                                      "trigger": Object {
+                                        "id": "test-0",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-1",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-1 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-1",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Eleventh test code monitor",
+                                      "enabled": true,
+                                      "id": "foo11",
+                                      "trigger": Object {
+                                        "id": "test-1",
+                                        "query": "test",
+                                      },
+                                    },
+                                    Object {
+                                      "actions": Object {
+                                        "enabled": true,
+                                        "id": "test-2",
+                                        "nodes": Array [
+                                          Object {
+                                            "enabled": true,
+                                            "id": "test-action-2 ",
+                                            "recipients": Object {
+                                              "nodes": Array [
+                                                Object {
+                                                  "id": "baz-2",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                      "description": "Twelfth test code monitor",
+                                      "enabled": true,
+                                      "id": "foo12",
+                                      "trigger": Object {
+                                        "id": "test-2",
+                                        "query": "test",
+                                      },
+                                    },
+                                  ],
+                                  "pageInfo": Object {
+                                    "endCursor": "foo12",
+                                    "hasNextPage": true,
+                                  },
+                                  "totalCount": 12,
+                                }
+                              }
+                              connectionQuery=""
+                              hasNextPage={true}
+                              noSummaryIfAllNodesVisible={true}
+                              noun="code monitor"
+                              pluralNoun="code monitors"
+                              totalCount={12}
+                            >
+                              <p
+                                className="filtered-connection__summary"
+                                data-testid="summary"
+                              >
+                                <small>
+                                  <span>
+                                    12
+                                     
+                                    code monitors
+                                     
+                                    total
+                                  </span>
+                                   
+                                </small>
+                              </p>
+                            </ConnectionNodesSummary>
+                            <button
+                              className="btn btn-sm filtered-connection__show-more btn-link"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              Show more
+                            </button>
+                          </div>
+                        </ConnectionNodes>
+                      </div>
+                    </FilteredConnection>
+                  </div>
+                </Container>
+              </div>
+            </div>
+            <div
+              className="mt-5"
+            >
+              We want to hear your feedback! 
+              <a
+                href="mailto:feedback@sourcegraph.com"
+              >
+                Share your thoughts
+              </a>
+            </div>
+          </CodeMonitorList>
         </div>
       </div>
-      <div
-        className="mt-5"
-      >
-        We want to hear your feedback!
-         
-        <a
-          href="mailto:feedback@sourcegraph.com"
-        >
-          Share your thoughts
-        </a>
-      </div>
-    </div>
-  </div>
-</CodeMonitoringPage>
+    </CodeMonitoringPage>
+  </Router>
+</MemoryRouter>
 `;

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -6,7 +6,7 @@ import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { requestGraphQL } from '../backend/graphql'
 import { FetchFeatureFlagsResult } from '../graphql-operations'
 
-export type FeatureFlagName = 'w0-signup-optimisation'
+export type FeatureFlagName = 'w0-signup-optimisation' | 'w1-signup-optimisation'
 
 export type FlagSet = Map<FeatureFlagName, boolean>
 


### PR DESCRIPTION
Initial prep work for #21161

- Add type for new feature flag `w1-signup-optimisation`
- Extract getting started tab and code monitor list tab to new componenents, `CodeMonitorList` and `CodeMonitoringGettingStarted`
- Remove prop-drilled `history` and `location` props from `CodeMonitoring` page and use `useHistory` and `useLocation` instead