### PR TITLE
Insights: Optimize historical backfill using only changed commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
-
+- Backend Code Insights only fills historical data frames that have changed to reduce the number of searches required. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
+- Backend Code Insights displays data points for a fixed 6 months period in 2 week intervals, and will carry observations forward that are missing. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
 ### Fixed
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Backend Code Insights only fills historical data frames that have changed to reduce the number of searches required. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
 - Backend Code Insights displays data points for a fixed 6 months period in 2 week intervals, and will carry observations forward that are missing. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
+
 ### Fixed
 
 -

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -8,9 +8,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
+
 	"golang.org/x/time/rate"
 
-	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 	"github.com/xhit/go-str2duration/v2"
@@ -64,6 +66,7 @@ import (
 // to backfill them by enqueueing work for executing searches with `before:` and `after:` filter
 // ranges.
 func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestore.Store, settingStore discovery.SettingStore, insightsStore *store.Store, observationContext *observation.Context) goroutine.BackgroundRoutine {
+	log15.Info("newInsightHistoricalEnqueuer")
 	metrics := metrics.NewOperationMetrics(
 		observationContext.Registerer,
 		"insights_historical_enqueuer",
@@ -87,6 +90,26 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 
 	repoStore := database.Repos(workerBaseStore.Handle().DB())
 
+	framesToBackfill := func() int {
+		if frames := conf.Get().InsightsHistoricalFrames; frames != 0 {
+			return frames
+		}
+		return 6 // 6 one-month frames.
+	}
+
+	frameLength := func() time.Duration {
+		if s := conf.Get().InsightsHistoricalFrameLength; s != "" {
+			parsed, err := str2duration.ParseDuration(s)
+			if err != nil {
+				log15.Error("insights: failed to parse site config insights.historical.frameLength", "error", err)
+			}
+			return parsed
+		}
+		return 30 * 24 * time.Hour // 6 one-month frames.
+	}
+
+	maxTime := time.Now().Add(-time.Duration(framesToBackfill()) * frameLength())
+
 	historicalEnqueuer := &historicalEnqueuer{
 		now:           time.Now,
 		settingStore:  settingStore,
@@ -101,22 +124,10 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 		gitFindNearestCommit: git.FindNearestCommit,
 
 		// Fill e.g. the last 52 weeks of data, recording 1 point per week.
-		framesToBackfill: func() int {
-			if frames := conf.Get().InsightsHistoricalFrames; frames != 0 {
-				return frames
-			}
-			return 6 // 6 one-month frames.
-		},
-		frameLength: func() time.Duration {
-			if s := conf.Get().InsightsHistoricalFrameLength; s != "" {
-				parsed, err := str2duration.ParseDuration(s)
-				if err != nil {
-					log15.Error("insights: failed to parse site config insights.historical.frameLength", "error", err)
-				}
-				return parsed
-			}
-			return 30 * 24 * time.Hour // 6 one-month frames.
-		},
+		framesToBackfill: framesToBackfill,
+		frameLength:      frameLength,
+
+		frameFilter: compression.NewHistoricalFilter(true, maxTime, insightsStore.Handle().DB()),
 
 		allReposIterator: (&discovery.AllReposIterator{
 			DefaultRepoLister:     dbcache.NewDefaultRepoLister(repoStore),
@@ -134,7 +145,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 	// fast as possible without wasting CPU cycles, but in reality the handler itself can take
 	// minutes to hours to complete as it intentionally enqueues work slowly to avoid putting
 	// pressure on the system.
-	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 5*time.Second, goroutine.NewHandlerWithErrorMessage(
+	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 15*time.Minute, goroutine.NewHandlerWithErrorMessage(
 		"insights_historical_enqueuer",
 		historicalEnqueuer.Handler,
 	), operation)
@@ -172,17 +183,18 @@ type RepoStore interface {
 //
 // It works roughly like this:
 //
-// * For every timeframe we want to backfill (e.g. 1 point every week for the past 52 weeks):
 //   * For every repository on Sourcegraph (a subset on Sourcegraph.com):
-//     * Consider yielding/sleeping.
-//     * Find the oldest commit in the repository.
-//       * For every unique search insight series (i.e. search query):
-//         * Consider yielding/sleeping.
-//         * If the series has data for this timeframe+repo already, nothing to do.
-//         * If the timeframe we're generating data for is before the oldest commit in the repo, record a zero value.
-//         * Else, locate the commit nearest to the point in time we're trying to get data for and
-//           enqueue a queryrunner job to search that repository commit - recording historical data
-//           for it.
+//     * Build a list of time frames that we should consider
+//	   * Check the commit index to see if any timeframes can be discarded (if they didn't change)
+//     * For each frame:
+//       * Find the oldest commit in the repository.
+//         * For every unique search insight series (i.e. search query):
+//           * Consider yielding/sleeping.
+//           * If the series has data for this timeframe+repo already, nothing to do.
+//           * If the timeframe we're generating data for is before the oldest commit in the repo, record a zero value.
+//           * Else, locate the commit nearest to the point in time we're trying to get data for and
+//             enqueue a queryrunner job to search that repository commit - recording historical data
+//            for it.
 //
 // As you can no doubt see, there is much complexity and potential room for duplicative API calls
 // here (e.g. "for every timeframe we list every repository"). For this exact reason, we do two
@@ -202,6 +214,7 @@ type historicalEnqueuer struct {
 	enqueueQueryRunnerJob func(ctx context.Context, job *queryrunner.Job) error
 	gitFirstEverCommit    func(ctx context.Context, repoName api.RepoName) (*git.Commit, error)
 	gitFindNearestCommit  func(ctx context.Context, repoName api.RepoName, revSpec string, target time.Time) (*git.Commit, error)
+	frameFilter           compression.DataFrameFilter
 
 	// framesToBackfill describes the number of historical timeframes to backfill data for.
 	framesToBackfill func() int
@@ -250,8 +263,7 @@ func (h *historicalEnqueuer) Handler(ctx context.Context) error {
 }
 
 // buildFrames is invoked to build historical data for all past timeframes that we care about
-// backfilling data for. This is done in small chunks, e.g. 52 frames to backfill with each frame
-// being 7 days long, specifically so that we perform work incrementally.
+// backfilling data for. This is done in small chunks, specifically so that we perform work incrementally.
 //
 // It is only called if there is at least one insights series defined.
 //
@@ -261,54 +273,15 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, uniqueSeries map[s
 		return nil // nothing to do.
 	}
 	var multi error
-	for frame := 0; frame < h.framesToBackfill(); frame++ {
-		// Determine the exact start and end time of this timeframe.
-		from := h.now().Add(-time.Duration(frame+1) * h.frameLength())
-		to := h.now().Add(-time.Duration(frame) * h.frameLength())
-		if h.now().After(h.now().Add(24 * time.Hour)) {
-			// We exclude today because it is the regular enqueuer's job to enqueue work for today.
-			to = to.Add(-24 * time.Hour)
-		}
 
-		// Build historical data for this timeframe.
-		softErr, hardErr := h.buildFrame(ctx, uniqueSeries, sortedSeriesIDs, from, to)
-		if softErr != nil {
-			multi = multierror.Append(multi, softErr)
-			continue
-		}
-		if hardErr != nil {
-			return multierror.Append(multi, hardErr)
-		}
-	}
-	return multi // return any soft errors we encountered
+	frames := Frames(h.framesToBackfill(), h.frameLength(), h.now())
+
+	hardErr := h.allReposIterator(ctx, h.buildForRepo(ctx, uniqueSeries, sortedSeriesIDs, frames, multi))
+	return hardErr
 }
 
-// buildFrame is invoked to build historical data for a specific past timeframe that we care about
-// backfilling data for.
-//
-// It is expected to backfill data for all unique series that are missing data, across all repos
-// (using h.allReposIterator.)
-//
-// It may return both hard errors (e.g. DB connection failure, future frames are unlikely to build)
-// and soft errors (e.g. user made a mistake or we did partial work, future frames will likely
-// succeed.)
-func (h *historicalEnqueuer) buildFrame(
-	ctx context.Context,
-	uniqueSeries map[string]*schema.InsightSeries,
-	sortedSeriesIDs []string,
-	from time.Time,
-	to time.Time,
-) (hardErr, softErr error) {
-	// We yield frequently for a small period of time for a few reasons:
-	//
-	// 1. To not call buildSeries too quickly and enqueue millions of jobs rapidly.
-	// 2. To avoid calling repoStore.GetByName() and git.FirstEverCommit() in a tight
-	//    loop for potentially 500,000+ repositories if there is actually no work to
-	//    perform (because all have had historical data built already.)
-	//
-
-	// For every repository that we want to potentially gather historical data for.
-	hardErr = h.allReposIterator(ctx, func(repoName string) error {
+func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[string]*schema.InsightSeries, sortedSeriesIDs []string, frames []compression.Frame, softErr error) func(repoName string) error {
+	return func(repoName string) error {
 		// Lookup the repository (we need its database ID)
 		repo, err := h.repoStore.GetByName(ctx, api.RepoName(repoName))
 		if err != nil {
@@ -316,8 +289,15 @@ func (h *historicalEnqueuer) buildFrame(
 			// deleted and allReposIterator had it cached.
 			if _, ok := err.(*database.RepoNotFoundErr); !ok {
 				return err // hard DB error
+			} else {
+				return nil
 			}
 		}
+
+		log15.Info("starting frames", "starting_frames", frames)
+
+		filtered := h.frameFilter.FilterFrames(ctx, frames, repo.ID)
+		log15.Info("sampling historical data frames", "repo_id", repo.ID, "frames", frames)
 
 		// Find the first commit made to the repository on the default branch.
 		firstHEADCommit, err := h.gitFirstEverCommit(ctx, api.RepoName(repoName))
@@ -336,46 +316,50 @@ func (h *historicalEnqueuer) buildFrame(
 		// For every series that we want to potentially gather historical data for, try.
 		for _, seriesID := range sortedSeriesIDs {
 			series := uniqueSeries[seriesID]
-			err := h.limiter.Wait(ctx)
-			if err != nil {
-				return err
+
+			for i := len(filtered) - 1; i >= 0; i-- {
+				currentFrame := filtered[i]
+
+				err := h.limiter.Wait(ctx)
+				if err != nil {
+					return err
+				}
+
+				// If we already have data for this frame+repo+series, then there's nothing to do.
+				var numDataPoints int
+				numDataPoints, err = h.insightsStore.CountData(ctx, store.CountDataOpts{
+					From:     &currentFrame.From,
+					To:       &currentFrame.To,
+					SeriesID: &seriesID,
+					RepoID:   &repo.ID,
+				})
+				if err != nil {
+					softErr = multierror.Append(softErr, err)
+				} else if numDataPoints > 0 {
+					continue
+				}
+
+				// Build historical data for this unique timeframe+repo+series.
+				softErr, err = h.buildSeries(ctx, &buildSeriesContext{
+					from:            currentFrame.From,
+					to:              currentFrame.To,
+					repo:            repo,
+					firstHEADCommit: firstHEADCommit,
+					seriesID:        seriesID,
+					series:          series,
+				})
+				if softErr != nil {
+					softErr = multierror.Append(softErr, softErr)
+					continue
+				}
+				if err != nil {
+					return multierror.Append(softErr, err)
+				}
 			}
 
-			// If we already have data for this frame+repo+series, then there's nothing to do.
-			var numDataPoints int
-			numDataPoints, hardErr = h.insightsStore.CountData(ctx, store.CountDataOpts{
-				From:     &from,
-				To:       &to,
-				SeriesID: &seriesID,
-				RepoID:   &repo.ID,
-			})
-			if err != nil {
-				return multierror.Append(softErr, hardErr)
-			}
-			if numDataPoints > 0 {
-				continue
-			}
-
-			// Build historical data for this unique timeframe+repo+series.
-			softErr, hardErr = h.buildSeries(ctx, &buildSeriesContext{
-				from:            from,
-				to:              to,
-				repo:            repo,
-				firstHEADCommit: firstHEADCommit,
-				seriesID:        seriesID,
-				series:          series,
-			})
-			if softErr != nil {
-				softErr = multierror.Append(softErr, softErr)
-				continue
-			}
-			if hardErr != nil {
-				return multierror.Append(softErr, hardErr)
-			}
 		}
 		return nil
-	})
-	return
+	}
 }
 
 // buildSeriesContext describes context/parameters for a call to buildSeries()
@@ -392,6 +376,22 @@ type buildSeriesContext struct {
 	// The series we're building historical data for.
 	seriesID string
 	series   *schema.InsightSeries
+}
+
+func Frames(numFrames int, frameLength time.Duration, current time.Time) []compression.Frame {
+	frames := make([]compression.Frame, 0)
+
+	for frame := 0; frame < numFrames; frame++ {
+		// Determine the exact start and end time of this timeframe.
+		from := current.Add(-time.Duration(frame+1) * frameLength)
+		to := current.Add(-time.Duration(frame) * frameLength)
+
+		frames = append([]compression.Frame{{
+			From: from,
+			To:   to,
+		}}, frames...)
+	}
+	return frames
 }
 
 // buildSeries is invoked to build historical data for every unique timeframe * repo * series that

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -66,7 +66,6 @@ import (
 // to backfill them by enqueueing work for executing searches with `before:` and `after:` filter
 // ranges.
 func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestore.Store, settingStore discovery.SettingStore, insightsStore *store.Store, observationContext *observation.Context) goroutine.BackgroundRoutine {
-	log15.Info("newInsightHistoricalEnqueuer")
 	metrics := metrics.NewOperationMetrics(
 		observationContext.Registerer,
 		"insights_historical_enqueuer",
@@ -294,10 +293,10 @@ func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[
 			}
 		}
 
-		log15.Info("starting frames", "starting_frames", frames)
+		log15.Info("insights: starting frames", "starting_frames", frames)
 
 		filtered := h.frameFilter.FilterFrames(ctx, frames, repo.ID)
-		log15.Info("sampling historical data frames", "repo_id", repo.ID, "frames", frames)
+		log15.Info("insights: sampling historical data frames", "repo_id", repo.ID, "frames", frames)
 
 		// Find the first commit made to the repository on the default branch.
 		firstHEADCommit, err := h.gitFirstEverCommit(ctx, api.RepoName(repoName))

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -35,9 +35,8 @@ func NewHistoricalFilter(enabled bool, maxHistorical time.Time, db dbutil.DB) Da
 			store:         NewCommitStore(db),
 			maxHistorical: maxHistorical,
 		}
-	} else {
-		return &NoopFilter{}
 	}
+	return &NoopFilter{}
 }
 
 func (n *NoopFilter) FilterFrames(ctx context.Context, frames []Frame, id api.RepoID) []Frame {
@@ -75,7 +74,7 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 
 		commits, err := c.store.Get(ctx, id, frame.From, frame.To)
 		if err != nil {
-			log15.Error("compression.go/FilterFrames unable to retrieve commits\n", "repo_id", id, "From", frame.From, "to", frame.To)
+			log15.Error("insights: compression.go/FilterFrames unable to retrieve commits\n", "repo_id", id, "from", frame.From, "to", frame.To)
 			include = append(include, frame)
 			continue
 		}

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -1,0 +1,95 @@
+package compression
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+type CommitFilter struct {
+	store         CommitStore
+	maxHistorical time.Time
+}
+
+type NoopFilter struct {
+}
+
+type Frame struct {
+	From   time.Time
+	To     time.Time
+	Commit string
+}
+
+type DataFrameFilter interface {
+	FilterFrames(ctx context.Context, frames []Frame, id api.RepoID) []Frame
+}
+
+func NewHistoricalFilter(enabled bool, maxHistorical time.Time, db dbutil.DB) DataFrameFilter {
+	if enabled {
+		return &CommitFilter{
+			store:         NewCommitStore(db),
+			maxHistorical: maxHistorical,
+		}
+	} else {
+		return &NoopFilter{}
+	}
+}
+
+func (n *NoopFilter) FilterFrames(ctx context.Context, frames []Frame, id api.RepoID) []Frame {
+	return frames
+}
+
+// FilterFrames will remove any data frames that can be safely skipped from a given frame set and for a given repository.
+func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.RepoID) []Frame {
+	if len(frames) <= 1 {
+		return frames
+	}
+
+	metadata, err := c.store.GetMetadata(ctx, id)
+	if err != nil {
+		// the commit index is considered optional so we can always fall back to every frame in this case
+		return frames
+	}
+
+	include := make([]Frame, 0)
+	// The first frame will always be included to establish a baseline measurement. This is important because
+	// it is possible that the commit index will report zero commits because they may have happened beyond the
+	// horizon of the indexer
+	include = append(include, frames[0])
+
+	// The last frame will always be excluded because this is the frame closest to now. In this case, we will allow
+	// the most recent sample to be resolved from the 'present day recorder' insight_enqueuer.go
+	for i := 1; i < len(frames)-1; i++ {
+		frame := frames[i]
+
+		if metadata.LastIndexedAt.Before(frame.To) {
+			// The commit indexer is not up to date enough to understand if this frame can be dropped
+			include = append(include, frame)
+			continue
+		}
+
+		commits, err := c.store.Get(ctx, id, frame.From, frame.To)
+		if err != nil {
+			log15.Error("compression.go/FilterFrames unable to retrieve commits\n", "repo_id", id, "From", frame.From, "to", frame.To)
+			include = append(include, frame)
+			continue
+		}
+		// TODO(insights): record the commit here to save time having to look up which revhash we need since we already have it
+
+		if len(commits) == 0 {
+			// We have established that
+			// 1. the commit index is sufficiently up to date
+			// 2. this time range [from, to) doesn't have any commits
+			// so we can skip this frame for this repo
+			continue
+		} else {
+			include = append(include, frame)
+		}
+	}
+	return include
+}

--- a/enterprise/internal/insights/compression/compression_test.go
+++ b/enterprise/internal/insights/compression/compression_test.go
@@ -1,0 +1,143 @@
+package compression
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFilterFrames(t *testing.T) {
+
+	ctx := context.Background()
+
+	maxHistorical := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	commitFilter := CommitFilter{
+		maxHistorical: maxHistorical,
+	}
+
+	t.Run("test empty frames", func(t *testing.T) {
+		want := []Frame{}
+		got := commitFilter.FilterFrames(ctx, []Frame{}, 1)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpeted frames filtered from empty input: %v", diff)
+		}
+	})
+
+	t.Run("test one frame", func(t *testing.T) {
+		want := []Frame{{
+			maxHistorical, maxHistorical.Add(time.Second * 500), "abcdef",
+		}}
+		got := commitFilter.FilterFrames(ctx, want, 1)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpeted frames filtered from single input: %v", diff)
+		}
+	})
+
+	t.Run("test unable to fetch metadata", func(t *testing.T) {
+		commitStore := NewMockCommitStore()
+		commitFilter.store = commitStore
+		want := []Frame{{
+			maxHistorical, maxHistorical.Add(time.Second * 500), "abcdef",
+		}, {
+			maxHistorical, maxHistorical.Add(time.Second * 500), "fedcba",
+		}}
+
+		commitStore.GetMetadataFunc.PushReturn(CommitIndexMetadata{}, errors.New("really bad error"))
+
+		got := commitFilter.FilterFrames(ctx, want, 1)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpeted frames when metadata is unavailable: %v", diff)
+		}
+
+	})
+
+	t.Run("test no commits two frames", func(t *testing.T) {
+		commitStore := NewMockCommitStore()
+		commitFilter.store = commitStore
+		input := []Frame{{
+			maxHistorical, maxHistorical.Add(time.Second * 500), "abcdef",
+		}, {
+			maxHistorical, maxHistorical.Add(time.Second * 500), "fedcba",
+		}}
+
+		want := []Frame{{
+			maxHistorical, maxHistorical.Add(time.Second * 500), "abcdef",
+		}}
+
+		got := commitFilter.FilterFrames(ctx, input, 1)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpeted frames when metadata is unavailable: %v", diff)
+		}
+	})
+
+	t.Run("test three frames middle has no commits", func(t *testing.T) {
+		commitStore := NewMockCommitStore()
+		commitFilter.store = commitStore
+		input := []Frame{{
+			toTime("2020-05-01"), toTime("2020-06-01"), "abcdef",
+		}, {
+			toTime("2020-06-01"), toTime("2020-07-01"), "fedcba",
+		}, {
+			toTime("2020-07-01"), toTime("2020-08-01"), "111222333",
+		}}
+
+		commitStore.GetMetadataFunc.PushReturn(CommitIndexMetadata{
+			RepoId:        1,
+			Enabled:       true,
+			LastIndexedAt: toTime("2021-01-01"),
+		}, nil)
+
+		// The middle commit will actually be the first one to call Get
+		commitStore.GetFunc.PushReturn([]CommitStamp{}, nil)
+
+		want := []Frame{input[0]}
+
+		got := commitFilter.FilterFrames(ctx, input, 1)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpeted frames: %v", diff)
+		}
+	})
+
+	t.Run("test three frames middle has no commits but index is behind", func(t *testing.T) {
+		commitStore := NewMockCommitStore()
+		commitFilter.store = commitStore
+		input := []Frame{{
+			toTime("2020-05-01"), toTime("2020-06-01"), "abcdef",
+		}, {
+			toTime("2020-06-01"), toTime("2020-07-01"), "fedcba",
+		}, {
+			toTime("2020-07-01"), toTime("2020-08-01"), "111222333",
+		}}
+
+		commitStore.GetMetadataFunc.PushReturn(CommitIndexMetadata{
+			RepoId:        1,
+			Enabled:       true,
+			LastIndexedAt: toTime("2020-06-02"),
+		}, nil)
+
+		commitStore.GetFunc.PushReturn([]CommitStamp{}, nil)
+
+		want := []Frame{input[0], input[1]}
+
+		got := commitFilter.FilterFrames(ctx, input, 1)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpeted frames: %v", diff)
+		}
+	})
+}
+
+func toTime(date string) time.Time {
+	result, _ := time.Parse("2006-01-02", date)
+	return result
+}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -115,6 +115,6 @@ func TestResolver_InsightSeries(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Want("insights[0][0].Points mocked", "[{p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:1 Metadata:[]}} {p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:2 Metadata:[]}} {p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:3 Metadata:[]}}]").Equal(t, fmt.Sprintf("%+v", points))
+		autogold.Want("insights[0][0].Points mocked", "[{p:{SeriesID: Time:{wall:0 ext:63271811045 loc:<nil>} Value:1 Metadata:[]}} {p:{SeriesID: Time:{wall:0 ext:63271811045 loc:<nil>} Value:2 Metadata:[]}} {p:{SeriesID: Time:{wall:0 ext:63271811045 loc:<nil>} Value:3 Metadata:[]}}]").Equal(t, fmt.Sprintf("%+v", points))
 	})
 }

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -149,25 +149,10 @@ order by interval_time desc
 //    thus the interval between data points may be irregular.
 // 4. Searches may not complete at the same exact time, so even in a perfect world if the interval
 //    should be 12h it may be off by a minute or so.
+// 5. Intervals that are missing a data point will need to resolve the last observation and carry it forward.
 //
 // Additionally, it is important to note that there may be data points associated with a repo OR not
 // associated with a repo at all (global.)
-//
-// Because we want 1 point per N interval, and do not want to display duplicate points in the UI, we
-// use a time_bucket() with an MAX() aggregation. This gives us one data point for some time interval,
-// even if multiple were recorded in that timeframe.
-//
-// One goal of this query is to get e.g. the total number of search results (value) across all repos
-// (or some subset selected by the WHERE clause.) In this case, you can imagine each repo having its
-// results recorded at the 12h interval. There may be duplicate points. The subquery uses a time_bucket()
-// and MAX() aggregation to get the "# of search results per unique repository", eliminating duplicate
-// data points, and the top-level SUM() adds those together to get "# of search results across all
-// repositories."
-//
-// Another goal of this query is to get e.g. "total # of services (value) deployed at our company",
-// in which case `repo_id` and other repo fields will be NULL. The inner query still eliminates potential
-// duplicate data points and the outer query in this case just SUMs one data point (as we don't have
-// points per repository.)
 
 func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 	preds := []*sqlf.Query{}

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -66,6 +66,7 @@ var _ Interface = &Store{}
 // otherwise.
 type SeriesPoint struct {
 	// Time (always UTC).
+	SeriesID string
 	Time     time.Time
 	Value    float64
 	Metadata []byte
@@ -93,12 +94,15 @@ type SeriesPointsOpts struct {
 	Limit int
 }
 
-// SeriesPoints queries data points over time for a specific insights' series.
+//SeriesPoints queries data points over time for a specific insights' series.
 func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error) {
 	points := make([]SeriesPoint, 0, opts.Limit)
-	err := s.query(ctx, seriesPointsQuery(opts), func(sc scanner) error {
+
+	q := seriesPointsQuery(opts)
+	err := s.query(ctx, q, func(sc scanner) error {
 		var point SeriesPoint
 		err := sc.Scan(
+			&point.SeriesID,
 			&point.Time,
 			&point.Value,
 			&point.Metadata,
@@ -111,6 +115,25 @@ func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]Seri
 	})
 	return points, err
 }
+
+// This query is a barebones implementation of per-repo per-series last-observation carried forward. Long term
+// this query is too expensive to run in real-time and should be moved to a materialized view.
+const lastObservationCarriedPointsSql = `select sub.series_id, sub.interval_time, sum(value) as value, null as metadata from (WITH target_times AS (SELECT *
+FROM GENERATE_SERIES(CURRENT_TIMESTAMP::date - INTERVAL '6 months', CURRENT_TIMESTAMP::date, '2 weeks') as interval_time)
+SELECT sub.series_id, sub.repo_id, sub.value, interval_time
+FROM (select distinct repo_id, series_id from series_points) as r
+cross join target_times tt
+join LATERAL (
+    select sp.* from series_points as sp
+    where sp.repo_id = r.repo_id and sp.time <= tt.interval_time and sp.series_id = r.series_id
+    order by time DESC
+    limit 1
+    ) sub on sub.repo_id = r.repo_id and r.series_id = sub.series_id
+order by interval_time, repo_id) as sub
+where %s
+group by sub.series_id, sub.interval_time
+order by interval_time desc
+`
 
 // Note that the series_points table may contain duplicate points, or points recorded at irregular
 // intervals. In specific:
@@ -145,26 +168,6 @@ func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]Seri
 // in which case `repo_id` and other repo fields will be NULL. The inner query still eliminates potential
 // duplicate data points and the outer query in this case just SUMs one data point (as we don't have
 // points per repository.)
-var seriesPointsQueryFmtstr = `
--- source: enterprise/internal/insights/store/store.go:SeriesPoints
-SELECT sub.time_bucket,
-	SUM(sub.max),
-	sub.metadata
-FROM (
-	SELECT time_bucket(INTERVAL '15 days', time) AS time_bucket,
-		MAX(value),
-		m.metadata,
-		series_id,
-		repo_id
-	FROM series_points p
-	LEFT JOIN metadata m ON p.metadata_id = m.id
-	WHERE %s
-	GROUP BY time_bucket, metadata, series_id, repo_id
-	ORDER BY time_bucket DESC
-) sub
-GROUP BY time_bucket, metadata
-ORDER BY time_bucket DESC
-`
 
 func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 	preds := []*sqlf.Query{}
@@ -176,21 +179,21 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 		preds = append(preds, sqlf.Sprintf("repo_id = %d", int32(*opts.RepoID)))
 	}
 	if opts.From != nil {
-		preds = append(preds, sqlf.Sprintf("time >= %s", *opts.From))
+		preds = append(preds, sqlf.Sprintf("interval_time >= %s", *opts.From))
 	}
 	if opts.To != nil {
-		preds = append(preds, sqlf.Sprintf("time <= %s", *opts.To))
-	}
-
-	if len(preds) == 0 {
-		preds = append(preds, sqlf.Sprintf("TRUE"))
+		preds = append(preds, sqlf.Sprintf("interval_time <= %s", *opts.To))
 	}
 	limitClause := ""
 	if opts.Limit > 0 {
 		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
 	}
+
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
 	return sqlf.Sprintf(
-		seriesPointsQueryFmtstr+limitClause,
+		lastObservationCarriedPointsSql+limitClause,
 		sqlf.Join(preds, "\n AND "),
 	)
 }

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
@@ -269,10 +271,21 @@ func TestRecordSeriesPoints(t *testing.T) {
 		t.Fatal(err)
 	}
 	autogold.Want("len(points)", int(4)).Equal(t, len(points))
-	autogold.Want("points[0].String()", want[0].String()).Equal(t, points[0].String())
-	autogold.Want("points[1].String()", want[1].String()).Equal(t, points[1].String())
-	autogold.Want("points[2].String()", want[2].String()).Equal(t, points[2].String())
-	autogold.Want("points[3].String()", want[3].String()).Equal(t, points[3].String())
+	if diff := cmp.Diff(4, len(points)); diff != "" {
+		t.Errorf("len(points): %v", diff)
+	}
+	if diff := cmp.Diff(want[0], points[0]); diff != "" {
+		t.Errorf("points[0].String(): %v", diff)
+	}
+	if diff := cmp.Diff(want[1], points[1]); diff != "" {
+		t.Errorf("points[1].String(): %v", diff)
+	}
+	if diff := cmp.Diff(want[2], points[2]); diff != "" {
+		t.Errorf("points[2].String(): %v", diff)
+	}
+	if diff := cmp.Diff(want[3], points[3]); diff != "" {
+		t.Errorf("points[3].String(): %v", diff)
+	}
 
 	// TODO: future: once querying by RepoName and/or OriginalRepoName is possible, test that here:
 	// // Confirm querying by repo name works as expected.

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -52,7 +52,7 @@ SELECT time,
     2,
     (SELECT id FROM repo_names WHERE name = 'github.com/gorilla/mux-renamed'),
     (SELECT id FROM repo_names WHERE name = 'github.com/gorilla/mux-original')
-	FROM generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-06-01 00:00:00', INTERVAL '240 min') AS time;
+	FROM GENERATE_SERIES(CURRENT_TIMESTAMP::date - INTERVAL '6 months', CURRENT_TIMESTAMP::date, '2 weeks') AS time;
 `)
 	if err != nil {
 		t.Fatal(err)
@@ -72,9 +72,8 @@ SELECT time,
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Want("SeriesPoints(2).len", int(12)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(2)[len()-1].String()", `SeriesPoint{Time: "2019-12-19 00:00:00 +0000 UTC", Value: 38.50014526394119, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
-		autogold.Want("SeriesPoints(2)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
+		t.Log(points)
+		autogold.Want("SeriesPoints(2).len", int(14)).Equal(t, len(points))
 	})
 
 	t.Run("subset of data", func(t *testing.T) {
@@ -86,9 +85,7 @@ SELECT time,
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Want("SeriesPoints(3).len", int(8)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(3)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
-		autogold.Want("SeriesPoints(3)[len()-1].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 36.186608083675935, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
+		autogold.Want("SeriesPoints(3).len", int(0)).Equal(t, len(points))
 	})
 
 	t.Run("latest 3 points", func(t *testing.T) {
@@ -100,9 +97,6 @@ SELECT time,
 			t.Fatal(err)
 		}
 		autogold.Want("SeriesPoints(4).len", int(3)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(4)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
-		autogold.Want("SeriesPoints(4)[1].String()", `SeriesPoint{Time: "2020-05-17 00:00:00 +0000 UTC", Value: 39.775432350908204, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[1].String())
-		autogold.Want("SeriesPoints(4)[2].String()", `SeriesPoint{Time: "2020-05-02 00:00:00 +0000 UTC", Value: 39.61012571588327, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[2].String())
 	})
 
 }
@@ -211,33 +205,40 @@ func TestRecordSeriesPoints(t *testing.T) {
 	defer cleanup()
 	store := NewWithClock(timescale, clock)
 
-	time := func(s string) time.Time {
-		v, err := time.Parse(time.RFC3339, s)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return v
-	}
+	//toTime := func(s string) time.Time {
+	//	v, err := time.Parse(time.RFC3339, s)
+	//	if err != nil {
+	//		t.Fatal(err)
+	//	}
+	//	return v
+	//}
 	optionalString := func(v string) *string { return &v }
 	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
 
-	// Record some data points.
+	current := time.Now().Truncate(24 * time.Hour)
+
+	// Record points that will verify last-observation carried forward. The last point should roll over two time frames.
+	// Metadata is currently not queried and will not resolve to reduce cardinality.
 	for _, record := range []RecordSeriesPointArgs{
 		{
 			SeriesID: "one",
-			Point:    SeriesPoint{Time: time("2020-03-01T00:00:00Z"), Value: 1.1},
+			Point:    SeriesPoint{Time: current, Value: 1.1},
 			RepoName: optionalString("repo1"),
 			RepoID:   optionalRepoID(3),
 			Metadata: map[string]interface{}{"some": "data"},
 		},
 		{
-			SeriesID: "two",
-			Point:    SeriesPoint{Time: time("2020-03-02T00:00:00Z"), Value: 2.2},
+			SeriesID: "one",
+			Point:    SeriesPoint{Time: current.Add(-time.Hour * 24 * 15), Value: 2.2},
+			RepoName: optionalString("repo1"),
+			RepoID:   optionalRepoID(3),
 			Metadata: []interface{}{"some", "data", "two"},
 		},
 		{
-			SeriesID: "no metadata",
-			Point:    SeriesPoint{Time: time("2020-03-03T00:00:00Z"), Value: 3.3},
+			SeriesID: "one",
+			Point:    SeriesPoint{Time: current.Add(-time.Hour * 24 * 43), Value: 3.3},
+			RepoName: optionalString("repo1"),
+			RepoID:   optionalRepoID(3),
 			Metadata: nil,
 		},
 	} {
@@ -246,23 +247,47 @@ func TestRecordSeriesPoints(t *testing.T) {
 		}
 	}
 
+	want := []SeriesPoint{
+		{
+			SeriesID: "one",
+			Time:     current,
+			Value:    1.1,
+		},
+		{
+			SeriesID: "one",
+			Time:     current.Add(-time.Hour * 24 * 14),
+			Value:    2.2,
+		},
+		{
+			SeriesID: "one",
+			Time:     current.Add(-time.Hour * 24 * 28),
+			Value:    3.3,
+		},
+		{
+			SeriesID: "one",
+			Time:     current.Add(-time.Hour * 24 * 42),
+			Value:    3.3,
+		},
+	}
+
 	// Confirm we get the expected data back.
 	points, err := store.SeriesPoints(ctx, SeriesPointsOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	autogold.Want("len(points)", int(3)).Equal(t, len(points))
-	autogold.Want("points[0].String()", `SeriesPoint{Time: "2020-03-03 00:00:00 +0000 UTC", Value: 3.3, Metadata: }`).Equal(t, points[0].String())
-	autogold.Want("points[1].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 2.2, Metadata: ["some", "data", "two"]}`).Equal(t, points[1].String())
-	autogold.Want("points[2].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 1.1, Metadata: {"some": "data"}}`).Equal(t, points[2].String())
+	autogold.Want("len(points)", int(4)).Equal(t, len(points))
+	autogold.Want("points[0].String()", want[0].String()).Equal(t, points[0].String())
+	autogold.Want("points[1].String()", want[1].String()).Equal(t, points[1].String())
+	autogold.Want("points[2].String()", want[2].String()).Equal(t, points[2].String())
+	autogold.Want("points[3].String()", want[3].String()).Equal(t, points[3].String())
 
-	// Confirm querying by repo ID works as expected.
-	forRepoIDPoints, err := store.SeriesPoints(ctx, SeriesPointsOpts{RepoID: optionalRepoID(3)})
-	if err != nil {
-		t.Fatal(err)
-	}
-	autogold.Want("len(forRepoIDPoints)", int(1)).Equal(t, len(forRepoIDPoints))
-	autogold.Want("forRepoIDPoints[0].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 1.1, Metadata: {"some": "data"}}`).Equal(t, forRepoIDPoints[0].String())
+	//// Confirm querying by repo ID works as expected.
+	//forRepoIDPoints, err := store.SeriesPoints(ctx, SeriesPointsOpts{RepoID: optionalRepoID(3)})
+	//if err != nil {
+	//	t.Fatal(err)
+	//}
+	//autogold.Want("len(forRepoIDPoints)", int(1)).Equal(t, len(forRepoIDPoints))
+	//autogold.Want("forRepoIDPoints[0].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 1.1, Metadata: {"some": "data"}}`).Equal(t, forRepoIDPoints[0].String())
 
 	// TODO: future: once querying by RepoName and/or OriginalRepoName is possible, test that here:
 	// // Confirm querying by repo name works as expected.

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -274,14 +274,6 @@ func TestRecordSeriesPoints(t *testing.T) {
 	autogold.Want("points[2].String()", want[2].String()).Equal(t, points[2].String())
 	autogold.Want("points[3].String()", want[3].String()).Equal(t, points[3].String())
 
-	//// Confirm querying by repo ID works as expected.
-	//forRepoIDPoints, err := store.SeriesPoints(ctx, SeriesPointsOpts{RepoID: optionalRepoID(3)})
-	//if err != nil {
-	//	t.Fatal(err)
-	//}
-	//autogold.Want("len(forRepoIDPoints)", int(1)).Equal(t, len(forRepoIDPoints))
-	//autogold.Want("forRepoIDPoints[0].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 1.1, Metadata: {"some": "data"}}`).Equal(t, forRepoIDPoints[0].String())
-
 	// TODO: future: once querying by RepoName and/or OriginalRepoName is possible, test that here:
 	// // Confirm querying by repo name works as expected.
 	// forRepoNamePoints, err := store.SeriesPoints(ctx, SeriesPointsOpts{RepoName: optionalString("repo1")})

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -205,13 +205,6 @@ func TestRecordSeriesPoints(t *testing.T) {
 	defer cleanup()
 	store := NewWithClock(timescale, clock)
 
-	//toTime := func(s string) time.Time {
-	//	v, err := time.Parse(time.RFC3339, s)
-	//	if err != nil {
-	//		t.Fatal(err)
-	//	}
-	//	return v
-	//}
 	optionalString := func(v string) *string { return &v }
 	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
 

--- a/migrations/codeinsights/1000000007_series_points_index.down.sql
+++ b/migrations/codeinsights/1000000007_series_points_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS series_points_series_id_repo_id_time_idx;
+
+COMMIT;

--- a/migrations/codeinsights/1000000007_series_points_index.up.sql
+++ b/migrations/codeinsights/1000000007_series_points_index.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS series_points_series_id_repo_id_time_idx ON series_points (series_id, repo_id, time);
+
+COMMIT;


### PR DESCRIPTION
Part of #21784 

This PR introduces an optimizer that will compress the number of historical data frames that need to be queried by polling against an index of commits.

The method of resolving points from the database had to be changed, and for now supports a fixed 6 month span at 2 weeks intervals (similar as before), but will align data points using last observation carried forward.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
