### PR TITLE
move statsDeref to a method on Stats

### DIFF
--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -27,7 +27,7 @@ func SearchRepositories(ctx context.Context, args *search.TextParameters, limit 
 		results, stats, err := MockSearchRepositories(args)
 		stream.Send(streaming.SearchEvent{
 			Results: results,
-			Stats:   statsDeref(stats),
+			Stats:   stats.Deref(),
 		})
 		return err
 	}

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -73,11 +72,4 @@ type SearchCursor struct {
 	// Finished tells if there are more results for the query or if we've
 	// consumed them all.
 	Finished bool
-}
-
-func statsDeref(s *streaming.Stats) streaming.Stats {
-	if s == nil {
-		return streaming.Stats{}
-	}
-	return *s
 }

--- a/internal/search/run/textsearch.go
+++ b/internal/search/run/textsearch.go
@@ -174,7 +174,7 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		matches, mockStats, err := MockSearchFilesInRepos(args)
 		stream.Send(streaming.SearchEvent{
 			Results: matches,
-			Stats:   statsDeref(mockStats),
+			Stats:   mockStats.Deref(),
 		})
 		return err
 	}

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -112,3 +112,11 @@ func (c *Stats) Equal(other *Stats) bool {
 func (c *Stats) AllReposTimedOut() bool {
 	return c.Status.All(search.RepoStatusTimedout) && c.Status.Len() == len(c.Repos)
 }
+
+// Deref returns the zero-valued stats if its receiver is nil
+func (c *Stats) Deref() Stats {
+	if c != nil {
+		return *c
+	}
+	return Stats{}
+}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -42,7 +42,7 @@ func Search(ctx context.Context, args *search.TextParameters, limit int, stream 
 		results, stats, err := MockSearchSymbols(ctx, args, limit)
 		stream.Send(streaming.SearchEvent{
 			Results: results,
-			Stats:   statsDeref(stats),
+			Stats:   stats.Deref(),
 		})
 		return err
 	}
@@ -368,11 +368,4 @@ func limitOrDefault(first *int32) int {
 		return DefaultSymbolLimit
 	}
 	return int(*first)
-}
-
-func statsDeref(s *streaming.Stats) streaming.Stats {
-	if s == nil {
-		return streaming.Stats{}
-	}
-	return *s
 }


### PR DESCRIPTION
This allows other packages to more easily dereference stats without
having to import or copy a small deref function from another package.

Depends on #22365 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
