### PR TITLE
lib/output: various tweaks to terminal handling

### DIFF
--- a/dev/sg/go.sum
+++ b/dev/sg/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
@@ -32,6 +34,8 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -165,6 +169,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -174,8 +180,6 @@ github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
-github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 h1:lh3PyZvY+B9nFliSGTn5uFuqQQJGuNrD0MLCokv09ag=
-github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -307,8 +311,9 @@ golang.org/x/sys v0.0.0-20210218084038-e8e29180ff58/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 h1:faDu4veV+8pcThn4fewv6TVlNCezafGoC1gM/mxQLbQ=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -325,6 +330,7 @@ golang.org/x/tools v0.0.0-20190327201419-c70d86f8b7cf/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190428024724-550556f78a90/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200624163319-25775e59acb7/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -373,6 +379,8 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
+gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=

--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,7 @@ require (
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210611083646-a4fc73990273
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.org/x/tools v0.1.4
 	google.golang.org/api v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,9 @@ cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
@@ -256,6 +257,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crewjam/httperr v0.0.0-20190612203328-a946449404da/go.mod h1:+rmNIXRvYMqLQeR4DHyTvs6y0MEMymTz4vyFpFkKTPs=
 github.com/crewjam/saml v0.4.1 h1:ZNSRJvdbypQDY2uApMngeIHNcxS6UCRAgiw3S+pmgRU=
 github.com/crewjam/saml v0.4.1/go.mod h1:vHcshzXm2WkPOV1dcToZa99cCB1h3nPiKLtLYK+erBE=
@@ -1067,6 +1070,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1109,8 +1114,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
-github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 h1:lh3PyZvY+B9nFliSGTn5uFuqQQJGuNrD0MLCokv09ag=
-github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -1738,8 +1741,9 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210503080704-8803ae5d1324/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 h1:faDu4veV+8pcThn4fewv6TVlNCezafGoC1gM/mxQLbQ=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -2042,6 +2046,7 @@ gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/klauspost/pgzip v1.2.5
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-runewidth v0.0.12
-	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1
+	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	golang.org/x/sys v0.0.0-20210611083646-a4fc73990273
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
@@ -33,6 +35,8 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -182,6 +186,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -194,8 +200,6 @@ github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
-github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 h1:lh3PyZvY+B9nFliSGTn5uFuqQQJGuNrD0MLCokv09ag=
-github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -326,8 +330,9 @@ golang.org/x/sys v0.0.0-20210218084038-e8e29180ff58/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 h1:faDu4veV+8pcThn4fewv6TVlNCezafGoC1gM/mxQLbQ=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -344,6 +349,7 @@ golang.org/x/tools v0.0.0-20190327201419-c70d86f8b7cf/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190428024724-550556f78a90/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200624163319-25775e59acb7/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -394,6 +400,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
+gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=

--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -17,11 +17,6 @@ type capabilities struct {
 }
 
 func detectCapabilities() (capabilities, error) {
-	// There's a pretty obvious flaw here in that we only check the terminal
-	// size once. We may want to consider adding a background goroutine that
-	// updates the capabilities struct every second or two, or at least listen
-	// for SIGWINCH on platforms that support it.
-
 	atty := isatty.IsTerminal(os.Stdout.Fd())
 	w, h := 80, 25
 	var err error

--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -4,8 +4,9 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/cockroachdb/errors"
 	"github.com/mattn/go-isatty"
-	"github.com/nsf/termbox-go"
+	"github.com/moby/term"
 )
 
 type capabilities struct {
@@ -15,28 +16,32 @@ type capabilities struct {
 	Width  int
 }
 
-func detectCapabilities() capabilities {
+func detectCapabilities() (capabilities, error) {
 	// There's a pretty obvious flaw here in that we only check the terminal
 	// size once. We may want to consider adding a background goroutine that
-	// updates the capabilities struct every second or two.
-	//
-	// Pulling in termbox is probably overkill, but finding a pure Go library
-	// that could just provide terminfo was surprisingly hard. At least termbox
-	// is widely used.
-	w, h := 80, 25
-	if err := termbox.Init(); err == nil {
-		w, h = termbox.Size()
-		termbox.Close()
-	}
+	// updates the capabilities struct every second or two, or at least listen
+	// for SIGWINCH on platforms that support it.
 
 	atty := isatty.IsTerminal(os.Stdout.Fd())
+	w, h := 80, 25
+	var err error
+	if atty {
+		size, err := term.GetWinsize(os.Stdout.Fd())
+		if err == nil {
+			if size != nil {
+				w, h = int(size.Width), int(size.Height)
+			} else {
+				err = errors.New("unexpected nil size from GetWinsize")
+			}
+		}
+	}
 
 	return capabilities{
 		Color:  detectColor(atty),
 		Isatty: atty,
 		Height: h,
 		Width:  w,
-	}
+	}, err
 }
 
 func detectColor(atty bool) bool {

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -4,7 +4,10 @@ package output
 import (
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -67,8 +70,58 @@ type OutputOpts struct {
 // hook into NewOutput to perform any required setup.
 var newOutputPlatformQuirks func(o *Output) error
 
+// newCapabilityWatcher returns a channel that receives a message when
+// capabilities are updated. By default, no watching functionality is
+// available.
+var newCapabilityWatcher func() chan capabilities = func() chan capabilities { return nil }
+
 func NewOutput(w io.Writer, opts OutputOpts) *Output {
-	caps := detectCapabilities()
+	caps, err := detectCapabilities()
+	o := &Output{caps: overrideCapabilitiesFromOptions(caps, opts), opts: opts, w: w}
+	if newOutputPlatformQuirks != nil {
+		if err := newOutputPlatformQuirks(o); err != nil {
+			o.Verbosef("Error handling platform quirks: %v", err)
+		}
+	}
+
+	// If we got an error earlier, now is where we'll report it to the user.
+	if err != nil {
+		block := o.Block(Linef(EmojiWarning, StyleWarning, "An error was returned when detecting the terminal size and capabilities:"))
+		block.Write("")
+		block.Write(err.Error())
+		block.Write("")
+		block.Write("Execution will continue, but please report this, along with your operating")
+		block.Write("system, terminal, and any other details, to:")
+		block.Write("  https://github.com/sourcegraph/sourcegraph")
+		block.Close()
+	}
+
+	if c := newCapabilityWatcher(); c != nil {
+		go func() {
+			for {
+				caps := <-c
+				o.caps = overrideCapabilitiesFromOptions(caps, o.opts)
+			}
+		}()
+	}
+
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGWINCH)
+		for {
+			<-c
+			os.Stderr.WriteString("WINCH\n")
+			caps, err := detectCapabilities()
+			if err == nil {
+				o.caps = caps
+			}
+		}
+	}()
+
+	return o
+}
+
+func overrideCapabilitiesFromOptions(caps capabilities, opts OutputOpts) capabilities {
 	if opts.ForceColor {
 		caps.Color = true
 	}
@@ -82,14 +135,7 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 		caps.Width = opts.ForceWidth
 	}
 
-	o := &Output{caps: caps, opts: opts, w: w}
-	if newOutputPlatformQuirks != nil {
-		if err := newOutputPlatformQuirks(o); err != nil {
-			o.Verbosef("Error handling platform quirks: %v", err)
-		}
-	}
-
-	return o
+	return caps
 }
 
 func (o *Output) Lock() {

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -4,10 +4,7 @@ package output
 import (
 	"fmt"
 	"io"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -104,19 +101,6 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 			}
 		}()
 	}
-
-	go func() {
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGWINCH)
-		for {
-			<-c
-			os.Stderr.WriteString("WINCH\n")
-			caps, err := detectCapabilities()
-			if err == nil {
-				o.caps = caps
-			}
-		}
-	}()
 
 	return o
 }

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -89,7 +89,7 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 		block.Write("")
 		block.Write("Execution will continue, but please report this, along with your operating")
 		block.Write("system, terminal, and any other details, to:")
-		block.Write("  https://github.com/sourcegraph/sourcegraph")
+		block.Write("  https://github.com/sourcegraph/sourcegraph/issues/new")
 		block.Close()
 	}
 

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -97,8 +97,7 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 	// is resized.
 	if c := newCapabilityWatcher(); c != nil {
 		go func() {
-			for {
-				caps := <-c
+			for caps := range c {
 				o.caps = overrideCapabilitiesFromOptions(caps, o.opts)
 			}
 		}()

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -93,6 +93,8 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 		block.Close()
 	}
 
+	// Set up a watcher so we can adjust the size of the output if the terminal
+	// is resized.
 	if c := newCapabilityWatcher(); c != nil {
 		go func() {
 			for {

--- a/lib/output/output_unix.go
+++ b/lib/output/output_unix.go
@@ -52,12 +52,14 @@ func init() {
 					if err == nil {
 						mu.RLock()
 						for _, out := range chans {
-							select {
-							case out <- caps:
-							// success
-							default:
-								continue
-							}
+							go func(out chan capabilities, caps capabilities) {
+								select {
+								case out <- caps:
+									// success
+								default:
+									// welp
+								}
+							}(out, caps)
 						}
 						mu.RUnlock()
 					}

--- a/lib/output/output_unix.go
+++ b/lib/output/output_unix.go
@@ -32,7 +32,9 @@ func init() {
 	newCapabilityWatcher = func() chan capabilities {
 		// Lazily initialise the required global state if we haven't already.
 		once.Do(func() {
+			mu.Lock()
 			chans = make([]chan capabilities, 0, 1)
+			mu.Unlock()
 
 			// Install the signal handler. To avoid race conditions, we should
 			// do this synchronously before spawning the goroutine that will

--- a/lib/output/output_unix.go
+++ b/lib/output/output_unix.go
@@ -10,33 +10,67 @@ import (
 )
 
 func init() {
-	chans := []chan capabilities{}
-	var mu sync.RWMutex
+	// The platforms this file builds on support the SIGWINCH signal, which
+	// indicates that the terminal has been resized. When we receive that
+	// signal, we can use this to re-detect the terminal capabilities.
+	//
+	// We won't do any setup until the first time newCapabilityWatcher is
+	// invoked, but we do need some shared state to be ready.
+	var (
+		// chans contains the listening channels that should be notified when
+		// capabilities are updated.
+		chans []chan capabilities
 
-	// On these platforms, we have the SIGWINCH signal available, which
-	// indicates that the terminal has been resized. When received, we can use
-	// this to re-detect the terminal capabilities.
-	go func() {
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGWINCH)
-		for {
-			<-c
-			caps, err := detectCapabilities()
-			// We won't bother reporting an error here; there's no harm in the
-			// previous capabilities being used besides possibly being ugly.
-			if err == nil {
-				mu.RLock()
-				for _, out := range chans {
-					go func(caps capabilities, out chan capabilities) {
-						out <- caps
-					}(caps, out)
-				}
-				mu.RUnlock()
-			}
-		}
-	}()
+		// mu guards the chans variable.
+		mu sync.RWMutex
+
+		// once guards the lazy initialisation, including installing the signal
+		// handler.
+		once sync.Once
+	)
 
 	newCapabilityWatcher = func() chan capabilities {
+		// Lazily initialise the required global state if we haven't already.
+		once.Do(func() {
+			chans = make([]chan capabilities, 0, 1)
+
+			// Install the signal handler. To avoid race conditions, we should
+			// do this synchronously before spawning the goroutine that will
+			// actually listen to the channel.
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, syscall.SIGWINCH)
+
+			go func() {
+				for {
+					<-c
+					caps, err := detectCapabilities()
+					// We won't bother reporting an error here; there's no harm
+					// in the previous capabilities being used besides possibly
+					// being ugly.
+					if err == nil {
+						mu.RLock()
+						for _, out := range chans {
+							// Technically, if the listener of this channel is
+							// no longer listening, sending caps to out will
+							// hang forever. To mitigate this, we'll run in a
+							// goroutine.
+							//
+							// Practically, there's only ever one Output
+							// instance in all our uses of this package, and it
+							// lives for the lifetime of the process. So the
+							// potential for a goroutine leak here is
+							// practically zero.
+							go func(caps capabilities, out chan capabilities) {
+								out <- caps
+							}(caps, out)
+						}
+						mu.RUnlock()
+					}
+				}
+			}()
+		})
+
+		// Now we can create and return the actual output channel.
 		out := make(chan capabilities)
 		mu.Lock()
 		defer mu.Unlock()

--- a/lib/output/output_unix.go
+++ b/lib/output/output_unix.go
@@ -1,0 +1,47 @@
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package output
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+func init() {
+	chans := []chan capabilities{}
+	var mu sync.RWMutex
+
+	// On these platforms, we have the SIGWINCH signal available, which
+	// indicates that the terminal has been resized. When received, we can use
+	// this to re-detect the terminal capabilities.
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGWINCH)
+		for {
+			<-c
+			caps, err := detectCapabilities()
+			// We won't bother reporting an error here; there's no harm in the
+			// previous capabilities being used besides possibly being ugly.
+			if err == nil {
+				mu.RLock()
+				for _, out := range chans {
+					go func(caps capabilities, out chan capabilities) {
+						out <- caps
+					}(caps, out)
+				}
+				mu.RUnlock()
+			}
+		}
+	}()
+
+	newCapabilityWatcher = func() chan capabilities {
+		out := make(chan capabilities)
+		mu.Lock()
+		defer mu.Unlock()
+		chans = append(chans, out)
+
+		return out
+	}
+}

--- a/lib/output/output_unix.go
+++ b/lib/output/output_unix.go
@@ -50,19 +50,12 @@ func init() {
 					if err == nil {
 						mu.RLock()
 						for _, out := range chans {
-							// Technically, if the listener of this channel is
-							// no longer listening, sending caps to out will
-							// hang forever. To mitigate this, we'll run in a
-							// goroutine.
-							//
-							// Practically, there's only ever one Output
-							// instance in all our uses of this package, and it
-							// lives for the lifetime of the process. So the
-							// potential for a goroutine leak here is
-							// practically zero.
-							go func(caps capabilities, out chan capabilities) {
-								out <- caps
-							}(caps, out)
+							select {
+							case out <- caps:
+							// success
+							default:
+								continue
+							}
 						}
 						mu.RUnlock()
 					}

--- a/lib/output/output_unix_test.go
+++ b/lib/output/output_unix_test.go
@@ -4,10 +4,9 @@ package output
 
 import (
 	"os"
-	"sync"
-	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -15,42 +14,69 @@ import (
 func TestCapabilityWatcher(t *testing.T) {
 	// Let's set up two capability watcher channels and ensure they both get
 	// triggered on a single SIGWINCH and that they receive the same value.
-	var (
-		capA        capabilities
-		capB        capabilities
-		invocations int32
-		wg          sync.WaitGroup
-	)
+	//
+	// We'll have them both send the capabilities they receive into this channel.
+	received := make(chan capabilities)
 
-	createWatcher := func(out *capabilities) {
+	createWatcher := func() {
 		c := newCapabilityWatcher()
 		if c == nil {
 			t.Error("unexpected nil watcher channel")
 		}
 
-		wg.Add(1)
 		go func() {
-			*out = <-c
-			atomic.AddInt32(&invocations, 1)
-			wg.Done()
+			// We only want to receive one capabilities struct on the channel;
+			// if we get more and the test hasn't terminated, that means that
+			// the capabilities aren't being fanned out correctly to each
+			// watcher.
+			caps := <-c
+			received <- caps
 		}()
 	}
-	createWatcher(&capA)
-	createWatcher(&capB)
+	createWatcher()
+	createWatcher()
 
+	// Now we set up the main test. To be able to raise signals on the current
+	// process, we need the current process.
 	proc, err := os.FindProcess(os.Getpid())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := proc.Signal(syscall.SIGWINCH); err != nil {
-		t.Fatal(err)
-	}
 
-	wg.Wait()
-	if invocations != 2 {
-		t.Errorf("unexpected number of invocations: have=%d want=2", invocations)
-	}
-	if diff := cmp.Diff(capA, capB); diff != "" {
-		t.Errorf("unexpected difference between capabilities:\n%s", diff)
+	// We need to track the capabilities we've seen, since we expect both
+	// watchers to receive a capabilities struct.
+	seen := []capabilities{}
+
+	// We're going to raise the signal on a ticker. The reason for this is that
+	// signal handler installation is asynchronous: Go starts a goroutine the
+	// first time a signal handler is installed, and there's no guarantee that
+	// the goroutine has even installed the OS-level signal handler at the point
+	// execution returns from signal.Notify(). The quickest, dirtiest solution
+	// is therefore to keep raising SIGWINCH until it's handled, which we can do
+	// with a ticker.
+	ticker := time.NewTicker(3 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		// Raise SIGWINCH when the ticker ticks.
+		case <-ticker.C:
+			if err := proc.Signal(syscall.SIGWINCH); err != nil {
+				t.Fatal(err)
+			}
+
+		// Handle the capabilities we see in the watchers, and test the results
+		// once we have capabilities from both watchers and terminate.
+		case caps := <-received:
+			seen = append(seen, caps)
+			if len(seen) > 2 {
+				t.Fatalf("too many capabilities")
+			} else if len(seen) == 2 {
+				if diff := cmp.Diff(seen[0], seen[1]); diff != "" {
+					t.Errorf("unexpected difference between capabilities:\n%s", diff)
+				}
+				return
+			}
+		}
 	}
 }

--- a/lib/output/output_unix_test.go
+++ b/lib/output/output_unix_test.go
@@ -1,0 +1,56 @@
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package output
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCapabilityWatcher(t *testing.T) {
+	// Let's set up two capability watcher channels and ensure they both get
+	// triggered on a single SIGWINCH and that they receive the same value.
+	var (
+		capA        capabilities
+		capB        capabilities
+		invocations int32
+		wg          sync.WaitGroup
+	)
+
+	createWatcher := func(out *capabilities) {
+		c := newCapabilityWatcher()
+		if c == nil {
+			t.Error("unexpected nil watcher channel")
+		}
+
+		wg.Add(1)
+		go func() {
+			*out = <-c
+			atomic.AddInt32(&invocations, 1)
+			wg.Done()
+		}()
+	}
+	createWatcher(&capA)
+	createWatcher(&capB)
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := proc.Signal(syscall.SIGWINCH); err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait()
+	if invocations != 2 {
+		t.Errorf("unexpected number of invocations: have=%d want=2", invocations)
+	}
+	if diff := cmp.Diff(capA, capB); diff != "" {
+		t.Errorf("unexpected difference between capabilities:\n%s", diff)
+	}
+}


### PR DESCRIPTION
This was inspired by a customer report of problems on Windows, but I've been wanting to do this for a while anyway.

This PR addresses a couple of issues:

1. We rely on termbox-go to detect the terminal size. termbox-go has a lot of functionality we don't need, and is now mostly unmaintained. Instead, we can use https://github.com/moby/term, which is maintained by the Docker team for their terminal needs, which are much closer to ours.
2. If terminals are resized during execution, many of the features of `Output` stop behaving nicely: progress bars will always use the original width, most notably, but wrapping of blocks will also stop working as expected. This PR adds a ticker (on Windows) or a `SIGWINCH` handler (basically everywhere else) to update the terminal size used by `Output` when it changes. This still isn't foolproof — the output can still be fairly ugly in the scrollback — but it's massively better than what we have today.

If and when we merge this, I'll then open a PR in src-cli to update the lib dependency.

Fixes #22374, fixes https://github.com/sourcegraph/src-cli/issues/270, fixes https://github.com/sourcegraph/src-cli/issues/473.