### PR TITLE
monitoring: Only monitor site level external services error rates

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3542,11 +3542,11 @@ with your code hosts connections or networking issues affecting communication wi
 
 ## repo-updater: syncer_sync_start
 
-<p class="subtitle">sync was started</p>
+<p class="subtitle">repo metadata sync was started</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> repo-updater: less than 0 sync was started for 9h0m0s
+- <span class="badge badge-warning">warning</span> repo-updater: less than 0 repo metadata sync was started for 9h0m0s
 
 **Possible solutions**
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3513,15 +3513,15 @@ with your code hosts connections or networking issues affecting communication wi
 
 ## repo-updater: src_repoupdater_syncer_sync_errors_total
 
-<p class="subtitle">sync error rate</p>
+<p class="subtitle">site level external service sync error rate</p>
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 0+ sync error rate for 10m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 0+ site level external service sync error rate for 10m0s
 
 **Possible solutions**
 
-- An alert here indicates errors syncing repo metadata with code hosts. This indicates that there could be a configuration issue
+- An alert here indicates errors syncing site level repo metadata with code hosts. This indicates that there could be a configuration issue
 with your code hosts connections or networking issues affecting communication with your code hosts.
 - Check the code host status indicator (cloud icon in top right of Sourcegraph homepage) for errors.
 - Make sure external services do not have invalid tokens by navigating to them in the web UI and clicking save. If there are no errors, they are valid.

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2072,7 +2072,7 @@ This panel indicates site level external service sync error rate.
 
 #### repo-updater: syncer_sync_start
 
-This panel indicates sync was started.
+This panel indicates repo metadata sync was started.
 
 > NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start).
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2062,7 +2062,7 @@ This panel indicates time since oldest sync.
 
 #### repo-updater: src_repoupdater_syncer_sync_errors_total
 
-This panel indicates sync error rate.
+This panel indicates site level external service sync error rate.
 
 > NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total).
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -60,13 +60,13 @@ func RepoUpdater() *monitoring.Container {
 						},
 						{
 							Name:        "src_repoupdater_syncer_sync_errors_total",
-							Description: "sync error rate",
-							Query:       `max by (family) (rate(src_repoupdater_syncer_sync_errors_total[5m]))`,
+							Description: "site level external service sync error rate",
+							Query:       `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user"}[5m]))`,
 							Critical:    monitoring.Alert().Greater(0, nil).For(10 * time.Minute),
 							Panel:       monitoring.Panel().Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: `
-								An alert here indicates errors syncing repo metadata with code hosts. This indicates that there could be a configuration issue
+								An alert here indicates errors syncing site level repo metadata with code hosts. This indicates that there could be a configuration issue
 								with your code hosts connections or networking issues affecting communication with your code hosts.
 								- Check the code host status indicator (cloud icon in top right of Sourcegraph homepage) for errors.
 								- Make sure external services do not have invalid tokens by navigating to them in the web UI and clicking save. If there are no errors, they are valid.

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -79,7 +79,7 @@ func RepoUpdater() *monitoring.Container {
 					{
 						{
 							Name:              "syncer_sync_start",
-							Description:       "sync was started",
+							Description:       "repo metadata sync was started",
 							Query:             `max by (family) (rate(src_repoupdater_syncer_start_sync[5m]))`,
 							Warning:           monitoring.Alert().LessOrEqual(0, nil).For(syncDurationThreshold),
 							Panel:             monitoring.Panel().LegendFormat("{{family}}").Unit(monitoring.Number),

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -80,9 +80,9 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:              "syncer_sync_start",
 							Description:       "repo metadata sync was started",
-							Query:             `max by (family) (rate(src_repoupdater_syncer_start_sync[5m]))`,
+							Query:             fmt.Sprintf(`max by (family, owner) (rate(src_repoupdater_syncer_start_sync[%s]))`, syncDurationThreshold.String()),
 							Warning:           monitoring.Alert().LessOrEqual(0, nil).For(syncDurationThreshold),
-							Panel:             monitoring.Panel().LegendFormat("{{family}}").Unit(monitoring.Number),
+							Panel:             monitoring.Panel().LegendFormat("Family: {{family}} Owner: {{owner}}").Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: "Check repo-updater logs for errors.",
 						},


### PR DESCRIPTION
Tweak monitoring to only consider site level external services since we have no
control over how user added external services are configured.