### PR TITLE
web: import large SCSS files into JS instead of SCSS to speed up Storybook build

### DIFF
--- a/client/branded/src/components/LoaderInput.story.tsx
+++ b/client/branded/src/components/LoaderInput.story.tsx
@@ -2,7 +2,7 @@ import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
-import webStyles from '@sourcegraph/web/src/main.scss'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { BrandedStory } from './BrandedStory'
 import { LoaderInput } from './LoaderInput'

--- a/client/branded/src/components/Toggle.story.tsx
+++ b/client/branded/src/components/Toggle.story.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import React, { useState } from 'react'
 
-import webStyles from '@sourcegraph/web/src/main.scss'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { Toggle } from './Toggle'
 

--- a/client/branded/src/components/ToggleBig.story.tsx
+++ b/client/branded/src/components/ToggleBig.story.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import React, { useState } from 'react'
 
-import webStyles from '@sourcegraph/web/src/main.scss'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { ToggleBig } from './ToggleBig'
 

--- a/client/branded/src/components/panel/Panel.story.tsx
+++ b/client/branded/src/components/panel/Panel.story.tsx
@@ -8,7 +8,7 @@ import { PanelViewData } from '@sourcegraph/shared/src/api/extension/extensionHo
 import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHelpers'
-import webStyles from '@sourcegraph/web/src/main.scss'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { BrandedStory } from '../BrandedStory'
 

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.story.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.story.tsx
@@ -5,7 +5,7 @@ import { of } from 'rxjs'
 
 import { Location } from '@sourcegraph/extension-api-types'
 import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHelpers'
-import webStyles from '@sourcegraph/web/src/main.scss'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { BrandedStory } from '../../BrandedStory'
 

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -1,5 +1,5 @@
 /*
-This is the main entry point for all styles of the web app.
+This is the main entry point for all styles for the web app.
 It should import all component stylesheets.
 */
 

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -1,6 +1,6 @@
 /*
-This is the main entry point for all styles
-It should import all component stylesheets
+This is the main entry point for all styles of the web app.
+It should import all component stylesheets.
 */
 
 // Use duplicate selectors for the light-theme

--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -1,7 +1,3 @@
-// Entry point for the web app
-
-@import './SourcegraphWebApp';
-
 // Enterprise styles
 @import './enterprise/extensions/registry/RegistryArea';
 @import './enterprise/extensions/registry/RegistryNewExtensionPage';

--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 // Enterprise styles
 @import './enterprise/extensions/registry/RegistryArea';
 @import './enterprise/extensions/registry/RegistryNewExtensionPage';

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -42,7 +42,7 @@
     &__actions,
     &__triggers {
         &--disabled {
-            color: $gray-17 !important;
+            color: var(--gray-08) !important;
             opacity: 0.5;
 
             // Avoid applying opacity twice

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.scss
@@ -1,5 +1,5 @@
 .action-area {
     &__test-action-error {
-        color: $danger;
+        color: var(--danger);
     }
 }

--- a/client/web/src/enterprise/components/EnterpriseWebStory.tsx
+++ b/client/web/src/enterprise/components/EnterpriseWebStory.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 
 import { WebStory, WebStoryProps } from '../../components/WebStory'
 import enterpriseWebStyles from '../../enterprise.scss'
+import webStyles from '../../SourcegraphWebApp.scss'
 
 /**
  * Wrapper component for enterprise webapp Storybook stories that provides light theme and react-router props.
  * Takes a render function as children that gets called with the props.
  */
 export const EnterpriseWebStory: React.FunctionComponent<WebStoryProps> = props => (
-    <WebStory {...props} webStyles={enterpriseWebStyles} />
+    <WebStory {...props} webStyles={webStyles + enterpriseWebStyles} />
 )

--- a/client/web/src/enterprise/main.tsx
+++ b/client/web/src/enterprise/main.tsx
@@ -10,6 +10,7 @@ import '../sentry'
 import React from 'react'
 import { render } from 'react-dom'
 
+import '../SourcegraphWebApp.scss'
 import '../enterprise.scss'
 import { KEYBOARD_SHORTCUTS } from '../keyboardShortcuts/keyboardShortcuts'
 import { SourcegraphWebApp } from '../SourcegraphWebApp'

--- a/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.scss
+++ b/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.scss
@@ -1,12 +1,13 @@
 /* stylelint-disable selector-class-pattern */
 .payment-token-form-control {
     &__card {
-        @extend .form-control;
         padding-top: 0.5rem;
 
         &.StripeElement--focus {
-            @extend .form-control, :focus;
+            box-shadow: var(--input-focus-box-shadow);
+            border-color: var(--input-focus-border-color);
         }
+
         &.StripeElement--webkit-autofill {
             background: transparent !important;
         }

--- a/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.tsx
@@ -21,7 +21,7 @@ export const PaymentTokenFormControl: React.FunctionComponent<Props> = props => 
     return (
         <div className="payment-token-form-control">
             <PatchedCardElement
-                className={`payment-token-form-control__card payment-token-form-control__card--${
+                className={`form-control payment-token-form-control__card payment-token-form-control__card--${
                     props.disabled ? 'disabled' : ''
                 }`}
                 disabled={props.disabled}

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`ProductSubscriptionForm edit existing subscription 1`] = `
           className="payment-token-form-control"
         >
           <CardElement
-            className="payment-token-form-control__card payment-token-form-control__card--disabled"
+            className="form-control payment-token-form-control__card payment-token-form-control__card--disabled"
             disabled={true}
             style={
               Object {
@@ -154,7 +154,7 @@ exports[`ProductSubscriptionForm new subscription for anonymous viewer (no accou
           className="payment-token-form-control"
         >
           <CardElement
-            className="payment-token-form-control__card payment-token-form-control__card--disabled"
+            className="form-control payment-token-form-control__card payment-token-form-control__card--disabled"
             disabled={true}
             style={
               Object {
@@ -232,7 +232,7 @@ exports[`ProductSubscriptionForm new subscription for existing account 1`] = `
           className="payment-token-form-control"
         >
           <CardElement
-            className="payment-token-form-control__card payment-token-form-control__card--disabled"
+            className="form-control payment-token-form-control__card payment-token-form-control__card--disabled"
             disabled={true}
             style={
               Object {

--- a/client/web/src/main.scss
+++ b/client/web/src/main.scss
@@ -1,6 +1,0 @@
-// Entry point for the web app
-
-@import './SourcegraphWebApp';
-
-// If you need to import any other stylesheet here, you should add the import statement to
-// SourcegraphWebApp.scss, not here, so that enterprise.scss also imports it.

--- a/client/web/src/main.tsx
+++ b/client/web/src/main.tsx
@@ -14,7 +14,7 @@ import { extensionAreaHeaderNavItems } from './extensions/extension/extensionAre
 import { extensionAreaRoutes } from './extensions/extension/routes'
 import { extensionsAreaHeaderActionButtons } from './extensions/extensionsAreaHeaderActionButtons'
 import { extensionsAreaRoutes } from './extensions/routes'
-import './main.scss'
+import './SourcegraphWebApp.scss'
 import { KEYBOARD_SHORTCUTS } from './keyboardShortcuts/keyboardShortcuts'
 import { orgAreaHeaderNavItems } from './org/area/navitems'
 import { orgAreaRoutes } from './org/area/routes'


### PR DESCRIPTION
## Context

SASS loader is not able to reuse the output of the already processed SASS files. 

```scss
// global-styles.scss
a { text-decoration: underline; }

// app.scss
@import './global-styles.scss';

// enterprise.scss
@import './global-styles.scss';
```

If we import both `app.scss` and `enterprise.scss` in our JS code, then `global-styles.scss` will be processed by Webpack twice completely from scratch. [fast-sass-laoder](https://github.com/yibn2008/fast-sass-loader#why-fast-sass-loader-is-faster-than-sass-loader-) has file-dedupe, but it's not safe to use it because the order of imported files matters in SASS. For example, we use this feature to overwrite Bootstrap variables.

It's not a problem for the web app because we import only one huge stylesheet there. But for in Storybook, we load multiple stylesheets for different stories, and they have _a lot_ of overlap. 

For example, `enterprise.scss` imports `SourcegraphWebApp.scss` internally and adds additional enterprise styles. It means that when we change one CSS rule in the web app, the SASS loader needs to process `enterprise.scss` and `SourcegraphWebApp.scss` as two separate independent stylesheets. Also, these stylesheets are both included in the Storybook main bundle, making it a lot bigger than it could be. 

This PR moves critical SCSS imports out of the SCSS files into React components to free the SASS loader from the redundant work and make the output Storybook bundle smaller.

## Changes

- Instead of importing `SourcegraphWebApp.scss` into `enterprise.scss` import `SourcegraphWebApp.scss` in React components next to `enterprise.scss`.
- Use `SourcegraphWebApp.scss` imports directly instead of loading it through `main.scss` to completely remove `main.scss` from the bundle.

## Bundle Analyzer

### Before the optimization:

<img width="948" alt="Screenshot 2021-06-22 at 14 18 23" src="https://user-images.githubusercontent.com/3846380/122917322-7e246d80-d390-11eb-8b70-5a0a3c772c3b.png">

### After: 

<img width="1200" alt="Screenshot 2021-06-22 at 14 15 53" src="https://user-images.githubusercontent.com/3846380/122917389-8da3b680-d390-11eb-97a1-7eaf99a9b97b.png">