### PR TITLE
web: propagate `aggregableBadges` to the `FileMatch` component correctly

### DIFF
--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -28,6 +28,7 @@ export interface MatchItem extends Badge {
      * The 0-based line number of this match.
      */
     line: number
+    aggregableBadges?: AggregableBadge[]
 }
 
 interface Props extends SettingsCascadeProps {
@@ -92,6 +93,7 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
                   })),
                   preview: match.line,
                   line: match.lineNumber,
+                  aggregableBadges: match.aggregableBadges,
               }))
             : []
 

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -1,6 +1,7 @@
 /* eslint-disable id-length */
 import { Observable, fromEvent, Subscription, OperatorFunction, pipe, Subscriber, Notification } from 'rxjs'
 import { defaultIfEmpty, map, materialize, scan } from 'rxjs/operators'
+import { AggregableBadge } from 'sourcegraph'
 
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
@@ -32,6 +33,7 @@ interface LineMatch {
     line: string
     lineNumber: number
     offsetAndLengths: number[][]
+    aggregableBadges?: AggregableBadge[]
 }
 
 export interface FileSymbolMatch {


### PR DESCRIPTION
## Changes

- `aggregableBadges` are propagated to the `FileMatch` description to show code-intel badges.

Fixes: https://github.com/sourcegraph/sourcegraph/issues/22411
For more context, see [this comment](https://github.com/sourcegraph/sourcegraph/issues/22411#issuecomment-869789402).