### PR TITLE
search frontend: restore contrast for query highlighting

### DIFF
--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -20,19 +20,19 @@ const SOURCEGRAPH_DARK = 'sourcegraph-dark'
 const darkColors: monaco.editor.IColors = {
     background: '#181b26', // --color-bg-1
     'editor.background': '#181b26', // --color-bg-1
-    'textLink.activeBackground': '#1d212f', // --color-bg-2
+    'textLink.activeBackground': '#343a4d', // --color-bg-3
     'editor.foreground': '#dbe2f0', // --search-query-text-color
     'editorCursor.foreground': '#dbe2f0', // --search-query-text-color
     'editorSuggestWidget.background': '#181b26', // --color-bg-1
     'editorSuggestWidget.foreground': '#dbe2f0', // --search-query-text-color
     'editorSuggestWidget.highlightForeground': '#4393e7', // --search-filter-keyword-color
-    'editorSuggestWidget.selectedBackground': '#1d212f', // --color-bg-2
-    'list.hoverBackground': '#1d212f', // --color-bg-2
+    'editorSuggestWidget.selectedBackground': '#343a4d', // --color-bg-3
+    'list.hoverBackground': '#343a4d', // --color-bg-3
     'editorSuggestWidget.border': '#262b38', // --border-color
     'editorHoverWidget.background': '#181b26', // --color-bg-1
     'editorHoverWidget.foreground': '#dbe2f0', // --search-query-text-color
     'editorHoverWidget.border': '#262b38', // --border-color
-    'editor.hoverHighlightBackground': '#1d212f', // --color-bg-2
+    'editor.hoverHighlightBackground': '#343a4d', // --color-bg-3
 }
 
 const darkRules: monaco.editor.ITokenThemeRule[] = [


### PR DESCRIPTION
In dark mode, redesign changes adds a background color highlighting that appears to emphasize text by creating a contrast with a _darker_ background color than the foreground. This is _maybe_ justified for the code highlighting in dark mode, which uses a slightly lighter foreground (though there are some [issues](https://sourcegraph.slack.com/archives/C0W2E592M/p1623874449250500)), but this same background color is used for the query hover highlighting, which has a darker background, so the highlighting is just invisble.

Before this PR (the highlight isn't visible):

<img width="712" alt="Screen Shot 2021-06-21 at 5 28 56 PM" src="https://user-images.githubusercontent.com/888624/122844646-f454a180-d2b6-11eb-813d-be29211d84e4.png">

After this PR:

<img width="696" alt="Screen Shot 2021-06-21 at 5 28 40 PM" src="https://user-images.githubusercontent.com/888624/122844672-033b5400-d2b7-11eb-9c50-a5536de2cd1d.png">

In fact, the "after" isn't high contrast enough for my liking, and is worse than before, but I'm going by the available palette in the [dark css theme](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/branded/src/global-styles/colors-redesign.scss?L133). It's kinda weird that the only other `--color-bg` options are darker and darker. (Could I perhaps add a `--color-bg-4` that's lighter? Appreciate input here).


For reference, the previous query background highlight color was 

- https://www.color-hex.com/color/495057

![Screen Shot 2021-06-21 at 5 37 55 PM](https://user-images.githubusercontent.com/888624/122844882-6fb65300-d2b7-11eb-98b5-d4cad69f446f.png)


The regression set it to

- https://www.color-hex.com/color/1d212f

![Screen Shot 2021-06-21 at 5 37 48 PM](https://user-images.githubusercontent.com/888624/122844894-73e27080-d2b7-11eb-8433-bf2bc4a066a0.png)


This PR makes it this now:

https://www.color-hex.com/color/343a4d

![Screen Shot 2021-06-21 at 5 37 41 PM](https://user-images.githubusercontent.com/888624/122844906-780e8e00-d2b7-11eb-847b-446c6d6da6ba.png)

