### PR TITLE
worker: Prevent panic if database initialization fails

### DIFF
--- a/cmd/worker/shared/db.go
+++ b/cmd/worker/shared/db.go
@@ -11,7 +11,11 @@ import (
 // InitDatabase initializes and returns a connection to the frontend database.
 func InitDatabase() (*sql.DB, error) {
 	conn, err := initDatabaseMemo.Init()
-	return conn.(*sql.DB), err
+	if err != nil {
+		return nil, err
+	}
+
+	return conn.(*sql.DB), nil
 }
 
 var initDatabaseMemo = NewMemoizedConstructor(func() (interface{}, error) {


### PR DESCRIPTION
Only perform a type asserion if the error was `nil`.

A panic occurs if the database could not be initialzed, and the cause of
the error is not provided.

This is because an unsafe type assertion is performed regardless of what
is returned by `initDatabaseMemo`.

See https://github.com/sourcegraph/sourcegraph/issues/22286.