### PR TITLE
gitserver: Reduce the number of repos we iterate over

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -306,14 +307,24 @@ func (s *Server) Janitor(interval time.Duration) {
 	}
 }
 
-// SyncRepoState syncs state on disk to the database for all repos and is expected to
-// run in a background goroutine.
+// SyncRepoState syncs state on disk to the database for all repos and is
+// expected to run in a background goroutine. We perform a full sync the first
+// time or if the known gitserver addresses has changed since the last run.
+// Otherwise, we only sync repos that have not yet been assigned a shard.
 func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int) {
+	fullSync := true
+	var previousAddrs []string
 	for {
 		addrs := conf.Get().ServiceConnections.GitServers
-		if err := s.syncRepoState(addrs, batchSize, perSecond); err != nil {
+		if !reflect.DeepEqual(addrs, previousAddrs) {
+			fullSync = true
+		}
+		// Copy addrs since we don't want to keep a pointer into the config struct
+		previousAddrs = append(previousAddrs[0:0], addrs...)
+		if err := s.syncRepoState(addrs, batchSize, perSecond, fullSync); err != nil {
 			log15.Error("Syncing repo state", "error ", err)
 		}
+		fullSync = false
 		time.Sleep(interval)
 	}
 }
@@ -348,7 +359,16 @@ var (
 	}, []string{"success"})
 )
 
-func (s *Server) syncRepoState(addrs []string, batchSize, perSecond int) error {
+func (s *Server) syncRepoState(addrs []string, batchSize, perSecond int, fullSync bool) error {
+	log15.Info("starting syncRepoState", "fullSync", fullSync)
+
+	// When fullSync is true we'll scan all repos in the database and ensure we set
+	// their clone state and assign any that belong to this shard with the correct
+	// shard_id.
+	//
+	// When fullSync is false, we assume that we only need to check repos that have
+	// not yet had their shard_id allocated.
+
 	// Sanity check our host exists in addrs before starting any work
 	var found bool
 	for _, a := range addrs {
@@ -407,7 +427,11 @@ func (s *Server) syncRepoState(addrs []string, batchSize, perSecond int) error {
 	}
 
 	var count int
-	err = store.IterateRepoGitserverStatus(ctx, func(repo types.RepoGitserverStatus) error {
+	options := database.IterateRepoGitserverStatusOptions{}
+	if !fullSync {
+		options.OnlyWithoutShard = true
+	}
+	err = store.IterateRepoGitserverStatus(ctx, options, func(repo types.RepoGitserverStatus) error {
 		count++
 		repoSyncStatePercentComplete.Set((float64(count) / float64(totalRepos)) * 100)
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -931,7 +931,7 @@ func TestSyncRepoState(t *testing.T) {
 		t.Fatal("Expected an error")
 	}
 
-	err = s.syncRepoState([]string{hostname}, 10, 10)
+	err = s.syncRepoState([]string{hostname}, 10, 10, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -95,7 +95,7 @@ FROM repo
     WHERE repo.deleted_at IS NULL
 `
 	if options.OnlyWithoutShard {
-		q = q + "AND shard_id = ''"
+		q = q + "AND (gr.shard_id = '' OR gr IS NULL)"
 	}
 
 	rows, err := s.Query(ctx, sqlf.Sprintf(q))

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -67,11 +67,16 @@ INSERT INTO
 	return errors.Wrap(err, "creating GitserverRepo")
 }
 
+type IterateRepoGitserverStatusOptions struct {
+	// If set, will only iterate over repos that have not been assigned to a shard
+	OnlyWithoutShard bool
+}
+
 // IterateRepoGitserverStatus iterates over the status of all repos by joining
 // our repo and gitserver_repos table. It is possible for us not to have a
 // corresponding row in gitserver_repos yet. repoFn will be called once for each
 // row. If it returns an error we'll abort iteration.
-func (s *GitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, repoFn func(repo types.RepoGitserverStatus) error) error {
+func (s *GitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions, repoFn func(repo types.RepoGitserverStatus) error) error {
 	if repoFn == nil {
 		return errors.New("nil repoFn")
 	}
@@ -89,6 +94,9 @@ FROM repo
     LEFT JOIN gitserver_repos gr ON gr.repo_id = repo.id
     WHERE repo.deleted_at IS NULL
 `
+	if options.OnlyWithoutShard {
+		q = q + "AND shard_id = ''"
+	}
 
 	rows, err := s.Query(ctx, sqlf.Sprintf(q))
 	if err != nil {

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -58,7 +58,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	var statusCount int
 
 	// Iterate
-	err = GitserverRepos(db).IterateRepoGitserverStatus(ctx, func(repo types.RepoGitserverStatus) error {
+	err = GitserverRepos(db).IterateRepoGitserverStatus(ctx, IterateRepoGitserverStatusOptions{}, func(repo types.RepoGitserverStatus) error {
 		repoCount++
 		if repo.GitserverRepo != nil {
 			statusCount++
@@ -80,6 +80,20 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	wantStatusCount := 1
 	if statusCount != wantStatusCount {
 		t.Fatalf("Expected %d statuses, got %d", wantStatusCount, statusCount)
+	}
+
+	var noShardCount int
+	// Iterate again against repos with no shard
+	err = GitserverRepos(db).IterateRepoGitserverStatus(ctx, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true}, func(repo types.RepoGitserverStatus) error {
+		noShardCount++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if noShardCount != 1 {
+		t.Fatalf("Want %d, got %d", 1, noShardCount)
 	}
 }
 

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -92,8 +92,9 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if noShardCount != 1 {
-		t.Fatalf("Want %d, got %d", 1, noShardCount)
+	wantNoShardCount := 1
+	if noShardCount != wantNoShardCount {
+		t.Fatalf("Want %d, got %d", wantNoShardCount, noShardCount)
 	}
 }
 


### PR DESCRIPTION
The main purpose of the change is to stop gitsever from iterating over
ALL repos in the database every 10 minutes.

Once we've iterated over all repos at least once without error we can be
sure that they have all been assigned a shard_id. On subsequent
iterations we only need to sync repos that don't yet have a shard_id.
Each instance currently takes care of updating clone status on demand.

As a special case, we need to ensure that we always perform a full sync
again if the gitserver addresses change as this leads to a full
rebalance with our current sharding method as it used md5 hashes.
