### PR TITLE
Update limitations

### DIFF
--- a/doc/code_insights/explanations/current_limitations_of_code_insights.md
+++ b/doc/code_insights/explanations/current_limitations_of_code_insights.md
@@ -4,17 +4,13 @@ Because code insights is currently a [prototype feature](../../admin/beta_and_pr
 
 If you have strong feedback, please do [let us know](mailto:feedback@sourcegraph.com).
 
-## The number of repositories in a search-based insight must be less than 50
+## The runtime of search-based Code Insights degrades quickly after ~50 repositories
 
-Code Insights currently depends on frontend API calls to Sourcegraph searches, so it can't run historical searches over more than 50 repositories due to that search limitation. 
+Because the Code Insights prototype currently runs on frontend API calls to Sourcegraph searches, it may run slowly (or possibly timeout) if you're using it over many repositories or with many data series for each insight. That said, a code insight caches locally after you've run it the first time.
 
-We're currently developing a scalable backend service that fixes this and are planning to release it by September 2021. 
+We're currently developing a scalable backend service that fixes this limitation, with a planned release by September 2021, that will allow you to run code insights over thousands of repositories at once. As of now, performance generally gets noticeably slower around 50 repositories, and becomes functionally unusable above 200 repositories.
 
-## Search-based Code Insights may run slowly for large numbers of repositories or data series
-
-Because Code Insights runs on the frontend, it may run slowly (or possibly timeout) if you're using it over very many repositories or with very many data series for each insight. That said, a code insight caches locally after you've run it the first time. 
-
-We're currently working on both backend and frontend improvements to increase the speed at which code insights returns data, and you can expect significant improvement by September 2021. 
+> Note: if your data series query is a `diff` search, there is an additional hard limit of 50 repositories. This limit will also be lifted as the product matures. 
 
 ## Known bugs
 


### PR DESCRIPTION
See [this slack thread](https://sourcegraph.slack.com/archives/C01RVEVPWLC/p1624411358007000) for full context / catalyst if curious – the TL;DR is that the 50-repo limit is specific to diff searches without a date specified, but there is still a hefty performance degradation with the frontend insights. 
