### PR TITLE
Add Code Insights built-in dashboards

### DIFF
--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -61,3 +61,12 @@ export interface InsightBuiltInDashboard {
 
     insightIds?: string[]
 }
+
+/**
+ * A built-in type of dashboard that contains all insights from all settings level
+ * like organizations level and personal settings.
+ */
+export const ALL_INSIGHTS_DASHBOARD: InsightBuiltInDashboard = {
+    title: 'All',
+    type: InsightsDashboardType.BuiltIn,
+}

--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -1,12 +1,35 @@
 import { InsightDashboard as InsightDashboardConfiguration } from '../../../schema/settings.schema'
 
-/**
- * Visibility setting which responsible for where dashboard will appear.
- * possible value 'personal' | '<org id 1> ... | ... <org id N>'
- */
-export type InsightDashboardVisibility = string
+export type InsightDashboard = InsightBuiltInDashboard | InsightCustomDashboard
 
-export interface InsightDashboard extends InsightDashboardConfiguration {
+/**
+ * All insights dashboards are separated on two categories.
+ */
+export enum InsightsDashboardType {
+    /**
+     * A built in dashboard that all users have as a default and non-removable
+     * dashboards like "all insights", "personal", "org level dashboard".
+     */
+    BuiltIn = 'built-in',
+
+    /**
+     * A Custom dashboard that a user created by dashboard creation UI.
+     * These dashboard types can be deleted or moved from user personal settings
+     * to org setting scope and vice versa.
+     */
+    Custom = 'custom',
+}
+
+/**
+ * An extended custom insights dashboard configuration.
+ */
+export interface InsightCustomDashboard extends InsightDashboardConfiguration {
+    /**
+     * All dashboards that were created in users settings explicitly are
+     * custom dashboards.
+     */
+    type: InsightsDashboardType.Custom
+
     /**
      * Subject that has a particular dashboard, it can be personal setting
      * or organization setting subject.
@@ -17,4 +40,24 @@ export interface InsightDashboard extends InsightDashboardConfiguration {
 export interface InsightDashboardOwner {
     id: string | null
     name: string
+}
+
+/**
+ * A built in insights dashboard.
+ */
+export interface InsightBuiltInDashboard {
+    type: InsightsDashboardType.BuiltIn
+
+    /**
+     * Title of insights dashboards ("All insights", "Personal", ...)
+     */
+    title?: string
+
+    /**
+     * Possible owner of dashboard. That might be equal to undefined when
+     * this dashboard is "all insights" dashboard.
+     */
+    owner?: InsightDashboardOwner
+
+    insightIds?: string[]
 }

--- a/client/web/src/insights/core/types/insight.ts
+++ b/client/web/src/insights/core/types/insight.ts
@@ -82,3 +82,7 @@ export function isSearchBasedInsight(insight: Insight): insight is SearchBasedIn
 export function isLangStatsInsight(insight: Insight): insight is LangStatsInsight {
     return insight.id.startsWith(InsightTypePrefix.langStats)
 }
+
+export function isInsightSettingKey(key: string): boolean {
+    return key.startsWith(InsightTypePrefix.search) || key.startsWith(InsightTypePrefix.langStats)
+}

--- a/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
+++ b/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
@@ -1,3 +1,5 @@
+import { ALL_INSIGHTS_DASHBOARD } from '../../../../core/types'
+
 import { getInsightsDashboards } from './use-dashboards'
 
 describe('getInsightsDashboards', () => {
@@ -24,10 +26,7 @@ describe('getInsightsDashboards', () => {
             ).toStrictEqual([
                 // Even with empty or errored value of user settings we still have
                 // generic built in insights dashboard - "All"
-                {
-                    type: 'built-in',
-                    title: 'All',
-                },
+                ALL_INSIGHTS_DASHBOARD,
             ])
         })
     })
@@ -60,10 +59,7 @@ describe('getInsightsDashboards', () => {
                     },
                 ])
             ).toStrictEqual([
-                {
-                    type: 'built-in',
-                    title: 'All',
-                },
+                ALL_INSIGHTS_DASHBOARD,
                 {
                     type: 'built-in',
                     insightIds: [],
@@ -112,10 +108,7 @@ describe('getInsightsDashboards', () => {
                     },
                 ])
             ).toStrictEqual([
-                {
-                    type: 'built-in',
-                    title: 'All',
-                },
+                ALL_INSIGHTS_DASHBOARD,
                 {
                     type: 'built-in',
                     insightIds: [],
@@ -190,10 +183,7 @@ describe('getInsightsDashboards', () => {
                     },
                 ])
             ).toStrictEqual([
-                {
-                    type: 'built-in',
-                    title: 'All',
-                },
+                ALL_INSIGHTS_DASHBOARD,
                 {
                     type: 'built-in',
                     insightIds: [],

--- a/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
+++ b/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
@@ -1,7 +1,88 @@
 import { getInsightsDashboards } from './use-dashboards'
 
 describe('getInsightsDashboards', () => {
+    describe('should return empty custom list', () => {
+        test('with null subject value', () => {
+            expect(getInsightsDashboards(null)).toStrictEqual([])
+        })
+
+        test('with error like settings value', () => {
+            expect(
+                getInsightsDashboards([
+                    {
+                        subject: {
+                            __typename: 'User',
+                            id: '101',
+                            username: 'emirkusturica',
+                            displayName: 'Emir Kusturica',
+                            viewerCanAdminister: true,
+                        },
+                        settings: new Error(),
+                        lastID: null,
+                    },
+                ])
+            ).toStrictEqual([
+                // Even with empty or errored value of user settings we still have
+                // generic built in insights dashboard - "All"
+                {
+                    type: 'built-in',
+                    title: 'All',
+                },
+            ])
+        })
+    })
+
     describe('should return dashboard list', () => {
+        test('with built in dashboard only if dashboard settings are empty', () => {
+            expect(
+                getInsightsDashboards([
+                    {
+                        subject: {
+                            __typename: 'Org',
+                            id: '102',
+                            name: 'sourcegraph',
+                            displayName: 'Sourcegraph',
+                            viewerCanAdminister: true,
+                        },
+                        settings: {},
+                        lastID: null,
+                    },
+                    {
+                        subject: {
+                            __typename: 'User',
+                            id: '101',
+                            username: 'emirkusturica',
+                            displayName: 'Emir Kusturica',
+                            viewerCanAdminister: true,
+                        },
+                        settings: {},
+                        lastID: null,
+                    },
+                ])
+            ).toStrictEqual([
+                {
+                    type: 'built-in',
+                    title: 'All',
+                },
+                {
+                    type: 'built-in',
+                    insightIds: [],
+                    owner: {
+                        id: '102',
+                        name: 'Sourcegraph',
+                    },
+                },
+                {
+                    type: 'built-in',
+                    insightIds: [],
+                    owner: {
+                        id: '101',
+                        name: 'Emir Kusturica',
+                    },
+                },
+            ])
+        })
+
         test('with personal (user-wide) dashboards only', () => {
             expect(
                 getInsightsDashboards([
@@ -32,6 +113,19 @@ describe('getInsightsDashboards', () => {
                 ])
             ).toStrictEqual([
                 {
+                    type: 'built-in',
+                    title: 'All',
+                },
+                {
+                    type: 'built-in',
+                    insightIds: [],
+                    owner: {
+                        id: '101',
+                        name: 'Emir Kusturica',
+                    },
+                },
+                {
+                    type: 'custom',
                     id: '001',
                     title: 'Test Dashboard',
                     insightIds: ['insightID1', 'insightID2'],
@@ -41,6 +135,7 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
+                    type: 'custom',
                     id: '002',
                     title: 'Another Test Dashboard',
                     insightIds: ['insightID3', 'insightID4'],
@@ -96,6 +191,27 @@ describe('getInsightsDashboards', () => {
                 ])
             ).toStrictEqual([
                 {
+                    type: 'built-in',
+                    title: 'All',
+                },
+                {
+                    type: 'built-in',
+                    insightIds: [],
+                    owner: {
+                        id: '102',
+                        name: 'Sourcegraph',
+                    },
+                },
+                {
+                    type: 'built-in',
+                    insightIds: [],
+                    owner: {
+                        id: '101',
+                        name: 'Emir Kusturica',
+                    },
+                },
+                {
+                    type: 'custom',
                     id: '001',
                     title: 'Test Dashboard',
                     insightIds: ['insightID1', 'insightID2'],
@@ -105,6 +221,7 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
+                    type: 'custom',
                     id: '002',
                     title: 'Another Test Dashboard',
                     insightIds: ['insightID3', 'insightID4'],

--- a/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboards.ts
+++ b/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboards.ts
@@ -16,6 +16,7 @@ import {
     InsightDashboardOwner,
     InsightsDashboardType,
     isInsightSettingKey,
+    ALL_INSIGHTS_DASHBOARD,
 } from '../../../../core/types'
 
 /**
@@ -45,19 +46,14 @@ export function getInsightsDashboards(subjects: ConfiguredSubjectOrError<Setting
  * Returns built in types of insights dashboards (all, personal, org level dashboards).
  */
 function getBuiltInDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): InsightBuiltInDashboard[] {
-    const allInsightDashboard: InsightBuiltInDashboard = {
-        title: 'All',
-        type: InsightsDashboardType.BuiltIn,
-    }
-
-    const subjectDashboards = subjects.reduce<InsightBuiltInDashboard[]>((dashboards, subject) => {
-        const settings = subject.settings
+    const subjectDashboards = subjects.reduce<InsightBuiltInDashboard[]>((dashboards, configuredSubject) => {
+        const { settings, subject } = configuredSubject
 
         if (isErrorLike(settings) || settings === null) {
             return dashboards
         }
 
-        const dashboardOwner = getDashboardOwner(subject.subject)
+        const dashboardOwner = getDashboardOwner(subject)
         const subjectInsightIds = Object.keys(settings).filter(isInsightSettingKey)
 
         const subjectDashboard: InsightBuiltInDashboard = {
@@ -69,16 +65,15 @@ function getBuiltInDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): I
         return [...dashboards, subjectDashboard]
     }, [])
 
-    return [allInsightDashboard, ...subjectDashboards]
+    return [ALL_INSIGHTS_DASHBOARD, ...subjectDashboards]
 }
 
 /**
  * Returns list of custom insights dashboards generated from settings cascade subjects.
- *
  */
 function getCustomDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): InsightCustomDashboard[] {
-    return subjects.reduce<InsightCustomDashboard[]>((dashboards, subject) => {
-        const settings = subject.settings
+    return subjects.reduce<InsightCustomDashboard[]>((dashboards, configuredSubject) => {
+        const { settings, subject } = configuredSubject
 
         if (isErrorLike(settings) || settings === null) {
             return dashboards
@@ -96,7 +91,7 @@ function getCustomDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): In
                 // Extend settings dashboard configuration with owner info
                 return {
                     type: InsightsDashboardType.Custom,
-                    owner: getDashboardOwner(subject.subject),
+                    owner: getDashboardOwner(subject),
                     ...dashboardSettings,
                 }
             })


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22218

### Backgound 

This PR extends `useDashobards()` hook (get operation for the dashboards) by "built-in" insights dashboards. These dashboards are not stored in user or organization settings. They are derived and can't be deleted or moved in another organization's scope. 

There are three types of built-in dashboards 

1. **All insights**
Combined insights from all dashboards (personal and custom) and organizations.

2. **Personal**
Insights from user personal settings

3. **Organization level**
Insights from particular org settings. For example in case when you have two organizations orgA and orgB you have two dashboards with the same names.

You can find information on how these types would work by this Figma design layout 

https://www.figma.com/file/g5lSlPBnHt00wCogjRFnt5/RFC-398%3A-Easily-Viewing-and-Sharing-Code-Insights-WIP?node-id=275%3A1628 

UI for this functionality will be started in the next Code insights Dasbhoards story tickets 
Next ticket - https://github.com/sourcegraph/sourcegraph/issues/22225
Tracking issue - https://github.com/sourcegraph/sourcegraph/issues/22215

