### PR TITLE
code monitoring: unauthenticated users can see getting started page if feature flag is on

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -2,20 +2,32 @@ import classnames from 'classnames'
 import React, { useCallback, useState } from 'react'
 import { useHistory, useLocation } from 'react-router'
 
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { Container } from '@sourcegraph/wildcard'
 
+import { AuthenticatedUser } from '../../auth'
 import { FilteredConnection } from '../../components/FilteredConnection'
 import { CodeMonitorFields, ListUserCodeMonitorsResult, ListUserCodeMonitorsVariables } from '../../graphql-operations'
+import { Settings } from '../../schema/settings.schema'
 
 import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
 import { CodeMonitoringPageProps } from './CodeMonitoringPage'
 
 type CodeMonitorFilter = 'all' | 'user'
 
-export const CodeMonitorList: React.FunctionComponent<
-    Omit<Required<CodeMonitoringPageProps>, 'showGettingStarted' | 'isLightTheme'>
-> = ({ authenticatedUser, settingsCascade, fetchUserCodeMonitors, toggleCodeMonitorEnabled }) => {
+interface CodeMonitorListProps
+    extends Required<Pick<CodeMonitoringPageProps, 'fetchUserCodeMonitors' | 'toggleCodeMonitorEnabled'>>,
+        SettingsCascadeProps<Settings> {
+    authenticatedUser: AuthenticatedUser
+}
+
+export const CodeMonitorList: React.FunctionComponent<CodeMonitorListProps> = ({
+    authenticatedUser,
+    settingsCascade,
+    fetchUserCodeMonitors,
+    toggleCodeMonitorEnabled,
+}) => {
     const location = useLocation()
     const history = useHistory()
     const [monitorListFilter, setMonitorListFilter] = useState<CodeMonitorFilter>('all')

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.module.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.module.scss
@@ -25,3 +25,8 @@
         padding-left: 2rem;
     }
 }
+
+.sign-up-card {
+    margin: -1rem 0 -1rem 0;
+    padding: 1rem;
+}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -7,7 +7,10 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import styles from './CodeMonitoringGettingStarted.module.scss'
 
-export const CodeMonitoringGettingStarted: React.FunctionComponent<ThemeProps> = ({ isLightTheme }) => {
+export const CodeMonitoringGettingStarted: React.FunctionComponent<ThemeProps & { isSignedIn: boolean }> = ({
+    isLightTheme,
+    isSignedIn,
+}) => {
     const assetsRoot = window.context?.assetsRoot || ''
 
     return (
@@ -32,10 +35,19 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<ThemeProps> =
                         <li>Identify when bad patterns are commited </li>
                         <li>Identify use of depricated libraries</li>
                     </ul>
-                    <Link to="/code-monitoring/new" className={classNames('btn btn-primary', styles.createButton)}>
-                        <PlusIcon className="icon-inline mr-2" />
-                        Create a code monitor
-                    </Link>
+                    {isSignedIn ? (
+                        <Link to="/code-monitoring/new" className={classNames('btn btn-primary', styles.createButton)}>
+                            <PlusIcon className="icon-inline mr-2" />
+                            Create a code monitor
+                        </Link>
+                    ) : (
+                        <Link
+                            to={`/sign-up?returnTo=${encodeURIComponent('/code-monitoring/new')}`}
+                            className={classNames('btn btn-primary', styles.createButton)}
+                        >
+                            Sign up to create a code monitor
+                        </Link>
+                    )}
                 </div>
             </div>
             <div className={classNames('container', styles.startingPointsContainer)}>
@@ -120,17 +132,32 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<ThemeProps> =
                             </a>
                         </div>
                     </div>
-                    <div className="col-4">
-                        <div>
-                            <h4>Questions and feedback</h4>
-                            <p className="text-muted">
-                                Have a question or idea about code monitoring? We want to hear your feedback!
-                            </p>
-                            <a href="mailto:feedback@sourcegraph.com" className="link">
-                                Share your thoughts
-                            </a>
+                    {isSignedIn ? (
+                        <div className="col-4">
+                            <div>
+                                <h4>Questions and feedback</h4>
+                                <p className="text-muted">
+                                    Have a question or idea about code monitoring? We want to hear your feedback!
+                                </p>
+                                <a href="mailto:feedback@sourcegraph.com" className="link">
+                                    Share your thoughts
+                                </a>
+                            </div>
                         </div>
-                    </div>
+                    ) : (
+                        <div className="col-4">
+                            <div className={classNames('card', styles.signUpCard)}>
+                                <h4>Free for registered users</h4>
+                                <p className="text-muted">Sign up and build your first code monitor today.</p>
+                                <Link
+                                    to={`/sign-up?returnTo=${encodeURIComponent('/code-monitoring/new')}`}
+                                    className="btn btn-primary"
+                                >
+                                    Sign up now
+                                </Link>
+                            </div>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -6,6 +6,7 @@ import sinon from 'sinon'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 
 import { AuthenticatedUser } from '../../auth'
+import { EMPTY_FEATURE_FLAGS } from '../../featureFlags/featureFlags'
 import { ListUserCodeMonitorsVariables } from '../../graphql-operations'
 import { EnterpriseWebStory } from '../components/EnterpriseWebStory'
 
@@ -27,6 +28,7 @@ const additionalProps = {
         }),
     toggleCodeMonitorEnabled: sinon.fake(),
     settingsCascade: EMPTY_SETTINGS_CASCADE,
+    featureFlags: EMPTY_FEATURE_FLAGS,
 }
 
 add(

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -58,7 +58,31 @@ add(
         design: {
             type: 'figma',
             url:
-                'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
+                'https://www.figma.com/file/6WMfHdPt2ovTE1P527brwc/Code-monitor-getting-started-21161?node-id=87%3A277',
+        },
+    }
+)
+
+add(
+    'Code monitoring getting started page - unauthenticated',
+    () => (
+        <EnterpriseWebStory initialEntries={['/code-monitoring/getting-started']}>
+            {props => (
+                <CodeMonitoringPage
+                    {...props}
+                    {...additionalProps}
+                    showGettingStarted={true}
+                    authenticatedUser={null}
+                    featureFlags={new Map([['w1-signup-optimisation', true]])}
+                />
+            )}
+        </EnterpriseWebStory>
+    ),
+    {
+        design: {
+            type: 'figma',
+            url:
+                'https://www.figma.com/file/6WMfHdPt2ovTE1P527brwc/Code-monitor-getting-started-21161?node-id=1%3A1650',
         },
     }
 )

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -7,6 +7,7 @@ import sinon from 'sinon'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 
 import { AuthenticatedUser } from '../../auth'
+import { EMPTY_FEATURE_FLAGS } from '../../featureFlags/featureFlags'
 import { ListCodeMonitors, ListUserCodeMonitorsVariables } from '../../graphql-operations'
 
 import { CodeMonitoringPage } from './CodeMonitoringPage'
@@ -26,6 +27,7 @@ const additionalProps = {
     toggleCodeMonitorEnabled: sinon.spy((id: string, enabled: boolean) => of({ id: 'test', enabled: true })),
     settingsCascade: EMPTY_SETTINGS_CASCADE,
     isLightTheme: false,
+    featureFlags: EMPTY_FEATURE_FLAGS,
 }
 
 const generateMockFetchMonitors = (count: number) => ({ id, first, after }: ListUserCodeMonitorsVariables) => {

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme'
+import * as H from 'history'
 import * as React from 'react'
 import { MemoryRouter } from 'react-router'
 import { of } from 'rxjs'
@@ -80,5 +81,53 @@ describe('CodeMonitoringListPage', () => {
         const toggle = component.find('.test-toggle-monitor-enabled')
         toggle.simulate('click')
         expect(additionalProps.toggleCodeMonitorEnabled.calledOnce)
+    })
+
+    test('Redirect to getting started if empty', () => {
+        const component = mount(
+            <MemoryRouter initialEntries={['/code-monitoring']}>
+                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(0)} />
+            </MemoryRouter>
+        )
+
+        const history: H.History = component.find('Router').prop('history')
+        expect(history.location.pathname).toBe('/code-monitoring/getting-started')
+    })
+
+    test('Do not redirect to getting started if not empty', () => {
+        const component = mount(
+            <MemoryRouter initialEntries={['/code-monitoring']}>
+                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
+            </MemoryRouter>
+        )
+
+        const history: H.History = component.find('Router').prop('history')
+        expect(history.location.pathname).toBe('/code-monitoring')
+    })
+
+    test('Redirect to sign in if not logged in', () => {
+        const component = mount(
+            <MemoryRouter initialEntries={['/code-monitoring']}>
+                <CodeMonitoringPage {...additionalProps} authenticatedUser={null} />
+            </MemoryRouter>
+        )
+
+        const history: H.History = component.find('Router').prop('history')
+        expect(history.location.pathname).toBe('/sign-in')
+    })
+
+    test('Redirect to getting started if not logged in and feature flag is enabled', () => {
+        const component = mount(
+            <MemoryRouter initialEntries={['/code-monitoring']}>
+                <CodeMonitoringPage
+                    {...additionalProps}
+                    authenticatedUser={null}
+                    featureFlags={new Map([['w1-signup-optimisation', true]])}
+                />
+            </MemoryRouter>
+        )
+
+        const history: H.History = component.find('Router').prop('history')
+        expect(history.location.pathname).toBe('/code-monitoring/getting-started')
     })
 })

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,6 +1,7 @@
 import PlusIcon from 'mdi-react/PlusIcon'
 import React, { useMemo, useEffect } from 'react'
 import { NavLink, Redirect } from 'react-router-dom'
+import { of } from 'rxjs'
 import { catchError, map, startWith } from 'rxjs/operators'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
@@ -14,6 +15,7 @@ import { PageHeader } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../../auth'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { PageTitle } from '../../components/PageTitle'
+import { FeatureFlagProps } from '../../featureFlags/featureFlags'
 import { Settings } from '../../schema/settings.schema'
 import { eventLogger } from '../../tracking/eventLogger'
 
@@ -24,8 +26,8 @@ import {
 import { CodeMonitoringGettingStarted } from './CodeMonitoringGettingStarted'
 import { CodeMonitorList } from './CodeMonitorList'
 
-export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings>, ThemeProps {
-    authenticatedUser: AuthenticatedUser
+export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings>, ThemeProps, FeatureFlagProps {
+    authenticatedUser: AuthenticatedUser | null
     fetchUserCodeMonitors?: typeof _fetchUserCodeMonitors
     toggleCodeMonitorEnabled?: typeof _toggleCodeMonitorEnabled
     showGettingStarted?: boolean
@@ -38,6 +40,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
     toggleCodeMonitorEnabled = _toggleCodeMonitorEnabled,
     showGettingStarted = false,
     isLightTheme,
+    featureFlags,
 }) => {
     useEffect(() => eventLogger.logViewEvent('CodeMonitoringPage'), [])
 
@@ -46,18 +49,25 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
     const userHasCodeMonitors = useObservable(
         useMemo(
             () =>
-                fetchUserCodeMonitors({
-                    id: authenticatedUser.id,
-                    first: 1,
-                    after: null,
-                }).pipe(
-                    map(monitors => monitors.nodes.length > 0),
-                    startWith(LOADING),
-                    catchError(error => [asError(error)])
-                ),
-            [authenticatedUser.id, fetchUserCodeMonitors]
+                authenticatedUser
+                    ? fetchUserCodeMonitors({
+                          id: authenticatedUser.id,
+                          first: 1,
+                          after: null,
+                      }).pipe(
+                          map(monitors => monitors.nodes.length > 0),
+                          startWith(LOADING),
+                          catchError(error => [asError(error)])
+                      )
+                    : of(false),
+            [authenticatedUser, fetchUserCodeMonitors]
         )
     )
+
+    // If feature flag is not on, make unauthenticated users sign in
+    if (!authenticatedUser && !featureFlags.get('w1-signup-optimisation')) {
+        return <Redirect to="/sign-in" />
+    }
 
     // If user has no code monitors, redirect to the getting started page
     if (!showGettingStarted && userHasCodeMonitors === false) {
@@ -137,7 +147,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
 
                     {showGettingStarted && <CodeMonitoringGettingStarted isLightTheme={isLightTheme} />}
 
-                    {showList && (
+                    {showList && authenticatedUser && (
                         <CodeMonitorList
                             settingsCascade={settingsCascade}
                             authenticatedUser={authenticatedUser}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -93,7 +93,8 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                 actions={
                     userHasCodeMonitors &&
                     userHasCodeMonitors !== 'loading' &&
-                    !isErrorLike(userHasCodeMonitors) && (
+                    !isErrorLike(userHasCodeMonitors) &&
+                    authenticatedUser && (
                         <Link to="/code-monitoring/new" className="btn btn-primary">
                             <PlusIcon className="icon-inline" />
                             Create
@@ -145,7 +146,9 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                         </div>
                     </div>
 
-                    {showGettingStarted && <CodeMonitoringGettingStarted isLightTheme={isLightTheme} />}
+                    {showGettingStarted && (
+                        <CodeMonitoringGettingStarted isLightTheme={isLightTheme} isSignedIn={!!authenticatedUser} />
+                    )}
 
                     {showList && authenticatedUser && (
                         <CodeMonitorList

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs'
 import { PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
+import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { PageTitle } from '../../components/PageTitle'
 import { CodeMonitorFields, MonitorEmailPriority } from '../../graphql-operations'
@@ -13,7 +14,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { createCodeMonitor as _createCodeMonitor } from './backend'
 import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-export interface CreateCodeMonitorPageProps {
+interface CreateCodeMonitorPageProps {
     location: H.Location
     history: H.History
     authenticatedUser: AuthenticatedUser
@@ -21,7 +22,7 @@ export interface CreateCodeMonitorPageProps {
     createCodeMonitor?: typeof _createCodeMonitor
 }
 
-export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPageProps> = ({
+const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPageProps> = ({
     authenticatedUser,
     history,
     location,
@@ -85,3 +86,5 @@ export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPag
         </div>
     )
 }
+
+export const CreateCodeMonitorPage = withAuthenticatedUser(AuthenticatedCreateCodeMonitorPage)

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -11,6 +11,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
+import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { PageTitle } from '../../components/PageTitle'
 import { CodeMonitorFields, MonitorEmailPriority } from '../../graphql-operations'
@@ -23,7 +24,7 @@ import {
 } from './backend'
 import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-export interface ManageCodeMonitorPageProps extends RouteComponentProps<{ id: Scalars['ID'] }> {
+interface ManageCodeMonitorPageProps extends RouteComponentProps<{ id: Scalars['ID'] }> {
     authenticatedUser: AuthenticatedUser
     location: H.Location
     history: H.History
@@ -33,7 +34,7 @@ export interface ManageCodeMonitorPageProps extends RouteComponentProps<{ id: Sc
     deleteCodeMonitor?: typeof _deleteCodeMonitor
 }
 
-export const ManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPageProps> = ({
+const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPageProps> = ({
     authenticatedUser,
     history,
     location,
@@ -129,3 +130,5 @@ export const ManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPag
         </div>
     )
 }
+
+export const ManageCodeMonitorPage = withAuthenticatedUser(AuthenticatedManageCodeMonitorPage)

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
           "username": "alice",
         }
       }
+      featureFlags={Map {}}
       fetchUserCodeMonitors={[Function]}
       isLightTheme={false}
       settingsCascade={
@@ -2093,6 +2094,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
           "username": "alice",
         }
       }
+      featureFlags={Map {}}
       fetchUserCodeMonitors={[Function]}
       isLightTheme={false}
       settingsCascade={
@@ -2998,6 +3000,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
           "username": "alice",
         }
       }
+      featureFlags={Map {}}
       fetchUserCodeMonitors={[Function]}
       isLightTheme={false}
       settingsCascade={

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
+import { Route, RouteComponentProps, Switch } from 'react-router'
 
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -8,13 +8,10 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { AuthenticatedUser } from '../../../auth'
-import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
 import { CodeMonitoringProps } from '../../../code-monitoring'
 import { Page } from '../../../components/Page'
+import { FeatureFlagProps } from '../../../featureFlags/featureFlags'
 import { lazyComponent } from '../../../util/lazyComponent'
-import { CodeMonitoringPageProps } from '../CodeMonitoringPage'
-import { CreateCodeMonitorPageProps } from '../CreateCodeMonitorPage'
-import { ManageCodeMonitorPageProps } from '../ManageCodeMonitorPage'
 
 interface Props
     extends RouteComponentProps<{}>,
@@ -23,66 +20,44 @@ interface Props
         TelemetryProps,
         PlatformContextProps,
         CodeMonitoringProps,
-        SettingsCascadeProps {
+        SettingsCascadeProps,
+        FeatureFlagProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }
 
-const CodeMonitoringPage = lazyComponent<CodeMonitoringPageProps, 'CodeMonitoringPage'>(
-    () => import('../CodeMonitoringPage'),
-    'CodeMonitoringPage'
-)
-const CreateCodeMonitorPage = lazyComponent<CreateCodeMonitorPageProps, 'CreateCodeMonitorPage'>(
-    () => import('../CreateCodeMonitorPage'),
-    'CreateCodeMonitorPage'
-)
-const ManageCodeMonitorPage = lazyComponent<ManageCodeMonitorPageProps, 'ManageCodeMonitorPage'>(
-    () => import('../ManageCodeMonitorPage'),
-    'ManageCodeMonitorPage'
-)
+const CodeMonitoringPage = lazyComponent(() => import('../CodeMonitoringPage'), 'CodeMonitoringPage')
+const CreateCodeMonitorPage = lazyComponent(() => import('../CreateCodeMonitorPage'), 'CreateCodeMonitorPage')
+const ManageCodeMonitorPage = lazyComponent(() => import('../ManageCodeMonitorPage'), 'ManageCodeMonitorPage')
 
 /**
  * The global code monitoring area.
  */
-export const GlobalCodeMonitoringArea: React.FunctionComponent<Props> = props => (
-    <AuthenticatedCodeMonitoringArea {...props} />
+export const GlobalCodeMonitoringArea: React.FunctionComponent<Props> = ({ match, ...outerProps }) => (
+    <div className="w-100">
+        <Page>
+            <Switch>
+                <Route
+                    path={match.url}
+                    render={props => <CodeMonitoringPage {...outerProps} {...props} />}
+                    exact={true}
+                />
+                <Route
+                    path={`${match.url}/getting-started`}
+                    render={props => <CodeMonitoringPage {...outerProps} {...props} showGettingStarted={true} />}
+                    exact={true}
+                />
+                <Route
+                    path={`${match.url}/new`}
+                    render={props => <CreateCodeMonitorPage {...outerProps} {...props} />}
+                    exact={true}
+                />
+                <Route
+                    path={`${match.path}/:id`}
+                    render={props => <ManageCodeMonitorPage {...outerProps} {...props} />}
+                    exact={true}
+                />
+            </Switch>
+        </Page>
+    </div>
 )
-
-interface AuthenticatedProps extends Props {
-    authenticatedUser: AuthenticatedUser
-}
-
-export const AuthenticatedCodeMonitoringArea = withAuthenticatedUser<AuthenticatedProps>(({ match, ...outerProps }) => {
-    if (!outerProps.authenticatedUser) {
-        return <Redirect to="/sign-in" />
-    }
-
-    return (
-        <div className="w-100">
-            <Page>
-                <Switch>
-                    <Route
-                        render={props => <CodeMonitoringPage {...outerProps} {...props} />}
-                        path={match.url}
-                        exact={true}
-                    />
-                    <Route
-                        render={props => <CodeMonitoringPage {...outerProps} {...props} showGettingStarted={true} />}
-                        path={`${match.url}/getting-started`}
-                        exact={true}
-                    />
-                    <Route
-                        path={`${match.url}/new`}
-                        render={props => <CreateCodeMonitorPage {...outerProps} {...props} />}
-                        exact={true}
-                    />
-                    <Route
-                        path={`${match.path}/:id`}
-                        render={props => <ManageCodeMonitorPage {...outerProps} {...props} />}
-                        exact={true}
-                    />
-                </Switch>
-            </Page>
-        </div>
-    )
-})


### PR DESCRIPTION
Part of #21161

- If the `w1-signup-optimisation` feature flag is on, unauthenticated users can access the Code Monitoring Getting Started page
- Unauthenticated users that try to access the create or manage code monitor pages will be redirected back after signing in. Some refactoring was done to make this cleaner.
- Hide "Create" button on top right of Code Monitoring page if user is not signed in
- Show sign up CTAs instead of "Create" button in middle of page and feedback section on bottom right if user is not signed in