### PR TITLE
Sync & store code host versions and send in ping data

### DIFF
--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -115,7 +115,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<Props> = props => {
                     Which code hosts are in use (GitHub, Bitbucket Server, GitLab, Phabricator, Gitolite, AWS
                     CodeCommit, Other)
                     <ul>
-                        <li>Which versions of the code host are used</li>
+                        <li>Which versions of the code hosts are used</li>
                     </ul>
                 </li>
                 <li>Whether new user signup is allowed (true/false)</li>

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -114,6 +114,9 @@ export const SiteAdminPingsPage: React.FunctionComponent<Props> = props => {
                 <li>
                     Which code hosts are in use (GitHub, Bitbucket Server, GitLab, Phabricator, Gitolite, AWS
                     CodeCommit, Other)
+                    <ul>
+                        <li>Which versions of the code host are used</li>
+                    </ul>
                 </li>
                 <li>Whether new user signup is allowed (true/false)</li>
                 <li>Whether a repository has ever been added (true/false)</li>

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -191,6 +191,7 @@ type pingRequest struct {
 	ExtensionsUsage     json.RawMessage `json:"extensionsUsage"`
 	CodeInsightsUsage   json.RawMessage `json:"codeInsightsUsage"`
 	CodeMonitoringUsage json.RawMessage `json:"codeMonitoringUsage"`
+	CodeHostVersions    json.RawMessage `json:"codeHostVersions"`
 	InitialAdminEmail   string          `json:"initAdmin"`
 	TotalUsers          int32           `json:"totalUsers"`
 	HasRepos            bool            `json:"repos"`
@@ -295,6 +296,7 @@ type pingPayload struct {
 	ExtensionsUsage      json.RawMessage `json:"extensions_usage"`
 	CodeInsightsUsage    json.RawMessage `json:"code_insights_usage"`
 	CodeMonitoringUsage  json.RawMessage `json:"code_monitoring_usage"`
+	CodeHostVersions     json.RawMessage `json:"code_host_versions"`
 	InstallerEmail       string          `json:"installer_email"`
 	AuthProviders        string          `json:"auth_providers"`
 	ExtServices          string          `json:"ext_services"`
@@ -378,6 +380,7 @@ func marshalPing(pr *pingRequest, hasUpdate bool, clientAddr string, now time.Ti
 		ExtensionsUsage:      pr.ExtensionsUsage,
 		CodeInsightsUsage:    pr.CodeInsightsUsage,
 		CodeMonitoringUsage:  pr.CodeMonitoringUsage,
+		CodeHostVersions:     pr.CodeHostVersions,
 		AuthProviders:        strings.Join(pr.AuthProviders, ","),
 		ExtServices:          strings.Join(pr.ExternalServices, ","),
 		BuiltinSignupAllowed: strconv.FormatBool(pr.BuiltinSignupAllowed),

--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -138,6 +138,7 @@ func TestSerializeBasic(t *testing.T) {
 		ClientVersionString:  "3.12.6",
 		AuthProviders:        []string{"foo", "bar"},
 		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
+		CodeHostVersions:     nil,
 		BuiltinSignupAllowed: true,
 		HasExtURL:            false,
 		UniqueUsers:          123,
@@ -189,6 +190,7 @@ func TestSerializeBasic(t *testing.T) {
 		"installer_email": "test@sourcegraph.com",
 		"auth_providers": "foo,bar",
 		"ext_services": "GITHUB,GITLAB",
+		"code_host_versions": null,
 		"builtin_signup_allowed": "true",
 		"deploy_type": "server",
 		"total_user_accounts": "234",
@@ -252,6 +254,7 @@ func TestSerializeFromQuery(t *testing.T) {
 		"installer_email": "test@sourcegraph.com",
 		"auth_providers": "foo,bar",
 		"ext_services": "GITHUB,GITLAB",
+		"code_host_versions": null,
 		"builtin_signup_allowed": "true",
 		"deploy_type": "server",
 		"total_user_accounts": "234",
@@ -263,13 +266,14 @@ func TestSerializeFromQuery(t *testing.T) {
 	}`)
 }
 
-func TestSerializeAutomationUsage(t *testing.T) {
+func TestSerializeBatchChangesUsage(t *testing.T) {
 	pr := &pingRequest{
 		ClientSiteID:         "0101-0101",
 		DeployType:           "server",
 		ClientVersionString:  "3.12.6",
 		AuthProviders:        []string{"foo", "bar"},
 		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
+		CodeHostVersions:     nil,
 		BuiltinSignupAllowed: true,
 		HasExtURL:            false,
 		UniqueUsers:          123,
@@ -322,6 +326,7 @@ func TestSerializeAutomationUsage(t *testing.T) {
 		"installer_email": "test@sourcegraph.com",
 		"auth_providers": "foo,bar",
 		"ext_services": "GITHUB,GITLAB",
+		"code_host_versions": null,
 		"builtin_signup_allowed": "true",
 		"deploy_type": "server",
 		"total_user_accounts": "234",
@@ -409,6 +414,7 @@ func TestSerializeCodeIntelUsage(t *testing.T) {
 		ClientVersionString:  "3.12.6",
 		AuthProviders:        []string{"foo", "bar"},
 		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
+		CodeHostVersions:     nil,
 		BuiltinSignupAllowed: true,
 		HasExtURL:            false,
 		UniqueUsers:          123,
@@ -520,6 +526,7 @@ func TestSerializeCodeIntelUsage(t *testing.T) {
 		"installer_email": "test@sourcegraph.com",
 		"auth_providers": "foo,bar",
 		"ext_services": "GITHUB,GITLAB",
+		"code_host_versions": null,
 		"builtin_signup_allowed": "true",
 		"deploy_type": "server",
 		"total_user_accounts": "234",
@@ -564,6 +571,7 @@ func TestSerializeOldCodeIntelUsage(t *testing.T) {
 		ClientVersionString:  "3.12.6",
 		AuthProviders:        []string{"foo", "bar"},
 		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
+		CodeHostVersions:     nil,
 		BuiltinSignupAllowed: true,
 		HasExtURL:            false,
 		UniqueUsers:          123,
@@ -675,6 +683,79 @@ func TestSerializeOldCodeIntelUsage(t *testing.T) {
 		"installer_email": "test@sourcegraph.com",
 		"auth_providers": "foo,bar",
 		"ext_services": "GITHUB,GITLAB",
+		"code_host_versions": null,
+		"builtin_signup_allowed": "true",
+		"deploy_type": "server",
+		"total_user_accounts": "234",
+		"has_external_url": "false",
+		"has_repos": "true",
+		"ever_searched": "false",
+		"ever_find_refs": "true",
+		"timestamp": "`+now.UTC().Format(time.RFC3339)+`"
+	}`)
+}
+
+func TestSerializeCodeHostVersions(t *testing.T) {
+	pr := &pingRequest{
+		ClientSiteID:         "0101-0101",
+		DeployType:           "server",
+		ClientVersionString:  "3.12.6",
+		AuthProviders:        []string{"foo", "bar"},
+		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
+		CodeHostVersions:     json.RawMessage([]byte(`[{"external_service_kind":"GITHUB","version":"1.2.3.4"}]`)),
+		BuiltinSignupAllowed: true,
+		HasExtURL:            false,
+		UniqueUsers:          123,
+		Activity:             nil,
+		BatchChangesUsage:    nil,
+		CodeIntelUsage:       nil,
+		CodeMonitoringUsage:  nil,
+		NewCodeIntelUsage:    nil,
+		SearchUsage:          nil,
+		GrowthStatistics:     nil,
+		SavedSearches:        nil,
+		HomepagePanels:       nil,
+		SearchOnboarding:     nil,
+		InitialAdminEmail:    "test@sourcegraph.com",
+		TotalUsers:           234,
+		HasRepos:             true,
+		EverSearched:         false,
+		EverFindRefs:         true,
+		RetentionStatistics:  nil,
+	}
+
+	now := time.Now()
+	payload, err := marshalPing(pr, true, "127.0.0.1", now)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+
+	compareJSON(t, payload, `{
+		"remote_ip": "127.0.0.1",
+		"remote_site_version": "3.12.6",
+		"remote_site_id": "0101-0101",
+		"license_key": "",
+		"has_update": "true",
+		"unique_users_today": "123",
+		"site_activity": null,
+		"batch_changes_usage": null,
+		"code_intel_usage": null,
+		"new_code_intel_usage": null,
+		"dependency_versions": null,
+		"extensions_usage": null,
+		"code_insights_usage": null,
+		"code_monitoring_usage": null,
+		"search_usage": null,
+		"growth_statistics": null,
+		"saved_searches": null,
+		"homepage_panels": null,
+		"search_onboarding": null,
+		"repositories": null,
+		"retention_statistics": null,
+		"installer_email": "test@sourcegraph.com",
+		"auth_providers": "foo,bar",
+		"ext_services": "GITHUB,GITLAB",
+		"code_host_versions": [{"external_service_kind":"GITHUB","version":"1.2.3.4"}],
 		"builtin_signup_allowed": "true",
 		"deploy_type": "server",
 		"total_user_accounts": "234",

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -25,6 +25,7 @@ By default, Sourcegraph also aggregates usage and performance metrics for some p
 - Whether the instance is deployed on localhost (true/false)
 - Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, SAML, GitHub, GitLab)
 - Which code hosts are in use (GitHub, Bitbucket Server, GitLab, Phabricator, Gitolite, AWS CodeCommit, Other)
+  - Which versions of the code host are used
 - Whether new user signup is allowed (true/false)
 - Whether a repository has ever been added (true/false)
 - Whether a code search has ever been executed (true/false)

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -25,7 +25,7 @@ By default, Sourcegraph also aggregates usage and performance metrics for some p
 - Whether the instance is deployed on localhost (true/false)
 - Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, SAML, GitHub, GitLab)
 - Which code hosts are in use (GitHub, Bitbucket Server, GitLab, Phabricator, Gitolite, AWS CodeCommit, Other)
-  - Which versions of the code host are used
+  - Which versions of the code hosts are used
 - Whether new user signup is allowed (true/false)
 - Whether a repository has ever been added (true/false)
 - Whether a code search has ever been executed (true/false)

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/versions"
 )
 
 func main() {
@@ -24,9 +25,10 @@ func main() {
 	go setAuthzProviders()
 
 	shared.Start(map[string]shared.Job{
-		"codeintel-commitgraph":   codeintel.NewCommitGraphJob(),
-		"codeintel-janitor":       codeintel.NewJanitorJob(),
-		"codeintel-auto-indexing": codeintel.NewIndexingJob(),
+		"codeintel-commitgraph":    codeintel.NewCommitGraphJob(),
+		"codeintel-janitor":        codeintel.NewJanitorJob(),
+		"codeintel-auto-indexing":  codeintel.NewIndexingJob(),
+		"codehost-version-syncing": versions.NewSyncingJob(),
 	})
 }
 

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1544,3 +1544,17 @@ func (c *Client) MergePullRequest(ctx context.Context, pr *PullRequest) error {
 	}
 	return nil
 }
+
+func (c *Client) GetVersion(ctx context.Context) (string, error) {
+	type version struct {
+		Version     string
+		BuildNumber string
+		BuildDate   string
+		DisplayName string
+	}
+
+	var v version
+
+	_, err := c.send(ctx, "GET", "/rest/api/1.0/application-properties", nil, nil, &v)
+	return v.Version, err
+}

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1546,14 +1546,12 @@ func (c *Client) MergePullRequest(ctx context.Context, pr *PullRequest) error {
 }
 
 func (c *Client) GetVersion(ctx context.Context) (string, error) {
-	type version struct {
+	var v struct {
 		Version     string
 		BuildNumber string
 		BuildDate   string
 		DisplayName string
 	}
-
-	var v version
 
 	_, err := c.send(ctx, "GET", "/rest/api/1.0/application-properties", nil, nil, &v)
 	return v.Version, err

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1275,11 +1275,6 @@ func TestClient_WithAuthenticator(t *testing.T) {
 }
 
 func TestClient_GetVersion(t *testing.T) {
-	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
-	if instanceURL == "" {
-		instanceURL = "https://bitbucket.sgdev.org"
-	}
-
 	fixture := "GetVersion"
 	cli, save := NewTestClient(t, fixture, *update)
 	defer save()

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1274,6 +1274,26 @@ func TestClient_WithAuthenticator(t *testing.T) {
 	}
 }
 
+func TestClient_GetVersion(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		instanceURL = "https://bitbucket.sgdev.org"
+	}
+
+	fixture := "GetVersion"
+	cli, save := NewTestClient(t, fixture, *update)
+	defer save()
+
+	have, err := cli.GetVersion(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := "7.11.2"; have != want {
+		t.Fatalf("wrong version. want=%s, have=%s", want, have)
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {

--- a/internal/extsvc/bitbucketserver/testdata/vcr/GetVersion.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/GetVersion.yaml
@@ -1,0 +1,40 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/application-properties
+    method: GET
+  response:
+    body: '{"version":"7.11.2","buildNumber":"7011002","buildDate":"1616539597394","displayName":"Bitbucket"}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 02 Jul 2021 10:47:10 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@UGPFWVx647x1328455x0'
+      X-Asessionid:
+      - 1ajg59f
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -212,6 +212,21 @@ func HTTPErrorCode(err error) int {
 	return 0
 }
 
+func (c *V3Client) GetVersion(ctx context.Context) (string, error) {
+	if c.githubDotCom {
+		return "unknown", nil
+	}
+
+	var empty interface{}
+
+	header, err := c.requestGetWithHeader(ctx, "/", &empty)
+	if err != nil {
+		return "", err
+	}
+	v := header.Get("X-GitHub-Enterprise-Version")
+	return v, nil
+}
+
 func (c *V3Client) GetAuthenticatedUser(ctx context.Context) (*User, error) {
 	var u User
 	err := c.requestGet(ctx, "/user", &u)

--- a/internal/extsvc/gitlab/version.go
+++ b/internal/extsvc/gitlab/version.go
@@ -1,0 +1,31 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// GetVersion retrieves the version of the Gitlab instance.
+func (c *Client) GetVersion(ctx context.Context) (string, error) {
+	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+
+	var v struct {
+		Version  string `json:"version"`
+		Revision string `json:"revision"`
+	}
+
+	req, err := http.NewRequest("GET", "version", nil)
+	if err != nil {
+		return "", errors.Wrap(err, "creating version request")
+	}
+
+	_, _, err = c.do(ctx, req, &v)
+	if err != nil {
+		return "", errors.Wrap(err, "requesting version")
+	}
+
+	return v.Version, nil
+}

--- a/internal/extsvc/gitlab/version.go
+++ b/internal/extsvc/gitlab/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// GetVersion retrieves the version of the Gitlab instance.
+// GetVersion retrieves the version of the GitLab instance.
 func (c *Client) GetVersion(ctx context.Context) (string, error) {
 	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
 

--- a/internal/extsvc/gitlab/version_test.go
+++ b/internal/extsvc/gitlab/version_test.go
@@ -1,0 +1,24 @@
+package gitlab
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	ctx := context.Background()
+
+	client := newTestClient(t)
+	client.httpClient = &mockHTTPResponseBody{
+		responseBody: `{"version":"12.7.2-ee","revision":"be1bc017799"}`,
+	}
+
+	have, err := client.GetVersion(ctx)
+	if err != nil {
+		t.Errorf("unexpected non-nil error: %+v", err)
+	}
+
+	if want := "12.7.2-ee"; have != want {
+		t.Errorf("wrong version. want=%s, have=%s", want, have)
+	}
+}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -270,8 +270,8 @@ func TestUniqueCodeHostIdentifier(t *testing.T) {
 		},
 		{
 			kind:   KindPerforce,
-			config: `{"p4port": "ssl:111.222.333.444:1666"}`,
-			want:   "",
+			config: `{"p4.port": "ssl:111.222.333.444:1666"}`,
+			want:   "ssl:111.222.333.444:1666",
 		},
 		{
 			kind:   KindPhabricator,

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -211,3 +211,87 @@ func TestDecodeURN(t *testing.T) {
 		})
 	}
 }
+
+func TestUniqueCodeHostIdentifier(t *testing.T) {
+	for _, tc := range []struct {
+		config string
+		kind   string
+		want   string
+	}{
+		{
+			kind:   KindGitLab,
+			config: `{"url": "https://example.com"}`,
+			want:   "https://example.com/",
+		},
+		{
+			kind:   KindGitHub,
+			config: `{"url": "https://github.com"}`,
+			want:   "https://github.com/",
+		},
+		{
+			kind:   KindGitHub,
+			config: `{"url": "https://github.example.com/"}`,
+			want:   "https://github.example.com/",
+		},
+		{
+			kind: KindAWSCodeCommit,
+			config: `{
+				"region": "eu-west-1",
+				"accessKeyID": "accesskey",
+				"secretAccessKey": "secretaccesskey",
+				"gitCredentials": {
+					"username": "my-user",
+					"password": "my-password"
+				}
+			}`,
+			want: "eu-west-1:accesskey",
+		},
+		{
+			kind:   KindBitbucketServer,
+			config: `{"url": "https://bitbucket.sgdev.org/"}`,
+			want:   "https://bitbucket.sgdev.org/",
+		},
+
+		{
+			kind:   KindBitbucketCloud,
+			config: `{"url": "https://bitbucket.org/"}`,
+			want:   "https://bitbucket.org/",
+		},
+
+		{
+			kind:   KindGitolite,
+			config: `{"host": "ssh://git@gitolite.example.com:2222/"}`,
+			want:   "ssh://git@gitolite.example.com:2222/",
+		},
+		{
+			kind:   KindGitolite,
+			config: `{"host": "git@gitolite.example.com"}`,
+			want:   "git@gitolite.example.com/",
+		},
+		{
+			kind:   KindPerforce,
+			config: `{"p4port": "ssl:111.222.333.444:1666"}`,
+			want:   "",
+		},
+		{
+			kind:   KindPhabricator,
+			config: `{"url": "https://phabricator.sgdev.org/"}`,
+			want:   "https://phabricator.sgdev.org/",
+		},
+		{
+			kind:   KindOther,
+			config: `{"url": "ssh://user@host.xz:2333/"}`,
+			want:   "ssh://user@host.xz:2333/",
+		},
+	} {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			have, err := UniqueCodeHostIdentifier(tc.kind, tc.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.want, have); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -284,7 +284,7 @@ func TestUniqueCodeHostIdentifier(t *testing.T) {
 			want:   "ssh://user@host.xz:2333/",
 		},
 	} {
-		t.Run(string(tc.kind), func(t *testing.T) {
+		t.Run(tc.kind, func(t *testing.T) {
 			have, err := UniqueCodeHostIdentifier(tc.kind, tc.config)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/extsvc/versions/doc.go
+++ b/internal/extsvc/versions/doc.go
@@ -1,0 +1,6 @@
+// Package versions provides functions for fetching, storing and retrieving the
+// versions of code host instances configured in the external services.
+//
+// The main consumer of this package is the updatecheck package that includes
+// the code host versions in ping data requests.
+package versions

--- a/internal/extsvc/versions/store.go
+++ b/internal/extsvc/versions/store.go
@@ -1,0 +1,48 @@
+package versions
+
+import (
+	"encoding/json"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
+)
+
+var (
+	pool        = redispool.Store
+	versionsKey = "extsvcversions"
+)
+
+type Version struct {
+	ExternalServiceKind string `json:"external_service_kind"`
+	Version             string `json:"version"`
+}
+
+func storeVersions(versions []*Version) error {
+	c := pool.Get()
+	defer c.Close()
+
+	payload, err := json.Marshal(versions)
+	if err != nil {
+		return err
+	}
+
+	return c.Send("SET", versionsKey, payload)
+}
+
+func GetVersions() ([]*Version, error) {
+	c := pool.Get()
+	defer c.Close()
+
+	var versions []*Version
+
+	raw, err := redis.Bytes(c.Do("GET", versionsKey))
+	if err != nil && err != redis.ErrNil {
+		return versions, err
+	}
+
+	if err := json.Unmarshal(raw, &versions); err != nil {
+		return versions, err
+	}
+
+	return versions, nil
+}

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -1,0 +1,109 @@
+package versions
+
+import (
+	"context"
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+const syncInterval = 24 * time.Hour
+
+func NewSyncingJob() shared.Job {
+	return &syncingJob{}
+}
+
+type syncingJob struct{}
+
+func (j *syncingJob) Config() []env.Config {
+	return []env.Config{}
+}
+
+func (j *syncingJob) Routines(_ context.Context) ([]goroutine.BackgroundRoutine, error) {
+	if envvar.SourcegraphDotComMode() {
+		// If we're on sourcegraph.com we don't want to run this
+		return nil, nil
+	}
+
+	db, err := shared.InitDatabase()
+	if err != nil {
+		return nil, err
+	}
+
+	cf := httpcli.NewExternalHTTPClientFactory()
+	sourcer := repos.NewSourcer(cf)
+
+	handler := goroutine.NewHandlerWithErrorMessage("sync versions of external services", func(ctx context.Context) error {
+		versions, err := loadVersions(ctx, db, sourcer)
+		if err != nil {
+			return err
+		}
+		return storeVersions(versions)
+	})
+
+	return []goroutine.BackgroundRoutine{
+		// Pass a fresh context, see docs for shared.Job
+		goroutine.NewPeriodicGoroutine(context.Background(), syncInterval, handler),
+	}, nil
+}
+
+func loadVersions(ctx context.Context, db dbutil.DB, sourcer repos.Sourcer) ([]*Version, error) {
+	var versions []*Version
+
+	es, err := database.ExternalServices(db).List(ctx, database.ExternalServicesListOptions{})
+	if err != nil {
+		return versions, err
+	}
+
+	// Group the external services by the code host instance they point at so
+	// we don't send >1 requests to the same instance.
+	unique := make(map[string]*types.ExternalService)
+	for _, svc := range es {
+		ident, err := extsvc.UniqueCodeHostIdentifier(svc.Kind, svc.Config)
+		if err != nil {
+			return versions, err
+		}
+
+		if _, ok := unique[ident]; ok {
+			continue
+		}
+		unique[ident] = svc
+	}
+
+	for _, svc := range unique {
+		sources, err := sourcer(svc)
+		if err != nil {
+			return versions, err
+		}
+		src := sources[0]
+
+		versionSrc, ok := src.(repos.VersionSource)
+		if !ok {
+			log15.Debug("external service source does not implement VersionSource interface", "kind", svc.Kind)
+			continue
+		}
+
+		v, err := versionSrc.Version(ctx)
+		if err != nil {
+			log15.Warn("failed to fetch version of code host", "version", v, "error", err)
+			continue
+		}
+
+		versions = append(versions, &Version{
+			ExternalServiceKind: svc.Kind,
+			Version:             v,
+		})
+	}
+
+	return versions, nil
+}

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/internal/extsvc/versions/sync_test.go
+++ b/internal/extsvc/versions/sync_test.go
@@ -1,0 +1,98 @@
+package versions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestGetAndStoreVersions(t *testing.T) {
+	oldHandler := log15.Root().GetHandler()
+	log15.Root().SetHandler(log15.DiscardHandler())
+	t.Cleanup(func() { log15.Root().SetHandler(oldHandler) })
+
+	es := []*types.ExternalService{
+		{Kind: extsvc.KindGitHub, DisplayName: "github.com 1", Config: `{"url": "https://github.com"}`},
+		{Kind: extsvc.KindGitHub, DisplayName: "github.com 2", Config: `{"url": "https://github.com"}`},
+		{Kind: extsvc.KindGitHub, DisplayName: "github enterprise", Config: `{"url": "https://github.example.com"}`},
+		{Kind: extsvc.KindGitHub, DisplayName: "gitlab", Config: `{"url": "https://gitlab.example.com"}`},
+		{Kind: extsvc.KindGitHub, DisplayName: "gitlab.com", Config: `{"url": "https://gitlab.com"}`},
+		{Kind: extsvc.KindGitHub, DisplayName: "bitbucket server", Config: `{"url": "https://bitbucket.sgdev.org"}`},
+		{Kind: extsvc.KindGitHub, DisplayName: "another bitbucket server", Config: `{"url": "https://bitbucket2.sgdev.org"}`},
+	}
+
+	mockExternalServices := func(t *testing.T, es []*types.ExternalService) {
+		database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+			return es, nil
+		}
+		t.Cleanup(func() { database.Mocks.ExternalServices.List = nil })
+	}
+
+	t.Run("success", func(t *testing.T) {
+		mockExternalServices(t, es)
+
+		src := &fakeVersionSource{version: "1.2.3.4", err: nil, es: es}
+
+		have, err := loadVersions(context.Background(), nil, newFakeSourcer(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(have) != 6 {
+			t.Errorf("wrong number of versions returned. want=%d, have=%d", 2, len(have))
+		}
+	})
+
+	t.Run("error fetching version", func(t *testing.T) {
+		mockExternalServices(t, es)
+
+		testErr := fmt.Errorf("what is up")
+		src := &fakeVersionSource{version: "1.2.3.4", err: testErr, es: es}
+
+		_, err := loadVersions(context.Background(), nil, newFakeSourcer(src))
+		if err != nil {
+			t.Fatal("error returned even though it should be logged and skipped")
+		}
+	})
+
+	t.Run("error parsing external service config", func(t *testing.T) {
+		invalidEs := []*types.ExternalService{
+			{Kind: extsvc.KindGitHub, DisplayName: "github.com 1", Config: `invalid bogus`},
+		}
+		mockExternalServices(t, invalidEs)
+
+		src := &fakeVersionSource{version: "1.2.3.4", err: nil, es: invalidEs}
+
+		_, err := loadVersions(context.Background(), nil, newFakeSourcer(src))
+		if err == nil {
+			t.Fatal("no error, but was expected")
+		}
+	})
+}
+
+type fakeVersionSource struct {
+	version string
+	err     error
+
+	es types.ExternalServices
+}
+
+func (f *fakeVersionSource) ListRepos(ctx context.Context, res chan repos.SourceResult) {}
+func (f *fakeVersionSource) ExternalServices() types.ExternalServices {
+	return f.es
+}
+func (f *fakeVersionSource) Version(context.Context) (string, error) {
+	return f.version, f.err
+}
+
+func newFakeSourcer(fakeSource *fakeVersionSource) repos.Sourcer {
+	return func(es ...*types.ExternalService) (repos.Sources, error) {
+		return repos.Sources([]repos.Source{fakeSource}), nil
+	}
+}

--- a/internal/extsvc/versions/sync_test.go
+++ b/internal/extsvc/versions/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repos"

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -33,6 +33,7 @@ type BitbucketServerSource struct {
 
 var _ Source = &BitbucketServerSource{}
 var _ UserSource = &BitbucketServerSource{}
+var _ VersionSource = &BitbucketServerSource{}
 
 // NewBitbucketServerSource returns a new BitbucketServerSource from the given external service.
 // rl is optional
@@ -323,4 +324,9 @@ func (s *BitbucketServerSource) AuthenticatedUsername(ctx context.Context) (stri
 func (s *BitbucketServerSource) ValidateAuthenticator(ctx context.Context) error {
 	_, err := s.client.AuthenticatedUsername(ctx)
 	return err
+}
+
+func (s *BitbucketServerSource) Version(ctx context.Context) (string, error) {
+	v, err := s.client.GetVersion(ctx)
+	return v, err
 }

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -327,6 +327,5 @@ func (s *BitbucketServerSource) ValidateAuthenticator(ctx context.Context) error
 }
 
 func (s *BitbucketServerSource) Version(ctx context.Context) (string, error) {
-	v, err := s.client.GetVersion(ctx)
-	return v, err
+	return s.client.GetVersion(ctx)
 }

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -198,8 +198,7 @@ func (s GithubSource) ValidateAuthenticator(ctx context.Context) error {
 }
 
 func (s GithubSource) Version(ctx context.Context) (string, error) {
-	v, err := s.v3Client.GetVersion(ctx)
-	return v, err
+	return s.v3Client.GetVersion(ctx)
 }
 
 // ListRepos returns all Github repositories accessible to all connections configured

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -51,6 +51,7 @@ type GithubSource struct {
 var _ Source = &GithubSource{}
 var _ UserSource = &GithubSource{}
 var _ AffiliatedRepositorySource = &GithubSource{}
+var _ VersionSource = &GithubSource{}
 
 // NewGithubSource returns a new GithubSource from the given external service.
 func NewGithubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GithubSource, error) {
@@ -194,6 +195,11 @@ type githubResult struct {
 func (s GithubSource) ValidateAuthenticator(ctx context.Context) error {
 	_, err := s.v3Client.GetAuthenticatedUser(ctx)
 	return err
+}
+
+func (s GithubSource) Version(ctx context.Context) (string, error) {
+	v, err := s.v3Client.GetVersion(ctx)
+	return v, err
 }
 
 // ListRepos returns all Github repositories accessible to all connections configured

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -41,6 +41,7 @@ type GitLabSource struct {
 var _ Source = &GitLabSource{}
 var _ UserSource = &GitLabSource{}
 var _ AffiliatedRepositorySource = &GitLabSource{}
+var _ VersionSource = &GitlabSource{}
 
 // NewGitLabSource returns a new GitLabSource from the given external service.
 func NewGitLabSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitLabSource, error) {
@@ -144,6 +145,10 @@ func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (Source, error) {
 	sc.client = sc.client.WithAuthenticator(a)
 
 	return &sc, nil
+}
+
+func (s GitLabSource) Version(ctx context.Context) (string, error) {
+	return s.client.GetVersion(ctx)
 }
 
 func (s GitLabSource) ValidateAuthenticator(ctx context.Context) error {

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -41,7 +41,7 @@ type GitLabSource struct {
 var _ Source = &GitLabSource{}
 var _ UserSource = &GitLabSource{}
 var _ AffiliatedRepositorySource = &GitLabSource{}
-var _ VersionSource = &GitlabSource{}
+var _ VersionSource = &GitLabSource{}
 
 // NewGitLabSource returns a new GitLabSource from the given external service.
 func NewGitLabSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitLabSource, error) {

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -106,6 +106,11 @@ type AffiliatedRepositorySource interface {
 	AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error)
 }
 
+// A VersionSource is a source that can query the version of the code host.
+type VersionSource interface {
+	Version(context.Context) (string, error)
+}
+
 // UnsupportedAuthenticatorError is returned by WithAuthenticator if the
 // authenticator isn't supported on that code host.
 type UnsupportedAuthenticatorError struct {

--- a/internal/repos/testdata/sources/githubenterprise-version.yaml
+++ b/internal/repos/testdata/sources/githubenterprise-version.yaml
@@ -1,0 +1,65 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://ghe.sgdev.org/api/v3
+    method: GET
+  response:
+    body: '{"current_user_url":"https://ghe.sgdev.org/api/v3/user","current_user_authorizations_html_url":"https://ghe.sgdev.org/settings/connections/applications{/client_id}","authorizations_url":"https://ghe.sgdev.org/api/v3/authorizations","code_search_url":"https://ghe.sgdev.org/api/v3/search/code?q={query}{&page,per_page,sort,order}","commit_search_url":"https://ghe.sgdev.org/api/v3/search/commits?q={query}{&page,per_page,sort,order}","emails_url":"https://ghe.sgdev.org/api/v3/user/emails","emojis_url":"https://ghe.sgdev.org/api/v3/emojis","events_url":"https://ghe.sgdev.org/api/v3/events","feeds_url":"https://ghe.sgdev.org/api/v3/feeds","followers_url":"https://ghe.sgdev.org/api/v3/user/followers","following_url":"https://ghe.sgdev.org/api/v3/user/following{/target}","gists_url":"https://ghe.sgdev.org/api/v3/gists{/gist_id}","hub_url":"https://ghe.sgdev.org/api/v3/hub","issue_search_url":"https://ghe.sgdev.org/api/v3/search/issues?q={query}{&page,per_page,sort,order}","issues_url":"https://ghe.sgdev.org/api/v3/issues","keys_url":"https://ghe.sgdev.org/api/v3/user/keys","label_search_url":"https://ghe.sgdev.org/api/v3/search/labels?q={query}&repository_id={repository_id}{&page,per_page}","notifications_url":"https://ghe.sgdev.org/api/v3/notifications","organization_url":"https://ghe.sgdev.org/api/v3/orgs/{org}","organization_repositories_url":"https://ghe.sgdev.org/api/v3/orgs/{org}/repos{?type,page,per_page,sort}","organization_teams_url":"https://ghe.sgdev.org/api/v3/orgs/{org}/teams","public_gists_url":"https://ghe.sgdev.org/api/v3/gists/public","rate_limit_url":"https://ghe.sgdev.org/api/v3/rate_limit","repository_url":"https://ghe.sgdev.org/api/v3/repos/{owner}/{repo}","repository_search_url":"https://ghe.sgdev.org/api/v3/search/repositories?q={query}{&page,per_page,sort,order}","current_user_repositories_url":"https://ghe.sgdev.org/api/v3/user/repos{?type,page,per_page,sort}","starred_url":"https://ghe.sgdev.org/api/v3/user/starred{/owner}{/repo}","starred_gists_url":"https://ghe.sgdev.org/api/v3/gists/starred","topic_search_url":"https://ghe.sgdev.org/api/v3/search/topics?q={query}{&page,per_page}","user_url":"https://ghe.sgdev.org/api/v3/users/{user}","user_organizations_url":"https://ghe.sgdev.org/api/v3/user/orgs","user_repositories_url":"https://ghe.sgdev.org/api/v3/users/{user}/repos{?type,page,per_page,sort}","user_search_url":"https://ghe.sgdev.org/api/v3/search/users?q={query}{&page,per_page,sort,order}"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 02 Jul 2021 09:47:26 GMT
+      Etag:
+      - W/"34473402a070f645b0e0293cf62e5a38"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      X-Accepted-Oauth-Scopes:
+      - ""
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Enterprise-Version:
+      - 2.22.6
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - b02d31f4-e4a4-4005-b734-1dda3c5ca90e
+      X-Oauth-Scopes:
+      - read:org, repo
+      X-Runtime-Rack:
+      - "0.015056"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/20033.

Approved RFC on metrics collection: [RFC 417 Review: Add code host versions to pings](https://docs.google.com/document/d/1Z68vV1SvCmRW5Hz5v4SkI8oUW4pgLmq5199RmLYToeU/edit?ts=60de7bdf#)
PR to update the Big Query schema: https://github.com/sourcegraph/analytics/pull/211

What we have here works roughly as follows:

* Every 24 hours we iterate over the list of external services
* We group those external services by "unique code host identifier" (see comments in code) to avoid sending >1 requests to the same code host instance
* We send a request to each* unique code host instance to get the version (*currently only GitHub, Gitlab, Bitbucket Server, since other versions are irrelevant to us in Batch Changes and I don't think querying the versions of gitolite, phabricator, etc. makes a lot of sense right now)
* We store the versions in Redis
* We only store **external service kind (GitHub, Gitlab, etc)** next to the version
* Whenever ping data is sent up to Sourcegraph.com these versions are included, as a JSON array that would look roughly like this:

```json
[
  {
    "external_service_kind": "GITHUB",
    "version": "unknown"
  },
  {
    "external_service_kind": "GITHUB",
    "version": "2.22.6"
  },
  {
    "external_service_kind": "BITBUCKETSERVER",
    "version": "7.11.2"
  },
  {
    "external_service_kind": "GITLAB",
    "version": "12.7.2-ee"
  }
]
```
