### PR TITLE
zoekt: update for more memory reduction patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210621220134-2602014e1faf
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210622031536-099907aa573a
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1339,8 +1339,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210621220134-2602014e1faf h1:bOgZDs0e7SZUJvb82vVXZcyGTYd+YnKsM3lQY+R2Jyg=
-github.com/sourcegraph/zoekt v0.0.0-20210621220134-2602014e1faf/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
+github.com/sourcegraph/zoekt v0.0.0-20210622031536-099907aa573a h1:IxUdGEzDWYzh+yaVof6QSBh4p0epg6mtSAzStBFCmvA=
+github.com/sourcegraph/zoekt v0.0.0-20210622031536-099907aa573a/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Changelog:
- 099907a indexdata: condense runeOffsets into a shorter form.
- fe82147 indexdata: lazily decode runeDocSections (for symbols) during searches.
- 63b1773 indexdata: store fileNameNgrams in compressed posting list form.
- fcdcbba zoekt-test: add an option to load shards from a dir and dump cpu/mem profiles
- 460e20a ci: bump go version to 1.16




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->