### PR TITLE
API docs: LSIF: protocol: empty index pages; public-by-default

### DIFF
--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -117,10 +117,10 @@ func NewDocumentationResult(id uint64, result Documentation) DocumentationResult
 // properly, and just chose to emit none specifically.
 //
 // If this documentationResult is for the project root, the identifier and searchKey should be an
-// empty string. Similarly, if there is no project root documentation (e.g. it would just be an
-// index page for documentation below the project root), an empty label and detail string should be
-// attached.
+// empty string.
 //
+// If a pages' only purpose is to connect other pages below it (i.e. it is an index page), it
+// should have empty label and detail strings attached.
 type Documentation struct {
 	// A human readable identifier for this documentationResult, uniquely identifying it within the
 	// scope of the parent page (or an empty string, if this is the root documentationResult.)
@@ -216,11 +216,9 @@ type Documentation struct {
 type DocumentationTag string
 
 const (
-	// The documentation describes a concept that is exported externally.
-	DocumentationExported DocumentationTag = "exported"
-
-	// The documentation describes a concept that is unexported / internal.
-	DocumentationUnexported DocumentationTag = "unexported"
+	// The documentation describes a concept that is private/unexported, not a public/exported
+	// concept.
+	DocumentationPrivate DocumentationTag = "private"
 
 	// The documentation describes a concept that is deprecated.
 	DocumentationDeprecated DocumentationTag = "deprecated"


### PR DESCRIPTION
* Document that empty label/detail pages are index pages rendered by clients.
* Replace "exported" and "unexported" (which has an ambiguous "what does no tags mean?" question)
  with just "private".
* Make all documentation public by default; private only if denoted as such.
  This reduces bugs from indexers emitting e.g. index pages without any tags.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>