### PR TITLE
syncer: Remove "subset" terminology

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -249,7 +249,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		// WARNING: This enables the streaming inserter which allows it to sync private repos. If
 		// this is ever enabled for sourcegraph.com, we want to be sure we are not unintentionally
 		// syncing private repos.
-		syncer.SubsetSynced = make(chan repos.Diff)
+		syncer.SingleRepoSynced = make(chan repos.Diff)
 	}
 
 	go watchSyncer(ctx, syncer, scheduler, gps)
@@ -434,7 +434,7 @@ func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps
 				}
 			}()
 
-		case diff := <-syncer.SubsetSynced:
+		case diff := <-syncer.SingleRepoSynced:
 			if !conf.Get().DisableAutoGitUpdates {
 				sched.UpdateFromDiff(diff)
 			}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -35,13 +35,9 @@ type Syncer struct {
 	// Synced is sent a collection of Repos that were synced by Sync (only if Synced is non-nil)
 	Synced chan Diff
 
-	// SubsetSynced is sent the result of a single repo sync that were synced by SyncRepo (only if
-	// SubsetSynced is non-nil)
-	//
-	// TODO: The name of this channel does not make it easy to understand its use case. This is
-	// triggered by the streaming inserter.
-	// https://sourcegraph.atlassian.net/browse/COREAPP-128
-	SubsetSynced chan Diff
+	// SingleRepoSynced is sent the result of a single repo sync that were synced by SyncRepo (only if
+	// SingleRepoSynced is non-nil)
+	SingleRepoSynced chan Diff
 
 	// Logger if non-nil is logged to.
 	Logger log15.Logger
@@ -221,7 +217,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 			}
 			return nil
 		}
-	} else if s.SubsetSynced != nil {
+	} else if s.SingleRepoSynced != nil {
 		// This is a site level external service. We have a channel to handle streaming inserts,
 		// therefore we should create an inserter. Note that it inserts outside of our transaction
 		// so that repos are visible to the rest of our system immediately.
@@ -579,9 +575,9 @@ func (s *Syncer) syncRepo(ctx context.Context, store *Store, insertOnly bool, pu
 		return Diff{}, errors.Wrap(err, "syncer.syncrepo.store.upsert-sources")
 	}
 
-	if s.SubsetSynced != nil {
+	if s.SingleRepoSynced != nil {
 		select {
-		case s.SubsetSynced <- diff:
+		case s.SingleRepoSynced <- diff:
 		case <-ctx.Done():
 		}
 	}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -519,24 +519,24 @@ func (s *Syncer) syncRepo(ctx context.Context, store *Store, insertOnly bool, pu
 		return Diff{}, nil
 	}
 
-	var storedSubset types.Repos
+	var storedRepos types.Repos
 	args := database.ReposListOptions{
 		Names:         []string{string(sourcedRepo.Name)},
 		ExternalRepos: []api.ExternalRepoSpec{sourcedRepo.ExternalRepo},
 		UseOr:         true,
 	}
-	if storedSubset, err = store.RepoStore.List(ctx, args); err != nil {
+	if storedRepos, err = store.RepoStore.List(ctx, args); err != nil {
 		return Diff{}, errors.Wrap(err, "syncer.syncrepo.store.list-repos")
 	}
 
-	if insertOnly && len(storedSubset) > 0 {
+	if insertOnly && len(storedRepos) > 0 {
 		return Diff{}, nil
 	}
 
-	// sourcedRepo only knows about one source so we need to add in the remaining stored
-	// sources
-	if len(storedSubset) == 1 {
-		for k, v := range storedSubset[0].Sources {
+	// sourcedRepo only knows about one source so we need to add in the remaining
+	// stored sources
+	if len(storedRepos) == 1 {
+		for k, v := range storedRepos[0].Sources {
 			// Don't update the source from sourcedRepo
 			if _, ok := sourcedRepo.Sources[k]; ok {
 				continue
@@ -546,9 +546,9 @@ func (s *Syncer) syncRepo(ctx context.Context, store *Store, insertOnly bool, pu
 	}
 
 	// NewDiff modifies the stored slice so we clone it before passing it
-	storedCopy := storedSubset.Clone()
+	storedCopy := storedRepos.Clone()
 
-	diff = NewDiff([]*types.Repo{sourcedRepo}, storedSubset)
+	diff = NewDiff([]*types.Repo{sourcedRepo}, storedRepos)
 
 	// We trust that if we determine that a repo needs to be deleted it should be deleted
 	// from all external services. By setting sources to nil this is forced when we call

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -1021,11 +1021,11 @@ func testSyncRun(db *sql.DB) func(t *testing.T, store *repos.Store) func(t *test
 			sourced := types.Repos{mk("initial"), mk("new")}
 
 			syncer := &repos.Syncer{
-				Sourcer:      repos.NewFakeSourcer(nil, repos.NewFakeSource(svc, nil, sourced...)),
-				Store:        store,
-				Synced:       make(chan repos.Diff),
-				SubsetSynced: make(chan repos.Diff),
-				Now:          time.Now,
+				Sourcer:          repos.NewFakeSourcer(nil, repos.NewFakeSource(svc, nil, sourced...)),
+				Store:            store,
+				Synced:           make(chan repos.Diff),
+				SingleRepoSynced: make(chan repos.Diff),
+				Now:              time.Now,
 			}
 
 			// Initial repos in store
@@ -1052,14 +1052,14 @@ func testSyncRun(db *sql.DB) func(t *testing.T, store *repos.Store) func(t *test
 				t.Fatalf("initial Synced mismatch (-want +got):\n%s", d)
 			}
 
-			// Next up it should find the new repo and send it down SubsetSynced
-			diff = <-syncer.SubsetSynced
+			// Next up it should find the new repo and send it down SingleRepoSynced
+			diff = <-syncer.SingleRepoSynced
 			if d := cmp.Diff(repos.Diff{Added: types.Repos{mk("new")}}, diff, ignore); d != "" {
-				t.Fatalf("SubsetSynced mismatch (-want +got):\n%s", d)
+				t.Fatalf("SingleRepoSynced mismatch (-want +got):\n%s", d)
 			}
 
 			// Finally we get the final diff, which will have everything listed as
-			// Unmodified since we added when we did SubsetSynced.
+			// Unmodified since we added when we did SingleRepoSynced.
 			diff = <-syncer.Synced
 			if d := cmp.Diff(repos.Diff{Unmodified: sourced}, diff, ignore); d != "" {
 				t.Fatalf("final Synced mismatch (-want +got):\n%s", d)


### PR DESCRIPTION
Renamed to remove the "subset" terminology since we don't use it anymore.
