### PR TITLE
Fix `repo:` filter in linked diff search for search-based live preview insight. 

### DIFF
--- a/client/web/src/insights/core/backend/api/get-search-insight-content/get-search-insight-content.ts
+++ b/client/web/src/insights/core/backend/api/get-search-insight-content/get-search-insight-content.ts
@@ -112,9 +112,11 @@ export async function getSearchInsightContent(insight: SearchInsightSettings): P
                 // easier to read (else the date component may be off by one day)
                 const after = formatISO(sub(date, step))
                 const before = formatISO(date)
-                const repoFilters = repos.map(repo => `repo:^${escapeRegExp(repo)}$`).join(' ')
-                const diffQuery = `${repoFilters} type:diff after:${after} before:${before} ${series.query}`
+                const repoFilter = `repo:^(${repos.map(escapeRegExp).join('|')})$`
+                const diffQuery = `${repoFilter} type:diff after:${after} before:${before} ${series.query}`
+
                 url.searchParams.set('q', diffQuery)
+
                 return url.href
             }),
         })),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph-search-insights/issues/7

Thanks, @felixfbecker we have a PR with the same fix in the search-based extension codebase about link generation PR https://github.com/sourcegraph/sourcegraph-search-insights/pull/11. This PR adds the same changes and fixes in the live preview creation UI for search-based insight.

