### PR TITLE
batches: fix credential migration progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- The Batch Changes user and site credential encryption migrators added in Sourcegraph 3.28 could report zero progress when encryption was disabled, even though they had nothing to do. This has been fixed, and progress will now be correctly reported. [#22277](https://github.com/sourcegraph/sourcegraph/issues/22277)
 
 ### Removed
 

--- a/enterprise/internal/batches/background/site_credential_migrator_test.go
+++ b/enterprise/internal/batches/background/site_credential_migrator_test.go
@@ -48,7 +48,7 @@ func TestSiteCredentialMigrator(t *testing.T) {
 		}
 
 		cred.EncryptedCredential = enc
-		cred.EncryptionKeyID = ""
+		cred.EncryptionKeyID = btypes.SiteCredentialUnmigratedEncryptionKeyID
 		if err := cstore.UpdateSiteCredential(ctx, cred); err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/batches/background/user_credential_migrator_test.go
+++ b/enterprise/internal/batches/background/user_credential_migrator_test.go
@@ -195,8 +195,9 @@ func createUnencryptedUserCredential(
 	if err := store.Exec(
 		ctx,
 		sqlf.Sprintf(
-			"UPDATE user_credentials SET credential = %s, encryption_key_id = 'unmigrated' WHERE id = %s",
+			"UPDATE user_credentials SET credential = %s, encryption_key_id = %s WHERE id = %s",
 			raw,
+			database.UserCredentialUnmigratedEncryptionKeyID,
 			cred.ID,
 		),
 	); err != nil {

--- a/enterprise/internal/batches/background/user_credential_migrator_test.go
+++ b/enterprise/internal/batches/background/user_credential_migrator_test.go
@@ -195,7 +195,7 @@ func createUnencryptedUserCredential(
 	if err := store.Exec(
 		ctx,
 		sqlf.Sprintf(
-			"UPDATE user_credentials SET credential = %s, encryption_key_id = '' WHERE id = %s",
+			"UPDATE user_credentials SET credential = %s, encryption_key_id = 'unmigrated' WHERE id = %s",
 			raw,
 			cred.ID,
 		),

--- a/enterprise/internal/batches/store/site_credentials.go
+++ b/enterprise/internal/batches/store/site_credentials.go
@@ -186,10 +186,17 @@ ORDER BY external_service_type ASC, external_service_id ASC
 func listSiteCredentialsQuery(opts ListSiteCredentialsOpts) *sqlf.Query {
 	preds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if opts.RequiresMigration {
-		preds = append(preds, sqlf.Sprintf("encryption_key_id IN ('', %s)", btypes.SiteCredentialPlaceholderEncryptionKeyID))
+		preds = append(preds, sqlf.Sprintf(
+			"encryption_key_id IN (%s, %s)",
+			btypes.SiteCredentialPlaceholderEncryptionKeyID,
+			btypes.SiteCredentialUnmigratedEncryptionKeyID,
+		))
 	}
 	if opts.OnlyEncrypted {
-		preds = append(preds, sqlf.Sprintf("encryption_key_id <> ''"))
+		preds = append(preds, sqlf.Sprintf(
+			"encryption_key_id NOT IN ('', %s)",
+			btypes.SiteCredentialUnmigratedEncryptionKeyID,
+		))
 	}
 
 	forUpdate := &sqlf.Query{}

--- a/enterprise/internal/batches/types/site_credential.go
+++ b/enterprise/internal/batches/types/site_credential.go
@@ -23,7 +23,10 @@ type SiteCredential struct {
 	Key encryption.Key
 }
 
-const SiteCredentialPlaceholderEncryptionKeyID = "previously-migrated"
+const (
+	SiteCredentialPlaceholderEncryptionKeyID = "previously-migrated"
+	SiteCredentialUnmigratedEncryptionKeyID  = "unmigrated"
+)
 
 // Authenticator decrypts and creates the authenticator associated with the site
 // credential.
@@ -31,7 +34,7 @@ func (sc *SiteCredential) Authenticator(ctx context.Context) (auth.Authenticator
 	// The record includes a field indicating the encryption key ID. We don't
 	// really have a way to look up a key by ID right now, so this is used as a
 	// marker of whether we should expect a key or not.
-	if sc.EncryptionKeyID == "" {
+	if sc.EncryptionKeyID == "" || sc.EncryptionKeyID == SiteCredentialUnmigratedEncryptionKeyID {
 		return database.UnmarshalAuthenticator(string(sc.EncryptedCredential))
 	}
 	if sc.Key == nil {

--- a/internal/database/user_credentials.go
+++ b/internal/database/user_credentials.go
@@ -41,7 +41,7 @@ func (uc *UserCredential) Authenticator(ctx context.Context) (auth.Authenticator
 	// The record includes a field indicating the encryption key ID. We don't
 	// really have a way to look up a key by ID right now, so this is used as a
 	// marker of whether we should expect a key or not.
-	if uc.EncryptionKeyID == "" {
+	if uc.EncryptionKeyID == "" || uc.EncryptionKeyID == UserCredentialUnmigratedEncryptionKeyID {
 		return UnmarshalAuthenticator(string(uc.EncryptedCredential))
 	}
 	if uc.key == nil {
@@ -87,7 +87,9 @@ const (
 	// Valid domain values for user credentials.
 	UserCredentialDomainBatches = "batches"
 
+	// Placeholder encryption key IDs.
 	UserCredentialPlaceholderEncryptionKeyID = "previously-migrated"
+	UserCredentialUnmigratedEncryptionKeyID  = "unmigrated"
 )
 
 // UserCredentialNotFoundErr is returned when a credential cannot be found from
@@ -340,10 +342,17 @@ func (s *UserCredentialsStore) List(ctx context.Context, opts UserCredentialsLis
 		preds = append(preds, sqlf.Sprintf("ssh_migration_applied = %s", *opts.SSHMigrationApplied))
 	}
 	if opts.RequiresMigration {
-		preds = append(preds, sqlf.Sprintf("encryption_key_id IN ('', %s)", UserCredentialPlaceholderEncryptionKeyID))
+		preds = append(preds, sqlf.Sprintf(
+			"encryption_key_id IN (%s, %s)",
+			UserCredentialPlaceholderEncryptionKeyID,
+			UserCredentialUnmigratedEncryptionKeyID,
+		))
 	}
 	if opts.OnlyEncrypted {
-		preds = append(preds, sqlf.Sprintf("encryption_key_id <> ''"))
+		preds = append(preds, sqlf.Sprintf(
+			"encryption_key_id NOT IN ('', %s)",
+			UserCredentialUnmigratedEncryptionKeyID,
+		))
 	}
 
 	if len(preds) == 0 {

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -61,17 +61,22 @@ func TestUserCredential_Authenticator(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		uc := &UserCredential{
-			EncryptionKeyID:     "",
-			EncryptedCredential: enc,
-			key:                 et.TestKey{},
-		}
 
-		have, err := uc.Authenticator(ctx)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		} else if diff := cmp.Diff(have, a); diff != "" {
-			t.Errorf("unexpected authenticator (-have +want):\n%s", diff)
+		for _, keyID := range []string{"", UserCredentialUnmigratedEncryptionKeyID} {
+			t.Run(keyID, func(t *testing.T) {
+				uc := &UserCredential{
+					EncryptionKeyID:     keyID,
+					EncryptedCredential: enc,
+					key:                 et.TestKey{},
+				}
+
+				have, err := uc.Authenticator(ctx)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else if diff := cmp.Diff(have, a); diff != "" {
+					t.Errorf("unexpected authenticator (-have +want):\n%s", diff)
+				}
+			})
 		}
 	})
 

--- a/migrations/frontend/1528395837_mark_unmigrated_credentials.down.sql
+++ b/migrations/frontend/1528395837_mark_unmigrated_credentials.down.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+UPDATE
+    user_credentials
+SET
+    encryption_key_id = ''
+WHERE
+    encryption_key_id = 'unmigrated';
+
+UPDATE
+    batch_changes_site_credentials
+SET
+    encryption_key_id = ''
+WHERE
+    encryption_key_id = 'unmigrated';
+
+COMMIT;

--- a/migrations/frontend/1528395837_mark_unmigrated_credentials.up.sql
+++ b/migrations/frontend/1528395837_mark_unmigrated_credentials.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Previously, we conflated unmigrated user and site credentials with
+-- unencrypted ones. Instead, we should separate these states with a placeholder
+-- so the out of band migration responsible for encrypting credentials reports
+-- its progress correctly.
+
+UPDATE
+    user_credentials
+SET
+    encryption_key_id = 'unmigrated'
+WHERE
+    encryption_key_id = '';
+
+UPDATE
+    batch_changes_site_credentials
+SET
+    encryption_key_id = 'unmigrated'
+WHERE
+    encryption_key_id = '';
+
+COMMIT;


### PR DESCRIPTION
Fixes #22277. (See that issue for the write up of _what_ is being fixed; I'll describe the _how_ below.)

Basically, we need to be able to distinguish unmigrated credential records from unencrypted ones in order for our out-of-band migrations to succeed in unencrypted environments; right now they're collapsed together because we (well, OK, I) overloaded the `encryption_key_id` field shortly before merging the encryption support. This PR uses an in-band migration to set all ambiguous fields to an `unmigrated` sentinel value, and then the out-of-band migrations have been slightly adjusted to look for that instead of an empty key.

This will work fine even for users who haven't yet upgraded to 3.28 **as long as they run all migrations in order**. (It doesn't matter if the OOB migrators aren't run between the 3.28 in-band migrations and the one in this PR.) If they don't, all bets are off. But that's normal and documented anyway.