### PR TITLE
web: integrate `DllPlugin` in Storybook development build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ sourcegraph-webapp-*.tgz
 *.tsbuildinfo
 graphql-operations.ts
 *.module.scss.d.ts
+dll-bundle
 
 # Extensions
 /client/extension-api/dist

--- a/client/storybook/README.md
+++ b/client/storybook/README.md
@@ -1,12 +1,52 @@
 # Storybook configuration
 
+Checkout the [Storybook section](https://docs.sourcegraph.com/dev/background-information/web/web_app#storybook) in the [Developing the Sourcegraph web app](https://docs.sourcegraph.com/dev/background-information/web/web_app) docs.
+
 ## Usage
 
 Storybook configuration is setup as a `yarn workspace` symlink.
 
-Important commands are expose via root `package.json`:
+Important commands are exposed via root `package.json`:
 
 ```sh
 yarn storybook
 yarn build-storybook
 ```
+
+## Environment variables
+
+```sh
+# Load only a subset of stories to boost build performance.
+STORIES_GLOB=client/web/src/**/*.story.tsx yarn start
+
+# Enable `webpack-bundle-analyzer` plugin.
+WEBPACK_BUNDLE_ANALYZER=true yarn start
+
+# Enable `speed-measure-webpack-plugin` plugin.
+WEBPACK_SPEED_ANALYZER=true yarn start
+
+# Enable `webpack-dll-plugin`.
+WEBPACK_DLL_PLUGIN=true yarn start
+
+# Enabled `webpack-progress-plugin`.
+WEBPACK_PROGRESS_PLUGIN=true yarn start
+
+# Enable minification and Webpack config production mode.
+MINIFY=true yarn build
+```
+
+## DLL Plugin
+
+The [DLL Plugin](https://webpack.js.org/plugins/dll-plugin/) is used to move most third-party dependencies into a separate pre-built bundle to speed up development build.
+
+### How `yarn start:dll` works
+
+1. `DllReferencePlugin` is enabled in the Storybook configuration via the `WEBPACK_DLL_PLUGIN` environment variable.
+2. If the DLL manifest is not available at `./assets/dll-bundle/dll-plugin.manifest.json`, the `yarn build:dll-bundle` command is executed to create a DLL bundle.
+3. The list of third-party dependencies from Webpack stats is required to create a DLL bundle. If Webpack stats are not available at `./storybook-static/preview-stats.json`, the `yarn build:webpack-stats` command is executed to create them.
+4. Webpack stats are generated from `storybook-start --webpack-stats-json` command.
+5. DLL bundle is built using Webpack config `./src/webpack.config.dll.ts`.
+6. `DllReferencePlugin` is initialized using just created DLL manifest.
+7. Storybook development server starts 🎉.
+
+If DLL bundle and Webpack stats are in place, all intermediate steps are skipped straight to the start of Storybook development server.

--- a/client/storybook/README.md
+++ b/client/storybook/README.md
@@ -1,6 +1,6 @@
 # Storybook configuration
 
-Checkout the [Storybook section](https://docs.sourcegraph.com/dev/background-information/web/web_app#storybook) in the [Developing the Sourcegraph web app](https://docs.sourcegraph.com/dev/background-information/web/web_app) docs.
+Check out the [Storybook section](https://docs.sourcegraph.com/dev/background-information/web/web_app#storybook) in the [Developing the Sourcegraph web app](https://docs.sourcegraph.com/dev/background-information/web/web_app) docs.
 
 ## Usage
 
@@ -37,7 +37,7 @@ MINIFY=true yarn build
 
 ## DLL Plugin
 
-The [DLL Plugin](https://webpack.js.org/plugins/dll-plugin/) is used to move most third-party dependencies into a separate pre-built bundle to speed up development build.
+The [DLL Plugin](https://webpack.js.org/plugins/dll-plugin/) is used to move most third-party dependencies into a separate pre-built bundle to speed up development build. To start Storybook development server with DLL Plugin enabled run: `yarn start:dll` from the Storybook workspace or `yarn storybook:dll` from the root folder.
 
 ### How `yarn start:dll` works
 

--- a/client/storybook/package.json
+++ b/client/storybook/package.json
@@ -11,7 +11,7 @@
     "build": "TS_NODE_TRANSPILE_ONLY=true build-storybook -c ./src -s ./assets",
     "build:webpack-stats": "TS_NODE_TRANSPILE_ONLY=true WEBPACK_DLL_PLUGIN=false start-storybook -c ./src -s ./assets --smoke-test --webpack-stats-json ./storybook-static --loglevel warn",
     "build:dll-bundle": "TS_NODE_TRANSPILE_ONLY=true webpack --config ./src/webpack.config.dll.ts --no-stats",
-    "start:dll": "TS_NODE_TRANSPILE_ONLY=true WEBPACK_DLL_PLUGIN=true start-storybook -p 9001 -c ./src -s ./assets --loglevel warn",
+    "start:dll": "TS_NODE_TRANSPILE_ONLY=true WEBPACK_DLL_PLUGIN=true start-storybook -p 9001 -c ./src -s ./assets",
     "clean:dll": "rm -rf assets/dll-bundle storybook-static/*-stats.json",
     "test": "jest"
   }

--- a/client/storybook/package.json
+++ b/client/storybook/package.json
@@ -9,6 +9,10 @@
     "eslint": "eslint --cache 'src/**/*.[jt]s?(x)'",
     "start": "TS_NODE_TRANSPILE_ONLY=true start-storybook -p 9001 -c ./src -s ./assets",
     "build": "TS_NODE_TRANSPILE_ONLY=true build-storybook -c ./src -s ./assets",
+    "build:webpack-stats": "TS_NODE_TRANSPILE_ONLY=true WEBPACK_DLL_PLUGIN=false start-storybook -c ./src -s ./assets --smoke-test --webpack-stats-json ./storybook-static --loglevel warn",
+    "build:dll-bundle": "TS_NODE_TRANSPILE_ONLY=true webpack --config ./src/webpack.config.dll.ts --no-stats",
+    "start:dll": "TS_NODE_TRANSPILE_ONLY=true WEBPACK_DLL_PLUGIN=true start-storybook -p 9001 -c ./src -s ./assets --loglevel warn",
+    "clean:dll": "rm -rf assets/dll-bundle storybook-static/*-stats.json",
     "test": "jest"
   }
 }

--- a/client/storybook/src/dllPlugin/ensureDllBundleIsReady.ts
+++ b/client/storybook/src/dllPlugin/ensureDllBundleIsReady.ts
@@ -1,0 +1,25 @@
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+import signale from 'signale'
+
+import { dllPluginConfig, storybookWorkspacePath, rootPath } from '../webpack.config.common'
+
+// Build DLL bundle with `yarn build:dll-bundle` if it's not available.
+export const ensureDllBundleIsReady = (): void => {
+    signale.start(`Checking if DLL bundle is available: ${path.relative(rootPath, dllPluginConfig.path)}`)
+
+    // eslint-disable-next-line no-sync
+    if (!fs.existsSync(dllPluginConfig.path)) {
+        signale.warn('DLL bundle not found!')
+        signale.await('Building new DLL bundle with `yarn build:dll-bundle`')
+
+        spawnSync('yarn', ['build:dll-bundle'], {
+            stdio: 'inherit',
+            cwd: storybookWorkspacePath,
+        })
+    }
+
+    signale.success('DLL bundle is ready!')
+}

--- a/client/storybook/src/dllPlugin/getVendorModules.ts
+++ b/client/storybook/src/dllPlugin/getVendorModules.ts
@@ -1,0 +1,29 @@
+import { Stats } from 'webpack'
+
+import { nodeModulesPath } from '../webpack.config.common'
+
+// Do not include Webpack related modules into a DLL bundle. It breaks development build.
+const SKIP_VENDOR_MODULES = ['webpack']
+
+// Get a list of files to include into a DLL bundle based on Webpack stats provided.
+export function getVendorModules(webpackStats: Stats.ToJsonOutput): Set<string> {
+    const vendorsChunk = webpackStats.chunks?.find(
+        chunk => typeof chunk.id === 'string' && chunk.id.includes('vendors')
+    )
+
+    if (!vendorsChunk || !vendorsChunk.modules) {
+        throw new Error('Vendors chunk not found in preview.stats.json!')
+    }
+
+    const vendorModules = vendorsChunk.modules
+        .map(({ identifier }) => {
+            // `identifier` contains loaders prefix, so `path.relative()` doesn't work for all cases.
+            const [relativePathToModule] = identifier.split(`${nodeModulesPath}/`).slice(-1)
+
+            // Remove suffix generated for some Storybook modules.
+            return relativePathToModule.replace('-generated-other-entry.js', '')
+        })
+        .filter(modulePath => !SKIP_VENDOR_MODULES.some(ignoreModule => modulePath.includes(ignoreModule)))
+
+    return new Set(vendorModules)
+}

--- a/client/storybook/src/dllPlugin/getWebpackStats.ts
+++ b/client/storybook/src/dllPlugin/getWebpackStats.ts
@@ -1,0 +1,34 @@
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+import signale from 'signale'
+import { Stats } from 'webpack'
+
+import { readJsonFile, storybookWorkspacePath, rootPath } from '../webpack.config.common'
+
+const webpackStatsPath = path.resolve(storybookWorkspacePath, 'storybook-static/preview-stats.json')
+
+export const ensureWebpackStatsAreReady = (): void => {
+    signale.start(`Checking if Webpack stats are available: ${path.relative(rootPath, webpackStatsPath)}`)
+
+    // eslint-disable-next-line no-sync
+    if (!fs.existsSync(webpackStatsPath)) {
+        signale.warn('Webpack stats not found!')
+        signale.await('Building Webpack stats with `yarn build:webpack-stats`')
+
+        spawnSync('yarn', ['build:webpack-stats'], {
+            stdio: 'inherit',
+            cwd: storybookWorkspacePath,
+        })
+    }
+
+    signale.success('Webpack stats are ready!')
+}
+
+// Read Webpack stats JSON file. If it's not available use `yarn build:webpack-stats` command to create it.
+export function getWebpackStats(): Stats.ToJsonOutput {
+    ensureWebpackStatsAreReady()
+
+    return readJsonFile(webpackStatsPath) as Stats.ToJsonOutput
+}

--- a/client/storybook/src/dllPlugin/index.ts
+++ b/client/storybook/src/dllPlugin/index.ts
@@ -1,0 +1,3 @@
+export * from './ensureDllBundleIsReady'
+export * from './getVendorModules'
+export * from './getWebpackStats'

--- a/client/storybook/src/environment-config.ts
+++ b/client/storybook/src/environment-config.ts
@@ -2,6 +2,8 @@ const getEnvironmentBoolean = (value = 'false'): boolean => Boolean(JSON.parse(v
 
 export const environment = {
     customStoriesGlob: process.env.STORIES_GLOB,
+    isDLLPluginEnabled: getEnvironmentBoolean(process.env.WEBPACK_DLL_PLUGIN),
+    isProgressPluginEnabled: getEnvironmentBoolean(process.env.WEBPACK_PROGRESS_PLUGIN),
     isBundleAnalyzerEnabled: getEnvironmentBoolean(process.env.WEBPACK_BUNDLE_ANALYZER),
     isSpeedAnalyzerEnabled: getEnvironmentBoolean(process.env.WEBPACK_SPEED_ANALYZER),
     shouldMinify: getEnvironmentBoolean(process.env.MINIFY),

--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -1,16 +1,28 @@
 import path from 'path'
 
+import { Options } from '@storybook/core-common'
+import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin'
 import { remove } from 'lodash'
-import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin'
+import signale from 'signale'
 import SpeedMeasurePlugin from 'speed-measure-webpack-plugin'
 import TerserPlugin from 'terser-webpack-plugin'
-import { Configuration, DefinePlugin, ProgressPlugin, RuleSetUseItem, RuleSetUse } from 'webpack'
+import { DllReferencePlugin, Configuration, DefinePlugin, ProgressPlugin, RuleSetUseItem, RuleSetUse } from 'webpack'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 
+import { ensureDllBundleIsReady } from './dllPlugin'
 import { environment } from './environment-config'
-
-const rootPath = path.resolve(__dirname, '../../../')
-const monacoEditorPaths = [path.resolve(rootPath, 'node_modules', 'monaco-editor')]
+import {
+    rootPath,
+    monacoEditorPath,
+    dllPluginConfig,
+    dllBundleManifestPath,
+    getMonacoCSSRule,
+    getMonacoTTFRule,
+    getMonacoWebpackPlugin,
+    nodeModulesPath,
+    getBasicCSSLoader,
+    readJsonFile,
+} from './webpack.config.common'
 
 const getStoriesGlob = (): string[] => {
     if (process.env.STORIES_GLOB) {
@@ -44,6 +56,18 @@ const getCSSLoaders = (...loaders: RuleSetUseItem[]): RuleSetUse => [
     },
 ]
 
+const getDllScriptTag = (): string => {
+    ensureDllBundleIsReady()
+    signale.await('Waiting for Webpack to compile Storybook preview.')
+
+    const dllManifest = readJsonFile(dllBundleManifestPath) as Record<string, string>
+
+    return `
+        <!-- Load JS bundle created by DLL_PLUGIN  -->
+        <script src="/dll-bundle/${dllManifest['dll.js']}"></script>
+    `
+}
+
 const config = {
     stories: getStoriesGlob(),
     addons: [
@@ -66,19 +90,23 @@ const config = {
         reactDocgen: false,
     },
 
-    webpackFinal: (config: Configuration) => {
+    // Include DLL bundle script tag into preview-head.html if DLLPlugin is enabled.
+    previewHead: (head: string) => `
+        ${head}
+        ${environment.isDLLPluginEnabled ? getDllScriptTag() : ''}
+    `,
+
+    webpackFinal: (config: Configuration, options: Options) => {
+        config.stats = 'errors-warnings'
         config.mode = environment.shouldMinify ? 'production' : 'development'
 
         // Check the default config is in an expected shape.
-        if (!config.module) {
+        if (!config.module || !config.plugins) {
             throw new Error(
                 'The format of the default storybook webpack config changed, please check if the config in ./src/main.ts is still valid'
             )
         }
 
-        if (!config.plugins) {
-            config.plugins = []
-        }
         config.plugins.push(
             new DefinePlugin({
                 NODE_ENV: JSON.stringify(config.mode),
@@ -106,10 +134,6 @@ const config = {
             ]
         }
 
-        if (process.env.CI) {
-            remove(config.plugins, plugin => plugin instanceof ProgressPlugin)
-        }
-
         // We don't use Storybook's default Babel config for our repo, it doesn't include everything we need.
         config.module.rules.splice(0, 1)
         config.module.rules.unshift({
@@ -121,40 +145,21 @@ const config = {
             },
         })
 
-        config.plugins.push(
-            new MonacoWebpackPlugin({
-                languages: ['json'],
-                features: [
-                    'bracketMatching',
-                    'clipboard',
-                    'coreCommands',
-                    'cursorUndo',
-                    'find',
-                    'format',
-                    'hover',
-                    'inPlaceReplace',
-                    'iPadShowKeyboard',
-                    'links',
-                    'suggest',
-                ],
-            })
-        )
-
-        const storybookDirectory = path.resolve(rootPath, 'node_modules/@storybook')
+        const storybookPath = path.resolve(nodeModulesPath, '@storybook')
 
         // Put our style rules at the beginning so they're processed by the time it
         // gets to storybook's style rules.
         config.module.rules.unshift({
             test: /\.(sass|scss)$/,
             // Make sure Storybook styles get handled by the Storybook config
-            exclude: [/\.module\.(sass|scss)$/, storybookDirectory],
-            use: getCSSLoaders('@terminus-term/to-string-loader', { loader: 'css-loader', options: { url: false } }),
+            exclude: [/\.module\.(sass|scss)$/, storybookPath],
+            use: getCSSLoaders('@terminus-term/to-string-loader', getBasicCSSLoader()),
         })
 
         config.module?.rules.unshift({
             test: /\.(sass|scss)$/,
             include: /\.module\.(sass|scss)$/,
-            exclude: storybookDirectory,
+            exclude: storybookPath,
             use: getCSSLoaders('style-loader', {
                 loader: 'css-loader',
                 options: {
@@ -173,30 +178,14 @@ const config = {
         if (!cssRule) {
             throw new Error('Cannot find original CSS rule')
         }
-        cssRule.include = storybookDirectory
+        cssRule.include = storybookPath
 
         config.module.rules.push({
             // CSS rule for external plain CSS (skip SASS and PostCSS for build perf)
             test: /\.css$/,
             // Make sure Storybook styles get handled by the Storybook config
-            exclude: [storybookDirectory, ...monacoEditorPaths],
-            use: ['@terminus-term/to-string-loader', { loader: 'css-loader', options: { url: false } }],
-        })
-
-        config.module.rules.push({
-            // CSS rule for monaco-editor, it expects styles to be loaded with `style-loader`.
-            test: /\.css$/,
-            include: monacoEditorPaths,
-            // Make sure Storybook styles get handled by the Storybook config
-            exclude: [storybookDirectory],
-            use: ['style-loader', { loader: 'css-loader' }],
-        })
-
-        config.module?.rules.unshift({
-            // TTF rule for monaco-editor
-            test: /\.ttf$/,
-            include: monacoEditorPaths,
-            use: ['file-loader'],
+            exclude: [storybookPath, monacoEditorPath],
+            use: ['@terminus-term/to-string-loader', getBasicCSSLoader()],
         })
 
         config.module.rules.push({
@@ -204,10 +193,32 @@ const config = {
             use: ['raw-loader'],
         })
 
-        Object.assign(config.entry, {
-            'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
-            'json.worker': 'monaco-editor/esm/vs/language/json/json.worker',
-        })
+        // Disable `CaseSensitivePathsPlugin` by default to speed up development build.
+        // Similar discussion: https://github.com/vercel/next.js/issues/6927#issuecomment-480579191
+        remove(config.plugins, plugin => plugin instanceof CaseSensitivePathsPlugin)
+
+        // Disable `ProgressPlugin` by default to speed up development build.
+        // Can be re-enabled by setting `WEBPACK_PROGRESS_PLUGIN` env variable.
+        if (!environment.isProgressPluginEnabled) {
+            remove(config.plugins, plugin => plugin instanceof ProgressPlugin)
+        }
+
+        if (environment.isDLLPluginEnabled && !options.webpackStatsJson) {
+            config.plugins.unshift(
+                new DllReferencePlugin({
+                    context: dllPluginConfig.context,
+                    manifest: dllPluginConfig.path,
+                })
+            )
+        } else {
+            config.plugins.push(getMonacoWebpackPlugin())
+            config.module.rules.push(getMonacoCSSRule(), getMonacoTTFRule())
+
+            Object.assign(config.entry, {
+                'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
+                'json.worker': 'monaco-editor/esm/vs/language/json/json.worker',
+            })
+        }
 
         if (environment.isBundleAnalyzerEnabled) {
             config.plugins.push(new BundleAnalyzerPlugin())

--- a/client/storybook/src/webpack.config.common.ts
+++ b/client/storybook/src/webpack.config.common.ts
@@ -1,0 +1,59 @@
+import fs from 'fs'
+import path from 'path'
+
+import { parse } from '@sqs/jsonc-parser'
+import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin'
+import { WebpackPluginInstance, RuleSetRule, RuleSetUseItem } from 'webpack'
+
+export const rootPath = path.resolve(__dirname, '../../..')
+export const nodeModulesPath = path.resolve(rootPath, 'node_modules')
+export const monacoEditorPath = path.resolve(nodeModulesPath, 'monaco-editor')
+export const storybookWorkspacePath = path.resolve(rootPath, 'client/storybook')
+export const dllBuildPath = path.resolve(storybookWorkspacePath, 'assets/dll-bundle')
+export const dllBundleManifestPath = path.resolve(dllBuildPath, 'dll-bundle.manifest.json')
+
+// eslint-disable-next-line no-sync
+export const readJsonFile = (path: string): unknown => parse(fs.readFileSync(path, 'utf-8')) as unknown
+
+// CSS rule for monaco-editor and other external plain CSS (skip SASS and PostCSS for build perf)
+export const getMonacoCSSRule = (): RuleSetRule => ({
+    test: /\.css$/,
+    include: [monacoEditorPath],
+    use: ['style-loader', { loader: 'css-loader' }],
+})
+
+// TTF rule for monaco-editor
+export const getMonacoTTFRule = (): RuleSetRule => ({
+    test: /\.ttf$/,
+    include: [monacoEditorPath],
+    use: ['file-loader'],
+})
+
+export const getBasicCSSLoader = (): RuleSetUseItem => ({
+    loader: 'css-loader',
+    options: { url: false },
+})
+
+export const getMonacoWebpackPlugin = (): WebpackPluginInstance =>
+    new MonacoWebpackPlugin({
+        languages: ['json'],
+        features: [
+            'bracketMatching',
+            'clipboard',
+            'coreCommands',
+            'cursorUndo',
+            'find',
+            'format',
+            'hover',
+            'inPlaceReplace',
+            'iPadShowKeyboard',
+            'links',
+            'suggest',
+        ],
+    })
+
+export const dllPluginConfig = {
+    context: dllBuildPath,
+    name: 'dll_lib',
+    path: path.resolve(dllBuildPath, 'dll-plugin.manifest.json'),
+}

--- a/client/storybook/src/webpack.config.dll.ts
+++ b/client/storybook/src/webpack.config.dll.ts
@@ -1,0 +1,48 @@
+import signale from 'signale'
+import { DllPlugin, Configuration } from 'webpack'
+import { WebpackManifestPlugin } from 'webpack-manifest-plugin'
+
+import { getWebpackStats, getVendorModules } from './dllPlugin'
+import {
+    monacoEditorPath,
+    dllPluginConfig,
+    getMonacoCSSRule,
+    getMonacoTTFRule,
+    getMonacoWebpackPlugin,
+    getBasicCSSLoader,
+    dllBundleManifestPath,
+} from './webpack.config.common'
+
+const webpackStats = getWebpackStats()
+signale.await('Waiting for Webpack to build DLL bundle based on vendor stats.')
+
+const config: Configuration = {
+    mode: 'development',
+    stats: 'errors-warnings',
+    entry: {
+        dll: [...getVendorModules(webpackStats), 'monaco-editor'],
+    },
+    output: {
+        filename: '[name].bundle.[contenthash].js',
+        path: dllPluginConfig.context,
+        library: dllPluginConfig.name,
+    },
+    module: {
+        rules: [
+            getMonacoCSSRule(),
+            getMonacoTTFRule(),
+            {
+                test: /\.css$/,
+                exclude: [monacoEditorPath],
+                use: [getBasicCSSLoader()],
+            },
+        ],
+    },
+    plugins: [
+        getMonacoWebpackPlugin(),
+        new DllPlugin(dllPluginConfig),
+        new WebpackManifestPlugin({ fileName: dllBundleManifestPath }),
+    ],
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test-e2e": "TS_NODE_PROJECT=client/web/src/end-to-end/tsconfig.json mocha ./client/web/src/end-to-end/end-to-end.test.ts",
     "cover-e2e": "nyc --hook-require=false --silent=true yarn test-e2e",
     "storybook": "yarn workspace @sourcegraph/storybook run start",
+    "storybook:dll": "yarn workspace @sourcegraph/storybook run start:dll",
     "storybook:branded": "yarn workspace @sourcegraph/branded run storybook",
     "storybook:browser": "yarn workspace @sourcegraph/browser run storybook",
     "storybook:shared": "yarn workspace @sourcegraph/shared run storybook",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "@testing-library/react-hooks": "^3.4.1",
     "@types/babel__core": "7.1.12",
     "@types/bloomfilter": "^0.0.0",
+    "@types/case-sensitive-paths-webpack-plugin": "^2.1.5",
     "@types/chai": "4.2.14",
     "@types/chai-as-promised": "7.1.3",
     "@types/chrome": "0.0.127",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4043,6 +4043,13 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/case-sensitive-paths-webpack-plugin@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.npmjs.org/@types/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.5.tgz#ac7b9b09f1e857e3df23628f41ce43e2742199b1"
+  integrity sha512-uCgGmNq/dKKMsQJTYLGl25z9xx/oHuXt9aE7hyu3UXBzJPdgMO6fEcZ3Tct/QFSy2FFTqJ1A2ha5DIn+sfUikA==
+  dependencies:
+    "@types/webpack" "^4"
+
 "@types/chai-as-promised@7.1.3":
   version "7.1.3"
   resolved "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.3.tgz#779166b90fda611963a3adbfd00b339d03b747bd"


### PR DESCRIPTION
## Description

This PR integrates [DLL Plugin](https://webpack.js.org/plugins/dll-plugin/) into our Storybook config. It allows moving most third-party dependencies into a separate pre-built bundle to speed up development build. To try it out, run `yarn storybook:dll` from the root folder or `yarn start:dll` from the Storybook workspace.

### Approach

The DLL Plugin needs a list of dependencies to put into a pre-build bundle. Ideally, it should happen automatically. 
Using dependencies from the `package.json` results in a couple of issues: 

1. A significant portion of dependencies ends up in the main bundle instead of the DLL because of different import types: common.js vs. ESM.
2. A big part of the dependencies not required for our bundle is included in the DLL bundle because it doesn't know which parts of the modules we actually need and include them.

Luckily, Webpack stats contain a precise list of vendor dependencies required for the Storybook development build. And it's quite easy to get them using the `storybook-start --webpack-stats-json` command. On the high level, the selected approach looks like this :

1. Generate Webpack stats from `storybook-start`.
2. Generate DLL bundle using vendor dependencies from the Webpack stats.
3. Use the DLL bundle manifest in the DLL references plugin to start the Storybook development server. 

## Changes

- Integrated `DLL Plugin` into Storybook Webpack config.
- Added logic to ensure that DLL bundle is available when starting Storybook with DLL plugin enabled.
- Added `DLL Plugin` and `Environment variables` sections to the Storybook `README.md`.
- Disabled `CaseSensitivePathsPlugin` and `ProgressPlugin` because they contributed a significant amount of time to the development build.

## Timings

Approximate timings based on local testing. `SCSS` and `TS` columns show recompilation time after the file save.

| **Command** | **Start Before** | **Start After** | **SCSS Before** | **SCSS After** |  **TS Before** | **TS After** | 
| --- | --- | --- | --- | --- | --- | --- |
| `yarn storybook` | 40s | 15s | 10s | 4.5s | 1.5s | 0.7s |
| `yarn storybook:wildcard` | 11s | 6.7s | 3s | 2.5s | 0.5s | 0.01s |
| `yarn storybook:branded` | 15s | 7s | - | - | - | - |
| `yarn storybook:web` | 31s | 13s | - | - | - | - |
| `yarn storybook:browser` | 11s | 5.2s | - | - | - | - |
| `yarn storybook:shared` | 11.8s | 5.8s | - | - | - | - |

SCSS recompilation is still slow because of the huge global stylesheets. Complete migration to CSS modules will significantly boost the recompilation performance in this area. 

## Notes

- Stories which require a Monaco editor are now much more responsive. There's no 1-2s freeze on the story mount 🎉. 
- `yarn start:dll` command is not the default start command till the implementation of https://github.com/sourcegraph/sourcegraph/issues/22312
- The initial startup is slower because the DLL bundle must be built before the development server starts. See more info on how it works [here](https://github.com/sourcegraph/sourcegraph/blob/ad4bf9c781d5c530145d1b70b4a91feea63048fd/client/storybook/README.md#dll-plugin).

<img width="100%" alt="Screenshot 2021-06-25 at 19 55 59" src="https://user-images.githubusercontent.com/3846380/123789071-56dd1b80-d90f-11eb-8820-831fc6ff75de.png">
<img width="68%" alt="Screenshot 2021-06-25 at 19 56 24" src="https://user-images.githubusercontent.com/3846380/123789093-5a70a280-d90f-11eb-8935-ff99084a2018.png">

## Bundle analyzer

Bundle analyzer screenshots for curiosity's sake. We still load all the vendor modules from the `Before` screenshot with DLL Plugin enabled, but we won't process them on the development server. 

| **Before** | **After** |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3846380/123772847-c1d22680-d8fe-11eb-9400-695e19a592af.png) | ![image](https://user-images.githubusercontent.com/3846380/123772890-cac2f800-d8fe-11eb-91b4-0b5b322fd970.png)

### Before 

<img width="1033" alt="Screenshot 2021-06-25 at 16 34 35" src="https://user-images.githubusercontent.com/3846380/123772159-35bfff00-d8fe-11eb-9ed5-8eec707cd564.png">

### After 

<img width="1033" alt="Screenshot 2021-06-25 at 16 34 07" src="https://user-images.githubusercontent.com/3846380/123771617-c9450000-d8fd-11eb-89e8-0d95f7917c80.png">