### PR TITLE
API docs: LSIF: protocol: add benchmark tag

### DIFF
--- a/lib/codeintel/lsif/protocol/documentation.go
+++ b/lib/codeintel/lsif/protocol/documentation.go
@@ -226,6 +226,9 @@ const (
 	// The documentation describes e.g. a test function or concept related to testing.
 	TagTest Tag = "test"
 
+	// The documentation describes e.g. a benchmark function or concept related to benchmarking.
+	TagBenchmark Tag = "benchmark"
+
 	// The documentation describes e.g. an example function or example code.
 	TagExample Tag = "example"
 


### PR DESCRIPTION
Similar to how there is a test tag that can be used to denote test functions,
add one for benchmarks.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
