### PR TITLE
batches: add batch changes badge and filtered page for repo

### DIFF
--- a/client/web/src/components/diff/DiffStat.scss
+++ b/client/web/src/components/diff/DiffStat.scss
@@ -4,8 +4,12 @@
 
     &__total {
         padding-right: 0.125rem;
-        // stylelint-disable-next-line declaration-property-unit-whitelist
-        margin-bottom: -1px;
+        padding-bottom: 0.25rem;
+    }
+
+    &__squares {
+        display: flex;
+        flex-wrap: nowrap;
     }
 
     &__square {

--- a/client/web/src/components/diff/DiffStat.scss
+++ b/client/web/src/components/diff/DiffStat.scss
@@ -2,11 +2,6 @@
     display: inline-flex;
     align-items: center;
 
-    &__total {
-        padding-right: 0.125rem;
-        padding-bottom: 0.25rem;
-    }
-
     &__squares {
         display: flex;
         flex-wrap: nowrap;

--- a/client/web/src/components/diff/DiffStat.story.tsx
+++ b/client/web/src/components/diff/DiffStat.story.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { WebStory } from '../WebStory'
 
-import { DiffStat } from './DiffStat'
+import { DiffStat, DiffStatStack } from './DiffStat'
 
 const { add } = storiesOf('web/diffs/DiffStat', module).addDecorator(story => (
     <div className="p-3 container">{story()}</div>
@@ -29,12 +29,4 @@ add('Expanded', () => (
     </WebStory>
 ))
 
-add('Separate lines', () => (
-    <WebStory>
-        {() => (
-            <div>
-                <DiffStat added={10} changed={4} deleted={8} expandedCounts={true} separateLines={true} />
-            </div>
-        )}
-    </WebStory>
-))
+add('DiffStatStack', () => <WebStory>{() => <DiffStatStack added={10} changed={4} deleted={8} />}</WebStory>)

--- a/client/web/src/components/diff/DiffStat.test.tsx
+++ b/client/web/src/components/diff/DiffStat.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 
-import { DiffStat } from './DiffStat'
+import { DiffStat, DiffStatSquares, DiffStatStack } from './DiffStat'
 
 describe('DiffStat', () => {
     test('standard', () =>
@@ -12,3 +12,9 @@ describe('DiffStat', () => {
             renderer.create(<DiffStat added={1} changed={2} deleted={3} expandedCounts={true} />).toJSON()
         ).toMatchSnapshot())
 })
+
+test('DiffStatSquares', () =>
+    expect(renderer.create(<DiffStatSquares added={1} changed={2} deleted={3} />).toJSON()).toMatchSnapshot())
+
+test('DiffStatStack', () =>
+    expect(renderer.create(<DiffStatStack added={1} changed={2} deleted={3} />).toJSON()).toMatchSnapshot())

--- a/client/web/src/components/diff/DiffStat.tsx
+++ b/client/web/src/components/diff/DiffStat.tsx
@@ -5,7 +5,7 @@ import { numberWithCommas, pluralize } from '@sourcegraph/shared/src/util/string
 
 const NUM_SQUARES = 5
 
-interface Props {
+interface DiffProps {
     /** Number of additions (added lines). */
     added: number
 
@@ -14,23 +14,54 @@ interface Props {
 
     /** Number of deletions (deleted lines). */
     deleted: number
+}
 
+interface DiffStatProps extends DiffProps {
     /* Show +/- numbers, not just the total change count. */
     expandedCounts?: boolean
-
-    separateLines?: boolean
 
     className?: string
 }
 
 /** Displays a diff stat (visual representation of added, changed, and deleted lines in a diff). */
-export const DiffStat: React.FunctionComponent<Props> = React.memo(function DiffStat({
+export const DiffStat: React.FunctionComponent<DiffStatProps> = React.memo(function DiffStat({
     added,
     changed,
     deleted,
     expandedCounts = false,
-    separateLines = false,
     className = '',
+}) {
+    const total = added + changed + deleted
+
+    const labels: string[] = []
+    if (added > 0) {
+        labels.push(`${numberWithCommas(added)} ${pluralize('addition', added)}`)
+    }
+    if (changed > 0) {
+        labels.push(`${numberWithCommas(changed)} ${pluralize('change', changed)}`)
+    }
+    if (deleted > 0) {
+        labels.push(`${numberWithCommas(deleted)} ${pluralize('deletion', deleted)}`)
+    }
+    return (
+        <div className={classNames('diff-stat', className)} data-tooltip={labels.join(', ')}>
+            {expandedCounts ? (
+                <>
+                    <strong className="text-success mr-1">+{numberWithCommas(added)}</strong>
+                    {changed > 0 && <strong className="text-warning mr-1">&bull;{numberWithCommas(changed)}</strong>}
+                    <strong className="text-danger">&minus;{numberWithCommas(deleted)}</strong>
+                </>
+            ) : (
+                <small>{numberWithCommas(total + changed)}</small>
+            )}
+        </div>
+    )
+})
+
+export const DiffStatSquares: React.FunctionComponent<DiffProps> = React.memo(function DiffStatSquares({
+    added,
+    changed,
+    deleted,
 }) {
     const total = added + changed + deleted
     const numberOfSquares = Math.min(NUM_SQUARES, total)
@@ -68,38 +99,29 @@ export const DiffStat: React.FunctionComponent<Props> = React.memo(function Diff
             new Array<'diff-stat__empty'>(NUM_SQUARES - numberOfSquares).fill('diff-stat__empty')
         )
 
-    const labels: string[] = []
-    if (added > 0) {
-        labels.push(`${numberWithCommas(added)} ${pluralize('addition', added)}`)
-    }
-    if (changed > 0) {
-        labels.push(`${numberWithCommas(changed)} ${pluralize('change', changed)}`)
-    }
-    if (deleted > 0) {
-        labels.push(`${numberWithCommas(deleted)} ${pluralize('deletion', deleted)}`)
-    }
     return (
-        <div
-            className={classNames('diff-stat', separateLines && 'flex-column', className)}
-            data-tooltip={labels.join(', ')}
-        >
-            {expandedCounts ? (
-                <span className="diff-stat__total font-weight-bold">
-                    <span className="text-success mr-1">+{numberWithCommas(added)}</span>
-                    {changed > 0 && <span className="text-warning mr-1">&bull;{numberWithCommas(changed)}</span>}
-                    <span className={classNames('text-danger', !separateLines && 'mr-1')}>
-                        &minus;{numberWithCommas(deleted)}
-                    </span>
-                </span>
-            ) : (
-                <small className="diff-stat__total">{numberWithCommas(total + changed)}</small>
-            )}
-            <div className="diff-stat__squares">
-                {squares.map((className, index) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <div key={index} className={`diff-stat__square ${className}`} />
-                ))}
-            </div>
+        <div className="diff-stat__squares">
+            {squares.map((className, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <div key={index} className={`diff-stat__square ${className}`} />
+            ))}
+        </div>
+    )
+})
+
+interface DiffStatStackProps extends DiffProps {
+    className?: string
+}
+
+/** A commonly used combined vertical stack of a `DiffStat` and a `DiffStatSquares` */
+export const DiffStatStack: React.FunctionComponent<DiffStatStackProps> = React.memo(function DiffStatStack({
+    className = '',
+    ...props
+}) {
+    return (
+        <div className={classNames('d-flex flex-column align-items-center', className)}>
+            <DiffStat className="pb-1" expandedCounts={true} {...props} />
+            <DiffStatSquares {...props} />
         </div>
     )
 })

--- a/client/web/src/components/diff/DiffStat.tsx
+++ b/client/web/src/components/diff/DiffStat.tsx
@@ -94,8 +94,9 @@ export const DiffStat: React.FunctionComponent<Props> = React.memo(function Diff
             ) : (
                 <small className="diff-stat__total">{numberWithCommas(total + changed)}</small>
             )}
-            <div>
+            <div className="diff-stat__squares">
                 {squares.map((className, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
                     <div key={index} className={`diff-stat__square ${className}`} />
                 ))}
             </div>

--- a/client/web/src/components/diff/FileDiffNode.scss
+++ b/client/web/src/components/diff/FileDiffNode.scss
@@ -42,14 +42,12 @@
             font-family: $code-font-family;
             color: var(--body-color);
             font-size: $code-font-size;
+            margin-left: 0.5rem;
             .theme-redesign & {
                 color: var(--link-color);
                 font-family: inherit;
                 font-size: 0.875rem;
             }
-        }
-        &-stat {
-            margin-right: 0.5rem;
         }
 
         &-actions {

--- a/client/web/src/components/diff/FileDiffNode.tsx
+++ b/client/web/src/components/diff/FileDiffNode.tsx
@@ -15,7 +15,7 @@ import { FileDiffFields } from '../../graphql-operations'
 import { DiffMode } from '../../repo/commit/RepositoryCommitPage'
 import { dirname } from '../../util/path'
 
-import { DiffStat } from './DiffStat'
+import { DiffStat, DiffStatSquares } from './DiffStat'
 import { ExtensionInfo } from './FileDiffConnection'
 import { FileDiffHunks } from './FileDiffHunks'
 
@@ -81,15 +81,13 @@ export const FileDiffNode: React.FunctionComponent<FileDiffNodeProps> = ({
     if (node.oldFile?.binary || node.newFile?.binary) {
         const sizeChange = (node.newFile?.byteSize ?? 0) - (node.oldFile?.byteSize ?? 0)
         const className = sizeChange >= 0 ? 'text-success' : 'text-danger'
-        stat = <strong className={classnames(className, 'mr-2 code')}>{prettyBytes(sizeChange)}</strong>
+        stat = <strong className={classnames(className, 'code')}>{prettyBytes(sizeChange)}</strong>
     } else {
         stat = (
-            <DiffStat
-                added={node.stat.added}
-                changed={node.stat.changed}
-                deleted={node.stat.deleted}
-                className="file-diff-node__header-stat"
-            />
+            <>
+                <DiffStat className="mr-1" {...node.stat} />
+                <DiffStatSquares {...node.stat} />
+            </>
         )
     }
 

--- a/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
@@ -27,7 +27,9 @@ exports[`DiffStat expandedCounts 1`] = `
       3
     </span>
   </span>
-  <div>
+  <div
+    className="diff-stat__squares"
+  >
     <div
       className="diff-stat__square bg-success"
     />
@@ -57,7 +59,9 @@ exports[`DiffStat standard 1`] = `
   >
     8
   </small>
-  <div>
+  <div
+    className="diff-stat__squares"
+  >
     <div
       className="diff-stat__square bg-success"
     />

--- a/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
@@ -5,47 +5,24 @@ exports[`DiffStat expandedCounts 1`] = `
   className="diff-stat"
   data-tooltip="1 addition, 2 changes, 3 deletions"
 >
-  <span
-    className="diff-stat__total font-weight-bold"
+  <strong
+    className="text-success mr-1"
   >
-    <span
-      className="text-success mr-1"
-    >
-      +
-      1
-    </span>
-    <span
-      className="text-warning mr-1"
-    >
-      •
-      2
-    </span>
-    <span
-      className="text-danger mr-1"
-    >
-      −
-      3
-    </span>
-  </span>
-  <div
-    className="diff-stat__squares"
+    +
+    1
+  </strong>
+  <strong
+    className="text-warning mr-1"
   >
-    <div
-      className="diff-stat__square bg-success"
-    />
-    <div
-      className="diff-stat__square bg-warning"
-    />
-    <div
-      className="diff-stat__square bg-danger"
-    />
-    <div
-      className="diff-stat__square bg-danger"
-    />
-    <div
-      className="diff-stat__square bg-danger"
-    />
-  </div>
+    •
+    2
+  </strong>
+  <strong
+    className="text-danger"
+  >
+    −
+    3
+  </strong>
 </div>
 `;
 
@@ -54,11 +31,61 @@ exports[`DiffStat standard 1`] = `
   className="diff-stat"
   data-tooltip="1 addition, 2 changes, 3 deletions"
 >
-  <small
-    className="diff-stat__total"
-  >
+  <small>
     8
   </small>
+</div>
+`;
+
+exports[`DiffStatSquares 1`] = `
+<div
+  className="diff-stat__squares"
+>
+  <div
+    className="diff-stat__square bg-success"
+  />
+  <div
+    className="diff-stat__square bg-warning"
+  />
+  <div
+    className="diff-stat__square bg-danger"
+  />
+  <div
+    className="diff-stat__square bg-danger"
+  />
+  <div
+    className="diff-stat__square bg-danger"
+  />
+</div>
+`;
+
+exports[`DiffStatStack 1`] = `
+<div
+  className="d-flex flex-column align-items-center"
+>
+  <div
+    className="diff-stat pb-1"
+    data-tooltip="1 addition, 2 changes, 3 deletions"
+  >
+    <strong
+      className="text-success mr-1"
+    >
+      +
+      1
+    </strong>
+    <strong
+      className="text-warning mr-1"
+    >
+      •
+      2
+    </strong>
+    <strong
+      className="text-danger"
+    >
+      −
+      3
+    </strong>
+  </div>
   <div
     className="diff-stat__squares"
   >

--- a/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.tsx
+++ b/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.tsx
@@ -12,7 +12,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { ErrorAlert } from '../../../components/alerts'
-import { DiffStat } from '../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { ExternalChangesetFields } from '../../../graphql-operations'
 import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
 import { ChangesetCheckStatusCell } from '../detail/changesets/ChangesetCheckStatusCell'
@@ -87,7 +87,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
             >
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} className="mr-3" />}
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             <span className="d-none d-md-inline">
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}
@@ -96,7 +96,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}
             </span>
             <div className="d-none d-md-flex justify-content-center">
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             {/* The button for expanding the information used on xs devices. */}
             <button

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
-import { DiffStat } from '../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { BatchChangeFields, ChangesetsStatsFields, DiffStatFields } from '../../../graphql-operations'
 
 import { BatchChangeStateBadge } from './BatchChangeStateBadge'
@@ -61,12 +61,7 @@ export const BatchChangeStatsCard: React.FunctionComponent<BatchChangeStatsCardP
                     </span>
                 </div>
                 <div className={classNames(styles.batchChangeStatsCardDivider, 'd-none d-md-block mx-3')} />
-                <DiffStat
-                    {...diff}
-                    expandedCounts={true}
-                    separateLines={true}
-                    className={styles.batchChangeStatsCardDiffStat}
-                />
+                <DiffStatStack className={styles.batchChangeStatsCardDiffStat} {...diff} />
                 <div className="d-flex flex-wrap justify-content-end flex-grow-1">
                     <BatchChangeStatsTotalAction count={stats.total} />
                     <ChangesetStatusUnpublished

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -277,8 +277,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                         extensionInfo: { extensionsController, hoverifier },
                         expandByDefault,
                         queryExternalChangesetWithFileDiffs,
-                        onSelect,
-                        isSelected: changesetSelected,
+                        selectable: { onSelect, isSelected: changesetSelected },
                     }}
                     queryConnection={queryChangesetsConnection}
                     hideSearch={true}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -252,7 +252,6 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                     history={history}
                     location={location}
                     onFiltersChange={setChangesetFiltersAndDeselectAll}
-                    searchPlaceholderText="Search title and repository name"
                 />
             )}
             {showSelectRow && queryArguments && (

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -252,6 +252,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                     history={history}
                     location={location}
                     onFiltersChange={setChangesetFiltersAndDeselectAll}
+                    searchPlaceholderText="Search title and repository name"
                 />
             )}
             {showSelectRow && queryArguments && (

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
@@ -17,12 +17,14 @@ export interface ChangesetFilterRowProps {
     history: H.History
     location: H.Location
     onFiltersChange: (newFilters: ChangesetFilters) => void
+    searchPlaceholderText: string
 }
 
 export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps> = ({
     history,
     location,
     onFiltersChange,
+    searchPlaceholderText,
 }) => {
     const searchElement = useRef<HTMLInputElement | null>(null)
     const searchParameters = new URLSearchParams(location.search)
@@ -93,7 +95,7 @@ export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps
                             type="search"
                             ref={searchElement}
                             defaultValue={search}
-                            placeholder="Search title and repository name"
+                            placeholder={searchPlaceholderText}
                         />
                     </Form>
                 </div>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
@@ -17,14 +17,12 @@ export interface ChangesetFilterRowProps {
     history: H.History
     location: H.Location
     onFiltersChange: (newFilters: ChangesetFilters) => void
-    searchPlaceholderText: string
 }
 
 export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps> = ({
     history,
     location,
     onFiltersChange,
-    searchPlaceholderText,
 }) => {
     const searchElement = useRef<HTMLInputElement | null>(null)
     const searchParameters = new URLSearchParams(location.search)
@@ -95,7 +93,7 @@ export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps
                             type="search"
                             ref={searchElement}
                             defaultValue={search}
-                            placeholder={searchPlaceholderText}
+                            placeholder="Search title and repository name"
                         />
                     </Form>
                 </div>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
@@ -25,25 +25,28 @@ export interface ChangesetNodeProps extends ThemeProps {
     extensionInfo?: {
         hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
     } & ExtensionsControllerProps
+    /**
+     * Element to precede the changeset so that it is separated from its neighbors when
+     * viewed in a list, defaults to a full-width light gray horizontal rule
+     */
+    separator?: React.ReactNode
     /** For testing purposes. */
     queryExternalChangesetWithFileDiffs?: typeof queryExternalChangesetWithFileDiffs
     /** For testing purposes. */
     expandByDefault?: boolean
 }
 
-export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({ node, ...props }) => {
-    if (node.__typename === 'ExternalChangeset') {
-        return (
-            <>
-                <span className={styles.changesetNodeSeparator} />
-                <ExternalChangesetNode node={node} {...props} />
-            </>
-        )
-    }
-    return (
-        <>
-            <span className={styles.changesetNodeSeparator} />
+export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({
+    node,
+    separator = <span className={styles.changesetNodeSeparator} />,
+    ...props
+}) => (
+    <>
+        {separator}
+        {node.__typename === 'ExternalChangeset' ? (
+            <ExternalChangesetNode node={node} {...props} />
+        ) : (
             <HiddenExternalChangesetNode node={node} {...props} />
-        </>
-    )
-}
+        )}
+    </>
+)

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
@@ -20,8 +20,10 @@ export interface ChangesetNodeProps extends ThemeProps {
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location
-    onSelect?: (id: string, selected: boolean) => void
-    isSelected?: (id: string) => boolean
+    selectable?: {
+        onSelect: (id: string, selected: boolean) => void
+        isSelected: (id: string) => boolean
+    }
     extensionInfo?: {
         hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
     } & ExtensionsControllerProps

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -33,8 +33,10 @@ import styles from './ExternalChangesetNode.module.scss'
 export interface ExternalChangesetNodeProps extends ThemeProps {
     node: ExternalChangesetFields
     viewerCanAdminister: boolean
-    onSelect?: (id: string, selected: boolean) => void
-    isSelected?: (id: string) => boolean
+    selectable?: {
+        onSelect: (id: string, selected: boolean) => void
+        isSelected: (id: string) => boolean
+    }
     history: H.History
     location: H.Location
     extensionInfo?: {
@@ -49,8 +51,7 @@ export interface ExternalChangesetNodeProps extends ThemeProps {
 export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNodeProps> = ({
     node: initialNode,
     viewerCanAdminister,
-    onSelect,
-    isSelected,
+    selectable,
     isLightTheme,
     history,
     location,
@@ -71,12 +72,10 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
         [isExpanded]
     )
 
-    const selected = isSelected?.(node.id)
+    const selected = selectable?.isSelected(node.id)
     const toggleSelected = useCallback((): void => {
-        if (onSelect !== undefined) {
-            onSelect(node.id, !selected)
-        }
-    }, [onSelect, selected, node.id])
+        selectable?.onSelect(node.id, !selected)
+    }, [selectable, selected, node.id])
 
     return (
         <>
@@ -92,17 +91,23 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                     <ChevronRightIcon className="icon-inline" aria-label="Expand section" />
                 )}
             </button>
-            <div className="p-2">
-                <input
-                    id={`select-changeset-${node.id}`}
-                    type="checkbox"
-                    className="btn"
-                    checked={selected}
-                    onChange={toggleSelected}
-                    disabled={!viewerCanAdminister}
-                    data-tooltip="Click to select changeset for bulk operation"
-                />
-            </div>
+            {selectable ? (
+                <div className="p-2">
+                    <input
+                        id={`select-changeset-${node.id}`}
+                        type="checkbox"
+                        className="btn"
+                        checked={selected}
+                        onChange={toggleSelected}
+                        disabled={!viewerCanAdminister}
+                        data-tooltip="Click to select changeset for bulk operation"
+                    />
+                </div>
+            ) : (
+                // 0-width empty element to allow us to keep the identical grid template of the parent
+                // list, regardless of whether or not the nodes have the checkbox selector
+                <span />
+            )}
             <ChangesetStatusCell
                 id={node.id}
                 state={node.state}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -15,7 +15,7 @@ import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { ErrorAlert, ErrorMessage } from '../../../../components/alerts'
-import { DiffStat } from '../../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../../components/diff/DiffStat'
 import { ChangesetSpecType, ExternalChangesetFields } from '../../../../graphql-operations'
 import {
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
@@ -130,7 +130,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
             >
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} className="mr-3" />}
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             <span
                 className={classNames(
@@ -154,7 +154,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                     node.diffStat && 'p-2'
                 )}
             >
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             {/* The button for expanding the information used on xs devices. */}
             <button

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -1,11 +1,9 @@
 import classNames from 'classnames'
-import PlusIcon from 'mdi-react/PlusIcon'
 import React, { useEffect, useCallback, useState, useMemo } from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Observable, ReplaySubject } from 'rxjs'
 import { filter, map, tap, withLatestFrom } from 'rxjs/operators'
 
-import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
@@ -30,6 +28,7 @@ import styles from './BatchChangeListPage.module.scss'
 import { BatchChangeNode, BatchChangeNodeProps } from './BatchChangeNode'
 import { BatchChangesListEmpty } from './BatchChangesListEmpty'
 import { BatchChangesListIntro } from './BatchChangesListIntro'
+import { NewBatchChangeButton } from './NewBatchChangeButton'
 
 export interface BatchChangeListPageProps extends TelemetryProps, Pick<RouteComponentProps, 'location'> {
     headingElement: 'h1' | 'h2'
@@ -127,7 +126,7 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
             <PageHeader
                 path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]}
                 className="test-batches-list-page mb-3"
-                actions={<NewBatchChangeButton location={location} />}
+                actions={<NewBatchChangeButton to={`${location.pathname}/create`} />}
                 headingElement={headingElement}
                 description="Run custom code over hundreds of repositories and manage the resulting changesets."
             />
@@ -193,16 +192,8 @@ const BatchChangeListEmptyElement: React.FunctionComponent<BatchChangeListEmptyE
         <p>
             <strong>No batch changes have been created</strong>
         </p>
-        <NewBatchChangeButton location={location} />
+        <NewBatchChangeButton to={`${location.pathname}/create`} />
     </div>
-)
-
-interface NewBatchChangeButtonProps extends Pick<RouteComponentProps, 'location'> {}
-
-const NewBatchChangeButton: React.FunctionComponent<NewBatchChangeButtonProps> = ({ location }) => (
-    <Link to={`${location.pathname}/create`} className="btn btn-primary">
-        <PlusIcon className="icon-inline" /> Create
-    </Link>
 )
 
 const BatchChangeListTabHeader: React.FunctionComponent<{

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -133,9 +133,9 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
             />
             <BatchChangesListIntro licensed={licensed} />
             <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
-            {selectedTab === 'gettingStarted' && <BatchChangesListEmpty />}
-            {selectedTab === 'batchChanges' && (
-                <Container className="mb-4">
+            <Container className="mb-4">
+                {selectedTab === 'gettingStarted' && <BatchChangesListEmpty />}
+                {selectedTab === 'batchChanges' && (
                     <FilteredConnection<ListBatchChange, Omit<BatchChangeNodeProps, 'node'>>
                         {...props}
                         location={location}
@@ -154,8 +154,8 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                         noSummaryIfAllNodesVisible={true}
                         emptyElement={<BatchChangeListEmptyElement location={location} />}
                     />
-                </Container>
-            )}
+                )}
+            </Container>
         </>
     )
 }

--- a/client/web/src/enterprise/batches/list/BatchChangesListEmpty.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListEmpty.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 
-import { Container } from '@sourcegraph/wildcard'
-
 export interface BatchChangesListEmptyProps {
     // Nothing for now.
 }
 
 export const BatchChangesListEmpty: React.FunctionComponent<BatchChangesListEmptyProps> = () => (
-    <Container>
+    <div>
         <h2 className="mb-4">Get started with batch changes</h2>
         <h3 className="mb-3">Tutorials to help with your first batch change</h3>
         <div className="row">
@@ -135,7 +133,7 @@ export const BatchChangesListEmpty: React.FunctionComponent<BatchChangesListEmpt
                 allowFullScreen={true}
             />
         </div>
-    </Container>
+    </div>
 )
 
 const FindReplaceIcon: React.FunctionComponent<{ className?: string }> = ({ className }) => (

--- a/client/web/src/enterprise/batches/list/NewBatchChangeButton.tsx
+++ b/client/web/src/enterprise/batches/list/NewBatchChangeButton.tsx
@@ -1,0 +1,12 @@
+import PlusIcon from 'mdi-react/PlusIcon'
+import React from 'react'
+
+import { Link, LinkProps } from '@sourcegraph/shared/src/components/Link'
+
+interface NewBatchChangeButtonProps extends Pick<LinkProps, 'to'> {}
+
+export const NewBatchChangeButton: React.FunctionComponent<NewBatchChangeButtonProps> = ({ to }) => (
+    <Link to={to} className="btn btn-primary">
+        <PlusIcon className="icon-inline" /> Create
+    </Link>
+)

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React from 'react'
 
-import { DiffStat } from '../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { BatchSpecFields } from '../../../graphql-operations'
 
 import styles from './BatchChangePreviewStatsBar.module.scss'
@@ -32,12 +32,7 @@ export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePrev
             <span className="badge badge-info text-uppercase mb-0">Preview</span>
         </h2>
         <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-sm-block mx-3')} />
-        <DiffStat
-            {...batchSpec.diffStat}
-            separateLines={true}
-            expandedCounts={true}
-            className={styles.batchChangePreviewStatsBarDiff}
-        />
+        <DiffStatStack className={styles.batchChangePreviewStatsBarDiff} {...batchSpec.diffStat} />
         <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-sm-none my-3')} />
         <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'mx-3 d-none d-sm-block d-md-none')} />
         <div className={classNames(styles.batchChangePreviewStatsBarMetrics, 'flex-grow-1 d-flex justify-content-end')}>

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -12,7 +12,7 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { Maybe } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { DiffStat } from '../../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../../components/diff/DiffStat'
 import { FileDiffConnection } from '../../../../components/diff/FileDiffConnection'
 import { FileDiffNode } from '../../../../components/diff/FileDiffNode'
 import { FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
@@ -531,7 +531,7 @@ const ApplyDiffStat: React.FunctionComponent<{ spec: VisibleChangesetApplyPrevie
     } else {
         diffStat = spec.targets.changesetSpec.description.diffStat
     }
-    return <DiffStat {...diffStat} expandedCounts={true} separateLines={true} />
+    return <DiffStatStack {...diffStat} />
 }
 
 const VisibleChangesetApplyPreviewNodeStatusCell: React.FunctionComponent<

--- a/client/web/src/enterprise/batches/repo/BatchChangeNode.module.scss
+++ b/client/web/src/enterprise/batches/repo/BatchChangeNode.module.scss
@@ -1,0 +1,69 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.node {
+    &__full-width {
+        grid-column: 1 / -1;
+    }
+
+    &__separator {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+        border-top: 1px solid var(--border-color-2);
+        padding-bottom: 1rem;
+    }
+
+    &__bottom-spacer {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+        padding-bottom: 0.75rem;
+    }
+
+    &__statuses {
+        @media (--xs-breakpoint-down) {
+            // Use up remaining width of the row.
+            grid-column: 1 / -1;
+        }
+        @media (--sm-breakpoint-down) {
+            // Use up remaining width of the row.
+            grid-column: 2 / -1;
+        }
+    }
+    &__bg-expanded {
+        background-color: var(--oc-blue-0);
+        :global(.theme-redesign) & {
+            background-color: var(--body-bg);
+        }
+    }
+    &__expanded-section {
+        // Make it full width in the current row.
+        grid-column: 2 / -1;
+        @media (--xs-breakpoint-down) {
+            grid-column: 1 / -1;
+        }
+    }
+    &__state,
+    &__information {
+        @media (--xs-breakpoint-down) {
+            grid-column: 1 / -1;
+        }
+    }
+    &__show-details {
+        @media (--xs-breakpoint-down) {
+            // Make it full width in the current row.
+            grid-column: 1 / -1;
+        }
+    }
+    &__retry {
+        &--spinning {
+            animation: 1s linear spin infinite;
+            @keyframes spin {
+                0% {
+                    transform: rotate(0deg);
+                }
+                100% {
+                    transform: rotate(360deg);
+                }
+            }
+        }
+    }
+}

--- a/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
@@ -16,8 +16,6 @@ export interface BatchChangeNodeProps extends ThemeProps {
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location
-    onSelectChangeset: (id: string, selected: boolean) => void
-    isChangesetSelected: (id: string) => boolean
     /** For testing purposes. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
     /** For testing purposes. */
@@ -27,8 +25,6 @@ export interface BatchChangeNodeProps extends ThemeProps {
 }
 
 export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
-    isChangesetSelected,
-    onSelectChangeset,
     node: initialNode,
     now = () => new Date(),
     ...props
@@ -63,14 +59,7 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
                 </div>
             </div>
             {node.changesets.nodes.map(changeset => (
-                <ChangesetNode
-                    {...props}
-                    isSelected={isChangesetSelected}
-                    onSelect={onSelectChangeset}
-                    key={changeset.id}
-                    node={changeset}
-                    separator={null}
-                />
+                <ChangesetNode {...props} key={changeset.id} node={changeset} separator={null} />
             ))}
             <div className={styles.nodeBottomSpacer} />
         </>

--- a/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
@@ -1,0 +1,77 @@
+import * as H from 'history'
+import React, { useState, useEffect } from 'react'
+
+import { Hoverifier } from '@sourcegraph/codeintellify'
+import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
+import { HoverMerged } from '@sourcegraph/shared/src/api/client/types/hover'
+import { Link } from '@sourcegraph/shared/src/components/Link'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
+
+import { Timestamp } from '../../../components/time/Timestamp'
+import { RepoBatchChange } from '../../../graphql-operations'
+import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
+import { ChangesetNode } from '../detail/changesets/ChangesetNode'
+
+import styles from './BatchChangeNode.module.scss'
+
+export interface BatchChangeNodeProps extends ThemeProps {
+    node: RepoBatchChange
+    viewerCanAdminister: boolean
+    history: H.History
+    location: H.Location
+    onSelect?: (id: string, selected: boolean) => void
+    isSelected?: (id: string) => boolean
+    extensionInfo?: {
+        hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
+    } & ExtensionsControllerProps
+    /** For testing purposes. */
+    queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
+    /** For testing purposes. */
+    expandByDefault?: boolean
+    /** Used for testing purposes. Sets the current date */
+    now?: () => Date
+}
+
+export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
+    node: initialNode,
+    now = () => new Date(),
+    ...props
+}) => {
+    const [node, setNode] = useState(initialNode)
+    useEffect(() => {
+        setNode(initialNode)
+    }, [initialNode])
+
+    return (
+        <>
+            <span className={styles.nodeSeparator} />
+            <div className={styles.nodeFullWidth}>
+                <div className="mt-1 mb-2 d-md-flex d-block align-items-baseline">
+                    <h2 className="m-0 d-md-inline-block d-block">
+                        <div className="d-md-inline-block d-block">
+                            <Link
+                                className="text-muted test-batches-namespace-link"
+                                to={`${node.namespace.url}/batch-changes`}
+                            >
+                                {node.namespace.namespaceName}
+                            </Link>
+                            <span className="text-muted d-inline-block mx-1">/</span>
+                        </div>
+                        <Link className="test-batches-link mr-2" to={node.url}>
+                            {node.name}
+                        </Link>
+                    </h2>
+                    <small className="text-muted d-sm-block">
+                        created <Timestamp date={node.createdAt} now={now} />
+                    </small>
+                </div>
+            </div>
+            {node.changesets.nodes.map(changeset => (
+                <ChangesetNode {...props} key={changeset.id} node={changeset} separator={null} />
+            ))}
+            <div className={styles.nodeBottomSpacer} />
+        </>
+    )
+}

--- a/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
@@ -1,13 +1,8 @@
 import * as H from 'history'
 import React, { useState, useEffect } from 'react'
 
-import { Hoverifier } from '@sourcegraph/codeintellify'
-import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
-import { HoverMerged } from '@sourcegraph/shared/src/api/client/types/hover'
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { Timestamp } from '../../../components/time/Timestamp'
 import { RepoBatchChange } from '../../../graphql-operations'
@@ -21,11 +16,8 @@ export interface BatchChangeNodeProps extends ThemeProps {
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location
-    onSelect?: (id: string, selected: boolean) => void
-    isSelected?: (id: string) => boolean
-    extensionInfo?: {
-        hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
-    } & ExtensionsControllerProps
+    onSelectChangeset: (id: string, selected: boolean) => void
+    isChangesetSelected: (id: string) => boolean
     /** For testing purposes. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
     /** For testing purposes. */
@@ -35,6 +27,8 @@ export interface BatchChangeNodeProps extends ThemeProps {
 }
 
 export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
+    isChangesetSelected,
+    onSelectChangeset,
     node: initialNode,
     now = () => new Date(),
     ...props
@@ -69,7 +63,14 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
                 </div>
             </div>
             {node.changesets.nodes.map(changeset => (
-                <ChangesetNode {...props} key={changeset.id} node={changeset} separator={null} />
+                <ChangesetNode
+                    {...props}
+                    isSelected={isChangesetSelected}
+                    onSelect={onSelectChangeset}
+                    key={changeset.id}
+                    node={changeset}
+                    separator={null}
+                />
             ))}
             <div className={styles.nodeBottomSpacer} />
         </>

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -8,7 +8,7 @@ import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileD
 
 import { queryRepoBatchChanges as _queryRepoBatchChanges } from './backend'
 import { BatchChangeRepoPage } from './BatchChangeRepoPage'
-import { HIDDEN_NODES, NODES } from './testData'
+import { NODES } from './testData'
 
 const { add } = storiesOf('web/batches/BatchChangeRepoPage', module)
     .addDecorator(story => <div className="p-3 container web-content">{story()}</div>)
@@ -38,7 +38,6 @@ const queryRepoBatchChanges = (nodes: RepoBatchChange[]): typeof _queryRepoBatch
     })
 
 const queryList = queryRepoBatchChanges(NODES)
-const queryHidden = queryRepoBatchChanges(HIDDEN_NODES)
 const queryNone = queryRepoBatchChanges([])
 
 const queryEmptyExternalChangesetWithFileDiffs: typeof _queryExternalChangesetWithFileDiffs = () =>
@@ -66,13 +65,6 @@ add('List of batch changes', () => (
                 queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
             />
         )}
-    </EnterpriseWebStory>
-))
-
-// TODO: Is this possible?? Can a user view a repository if they don't have access to it on the code host?
-add('Hidden changesets', () => (
-    <EnterpriseWebStory initialEntries={['/github.com/sourcegraph/awesome/-/batch-changes']}>
-        {props => <BatchChangeRepoPage {...props} repo={repoDefaults} queryRepoBatchChanges={queryHidden} />}
     </EnterpriseWebStory>
 ))
 

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -6,7 +6,10 @@ import { RepoBatchChange, RepositoryFields } from '../../../graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
 
-import { queryRepoBatchChanges as _queryRepoBatchChanges } from './backend'
+import {
+    queryRepoBatchChanges as _queryRepoBatchChanges,
+    queryRepoBatchChangeStats as _queryRepoBatchChangeStats,
+} from './backend'
 import { BatchChangeRepoPage } from './BatchChangeRepoPage'
 import { NODES } from './testData'
 
@@ -27,6 +30,38 @@ const repoDefaults: RepositoryFields = {
     name: 'github.com/sourcegraph/awesome',
     url: 'http://test.test/awesome',
 }
+
+const queryRepoBatchChangeStats: typeof _queryRepoBatchChangeStats = () =>
+    of({
+        batchChangesDiffStat: {
+            added: 247,
+            changed: 1896,
+            deleted: 990,
+        },
+        changesetsStats: {
+            unpublished: 1,
+            open: 2,
+            merged: 47,
+            closed: 9,
+            total: 59,
+        },
+    })
+
+const queryEmptyRepoBatchChangeStats: typeof _queryRepoBatchChangeStats = () =>
+    of({
+        batchChangesDiffStat: {
+            added: 0,
+            changed: 0,
+            deleted: 0,
+        },
+        changesetsStats: {
+            unpublished: 0,
+            open: 0,
+            merged: 0,
+            closed: 0,
+            total: 0,
+        },
+    })
 
 const queryRepoBatchChanges = (nodes: RepoBatchChange[]): typeof _queryRepoBatchChanges => () =>
     of({
@@ -60,7 +95,9 @@ add('List of batch changes', () => (
         {props => (
             <BatchChangeRepoPage
                 {...props}
+                isSourcegraphDotCom={false}
                 repo={repoDefaults}
+                queryRepoBatchChangeStats={queryRepoBatchChangeStats}
                 queryRepoBatchChanges={queryList}
                 queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
             />
@@ -70,6 +107,14 @@ add('List of batch changes', () => (
 
 add('No batch changes', () => (
     <EnterpriseWebStory initialEntries={['/github.com/sourcegraph/awesome/-/batch-changes']}>
-        {props => <BatchChangeRepoPage {...props} repo={repoDefaults} queryRepoBatchChanges={queryNone} />}
+        {props => (
+            <BatchChangeRepoPage
+                {...props}
+                isSourcegraphDotCom={false}
+                repo={repoDefaults}
+                queryRepoBatchChangeStats={queryEmptyRepoBatchChangeStats}
+                queryRepoBatchChanges={queryNone}
+            />
+        )}
     </EnterpriseWebStory>
 ))

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -1,0 +1,83 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { of } from 'rxjs'
+
+import { RepoBatchChange, RepositoryFields } from '../../../graphql-operations'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
+
+import { queryRepoBatchChanges as _queryRepoBatchChanges } from './backend'
+import { BatchChangeRepoPage } from './BatchChangeRepoPage'
+import { HIDDEN_NODES, NODES } from './testData'
+
+const { add } = storiesOf('web/batches/BatchChangeRepoPage', module)
+    .addDecorator(story => <div className="p-3 container web-content">{story()}</div>)
+    .addParameters({
+        chromatic: {
+            viewports: [320, 576, 978, 1440],
+        },
+    })
+
+const repoDefaults: RepositoryFields = {
+    description: 'An awesome repo!',
+    defaultBranch: null,
+    viewerCanAdminister: false,
+    externalURLs: [],
+    id: 'repoid',
+    name: 'github.com/sourcegraph/awesome',
+    url: 'http://test.test/awesome',
+}
+
+const queryRepoBatchChanges = (nodes: RepoBatchChange[]): typeof _queryRepoBatchChanges => () =>
+    of({
+        batchChanges: {
+            totalCount: Object.values(nodes).length,
+            nodes: Object.values(nodes),
+            pageInfo: { endCursor: null, hasNextPage: false },
+        },
+    })
+
+const queryList = queryRepoBatchChanges(NODES)
+const queryHidden = queryRepoBatchChanges(HIDDEN_NODES)
+const queryNone = queryRepoBatchChanges([])
+
+const queryEmptyExternalChangesetWithFileDiffs: typeof _queryExternalChangesetWithFileDiffs = () =>
+    of({
+        diff: {
+            __typename: 'PreviewRepositoryComparison',
+            fileDiffs: {
+                nodes: [],
+                totalCount: 0,
+                pageInfo: {
+                    endCursor: null,
+                    hasNextPage: false,
+                },
+            },
+        },
+    })
+
+add('List of batch changes', () => (
+    <EnterpriseWebStory initialEntries={['/github.com/sourcegraph/awesome/-/batch-changes']}>
+        {props => (
+            <BatchChangeRepoPage
+                {...props}
+                repo={repoDefaults}
+                queryRepoBatchChanges={queryList}
+                queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
+// TODO: Is this possible?? Can a user view a repository if they don't have access to it on the code host?
+add('Hidden changesets', () => (
+    <EnterpriseWebStory initialEntries={['/github.com/sourcegraph/awesome/-/batch-changes']}>
+        {props => <BatchChangeRepoPage {...props} repo={repoDefaults} queryRepoBatchChanges={queryHidden} />}
+    </EnterpriseWebStory>
+))
+
+add('No batch changes', () => (
+    <EnterpriseWebStory initialEntries={['/github.com/sourcegraph/awesome/-/batch-changes']}>
+        {props => <BatchChangeRepoPage {...props} repo={repoDefaults} queryRepoBatchChanges={queryNone} />}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
@@ -19,6 +19,7 @@ import {
     ChangesetStatusClosed,
     ChangesetStatusMerged,
 } from '../detail/changesets/ChangesetStatusCell'
+import { NewBatchChangeButton } from '../list/NewBatchChangeButton'
 
 import {
     queryRepoBatchChanges as _queryRepoBatchChanges,
@@ -30,6 +31,7 @@ interface BatchChangeRepoPageProps extends ThemeProps {
     history: H.History
     location: H.Location
     repo: RepositoryFields
+    isSourcegraphDotCom: boolean
     /** For testing only. */
     queryRepoBatchChangeStats?: typeof _queryRepoBatchChangeStats
     /** For testing only. */
@@ -40,6 +42,7 @@ interface BatchChangeRepoPageProps extends ThemeProps {
 
 export const BatchChangeRepoPage: React.FunctionComponent<BatchChangeRepoPageProps> = ({
     repo,
+    isSourcegraphDotCom,
     queryRepoBatchChangeStats = _queryRepoBatchChangeStats,
     ...context
 }) => {
@@ -50,17 +53,32 @@ export const BatchChangeRepoPage: React.FunctionComponent<BatchChangeRepoPagePro
     )
     const hasChangesets = stats?.changesetsStats.total
 
+    const createButton = (
+        <NewBatchChangeButton
+            to={`${isSourcegraphDotCom ? 'https://about.sourcegraph.com' : ''}/batch-changes/create`}
+        />
+    )
+
     return (
         <Page>
             <PageTitle title="Batch Changes" />
-            <PageHeader path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]} headingElement="h1" />
-            {hasChangesets && stats?.batchChangesDiffStat && stats?.changesetsStats && (
+            <PageHeader
+                path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]}
+                headingElement="h1"
+                actions={hasChangesets ? undefined : createButton}
+                description={
+                    hasChangesets
+                        ? undefined
+                        : 'Run custom code over this repository and others, and manage the resulting changesets.'
+                }
+            />
+            {hasChangesets && stats?.batchChangesDiffStat && stats?.changesetsStats ? (
                 <div className="d-flex align-items-center mt-4 mb-3">
                     <h2 className="mb-0 pb-1">{repoDisplayName}</h2>
                     <DiffStat className="d-flex flex-1 ml-2" expandedCounts={true} {...stats.batchChangesDiffStat} />
                     <StatsBar stats={stats.changesetsStats} />
                 </div>
-            )}
+            ) : null}
             {hasChangesets ? (
                 <p>
                     Batch changes has created {stats?.changesetsStats.total} changesets on {repoDisplayName}

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
@@ -1,0 +1,66 @@
+import * as H from 'history'
+import React from 'react'
+
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { PageHeader } from '@sourcegraph/wildcard'
+
+import { BatchChangesIcon } from '../../../batches/icons'
+import { Page } from '../../../components/Page'
+import { PageTitle } from '../../../components/PageTitle'
+import { RepositoryFields } from '../../../graphql-operations'
+import { BatchChangeStatsTotalAction } from '../detail/BatchChangeStatsCard'
+import {
+    ChangesetStatusUnpublished,
+    ChangesetStatusOpen,
+    ChangesetStatusClosed,
+    ChangesetStatusMerged,
+} from '../detail/changesets/ChangesetStatusCell'
+
+import { queryRepoBatchChanges as _queryRepoBatchChanges } from './backend'
+import { RepoBatchChanges } from './RepoBatchChanges'
+// import { PreviewActionImport } from './preview/list/PreviewActions'
+
+interface BatchChangeRepoPageProps extends ThemeProps {
+    history: H.History
+    location: H.Location
+    repo: RepositoryFields
+    /** For testing only. */
+    queryRepoBatchChanges?: typeof _queryRepoBatchChanges
+}
+
+export const BatchChangeRepoPage: React.FunctionComponent<BatchChangeRepoPageProps> = ({ repo, ...context }) => {
+    const repoDisplayName = displayRepoName(repo.name)
+
+    return (
+        <Page>
+            <PageTitle title="Batch Changes" />
+            <PageHeader path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]} headingElement="h1" />
+            <div className="d-flex align-items-center mt-4 mb-3">
+                <h2 className="mb-0">{repoDisplayName}</h2>
+                <div className="d-flex flex-1 ml-2">+1000 •4000 -2000</div>
+                <StatsBar />
+            </div>
+            <p>Batch changes has created 78 changesets on {repoDisplayName}</p>
+            <RepoBatchChanges
+                batchChangeID="QmF0Y2hDaGFuZ2U6Mw=="
+                viewerCanAdminister={true}
+                repo={repo}
+                {...context}
+            />
+        </Page>
+    )
+}
+
+const ACTION_CLASSNAMES = 'd-flex flex-column text-muted justify-content-center align-items-center mx-2'
+
+const StatsBar: React.FunctionComponent<{}> = () => (
+    <div className="d-flex flex-wrap align-items-center">
+        <BatchChangeStatsTotalAction count={78} />
+        <ChangesetStatusOpen className={ACTION_CLASSNAMES} label={`${3} Open`} />
+        <ChangesetStatusUnpublished className={ACTION_CLASSNAMES} label={`${1} Unpublished`} />
+        <ChangesetStatusClosed className={ACTION_CLASSNAMES} label={`${5} Closed`} />
+        <ChangesetStatusMerged className={ACTION_CLASSNAMES} label={`${67} Merged`} />
+        {/* <PreviewActionImport className={ACTION_CLASSNAMES} label={`${21} Import`} /> */}
+    </div>
+)

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import React from 'react'
+import React, { ReactElement } from 'react'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -9,6 +9,7 @@ import { BatchChangesIcon } from '../../../batches/icons'
 import { Page } from '../../../components/Page'
 import { PageTitle } from '../../../components/PageTitle'
 import { RepositoryFields } from '../../../graphql-operations'
+import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
 import { BatchChangeStatsTotalAction } from '../detail/BatchChangeStatsCard'
 import {
     ChangesetStatusUnpublished,
@@ -19,7 +20,6 @@ import {
 
 import { queryRepoBatchChanges as _queryRepoBatchChanges } from './backend'
 import { RepoBatchChanges } from './RepoBatchChanges'
-// import { PreviewActionImport } from './preview/list/PreviewActions'
 
 interface BatchChangeRepoPageProps extends ThemeProps {
     history: H.History
@@ -27,6 +27,8 @@ interface BatchChangeRepoPageProps extends ThemeProps {
     repo: RepositoryFields
     /** For testing only. */
     queryRepoBatchChanges?: typeof _queryRepoBatchChanges
+    /** For testing only. */
+    queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
 }
 
 export const BatchChangeRepoPage: React.FunctionComponent<BatchChangeRepoPageProps> = ({ repo, ...context }) => {
@@ -42,25 +44,22 @@ export const BatchChangeRepoPage: React.FunctionComponent<BatchChangeRepoPagePro
                 <StatsBar />
             </div>
             <p>Batch changes has created 78 changesets on {repoDisplayName}</p>
-            <RepoBatchChanges
-                batchChangeID="QmF0Y2hDaGFuZ2U6Mw=="
-                viewerCanAdminister={true}
-                repo={repo}
-                {...context}
-            />
+            <RepoBatchChanges viewerCanAdminister={true} repo={repo} {...context} />
         </Page>
     )
 }
 
 const ACTION_CLASSNAMES = 'd-flex flex-column text-muted justify-content-center align-items-center mx-2'
 
+// TODO: Generalize icon label type to accept strings
+const element = (string: string): ReactElement => <span>{string}</span>
+
 const StatsBar: React.FunctionComponent<{}> = () => (
     <div className="d-flex flex-wrap align-items-center">
         <BatchChangeStatsTotalAction count={78} />
-        <ChangesetStatusOpen className={ACTION_CLASSNAMES} label={`${3} Open`} />
-        <ChangesetStatusUnpublished className={ACTION_CLASSNAMES} label={`${1} Unpublished`} />
-        <ChangesetStatusClosed className={ACTION_CLASSNAMES} label={`${5} Closed`} />
-        <ChangesetStatusMerged className={ACTION_CLASSNAMES} label={`${67} Merged`} />
-        {/* <PreviewActionImport className={ACTION_CLASSNAMES} label={`${21} Import`} /> */}
+        <ChangesetStatusOpen className={ACTION_CLASSNAMES} label={element(`${3} Open`)} />
+        <ChangesetStatusUnpublished className={ACTION_CLASSNAMES} label={element(`${1} Unpublished`)} />
+        <ChangesetStatusClosed className={ACTION_CLASSNAMES} label={element(`${5} Closed`)} />
+        <ChangesetStatusMerged className={ACTION_CLASSNAMES} label={element(`${67} Merged`)} />
     </div>
 )

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.module.scss
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.module.scss
@@ -1,0 +1,9 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.batch-changes {
+    &__grid {
+        display: grid;
+        grid-template-columns: [checkbox] min-content [caret] min-content [status] min-content [info] minmax(auto, 1fr) [checkstate] min-content [reviewstate] min-content [diffstat] min-content [end];
+        align-items: center;
+    }
+}

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -8,6 +8,7 @@ import { Container } from '@sourcegraph/wildcard'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
 import { RepoBatchChange, RepositoryFields } from '../../../graphql-operations'
 import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
+import { BatchChangesListEmpty } from '../list/BatchChangesListEmpty'
 
 import { queryRepoBatchChanges as _queryRepoBatchChanges } from './backend'
 import { BatchChangeNode, BatchChangeNodeProps } from './BatchChangeNode'
@@ -73,7 +74,6 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
                 nodeComponent={BatchChangeNode}
                 nodeComponentProps={{
                     isLightTheme,
-                    viewerCanAdminister,
                     history,
                     location,
                     queryExternalChangesetWithFileDiffs,
@@ -89,13 +89,7 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
                 headComponent={RepoBatchChangesHeader}
                 cursorPaging={true}
                 noSummaryIfAllNodesVisible={true}
-                emptyElement={
-                    <div className="w-100 py-5 text-center">
-                        <p>
-                            <strong>No batch changes have been created</strong>
-                        </p>
-                    </div>
-                }
+                emptyElement={<BatchChangesListEmpty />}
             />
         </Container>
     )

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -77,6 +77,7 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
                     history,
                     location,
                     queryExternalChangesetWithFileDiffs,
+                    viewerCanAdminister,
                 }}
                 queryConnection={query}
                 hideSearch={true}

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -29,7 +29,7 @@ interface Props extends ThemeProps {
 }
 
 /**
- * A list of a batch change's changesets.
+ * A list of batch changes affecting a particular repo.
  */
 export const RepoBatchChanges: React.FunctionComponent<Props> = ({
     viewerCanAdminister,

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -26,8 +26,6 @@ interface Props extends ThemeProps {
     queryRepoBatchChanges?: typeof _queryRepoBatchChanges
     /** For testing only. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
-    /** For testing only. */
-    expandByDefault?: boolean
 }
 
 /**
@@ -42,7 +40,6 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
     hideFilters = false,
     queryRepoBatchChanges = _queryRepoBatchChanges,
     queryExternalChangesetWithFileDiffs = _queryExternalChangesetWithFileDiffs,
-    expandByDefault,
 }) => {
     // Whether all the changesets are selected, beyond the scope of what's on screen right now.
     const [allSelected, setAllSelected] = useState<boolean>(false)
@@ -203,7 +200,6 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
                     viewerCanAdminister,
                     history,
                     location,
-                    expandByDefault,
                     queryExternalChangesetWithFileDiffs,
                     isChangesetSelected: changesetSelected,
                     onSelectChangeset,

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -1,0 +1,242 @@
+import * as H from 'history'
+import React, { useState, useCallback } from 'react'
+import { map, tap } from 'rxjs/operators'
+
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Container } from '@sourcegraph/wildcard'
+
+import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
+import { AllChangesetIDsVariables, RepoBatchChange, RepositoryFields, Scalars } from '../../../graphql-operations'
+import { PreviewFilterRow, PreviewFilters } from '../preview/list/PreviewFilterRow'
+
+import { queryRepoBatchChanges as _queryRepoBatchChanges } from './backend'
+import { BatchChangeNode, BatchChangeNodeProps } from './BatchChangeNode'
+import styles from './RepoBatchChanges.module.scss'
+
+interface Props extends ThemeProps {
+    batchChangeID: Scalars['ID']
+    viewerCanAdminister: boolean
+    history: H.History
+    location: H.Location
+    repo: RepositoryFields
+    hideFilters?: boolean
+    onlyArchived?: boolean
+
+    /** For testing only. */
+    queryRepoBatchChanges?: typeof _queryRepoBatchChanges
+    /** For testing only. */
+    // queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
+    /** For testing only. */
+    expandByDefault?: boolean
+}
+
+/**
+ * A list of a batch change's changesets.
+ */
+export const RepoBatchChanges: React.FunctionComponent<Props> = ({
+    batchChangeID,
+    viewerCanAdminister,
+    history,
+    location,
+    repo,
+    isLightTheme,
+    hideFilters = false,
+    queryRepoBatchChanges = _queryRepoBatchChanges,
+    // queryExternalChangesetWithFileDiffs,
+    expandByDefault,
+}) => {
+    const [filters, setFilters] = useState<PreviewFilters>({
+        search: null,
+        currentState: null,
+        action: null,
+    })
+
+    // Whether all the changesets are selected, beyond the scope of what's on screen right now.
+    const [allSelected, setAllSelected] = useState<boolean>(false)
+    // // The overall amount of all changesets in the connection.
+    // const [totalChangesetCount, setTotalChangesetCount] = useState<number>(0)
+    // All changesets that are currently in view and can be selected. That currently
+    // just means they are visible.
+    const [availableBatchChanges, setAvailableBatchChanges] = useState<Set<Scalars['ID']>>(new Set())
+    // The list of all selected changesets. This list does not reflect the selection
+    // when `allSelected` is true.
+    const [selectedBatchChanges, setSelectedBatchChanges] = useState<Set<Scalars['ID']>>(new Set())
+
+    // const onSelect = useCallback((id: string, selected: boolean): void => {
+    //     if (selected) {
+    //         setSelectedChangesets(previous => {
+    //             const newSet = new Set(previous).add(id)
+    //             return newSet
+    //         })
+    //         return
+    //     }
+    //     setSelectedChangesets(previous => {
+    //         const newSet = new Set(previous)
+    //         newSet.delete(id)
+    //         return newSet
+    //     })
+    //     setAllSelected(false)
+    // }, [])
+
+    // /**
+    //  * Whether the given changeset is currently selected. Returns always true, if `allSelected` is true.
+    //  */
+    // const changesetSelected = useCallback((id: Scalars['ID']): boolean => allSelected || selectedChangesets.has(id), [
+    //     allSelected,
+    //     selectedChangesets,
+    // ])
+
+    const deselectAll = useCallback((): void => {
+        setSelectedBatchChanges(new Set())
+        setAllSelected(false)
+    }, [setSelectedBatchChanges])
+
+    const selectAll = useCallback((): void => {
+        setSelectedBatchChanges(availableBatchChanges)
+    }, [availableBatchChanges, setSelectedBatchChanges])
+
+    // True when all in the current list are selected. It ticks the header row
+    // checkbox when true.
+    const allSelectedCheckboxChecked = allSelected || selectedBatchChanges.size === availableBatchChanges.size
+
+    const toggleSelectAll = useCallback((): void => {
+        if (allSelectedCheckboxChecked) {
+            deselectAll()
+        } else {
+            selectAll()
+        }
+    }, [allSelectedCheckboxChecked, selectAll, deselectAll])
+
+    // const onSelectAll = useCallback(() => {
+    //     setAllSelected(true)
+    // }, [])
+
+    // const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
+    //     checkState: null,
+    //     state: null,
+    //     reviewState: null,
+    //     search: null,
+    // })
+
+    // const setChangesetFiltersAndDeselectAll = useCallback(
+    //     (filters: ChangesetFilters) => {
+    //         deselectAll()
+    //         setChangesetFilters(filters)
+    //     },
+    //     [deselectAll, setChangesetFilters]
+    // )
+
+    const query = useCallback(
+        (args: FilteredConnectionQueryArguments) => {
+            const passedArguments = {
+                name: repo.name,
+                repoID: repo.id,
+                first: args.first ?? null,
+                after: args.after ?? null,
+                search: filters.search,
+                currentState: filters.currentState,
+                action: filters.action,
+            }
+            return queryRepoBatchChanges(passedArguments).pipe(
+                tap(data => {
+                    if (!data) {
+                        return
+                    }
+                    // Available batch changes are all batch changes that the user can view.
+                    setAvailableBatchChanges(new Set(data.batchChanges.nodes.map(node => node.id)))
+                    // Remember the totalCount.
+                    // setTotalChangesetCount(data.totalCount)
+                }),
+                map(data => {
+                    if (!data) {
+                        return {
+                            totalCount: 0,
+                            nodes: [],
+                            pageInfo: {
+                                endCursor: null,
+                                hasNextPage: false,
+                            },
+                        }
+                    }
+                    // TODO:
+                    console.log({ data })
+                    return data.batchChanges
+                })
+            )
+        },
+        [queryRepoBatchChanges, filters.search, filters.currentState, filters.action, repo.id, repo.name]
+    )
+
+    return (
+        <Container>
+            <PreviewFilterRow history={history} location={location} onFiltersChange={setFilters} />
+            <FilteredConnection<RepoBatchChange, Omit<BatchChangeNodeProps, 'node'>, RepoBatchChangesHeaderProps>
+                history={history}
+                location={location}
+                nodeComponent={BatchChangeNode}
+                nodeComponentProps={{
+                    isLightTheme,
+                    viewerCanAdminister,
+                    history,
+                    location,
+                    expandByDefault,
+                }}
+                queryConnection={query}
+                hideSearch={true}
+                defaultFirst={15}
+                noun="batch change"
+                pluralNoun="batch changes"
+                listComponent="div"
+                listClassName={styles.batchChangesGrid}
+                className="filtered-connection__centered-summary mt-2"
+                headComponent={RepoBatchChangesHeader}
+                headComponentProps={{
+                    allSelected: allSelectedCheckboxChecked,
+                    toggleSelectAll,
+                    disabled: !viewerCanAdminister,
+                }}
+                cursorPaging={true}
+                noSummaryIfAllNodesVisible={true}
+                emptyElement={
+                    <div className="w-100 py-5 text-center">
+                        <p>
+                            <strong>No batch changes have been created</strong>
+                        </p>
+                    </div>
+                }
+            />
+        </Container>
+    )
+}
+
+interface RepoBatchChangesHeaderProps {
+    allSelected?: boolean
+    toggleSelectAll?: () => void
+    disabled?: boolean
+}
+
+export const RepoBatchChangesHeader: React.FunctionComponent<RepoBatchChangesHeaderProps> = ({
+    allSelected,
+    toggleSelectAll,
+    disabled,
+}) => (
+    <>
+        <span className="d-none d-md-block" />
+        {toggleSelectAll && (
+            <input
+                type="checkbox"
+                className="btn ml-2"
+                checked={allSelected}
+                onChange={toggleSelectAll}
+                disabled={!!disabled}
+                data-tooltip="Click to select all changesets"
+                aria-label="Click to select all changesets"
+            />
+        )}
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
+    </>
+)

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -45,12 +45,6 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
     // queryExternalChangesetWithFileDiffs,
     expandByDefault,
 }) => {
-    const [filters, setFilters] = useState<PreviewFilters>({
-        search: null,
-        currentState: null,
-        action: null,
-    })
-
     // Whether all the changesets are selected, beyond the scope of what's on screen right now.
     const [allSelected, setAllSelected] = useState<boolean>(false)
     // // The overall amount of all changesets in the connection.
@@ -111,20 +105,20 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
     //     setAllSelected(true)
     // }, [])
 
-    // const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
-    //     checkState: null,
-    //     state: null,
-    //     reviewState: null,
-    //     search: null,
-    // })
+    const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
+        checkState: null,
+        state: null,
+        reviewState: null,
+        search: null,
+    })
 
-    // const setChangesetFiltersAndDeselectAll = useCallback(
-    //     (filters: ChangesetFilters) => {
-    //         deselectAll()
-    //         setChangesetFilters(filters)
-    //     },
-    //     [deselectAll, setChangesetFilters]
-    // )
+    const setChangesetFiltersAndDeselectAll = useCallback(
+        (filters: ChangesetFilters) => {
+            deselectAll()
+            setChangesetFilters(filters)
+        },
+        [deselectAll, setChangesetFilters]
+    )
 
     const query = useCallback(
         (args: FilteredConnectionQueryArguments) => {
@@ -133,9 +127,11 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
                 repoID: repo.id,
                 first: args.first ?? null,
                 after: args.after ?? null,
-                search: filters.search,
-                currentState: filters.currentState,
-                action: filters.action,
+                search: changesetFilters.search,
+                // TODO:
+                // state: changesetFilters.state,
+                // reviewState: changesetFilters.reviewState,
+                // checkState: changesetFilters.checkState,
             }
             return queryRepoBatchChanges(passedArguments).pipe(
                 tap(data => {
@@ -164,12 +160,36 @@ export const RepoBatchChanges: React.FunctionComponent<Props> = ({
                 })
             )
         },
-        [queryRepoBatchChanges, filters.search, filters.currentState, filters.action, repo.id, repo.name]
+        [queryRepoBatchChanges, changesetFilters.search, repo.id, repo.name]
     )
+
+    // TODO:
+    // const showSelectRow = viewerCanAdminister && selectedChangesets.size > 0
+    const showSelectRow = false
 
     return (
         <Container>
-            <PreviewFilterRow history={history} location={location} onFiltersChange={setFilters} />
+            {!hideFilters && !showSelectRow && (
+                <ChangesetFilterRow
+                    history={history}
+                    location={location}
+                    onFiltersChange={setChangesetFiltersAndDeselectAll}
+                    searchPlaceholderText="Search changeset title"
+                />
+            )}
+            {/* TODO: */}
+            {/* {showSelectRow && queryArguments && (
+                <ChangesetSelectRow
+                    batchChangeID={batchChangeID}
+                    selected={selectedChangesets}
+                    onSubmit={deselectAll}
+                    totalCount={totalChangesetCount}
+                    allVisibleSelected={allSelectedCheckboxChecked}
+                    allSelected={allSelected}
+                    setAllSelected={onSelectAll}
+                    queryArguments={queryArguments}
+                />
+            )} */}
             <FilteredConnection<RepoBatchChange, Omit<BatchChangeNodeProps, 'node'>, RepoBatchChangesHeaderProps>
                 history={history}
                 location={location}

--- a/client/web/src/enterprise/batches/repo/RepositoryBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/repo/RepositoryBatchChangesArea.tsx
@@ -26,6 +26,7 @@ export interface RepositoryBatchChangesAreaPageProps
      */
     repo: RepositoryFields
     globbing: boolean
+    isSourcegraphDotCom: boolean
 }
 
 /**

--- a/client/web/src/enterprise/batches/repo/RepositoryBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/repo/RepositoryBatchChangesArea.tsx
@@ -1,0 +1,60 @@
+import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import React, { useMemo } from 'react'
+import { Route, RouteComponentProps, Switch } from 'react-router'
+
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+
+import { BreadcrumbSetters } from '../../../components/Breadcrumbs'
+import { HeroPage } from '../../../components/HeroPage'
+import { RepositoryFields } from '../../../graphql-operations'
+import { PatternTypeProps } from '../../../search'
+
+import { BatchChangeRepoPage } from './BatchChangeRepoPage'
+
+const NotFoundPage: React.FunctionComponent = () => (
+    <HeroPage
+        icon={MapSearchIcon}
+        title="404: Not Found"
+        subtitle="Sorry, the requested repository stats page was not found."
+    />
+)
+
+/**
+ * Properties passed to all page components in the repository batch changes area.
+ */
+export interface RepositoryBatchChangesAreaPageProps
+    extends ThemeProps,
+        RouteComponentProps<{}>,
+        BreadcrumbSetters,
+        Omit<PatternTypeProps, 'setPatternType'> {
+    /**
+     * The active repository.
+     */
+    repo: RepositoryFields
+    globbing: boolean
+}
+
+/**
+ * Renders pages related to repository batch changes.
+ */
+export const RepositoryBatchChangesArea: React.FunctionComponent<RepositoryBatchChangesAreaPageProps> = ({
+    match,
+    useBreadcrumb,
+    ...props
+}) => {
+    useBreadcrumb(useMemo(() => ({ key: 'batch-changes', element: 'Batch Changes' }), []))
+
+    return (
+        <div className="repository-batch-changes-area container mt-3">
+            <Switch>
+                <Route
+                    path={`${match.url}`}
+                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                    exact={true}
+                    render={routeComponentProps => <BatchChangeRepoPage {...routeComponentProps} {...props} />}
+                />
+                <Route key="hardcoded-key" component={NotFoundPage} />
+            </Switch>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/batches/repo/RepositoryBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/repo/RepositoryBatchChangesArea.tsx
@@ -11,13 +11,7 @@ import { PatternTypeProps } from '../../../search'
 
 import { BatchChangeRepoPage } from './BatchChangeRepoPage'
 
-const NotFoundPage: React.FunctionComponent = () => (
-    <HeroPage
-        icon={MapSearchIcon}
-        title="404: Not Found"
-        subtitle="Sorry, the requested repository stats page was not found."
-    />
-)
+const NotFoundPage: React.FunctionComponent = () => <HeroPage icon={MapSearchIcon} title="404: Not Found" />
 
 /**
  * Properties passed to all page components in the repository batch changes area.

--- a/client/web/src/enterprise/batches/repo/backend.ts
+++ b/client/web/src/enterprise/batches/repo/backend.ts
@@ -7,18 +7,19 @@ import { requestGraphQL } from '../../../backend/graphql'
 import { RepoBatchChangesResult, RepoBatchChangesVariables } from '../../../graphql-operations'
 import { changesetFieldsFragment } from '../detail/backend'
 
-const changesetsStatsFragment = gql`
-    fragment ChangesetsStatsFields on ChangesetsStats {
-        total
-        closed
-        deleted
-        draft
-        merged
-        open
-        unpublished
-        archived
-    }
-`
+// TODO: Changeset stats/diff stats queries
+// const changesetsStatsFragment = gql`
+//     fragment ChangesetsStatsFields on ChangesetsStats {
+//         total
+//         closed
+//         deleted
+//         draft
+//         merged
+//         open
+//         unpublished
+//         archived
+//     }
+// `
 
 const repoBatchChangeFragment = gql`
     fragment RepoBatchChange on BatchChange {

--- a/client/web/src/enterprise/batches/repo/backend.ts
+++ b/client/web/src/enterprise/batches/repo/backend.ts
@@ -1,0 +1,103 @@
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
+
+import { requestGraphQL } from '../../../backend/graphql'
+import { RepoBatchChangesResult, RepoBatchChangesVariables } from '../../../graphql-operations'
+import { changesetFieldsFragment } from '../detail/backend'
+
+const changesetsStatsFragment = gql`
+    fragment ChangesetsStatsFields on ChangesetsStats {
+        total
+        closed
+        deleted
+        draft
+        merged
+        open
+        unpublished
+        archived
+    }
+`
+
+const repoBatchChangeFragment = gql`
+    fragment RepoBatchChange on BatchChange {
+        id
+        url
+        name
+        namespace {
+            namespaceName
+            url
+        }
+        description
+        createdAt
+        closedAt
+        changesets(first: 10, repo: $repoID) {
+            totalCount
+            pageInfo {
+                endCursor
+                hasNextPage
+            }
+            nodes {
+                ...ChangesetFields
+            }
+        }
+        changesetsStats {
+            open
+            closed
+            merged
+        }
+    }
+
+    ${changesetFieldsFragment}
+`
+
+export const queryRepoBatchChanges = ({
+    name,
+    repoID,
+    first = null,
+    after = null,
+    state = null,
+    viewerCanAdminister = null,
+}: Partial<RepoBatchChangesVariables> & Pick<RepoBatchChangesVariables, 'name' | 'repoID'>): Observable<
+    RepoBatchChangesResult['repository']
+> =>
+    requestGraphQL<RepoBatchChangesResult, RepoBatchChangesVariables>(
+        gql`
+            query RepoBatchChanges(
+                $name: String!
+                $repoID: ID!
+                $first: Int
+                $after: String
+                $state: BatchChangeState
+                $viewerCanAdminister: Boolean
+            ) {
+                repository(name: $name) {
+                    batchChanges(
+                        first: $first
+                        after: $after
+                        state: $state
+                        viewerCanAdminister: $viewerCanAdminister
+                    ) {
+                        nodes {
+                            ...RepoBatchChange
+                        }
+                        pageInfo {
+                            endCursor
+                            hasNextPage
+                        }
+                        totalCount
+                    }
+                }
+            }
+
+            ${repoBatchChangeFragment}
+        `,
+        { name, repoID, first, after, state, viewerCanAdminister }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            console.log(data)
+            return data.repository
+        })
+    )

--- a/client/web/src/enterprise/batches/repo/backend.ts
+++ b/client/web/src/enterprise/batches/repo/backend.ts
@@ -4,22 +4,52 @@ import { map } from 'rxjs/operators'
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 
 import { requestGraphQL } from '../../../backend/graphql'
-import { RepoBatchChangesResult, RepoBatchChangesVariables } from '../../../graphql-operations'
+import {
+    RepoBatchChangesResult,
+    RepoBatchChangesVariables,
+    RepoBatchChangeStatsVariables,
+    RepoBatchChangeStatsResult,
+} from '../../../graphql-operations'
 import { changesetFieldsFragment } from '../detail/backend'
 
-// TODO: Changeset stats/diff stats queries
-// const changesetsStatsFragment = gql`
-//     fragment ChangesetsStatsFields on ChangesetsStats {
-//         total
-//         closed
-//         deleted
-//         draft
-//         merged
-//         open
-//         unpublished
-//         archived
-//     }
-// `
+const repoBatchChangeStatsFragment = gql`
+    fragment RepoBatchChangeStats on Repository {
+        batchChangesDiffStat {
+            added
+            changed
+            deleted
+        }
+        changesetsStats {
+            unpublished
+            open
+            merged
+            closed
+            total
+        }
+    }
+`
+
+export const queryRepoBatchChangeStats = ({
+    name,
+}: RepoBatchChangeStatsVariables): Observable<RepoBatchChangeStatsResult['repository']> =>
+    requestGraphQL<RepoBatchChangeStatsResult, RepoBatchChangeStatsVariables>(
+        gql`
+            query RepoBatchChangeStats($name: String!) {
+                repository(name: $name) {
+                    ...RepoBatchChangeStats
+                }
+            }
+
+            ${repoBatchChangeStatsFragment}
+        `,
+        { name }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            console.log(data)
+            return data.repository
+        })
+    )
 
 const repoBatchChangeFragment = gql`
     fragment RepoBatchChange on BatchChange {

--- a/client/web/src/enterprise/batches/repo/testData.ts
+++ b/client/web/src/enterprise/batches/repo/testData.ts
@@ -1,0 +1,191 @@
+import { subDays } from 'date-fns'
+
+import {
+    ChangesetCheckState,
+    ChangesetReviewState,
+    ChangesetSpecType,
+    ChangesetState,
+} from '@sourcegraph/shared/src/graphql-operations'
+
+import { ChangesetFields, RepoBatchChange } from '../../../graphql-operations'
+
+export const now = new Date()
+
+const HIDDEN_EXTERNAL_CHANGESET: ChangesetFields = {
+    __typename: 'HiddenExternalChangeset',
+    createdAt: subDays(now, 5).toISOString(),
+    state: ChangesetState.OPEN,
+    id: 'someh4',
+    nextSyncAt: null,
+    updatedAt: subDays(now, 5).toISOString(),
+}
+
+const READY_EXTERNAL_CHANGESET: ChangesetFields = {
+    __typename: 'ExternalChangeset',
+    body: 'body',
+    checkState: ChangesetCheckState.PASSED,
+    diffStat: {
+        added: 10,
+        changed: 9,
+        deleted: 1,
+    },
+    externalID: '123',
+    externalURL: {
+        url: 'http://test.test/123',
+    },
+    labels: [{ color: '93ba13', description: 'Very awesome description', text: 'Some label' }],
+    repository: {
+        id: 'repoid',
+        name: 'github.com/sourcegraph/awesome',
+        url: 'http://test.test/awesome',
+    },
+    reviewState: ChangesetReviewState.COMMENTED,
+    title: 'Add prettier to all projects',
+    createdAt: subDays(now, 10).toISOString(),
+    updatedAt: subDays(now, 1).toISOString(),
+    state: ChangesetState.OPEN,
+    nextSyncAt: null,
+    id: 'somev1',
+    error: null,
+    syncerError: null,
+    currentSpec: {
+        id: 'spec-rand-id-1',
+        type: ChangesetSpecType.BRANCH,
+        description: {
+            __typename: 'GitBranchChangesetDescription',
+            headRef: 'my-branch',
+        },
+    },
+}
+
+const FAILED_EXTERNAL_CHANGESET: ChangesetFields = {
+    __typename: 'ExternalChangeset',
+    body: 'body',
+    checkState: null,
+    diffStat: {
+        added: 10,
+        changed: 9,
+        deleted: 1,
+    },
+    externalID: null,
+    externalURL: null,
+    labels: [],
+    repository: {
+        id: 'repoid',
+        name: 'github.com/sourcegraph/awesome',
+        url: 'http://test.test/awesome',
+    },
+    reviewState: null,
+    title: 'Add prettier to all projects',
+    createdAt: subDays(now, 30).toISOString(),
+    updatedAt: subDays(now, 2).toISOString(),
+    state: ChangesetState.RETRYING,
+    nextSyncAt: null,
+    id: 'somev2',
+    error: 'Cannot create PR, insufficient token scope.',
+    syncerError: null,
+    currentSpec: {
+        id: 'spec-rand-id-2',
+        type: ChangesetSpecType.BRANCH,
+        description: {
+            __typename: 'GitBranchChangesetDescription',
+            headRef: 'my-branch',
+        },
+    },
+}
+
+export const HIDDEN_NODES: RepoBatchChange[] = new Array<RepoBatchChange>(4).fill({
+    id: 'test',
+    url: '/users/alice/batch-change/test',
+    name: 'Awesome batch',
+    description: 'Wow so cool!',
+    createdAt: subDays(now, 5).toISOString(),
+    closedAt: null,
+    changesetsStats: {
+        open: 10,
+        closed: 0,
+        merged: 5,
+    },
+    changesets: {
+        totalCount: 2,
+        pageInfo: { endCursor: null, hasNextPage: false },
+        nodes: [HIDDEN_EXTERNAL_CHANGESET, HIDDEN_EXTERNAL_CHANGESET, HIDDEN_EXTERNAL_CHANGESET],
+    },
+    namespace: {
+        namespaceName: 'alice',
+        url: '/users/alice',
+    },
+})
+
+export const NODES: RepoBatchChange[] = [
+    {
+        id: 'test',
+        url: '/users/alice/batch-change/test',
+        name: 'Awesome batch',
+        description: `# What this does
+
+This is my thorough explanation. And it can also get very long, in that case the UI doesn't break though, which is good. And one more line to finally be longer than the viewport.`,
+        createdAt: subDays(now, 1).toISOString(),
+        closedAt: null,
+        changesetsStats: {
+            open: 10,
+            closed: 0,
+            merged: 5,
+        },
+        changesets: {
+            totalCount: 2,
+            pageInfo: { endCursor: null, hasNextPage: false },
+            nodes: [READY_EXTERNAL_CHANGESET, READY_EXTERNAL_CHANGESET],
+        },
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
+        },
+    },
+    {
+        id: 'test2',
+        url: '/users/alice/batch-changes/test2',
+        name: 'Awesome batch',
+        description: null,
+        createdAt: subDays(now, 5).toISOString(),
+        closedAt: null,
+        changesetsStats: {
+            open: 10,
+            closed: 0,
+            merged: 5,
+        },
+        changesets: {
+            totalCount: 1,
+            pageInfo: { endCursor: null, hasNextPage: false },
+            nodes: [READY_EXTERNAL_CHANGESET],
+        },
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
+        },
+    },
+    {
+        id: 'test3',
+        url: '/users/alice/batch-changes/test3',
+        name: 'Awesome batch',
+        description: `# My batch
+
+        This is my thorough explanation.`,
+        createdAt: subDays(now, 30).toISOString(),
+        closedAt: subDays(now, 3).toISOString(),
+        changesetsStats: {
+            open: 0,
+            closed: 10,
+            merged: 5,
+        },
+        changesets: {
+            totalCount: 2,
+            pageInfo: { endCursor: null, hasNextPage: false },
+            nodes: [FAILED_EXTERNAL_CHANGESET],
+        },
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
+        },
+    },
+]

--- a/client/web/src/enterprise/batches/repo/testData.ts
+++ b/client/web/src/enterprise/batches/repo/testData.ts
@@ -11,15 +11,6 @@ import { ChangesetFields, RepoBatchChange } from '../../../graphql-operations'
 
 export const now = new Date()
 
-const HIDDEN_EXTERNAL_CHANGESET: ChangesetFields = {
-    __typename: 'HiddenExternalChangeset',
-    createdAt: subDays(now, 5).toISOString(),
-    state: ChangesetState.OPEN,
-    id: 'someh4',
-    nextSyncAt: null,
-    updatedAt: subDays(now, 5).toISOString(),
-}
-
 const READY_EXTERNAL_CHANGESET: ChangesetFields = {
     __typename: 'ExternalChangeset',
     body: 'body',
@@ -94,29 +85,6 @@ const FAILED_EXTERNAL_CHANGESET: ChangesetFields = {
     },
 }
 
-export const HIDDEN_NODES: RepoBatchChange[] = new Array<RepoBatchChange>(4).fill({
-    id: 'test',
-    url: '/users/alice/batch-change/test',
-    name: 'Awesome batch',
-    description: 'Wow so cool!',
-    createdAt: subDays(now, 5).toISOString(),
-    closedAt: null,
-    changesetsStats: {
-        open: 10,
-        closed: 0,
-        merged: 5,
-    },
-    changesets: {
-        totalCount: 2,
-        pageInfo: { endCursor: null, hasNextPage: false },
-        nodes: [HIDDEN_EXTERNAL_CHANGESET, HIDDEN_EXTERNAL_CHANGESET, HIDDEN_EXTERNAL_CHANGESET],
-    },
-    namespace: {
-        namespaceName: 'alice',
-        url: '/users/alice',
-    },
-})
-
 export const NODES: RepoBatchChange[] = [
     {
         id: 'test',
@@ -135,7 +103,12 @@ This is my thorough explanation. And it can also get very long, in that case the
         changesets: {
             totalCount: 2,
             pageInfo: { endCursor: null, hasNextPage: false },
-            nodes: [READY_EXTERNAL_CHANGESET, READY_EXTERNAL_CHANGESET],
+            nodes: [
+                READY_EXTERNAL_CHANGESET,
+                READY_EXTERNAL_CHANGESET,
+                READY_EXTERNAL_CHANGESET,
+                READY_EXTERNAL_CHANGESET,
+            ],
         },
         namespace: {
             namespaceName: 'alice',

--- a/client/web/src/enterprise/repo/routes.tsx
+++ b/client/web/src/enterprise/repo/routes.tsx
@@ -1,7 +1,31 @@
+import React from 'react'
+
 import { RepoContainerRoute } from '../../repo/RepoContainer'
 import { RepoRevisionContainerRoute } from '../../repo/RepoRevisionContainer'
 import { repoContainerRoutes, repoRevisionContainerRoutes } from '../../repo/routes'
+import { lazyComponent } from '../../util/lazyComponent'
 
-export const enterpriseRepoContainerRoutes: readonly RepoContainerRoute[] = repoContainerRoutes
+const RepositoryGitDataContainer = lazyComponent(
+    () => import('../../repo/RepositoryGitDataContainer'),
+    'RepositoryGitDataContainer'
+)
+
+const RepositoryBatchChangesArea = lazyComponent(
+    () => import('../batches/repo/RepositoryBatchChangesArea'),
+    'RepositoryBatchChangesArea'
+)
+
+export const enterpriseRepoContainerRoutes: readonly RepoContainerRoute[] = [
+    ...repoContainerRoutes,
+
+    {
+        path: '/-/batch-changes',
+        render: context => (
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
+                <RepositoryBatchChangesArea {...context} />
+            </RepositoryGitDataContainer>
+        ),
+    },
+]
 
 export const enterpriseRepoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] = repoRevisionContainerRoutes

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -92,6 +92,8 @@ export interface RepoContainerContext
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 
     globbing: boolean
+
+    showBatchChanges: boolean
 }
 
 /** A sub-route of {@link RepoContainer}. */
@@ -125,6 +127,7 @@ interface RepoContainerProps
     onNavbarQueryChange: (state: QueryState) => void
     history: H.History
     globbing: boolean
+    showBatchChanges: boolean
 }
 
 export const HOVER_COUNT_KEY = 'hover-count'

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -85,6 +85,7 @@ export interface RepoContainerContext
     authenticatedUser: AuthenticatedUser | null
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
+    isSourcegraphDotCom: boolean
 
     /** The URL route match for {@link RepoContainer}. */
     routePrefix: string
@@ -127,6 +128,7 @@ interface RepoContainerProps
     onNavbarQueryChange: (state: QueryState) => void
     history: H.History
     globbing: boolean
+    isSourcegraphDotCom: boolean
     showBatchChanges: boolean
 }
 

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -109,7 +109,7 @@ interface RepoRevisionContainerProps
     history: H.History
 
     globbing: boolean
-
+    isSourcegraphDotCom: boolean
     showBatchChanges: boolean
 }
 

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -69,6 +69,8 @@ export interface RepoRevisionContainerContext
     routePrefix: string
 
     globbing: boolean
+
+    showBatchChanges: boolean
 }
 
 /** A sub-route of {@link RepoRevisionContainer}. */
@@ -107,6 +109,8 @@ interface RepoRevisionContainerProps
     history: H.History
 
     globbing: boolean
+
+    showBatchChanges: boolean
 }
 
 interface RepoRevisionBreadcrumbProps

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -44,10 +44,6 @@ const RepositoryReleasesArea = lazyComponent(
 const RepoSettingsArea = lazyComponent(() => import('./settings/RepoSettingsArea'), 'RepoSettingsArea')
 const RepositoryCompareArea = lazyComponent(() => import('./compare/RepositoryCompareArea'), 'RepositoryCompareArea')
 const RepositoryStatsArea = lazyComponent(() => import('./stats/RepositoryStatsArea'), 'RepositoryStatsArea')
-const RepositoryBatchChangesArea = lazyComponent(
-    () => import('../enterprise/batches/repo/RepositoryBatchChangesArea'),
-    'RepositoryBatchChangesArea'
-)
 
 export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
@@ -65,14 +61,6 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
                     telemetryService={context.telemetryService}
                 />
             </div>
-        ),
-    },
-    {
-        path: '/-/batch-changes',
-        render: context => (
-            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
-                <RepositoryBatchChangesArea {...context} />
-            </RepositoryGitDataContainer>
         ),
     },
     {

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -44,6 +44,10 @@ const RepositoryReleasesArea = lazyComponent(
 const RepoSettingsArea = lazyComponent(() => import('./settings/RepoSettingsArea'), 'RepoSettingsArea')
 const RepositoryCompareArea = lazyComponent(() => import('./compare/RepositoryCompareArea'), 'RepositoryCompareArea')
 const RepositoryStatsArea = lazyComponent(() => import('./stats/RepositoryStatsArea'), 'RepositoryStatsArea')
+const RepositoryBatchChangesArea = lazyComponent(
+    () => import('../enterprise/batches/repo/RepositoryBatchChangesArea'),
+    'RepositoryBatchChangesArea'
+)
 
 export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
@@ -61,6 +65,14 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
                     telemetryService={context.telemetryService}
                 />
             </div>
+        ),
+    },
+    {
+        path: '/-/batch-changes',
+        render: context => (
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
+                <RepositoryBatchChangesArea {...context} />
+            </RepositoryGitDataContainer>
         ),
     },
     {

--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -39,6 +39,10 @@
         }
     }
 
+    .batch-change-badge {
+        top: 0;
+    }
+
     .git-commit-node {
         padding-left: 0;
         padding-right: 0;

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -39,6 +39,7 @@ import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { getFileDecorations } from '../../backend/features'
 import { queryGraphQL } from '../../backend/graphql'
+import { BatchChangesIcon } from '../../batches/icons'
 import { ErrorAlert } from '../../components/alerts'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { FilteredConnection } from '../../components/FilteredConnection'
@@ -374,11 +375,33 @@ export const TreePage: React.FunctionComponent<Props> = ({
                         <header className="mb-3">
                             {treeOrError.isRoot ? (
                                 <>
-                                    <PageHeader
-                                        path={[{ icon: SourceRepositoryIcon, text: displayRepoName(repo.name) }]}
-                                        className="mb-3 test-tree-page-title"
-                                    />
-                                    {repo.description && <p>{repo.description}</p>}
+                                    <div className="d-flex justify-content-between">
+                                        <PageHeader
+                                            path={[{ icon: SourceRepositoryIcon, text: displayRepoName(repo.name) }]}
+                                            className="mb-3 test-tree-page-title"
+                                        />
+                                        {repo.description && <p>{repo.description}</p>}
+                                        <Link
+                                            className="btn btn-sm btn-outline-secondary d-flex align-items-center mb-1 text-uppercase"
+                                            to={`/${encodeURIPathComponent(repo.name)}/-/batch-changes`}
+                                            aria-label="Batch Changes"
+                                        >
+                                            <BatchChangesIcon className="mr-2" />
+                                            Batch Changes
+                                            <span
+                                                className="badge badge-success batch-change-badge d-flex flex-column ml-2"
+                                                data-tooltip="10 open changesets"
+                                            >
+                                                10
+                                            </span>
+                                            <span
+                                                className="badge badge-merged batch-change-badge ml-2"
+                                                data-tooltip="12 merged changesets"
+                                            >
+                                                12
+                                            </span>
+                                        </Link>
+                                    </div>
                                     <div className="btn-group">
                                         {enableAPIDocs && (
                                             <Link

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -124,6 +124,7 @@ interface Props
     location: H.Location
     history: H.History
     globbing: boolean
+    showBatchChanges: boolean
 }
 
 export const treePageRepositoryFragment = gql`
@@ -144,6 +145,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
     caseSensitive,
     settingsCascade,
     useBreadcrumb,
+    showBatchChanges,
     ...props
 }) => {
     useEffect(() => {
@@ -353,6 +355,27 @@ export const TreePage: React.FunctionComponent<Props> = ({
             )}
         </div>
     )
+
+    const batchChangesBadge = showBatchChanges ? (
+        <Link
+            className="btn btn-sm btn-outline-secondary d-flex align-items-center mb-1 text-uppercase"
+            to={`/${encodeURIPathComponent(repo.name)}/-/batch-changes`}
+            aria-label="Batch Changes"
+        >
+            <BatchChangesIcon className="mr-2" />
+            Batch Changes
+            <span
+                className="badge badge-success batch-change-badge d-flex flex-column ml-2"
+                data-tooltip="10 open changesets"
+            >
+                10
+            </span>
+            <span className="badge badge-merged batch-change-badge ml-2" data-tooltip="12 merged changesets">
+                12
+            </span>
+        </Link>
+    ) : null
+
     return (
         <div className="tree-page">
             <Container className="tree-page__container">
@@ -381,26 +404,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                             className="mb-3 test-tree-page-title"
                                         />
                                         {repo.description && <p>{repo.description}</p>}
-                                        <Link
-                                            className="btn btn-sm btn-outline-secondary d-flex align-items-center mb-1 text-uppercase"
-                                            to={`/${encodeURIPathComponent(repo.name)}/-/batch-changes`}
-                                            aria-label="Batch Changes"
-                                        >
-                                            <BatchChangesIcon className="mr-2" />
-                                            Batch Changes
-                                            <span
-                                                className="badge badge-success batch-change-badge d-flex flex-column ml-2"
-                                                data-tooltip="10 open changesets"
-                                            >
-                                                10
-                                            </span>
-                                            <span
-                                                className="badge badge-merged batch-change-badge ml-2"
-                                                data-tooltip="12 merged changesets"
-                                            >
-                                                12
-                                            </span>
-                                        </Link>
+                                        {batchChangesBadge}
                                     </div>
                                     <div className="btn-group">
                                         {enableAPIDocs && (

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -403,9 +403,9 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                             path={[{ icon: SourceRepositoryIcon, text: displayRepoName(repo.name) }]}
                                             className="mb-3 test-tree-page-title"
                                         />
-                                        {repo.description && <p>{repo.description}</p>}
                                         {batchChangesBadge}
                                     </div>
+                                    {repo.description && <p>{repo.description}</p>}
                                     <div className="btn-group">
                                         {enableAPIDocs && (
                                             <Link

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -287,6 +287,7 @@ type BatchChangesResolver interface {
 	BatchChanges(cx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
 
 	BatchChangesCodeHosts(ctx context.Context, args *ListBatchChangesCodeHostsArgs) (BatchChangesCodeHostConnectionResolver, error)
+	RepoChangesetsStats(ctx context.Context, repo *graphql.ID) (RepoChangesetsStatsResolver, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
 }
@@ -597,19 +598,23 @@ type BatchChangesConnectionResolver interface {
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
+type RepoChangesetsStatsResolver interface {
+	Unpublished() int32
+	Open() int32
+	Merged() int32
+	Closed() int32
+	Total() int32
+}
+
 type ChangesetsStatsResolver interface {
+	RepoChangesetsStatsResolver
 	Retrying() int32
 	Failed() int32
 	Scheduled() int32
 	Processing() int32
-	Unpublished() int32
 	Draft() int32
-	Open() int32
-	Merged() int32
-	Closed() int32
 	Deleted() int32
 	Archived() int32
-	Total() int32
 }
 
 type ChangesetsConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -121,6 +121,7 @@ type ListBatchChangesArgs struct {
 	ViewerCanAdminister *bool
 
 	Namespace *graphql.ID
+	Repo      *graphql.ID
 }
 
 type CloseBatchChangeArgs struct {
@@ -560,6 +561,7 @@ type ListChangesetsArgs struct {
 	Search                         *string
 
 	OnlyArchived bool
+	Repo         *graphql.ID
 }
 
 type BatchChangeResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -288,6 +288,7 @@ type BatchChangesResolver interface {
 
 	BatchChangesCodeHosts(ctx context.Context, args *ListBatchChangesCodeHostsArgs) (BatchChangesCodeHostConnectionResolver, error)
 	RepoChangesetsStats(ctx context.Context, repo *graphql.ID) (RepoChangesetsStatsResolver, error)
+	RepoDiffStat(ctx context.Context, repo *graphql.ID) (*DiffStat, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2743,6 +2743,42 @@ extend type User {
     ): BatchChangesCodeHostConnection!
 }
 
+extend type Repository {
+    """
+    Stats on all the changesets that have been applied to this repository by batch
+    changes.
+    """
+    changesetsStats: RepoChangesetsStats!
+
+    """
+    A list of batch changes that have applied a changeset to this repository.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): BatchChangeConnection!
+
+    """
+    A diff stat for all the changesets that have been applied to this repository
+    by batch changes.
+    """
+    batchChangesDiffStat: DiffStat!
+}
+
 """
 A connection of all code hosts usable with batch changes and accessible by the user
 this is requested on.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2310,9 +2310,13 @@ type BatchChange implements Node {
         """
         search: String
         """
-        Only return changesets that are archived in this campaign.
+        Only return changesets that are archived in this batch change.
         """
         onlyArchived: Boolean = false
+        """
+        Only include changesets belonging to the given repository.
+        """
+        repo: ID
     ): ChangesetConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1258,6 +1258,32 @@ type ChangesetsStats {
 }
 
 """
+Stats on all the changesets that have been applied to this repository by batch changes.
+"""
+type RepoChangesetsStats {
+    """
+    The count of unpublished changesets.
+    """
+    unpublished: Int!
+    """
+    The count of externalState: OPEN changesets.
+    """
+    open: Int!
+    """
+    The count of externalState: MERGED changesets.
+    """
+    merged: Int!
+    """
+    The count of externalState: CLOSED changesets.
+    """
+    closed: Int!
+    """
+    The count of all changesets.
+    """
+    total: Int!
+}
+
+"""
 A list of changesets.
 """
 type ChangesetConnection {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -152,6 +152,11 @@ func (r *RepositoryResolver) ChangesetsStats(ctx context.Context) (RepoChangeset
 	return EnterpriseResolvers.batchChangesResolver.RepoChangesetsStats(ctx, &id)
 }
 
+func (r *RepositoryResolver) BatchChangesDiffStat(ctx context.Context) (*DiffStat, error) {
+	id := r.ID()
+	return EnterpriseResolvers.batchChangesResolver.RepoDiffStat(ctx, &id)
+}
+
 type RepositoryCommitArgs struct {
 	Rev          string
 	InputRevspec *string

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -141,6 +141,12 @@ func (r *RepositoryResolver) CloneInProgress(ctx context.Context) (bool, error) 
 	return r.MirrorInfo().CloneInProgress(ctx)
 }
 
+func (r *RepositoryResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
+	id := r.ID()
+	args.Repo = &id
+	return EnterpriseResolvers.batchChangesResolver.BatchChanges(ctx, args)
+}
+
 type RepositoryCommitArgs struct {
 	Rev          string
 	InputRevspec *string

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -147,6 +147,11 @@ func (r *RepositoryResolver) BatchChanges(ctx context.Context, args *ListBatchCh
 	return EnterpriseResolvers.batchChangesResolver.BatchChanges(ctx, args)
 }
 
+func (r *RepositoryResolver) ChangesetsStats(ctx context.Context) (RepoChangesetsStatsResolver, error) {
+	id := r.ID()
+	return EnterpriseResolvers.batchChangesResolver.RepoChangesetsStats(ctx, &id)
+}
+
 type RepositoryCommitArgs struct {
 	Rev          string
 	InputRevspec *string

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2387,6 +2387,28 @@ type Repository implements Node & GenericSearchResultInterface {
     The star count the repository has in the code host.
     """
     stars: Int!
+
+    """
+    A list of batch changes that have applied a changeset to this repository.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): BatchChangeConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2415,6 +2415,12 @@ type Repository implements Node & GenericSearchResultInterface {
         """
         viewerCanAdminister: Boolean
     ): BatchChangeConnection!
+
+    """
+    A diff stat for all the changesets that have been applied to this repository
+    by batch changes.
+    """
+    batchChangesDiffStat: DiffStat!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2387,40 +2387,6 @@ type Repository implements Node & GenericSearchResultInterface {
     The star count the repository has in the code host.
     """
     stars: Int!
-
-    """
-    Stats on all the changesets that have been applied to this repository by batch
-    changes.
-    """
-    changesetsStats: RepoChangesetsStats!
-
-    """
-    A list of batch changes that have applied a changeset to this repository.
-    """
-    batchChanges(
-        """
-        Returns the first n batch changes from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return batch changes in this state.
-        """
-        state: BatchChangeState
-        """
-        Only include batch changes that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): BatchChangeConnection!
-
-    """
-    A diff stat for all the changesets that have been applied to this repository
-    by batch changes.
-    """
-    batchChangesDiffStat: DiffStat!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2389,6 +2389,12 @@ type Repository implements Node & GenericSearchResultInterface {
     stars: Int!
 
     """
+    Stats on all the changesets that have been applied to this repository by batch
+    changes.
+    """
+    changesetsStats: RepoChangesetsStats!
+
+    """
     A list of batch changes that have applied a changeset to this repository.
     """
     batchChanges(

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -245,7 +245,7 @@ func initRouter(db dbutil.DB, router *mux.Router) {
 	router.Get(routeRepoSettings).Handler(handler(serveBrandedPageString("Repository settings", nil)))
 	router.Get(routeRepoCommit).Handler(handler(serveBrandedPageString("Commit", nil)))
 	router.Get(routeRepoBranches).Handler(handler(serveBrandedPageString("Branches", nil)))
-	router.Get(routeRepoBatchChanges).Handler(handler(serveBrandedPageString("Batch changes", nil)))
+	router.Get(routeRepoBatchChanges).Handler(handler(serveBrandedPageString("Batch Changes", nil)))
 	router.Get(routeRepoDocs).Handler(handler(serveBrandedPageString("API docs", nil)))
 	router.Get(routeRepoCommits).Handler(handler(serveBrandedPageString("Commits", nil)))
 	router.Get(routeRepoTags).Handler(handler(serveBrandedPageString("Tags", nil)))

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -32,48 +32,49 @@ import (
 )
 
 const (
-	routeHome           = "home"
-	routeSearch         = "search"
-	routeSearchBadge    = "search-badge"
-	routeRepo           = "repo"
-	routeRepoSettings   = "repo-settings"
-	routeRepoCommit     = "repo-commit"
-	routeRepoBranches   = "repo-branches"
-	routeRepoDocs       = "repo-docs"
-	routeRepoCommits    = "repo-commits"
-	routeRepoTags       = "repo-tags"
-	routeRepoCompare    = "repo-compare"
-	routeRepoStats      = "repo-stats"
-	routeInsights       = "insights"
-	routeBatchChanges   = "batch-changes"
-	routeCodeMonitoring = "code-monitoring"
-	routeContexts       = "contexts"
-	routeThreads        = "threads"
-	routeTree           = "tree"
-	routeBlob           = "blob"
-	routeRaw            = "raw"
-	routeOrganizations  = "org"
-	routeSettings       = "settings"
-	routeSiteAdmin      = "site-admin"
-	routeAPIConsole     = "api-console"
-	routeUser           = "user"
-	routeUserSettings   = "user-settings"
-	routeUserRedirect   = "user-redirect"
-	routeAboutSubdomain = "about-subdomain"
-	aboutRedirectScheme = "https"
-	aboutRedirectHost   = "about.sourcegraph.com"
-	routeSurvey         = "survey"
-	routeSurveyScore    = "survey-score"
-	routeRegistry       = "registry"
-	routeExtensions     = "extensions"
-	routeHelp           = "help"
-	routeRepoGroups     = "repo-groups"
-	routeCncf           = "repo-groups.cncf"
-	routeSnippets       = "snippets"
-	routeSubscriptions  = "subscriptions"
-	routeStats          = "stats"
-	routeViews          = "views"
-	routeDevToolTime    = "devtooltime"
+	routeHome             = "home"
+	routeSearch           = "search"
+	routeSearchBadge      = "search-badge"
+	routeRepo             = "repo"
+	routeRepoSettings     = "repo-settings"
+	routeRepoCommit       = "repo-commit"
+	routeRepoBranches     = "repo-branches"
+	routeRepoBatchChanges = "repo-batch-changes"
+	routeRepoDocs         = "repo-docs"
+	routeRepoCommits      = "repo-commits"
+	routeRepoTags         = "repo-tags"
+	routeRepoCompare      = "repo-compare"
+	routeRepoStats        = "repo-stats"
+	routeInsights         = "insights"
+	routeBatchChanges     = "batch-changes"
+	routeCodeMonitoring   = "code-monitoring"
+	routeContexts         = "contexts"
+	routeThreads          = "threads"
+	routeTree             = "tree"
+	routeBlob             = "blob"
+	routeRaw              = "raw"
+	routeOrganizations    = "org"
+	routeSettings         = "settings"
+	routeSiteAdmin        = "site-admin"
+	routeAPIConsole       = "api-console"
+	routeUser             = "user"
+	routeUserSettings     = "user-settings"
+	routeUserRedirect     = "user-redirect"
+	routeAboutSubdomain   = "about-subdomain"
+	aboutRedirectScheme   = "https"
+	aboutRedirectHost     = "about.sourcegraph.com"
+	routeSurvey           = "survey"
+	routeSurveyScore      = "survey-score"
+	routeRegistry         = "registry"
+	routeExtensions       = "extensions"
+	routeHelp             = "help"
+	routeRepoGroups       = "repo-groups"
+	routeCncf             = "repo-groups.cncf"
+	routeSnippets         = "snippets"
+	routeSubscriptions    = "subscriptions"
+	routeStats            = "stats"
+	routeViews            = "views"
+	routeDevToolTime      = "devtooltime"
 
 	routeSearchQueryBuilder = "search.query-builder"
 	routeSearchStream       = "search.stream"
@@ -195,6 +196,7 @@ func newRouter() *mux.Router {
 	repo.PathPrefix("/settings").Methods("GET").Name(routeRepoSettings)
 	repo.PathPrefix("/commit").Methods("GET").Name(routeRepoCommit)
 	repo.PathPrefix("/branches").Methods("GET").Name(routeRepoBranches)
+	repo.PathPrefix("/batch-changes").Methods("GET").Name(routeRepoBatchChanges)
 	repo.PathPrefix("/tags").Methods("GET").Name(routeRepoTags)
 	repo.PathPrefix("/compare").Methods("GET").Name(routeRepoCompare)
 	repo.PathPrefix("/stats").Methods("GET").Name(routeRepoStats)
@@ -243,6 +245,7 @@ func initRouter(db dbutil.DB, router *mux.Router) {
 	router.Get(routeRepoSettings).Handler(handler(serveBrandedPageString("Repository settings", nil)))
 	router.Get(routeRepoCommit).Handler(handler(serveBrandedPageString("Commit", nil)))
 	router.Get(routeRepoBranches).Handler(handler(serveBrandedPageString("Branches", nil)))
+	router.Get(routeRepoBatchChanges).Handler(handler(serveBrandedPageString("Batch changes", nil)))
 	router.Get(routeRepoDocs).Handler(handler(serveBrandedPageString("API docs", nil)))
 	router.Get(routeRepoCommits).Handler(handler(serveBrandedPageString("Commits", nil)))
 	router.Get(routeRepoTags).Handler(handler(serveBrandedPageString("Tags", nil)))

--- a/enterprise/internal/batches/resolvers/changeset_connection.go
+++ b/enterprise/internal/batches/resolvers/changeset_connection.go
@@ -74,6 +74,7 @@ func (r *changesetsConnectionResolver) TotalCount(ctx context.Context) (int32, e
 		EnforceAuthz:         !r.optsSafe,
 		OnlyArchived:         r.opts.OnlyArchived,
 		IncludeArchived:      r.opts.IncludeArchived,
+		RepoID:               r.opts.RepoID,
 	})
 	return int32(count), err
 }

--- a/enterprise/internal/batches/resolvers/changesets_stats.go
+++ b/enterprise/internal/batches/resolvers/changesets_stats.go
@@ -47,3 +47,25 @@ func (r *changesetsStatsResolver) Archived() int32 {
 func (r *changesetsStatsResolver) Total() int32 {
 	return r.stats.Total
 }
+
+type repoChangesetsStatsResolver struct {
+	stats btypes.RepoChangesetsStats
+}
+
+var _ graphqlbackend.RepoChangesetsStatsResolver = &repoChangesetsStatsResolver{}
+
+func (r *repoChangesetsStatsResolver) Unpublished() int32 {
+	return r.stats.Unpublished
+}
+func (r *repoChangesetsStatsResolver) Open() int32 {
+	return r.stats.Open
+}
+func (r *repoChangesetsStatsResolver) Merged() int32 {
+	return r.stats.Merged
+}
+func (r *repoChangesetsStatsResolver) Closed() int32 {
+	return r.stats.Closed
+}
+func (r *repoChangesetsStatsResolver) Total() int32 {
+	return r.stats.Total
+}

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -722,6 +722,14 @@ func (r *Resolver) BatchChanges(ctx context.Context, args *graphqlbackend.ListBa
 		}
 	}
 
+	if args.Repo != nil {
+		repoID, err := graphqlbackend.UnmarshalRepositoryID(*args.Repo)
+		if err != nil {
+			return nil, err
+		}
+		opts.RepoID = repoID
+	}
+
 	return &batchChangesConnectionResolver{
 		store: r.store,
 		opts:  opts,
@@ -880,6 +888,13 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 	}
 	if args.OnlyArchived {
 		opts.OnlyArchived = args.OnlyArchived
+	}
+	if args.Repo != nil {
+		repoID, err := graphqlbackend.UnmarshalRepositoryID(*args.Repo)
+		if err != nil {
+			return opts, false, errors.Wrap(err, "unmarshalling repo id")
+		}
+		opts.RepoID = repoID
 	}
 
 	return opts, safe, nil

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -749,6 +749,19 @@ func (r *Resolver) RepoChangesetsStats(ctx context.Context, repo *graphql.ID) (g
 	return &repoChangesetsStatsResolver{stats: stats}, nil
 }
 
+func (r *Resolver) RepoDiffStat(ctx context.Context, repo *graphql.ID) (*graphqlbackend.DiffStat, error) {
+	repoID, err := graphqlbackend.UnmarshalRepositoryID(*repo)
+	if err != nil {
+		return nil, err
+	}
+
+	diffStat, err := r.store.GetRepoDiffStat(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	return graphqlbackend.NewDiffStat(*diffStat), nil
+}
+
 func (r *Resolver) BatchChangesCodeHosts(ctx context.Context, args *graphqlbackend.ListBatchChangesCodeHostsArgs) (graphqlbackend.BatchChangesCodeHostConnectionResolver, error) {
 	if err := batchChangesEnabled(ctx, r.store.DB()); err != nil {
 		return nil, err

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -736,6 +736,19 @@ func (r *Resolver) BatchChanges(ctx context.Context, args *graphqlbackend.ListBa
 	}, nil
 }
 
+func (r *Resolver) RepoChangesetsStats(ctx context.Context, repo *graphql.ID) (graphqlbackend.RepoChangesetsStatsResolver, error) {
+	repoID, err := graphqlbackend.UnmarshalRepositoryID(*repo)
+	if err != nil {
+		return nil, err
+	}
+
+	stats, err := r.store.GetRepoChangesetsStats(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	return &repoChangesetsStatsResolver{stats: stats}, nil
+}
+
 func (r *Resolver) BatchChangesCodeHosts(ctx context.Context, args *graphqlbackend.ListBatchChangesCodeHostsArgs) (graphqlbackend.BatchChangesCodeHostConnectionResolver, error) {
 	if err := batchChangesEnabled(ctx, r.store.DB()); err != nil {
 		return nil, err

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -746,7 +746,7 @@ func (r *Resolver) RepoChangesetsStats(ctx context.Context, repo *graphql.ID) (g
 	if err != nil {
 		return nil, err
 	}
-	return &repoChangesetsStatsResolver{stats: stats}, nil
+	return &repoChangesetsStatsResolver{stats: *stats}, nil
 }
 
 func (r *Resolver) RepoDiffStat(ctx context.Context, repo *graphql.ID) (*graphqlbackend.DiffStat, error) {

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -296,7 +296,7 @@ func countChangesetsQuery(opts *CountChangesetsOpts, authzConds *sqlf.Query) *sq
 		preds = append(preds, authzConds)
 	}
 	if opts.RepoID != 0 {
-		preds = append(preds, sqlf.Sprintf("changesets.repo_id = %s", opts.RepoID))
+		preds = append(preds, sqlf.Sprintf("repo.id = %s", opts.RepoID))
 	}
 
 	join := sqlf.Sprintf("")
@@ -586,7 +586,7 @@ func listChangesetsQuery(opts *ListChangesetsOpts, authzConds *sqlf.Query) *sqlf
 		preds = append(preds, authzConds)
 	}
 	if opts.RepoID != 0 {
-		preds = append(preds, sqlf.Sprintf("changesets.repo_id = %s", opts.RepoID))
+		preds = append(preds, sqlf.Sprintf("repo.id = %s", opts.RepoID))
 	}
 
 	join := sqlf.Sprintf("")

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -232,6 +232,7 @@ type CountChangesetsOpts struct {
 	PublicationState     *btypes.ChangesetPublicationState
 	TextSearch           []search.TextSearchTerm
 	EnforceAuthz         bool
+	RepoID               api.RepoID
 }
 
 // CountChangesets returns the number of changesets in the database.
@@ -293,6 +294,9 @@ func countChangesetsQuery(opts *CountChangesetsOpts, authzConds *sqlf.Query) *sq
 	}
 	if opts.EnforceAuthz {
 		preds = append(preds, authzConds)
+	}
+	if opts.RepoID != 0 {
+		preds = append(preds, sqlf.Sprintf("changesets.repo_id = %s", opts.RepoID))
 	}
 
 	join := sqlf.Sprintf("")
@@ -487,6 +491,7 @@ type ListChangesetsOpts struct {
 	OwnedByBatchChangeID int64
 	TextSearch           []search.TextSearchTerm
 	EnforceAuthz         bool
+	RepoID               api.RepoID
 }
 
 // ListChangesets lists Changesets with the given filters.
@@ -579,6 +584,9 @@ func listChangesetsQuery(opts *ListChangesetsOpts, authzConds *sqlf.Query) *sqlf
 	}
 	if opts.EnforceAuthz {
 		preds = append(preds, authzConds)
+	}
+	if opts.RepoID != 0 {
+		preds = append(preds, sqlf.Sprintf("changesets.repo_id = %s", opts.RepoID))
 	}
 
 	join := sqlf.Sprintf("")

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -944,8 +944,14 @@ WHERE
 `
 
 // GetRepoChangesetsStats returns statistics on all the changesets associated to the given repo.
-func (s *Store) GetRepoChangesetsStats(ctx context.Context, repoID api.RepoID) (stats btypes.RepoChangesetsStats, err error) {
-	q := getRepoChangesetsStatsQuery(int64(repoID))
+func (s *Store) GetRepoChangesetsStats(ctx context.Context, repoID api.RepoID) (*btypes.RepoChangesetsStats, error) {
+	authzConds, err := database.AuthzQueryConds(ctx, s.Handle().DB())
+	if err != nil {
+		return nil, errors.Wrap(err, "GetRepoChangesetsStats generating authz query conds")
+	}
+	q := getRepoChangesetsStatsQuery(int64(repoID), authzConds)
+
+	var stats btypes.RepoChangesetsStats
 	err = s.query(ctx, q, func(sc scanner) error {
 		if err := sc.Scan(
 			&stats.Total,
@@ -959,9 +965,9 @@ func (s *Store) GetRepoChangesetsStats(ctx context.Context, repoID api.RepoID) (
 		return err
 	})
 	if err != nil {
-		return stats, err
+		return &stats, err
 	}
-	return stats, nil
+	return &stats, nil
 }
 
 func (s *Store) EnqueueNextScheduledChangeset(ctx context.Context) (*btypes.Changeset, error) {
@@ -1071,10 +1077,11 @@ func getChangesetsStatsQuery(batchChangeID int64) *sqlf.Query {
 	)
 }
 
-func getRepoChangesetsStatsQuery(repoID int64) *sqlf.Query {
+func getRepoChangesetsStatsQuery(repoID int64, authzConds *sqlf.Query) *sqlf.Query {
 	return sqlf.Sprintf(
 		getRepoChangesetStatsFmtstr,
 		strconv.Itoa(int(repoID)),
+		authzConds,
 	)
 }
 
@@ -1087,5 +1094,8 @@ SELECT
 	COUNT(*) FILTER (WHERE changesets.external_state = 'MERGED' ) AS merged,
 	COUNT(*) FILTER (WHERE changesets.external_state = 'OPEN'   ) AS open
 FROM changesets
-WHERE changesets.repo_id = %s
+INNER JOIN repo ON changesets.repo_id = repo.id
+WHERE changesets.repo_id = %s AND
+-- authz conditions:
+%s
 `

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -888,20 +888,25 @@ func WithExternalID(id string) func(*Changeset) bool {
 	return func(c *Changeset) bool { return c.ExternalID == id }
 }
 
-// ChangesetsStats holds stats information on a list of changesets.
-type ChangesetsStats struct {
-	Retrying    int32
-	Failed      int32
-	Scheduled   int32
-	Processing  int32
+// ChangesetsStats holds stats information on a list of changesets for a repo.
+type RepoChangesetsStats struct {
 	Unpublished int32
-	Draft       int32
 	Open        int32
 	Merged      int32
 	Closed      int32
-	Deleted     int32
-	Archived    int32
 	Total       int32
+}
+
+// ChangesetsStats holds additional stats information on a list of changesets.
+type ChangesetsStats struct {
+	RepoChangesetsStats
+	Retrying   int32
+	Failed     int32
+	Scheduled  int32
+	Processing int32
+	Draft      int32
+	Deleted    int32
+	Archived   int32
 }
 
 // ChangesetEventKindFor returns the ChangesetEventKind for the given

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -888,7 +888,7 @@ func WithExternalID(id string) func(*Changeset) bool {
 	return func(c *Changeset) bool { return c.ExternalID == id }
 }
 
-// ChangesetsStats holds stats information on a list of changesets for a repo.
+// RepoChangesetsStats holds stats information on a list of changesets for a repo.
 type RepoChangesetsStats struct {
 	Unpublished int32
 	Open        int32


### PR DESCRIPTION
Closes #20309.

Hello, fellow batchers, and welcome to episode 1 of Repo Batch Changes Badge, otherwise known as RBCB! The synopsis is simple but compelling:

> An unsuspecting Sourcegraph user discovers a treasure trove hidden right beside their repositories. 
What will they do when they uncover... batch changes??

In this pilot episode, we'll introduce you to the full cast of characters and tease the long-running plot, essentially a whole new mode of interacting with existing batch changes from a repository. And we promise there's no cliffhanger ending.

## The cast
(aka the main things I'd love for you to pay attention to in this early review 😛)

<table><tr><td><h3>The Batch Changes Badge</h3></td><td><img src="https://user-images.githubusercontent.com/8942601/123499652-1323a280-d5ed-11eb-880d-72ba586044bf.png" width="200"></td></tr></table>

Your charming, enigmatic protagonist who only shows up when there's something exciting happening.

Though I haven't finished hooking this up to GraphQL yet, I was imagining that for visibility we show this badge whenever either

- The number of open changesets on this repository is > 0, or
- The number of merged changesets on this repository is > 0,

as both would provide something for the user to look at when they get to the new repo page and draw positive attention to batch changes, even if it's not much.

<table><tr><td><h3>The <a href="https://5f0f381c0e50750022dc6bf7-tylinnzafb.chromatic.com/?path=/story/web-batches-batchchangerepopage--list-of-batch-changes" target="_blank">Repo Batch Changes Page</a></h3></td><td><img src="https://user-images.githubusercontent.com/8942601/123499805-19664e80-d5ee-11eb-8c96-32482a39b6c9.png" width="300"></td></tr></table>

They've got lots to show and tell, but you feel like you've seen it all before...

(...that's because you have -- I basically created a mash-up of components from the `BatchChangeListPage` and the `BatchChangeDetailsPage`)

The screenwriters couldn't totally agree on the character design and landed somewhere between [this](https://www.figma.com/file/Wz9saTgmxwn1vgD3zPjTh8/expansion-ideas?node-id=35%3A812) and [this](https://www.figma.com/file/Wz9saTgmxwn1vgD3zPjTh8/expansion-ideas?node-id=42%3A2690); they mostly just wanted the character to feel natural amidst the characters it draws inspiration from.

The search + filters, bulk actions, and stats aren't fully wired up to GraphQL yet either because I wanted to get feedback on if they all make sense here or not first. The interesting thing to note about the search and filters is that they'd be applied to the individual changesets, not the parent batch changes, as I felt it made more sense that a user would want to operate on the specific changesets that are attached to this repository from here, and not so much the batch changes they originated from. This will also make wiring these up slightly more complicated, but my plan is to apply them to the nested changesets query and then hide the batch changes from the list that don't have any changesets matching the filters.

I will probably initially release this without bulk action support because the bulk action mutations currently require the `batchChange` id as an argument in order to check permissions, which gets more complicated if our bulk action is happening across multiple batch changes. I can just hide the checkboxes initially.

I have chosen for now to omit the Open/Closed label on the batch change itself, as well, as it doesn't feel like it adds much to this page. I'm also not yet sold on the visual indicator for the batch change that we had sketched up here on the right:

![image](https://user-images.githubusercontent.com/8942601/123500062-18ceb780-d5f0-11eb-977c-e81328ef3330.png)

If anyone feels particularly strongly about either of those elements I'm happy to experiment though.

<table><tr><td><h3>The <a href="https://github.com/sourcegraph/sourcegraph/pull/22372/files?file-filters%5B%5D=.graphql#diff-e81543ff15f2f5ee599339869bf4adacf439d298eb13eb80909c1aba6404030f">new Repo query fields</a></h3></td><td><img src="https://user-images.githubusercontent.com/8942601/123500193-1caf0980-d5f1-11eb-8d3d-2d552017778d.png" width="300"></td></tr></table>

They're the new kid in town who is interested in one thing and one thing only: their repository!

I basically replicated the `batchChanges`, `changesetsStats`, and `diffStat` fields from elsewhere on the schema and tailored them to the details these pages want for a specific repository. The `changesetStats` will power both the Batch Changes Badge as well as the stats row at the top of the Repo Batch Changes Page.

With the exception of the bulk action support described above, there were no additional mutation requirements needed for this new badge and page.

## On the next episode...

(aka questions that I would love your input on!!)

1. ✅ How do repo permissions work? Is it possible for a user to view this (or any other) repo page on Sourcegraph for a repo they don't have access to on the codehost? Would they just see a bunch of `HiddenExternalChangeset`s if they did? **A: It shouldn't be possible.**
2. ✅ Does having search + filters for changesets (vs. for the batch changes themselves) make sense on this list? **A: Exclude search + filters from initial release.**
3. ✅ Which changesets stats should we include on the row at the top of the page? Currently I have total, open, unpublished, closed, and merged. **A: Seems like a good set.**
	3a. ✅ If a given stat has 0 of its type (e.g. 0 closed changesets), should I omit the stat from the row, or keep it and just show 0? **A: Keep it and show 0.**
4. ✅ Erik already gave me some pointers on handling the enterprise-in-OSS parts of this, is there anything else I missed here? **A: Looks good.**
5. I am generally erring on the side of duplicating code here over generalizing existing code or forming new abstractions when it would only serve two places. I'm going to do a lap of cleanup and assess if any of these places make sense to DRY up, but if anything jumps out at you as being better served that way, please suggest it!
6. ✅ What stories should we include for the Repo Batch Changes page? I currently have with a full list, with a list with hidden external changesets, and with no batch changes. **A: Can safely exclude the middle one, shouldn't be possible. No others needed.**


## Plot holes

(aka tracking the things that I'm still working on/cleaning up for this PR)

- [x] Wire up changeset stats queries on the frontend
- [x] Wire up diff stat query on the frontend
- [x] ~Wire up changeset search + filters query parameters~
- [x] ~Hide a batch change from the list if all of its changesets are hidden by the current search parameters~
- [x] Clean up repo permissions
- [x] Exclude archived changesets from queries, stats
- [ ] Write backend tests for new GraphQL queries
- [x] If page is empty, point user to batch changes getting started materials
- [x] Fix initial page title
- [ ] File issue to track enhancements: bulk action support, search + filters
- [ ] CHANGELOG entry