### PR TITLE
web: avoid CSS strings concatenation in the `EnterpriseStory` component

### DIFF
--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { MemoryRouter, MemoryRouterProps } from 'react-router'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { useStyles } from '@sourcegraph/storybook/src/hooks/useStyles'
+import { usePrependStyles } from '@sourcegraph/storybook/src/hooks/usePrependStyles'
 import { useTheme } from '@sourcegraph/storybook/src/hooks/useTheme'
 
 import brandedStyles from '../global-styles/index.scss'
@@ -24,7 +24,7 @@ export const BrandedStory: React.FunctionComponent<BrandedProps> = ({
     ...memoryRouterProps
 }) => {
     const isLightTheme = useTheme()
-    useStyles(styles)
+    usePrependStyles('branded-story-styles', styles)
 
     return (
         <MemoryRouter {...memoryRouterProps}>

--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -9,19 +9,20 @@ import brandedStyles from '../global-styles/index.scss'
 
 import { Tooltip } from './tooltip/Tooltip'
 
-export interface WebStoryProps extends MemoryRouterProps {
+export interface BrandedProps extends MemoryRouterProps {
     children: React.FunctionComponent<ThemeProps>
+    styles?: string
 }
 
 /**
- * Wrapper component for webapp Storybook stories that provides light theme and react-router props.
+ * Wrapper component for branded Storybook stories that provides light theme and react-router props.
  * Takes a render function as children that gets called with the props.
  */
-export const BrandedStory: React.FunctionComponent<
-    WebStoryProps & {
-        styles?: string
-    }
-> = ({ children: Children, styles = brandedStyles, ...memoryRouterProps }) => {
+export const BrandedStory: React.FunctionComponent<BrandedProps> = ({
+    children: Children,
+    styles = brandedStyles,
+    ...memoryRouterProps
+}) => {
     const isLightTheme = useTheme()
     useStyles(styles)
 

--- a/client/storybook/src/hooks/usePrependStyles.ts
+++ b/client/storybook/src/hooks/usePrependStyles.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react'
 
-const createStyleTag = (id: string): HTMLStyleElement => {
+const prependStyleTag = (id: string): HTMLStyleElement => {
     const styleTag = document.createElement('style')
     styleTag.id = id
 
@@ -16,16 +16,17 @@ const createStyleTag = (id: string): HTMLStyleElement => {
  * @param css Stringified CSS to inject into a `<style>` tag
  * @returns The created `<style>` tag
  */
-export const useStyles = (css?: string): HTMLStyleElement | undefined => {
+export const usePrependStyles = (styleTagId: string, css?: string): HTMLStyleElement | undefined => {
     const styleTag = useMemo(() => {
         if (!css) {
             return undefined
         }
 
-        const styleTag = document.querySelector<HTMLStyleElement>('story-styles') || createStyleTag('story-styles')
+        const styleTag = document.querySelector<HTMLStyleElement>(styleTagId) || prependStyleTag(styleTagId)
         styleTag.textContent = css
+
         return styleTag
-    }, [css])
+    }, [styleTagId, css])
 
     useEffect(() => () => styleTag?.remove(), [styleTag])
 

--- a/client/storybook/src/hooks/usePrependStyles.ts
+++ b/client/storybook/src/hooks/usePrependStyles.ts
@@ -14,9 +14,8 @@ const prependStyleTag = (id: string): HTMLStyleElement => {
  * Apply a CSS string to the document head
  *
  * @param css Stringified CSS to inject into a `<style>` tag
- * @returns The created `<style>` tag
  */
-export const usePrependStyles = (styleTagId: string, css?: string): HTMLStyleElement | undefined => {
+export const usePrependStyles = (styleTagId: string, css?: string): void => {
     const styleTag = useMemo(() => {
         if (!css) {
             return undefined
@@ -29,6 +28,4 @@ export const usePrependStyles = (styleTagId: string, css?: string): HTMLStyleEle
     }, [styleTagId, css])
 
     useEffect(() => () => styleTag?.remove(), [styleTag])
-
-    return styleTag
 }

--- a/client/storybook/src/hooks/useStyles.ts
+++ b/client/storybook/src/hooks/useStyles.ts
@@ -16,14 +16,18 @@ const createStyleTag = (id: string): HTMLStyleElement => {
  * @param css Stringified CSS to inject into a `<style>` tag
  * @returns The created `<style>` tag
  */
-export const useStyles = (css: string): HTMLStyleElement => {
+export const useStyles = (css?: string): HTMLStyleElement | undefined => {
     const styleTag = useMemo(() => {
+        if (!css) {
+            return undefined
+        }
+
         const styleTag = document.querySelector<HTMLStyleElement>('story-styles') || createStyleTag('story-styles')
         styleTag.textContent = css
         return styleTag
     }, [css])
 
-    useEffect(() => () => styleTag.remove(), [styleTag])
+    useEffect(() => () => styleTag?.remove(), [styleTag])
 
     return styleTag
 }

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, MemoryRouterProps, RouteComponentProps, withRouter } from
 import { Tooltip } from '@sourcegraph/branded/src/components/tooltip/Tooltip'
 import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { useStyles } from '@sourcegraph/storybook/src/hooks/useStyles'
+import { usePrependStyles } from '@sourcegraph/storybook/src/hooks/usePrependStyles'
 import { useTheme } from '@sourcegraph/storybook/src/hooks/useTheme'
 
 import webStyles from '../SourcegraphWebApp.scss'
@@ -31,8 +31,8 @@ export const WebStory: React.FunctionComponent<WebStoryProps> = ({
     const breadcrumbSetters = useBreadcrumbs()
     const Children = useMemo(() => withRouter(children), [children])
 
-    useStyles(webStyles)
-    useStyles(additionalWebStyles)
+    usePrependStyles('additional-web-styles', additionalWebStyles)
+    usePrependStyles('web-styles', webStyles)
 
     return (
         <MemoryRouter {...memoryRouterProps}>

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -7,7 +7,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useStyles } from '@sourcegraph/storybook/src/hooks/useStyles'
 import { useTheme } from '@sourcegraph/storybook/src/hooks/useTheme'
 
-import _webStyles from '../SourcegraphWebApp.scss'
+import webStyles from '../SourcegraphWebApp.scss'
 
 import { BreadcrumbSetters, BreadcrumbsProps, useBreadcrumbs } from './Breadcrumbs'
 
@@ -15,21 +15,24 @@ export interface WebStoryProps extends MemoryRouterProps {
     children: React.FunctionComponent<
         ThemeProps & BreadcrumbSetters & BreadcrumbsProps & TelemetryProps & RouteComponentProps<any>
     >
+    additionalWebStyles?: string
 }
 
 /**
  * Wrapper component for webapp Storybook stories that provides light theme and react-router props.
  * Takes a render function as children that gets called with the props.
  */
-export const WebStory: React.FunctionComponent<
-    WebStoryProps & {
-        webStyles?: string
-    }
-> = ({ children, webStyles = _webStyles, ...memoryRouterProps }) => {
+export const WebStory: React.FunctionComponent<WebStoryProps> = ({
+    children,
+    additionalWebStyles,
+    ...memoryRouterProps
+}) => {
     const isLightTheme = useTheme()
     const breadcrumbSetters = useBreadcrumbs()
     const Children = useMemo(() => withRouter(children), [children])
+
     useStyles(webStyles)
+    useStyles(additionalWebStyles)
 
     return (
         <MemoryRouter {...memoryRouterProps}>

--- a/client/web/src/enterprise/components/EnterpriseWebStory.tsx
+++ b/client/web/src/enterprise/components/EnterpriseWebStory.tsx
@@ -2,12 +2,11 @@ import React from 'react'
 
 import { WebStory, WebStoryProps } from '../../components/WebStory'
 import enterpriseWebStyles from '../../enterprise.scss'
-import webStyles from '../../SourcegraphWebApp.scss'
 
 /**
  * Wrapper component for enterprise webapp Storybook stories that provides light theme and react-router props.
  * Takes a render function as children that gets called with the props.
  */
 export const EnterpriseWebStory: React.FunctionComponent<WebStoryProps> = props => (
-    <WebStory {...props} webStyles={webStyles + enterpriseWebStyles} />
+    <WebStory {...props} additionalWebStyles={enterpriseWebStyles} />
 )


### PR DESCRIPTION
## Changes

- Now, enterprise styles are inserted into a separate style tag.

Based on [the discussion](https://github.com/sourcegraph/sourcegraph/pull/22289#discussion_r657117579).

## Notes

I've tried the approach with the array of styles passed to the `<WebStory />`, but it adds a lot of extra complexity to the `useStyles` hook that we don't actually need — generic solution for any number of stylesheets. Calling `useStyles` explicitly for additional styles passed to the `<WebStory />` looks like a good compromise. 