### PR TITLE
code-intel: allow using non default http client for LSIF index upload

### DIFF
--- a/lib/codeintel/upload/upload_options.go
+++ b/lib/codeintel/upload/upload_options.go
@@ -1,10 +1,16 @@
 package upload
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
+
+type Client interface {
+	// Do runs an http.Request against the Sourcegraph API.
+	Do(req *http.Request) (*http.Response, error)
+}
 
 type UploadOptions struct {
 	SourcegraphInstanceOptions
@@ -21,6 +27,7 @@ type SourcegraphInstanceOptions struct {
 	MaxRetries          int               // The maximum number of retries per request
 	RetryInterval       time.Duration     // Sleep duration between retries
 	MaxPayloadSizeBytes int64             // The maximum number of bytes sent in a single request
+	HTTPClient          Client
 }
 
 type OutputOptions struct {

--- a/lib/codeintel/upload/upload_test.go
+++ b/lib/codeintel/upload/upload_test.go
@@ -26,6 +26,14 @@ func TestUploadIndex(t *testing.T) {
 			t.Fatalf("unexpected error reading request body: %s", err)
 		}
 
+		if r.Header.Get("Content-Type") != "application/x-ndjson+lsif" {
+			t.Fatalf("Content-Type header expected to be '%s', got '%s'", "application/x-ndjson+lsif", r.Header.Get("Content-Type"))
+		}
+
+		if r.Header.Get("Authorization") != "token hunter2" {
+			t.Fatalf("Authorization header expected to be '%s', got '%s'", "token hunter2", r.Header.Get("Authorization"))
+		}
+
 		gzipReader, err := gzip.NewReader(bytes.NewReader(payload))
 		if err != nil {
 			t.Fatalf("unexpected error creating gzip.Reader: %s", err)
@@ -52,7 +60,7 @@ func TestUploadIndex(t *testing.T) {
 	_, _ = io.Copy(f, bytes.NewReader(expectedPayload))
 	_ = f.Close()
 
-	id, err := UploadIndex(f.Name(), UploadOptions{
+	id, err := UploadIndex(f.Name(), http.DefaultClient, UploadOptions{
 		UploadRecordOptions: UploadRecordOptions{
 			Repo:    "foo/bar",
 			Commit:  "deadbeef",
@@ -115,7 +123,7 @@ func TestUploadIndexMultipart(t *testing.T) {
 	_, _ = io.Copy(f, bytes.NewReader(expectedPayload))
 	_ = f.Close()
 
-	id, err := UploadIndex(f.Name(), UploadOptions{
+	id, err := UploadIndex(f.Name(), http.DefaultClient, UploadOptions{
 		UploadRecordOptions: UploadRecordOptions{
 			Repo:    "foo/bar",
 			Commit:  "deadbeef",


### PR DESCRIPTION
Updates lib/codeintel/upload to allow taking in a custom HTTP client. Please see the related src-cli PR for rationale and library consumption example https://github.com/sourcegraph/src-cli/pull/559.

`net/http.DefaultClient` implements the `Client` interface (guaranteed by the tests that use `net/http.DefaultClient`) in case we don't have a need for a customized client/wrapper when using this library in other parts of the codebase outside of src-cli.

cc @efritz for 👀 after PTO

