### PR TITLE
API docs: web: adjust frontend to render new backend data format

### DIFF
--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -15,9 +15,21 @@ interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec {
 
     history: H.History
     location: H.Location
+
+    /** The documentation node to render */
     node: GQLDocumentationNode
+
+    /** How far deep we are in the tree of documentation nodes */
     depth: number
+
+    /** The pathID of the page containing this documentation node */
     pagePathID: string
+
+    /** If true, render subpage index only */
+    subpagesOnly: boolean
+
+    /** If true, render content index only */
+    contentOnly: boolean
 }
 
 export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, depth, ...props }) => {
@@ -27,33 +39,72 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, d
         revision: props.revision || '',
     }
     const hashIndex = node.pathID.indexOf('#')
-    const hash = hashIndex ? node.pathID.slice(hashIndex + '#'.length) : ''
-    const thisPage = toDocumentationURL({ ...repoRevision, pathID: node.pathID })
+    const hash = hashIndex != -1 ? node.pathID.slice(hashIndex + '#'.length) : ''
+    const path = node.pathID.slice('/'.length, hashIndex)
+    const thisPage = toDocumentationURL({ ...repoRevision, pathID: path + '#' + hash })
+
+    if (props.subpagesOnly) {
+        return (
+            <div className="documentation-index-node">
+                <ul className="pl-3">
+                    {node.children?.map((child, index) =>
+                        child.pathID ? (
+                            <div key={`${depth}-${index}`} className="text-nowrap">
+                                <Link to={toDocumentationURL({ ...repoRevision, pathID: child.pathID })}>
+                                    {child.pathID.slice('/'.length) + '/'}
+                                </Link>
+                            </div>
+                        ) : null
+                    )}
+                </ul>
+            </div>
+        )
+    }
+    if (props.contentOnly) {
+        return (
+            <div className="documentation-index-node">
+                <Link id={'index-' + hash} to={thisPage} className="text-nowrap">
+                    {node.label.value}
+                </Link>
+                <ul className="pl-3">
+                    {node.children?.map((child, index) =>
+                        child.pathID ? null : (
+                            <DocumentationIndexNode
+                                key={`${depth}-${index}`}
+                                {...props}
+                                node={child.node!}
+                                depth={depth + 1}
+                                subpagesOnly={false}
+                                contentOnly={true}
+                            />
+                        )
+                    )}
+                </ul>
+            </div>
+        )
+    }
 
     return (
         <div className="documentation-index-node">
-            <Link id={'index-' + hash} to={thisPage} className="text-nowrap">
-                {node.label.value}
+            <Link id={'index-subpages'} to={thisPage} className="text-nowrap">
+                Subpages
             </Link>
-
-            <ul className="pl-3">
-                {node.children?.map((child, index) =>
-                    child.pathID ? (
-                        <li key={`${depth}-${index}`}>
-                            <Link to={toDocumentationURL({ ...repoRevision, pathID: child.pathID })}>
-                                {child.pathID}
-                            </Link>
-                        </li>
-                    ) : (
-                        <DocumentationIndexNode
-                            key={`${depth}-${index}`}
-                            {...props}
-                            node={child.node!}
-                            depth={depth + 1}
-                        />
-                    )
-                )}
-            </ul>
+            <DocumentationIndexNode
+                key={`${depth}-subpages`}
+                {...props}
+                node={node}
+                depth={depth + 1}
+                subpagesOnly={true}
+                contentOnly={false}
+            />
+            <DocumentationIndexNode
+                key={`${depth}-content`}
+                {...props}
+                node={node}
+                depth={depth + 1}
+                subpagesOnly={false}
+                contentOnly={true}
+            />
         </div>
     )
 }

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -60,8 +60,10 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
         revision: props.revision || '',
     }
     const hashIndex = node.pathID.indexOf('#')
-    const hash = hashIndex ? node.pathID.slice(hashIndex + '#'.length) : ''
-    const thisPage = toDocumentationURL({ ...repoRevision, pathID: node.pathID })
+    const hash = hashIndex != -1 ? node.pathID.slice(hashIndex + '#'.length) : ''
+    const path = node.pathID.slice('/'.length, hashIndex)
+    const thisPage = toDocumentationURL({ ...repoRevision, pathID: path + '#' + hash })
+
     useBreadcrumb(
         useMemo(
             () =>

--- a/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
@@ -80,7 +80,14 @@ export const RepositoryDocumentationSidebar: React.FunctionComponent<Props> = ({
                         </Button>
                     </div>
                     <div aria-hidden={true} className="d-flex explorer overflow-auto px-3">
-                        <DocumentationIndexNode {...props} node={props.node} pagePathID={props.pagePathID} depth={0} />
+                        <DocumentationIndexNode
+                            {...props}
+                            node={props.node}
+                            pagePathID={props.pagePathID}
+                            depth={0}
+                            subpagesOnly={false}
+                            contentOnly={false}
+                        />
                     </div>
                 </div>
             }


### PR DESCRIPTION
requires a few frontend changes to faithfully render. This is those changes.

This isn't a final form, it's just a stepping stone with approximately the same frontend as what we had before. The cool/new things will come later.

The main change here is that subpages now have a dedicated index section:

<img width="797" alt="image" src="https://user-images.githubusercontent.com/3173176/123328503-7da2e880-d4f0-11eb-9b56-79f06a470e27.png">

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>