### PR TITLE
 search frontend: remove smartQuery flag

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -22,6 +22,26 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 2,
+                "scopes": "metaRegexpAssertion"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaPathSeparator"
+              },
+              {
+                "startIndex": 14,
                 "scopes": "identifier"
               },
               {
@@ -65,7 +85,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 4,
-                "scopes": "identifier"
+                "scopes": "openingParen"
               },
               {
                 "startIndex": 5,
@@ -93,14 +113,14 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 14,
-                "scopes": "identifier"
+                "scopes": "closingParen"
               }
             ]
         `)
     })
 
     test('no decoration for literal', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('(a\\sb)', false, SearchPatternType.literal)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('(a\\sb)', false, SearchPatternType.literal))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -112,7 +132,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate regexp character set and group', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('(a\\sb)', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('(a\\sb)', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -140,7 +160,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate regexp assertion', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('^oh\\.hai$', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('^oh\\.hai$', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -168,7 +188,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate regexp quantifiers', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('a*?(b)+', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('a*?(b)+', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -204,7 +224,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate range quantifier', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('b{1} c{1,2} d{3,}?', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('b{1} c{1,2} d{3,}?', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -248,7 +268,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate paren groups', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('((a) or b)', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('((a) or b)', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -292,7 +312,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate non-capturing paren groups', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('(?:a(?:b))', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('(?:a(?:b))', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -324,7 +344,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate character classes', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('([a-z])', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('([a-z])', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -360,7 +380,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate character classes', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('[a-z][--z][--z]', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('[a-z][--z][--z]', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -430,8 +450,7 @@ describe('getMonacoTokens()', () => {
     test('decorate regexp field values', () => {
         expect(
             getMonacoTokens(
-                toSuccess(scanSearchQuery('repo:^foo$ count:10 file:.* fork:yes', false, SearchPatternType.regexp)),
-                true
+                toSuccess(scanSearchQuery('repo:^foo$ count:10 file:.* fork:yes', false, SearchPatternType.regexp))
             )
         ).toMatchInlineSnapshot(`
             [
@@ -496,7 +515,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate regexp | operator, single pattern', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('[|]\\|((a|b)|d)|e', false, SearchPatternType.regexp)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('[|]\\|((a|b)|d)|e', false, SearchPatternType.regexp))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -564,9 +583,8 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate regexp | operator, multiple patterns', () => {
-        expect(
-            getMonacoTokens(toSuccess(scanSearchQuery('repo:(a|b) (c|d) (e|f)', false, SearchPatternType.regexp)), true)
-        ).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:(a|b) (c|d) (e|f)', false, SearchPatternType.regexp))))
+            .toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -646,10 +664,7 @@ describe('getMonacoTokens()', () => {
 
     test('decorate escaped characters', () => {
         expect(
-            getMonacoTokens(
-                toSuccess(scanSearchQuery('[--\\\\abc] \\|\\.|\\(\\)', false, SearchPatternType.regexp)),
-                true
-            )
+            getMonacoTokens(toSuccess(scanSearchQuery('[--\\\\abc] \\|\\.|\\(\\)', false, SearchPatternType.regexp)))
         ).toMatchInlineSnapshot(`
             [
               {
@@ -719,8 +734,7 @@ describe('getMonacoTokens()', () => {
     test('decorate structural holes', () => {
         expect(
             getMonacoTokens(
-                toSuccess(scanSearchQuery('r:foo Search(thing::[x], :[y])', false, SearchPatternType.structural)),
-                true
+                toSuccess(scanSearchQuery('r:foo Search(thing::[x], :[y])', false, SearchPatternType.structural))
             )
         ).toMatchInlineSnapshot(`
             [
@@ -761,9 +775,8 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate structural holes with valid inlined regexp', () => {
-        expect(
-            getMonacoTokens(toSuccess(scanSearchQuery('r:foo a:[x~[\\]]]b', false, SearchPatternType.structural)), true)
-        ).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:foo a:[x~[\\]]]b', false, SearchPatternType.structural))))
+            .toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -818,9 +831,8 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate structural holes with valid inlined regexp, no variable', () => {
-        expect(
-            getMonacoTokens(toSuccess(scanSearchQuery('repo:foo :[~a?|b*]', false, SearchPatternType.structural)), true)
-        ).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo :[~a?|b*]', false, SearchPatternType.structural))))
+            .toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -879,12 +891,8 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate structural hole ... alias', () => {
-        expect(
-            getMonacoTokens(
-                toSuccess(scanSearchQuery('r:foo a...b...c....', false, SearchPatternType.structural)),
-                true
-            )
-        ).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:foo a...b...c....', false, SearchPatternType.structural))))
+            .toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -931,7 +939,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate structural hole ... alias', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:foo ...:...', false, SearchPatternType.structural)), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:foo ...:...', false, SearchPatternType.structural))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -963,7 +971,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate repo revision syntax, separate revisions', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo@HEAD:v1.2:3')), true)).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo@HEAD:v1.2:3')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1002,7 +1010,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate revision field syntax, separate revisions', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo rev:HEAD:v1.2:3')), true)).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo rev:HEAD:v1.2:3')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1045,7 +1053,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('do not decorate regex syntax when filter value is quoted', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:"^do-not-attempt$" file:\'.*\'')), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:"^do-not-attempt$" file:\'.*\''))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -1073,7 +1081,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate repo revision syntax, path with wildcard and negation', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo@*refs/heads/*:*!refs/heads/release*')), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo@*refs/heads/*:*!refs/heads/release*'))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -1137,7 +1145,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('decorate search context value', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('context:@user')), true)).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('context:@user')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1156,7 +1164,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('returns path separator tokens for regexp values', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com/sourcegraph@HEAD f:a/b/')), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com/sourcegraph@HEAD f:a/b/'))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -1224,7 +1232,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('returns regexp highlighting if path separators cannot be parsed', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com(/)sourcegraph')), true)).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com(/)sourcegraph')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1267,8 +1275,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('highlight recognized predicate with body as regexp', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains.file(README.md)')), true))
-            .toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains.file(README.md)')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1311,7 +1318,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('highlight recognized predicate with multiple fields', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains(file:README.md content:^fix$)')), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains(file:README.md content:^fix$)'))))
             .toMatchInlineSnapshot(`
             [
               {

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -1087,47 +1087,11 @@ const decoratedToMonaco = (token: DecoratedToken): Monaco.languages.IToken => {
     }
 }
 
-const toMonaco = (token: Token): Monaco.languages.IToken[] => {
-    switch (token.type) {
-        case 'filter': {
-            const monacoTokens: Monaco.languages.IToken[] = []
-            monacoTokens.push({
-                startIndex: token.field.range.start,
-                scopes: 'field',
-            })
-            if (token.value) {
-                monacoTokens.push({
-                    startIndex: token.value.range.start,
-                    scopes: 'identifier',
-                })
-            }
-            return monacoTokens
-        }
-        case 'whitespace':
-        case 'keyword':
-        case 'comment':
-            return [
-                {
-                    startIndex: token.range.start,
-                    scopes: token.type,
-                },
-            ]
-        default:
-            return [
-                {
-                    startIndex: token.range.start,
-                    scopes: 'identifier',
-                },
-            ]
-    }
-}
-
 /**
- * Returns the tokens in a scanned search query displayed in the Monaco query input. If the experimental
- * decorate flag is true, a list of {@link DecoratedToken} provides more contextual highlighting for patterns.
+ * Decorates tokens for contextual highlighting (e.g. for regexp metasyntax) and returns the tokens converted to Monaco token types.
  */
-export const getMonacoTokens = (tokens: Token[], toDecorate = false): Monaco.languages.IToken[] =>
-    toDecorate ? tokens.flatMap(token => decorate(token).map(decoratedToMonaco)) : tokens.flatMap(toMonaco)
+export const getMonacoTokens = (tokens: Token[]): Monaco.languages.IToken[] =>
+    tokens.flatMap(token => decorate(token).map(decoratedToMonaco))
 
 /**
  * Converts a zero-indexed, single-line {@link CharacterRange} to a Monaco {@link IRange}.

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -14,152 +14,242 @@ const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSucce
 describe('getHoverResult()', () => {
     test('returns hover contents for filters', () => {
         const scannedQuery = toSuccess(scanSearchQuery('repo:sourcegraph file:code_intelligence'))
-        expect(getHoverResult(scannedQuery, { column: 4 })).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "Include only results from repositories matching the given search pattern."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 17
-              }
-            }
-        `)
-        expect(getHoverResult(scannedQuery, { column: 18 })).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
+                {
+                  "value": "Matches the string \`sourcegraph\`."
+                },
                 {
                   "value": "Include only results from files matching the given search pattern."
+                },
+                {
+                  "value": "Matches the string \`code_intelligence\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 18,
+                "startColumn": 23,
                 "endColumn": 40
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 30 })).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "Matches the string \`sourcegraph\`."
+                },
+                {
                   "value": "Include only results from files matching the given search pattern."
+                },
+                {
+                  "value": "Matches the string \`code_intelligence\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 18,
+                "startColumn": 23,
+                "endColumn": 40
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "Matches the string \`sourcegraph\`."
+                },
+                {
+                  "value": "Include only results from files matching the given search pattern."
+                },
+                {
+                  "value": "Matches the string \`code_intelligence\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 23,
                 "endColumn": 40
               }
             }
         `)
     })
 
-    test('smartQuery flag returns hover contents for fields and regexp values', () => {
+    test('returns hover contents for fields and regexp values', () => {
         const scannedQuery = toSuccess(scanSearchQuery('repo:^hey$'))
-        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`hey\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 1,
+                "startColumn": 10,
+                "endColumn": 11
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`hey\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 10,
+                "endColumn": 11
+              }
+            }
+        `)
+    })
+
+    test('returns hover contents regexp patterns', () => {
+        const scannedQuery = toSuccess(scanSearchQuery('\\b.*?', false, SearchPatternType.regexp))
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
+                },
+                {
+                  "value": "**Dot**. Match any character except a line break."
+                },
+                {
+                  "value": "**Zero or more**. Match zero or more of the previous expression."
+                },
+                {
+                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 5,
                 "endColumn": 6
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 6 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 6,
-                "endColumn": 7
-              }
-            }
-        `)
-    })
-
-    test('smartQuery flag returns hover contents regexp patterns', () => {
-        const scannedQuery = toSuccess(scanSearchQuery('\\b.*?', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 3
-              }
-            }
-        `)
-        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
-                {
-                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 3
-              }
-            }
-        `)
-        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Dot**. Match any character except a line break."
+                },
+                {
+                  "value": "**Zero or more**. Match zero or more of the previous expression."
+                },
+                {
+                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 3,
-                "endColumn": 4
+                "startColumn": 5,
+                "endColumn": 6
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 4 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
+                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
+                },
+                {
+                  "value": "**Dot**. Match any character except a line break."
+                },
+                {
                   "value": "**Zero or more**. Match zero or more of the previous expression."
+                },
+                {
+                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 4,
-                "endColumn": 5
+                "startColumn": 5,
+                "endColumn": 6
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 5 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
+                {
+                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
+                },
+                {
+                  "value": "**Dot**. Match any character except a line break."
+                },
+                {
+                  "value": "**Zero or more**. Match zero or more of the previous expression."
+                },
+                {
+                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 5,
+                "endColumn": 6
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
+                },
+                {
+                  "value": "**Dot**. Match any character except a line break."
+                },
+                {
+                  "value": "**Zero or more**. Match zero or more of the previous expression."
+                },
                 {
                   "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
@@ -174,41 +264,68 @@ describe('getHoverResult()', () => {
         `)
     })
 
-    test('smartQuery flag regexp group range encloses pattern', () => {
+    test('regexp group range encloses pattern', () => {
         const scannedQuery = toSuccess(scanSearchQuery('(abcd){1,3}', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Group**. Groups together multiple expressions to match."
+                },
+                {
+                  "value": "Matches the string \`abcd\`."
+                },
+                {
+                  "value": "**Group**. Groups together multiple expressions to match."
+                },
+                {
+                  "value": "**Range**. Match between 1 and 3 of the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 7
+                "startColumn": 7,
+                "endColumn": 12
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
+                  "value": "**Group**. Groups together multiple expressions to match."
+                },
+                {
                   "value": "Matches the string \`abcd\`."
+                },
+                {
+                  "value": "**Group**. Groups together multiple expressions to match."
+                },
+                {
+                  "value": "**Range**. Match between 1 and 3 of the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 2,
-                "endColumn": 6
+                "startColumn": 7,
+                "endColumn": 12
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 8 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
+                {
+                  "value": "**Group**. Groups together multiple expressions to match."
+                },
+                {
+                  "value": "Matches the string \`abcd\`."
+                },
+                {
+                  "value": "**Group**. Groups together multiple expressions to match."
+                },
                 {
                   "value": "**Range**. Match between 1 and 3 of the previous expression."
                 }
@@ -223,71 +340,131 @@ describe('getHoverResult()', () => {
         `)
     })
 
-    test('smartQuery flag on regexp escape characters', () => {
+    test('regexp escape characters', () => {
         const scannedQuery = toSuccess(scanSearchQuery('\\q\\r\\n\\.\\\\', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Escaped Character**. The character \`q\` is escaped."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 3
-              }
-            }
-        `)
-        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Escaped Character**. Match a carriage return."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 3,
-                "endColumn": 5
-              }
-            }
-        `)
-        expect(getHoverResult(scannedQuery, { column: 5 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Escaped Character**. Match a new line."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`.\`."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 5,
-                "endColumn": 7
+                "startColumn": 9,
+                "endColumn": 11
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 7 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
+                  "value": "**Escaped Character**. The character \`q\` is escaped."
+                },
+                {
+                  "value": "**Escaped Character**. Match a carriage return."
+                },
+                {
+                  "value": "**Escaped Character**. Match a new line."
+                },
+                {
                   "value": "**Escaped Character**. Match the character \`.\`."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 7,
-                "endColumn": 9
+                "startColumn": 9,
+                "endColumn": 11
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 9 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
+                {
+                  "value": "**Escaped Character**. The character \`q\` is escaped."
+                },
+                {
+                  "value": "**Escaped Character**. Match a carriage return."
+                },
+                {
+                  "value": "**Escaped Character**. Match a new line."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`.\`."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`\\\\\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 9,
+                "endColumn": 11
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Escaped Character**. The character \`q\` is escaped."
+                },
+                {
+                  "value": "**Escaped Character**. Match a carriage return."
+                },
+                {
+                  "value": "**Escaped Character**. Match a new line."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`.\`."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`\\\\\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 9,
+                "endColumn": 11
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Escaped Character**. The character \`q\` is escaped."
+                },
+                {
+                  "value": "**Escaped Character**. Match a carriage return."
+                },
+                {
+                  "value": "**Escaped Character**. Match a new line."
+                },
+                {
+                  "value": "**Escaped Character**. Match the character \`.\`."
+                },
                 {
                   "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
@@ -302,27 +479,81 @@ describe('getHoverResult()', () => {
         `)
     })
 
-    test('smartQuery flag on ordinary and negated character class', () => {
+    test('ordinary and negated character class', () => {
         const scannedQuery = toSuccess(scanSearchQuery('[^a-z][0-9]', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Negated character class**. Match any character _not_ inside the square brackets."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`a-z\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`a-z\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`a-z\`."
+                },
+                {
+                  "value": "**Character class**. Match any character inside the square brackets."
+                },
+                {
+                  "value": "**Character class**. Match any character inside the square brackets."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`0-9\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`0-9\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`0-9\`."
+                },
+                {
+                  "value": "**Character class**. Match any character inside the square brackets."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 7
+                "startColumn": 7,
+                "endColumn": 12
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery, { column: 7 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
+                {
+                  "value": "**Negated character class**. Match any character _not_ inside the square brackets."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`a-z\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`a-z\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`a-z\`."
+                },
+                {
+                  "value": "**Character class**. Match any character inside the square brackets."
+                },
+                {
+                  "value": "**Character class**. Match any character inside the square brackets."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`0-9\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`0-9\`."
+                },
+                {
+                  "value": "**Character range**. Match a character in the range \`0-9\`."
+                },
                 {
                   "value": "**Character class**. Match any character inside the square brackets."
                 }
@@ -337,9 +568,9 @@ describe('getHoverResult()', () => {
         `)
     })
 
-    test('smartQuery flag as literal search interprets parentheses as patterns', () => {
+    test('literal search interprets parentheses as patterns', () => {
         const scannedQuery = toSuccess(scanSearchQuery('(abcd)', false, SearchPatternType.literal))
-        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
@@ -354,7 +585,7 @@ describe('getHoverResult()', () => {
               }
             }
         `)
-        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
@@ -371,7 +602,7 @@ describe('getHoverResult()', () => {
         `)
     })
 
-    test('smartQuery flag returns hover contents for revision syntax', () => {
+    test('returns hover contents for revision syntax', () => {
         const scannedQuery = toSuccess(
             scanSearchQuery(
                 'repo:^foo$@head:v1.3 rev:*refs/heads/*:*!refs/heads/release*',
@@ -380,57 +611,66 @@ describe('getHoverResult()', () => {
             )
         )
 
-        expect(getHoverResult(scannedQuery, { column: 11 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`foo\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                },
                 {
                   "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 11,
-                "endColumn": 12
-              }
-            }
-        `)
-
-        expect(getHoverResult(scannedQuery, { column: 12 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 12,
-                "endColumn": 16
-              }
-            }
-        `)
-
-        expect(getHoverResult(scannedQuery, { column: 16 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 16,
-                "endColumn": 17
-              }
-            }
-        `)
-
-        expect(getHoverResult(scannedQuery, { column: 17 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
                 {
                   "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
@@ -438,146 +678,662 @@ describe('getHoverResult()', () => {
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 17,
-                "endColumn": 21
+                "startColumn": 61,
+                "endColumn": 61
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery, { column: 26 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`foo\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                },
+                {
+                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
                 {
                   "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 26,
-                "endColumn": 27
-              }
-            }
-        `)
-
-        expect(getHoverResult(scannedQuery, { column: 27 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 27,
-                "endColumn": 38
+                "startColumn": 61,
+                "endColumn": 61
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery, { column: 41 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`foo\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                },
+                {
+                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
                   "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 40,
-                "endColumn": 42
+                "startColumn": 61,
+                "endColumn": 61
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`foo\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                },
+                {
+                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 61,
+                "endColumn": 61
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`foo\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                },
+                {
+                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 61,
+                "endColumn": 61
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`foo\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                },
+                {
+                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 61,
+                "endColumn": 61
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                },
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "Matches the string \`foo\`."
+                },
+                {
+                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
+                },
+                {
+                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                },
+                {
+                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                },
+                {
+                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                },
+                {
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                },
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                },
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 61,
+                "endColumn": 61
               }
             }
         `)
     })
 
-    test('smartQuery flag returns hover contents for structural syntax', () => {
+    test('returns hover contents for structural syntax', () => {
         const scannedQuery = toSuccess(scanSearchQuery(':[var~\\w+] ...', false, SearchPatternType.structural))
 
-        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
+                  "value": "Matches the character \`\`."
+                },
+                {
                   "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 11
-              }
-            }
-        `)
-
-        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 3,
-                "endColumn": 6
-              }
-            }
-        `)
-
-        expect(getHoverResult(scannedQuery, { column: 6 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 6,
-                "endColumn": 7
-              }
-            }
-        `)
-
-        expect(getHoverResult(scannedQuery, { column: 9 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
+                {
+                  "value": "**Word**. Match any word character. "
+                },
                 {
                   "value": "**One or more**. Match one or more of the previous expression."
-                }
-              ],
-              "range": {
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 9,
-                "endColumn": 10
-              }
-            }
-        `)
-        expect(getHoverResult(scannedQuery, { column: 10 }, true)).toMatchInlineSnapshot(`
-            {
-              "contents": [
+                },
                 {
                   "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 11
+                "startColumn": 12,
+                "endColumn": 15
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery, { column: 12 }, true)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
             {
               "contents": [
+                {
+                  "value": "Matches the character \`\`."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
+                },
+                {
+                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
+                },
+                {
+                  "value": "**Word**. Match any word character. "
+                },
+                {
+                  "value": "**One or more**. Match one or more of the previous expression."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 12,
+                "endColumn": 15
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Matches the character \`\`."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
+                },
+                {
+                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
+                },
+                {
+                  "value": "**Word**. Match any word character. "
+                },
+                {
+                  "value": "**One or more**. Match one or more of the previous expression."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 12,
+                "endColumn": 15
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Matches the character \`\`."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
+                },
+                {
+                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
+                },
+                {
+                  "value": "**Word**. Match any word character. "
+                },
+                {
+                  "value": "**One or more**. Match one or more of the previous expression."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 12,
+                "endColumn": 15
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Matches the character \`\`."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
+                },
+                {
+                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
+                },
+                {
+                  "value": "**Word**. Match any word character. "
+                },
+                {
+                  "value": "**One or more**. Match one or more of the previous expression."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 12,
+                "endColumn": 15
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Matches the character \`\`."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
+                {
+                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
+                },
+                {
+                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
+                },
+                {
+                  "value": "**Word**. Match any word character. "
+                },
+                {
+                  "value": "**One or more**. Match one or more of the previous expression."
+                },
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                },
                 {
                   "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
@@ -596,18 +1352,27 @@ describe('getHoverResult()', () => {
 test('returns hover contents for select', () => {
     const scannedQuery = toSuccess(scanSearchQuery('select:repo repo:foo', false, SearchPatternType.literal))
 
-    expect(getHoverResult(scannedQuery, { column: 8 }, true)).toMatchInlineSnapshot(`
+    expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
         {
           "contents": [
             {
+              "value": "Selects the kind of result to display."
+            },
+            {
               "value": "Select and display distinct repository paths from search results."
+            },
+            {
+              "value": "Include only results from repositories matching the given search pattern."
+            },
+            {
+              "value": "Matches the string \`foo\`."
             }
           ],
           "range": {
             "startLineNumber": 1,
             "endLineNumber": 1,
-            "startColumn": 8,
-            "endColumn": 12
+            "startColumn": 18,
+            "endColumn": 21
           }
         }
     `)
@@ -616,9 +1381,27 @@ test('returns hover contents for select', () => {
 test('returns repo:contains hovers', () => {
     const scannedQuery = toSuccess(scanSearchQuery('repo:contains.file(foo)', false, SearchPatternType.literal))
 
-    expect(getHoverResult(scannedQuery, { column: 8 }, true)).toMatchInlineSnapshot(`
+    expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
         {
           "contents": [
+            {
+              "value": "Include only results from repositories matching the given search pattern."
+            },
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
+            },
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
+            },
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
+            },
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
+            },
+            {
+              "value": "Matches the string \`foo\`."
+            },
             {
               "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
             }

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -193,18 +193,11 @@ const toHover = (token: DecoratedToken): string => {
     return ''
 }
 
-const inside = (column: number) => ({ range }: Pick<Token | DecoratedToken, 'range'>): boolean =>
-    range.start + 1 <= column && range.end >= column
-
 /**
  * Returns the hover result for a hovered search token in the Monaco query input.
  */
-export const getHoverResult = (
-    tokens: Token[],
-    { column }: Pick<Monaco.Position, 'column'>,
-    smartQuery = false
-): Monaco.languages.Hover | null => {
-    const tokensAtCursor = (smartQuery ? tokens.flatMap(decorate) : tokens).filter(inside(column))
+export const getHoverResult = (tokens: Token[]): Monaco.languages.Hover | null => {
+    const tokensAtCursor = tokens.flatMap(decorate)
     if (tokensAtCursor.length === 0) {
         return null
     }
@@ -212,21 +205,6 @@ export const getHoverResult = (
     let range: Monaco.IRange | undefined
     tokensAtCursor.map(token => {
         switch (token.type) {
-            case 'filter': {
-                // This 'filter' branch only exists to preserve previous behavior when smmartQuery is false.
-                // When smartQuery is true, 'filter' tokens are handled by the 'field' case and its values in
-                // the rest of this switch statement.
-                const resolvedFilter = resolveFilter(token.field.value)
-                if (resolvedFilter) {
-                    values.push(
-                        'negated' in resolvedFilter
-                            ? resolvedFilter.definition.description(resolvedFilter.negated)
-                            : resolvedFilter.definition.description
-                    )
-                    range = toMonacoRange(token.range)
-                }
-                break
-            }
             case 'field': {
                 const resolvedFilter = resolveFilter(token.value)
                 if (resolvedFilter) {

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -49,7 +49,6 @@ export function getProviders(
     options: {
         patternType: SearchPatternType
         globbing: boolean
-        enableSmartQuery: boolean
         interpretComments?: boolean
         isSourcegraphDotCom?: boolean
     }
@@ -72,7 +71,7 @@ export function getProviders(
                 const result = scanSearchQuery(line, options.interpretComments ?? false, options.patternType)
                 if (result.type === 'success') {
                     return {
-                        tokens: getMonacoTokens(result.term, options.enableSmartQuery),
+                        tokens: getMonacoTokens(result.term),
                         endState: SCANNER_STATE,
                     }
                 }
@@ -84,11 +83,7 @@ export function getProviders(
                 scannedQueries
                     .pipe(
                         first(),
-                        map(({ scanned }) =>
-                            scanned.type === 'error'
-                                ? null
-                                : getHoverResult(scanned.term, position, options.enableSmartQuery)
-                        ),
+                        map(({ scanned }) => (scanned.type === 'error' ? null : getHoverResult(scanned.term))),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )
                     .toPromise(),

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -128,7 +128,6 @@ export interface LayoutProps
     globbing: boolean
     showMultilineSearchConsole: boolean
     showQueryBuilder: boolean
-    enableSmartQuery: boolean
     isSourcegraphDotCom: boolean
     showBatchChanges: boolean
     fetchSavedSearches: () => Observable<GQL.ISavedSearch[]>

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -205,11 +205,6 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
     showQueryBuilder: boolean
 
     /**
-     * Wether to enable enable contextual syntax highlighting and hovers for search queries
-     */
-    enableSmartQuery: boolean
-
-    /**
      * Whether the code monitoring feature flag is enabled.
      */
     enableCodeMonitoring: boolean
@@ -316,7 +311,6 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             globbing: false,
             showMultilineSearchConsole: false,
             showQueryBuilder: false,
-            enableSmartQuery: false,
             enableCodeMonitoring: false,
             // Disabling linter here as otherwise the application fails to compile. Bad lint?
             // See 7a137b201330eb2118c746f8cc5acddf63c1f039
@@ -566,7 +560,6 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                             globbing={this.state.globbing}
                                             showMultilineSearchConsole={this.state.showMultilineSearchConsole}
                                             showQueryBuilder={this.state.showQueryBuilder}
-                                            enableSmartQuery={this.state.enableSmartQuery}
                                             enableCodeMonitoring={this.state.enableCodeMonitoring}
                                             fetchSavedSearches={fetchSavedSearches}
                                             fetchRecentSearches={fetchRecentSearches}

--- a/client/web/src/nav/GlobalNavbar.story.tsx
+++ b/client/web/src/nav/GlobalNavbar.story.tsx
@@ -44,7 +44,6 @@ const defaultProps = (
     setVersionContext: () => Promise.resolve(undefined),
     availableVersionContexts: [],
     globbing: false,
-    enableSmartQuery: false,
     parsedSearchQuery: 'r:golang/oauth2 test f:travis',
     patternType: SearchPatternType.literal,
     setPatternType: () => undefined,

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -55,7 +55,6 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
     defaultSearchContextSpec: '',
     variant: 'default',
     globbing: false,
-    enableSmartQuery: false,
     showOnboardingTour: false,
     branding: undefined,
     routes: [],

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -89,8 +89,6 @@ interface Props
     // Whether globbing is enabled for filters.
     globbing: boolean
 
-    // Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets.
-    enableSmartQuery: boolean
     userSettingsSideBarItems?: UserSettingsSidebarItems
 
     /**

--- a/client/web/src/repogroups/RepogroupPage.story.tsx
+++ b/client/web/src/repogroups/RepogroupPage.story.tsx
@@ -105,7 +105,6 @@ const commonProps = () =>
         authenticatedUser: authUser,
         repogroupMetadata: python2To3Metadata,
         globbing: false,
-        enableSmartQuery: false,
         showOnboardingTour: false,
         showQueryBuilder: false,
         fetchAutoDefinedSearchContexts: mockFetchAutoDefinedSearchContexts(),

--- a/client/web/src/repogroups/RepogroupPage.tsx
+++ b/client/web/src/repogroups/RepogroupPage.tsx
@@ -64,9 +64,6 @@ export interface RepogroupPageProps
 
     /** Whether globbing is enabled for filters. */
     globbing: boolean
-
-    // Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets.
-    enableSmartQuery: boolean
 }
 
 export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props: RepogroupPageProps) => {

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -91,7 +91,6 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
         const subscription = addSourcegraphSearchCodeIntelligence(monacoInstance, searchQuery, fetchSuggestions, {
             patternType,
             globbing,
-            enableSmartQuery: true,
             interpretComments: true,
         })
         return () => subscription.unsubscribe()

--- a/client/web/src/search/input/MonacoQueryInput.story.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.story.tsx
@@ -19,7 +19,6 @@ const defaultProps: MonacoQueryInputProps = {
     globbing: false,
     queryState: { query: 'hello repo:test' },
     isSourcegraphDotCom: false,
-    enableSmartQuery: false,
     patternType: SearchPatternType.literal,
     caseSensitive: false,
     versionContext: undefined,

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -42,9 +42,6 @@ export interface MonacoQueryInputProps
     // Whether globbing is enabled for filters.
     globbing: boolean
 
-    // Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets.
-    enableSmartQuery: boolean
-
     // Whether comments are parsed and highlighted
     interpretComments?: boolean
 
@@ -73,7 +70,6 @@ export function addSourcegraphSearchCodeIntelligence(
         patternType: SearchPatternType
         globbing: boolean
         interpretComments?: boolean
-        enableSmartQuery: boolean
         isSourcegraphDotCom?: boolean
     }
 ): Subscription {
@@ -157,7 +153,6 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
     versionContext,
     patternType,
     globbing,
-    enableSmartQuery,
     interpretComments,
     isSourcegraphDotCom,
     isLightTheme,
@@ -212,7 +207,6 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
             {
                 patternType,
                 globbing,
-                enableSmartQuery,
                 interpretComments,
                 isSourcegraphDotCom,
             }
@@ -224,7 +218,6 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
         fetchSuggestionsWithContext,
         patternType,
         globbing,
-        enableSmartQuery,
         interpretComments,
         isSourcegraphDotCom,
     ])

--- a/client/web/src/search/input/SearchBox.story.tsx
+++ b/client/web/src/search/input/SearchBox.story.tsx
@@ -31,7 +31,6 @@ const defaultProps: SearchBoxProps = {
     globbing: false,
     queryState: { query: 'hello repo:test' },
     isSourcegraphDotCom: false,
-    enableSmartQuery: false,
     patternType: SearchPatternType.literal,
     setPatternType: () => {},
     caseSensitive: false,

--- a/client/web/src/search/input/SearchBox.tsx
+++ b/client/web/src/search/input/SearchBox.tsx
@@ -40,9 +40,6 @@ export interface SearchBoxProps
     /** Whether globbing is enabled for filters. */
     globbing: boolean
 
-    /** Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets. */
-    enableSmartQuery: boolean
-
     /** Whether comments are parsed and highlighted */
     interpretComments?: boolean
 

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -32,7 +32,6 @@ interface Props
     isSourcegraphDotCom: boolean
     onChange: (newValue: QueryState) => void
     globbing: boolean
-    enableSmartQuery: boolean
     isSearchAutoFocusRequired?: boolean
     setVersionContext: (versionContext: string | undefined) => Promise<void>
     availableVersionContexts: VersionContext[] | undefined

--- a/client/web/src/search/input/SearchPage.story.tsx
+++ b/client/web/src/search/input/SearchPage.story.tsx
@@ -36,7 +36,6 @@ const defaultProps = (props: ThemeProps): SearchPageProps => ({
     setVersionContext: () => Promise.resolve(undefined),
     availableVersionContexts: [],
     globbing: false,
-    enableSmartQuery: false,
     parsedSearchQuery: 'r:golang/oauth2 test f:travis',
     patternType: SearchPatternType.literal,
     setPatternType: () => undefined,

--- a/client/web/src/search/input/SearchPage.test.tsx
+++ b/client/web/src/search/input/SearchPage.test.tsx
@@ -44,7 +44,6 @@ describe('SearchPage', () => {
         setVersionContext: () => Promise.resolve(),
         availableVersionContexts: [],
         globbing: false,
-        enableSmartQuery: false,
         parsedSearchQuery: 'r:golang/oauth2 test f:travis',
         patternType: SearchPatternType.literal,
         setPatternType: () => undefined,

--- a/client/web/src/search/input/SearchPage.tsx
+++ b/client/web/src/search/input/SearchPage.tsx
@@ -66,9 +66,6 @@ export interface SearchPageProps
 
     // Whether globbing is enabled for filters.
     globbing: boolean
-
-    // Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets.
-    enableSmartQuery: boolean
 }
 
 /**

--- a/client/web/src/search/input/SearchPageInput.tsx
+++ b/client/web/src/search/input/SearchPageInput.tsx
@@ -52,8 +52,6 @@ interface Props
     availableVersionContexts: VersionContext[] | undefined
     /** Whether globbing is enabled for filters. */
     globbing: boolean
-    // Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets.
-    enableSmartQuery: boolean
     /** Show the query builder link. */
     showQueryBuilder: boolean
     /** A query fragment to appear at the beginning of the input. */

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -67,7 +67,6 @@ export function experimentalFeaturesFromSettings(
     showSearchContext: boolean
     showSearchContextManagement: boolean
     showQueryBuilder: boolean
-    enableSmartQuery: boolean
     enableCodeMonitoring: boolean
     enableAPIDocs: boolean
     designRefreshToggleEnabled: boolean
@@ -84,7 +83,6 @@ export function experimentalFeaturesFromSettings(
         showSearchContextManagement = false,
         showMultilineSearchConsole = false,
         showQueryBuilder = false,
-        enableSmartQuery = true,
         codeMonitoring = true, // Default to true if not set
         // eslint-disable-next-line unicorn/prevent-abbreviations
         apiDocs = false,
@@ -99,7 +97,6 @@ export function experimentalFeaturesFromSettings(
         showEnterpriseHomePanels,
         showMultilineSearchConsole,
         showQueryBuilder,
-        enableSmartQuery,
         enableCodeMonitoring: codeMonitoring,
         enableAPIDocs: apiDocs,
         designRefreshToggleEnabled,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1335,7 +1335,7 @@ type SettingsExperimentalFeatures struct {
 	DesignRefreshToggleEnabled *bool `json:"designRefreshToggleEnabled,omitempty"`
 	// EnableFastResultLoading description: Enables optimized search result loading (syntax highlighting / file contents fetching)
 	EnableFastResultLoading *bool `json:"enableFastResultLoading,omitempty"`
-	// EnableSmartQuery description: Enables contextual syntax highlighting and hovers for search queries in the web app
+	// EnableSmartQuery description: REMOVED. Previously, added more syntax highlighting and hovers for queries in the web app. This behavior is active by default now.
 	EnableSmartQuery *bool `json:"enableSmartQuery,omitempty"`
 	// FuzzyFinder description: Enables fuzzy finder with keyboard shortcut `t`.
 	FuzzyFinder *bool `json:"fuzzyFinder,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -133,7 +133,7 @@
           }
         },
         "enableSmartQuery": {
-          "description": "Enables contextual syntax highlighting and hovers for search queries in the web app",
+          "description": "REMOVED. Previously, added more syntax highlighting and hovers for queries in the web app. This behavior is active by default now.",
           "type": "boolean",
           "default": true,
           "!go": {


### PR DESCRIPTION
This removes the `smartQuery` flag I developed behind when introducing additional highlighting/hovers. It's been activated by default for ~6 months now so let's delete it. Go by commit, but this is not the type of PR you want to spend a lot of time reviewing, it is just deleting things in a lot of placing to make sure things compile and tests pass, so feel free to rubber stamp :-)

The PR adds a lot of lines because I removed a param that was used in tests to output only one hover at a simulated cursor position, but now it outputs hover info for the entire query. I prefer not polluting our actual function signatures with parameters that are only used by tests, and since I changed the tests to update with snapshot values, this is OK for this PR. In future PR I will look into reducing the output here on the testing side, and not in our function signatures.