### PR TITLE
monitoring: Don't group sync_start by owner

### DIFF
--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -80,7 +80,7 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:              "syncer_sync_start",
 							Description:       "repo metadata sync was started",
-							Query:             fmt.Sprintf(`max by (family, owner) (rate(src_repoupdater_syncer_start_sync[%s]))`, syncDurationThreshold.String()),
+							Query:             fmt.Sprintf(`max by (family) (rate(src_repoupdater_syncer_start_sync{family="Syncer.SyncExternalService"}[%s]))`, syncDurationThreshold.String()),
 							Warning:           monitoring.Alert().LessOrEqual(0, nil).For(syncDurationThreshold),
 							Panel:             monitoring.Panel().LegendFormat("Family: {{family}} Owner: {{owner}}").Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,


### PR DESCRIPTION
We only care about whether a sync was started, not whether it was site
or user owned.

Specifically, on .com, we don't expect to have any site level services
that perform background syncing which could lead us to falsely alert
when we see zero site level services sync.
