### PR TITLE
monitoring: Add gitserver cleanup panel

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -832,6 +832,38 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 <br />
 
+### Git Server: Gitserver cleanup jobs
+
+#### gitserver: janitor_running
+
+This panel indicates if the janitor process is running.
+
+1, if the janitor process is currently running
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### gitserver: janitor_job_duration
+
+This panel indicates 95th percentile job run duration.
+
+95th percentile job run duration
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### gitserver: repos_removed
+
+This panel indicates repositories removed due to disk pressure.
+
+Repositories removed due to disk pressure
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 ### Git Server: Container monitoring (not available on server)
 
 #### gitserver: container_cpu_usage

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2043,7 +2043,7 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 This panel indicates time since last sync.
 
-A high value here indicates issues synchronizing repository permissions.
+A high value here indicates issues synchronizing repo metadata.
 If the value is persistently high, make sure all external services have valid tokens.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -248,6 +248,45 @@ func GitServer() *monitoring.Container {
 				},
 			},
 			{
+				Title:  "Gitserver cleanup jobs",
+				Hidden: true,
+				Rows: []monitoring.Row{
+					{
+						{
+							Name:           "janitor_running",
+							Description:    "if the janitor process is running",
+							Query:          "src_gitserver_janitor_running",
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("janitor process running").Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerCoreApplication,
+							Interpretation: "1, if the janitor process is currently running",
+						},
+					},
+					{
+						{
+							Name:           "janitor_job_duration",
+							Description:    "95th percentile job run duration",
+							Query:          "histogram_quantile(0.95, sum(rate(src_gitserver_janitor_job_duration_seconds_bucket[5m])) by (le, job_name))",
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("{{job_name}}").Unit(monitoring.Seconds),
+							Owner:          monitoring.ObservableOwnerCoreApplication,
+							Interpretation: "95th percentile job run duration",
+						},
+					},
+					{
+						{
+							Name:           "repos_removed",
+							Description:    "repositories removed due to disk pressure",
+							Query:          "sum by (instance) (rate(src_gitserver_repos_removed_disk_pressure[5m]))",
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerCoreApplication,
+							Interpretation: "Repositories removed due to disk pressure",
+						},
+					},
+				},
+			},
+			{
 				Title:  shared.TitleContainerMonitoring,
 				Hidden: true,
 				Rows: []monitoring.Row{

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -37,7 +37,7 @@ func RepoUpdater() *monitoring.Container {
 							Panel:       monitoring.Panel().Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerCoreApplication,
 							Interpretation: `
-								A high value here indicates issues synchronizing repository permissions.
+								A high value here indicates issues synchronizing repo metadata.
 								If the value is persistently high, make sure all external services have valid tokens.
 							`,
 						},


### PR DESCRIPTION
Add a panel showing:

* if the janitor process is running
* 95th percentile job run duration
* repositories removed due to disk pressure