### PR TITLE
Fix race condition in log output by writing to same buffer

### DIFF
--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -34,9 +34,9 @@ func condensedFormat(r *log15.Record) []byte {
 	text := logLabels[r.Lvl]
 	var msg bytes.Buffer
 	if colorAttr != 0 {
-		fmt.Print(color.New(colorAttr).Sprint(text) + " " + r.Msg)
+		fmt.Fprint(&msg, color.New(colorAttr).Sprint(text)+" "+r.Msg)
 	} else {
-		fmt.Print(&msg, r.Msg)
+		fmt.Fprint(&msg, r.Msg)
 	}
 	if len(r.Ctx) > 0 {
 		for i := 0; i < len(r.Ctx); i += 2 {


### PR DESCRIPTION
Before this change the logging code worked "by accident": some writes
went to `os.Stdout` (through `fmt.Print`) and others went to a buffer
and *then* to `os.Stdout`.

But these writes were not ordered, because they depend on how often
`os.Stdout` is flushed.

That lead to `sg` sometimes printing logs out of order: the end of the
line before the start of the line.

This fixes that.
