### PR TITLE
code monitoring: show tabs always, add Getting started to tabs

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -13,12 +13,9 @@ import { CodeMonitoringPageProps } from './CodeMonitoringPage'
 
 type CodeMonitorFilter = 'all' | 'user'
 
-export const CodeMonitorList: React.FunctionComponent<Required<CodeMonitoringPageProps>> = ({
-    authenticatedUser,
-    settingsCascade,
-    fetchUserCodeMonitors,
-    toggleCodeMonitorEnabled,
-}) => {
+export const CodeMonitorList: React.FunctionComponent<
+    Omit<Required<CodeMonitoringPageProps>, 'showGettingStarted'>
+> = ({ authenticatedUser, settingsCascade, fetchUserCodeMonitors, toggleCodeMonitorEnabled }) => {
     const location = useLocation()
     const history = useHistory()
     const [monitorListFilter, setMonitorListFilter] = useState<CodeMonitorFilter>('all')

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 
 export const CodeMonitoringGettingStarted: React.FunctionComponent<{}> = () => (
-    <div className="mt-5">
+    <div>
         <div className="d-flex flex-column mb-5">
             <h2>Get started with code monitoring</h2>
             <p className="text-muted code-monitoring-page__start-subheading mb-4">

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -31,7 +31,11 @@ const additionalProps = {
 
 add(
     'Code monitoring list page',
-    () => <EnterpriseWebStory>{props => <CodeMonitoringPage {...props} {...additionalProps} />}</EnterpriseWebStory>,
+    () => (
+        <EnterpriseWebStory initialEntries={['/code-monitoring']}>
+            {props => <CodeMonitoringPage {...props} {...additionalProps} />}
+        </EnterpriseWebStory>
+    ),
     {
         design: {
             type: 'figma',
@@ -42,25 +46,10 @@ add(
 )
 
 add(
-    'Code monitoring list page empty state',
+    'Code monitoring getting started page',
     () => (
-        <EnterpriseWebStory>
-            {props => (
-                <CodeMonitoringPage
-                    {...props}
-                    {...additionalProps}
-                    fetchUserCodeMonitors={({ id, first, after }: ListUserCodeMonitorsVariables) =>
-                        of({
-                            nodes: [],
-                            pageInfo: {
-                                endCursor: '',
-                                hasNextPage: false,
-                            },
-                            totalCount: 0,
-                        })
-                    }
-                />
-            )}
+        <EnterpriseWebStory initialEntries={['/code-monitoring/getting-started']}>
+            {props => <CodeMonitoringPage {...props} {...additionalProps} showGettingStarted={true} />}
         </EnterpriseWebStory>
     ),
     {

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,5 +1,7 @@
+import classNames from 'classnames'
 import PlusIcon from 'mdi-react/PlusIcon'
 import React, { useMemo, useEffect } from 'react'
+import { NavLink, Redirect } from 'react-router-dom'
 import { catchError, map, startWith } from 'rxjs/operators'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
@@ -26,6 +28,7 @@ export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings> 
     authenticatedUser: AuthenticatedUser
     fetchUserCodeMonitors?: typeof _fetchUserCodeMonitors
     toggleCodeMonitorEnabled?: typeof _toggleCodeMonitorEnabled
+    showGettingStarted?: boolean
 }
 
 export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = ({
@@ -33,6 +36,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
     authenticatedUser,
     fetchUserCodeMonitors = _fetchUserCodeMonitors,
     toggleCodeMonitorEnabled = _toggleCodeMonitorEnabled,
+    showGettingStarted = false,
 }) => {
     useEffect(() => eventLogger.logViewEvent('CodeMonitoringPage'), [])
 
@@ -53,6 +57,17 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
             [authenticatedUser.id, fetchUserCodeMonitors]
         )
     )
+
+    // If user has no code monitors, redirect to the getting started page
+    if (!showGettingStarted && userHasCodeMonitors === false) {
+        return <Redirect to="/code-monitoring/getting-started" />
+    }
+
+    const showList =
+        userHasCodeMonitors &&
+        userHasCodeMonitors !== 'loading' &&
+        !isErrorLike(userHasCodeMonitors) &&
+        !showGettingStarted
 
     return (
         <div className="code-monitoring-page">
@@ -88,30 +103,48 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
             />
             {userHasCodeMonitors === 'loading' && <LoadingSpinner />}
 
-            {!userHasCodeMonitors && <CodeMonitoringGettingStarted />}
-
-            {userHasCodeMonitors && userHasCodeMonitors !== 'loading' && !isErrorLike(userHasCodeMonitors) && (
-                <>
-                    <div className="d-flex flex-column">
-                        <div className="code-monitoring-page-tabs mb-4">
-                            <div className="nav nav-tabs">
-                                <div className="nav-item">
-                                    <div className="nav-link active">
-                                        <span className="text-content" data-tab-content="Code monitors">
-                                            Code monitors
-                                        </span>
-                                    </div>
-                                </div>
+            {(showGettingStarted || showList) && (
+                <div className="d-flex flex-column">
+                    <div className="code-monitoring-page-tabs mb-4">
+                        <div className="nav nav-tabs">
+                            <div className="nav-item">
+                                <NavLink
+                                    to="/code-monitoring"
+                                    className="nav-link"
+                                    activeClassName="active"
+                                    exact={true}
+                                >
+                                    <span className="text-content" data-tab-content="Code monitors">
+                                        Code monitors
+                                    </span>
+                                </NavLink>
+                            </div>
+                            <div className="nav-item">
+                                <NavLink
+                                    to="/code-monitoring/getting-started"
+                                    className="nav-link"
+                                    activeClassName="active"
+                                    exact={true}
+                                >
+                                    <span className="text-content" data-tab-content="Getting started">
+                                        Getting started
+                                    </span>
+                                </NavLink>
                             </div>
                         </div>
+                    </div>
+
+                    {showGettingStarted && <CodeMonitoringGettingStarted />}
+
+                    {showList && (
                         <CodeMonitorList
                             settingsCascade={settingsCascade}
                             authenticatedUser={authenticatedUser}
                             fetchUserCodeMonitors={fetchUserCodeMonitors}
                             toggleCodeMonitorEnabled={toggleCodeMonitorEnabled}
                         />
-                    </div>
-                </>
+                    )}
+                </div>
             )}
         </div>
     )

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import PlusIcon from 'mdi-react/PlusIcon'
 import React, { useMemo, useEffect } from 'react'
 import { NavLink, Redirect } from 'react-router-dom'

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -148,16 +148,95 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
               <div
                 className="nav-item"
               >
-                <div
-                  className="nav-link active"
+                <NavLink
+                  activeClassName="active"
+                  className="nav-link"
+                  exact={true}
+                  to="/code-monitoring"
                 >
-                  <span
-                    className="text-content"
-                    data-tab-content="Code monitors"
+                  <Link
+                    aria-current="page"
+                    className="nav-link active"
+                    style={Object {}}
+                    to={
+                      Object {
+                        "hash": "",
+                        "key": null,
+                        "pathname": "/code-monitoring",
+                        "search": "",
+                        "state": null,
+                      }
+                    }
                   >
-                    Code monitors
-                  </span>
-                </div>
+                    <LinkAnchor
+                      aria-current="page"
+                      className="nav-link active"
+                      href="/code-monitoring"
+                      navigate={[Function]}
+                      style={Object {}}
+                    >
+                      <a
+                        aria-current="page"
+                        className="nav-link active"
+                        href="/code-monitoring"
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        <span
+                          className="text-content"
+                          data-tab-content="Code monitors"
+                        >
+                          Code monitors
+                        </span>
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </NavLink>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <NavLink
+                  activeClassName="active"
+                  className="nav-link"
+                  exact={true}
+                  to="/code-monitoring/getting-started"
+                >
+                  <Link
+                    aria-current={null}
+                    className="nav-link"
+                    to={
+                      Object {
+                        "hash": "",
+                        "key": null,
+                        "pathname": "/code-monitoring/getting-started",
+                        "search": "",
+                        "state": null,
+                      }
+                    }
+                  >
+                    <LinkAnchor
+                      aria-current={null}
+                      className="nav-link"
+                      href="/code-monitoring/getting-started"
+                      navigate={[Function]}
+                    >
+                      <a
+                        aria-current={null}
+                        className="nav-link"
+                        href="/code-monitoring/getting-started"
+                        onClick={[Function]}
+                      >
+                        <span
+                          className="text-content"
+                          data-tab-content="Getting started"
+                        >
+                          Getting started
+                        </span>
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </NavLink>
               </div>
             </div>
           </div>
@@ -2152,16 +2231,95 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
               <div
                 className="nav-item"
               >
-                <div
-                  className="nav-link active"
+                <NavLink
+                  activeClassName="active"
+                  className="nav-link"
+                  exact={true}
+                  to="/code-monitoring"
                 >
-                  <span
-                    className="text-content"
-                    data-tab-content="Code monitors"
+                  <Link
+                    aria-current="page"
+                    className="nav-link active"
+                    style={Object {}}
+                    to={
+                      Object {
+                        "hash": "",
+                        "key": null,
+                        "pathname": "/code-monitoring",
+                        "search": "",
+                        "state": null,
+                      }
+                    }
                   >
-                    Code monitors
-                  </span>
-                </div>
+                    <LinkAnchor
+                      aria-current="page"
+                      className="nav-link active"
+                      href="/code-monitoring"
+                      navigate={[Function]}
+                      style={Object {}}
+                    >
+                      <a
+                        aria-current="page"
+                        className="nav-link active"
+                        href="/code-monitoring"
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        <span
+                          className="text-content"
+                          data-tab-content="Code monitors"
+                        >
+                          Code monitors
+                        </span>
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </NavLink>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <NavLink
+                  activeClassName="active"
+                  className="nav-link"
+                  exact={true}
+                  to="/code-monitoring/getting-started"
+                >
+                  <Link
+                    aria-current={null}
+                    className="nav-link"
+                    to={
+                      Object {
+                        "hash": "",
+                        "key": null,
+                        "pathname": "/code-monitoring/getting-started",
+                        "search": "",
+                        "state": null,
+                      }
+                    }
+                  >
+                    <LinkAnchor
+                      aria-current={null}
+                      className="nav-link"
+                      href="/code-monitoring/getting-started"
+                      navigate={[Function]}
+                    >
+                      <a
+                        aria-current={null}
+                        className="nav-link"
+                        href="/code-monitoring/getting-started"
+                        onClick={[Function]}
+                      >
+                        <span
+                          className="text-content"
+                          data-tab-content="Getting started"
+                        >
+                          Getting started
+                        </span>
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </NavLink>
               </div>
             </div>
           </div>
@@ -2987,16 +3145,95 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
               <div
                 className="nav-item"
               >
-                <div
-                  className="nav-link active"
+                <NavLink
+                  activeClassName="active"
+                  className="nav-link"
+                  exact={true}
+                  to="/code-monitoring"
                 >
-                  <span
-                    className="text-content"
-                    data-tab-content="Code monitors"
+                  <Link
+                    aria-current="page"
+                    className="nav-link active"
+                    style={Object {}}
+                    to={
+                      Object {
+                        "hash": "",
+                        "key": null,
+                        "pathname": "/code-monitoring",
+                        "search": "",
+                        "state": null,
+                      }
+                    }
                   >
-                    Code monitors
-                  </span>
-                </div>
+                    <LinkAnchor
+                      aria-current="page"
+                      className="nav-link active"
+                      href="/code-monitoring"
+                      navigate={[Function]}
+                      style={Object {}}
+                    >
+                      <a
+                        aria-current="page"
+                        className="nav-link active"
+                        href="/code-monitoring"
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        <span
+                          className="text-content"
+                          data-tab-content="Code monitors"
+                        >
+                          Code monitors
+                        </span>
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </NavLink>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <NavLink
+                  activeClassName="active"
+                  className="nav-link"
+                  exact={true}
+                  to="/code-monitoring/getting-started"
+                >
+                  <Link
+                    aria-current={null}
+                    className="nav-link"
+                    to={
+                      Object {
+                        "hash": "",
+                        "key": null,
+                        "pathname": "/code-monitoring/getting-started",
+                        "search": "",
+                        "state": null,
+                      }
+                    }
+                  >
+                    <LinkAnchor
+                      aria-current={null}
+                      className="nav-link"
+                      href="/code-monitoring/getting-started"
+                      navigate={[Function]}
+                    >
+                      <a
+                        aria-current={null}
+                        className="nav-link"
+                        href="/code-monitoring/getting-started"
+                        onClick={[Function]}
+                      >
+                        <span
+                          className="text-content"
+                          data-tab-content="Getting started"
+                        >
+                          Getting started
+                        </span>
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </NavLink>
               </div>
             </div>
           </div>

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -67,6 +67,11 @@ export const AuthenticatedCodeMonitoringArea = withAuthenticatedUser<Authenticat
                         exact={true}
                     />
                     <Route
+                        render={props => <CodeMonitoringPage {...outerProps} {...props} showGettingStarted={true} />}
+                        path={`${match.url}/getting-started`}
+                        exact={true}
+                    />
+                    <Route
                         path={`${match.url}/new`}
                         render={props => <CreateCodeMonitorPage {...outerProps} {...props} />}
                         exact={true}


### PR DESCRIPTION
Part of #21161

- Always show tabs on Code Monitoring page
- Add "Getting started" to tabs
- "Getting started" page can now always be accessed with `code-monitoring/getting-started` route

Notes:
- This retains the current behavior: when user doesn't have any monitors, they will always be redirected to "Getting started" page (so clicking the "Code monitors" tab will be a no-op). This will change with future work on #21161

![image](https://user-images.githubusercontent.com/206864/122829861-610e7280-d29c-11eb-8b2f-48331fb625e0.png)

![image](https://user-images.githubusercontent.com/206864/122829879-666bbd00-d29c-11eb-9e2a-1f2a6e41c5b1.png)
