### PR TITLE
specialize search.Promise for repos

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -436,7 +436,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 
 	args := search.TextParameters{
 		PatternInfo:     p,
-		RepoPromise:     (&search.Promise{}).Resolve(resolved.RepoRevs),
+		RepoPromise:     (&search.RepoPromise{}).Resolve(resolved.RepoRevs),
 		Query:           r.Query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
 		Zoekt:           r.zoekt,
@@ -481,18 +481,4 @@ func (e *badRequestError) Error() string {
 
 func (e *badRequestError) Cause() error {
 	return e.err
-}
-
-// getRepos is a wrapper around p.Get. It returns an error if the promise
-// contains an underlying type other than []*search.RepositoryRevisions.
-func getRepos(ctx context.Context, p *search.Promise) ([]*search.RepositoryRevisions, error) {
-	v, err := p.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-	repoRevs, ok := v.([]*search.RepositoryRevisions)
-	if !ok {
-		return nil, fmt.Errorf("unexpected underlying type (%T) of promise", v)
-	}
-	return repoRevs, nil
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1388,7 +1388,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 
 		Zoekt:        r.zoekt,
 		SearcherURLs: r.searcherURLs,
-		RepoPromise:  &search.Promise{},
+		RepoPromise:  &search.RepoPromise{},
 	}
 	if err := args.PatternInfo.Validate(); err != nil {
 		return nil, &badRequestError{err}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -399,7 +399,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		fileMatches, _, err := streaming.CollectStream(func(stream streaming.Sender) error {
 			return run.SearchSymbols(ctx, &search.TextParameters{
 				PatternInfo:  p,
-				RepoPromise:  (&search.Promise{}).Resolve(resolved.RepoRevs),
+				RepoPromise:  (&search.RepoPromise{}).Resolve(resolved.RepoRevs),
 				Query:        r.Query,
 				Zoekt:        r.zoekt,
 				SearcherURLs: r.searcherURLs,

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -155,7 +155,7 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
-			repos, err := getRepos(context.Background(), args.RepoPromise)
+			repos, err := args.RepoPromise.Get(context.Background())
 			if err != nil {
 				t.Error(err)
 			}
@@ -272,7 +272,7 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
-			repos, err := getRepos(context.Background(), args.RepoPromise)
+			repos, err := args.RepoPromise.Get(context.Background())
 			if err != nil {
 				t.Error(err)
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
@@ -534,36 +533,6 @@ func mkFileMatch(repo types.RepoName, path string, lineNumbers ...int32) *result
 			Repo: repo,
 		},
 		LineMatches: lines,
-	}
-}
-
-func repoRev(revSpec string) *search.RepositoryRevisions {
-	return &search.RepositoryRevisions{
-		Repo: types.RepoName{ID: api.RepoID(0), Name: "test/repo"},
-		Revs: []search.RevisionSpecifier{
-			{RevSpec: revSpec},
-		},
-	}
-}
-
-func TestGetRepos(t *testing.T) {
-	in := []*search.RepositoryRevisions{repoRev("HEAD")}
-	rp := (&search.Promise{}).Resolve(in)
-	out, err := getRepos(context.Background(), rp)
-	if err != nil {
-		t.Error(err)
-	}
-	if ok := reflect.DeepEqual(in, out); !ok {
-		t.Errorf("got %+v, expected %+v", out, in)
-	}
-}
-
-func TestGetReposWrongUnderlyingType(t *testing.T) {
-	in := "anything"
-	rp := (&search.Promise{}).Resolve(in)
-	_, err := getRepos(context.Background(), rp)
-	if err == nil {
-		t.Errorf("Expected error, got nil")
 	}
 }
 

--- a/internal/search/repos_promise.go
+++ b/internal/search/repos_promise.go
@@ -5,20 +5,20 @@ import (
 	"sync"
 )
 
-type Promise struct {
+type RepoPromise struct {
 	initOnce sync.Once
 	done     chan struct{}
 
 	valueOnce sync.Once
-	value     interface{}
+	value     []*RepositoryRevisions
 }
 
-func (p *Promise) init() {
+func (p *RepoPromise) init() {
 	p.initOnce.Do(func() { p.done = make(chan struct{}) })
 }
 
 // Resolve returns a promise that is resolved with a given value.
-func (p *Promise) Resolve(v interface{}) *Promise {
+func (p *RepoPromise) Resolve(v []*RepositoryRevisions) *RepoPromise {
 	p.valueOnce.Do(func() {
 		p.init()
 		p.value = v
@@ -27,9 +27,9 @@ func (p *Promise) Resolve(v interface{}) *Promise {
 	return p
 }
 
-// Get returns the value. It blocks until the promise resolves or the context is
-// canceled.
-func (p *Promise) Get(ctx context.Context) (interface{}, error) {
+// Get returns the resolved revisions. It blocks until the promise resolves or
+// the context is canceled.
+func (p *RepoPromise) Get(ctx context.Context) ([]*RepositoryRevisions, error) {
 	p.init()
 	select {
 	case <-ctx.Done():

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -180,7 +180,7 @@ func (a *Aggregator) DoCommitSearch(ctx context.Context, tp *search.TextParamete
 }
 
 func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameters, resultType string) error {
-	repos, err := getRepos(ctx, args.RepoPromise)
+	repos, err := args.RepoPromise.Get(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/search/run/aggregator_test.go
+++ b/internal/search/run/aggregator_test.go
@@ -71,7 +71,7 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 		haveErr := checkDiffCommitSearchLimits(
 			context.Background(),
 			&search.TextParameters{
-				RepoPromise: (&search.Promise{}).Resolve(repoRevs),
+				RepoPromise: (&search.RepoPromise{}).Resolve(repoRevs),
 				Query:       test.fields,
 			},
 			test.resultType)

--- a/internal/search/run/commit.go
+++ b/internal/search/run/commit.go
@@ -389,7 +389,7 @@ func ResolveCommitParameters(ctx context.Context, tp *search.TextParameters) (*s
 		PathPatternsAreRegExps:       true,
 		PathPatternsAreCaseSensitive: old.PathPatternsAreCaseSensitive,
 	}
-	repos, err := getRepos(ctx, tp.RepoPromise)
+	repos, err := tp.RepoPromise.Get(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -83,7 +83,7 @@ func SearchRepositories(ctx context.Context, args *search.TextParameters, limit 
 	}
 
 	// Filter args.Repos by matching their names against the query pattern.
-	resolved, err := getRepos(ctx, args.RepoPromise)
+	resolved, err := args.RepoPromise.Get(ctx)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			newArgs.RepoPromise = (&search.Promise{}).Resolve(repos)
+			newArgs.RepoPromise = (&search.RepoPromise{}).Resolve(repos)
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
 			matches, _, err := SearchFilesInReposBatch(ctx, &newArgs)
@@ -251,7 +251,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			rp := (&search.Promise{}).Resolve(repos)
+			rp := (&search.RepoPromise{}).Resolve(repos)
 			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -31,7 +31,7 @@ func TestSearchRepositories(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
 	MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
-		repos, err := getRepos(context.Background(), args.RepoPromise)
+		repos, err := args.RepoPromise.Get(context.Background())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -99,7 +99,7 @@ func TestSearchRepositories(t *testing.T) {
 			pattern := search.ToTextPatternInfo(b, search.Batch, query.Identity)
 			matches, _, err := searchRepositoriesBatch(context.Background(), &search.TextParameters{
 				PatternInfo: pattern,
-				RepoPromise: (&search.Promise{}).Resolve(repositories),
+				RepoPromise: (&search.RepoPromise{}).Resolve(repositories),
 				Query:       q,
 				Zoekt:       zoekt,
 			}, int32(100))
@@ -129,7 +129,7 @@ func searchRepositoriesBatch(ctx context.Context, args *search.TextParameters, l
 
 func TestRepoShouldBeAdded(t *testing.T) {
 	MockSearchFilesInRepos = func(args *search.TextParameters) (matches []result.Match, common *streaming.Stats, err error) {
-		repos, err := getRepos(context.Background(), args.RepoPromise)
+		repos, err := args.RepoPromise.Get(context.Background())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -285,7 +285,7 @@ func BenchmarkSearchRepositories(b *testing.B) {
 	pattern := search.ToTextPatternInfo(bq, search.Batch, query.Identity)
 	tp := search.TextParameters{
 		PatternInfo: pattern,
-		RepoPromise: (&search.Promise{}).Resolve(repos),
+		RepoPromise: (&search.RepoPromise{}).Resolve(repos),
 		Query:       q,
 	}
 	for i := 0; i < b.N; i++ {

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -1,8 +1,6 @@
 package run
 
 import (
-	"context"
-	"fmt"
 	"math"
 
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -115,20 +113,6 @@ func handleRepoSearchResult(repoRev *search.RepositoryRevisions, limitHit, timed
 		Status:     search.RepoStatusSingleton(repoRev.Repo.ID, status),
 		IsLimitHit: limitHit,
 	}, fatalErr
-}
-
-// getRepos is a wrapper around p.Get. It returns an error if the promise
-// contains an underlying type other than []*search.RepositoryRevisions.
-func getRepos(ctx context.Context, p *search.Promise) ([]*search.RepositoryRevisions, error) {
-	v, err := p.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-	repoRevs, ok := v.([]*search.RepositoryRevisions)
-	if !ok {
-		return nil, fmt.Errorf("unexpected underlying type (%T) of promise", v)
-	}
-	return repoRevs, nil
 }
 
 func statsDeref(s *streaming.Stats) streaming.Stats {

--- a/internal/search/run/symbol.go
+++ b/internal/search/run/symbol.go
@@ -44,7 +44,7 @@ func SearchSymbols(ctx context.Context, args *search.TextParameters, limit int, 
 		return err
 	}
 
-	repos, err := getRepos(ctx, args.RepoPromise)
+	repos, err := args.RepoPromise.Get(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/search/run/textsearch_test.go
+++ b/internal/search/run/textsearch_test.go
@@ -85,7 +85,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  (&search.Promise{}).Resolve(repoRevs),
+		RepoPromise:  (&search.RepoPromise{}).Resolve(repoRevs),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
@@ -115,7 +115,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  (&search.Promise{}).Resolve(makeRepositoryRevisions("foo/no-rev@dev")),
+		RepoPromise:  (&search.RepoPromise{}).Resolve(makeRepositoryRevisions("foo/no-rev@dev")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
@@ -172,7 +172,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  (&search.Promise{}).Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/three")),
+		RepoPromise:  (&search.RepoPromise{}).Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/three")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
@@ -238,12 +238,12 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  (&search.Promise{}).Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/")),
+		RepoPromise:  (&search.RepoPromise{}).Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
 	}
-	repos, _ := getRepos(context.Background(), args.RepoPromise)
+	repos, _ := args.RepoPromise.Get(context.Background())
 	repos[0].ListRefs = func(context.Context, api.RepoName) ([]git.Ref, error) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -128,7 +128,7 @@ type TextParameters struct {
 
 	// Performance optimization: For global queries, resolving repositories and
 	// querying zoekt happens concurrently.
-	RepoPromise *Promise
+	RepoPromise *RepoPromise
 	Mode        GlobalSearchMode
 
 	// Query is the parsed query from the user. You should be using Pattern

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestPromiseGet(t *testing.T) {
-	in := "anything"
-	p := (&Promise{}).Resolve(in)
+	in := []*RepositoryRevisions{nil}
+	p := (&RepoPromise{}).Resolve(in)
 	out, err := p.Get(context.Background())
 	if err != nil {
 		t.Fatal("error should have been nil, because we supplied a context.Background()")
@@ -19,7 +19,7 @@ func TestPromiseGet(t *testing.T) {
 }
 
 func TestPromiseGetWithCancel(t *testing.T) {
-	rp := Promise{}
+	rp := RepoPromise{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := rp.Get(ctx)
@@ -30,8 +30,8 @@ func TestPromiseGetWithCancel(t *testing.T) {
 
 func TestPromiseGetConcurrent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	in := "anything"
-	p := Promise{}
+	in := []*RepositoryRevisions{nil}
+	p := RepoPromise{}
 	go func() {
 		p.Resolve(in)
 	}()

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -215,7 +215,7 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	repos, err := getRepos(ctx, args.RepoPromise)
+	repos, err := args.RepoPromise.Get(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 	g.Go(func() error {
 		defer close(reposResolved)
 		if args.Mode == search.ZoektGlobalSearch || args.PatternInfo.Select.Root() == filter.Repository {
-			repos, err := getRepos(ctx, args.RepoPromise)
+			repos, err := args.RepoPromise.Get(ctx)
 			if err != nil {
 				return err
 			}
@@ -497,20 +497,6 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 		return nil
 	}
 	return nil
-}
-
-// getRepos is a wrapper around p.Get. It returns an error if the promise
-// contains an underlying type other than []*search.RepositoryRevisions.
-func getRepos(ctx context.Context, p *search.Promise) ([]*search.RepositoryRevisions, error) {
-	v, err := p.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-	repoRevs, ok := v.([]*search.RepositoryRevisions)
-	if !ok {
-		return nil, fmt.Errorf("unexpected underlying type (%T) of promise", v)
-	}
-	return repoRevs, nil
 }
 
 // bufferedSender returns a buffered Sender with capacity cap, and a cleanup

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -259,7 +259,7 @@ func TestIndexedSearch(t *testing.T) {
 			args := &search.TextParameters{
 				Query:           q,
 				PatternInfo:     tt.args.patternInfo,
-				RepoPromise:     (&search.Promise{}).Resolve(tt.args.repos),
+				RepoPromise:     (&search.RepoPromise{}).Resolve(tt.args.repos),
 				UseFullDeadline: tt.args.useFullDeadline,
 				Zoekt: &searchbackend.Zoekt{
 					Client: &searchbackend.FakeSearcher{


### PR DESCRIPTION
The type search.Promise was written to be generic for any type, but was
only ever used as a promise for []*search.RepositoryRevisions.

By specializing this, we can get rid of the `getRepos` functions
spread throughout the codebase, as well as avoid all the interface
conversion where it's used.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
