### PR TITLE
Add Code Insights dashboard insights fetching

### DIFF
--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -149,7 +149,12 @@ export interface FlatExtensionHostAPI {
 
     // Views
     getPanelViews: () => ProxySubscribable<PanelViewData[]>
-    getInsightsViews: (context: ViewContexts['insightsPage']) => ProxySubscribable<ViewProviderResult[]>
+    getInsightsViews: (
+        context: ViewContexts['insightsPage'],
+        // Resolve only insights that were included in that
+        // ids list. Used for the insights dashboard functionality.
+        insightIds?: string[]
+    ) => ProxySubscribable<ViewProviderResult[]>
     getHomepageViews: (context: ViewContexts['homepage']) => ProxySubscribable<ViewProviderResult[]>
     getGlobalPageViews: (context: ViewContexts['global/page']) => ProxySubscribable<ViewProviderResult[]>
     getDirectoryViews: (

--- a/client/shared/src/api/extension/api/getInsightsViews.ts
+++ b/client/shared/src/api/extension/api/getInsightsViews.ts
@@ -1,0 +1,40 @@
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { ContributableViewContainer } from '../../protocol'
+import { RegisteredViewProvider, ViewContexts, ViewProviderResult } from '../extensionHostApi'
+
+import { callViewProvidersInParallel } from './callViewProvidersInParallel'
+import { proxySubscribable, ProxySubscribable } from './common'
+
+type InsightsPageViewContextType = typeof ContributableViewContainer.InsightsPage
+type InsightsPageContext = ViewContexts[InsightsPageViewContextType]
+
+/**
+ * Returns insights result list for the insights page.
+ *
+ * @param context - Insights page context meta data.
+ * @param providers - List of all insights providers.
+ */
+export function getInsightsViews(
+    context: InsightsPageContext,
+    providers: Observable<readonly RegisteredViewProvider<InsightsPageViewContextType>[]>
+): ProxySubscribable<ViewProviderResult[]> {
+    const dashboardInsights = providers.pipe(
+        map(providers =>
+            providers.filter(provider => {
+                // If insight ids was specified we should resolve only
+                // insights from this list
+                if (context.insightIds) {
+                    return context.insightIds.includes(provider.id)
+                }
+
+                // Otherwise we are in all insights mode and have to resolve
+                // all insights that we have.
+                return true
+            })
+        )
+    )
+
+    return proxySubscribable(callViewProvidersInParallel(context, dashboardInsights))
+}

--- a/client/shared/src/api/extension/api/getInsightsViews.ts
+++ b/client/shared/src/api/extension/api/getInsightsViews.ts
@@ -15,18 +15,21 @@ type InsightsPageContext = ViewContexts[InsightsPageViewContextType]
  *
  * @param context - Insights page context meta data.
  * @param providers - List of all insights providers.
+ * @param insightIds - list of insights ids to resolve from the providers.
  */
 export function getInsightsViews(
     context: InsightsPageContext,
-    providers: Observable<readonly RegisteredViewProvider<InsightsPageViewContextType>[]>
+    providers: Observable<readonly RegisteredViewProvider<InsightsPageViewContextType>[]>,
+    insightIds?: string[]
 ): ProxySubscribable<ViewProviderResult[]> {
+    const insightsIdSet = new Set(insightIds)
     const dashboardInsights = providers.pipe(
         map(providers =>
             providers.filter(provider => {
                 // If insight ids was specified we should resolve only
                 // insights from this list
-                if (context.insightIds) {
-                    return context.insightIds.includes(provider.id)
+                if (insightIds) {
+                    return insightsIdSet.has(provider.id)
                 }
 
                 // Otherwise we are in all insights mode and have to resolve

--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -425,7 +425,8 @@ export function createExtensionHostAPI(state: ExtensionHostState): FlatExtension
                 )
             ),
 
-        getInsightsViews: context => getInsightsViews(context, state.insightsPageViewProviders),
+        getInsightsViews: (context, insightIds) =>
+            getInsightsViews(context, state.insightsPageViewProviders, insightIds),
         getHomepageViews: context => proxySubscribable(callViewProviders(context, state.homepageViewProviders)),
         getGlobalPageViews: context => proxySubscribable(callViewProviders(context, state.globalPageViewProviders)),
         getDirectoryViews: context =>
@@ -639,11 +640,7 @@ function mergeLinkPreviews(
 export interface ViewContexts {
     [ContributableViewContainer.Panel]: never
     [ContributableViewContainer.Homepage]: {}
-    [ContributableViewContainer.InsightsPage]: {
-        // Resolve only insights that were included in that
-        // ids list. Used for the insights dashboard functionality.
-        insightIds?: string[]
-    }
+    [ContributableViewContainer.InsightsPage]: {}
     [ContributableViewContainer.GlobalPage]: Record<string, string>
     [ContributableViewContainer.Directory]: sourcegraph.DirectoryViewContext
 }

--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -26,7 +26,6 @@ import { FlatExtensionHostAPI } from '../contract'
 import { ContributableViewContainer, TextDocumentPositionParameters } from '../protocol'
 import { ExtensionViewer, ViewerId, ViewerWithPartialModel } from '../viewerTypes'
 
-import { callViewProvidersInParallel } from './api/callViewProvidersInParallel'
 import { ExtensionCodeEditor } from './api/codeEditor'
 import { providerResultToObservable, ProxySubscribable, proxySubscribable } from './api/common'
 import { computeContext, Context, ContributionScope } from './api/context/context'
@@ -38,6 +37,7 @@ import {
 } from './api/contribution'
 import { validateFileDecoration } from './api/decorations'
 import { ExtensionDirectoryViewer } from './api/directoryViewer'
+import { getInsightsViews } from './api/getInsightsViews'
 import { ExtensionDocument } from './api/textDocument'
 import { fromLocation, toPosition } from './api/types'
 import { ExtensionWorkspaceRoot } from './api/workspaceRoot'
@@ -425,8 +425,7 @@ export function createExtensionHostAPI(state: ExtensionHostState): FlatExtension
                 )
             ),
 
-        getInsightsViews: context =>
-            proxySubscribable(callViewProvidersInParallel(context, state.insightsPageViewProviders)),
+        getInsightsViews: context => getInsightsViews(context, state.insightsPageViewProviders),
         getHomepageViews: context => proxySubscribable(callViewProviders(context, state.homepageViewProviders)),
         getGlobalPageViews: context => proxySubscribable(callViewProviders(context, state.globalPageViewProviders)),
         getDirectoryViews: context =>
@@ -640,7 +639,11 @@ function mergeLinkPreviews(
 export interface ViewContexts {
     [ContributableViewContainer.Panel]: never
     [ContributableViewContainer.Homepage]: {}
-    [ContributableViewContainer.InsightsPage]: {}
+    [ContributableViewContainer.InsightsPage]: {
+        // Resolve only insights that were included in that
+        // ids list. Used for the insights dashboard functionality.
+        insightIds?: string[]
+    }
     [ContributableViewContainer.GlobalPage]: Record<string, string>
     [ContributableViewContainer.Directory]: sourcegraph.DirectoryViewContext
 }

--- a/client/web/src/insights/InsightsRouter.tsx
+++ b/client/web/src/insights/InsightsRouter.tsx
@@ -73,9 +73,9 @@ export const InsightsRouter = withAuthenticatedUser<InsightsRouterProps>(props =
 
             {codeInsightsDashboards && (
                 <Route
-                    path={`${match.url}/dashboard/:id?`}
-                    render={(props: RouteComponentProps<{ id: string }>) => (
-                        <DashboardsLazyPage dashboardID={props.match.params.id} {...outerProps} />
+                    path={`${match.url}/dashboard/:dashboardId?`}
+                    render={(props: RouteComponentProps<{ dashboardId: string }>) => (
+                        <DashboardsLazyPage dashboardID={props.match.params.dashboardId} {...outerProps} />
                     )}
                 />
             )}

--- a/client/web/src/insights/InsightsRouter.tsx
+++ b/client/web/src/insights/InsightsRouter.tsx
@@ -71,7 +71,14 @@ export const InsightsRouter = withAuthenticatedUser<InsightsRouterProps>(props =
                 )}
             />
 
-            {codeInsightsDashboards && <Route path={`${match.url}/dashboard`} render={() => <DashboardsLazyPage />} />}
+            {codeInsightsDashboards && (
+                <Route
+                    path={`${match.url}/dashboard/:id?`}
+                    render={(props: RouteComponentProps<{ id: string }>) => (
+                        <DashboardsLazyPage dashboardID={props.match.params.id} {...outerProps} />
+                    )}
+                />
+            )}
 
             <Route component={NotFoundPage} key="hardcoded-key" />
         </Switch>

--- a/client/web/src/insights/core/backend/api/get-combined-views.ts
+++ b/client/web/src/insights/core/backend/api/get-combined-views.ts
@@ -1,6 +1,6 @@
 import { Remote } from 'comlink'
 import { combineLatest, from, Observable, of } from 'rxjs'
-import { catchError, map, switchMap } from 'rxjs/operators'
+import { catchError, map, startWith, switchMap } from 'rxjs/operators'
 
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
@@ -31,18 +31,21 @@ export const getCombinedViews = (
             )
         ),
         fetchBackendInsights().pipe(
+            startWith(null),
             map(backendInsights =>
-                backendInsights.map(
-                    (insight, index): ViewInsightProviderResult => ({
-                        id: `Backend insight ${index + 1}`,
-                        view: {
-                            title: insight.title,
-                            subtitle: insight.description,
-                            content: [createViewContent(insight)],
-                        },
-                        source: ViewInsightProviderSourceType.Backend,
-                    })
-                )
+                backendInsights === null
+                    ? [{  id: 'Backend insights', view: undefined, source: ViewInsightProviderSourceType.Backend, }]
+                    : backendInsights?.map(
+                        (insight, index): ViewInsightProviderResult => ({
+                            id: `Backend insight ${index + 1}`,
+                            view: {
+                                title: insight.title,
+                                subtitle: insight.description,
+                                content: [createViewContent(insight)],
+                            },
+                            source: ViewInsightProviderSourceType.Backend,
+                        })
+                    )
             ),
             catchError(error =>
                 of<ViewInsightProviderResult[]>([

--- a/client/web/src/insights/core/backend/api/get-combined-views.ts
+++ b/client/web/src/insights/core/backend/api/get-combined-views.ts
@@ -57,13 +57,14 @@ export const getCombinedViews = (
     ]).pipe(map(([extensionViews, backendInsights]) => [...backendInsights, ...extensionViews]))
 
 /**
- * Get insights views for insights page.
- * */
+ * Get insights views for the insights page.
+ */
 export const getInsightCombinedViews = (
-    extensionApi: Promise<Remote<FlatExtensionHostAPI>>
+    extensionApi: Promise<Remote<FlatExtensionHostAPI>>,
+    insightIds?: string[]
 ): Observable<ViewInsightProviderResult[]> =>
     getCombinedViews(() =>
         from(extensionApi).pipe(
-            switchMap(extensionHostAPI => wrapRemoteObservable(extensionHostAPI.getInsightsViews({})))
+            switchMap(extensionHostAPI => wrapRemoteObservable(extensionHostAPI.getInsightsViews({ insightIds })))
         )
     )

--- a/client/web/src/insights/core/backend/api/get-combined-views.ts
+++ b/client/web/src/insights/core/backend/api/get-combined-views.ts
@@ -34,18 +34,18 @@ export const getCombinedViews = (
             startWith(null),
             map(backendInsights =>
                 backendInsights === null
-                    ? [{  id: 'Backend insights', view: undefined, source: ViewInsightProviderSourceType.Backend, }]
+                    ? [{ id: 'Backend insights', view: undefined, source: ViewInsightProviderSourceType.Backend }]
                     : backendInsights?.map(
-                        (insight, index): ViewInsightProviderResult => ({
-                            id: `Backend insight ${index + 1}`,
-                            view: {
-                                title: insight.title,
-                                subtitle: insight.description,
-                                content: [createViewContent(insight)],
-                            },
-                            source: ViewInsightProviderSourceType.Backend,
-                        })
-                    )
+                          (insight, index): ViewInsightProviderResult => ({
+                              id: `Backend insight ${index + 1}`,
+                              view: {
+                                  title: insight.title,
+                                  subtitle: insight.description,
+                                  content: [createViewContent(insight)],
+                              },
+                              source: ViewInsightProviderSourceType.Backend,
+                          })
+                      )
             ),
             catchError(error =>
                 of<ViewInsightProviderResult[]>([

--- a/client/web/src/insights/core/backend/api/get-combined-views.ts
+++ b/client/web/src/insights/core/backend/api/get-combined-views.ts
@@ -68,6 +68,6 @@ export const getInsightCombinedViews = (
 ): Observable<ViewInsightProviderResult[]> =>
     getCombinedViews(() =>
         from(extensionApi).pipe(
-            switchMap(extensionHostAPI => wrapRemoteObservable(extensionHostAPI.getInsightsViews({ insightIds })))
+            switchMap(extensionHostAPI => wrapRemoteObservable(extensionHostAPI.getInsightsViews({}, insightIds)))
         )
     )

--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -49,7 +49,8 @@ export interface ApiService {
     ) => Observable<ViewInsightProviderResult[]>
 
     getInsightCombinedViews: (
-        extensionApi: Promise<Remote<FlatExtensionHostAPI>>
+        extensionApi: Promise<Remote<FlatExtensionHostAPI>>,
+        insightsIds?: string[]
     ) => Observable<ViewInsightProviderResult[]>
 
     getSubjectSettings: (id: string) => Observable<SubjectSettingsResult>

--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -1,0 +1,11 @@
+/**
+ * Visibility setting which responsible for where dashboard will appear.
+ * possible value 'personal' | '<org id 1> ... | ... <org id N>'
+ */
+export type InsightDashboardVisibility = string
+
+export interface InsightDashboard {
+    id: string
+    visibility: InsightDashboardVisibility
+    insightsIds: string[]
+}

--- a/client/web/src/insights/core/types/index.ts
+++ b/client/web/src/insights/core/types/index.ts
@@ -1,0 +1,2 @@
+export * from './insight'
+export * from './dashboard'

--- a/client/web/src/insights/core/types/insight.ts
+++ b/client/web/src/insights/core/types/insight.ts
@@ -1,6 +1,6 @@
 import { Duration } from 'date-fns'
 
-import { DataSeries } from './backend/types'
+import { DataSeries } from '../backend/types'
 
 export enum InsightTypePrefix {
     search = 'searchInsights.insight',

--- a/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
@@ -30,7 +30,7 @@ export interface DashboardsPageProps
  * Displays insights dashboard page - dashboard selector and grid of insights from the dashboard.
  */
 export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = props => {
-    const { dashboardID, settingsCascade } = props
+    const { dashboardID, settingsCascade, extensionsController } = props
     const { getInsightCombinedViews } = useContext(InsightsApiContext)
 
     const insightIds = useMemo(() => {
@@ -48,8 +48,8 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
     }, [dashboardID, settingsCascade])
 
     const views = useObservable(
-        useMemo(() => getInsightCombinedViews(props.extensionsController?.extHostAPI, insightIds), [
-            props.extensionsController,
+        useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, insightIds), [
+            extensionsController,
             insightIds,
             getInsightCombinedViews,
         ])

--- a/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
@@ -1,20 +1,61 @@
 import PlusIcon from 'mdi-react/PlusIcon'
-import React from 'react'
+import React, { useContext, useMemo } from 'react'
 
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { PageHeader } from '@sourcegraph/wildcard/src'
 
 import { FeedbackBadge } from '../../../components/FeedbackBadge'
 import { Page } from '../../../components/Page'
-import { CodeInsightsIcon } from '../../components'
+import { CodeInsightsIcon, InsightsViewGrid, InsightsViewGridProps } from '../../components'
+import { InsightsApiContext } from '../../core/backend/api-provider'
 
-export interface DashboardsPageProps {}
+export interface DashboardsPageProps
+    extends Omit<InsightsViewGridProps, 'views'>,
+        SettingsCascadeProps,
+        ExtensionsControllerProps {
+    /**
+     * Possible dashboard id. All insights on the page will be get from
+     * dashboard's info from user/org by id. In case if id equals undefined
+     * we will get insights from final version of merged settings (all insights)
+     */
+    dashboardID?: string
+}
 
 /**
  * Displays insights dashboard page - dashboard selector and grid of insights from the dashboard.
  */
-export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = () => (
-    <div className="w-100">
+export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = props => {
+    const { dashboardID, settingsCascade } = props
+    const { getInsightCombinedViews } = useContext(InsightsApiContext)
+
+    const insightIds = useMemo(() => {
+        if (isErrorLike(settingsCascade.final) || !settingsCascade.final || !dashboardID) {
+            return undefined
+        }
+
+        const dashboardConfiguration = settingsCascade.final[`insightDashboard.${dashboardID}`]
+
+        if (!dashboardConfiguration) {
+            return []
+        }
+
+        return dashboardConfiguration.ids
+    }, [dashboardID, settingsCascade])
+
+    const views = useObservable(
+        useMemo(() => getInsightCombinedViews(props.extensionsController?.extHostAPI, insightIds), [
+            props.extensionsController,
+            insightIds,
+            getInsightCombinedViews,
+        ])
+    )
+
+    return (
         <Page>
             <PageHeader
                 annotation={<FeedbackBadge status="prototype" feedback={{ mailto: 'support@sourcegraph.com' }} />}
@@ -26,7 +67,13 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = () =
                 }
                 className="mb-3"
             />
-            Dashboard content
+            {views === undefined ? (
+                <div className="d-flex w-100">
+                    <LoadingSpinner className="my-4" />
+                </div>
+            ) : (
+                <InsightsViewGrid {...props} views={views} hasContextMenu={true} />
+            )}
         </Page>
-    </div>
-)
+    )
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22216

### Background

Currently, `/insights` page loads all insights that the user has. Since we want to add insight dashboard separation and view only sub-set of all insights according to dashboard insight meta info on dashboard page `/insights/dashboard/<id of dashboard>`  we have to change our call view provider logic by adding dashboard insight IDs information filtering.



### What was done.

- [x] Add dashboard logic to the extension API 
- [x] Add URL param to the dashboard page
- [x] Connect URL param value and dashboard insights selection
- [x] Fixed loading of backend insight. Before this PR backend insight loading blocks progressive loading of ext-based insight. That was solved by adding start initial value for backend insight view. 