### PR TITLE
return `[]result.Match` from search functions

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -155,7 +155,7 @@ func TestSearchResults(t *testing.T) {
 		defer func() { run.MockSearchRepositories = nil }()
 
 		calledSearchSymbols := false
-		run.MockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*result.FileMatch, common *streaming.Stats, err error) {
+		run.MockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []result.Match, common *streaming.Stats, err error) {
 			calledSearchSymbols = true
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
@@ -220,7 +220,7 @@ func TestSearchResults(t *testing.T) {
 		defer func() { run.MockSearchRepositories = nil }()
 
 		calledSearchSymbols := false
-		run.MockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*result.FileMatch, common *streaming.Stats, err error) {
+		run.MockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []result.Match, common *streaming.Stats, err error) {
 			calledSearchSymbols = true
 			if want := `"foo\\d \"bar*\""`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -113,7 +113,7 @@ func TestSearchResults(t *testing.T) {
 		database.Mocks.Repos.MockGet(t, 1)
 		database.Mocks.Repos.Count = mockCount
 
-		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
+		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			return nil, &streaming.Stats{}, nil
 		}
 		defer func() { run.MockSearchFilesInRepos = nil }()
@@ -166,14 +166,14 @@ func TestSearchResults(t *testing.T) {
 		defer func() { run.MockSearchSymbols = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
+		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			repo := types.RepoName{ID: 1, Name: "repo"}
 			fm := mkFileMatch(repo, "dir/file", 123)
-			return []*result.FileMatch{fm}, &streaming.Stats{}, nil
+			return []result.Match{fm}, &streaming.Stats{}, nil
 		}
 		defer func() { run.MockSearchFilesInRepos = nil }()
 
@@ -231,14 +231,14 @@ func TestSearchResults(t *testing.T) {
 		defer func() { run.MockSearchSymbols = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
+		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			repo := types.RepoName{ID: 1, Name: "repo"}
 			fm := mkFileMatch(repo, "dir/file", 123)
-			return []*result.FileMatch{fm}, &streaming.Stats{}, nil
+			return []result.Match{fm}, &streaming.Stats{}, nil
 		}
 		defer func() { run.MockSearchFilesInRepos = nil }()
 

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -101,7 +101,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer git.ResetMocks()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
+		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := "foo"; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
@@ -110,7 +110,7 @@ func TestSearchSuggestions(t *testing.T) {
 			rev := "rev"
 			fm.CommitID = "rev"
 			fm.InputRev = &rev
-			return []*result.FileMatch{fm}, &streaming.Stats{}, nil
+			return []result.Match{fm}, &streaming.Stats{}, nil
 		}
 		defer func() { run.MockSearchFilesInRepos = nil }()
 		for _, v := range searchVersions {
@@ -151,7 +151,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
+		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
@@ -162,7 +162,7 @@ func TestSearchSuggestions(t *testing.T) {
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}
-			return []*result.FileMatch{
+			return []result.Match{
 				mkFileMatch(types.RepoName{Name: "foo-repo"}, "dir/file"),
 			}, &streaming.Stats{}, nil
 		}
@@ -268,7 +268,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
+		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
@@ -279,7 +279,7 @@ func TestSearchSuggestions(t *testing.T) {
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}
-			return []*result.FileMatch{mkFileMatch(types.RepoName{Name: "foo-repo"}, "dir/bar-file")}, &streaming.Stats{}, nil
+			return []result.Match{mkFileMatch(types.RepoName{Name: "foo-repo"}, "dir/bar-file")}, &streaming.Stats{}, nil
 		}
 		defer func() { run.MockSearchFilesInRepos = nil }()
 

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -50,7 +50,7 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 	}
 
-	run.MockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*result.FileMatch, common *streaming.Stats, err error) {
+	run.MockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []result.Match, common *streaming.Stats, err error) {
 		// TODO test symbol suggestions
 		return nil, nil, nil
 	}

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -30,7 +30,7 @@ func TestSearchRepositories(t *testing.T) {
 
 	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
-	MockSearchFilesInRepos = func(args *search.TextParameters) (matches []*result.FileMatch, common *streaming.Stats, err error) {
+	MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
 		repos, err := getRepos(context.Background(), args.RepoPromise)
 		if err != nil {
 			return nil, nil, err
@@ -39,7 +39,7 @@ func TestSearchRepositories(t *testing.T) {
 		rev := "1a2b3c"
 		switch repoName {
 		case "foo/one":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     types.RepoName{ID: 123, Name: repoName},
 					InputRev: &rev,
@@ -47,7 +47,7 @@ func TestSearchRepositories(t *testing.T) {
 				},
 			}}, &streaming.Stats{}, nil
 		case "bar/one":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     types.RepoName{ID: 789, Name: repoName},
 					InputRev: &rev,
@@ -55,7 +55,7 @@ func TestSearchRepositories(t *testing.T) {
 				},
 			}}, &streaming.Stats{}, nil
 		case "foo/no-match":
-			return []*result.FileMatch{}, &streaming.Stats{}, nil
+			return []result.Match{}, &streaming.Stats{}, nil
 		default:
 			return nil, &streaming.Stats{}, errors.New("Unexpected repo")
 		}
@@ -128,7 +128,7 @@ func searchRepositoriesBatch(ctx context.Context, args *search.TextParameters, l
 }
 
 func TestRepoShouldBeAdded(t *testing.T) {
-	MockSearchFilesInRepos = func(args *search.TextParameters) (matches []*result.FileMatch, common *streaming.Stats, err error) {
+	MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
 		repos, err := getRepos(context.Background(), args.RepoPromise)
 		if err != nil {
 			return nil, nil, err
@@ -137,7 +137,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		rev := "1a2b3c"
 		switch repoName {
 		case "foo/one":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     types.RepoName{ID: 123, Name: repoName},
 					InputRev: &rev,
@@ -156,9 +156,9 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []*result.FileMatch, common *streaming.Stats, err error) {
+		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
 			rev := "1a2b3c"
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     types.RepoName{ID: 123, Name: repo.Repo.Name},
 					InputRev: &rev,
@@ -178,7 +178,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has repoHasFile filter ", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []*result.FileMatch, common *streaming.Stats, err error) {
+		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
 			return nil, &streaming.Stats{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustInclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
@@ -193,9 +193,9 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []*result.FileMatch, common *streaming.Stats, err error) {
+		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
 			rev := "1a2b3c"
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     types.RepoName{ID: 123, Name: repo.Repo.Name},
 					InputRev: &rev,
@@ -215,7 +215,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []*result.FileMatch, common *streaming.Stats, err error) {
+		MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
 			return nil, &streaming.Stats{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustExclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}

--- a/internal/search/run/textsearch.go
+++ b/internal/search/run/textsearch.go
@@ -30,9 +30,9 @@ import (
 // A global limiter on number of concurrent searcher searches.
 var textSearchLimiter = mutablelimiter.New(32)
 
-var mockSearchFilesInRepo func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*result.FileMatch, limitHit bool, err error)
+var mockSearchFilesInRepo func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.Match, limitHit bool, err error)
 
-func SearchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo types.RepoName, gitserverRepo api.RepoName, rev string, index bool, info *search.TextPatternInfo, fetchTimeout time.Duration) ([]*result.FileMatch, bool, error) {
+func SearchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo types.RepoName, gitserverRepo api.RepoName, rev string, index bool, info *search.TextPatternInfo, fetchTimeout time.Duration) ([]result.Match, bool, error) {
 	if mockSearchFilesInRepo != nil {
 		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout)
 	}
@@ -64,13 +64,13 @@ func SearchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 			return nil, false, err
 		}
 	}
-	matches, limitHit, err := searcher.Search(ctx, searcherURLs, gitserverRepo, rev, commit, index, info, fetchTimeout, indexerEndpoints)
+	searcherMatches, limitHit, err := searcher.Search(ctx, searcherURLs, gitserverRepo, rev, commit, index, info, fetchTimeout, indexerEndpoints)
 	if err != nil {
 		return nil, false, err
 	}
 
-	fileMatches := make([]*result.FileMatch, 0, len(matches))
-	for _, fm := range matches {
+	matches := make([]result.Match, 0, len(searcherMatches))
+	for _, fm := range searcherMatches {
 		lineMatches := make([]*result.LineMatch, 0, len(fm.LineMatches))
 		for _, lm := range fm.LineMatches {
 			ranges := make([][2]int32, 0, len(lm.OffsetAndLengths))
@@ -84,7 +84,7 @@ func SearchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 			})
 		}
 
-		fileMatches = append(fileMatches, &result.FileMatch{
+		matches = append(matches, &result.FileMatch{
 			File: result.File{
 				Path:     fm.Path,
 				Repo:     repo,
@@ -96,7 +96,7 @@ func SearchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 		})
 	}
 
-	return fileMatches, limitHit, err
+	return matches, limitHit, err
 }
 
 // repoShouldBeSearched determines whether a repository should be searched in, based on whether the repository
@@ -139,15 +139,6 @@ func repoHasFilesWithNamesMatching(ctx context.Context, searcherURLs *endpoint.M
 	return true, nil
 }
 
-func fileMatchesToMatches(fms []*result.FileMatch) []result.Match {
-	matches := make([]result.Match, 0, len(fms))
-	for _, fm := range fms {
-		newFm := fm
-		matches = append(matches, newFm)
-	}
-	return matches
-}
-
 func matchesToFileMatches(matches []result.Match) ([]*result.FileMatch, error) {
 	fms := make([]*result.FileMatch, 0, len(matches))
 	for _, match := range matches {
@@ -174,14 +165,14 @@ func SearchFilesInReposBatch(ctx context.Context, args *search.TextParameters) (
 	return fms, stats, err
 }
 
-var MockSearchFilesInRepos func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error)
+var MockSearchFilesInRepos func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error)
 
 // SearchFilesInRepos searches a set of repos for a pattern.
 func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
 	if MockSearchFilesInRepos != nil {
 		matches, mockStats, err := MockSearchFilesInRepos(args)
 		stream.Send(streaming.SearchEvent{
-			Results: fileMatchesToMatches(matches),
+			Results: matches,
 			Stats:   statsDeref(mockStats),
 		})
 		return err
@@ -332,7 +323,7 @@ func callSearcherOverRepos(
 					// non-diff search reports timeout through err, so pass false for timedOut
 					stats, err := handleRepoSearchResult(repoRev, repoLimitHit, false, err)
 					stream.Send(streaming.SearchEvent{
-						Results: fileMatchesToMatches(matches),
+						Results: matches,
 						Stats:   stats,
 					})
 					return err

--- a/internal/search/run/textsearch_test.go
+++ b/internal/search/run/textsearch_test.go
@@ -33,11 +33,11 @@ import (
 )
 
 func TestSearchFilesInRepos(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*result.FileMatch, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.Match, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -45,7 +45,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 				},
 			}}, false, nil
 		case "foo/two":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -128,11 +128,11 @@ func TestSearchFilesInRepos(t *testing.T) {
 }
 
 func TestSearchFilesInReposStream(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*result.FileMatch, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.Match, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -140,7 +140,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 				},
 			}}, false, nil
 		case "foo/two":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -148,7 +148,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 				},
 			}}, false, nil
 		case "foo/three":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -204,11 +204,11 @@ func assertReposStatus(t *testing.T, repoNames map[api.RepoID]string, got search
 }
 
 func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*result.FileMatch, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.Match, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
-			return []*result.FileMatch{{
+			return []result.Match{&result.FileMatch{
 				File: result.File{
 					Repo:     repo,
 					CommitID: api.CommitID(rev),


### PR DESCRIPTION
This chnages symbol and textsearch to return `[]result.Match` rather than `[]*result.FileMatch`. This is slightly less specific of a return value, but this allows us to get rid of the conversion code, which is not free (thanks to no generics). Since we never do any processing on our results that is specific to the result type (we do it all through the interface), having the more specific return value felt unnecessary. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
