### PR TITLE
Rename default repos to indexable repos

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -162,7 +162,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 // ListIndexable calls database.IndexableRepos.List, with tracing. It lists ALL
 // default repos which could include private user added repos.
 func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err error) {
-	ctx, done := trace(ctx, "Repos", "ListSearchable", nil, &err)
+	ctx, done := trace(ctx, "Repos", "ListIndexable", nil, &err)
 	defer func() {
 		if err == nil {
 			span := opentracing.SpanFromContext(ctx)

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -41,12 +41,12 @@ func (e ErrRepoSeeOther) Error() string {
 
 var Repos = &repos{
 	store: database.GlobalRepos,
-	cache: dbcache.NewDefaultRepoLister(database.GlobalRepos),
+	cache: dbcache.NewIndexableReposLister(database.GlobalRepos),
 }
 
 type repos struct {
 	store *database.RepoStore
-	cache *dbcache.DefaultRepoLister
+	cache *dbcache.IndexableReposLister
 }
 
 func (s *repos) Get(ctx context.Context, repo api.RepoID) (_ *types.Repo, err error) {
@@ -159,10 +159,10 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 	return s.store.List(ctx, opt)
 }
 
-// ListIndexable calls database.DefaultRepos.List, with tracing. It lists ALL
+// ListIndexable calls database.IndexableRepos.List, with tracing. It lists ALL
 // default repos which could include private user added repos.
 func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err error) {
-	ctx, done := trace(ctx, "Repos", "ListIndexable", nil, &err)
+	ctx, done := trace(ctx, "Repos", "ListSearchable", nil, &err)
 	defer func() {
 		if err == nil {
 			span := opentracing.SpanFromContext(ctx)
@@ -173,11 +173,11 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err 
 	return s.cache.List(ctx)
 }
 
-// ListDefault calls database.DefaultRepos.ListPublic, with tracing.
-// It lists all public default repos and also any private repos added by the
-// current user.
-func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err error) {
-	ctx, done := trace(ctx, "Repos", "ListDefault", nil, &err)
+// ListSearchable calls database.IndexableRepos.ListPublic, with tracing.
+// It lists all public indexable repos and also any private repos added by the
+// current user. Only used on sourcegraph.com where we don't have every repo indexed.
+func (s *repos) ListSearchable(ctx context.Context) (repos []types.RepoName, err error) {
+	ctx, done := trace(ctx, "Repos", "ListSearchable", nil, &err)
 	defer func() {
 		if err == nil {
 			span := opentracing.SpanFromContext(ctx)

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -404,9 +404,9 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 		Limit:              opts.limit,
 	}
 	repositoryResolver := &searchrepos.Resolver{
-		DB:               r.db,
-		Zoekt:            r.zoekt,
-		DefaultReposFunc: backend.Repos.ListDefault,
+		DB:                 r.db,
+		Zoekt:              r.zoekt,
+		IndexableReposFunc: backend.Repos.ListSearchable,
 	}
 
 	return repositoryResolver.Resolve(ctx, options)

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -404,9 +404,9 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 		Limit:              opts.limit,
 	}
 	repositoryResolver := &searchrepos.Resolver{
-		DB:                 r.db,
-		Zoekt:              r.zoekt,
-		IndexableReposFunc: backend.Repos.ListSearchable,
+		DB:                  r.db,
+		Zoekt:               r.zoekt,
+		SearchableReposFunc: backend.Repos.ListSearchable,
 	}
 
 	return repositoryResolver.Resolve(ctx, options)

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -111,9 +111,9 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Options) bool {
 	options.UserSettings = r.UserSettings
 	repositoryResolver := &searchrepos.Resolver{
-		DB:               r.db,
-		Zoekt:            r.zoekt,
-		DefaultReposFunc: backend.Repos.ListDefault,
+		DB:                 r.db,
+		Zoekt:              r.zoekt,
+		IndexableReposFunc: backend.Repos.ListSearchable,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -111,9 +111,9 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Options) bool {
 	options.UserSettings = r.UserSettings
 	repositoryResolver := &searchrepos.Resolver{
-		DB:                 r.db,
-		Zoekt:              r.zoekt,
-		IndexableReposFunc: backend.Repos.ListSearchable,
+		DB:                  r.db,
+		Zoekt:               r.zoekt,
+		SearchableReposFunc: backend.Repos.ListSearchable,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -61,8 +61,8 @@ func (mockAddrForRepo) AddrForRepo(name api.RepoName) string {
 }
 
 func TestReposIndex(t *testing.T) {
-	defaultRepos := []string{"github.com/popular/foo", "github.com/popular/bar"}
-	allRepos := append(defaultRepos, "github.com/alice/foo", "github.com/alice/bar")
+	indexableRepos := []string{"github.com/popular/foo", "github.com/popular/bar"}
+	allRepos := append(indexableRepos, "github.com/alice/foo", "github.com/alice/bar")
 
 	cases := []struct {
 		name string
@@ -73,8 +73,8 @@ func TestReposIndex(t *testing.T) {
 		name: "indexers",
 		srv: &reposListServer{
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -84,8 +84,8 @@ func TestReposIndex(t *testing.T) {
 		name: "indexers",
 		srv: &reposListServer{
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -96,8 +96,8 @@ func TestReposIndex(t *testing.T) {
 		srv: &reposListServer{
 			SourcegraphDotComMode: true,
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -107,8 +107,8 @@ func TestReposIndex(t *testing.T) {
 		name: "none",
 		srv: &reposListServer{
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -146,13 +146,13 @@ func TestReposIndex(t *testing.T) {
 }
 
 type mockRepos struct {
-	defaultRepos []string
-	repos        []string
+	indexableRepos []string
+	repos          []string
 }
 
 func (r *mockRepos) ListIndexable(context.Context) ([]types.RepoName, error) {
 	var repos []types.RepoName
-	for _, name := range r.defaultRepos {
+	for _, name := range r.indexableRepos {
 		repos = append(repos, types.RepoName{
 			Name: api.RepoName(name),
 		})

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -195,7 +195,6 @@ func Main(enterpriseInit EnterpriseInit) {
 			OnlyCloudDefault: true,
 			Kinds:            []string{extsvc.KindGitHub, extsvc.KindGitLab},
 		})
-
 		if err != nil {
 			log.Fatalf("failed to list external services: %v", err)
 		}
@@ -456,11 +455,11 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 
 		// Fetch ALL default repos that are NOT cloned so that we can add them to the
 		// scheduler
-		opts := database.ListDefaultReposOptions{
+		opts := database.ListIndexableReposOptions{
 			OnlyUncloned:   true,
 			IncludePrivate: true,
 		}
-		if u, err := baseRepoStore.ListDefaultRepos(ctx, opts); err != nil {
+		if u, err := baseRepoStore.ListIndexableRepos(ctx, opts); err != nil {
 			log15.Error("Listing default repos", "error", err)
 			return
 		} else {

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -131,7 +131,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 		frameFilter: compression.NewHistoricalFilter(true, maxTime, insightsStore.Handle().DB()),
 
 		allReposIterator: (&discovery.AllReposIterator{
-			DefaultRepoLister:     dbcache.NewDefaultRepoLister(repoStore),
+			IndexableReposLister:  dbcache.NewIndexableReposLister(repoStore),
 			RepoStore:             repoStore,
 			Clock:                 time.Now,
 			SourcegraphDotComMode: envvar.SourcegraphDotComMode(),

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -43,7 +43,7 @@ func NewCommitIndexer(background context.Context, base dbutil.DB, insights dbuti
 	commitStore := NewCommitStore(insights)
 
 	iterator := discovery.AllReposIterator{
-		DefaultRepoLister:     dbcache.NewDefaultRepoLister(repoStore),
+		IndexableReposLister:  dbcache.NewIndexableReposLister(repoStore),
 		RepoStore:             repoStore,
 		Clock:                 time.Now,
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),

--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// DefaultRepoLister is a subset of the API exposed by the backend.CachedDefaultRepoLister.
-type DefaultRepoLister interface {
+// IndexableReposLister is a subset of the API exposed by the backend.ListIndexable.
+type IndexableReposLister interface {
 	List(ctx context.Context) ([]types.RepoName, error)
 }
 
@@ -26,7 +26,7 @@ type RepoStore interface {
 // It caches multiple consecutive uses in order to ensure repository lists (which can be quite
 // large, e.g. 500,000+ repositories) are only fetched as frequently as needed.
 type AllReposIterator struct {
-	DefaultRepoLister     DefaultRepoLister
+	IndexableReposLister  IndexableReposLister
 	RepoStore             RepoStore
 	Clock                 func() time.Time
 	SourcegraphDotComMode bool // result of envvar.SourcegraphDotComMode()
@@ -63,9 +63,9 @@ func (a *AllReposIterator) ForEach(ctx context.Context, forEach func(repoName st
 			// We shouldn't try to fill historical data for ALL repos on Sourcegraph.com, it would take
 			// forever. Instead, we use the same list of default repositories used when you do a global
 			// search on Sourcegraph.com.
-			res, err := a.DefaultRepoLister.List(ctx)
+			res, err := a.IndexableReposLister.List(ctx)
 			if err != nil {
-				return errors.Wrap(err, "DefaultRepoLister.List")
+				return errors.Wrap(err, "IndexableReposLister.List")
 			}
 			for _, r := range res {
 				a.cachedRepoNames = append(a.cachedRepoNames, string(r.Name))

--- a/enterprise/internal/insights/discovery/all_repos_iterator_test.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator_test.go
@@ -16,7 +16,7 @@ import (
 // TestAllReposIterator tests the AllReposIterator in the common use cases.
 func TestAllReposIterator(t *testing.T) {
 	ctx := context.Background()
-	defaultRepoLister := NewMockDefaultRepoLister()
+	indexableReposLister := NewMockIndexableReposLister()
 	repoStore := NewMockRepoStore()
 	var timeOffset time.Duration
 	clock := func() time.Time { return time.Now().Add(timeOffset) }
@@ -40,7 +40,7 @@ func TestAllReposIterator(t *testing.T) {
 	})
 
 	iter := &AllReposIterator{
-		DefaultRepoLister:       defaultRepoLister,
+		IndexableReposLister:    indexableReposLister,
 		RepoStore:               repoStore,
 		Clock:                   clock,
 		RepositoryListCacheTime: 15 * time.Minute,
@@ -158,18 +158,18 @@ func TestAllReposIterator(t *testing.T) {
 // this cruft.)
 func TestAllReposIterator_DotCom(t *testing.T) {
 	ctx := context.Background()
-	defaultRepoLister := NewMockDefaultRepoLister()
+	indexableReposLister := NewMockIndexableReposLister()
 	repoStore := NewMockRepoStore()
 	var timeOffset time.Duration
 	clock := func() time.Time { return time.Now().Add(timeOffset) }
 
 	// Mock the _default_ ("Sourcegraph.com") repo store listing, and confirm calls to it are cached.
 	var (
-		defaultRepoStoreListCalls int // There is no pagination with this store! We'll probably want that, eventually.
-		nextRepoID                api.RepoID
+		indexableReposListCall int // There is no pagination with this store! We'll probably want that, eventually.
+		nextRepoID             api.RepoID
 	)
-	defaultRepoLister.ListFunc.SetDefaultHook(func(ctx context.Context) ([]types.RepoName, error) {
-		defaultRepoStoreListCalls++
+	indexableReposLister.ListFunc.SetDefaultHook(func(ctx context.Context) ([]types.RepoName, error) {
+		indexableReposListCall++
 		var result []types.RepoName
 		for i := 0; i < 9; i++ {
 			nextRepoID++
@@ -179,7 +179,7 @@ func TestAllReposIterator_DotCom(t *testing.T) {
 	})
 
 	iter := &AllReposIterator{
-		DefaultRepoLister:       defaultRepoLister,
+		IndexableReposLister:    indexableReposLister,
 		RepoStore:               repoStore,
 		Clock:                   clock,
 		SourcegraphDotComMode:   true,
@@ -196,11 +196,11 @@ func TestAllReposIterator_DotCom(t *testing.T) {
 		autogold.Want("items0", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}).Equal(t, each)
 	}
 
-	// Were the DefaultRepoStore.List calls as we expected?
-	autogold.Want("defaultRepoStoreListCalls0", int(1)).Equal(t, defaultRepoStoreListCalls)
+	// Were the IndexableRepos.List calls as we expected?
+	autogold.Want("indexableReposStoreListCalls0", int(1)).Equal(t, indexableReposListCall)
 
-	// Again: do we get all 9 repositories, but this time all DefaultRepoStore.List calls were cached?
-	defaultRepoStoreListCalls = 0
+	// Again: do we get all 9 repositories, but this time all IndexableRepos.List calls were cached?
+	indexableReposListCall = 0
 	nextRepoID = 0
 	{
 		var each []string
@@ -209,12 +209,12 @@ func TestAllReposIterator_DotCom(t *testing.T) {
 			return nil
 		})
 		autogold.Want("items1", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}).Equal(t, each)
-		autogold.Want("defaultRepoStoreListCalls1", int(0)).Equal(t, defaultRepoStoreListCalls)
+		autogold.Want("indexableReposStoreListCalls1", int(0)).Equal(t, indexableReposListCall)
 	}
 
-	// If the clock moves forward, does the cache expire and new DefaultRepoStore.List calls are made?
+	// If the clock moves forward, does the cache expire and new IndexableRepos.List calls are made?
 	timeOffset += iter.RepositoryListCacheTime
-	defaultRepoStoreListCalls = 0
+	indexableReposListCall = 0
 	nextRepoID = 0
 	{
 		var each []string
@@ -223,6 +223,6 @@ func TestAllReposIterator_DotCom(t *testing.T) {
 			return nil
 		})
 		autogold.Want("items2", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}).Equal(t, each)
-		autogold.Want("repoStoreListCalls2", int(1)).Equal(t, defaultRepoStoreListCalls)
+		autogold.Want("repoStoreListCalls2", int(1)).Equal(t, indexableReposListCall)
 	}
 }

--- a/enterprise/internal/insights/discovery/gen.go
+++ b/enterprise/internal/insights/discovery/gen.go
@@ -1,5 +1,5 @@
 package discovery
 
 //go:generate ../../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i SettingStore -o mock_setting_store.go
-//go:generate ../../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i DefaultRepoLister -o mock_default_repo_lister.go
+//go:generate ../../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i IndexableReposLister -o mock_indexable_repos_lister.go
 //go:generate ../../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i RepoStore -o mock_repo_store.go

--- a/enterprise/internal/insights/discovery/mock_default_repo_lister.go
+++ b/enterprise/internal/insights/discovery/mock_default_repo_lister.go
@@ -9,21 +9,21 @@ import (
 	types "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// MockDefaultRepoLister is a mock implementation of the DefaultRepoLister
+// MockIndexableReposLister is a mock implementation of the IndexableReposLister
 // interface (from the package
 // github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery)
 // used for unit testing.
-type MockDefaultRepoLister struct {
+type MockIndexableReposLister struct {
 	// ListFunc is an instance of a mock function object controlling the
 	// behavior of the method List.
 	ListFunc *DefaultRepoListerListFunc
 }
 
-// NewMockDefaultRepoLister creates a new mock of the DefaultRepoLister
+// NewMockIndexableReposLister creates a new mock of the IndexableReposLister
 // interface. All methods return zero values for all results, unless
 // overwritten.
-func NewMockDefaultRepoLister() *MockDefaultRepoLister {
-	return &MockDefaultRepoLister{
+func NewMockIndexableReposLister() *MockIndexableReposLister {
+	return &MockIndexableReposLister{
 		ListFunc: &DefaultRepoListerListFunc{
 			defaultHook: func(context.Context) ([]types.RepoName, error) {
 				return nil, nil
@@ -33,10 +33,10 @@ func NewMockDefaultRepoLister() *MockDefaultRepoLister {
 }
 
 // NewMockDefaultRepoListerFrom creates a new mock of the
-// MockDefaultRepoLister interface. All methods delegate to the given
+// MockIndexableReposLister interface. All methods delegate to the given
 // implementation, unless overwritten.
-func NewMockDefaultRepoListerFrom(i DefaultRepoLister) *MockDefaultRepoLister {
-	return &MockDefaultRepoLister{
+func NewMockDefaultRepoListerFrom(i IndexableReposLister) *MockIndexableReposLister {
+	return &MockIndexableReposLister{
 		ListFunc: &DefaultRepoListerListFunc{
 			defaultHook: i.List,
 		},
@@ -44,7 +44,7 @@ func NewMockDefaultRepoListerFrom(i DefaultRepoLister) *MockDefaultRepoLister {
 }
 
 // DefaultRepoListerListFunc describes the behavior when the List method of
-// the parent MockDefaultRepoLister instance is invoked.
+// the parent MockIndexableReposLister instance is invoked.
 type DefaultRepoListerListFunc struct {
 	defaultHook func(context.Context) ([]types.RepoName, error)
 	hooks       []func(context.Context) ([]types.RepoName, error)
@@ -54,21 +54,21 @@ type DefaultRepoListerListFunc struct {
 
 // List delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDefaultRepoLister) List(v0 context.Context) ([]types.RepoName, error) {
+func (m *MockIndexableReposLister) List(v0 context.Context) ([]types.RepoName, error) {
 	r0, r1 := m.ListFunc.nextHook()(v0)
 	m.ListFunc.appendCall(DefaultRepoListerListFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the List method of the
-// parent MockDefaultRepoLister instance is invoked and the hook queue is
+// parent MockIndexableReposLister instance is invoked and the hook queue is
 // empty.
 func (f *DefaultRepoListerListFunc) SetDefaultHook(hook func(context.Context) ([]types.RepoName, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// List method of the parent MockDefaultRepoLister instance invokes the hook
+// List method of the parent MockIndexableReposLister instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
 func (f *DefaultRepoListerListFunc) PushHook(hook func(context.Context) ([]types.RepoName, error)) {
@@ -124,7 +124,7 @@ func (f *DefaultRepoListerListFunc) History() []DefaultRepoListerListFuncCall {
 }
 
 // DefaultRepoListerListFuncCall is an object that describes an invocation
-// of method List on an instance of MockDefaultRepoLister.
+// of method List on an instance of MockIndexableReposLister.
 type DefaultRepoListerListFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.

--- a/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
+++ b/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
@@ -9,22 +9,22 @@ import (
 	types "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// MockIndexableReposLister is a mock implementation of the IndexableReposLister
-// interface (from the package
+// MockIndexableReposLister is a mock implementation of the
+// IndexableReposLister interface (from the package
 // github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery)
 // used for unit testing.
 type MockIndexableReposLister struct {
 	// ListFunc is an instance of a mock function object controlling the
 	// behavior of the method List.
-	ListFunc *DefaultRepoListerListFunc
+	ListFunc *IndexableReposListerListFunc
 }
 
-// NewMockIndexableReposLister creates a new mock of the IndexableReposLister
-// interface. All methods return zero values for all results, unless
-// overwritten.
+// NewMockIndexableReposLister creates a new mock of the
+// IndexableReposLister interface. All methods return zero values for all
+// results, unless overwritten.
 func NewMockIndexableReposLister() *MockIndexableReposLister {
 	return &MockIndexableReposLister{
-		ListFunc: &DefaultRepoListerListFunc{
+		ListFunc: &IndexableReposListerListFunc{
 			defaultHook: func(context.Context) ([]types.RepoName, error) {
 				return nil, nil
 			},
@@ -32,23 +32,23 @@ func NewMockIndexableReposLister() *MockIndexableReposLister {
 	}
 }
 
-// NewMockDefaultRepoListerFrom creates a new mock of the
+// NewMockIndexableReposListerFrom creates a new mock of the
 // MockIndexableReposLister interface. All methods delegate to the given
 // implementation, unless overwritten.
-func NewMockDefaultRepoListerFrom(i IndexableReposLister) *MockIndexableReposLister {
+func NewMockIndexableReposListerFrom(i IndexableReposLister) *MockIndexableReposLister {
 	return &MockIndexableReposLister{
-		ListFunc: &DefaultRepoListerListFunc{
+		ListFunc: &IndexableReposListerListFunc{
 			defaultHook: i.List,
 		},
 	}
 }
 
-// DefaultRepoListerListFunc describes the behavior when the List method of
-// the parent MockIndexableReposLister instance is invoked.
-type DefaultRepoListerListFunc struct {
+// IndexableReposListerListFunc describes the behavior when the List method
+// of the parent MockIndexableReposLister instance is invoked.
+type IndexableReposListerListFunc struct {
 	defaultHook func(context.Context) ([]types.RepoName, error)
 	hooks       []func(context.Context) ([]types.RepoName, error)
-	history     []DefaultRepoListerListFuncCall
+	history     []IndexableReposListerListFuncCall
 	mutex       sync.Mutex
 }
 
@@ -56,22 +56,22 @@ type DefaultRepoListerListFunc struct {
 // parameter and result values of this invocation.
 func (m *MockIndexableReposLister) List(v0 context.Context) ([]types.RepoName, error) {
 	r0, r1 := m.ListFunc.nextHook()(v0)
-	m.ListFunc.appendCall(DefaultRepoListerListFuncCall{v0, r0, r1})
+	m.ListFunc.appendCall(IndexableReposListerListFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the List method of the
 // parent MockIndexableReposLister instance is invoked and the hook queue is
 // empty.
-func (f *DefaultRepoListerListFunc) SetDefaultHook(hook func(context.Context) ([]types.RepoName, error)) {
+func (f *IndexableReposListerListFunc) SetDefaultHook(hook func(context.Context) ([]types.RepoName, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// List method of the parent MockIndexableReposLister instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *DefaultRepoListerListFunc) PushHook(hook func(context.Context) ([]types.RepoName, error)) {
+// List method of the parent MockIndexableReposLister instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *IndexableReposListerListFunc) PushHook(hook func(context.Context) ([]types.RepoName, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -79,7 +79,7 @@ func (f *DefaultRepoListerListFunc) PushHook(hook func(context.Context) ([]types
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DefaultRepoListerListFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
+func (f *IndexableReposListerListFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
 	f.SetDefaultHook(func(context.Context) ([]types.RepoName, error) {
 		return r0, r1
 	})
@@ -87,13 +87,13 @@ func (f *DefaultRepoListerListFunc) SetDefaultReturn(r0 []types.RepoName, r1 err
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DefaultRepoListerListFunc) PushReturn(r0 []types.RepoName, r1 error) {
+func (f *IndexableReposListerListFunc) PushReturn(r0 []types.RepoName, r1 error) {
 	f.PushHook(func(context.Context) ([]types.RepoName, error) {
 		return r0, r1
 	})
 }
 
-func (f *DefaultRepoListerListFunc) nextHook() func(context.Context) ([]types.RepoName, error) {
+func (f *IndexableReposListerListFunc) nextHook() func(context.Context) ([]types.RepoName, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -106,26 +106,26 @@ func (f *DefaultRepoListerListFunc) nextHook() func(context.Context) ([]types.Re
 	return hook
 }
 
-func (f *DefaultRepoListerListFunc) appendCall(r0 DefaultRepoListerListFuncCall) {
+func (f *IndexableReposListerListFunc) appendCall(r0 IndexableReposListerListFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of DefaultRepoListerListFuncCall objects
+// History returns a sequence of IndexableReposListerListFuncCall objects
 // describing the invocations of this function.
-func (f *DefaultRepoListerListFunc) History() []DefaultRepoListerListFuncCall {
+func (f *IndexableReposListerListFunc) History() []IndexableReposListerListFuncCall {
 	f.mutex.Lock()
-	history := make([]DefaultRepoListerListFuncCall, len(f.history))
+	history := make([]IndexableReposListerListFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// DefaultRepoListerListFuncCall is an object that describes an invocation
-// of method List on an instance of MockIndexableReposLister.
-type DefaultRepoListerListFuncCall struct {
+// IndexableReposListerListFuncCall is an object that describes an
+// invocation of method List on an instance of MockIndexableReposLister.
+type IndexableReposListerListFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -139,12 +139,12 @@ type DefaultRepoListerListFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DefaultRepoListerListFuncCall) Args() []interface{} {
+func (c IndexableReposListerListFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DefaultRepoListerListFuncCall) Results() []interface{} {
+func (c IndexableReposListerListFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func TestListDefaultRepos(t *testing.T) {
+func TestListIndexableRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -93,7 +93,7 @@ func TestListDefaultRepos(t *testing.T) {
 				}
 			}
 
-			repos, err := NewDefaultRepoLister(database.Repos(db)).List(ctx)
+			repos, err := NewIndexableReposLister(database.Repos(db)).List(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -146,7 +146,7 @@ func TestListDefaultRepos(t *testing.T) {
 		}
 
 		t.Run("List ALL repos", func(t *testing.T) {
-			repos, err := NewDefaultRepoLister(database.Repos(db)).List(ctx)
+			repos, err := NewIndexableReposLister(database.Repos(db)).List(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -174,7 +174,7 @@ func TestListDefaultRepos(t *testing.T) {
 		})
 
 		t.Run("List only public default repos", func(t *testing.T) {
-			repos, err := NewDefaultRepoLister(database.Repos(db)).ListPublic(ctx)
+			repos, err := NewIndexableReposLister(database.Repos(db)).ListPublic(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -210,7 +210,7 @@ func BenchmarkDefaultRepos_List_Empty(b *testing.B) {
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err := NewDefaultRepoLister(database.Repos(db)).List(ctx)
+		_, err := NewIndexableReposLister(database.Repos(db)).List(ctx)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -2,7 +2,6 @@ package dbcache
 
 import (
 	"context"
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -21,37 +19,6 @@ import (
 func TestListIndexableRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
-	}
-	tcs := []struct {
-		name  string
-		repos []types.RepoName
-	}{
-		{
-			name:  "empty case",
-			repos: nil,
-		},
-		{
-			name: "one repo",
-			repos: []types.RepoName{
-				{
-					ID:   api.RepoID(1),
-					Name: "github.com/foo/bar",
-				},
-			},
-		},
-		{
-			name: "two repos",
-			repos: []types.RepoName{
-				{
-					ID:   api.RepoID(1),
-					Name: "github.com/foo/bar",
-				},
-				{
-					ID:   api.RepoID(2),
-					Name: "github.com/baz/qux",
-				},
-			},
-		},
 	}
 
 	createExternalService := func(ctx context.Context, db dbutil.DB) *types.ExternalService {
@@ -70,42 +37,6 @@ func TestListIndexableRepos(t *testing.T) {
 		return es
 	}
 
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			db := dbtesting.GetDB(t)
-			ctx := context.Background()
-
-			es := createExternalService(ctx, db)
-
-			for _, r := range tc.repos {
-				if _, err := db.ExecContext(ctx, `INSERT INTO repo(id, name) VALUES ($1, $2)`, r.ID, r.Name); err != nil {
-					t.Fatal(err)
-				}
-				if _, err := db.ExecContext(ctx, `INSERT INTO default_repos(repo_id) VALUES ($1)`, r.ID); err != nil {
-					t.Fatal(err)
-				}
-				if _, err := db.ExecContext(ctx, `INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES ($1, $2, 'example.com')`, r.ID, es.ID); err != nil {
-					t.Fatal(err)
-				}
-
-				if _, err := db.ExecContext(ctx, `INSERT INTO gitserver_repos(repo_id, clone_status, shard_id) VALUES ($1, $2, 'test');`, r.ID, types.CloneStatusCloned); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			repos, err := NewIndexableReposLister(database.Repos(db)).List(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			sort.Sort(types.RepoNames(repos))
-			sort.Sort(types.RepoNames(tc.repos))
-			if diff := cmp.Diff(tc.repos, repos, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-
 	t.Run("user-added repos", func(t *testing.T) {
 		db := dbtest.NewDB(t, "")
 		ctx := context.Background()
@@ -122,9 +53,8 @@ func TestListIndexableRepos(t *testing.T) {
 			INSERT INTO external_services(id, kind, display_name, config, namespace_user_id) VALUES (100, 'github', 'github', '{}', 1);
 			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (10, 100, '', 1);
 
-			-- insert one repo referenced in the default repo table
-			INSERT INTO repo(id, name, stars) VALUES (11, 'github.com/foo/bar11', 4);
-			INSERT INTO default_repos(repo_id) VALUES(11);
+			-- insert one repo with more than 20 stars in the repo table
+			INSERT INTO repo(id, name, stars) VALUES (11, 'github.com/foo/bar11', 25);
 			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (11, 1, '', NULL);
 
 			-- insert a repo only referenced by a cloud_default external service
@@ -152,12 +82,12 @@ func TestListIndexableRepos(t *testing.T) {
 			}
 			want := []types.RepoName{
 				{
-					ID:   api.RepoID(10),
-					Name: "github.com/foo/bar10",
-				},
-				{
 					ID:   api.RepoID(11),
 					Name: "github.com/foo/bar11",
+				},
+				{
+					ID:   api.RepoID(10),
+					Name: "github.com/foo/bar10",
 				},
 				{
 					ID:   api.RepoID(14),
@@ -180,12 +110,12 @@ func TestListIndexableRepos(t *testing.T) {
 			}
 			want := []types.RepoName{
 				{
-					ID:   api.RepoID(10),
-					Name: "github.com/foo/bar10",
-				},
-				{
 					ID:   api.RepoID(11),
 					Name: "github.com/foo/bar11",
+				},
+				{
+					ID:   api.RepoID(10),
+					Name: "github.com/foo/bar10",
 				},
 				{
 					ID:   api.RepoID(14),
@@ -199,7 +129,7 @@ func TestListIndexableRepos(t *testing.T) {
 	})
 }
 
-func BenchmarkDefaultRepos_List_Empty(b *testing.B) {
+func BenchmarkIndexableRepos_List_Empty(b *testing.B) {
 	db := dbtest.NewDB(b, "")
 
 	ctx := context.Background()

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -847,7 +847,7 @@ type ListIndexableReposOptions struct {
 // ListIndexableRepos returns a list of repos to be indexed for search on sourcegraph.com.
 // This includes all repos with >= 20 stars as well as user added repos.
 func (s *RepoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableReposOptions) (results []types.RepoName, err error) {
-	tr, ctx := trace.New(ctx, "repos.ListSearchable", "")
+	tr, ctx := trace.New(ctx, "repos.ListIndexable", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -902,7 +902,7 @@ func (s *RepoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableRe
 
 const listIndexableReposQuery = `
 WITH s AS (
-	SELECT id
+	SELECT id as repo_id
 	FROM repo
 	WHERE stars >= 20
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -837,17 +837,17 @@ const userPublicReposQuery = `
 SELECT repo_id as id FROM user_public_repos WHERE user_id = %d
 `
 
-type ListDefaultReposOptions struct {
+type ListIndexableReposOptions struct {
 	// If true, will only include uncloned default repos
 	OnlyUncloned bool
 	// If true, we include user added private repos
 	IncludePrivate bool
 }
 
-// ListDefaultRepos returns a list of default repos. Default repos are a union of
-// repos in our default_repos table and repos owned by users.
-func (s *RepoStore) ListDefaultRepos(ctx context.Context, opts ListDefaultReposOptions) (results []types.RepoName, err error) {
-	tr, ctx := trace.New(ctx, "repos.ListDefaultRepos", "")
+// ListIndexableRepos returns a list of repos to be indexed for search on sourcegraph.com.
+// This includes all repos with >= 20 stars as well as user added repos.
+func (s *RepoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableReposOptions) (results []types.RepoName, err error) {
+	tr, ctx := trace.New(ctx, "repos.ListSearchable", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -875,7 +875,7 @@ func (s *RepoStore) ListDefaultRepos(ctx context.Context, opts ListDefaultReposO
 	}
 
 	q := sqlf.Sprintf(
-		listDefaultReposQuery,
+		listIndexableReposQuery,
 		sqlf.Join(joins, "\n"),
 		sqlf.Join(where, "\nAND "),
 	)
@@ -900,10 +900,11 @@ func (s *RepoStore) ListDefaultRepos(ctx context.Context, opts ListDefaultReposO
 	return results, nil
 }
 
-const listDefaultReposQuery = `
+const listIndexableReposQuery = `
 WITH s AS (
-	SELECT repo_id
-	FROM default_repos
+	SELECT id
+	FROM repo
+	WHERE stars >= 20
 
 	UNION ALL
 

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -376,7 +376,7 @@ func TestRepos_Create(t *testing.T) {
 	})
 }
 
-func TestListDefaultReposUncloned(t *testing.T) {
+func TestListIndexableRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -428,7 +428,7 @@ func TestListDefaultReposUncloned(t *testing.T) {
 		}
 	}
 
-	repos, err := Repos(db).ListDefaultRepos(ctx, ListDefaultReposOptions{
+	repos, err := Repos(db).ListIndexableRepos(ctx, ListIndexableReposOptions{
 		OnlyUncloned: true,
 	})
 	if err != nil {

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -384,18 +384,27 @@ func TestListIndexableRepos(t *testing.T) {
 	t.Parallel()
 	db := dbtest.NewDB(t, "")
 
-	reposToAdd := []types.RepoName{
+	reposToAdd := []types.Repo{
 		{
-			ID:   api.RepoID(1),
-			Name: "github.com/foo/bar1",
+			ID:    api.RepoID(1),
+			Name:  "github.com/foo/bar1",
+			Stars: 20,
 		},
 		{
-			ID:   api.RepoID(2),
-			Name: "github.com/baz/bar2",
+			ID:    api.RepoID(2),
+			Name:  "github.com/baz/bar2",
+			Stars: 30,
 		},
 		{
-			ID:   api.RepoID(3),
-			Name: "github.com/foo/bar3",
+			ID:      api.RepoID(3),
+			Name:    "github.com/foo/bar3",
+			Private: true,
+			Stars:   0, // Will still be returned because it gets added by a user.
+		},
+		{
+			ID:    api.RepoID(4),
+			Name:  "github.com/foo/bar4",
+			Stars: 10, // Not enough stars
 		},
 	}
 
@@ -409,16 +418,17 @@ func TestListIndexableRepos(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, r := range reposToAdd {
+		if _, err := db.ExecContext(ctx, `INSERT INTO repo(id, name, stars, private) VALUES ($1, $2, $3, $4)`, r.ID, r.Name, r.Stars, r.Private); err != nil {
+			t.Fatal(err)
+		}
+
+		if r.Private {
+			if _, err := db.ExecContext(ctx, `INSERT INTO external_service_repos VALUES (1, $1, $2, 1);`, r.ID, r.Name); err != nil {
+				t.Fatal(err)
+			}
+		}
+
 		cloned := int(r.ID) > 1
-		if _, err := db.ExecContext(ctx, `INSERT INTO repo(id, name, cloned) VALUES ($1, $2, $3)`, r.ID, r.Name, cloned); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := db.ExecContext(ctx, `INSERT INTO default_repos(repo_id) VALUES ($1)`, r.ID); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := db.ExecContext(ctx, `INSERT INTO external_service_repos VALUES (1, $1, 'https://github.com/foo/bar13', 1);`, r.ID); err != nil {
-			t.Fatal(err)
-		}
 		cloneStatus := types.CloneStatusCloned
 		if !cloned {
 			cloneStatus = types.CloneStatusNotCloned
@@ -428,16 +438,43 @@ func TestListIndexableRepos(t *testing.T) {
 		}
 	}
 
-	repos, err := Repos(db).ListIndexableRepos(ctx, ListIndexableReposOptions{
-		OnlyUncloned: true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range []struct {
+		name string
+		opts ListIndexableReposOptions
+		want []api.RepoID
+	}{
+		{
+			name: "no opts",
+			want: []api.RepoID{2, 1}, // No private repos returned by default
+		},
+		{
+			name: "only uncloned",
+			opts: ListIndexableReposOptions{OnlyUncloned: true},
+			want: []api.RepoID{1},
+		},
+		{
+			name: "include private",
+			opts: ListIndexableReposOptions{IncludePrivate: true},
+			want: []api.RepoID{2, 1, 3},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	sort.Sort(types.RepoNames(repos))
-	sort.Sort(types.RepoNames(reposToAdd))
-	if diff := cmp.Diff(reposToAdd[:1], repos, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+			repos, err := Repos(db).ListIndexableRepos(ctx, tc.opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			have := make([]api.RepoID, 0, len(repos))
+			for _, r := range repos {
+				have = append(have, r.ID)
+			}
+
+			if diff := cmp.Diff(tc.want, have, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch (-want +have):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -129,7 +129,7 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 		if err != nil {
 			return Resolved{}, errors.Wrap(err, "getting list of default repos")
 		}
-		tr.LazyPrintf("defaultrepos: took %s to add %d repos", time.Since(start), len(indexableRepos))
+		tr.LazyPrintf("indexableRepos: took %s to add %d repos", time.Since(start), len(indexableRepos))
 
 		// Search all default repos since indexed search is fast.
 		if len(indexableRepos) > limit {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -121,26 +121,26 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 		return Resolved{}, err
 	}
 
-	var indexableRepos []types.RepoName
+	var searchableRepos []types.RepoName
 
 	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 && !query.HasTypeRepo(op.Query) && searchcontexts.IsGlobalSearchContext(searchContext) {
 		start := time.Now()
-		indexableRepos, err = searchableRepositories(ctx, r.SearchableReposFunc, r.Zoekt, excludePatterns)
+		searchableRepos, err = searchableRepositories(ctx, r.SearchableReposFunc, r.Zoekt, excludePatterns)
 		if err != nil {
 			return Resolved{}, errors.Wrap(err, "getting list of default repos")
 		}
-		tr.LazyPrintf("indexableRepos: took %s to add %d repos", time.Since(start), len(indexableRepos))
+		tr.LazyPrintf("searchableRepos: took %s to add %d repos", time.Since(start), len(searchableRepos))
 
 		// Search all default repos since indexed search is fast.
-		if len(indexableRepos) > limit {
-			limit = len(indexableRepos)
+		if len(searchableRepos) > limit {
+			limit = len(searchableRepos)
 		}
 	}
 
 	var repos []types.RepoName
 	var excluded ExcludedRepos
-	if len(indexableRepos) > 0 {
-		repos = indexableRepos
+	if len(searchableRepos) > 0 {
+		repos = searchableRepos
 		if len(repos) > limit {
 			repos = repos[:limit]
 		}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -46,9 +46,9 @@ func (r *Resolved) String() string {
 }
 
 type Resolver struct {
-	DB               dbutil.DB
-	Zoekt            *searchbackend.Zoekt
-	DefaultReposFunc defaultReposFunc
+	DB                 dbutil.DB
+	Zoekt              *searchbackend.Zoekt
+	IndexableReposFunc indexableReposFunc
 }
 
 func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
@@ -121,26 +121,26 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 		return Resolved{}, err
 	}
 
-	var defaultRepos []types.RepoName
+	var indexableRepos []types.RepoName
 
 	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 && !query.HasTypeRepo(op.Query) && searchcontexts.IsGlobalSearchContext(searchContext) {
 		start := time.Now()
-		defaultRepos, err = defaultRepositories(ctx, r.DefaultReposFunc, r.Zoekt, excludePatterns)
+		indexableRepos, err = indexableRepositories(ctx, r.IndexableReposFunc, r.Zoekt, excludePatterns)
 		if err != nil {
 			return Resolved{}, errors.Wrap(err, "getting list of default repos")
 		}
-		tr.LazyPrintf("defaultrepos: took %s to add %d repos", time.Since(start), len(defaultRepos))
+		tr.LazyPrintf("defaultrepos: took %s to add %d repos", time.Since(start), len(indexableRepos))
 
 		// Search all default repos since indexed search is fast.
-		if len(defaultRepos) > limit {
-			limit = len(defaultRepos)
+		if len(indexableRepos) > limit {
+			limit = len(indexableRepos)
 		}
 	}
 
 	var repos []types.RepoName
 	var excluded ExcludedRepos
-	if len(defaultRepos) > 0 {
-		repos = defaultRepos
+	if len(indexableRepos) > 0 {
+		repos = indexableRepos
 		if len(repos) > limit {
 			repos = repos[:limit]
 		}
@@ -611,34 +611,34 @@ func findPatternRevs(includePatterns []string) (includePatternRevs []patternRevs
 	return
 }
 
-type defaultReposFunc func(ctx context.Context) ([]types.RepoName, error)
+type indexableReposFunc func(ctx context.Context) ([]types.RepoName, error)
 
-// defaultRepositories returns the intersection of calling getRawDefaultRepos
+// indexableRepositories returns the intersection of calling gettRawIndexableRepos
 // (db) and indexed repos (zoekt), minus repos matching excludePatterns.
-func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFunc, z *searchbackend.Zoekt, excludePatterns []string) (_ []types.RepoName, err error) {
-	tr, ctx := trace.New(ctx, "defaultRepositories", "")
+func indexableRepositories(ctx context.Context, getRawIndexableRepos indexableReposFunc, z *searchbackend.Zoekt, excludePatterns []string) (_ []types.RepoName, err error) {
+	tr, ctx := trace.New(ctx, "indexableRepositories", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	// Get the list of default repos from the database.
-	defaultRepos, err := getRawDefaultRepos(ctx)
+	// Get the list of indexable repos from the database.
+	indexableRepos, err := getRawIndexableRepos(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "querying database for default repos")
+		return nil, errors.Wrap(err, "querying database for indexable repos")
 	}
-	tr.LazyPrintf("getRawDefaultRepos - done")
+	tr.LazyPrintf("getRawIndexableRepos - done")
 
 	// Remove excluded repos.
 	if len(excludePatterns) > 0 {
 		patterns, _ := regexp.Compile(`(?i)` + UnionRegExps(excludePatterns))
-		filteredRepos := defaultRepos[:0]
-		for _, repo := range defaultRepos {
+		filteredRepos := indexableRepos[:0]
+		for _, repo := range indexableRepos {
 			if matched := patterns.MatchString(string(repo.Name)); !matched {
 				filteredRepos = append(filteredRepos, repo)
 			}
 		}
-		defaultRepos = filteredRepos
+		indexableRepos = filteredRepos
 		tr.LazyPrintf("remove excluded repos - done")
 	}
 
@@ -651,9 +651,9 @@ func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFun
 	}
 	tr.LazyPrintf("zoekt.ListAll - done")
 
-	// In place filtering of defaultRepos to only include names from set.
-	repos := defaultRepos[:0]
-	for _, r := range defaultRepos {
+	// In place filtering of indexableRepos to only include names from set.
+	repos := indexableRepos[:0]
+	for _, r := range indexableRepos {
 		if _, ok := set[string(r.Name)]; ok {
 			repos = append(repos, r)
 		}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -164,7 +164,6 @@ func TestRevisionValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.repoFilters[0], func(t *testing.T) {
-
 			op := Options{RepoFilters: tt.repoFilters}
 			repositoryResolver := &Resolver{}
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
@@ -305,7 +304,7 @@ func BenchmarkGetRevsForMatchedRepo(b *testing.B) {
 	})
 }
 
-func TestDefaultRepositories(t *testing.T) {
+func TestIndexableRepositories(t *testing.T) {
 	tcs := []struct {
 		name             string
 		defaultsInDb     []string
@@ -348,8 +347,7 @@ func TestDefaultRepositories(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {``
-
+		t.Run(tc.name, func(t *testing.T) {
 			var drs []types.RepoName
 			for i, name := range tc.defaultsInDb {
 				r := types.RepoName{
@@ -387,7 +385,7 @@ func TestDefaultRepositories(t *testing.T) {
 	}
 }
 
-func TestUseDefaultReposIfMissingOrGlobalSearchContext(t *testing.T) {
+func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 	orig := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)
 	defer envvar.MockSourcegraphDotComMode(orig)
@@ -397,19 +395,19 @@ func TestUseDefaultReposIfMissingOrGlobalSearchContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantDefaultRepoNames := []string{
+	wantIndexableRepos := []string{
 		"default/one",
 		"default/two",
 		"default/three",
 	}
-	defaultRepos := make([]types.RepoName, len(wantDefaultRepoNames))
-	zoektRepoListEntries := make([]*zoekt.RepoListEntry, len(wantDefaultRepoNames))
-	mockDefaultReposFunc := func(_ context.Context) ([]types.RepoName, error) {
-		return defaultRepos, nil
+	indexableRepos := make([]types.RepoName, len(wantIndexableRepos))
+	zoektRepoListEntries := make([]*zoekt.RepoListEntry, len(wantIndexableRepos))
+	mockIndexableReposFunc := func(_ context.Context) ([]types.RepoName, error) {
+		return indexableRepos, nil
 	}
 
-	for idx, name := range wantDefaultRepoNames {
-		defaultRepos[idx] = types.RepoName{Name: api.RepoName(name)}
+	for idx, name := range wantIndexableRepos {
+		indexableRepos[idx] = types.RepoName{Name: api.RepoName(name)}
 		zoektRepoListEntries[idx] = &zoekt.RepoListEntry{
 			Repository: zoekt.Repository{
 				Name:     name,
@@ -437,7 +435,7 @@ func TestUseDefaultReposIfMissingOrGlobalSearchContext(t *testing.T) {
 				SearchContextSpec: tt.searchContextSpec,
 				Query:             queryInfo,
 			}
-			repositoryResolver := &Resolver{Zoekt: mockZoekt, IndexableReposFunc: mockDefaultReposFunc}
+			repositoryResolver := &Resolver{Zoekt: mockZoekt, IndexableReposFunc: mockIndexableReposFunc}
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
 			if err != nil {
 				t.Fatal(err)
@@ -446,8 +444,8 @@ func TestUseDefaultReposIfMissingOrGlobalSearchContext(t *testing.T) {
 			for _, repoRev := range resolved.RepoRevs {
 				repoNames = append(repoNames, string(repoRev.Repo.Name))
 			}
-			if !reflect.DeepEqual(repoNames, wantDefaultRepoNames) {
-				t.Errorf("names of default repos = %v, want %v", repoNames, wantDefaultRepoNames)
+			if !reflect.DeepEqual(repoNames, wantIndexableRepos) {
+				t.Errorf("names of default repos = %v, want %v", repoNames, wantIndexableRepos)
 			}
 		})
 	}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -348,7 +348,7 @@ func TestDefaultRepositories(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {``
 
 			var drs []types.RepoName
 			for i, name := range tc.defaultsInDb {
@@ -358,7 +358,7 @@ func TestDefaultRepositories(t *testing.T) {
 				}
 				drs = append(drs, r)
 			}
-			getRawDefaultRepos := func(ctx context.Context) ([]types.RepoName, error) {
+			getRawIndexableRepos := func(ctx context.Context) ([]types.RepoName, error) {
 				return drs, nil
 			}
 
@@ -372,7 +372,7 @@ func TestDefaultRepositories(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			drs, err := defaultRepositories(ctx, getRawDefaultRepos, z, tc.excludePatterns)
+			drs, err := indexableRepositories(ctx, getRawIndexableRepos, z, tc.excludePatterns)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -437,7 +437,7 @@ func TestUseDefaultReposIfMissingOrGlobalSearchContext(t *testing.T) {
 				SearchContextSpec: tt.searchContextSpec,
 				Query:             queryInfo,
 			}
-			repositoryResolver := &Resolver{Zoekt: mockZoekt, DefaultReposFunc: mockDefaultReposFunc}
+			repositoryResolver := &Resolver{Zoekt: mockZoekt, IndexableReposFunc: mockDefaultReposFunc}
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -370,7 +370,7 @@ func TestIndexableRepositories(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			drs, err := indexableRepositories(ctx, getRawIndexableRepos, z, tc.excludePatterns)
+			drs, err := searchableRepositories(ctx, getRawIndexableRepos, z, tc.excludePatterns)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -435,7 +435,7 @@ func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 				SearchContextSpec: tt.searchContextSpec,
 				Query:             queryInfo,
 			}
-			repositoryResolver := &Resolver{Zoekt: mockZoekt, IndexableReposFunc: mockIndexableReposFunc}
+			repositoryResolver := &Resolver{Zoekt: mockZoekt, SearchableReposFunc: mockIndexableReposFunc}
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
When we introduced the `default_repos` table we didn't have the `repo.stars` column, so we manually selected specific repos that should be indexed on sourcegraph.com. With the addition of `repo.stars` we can instead select all repos that have `stars >= 20`, which is our baseline for 5m indexed repos on dot com.

A follow up PR will drop the `default_repos` table and I will modify ghdump to [skip the step of adding repos to it](https://github.com/sourcegraph/ghdump/blob/master/addrepo/addrepo.go#L165).

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
