### PR TITLE
Fix oval loading spinners on search page

### DIFF
--- a/client/web/src/search/panels/LoadingPanelView.tsx
+++ b/client/web/src/search/panels/LoadingPanelView.tsx
@@ -4,9 +4,7 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
 export const LoadingPanelView: React.FunctionComponent<{ text: string }> = ({ text }) => (
     <div className="d-flex justify-content-center align-items-center panel-container__empty-container panel-container__loading-container">
-        <div className="icon-inline">
-            <LoadingSpinner />
-        </div>
+        <LoadingSpinner className="icon-inline" />
         <span className="text-muted">{text}</span>
     </div>
 )


### PR DESCRIPTION
Fix #22287 - oval landing spinners on sourcegraph.com/search. Seems to be caused by the [smaller size for inline icons in the redesign](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@c1a731bcb5775642b621fd50b18202c2cfbc1f1b/-/blob/client/shared/src/global-styles/icons.scss?L21&subtree=true), interacting with margin on the loading spinner itself.

Putting `icon-inline` on the `LoadingSpinner` itself fixes the problem and seems to be the common way that we use the loading spinner (see [here](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%3CLoadingSpinner+className%3D%22icon-inline%22&patternType=literal)).

**New behavior**

https://user-images.githubusercontent.com/17293/123288334-c4540b00-d50f-11eb-971a-398aa1af3388.mp4

