### PR TITLE
API docs: LSIF: protocol: add all the tags

### DIFF
--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -210,18 +210,62 @@ type Documentation struct {
 	SearchKey string `json:"searchKey"`
 
 	// Tags about the type of content this documentation contains.
-	Tags []DocumentationTag `json:"tags"`
+	Tags []Tag `json:"tags"`
 }
 
-type DocumentationTag string
+type Tag string
 
 const (
 	// The documentation describes a concept that is private/unexported, not a public/exported
 	// concept.
-	DocumentationPrivate DocumentationTag = "private"
+	TagPrivate Tag = "private"
 
 	// The documentation describes a concept that is deprecated.
-	DocumentationDeprecated DocumentationTag = "deprecated"
+	TagDeprecated Tag = "deprecated"
+
+	// The documentation describes e.g. a test function or concept related to testing.
+	TagTest Tag = "test"
+
+	// The documentation describes e.g. an example function or example code.
+	TagExample Tag = "example"
+
+	// The documentation describes license information.
+	TagLicense Tag = "license"
+
+	// The documentation describes owner information.
+	TagOwner Tag = "owner"
+
+	// The documentation describes package/library registry information, e.g. where a package is
+	// available for download.
+	TagRegistryInfo Tag = "owner"
+
+	// Tags derived from SymbolKind
+	TagFile          Tag = "file"
+	TagModule        Tag = "module"
+	TagNamespace     Tag = "namespace"
+	TagPackage       Tag = "package"
+	TagClass         Tag = "class"
+	TagMethod        Tag = "method"
+	TagProperty      Tag = "property"
+	TagField         Tag = "field"
+	TagConstructor   Tag = "constructor"
+	TagEnum          Tag = "enum"
+	TagInterface     Tag = "interface"
+	TagFunction      Tag = "function"
+	TagVariable      Tag = "variable"
+	TagConstant      Tag = "constant"
+	TagString        Tag = "string"
+	TagNumber        Tag = "number"
+	TagBoolean       Tag = "boolean"
+	TagArray         Tag = "array"
+	TagObject        Tag = "object"
+	TagKey           Tag = "key"
+	TagNull          Tag = "null"
+	TagEnumNumber    Tag = "enumNumber"
+	TagStruct        Tag = "struct"
+	TagEvent         Tag = "event"
+	TagOperator      Tag = "operator"
+	TagTypeParameter Tag = "typeParameter"
 )
 
 // A "documentationString" edge connects a "documentationResult" vertex to its label or detail


### PR DESCRIPTION
@felixfbecker brought up a small request: to add symbol type icons next
to e.g. functions, and any other type of symbol found in API docs. This
got me thinking about how to implement this.

For one aspect, we don't have this data today. Since API docs are emitted
as dumb hierarchial e.g. sections of markdown documentation, there isn't
any indicator of what is actually in those sections of documentation -
that is, we don't know what kind of symbol the documentation is describing
or even if it is a symbol.

We could just expose an optional `SymbolKind`, as `workspace/symbols` etc.
do - but it would be a little odd as it would be the only part of the
documentation extension to LSIF which is symbol-specific, so far it is
completely agnostic from the types of content being documented.

Instead, I've opted to extend the tagging system (which thus far was only
used to distinguish between public/private documentation) with all the same
types of `SymbolKind` (so they can be easily mapped if desired). I've also
added tags for some other useful things:

* Test functions
* Example functions/code
* License information
* Owner information
* Package registry information

There are two other benefits to this form of tagging:

1. There can be multiple tags for a given piece of documentation, something can be a `constant` and a `string`
   and an `array`, whereas with `SymbolKind` one must be chosen.
2. We can use these as search filters with the same name, e.g. you could
   search over API docs with `tag:example` (or some similar syntax) in the future.

Helps #22326

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>