### PR TITLE
web: keep `groupsToDisplay` and `groups` indexes in sync to show correct file locations

### DIFF
--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -220,7 +220,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                 return group
             }
             return null
-        }).filter(Boolean) as LocationGroup[]
+        })
 
         return (
             <div>
@@ -238,37 +238,45 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                 >
                     <div className="d-flex">
                         {selectedGroups &&
-                            groupsToDisplay.map((group, index) => (
-                                <Resizable
-                                    key={index}
-                                    className={styles.resizableGroup}
-                                    handleClassName={styles.resizableHandle}
-                                    handlePosition="right"
-                                    storageKey={`hierarchical-locations-view-resizable:${group.name}`}
-                                    defaultSize={group.defaultSize}
-                                    element={
-                                        <div
-                                            data-testid="hierarchical-locations-view-list"
-                                            className={classNames('list-group', styles.groupList)}
-                                        >
-                                            {groups[index].map((group, innerIndex) => (
-                                                <HierarchicalLocationsViewButton
-                                                    key={innerIndex}
-                                                    groupKey={group.key}
-                                                    groupCount={group.count}
-                                                    isActive={selectedGroups[index] === group.key}
-                                                    onClick={event =>
-                                                        this.onSelectTree(event, selectedGroups, index, group.key)
-                                                    }
-                                                />
-                                            ))}
-                                            {this.state.locationsOrError.isLoading && (
-                                                <LoadingSpinner className="icon-inline m-2 flex-shrink-0 test-loading-spinner" />
-                                            )}
-                                        </div>
-                                    }
-                                />
-                            ))}
+                            groupsToDisplay.map(
+                                (group, index) =>
+                                    group && (
+                                        <Resizable
+                                            key={index}
+                                            className={styles.resizableGroup}
+                                            handleClassName={styles.resizableHandle}
+                                            handlePosition="right"
+                                            storageKey={`hierarchical-locations-view-resizable:${group.name}`}
+                                            defaultSize={group.defaultSize}
+                                            element={
+                                                <div
+                                                    data-testid="hierarchical-locations-view-list"
+                                                    className={classNames('list-group', styles.groupList)}
+                                                >
+                                                    {groups[index].map((group, innerIndex) => (
+                                                        <HierarchicalLocationsViewButton
+                                                            key={innerIndex}
+                                                            groupKey={group.key}
+                                                            groupCount={group.count}
+                                                            isActive={selectedGroups[index] === group.key}
+                                                            onClick={event =>
+                                                                this.onSelectTree(
+                                                                    event,
+                                                                    selectedGroups,
+                                                                    index,
+                                                                    group.key
+                                                                )
+                                                            }
+                                                        />
+                                                    ))}
+                                                    {this.state.locationsOrError.isLoading && (
+                                                        <LoadingSpinner className="icon-inline m-2 flex-shrink-0 test-loading-spinner" />
+                                                    )}
+                                                </div>
+                                            }
+                                        />
+                                    )
+                            )}
                     </div>
                     <FileLocations
                         className={styles.fileLocations}

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -191,7 +191,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
           >
             <span
               className="locationName"
-              title="github.com/foo/bar"
+              title="file1.txt"
             >
               <span
                 className="locationNameText"
@@ -200,9 +200,8 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                   className=""
                 >
                    
-                  foo/
                   <span>
-                    bar
+                    file1.txt
                   </span>
                 </span>
               </span>
@@ -210,7 +209,36 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
             <span
               className="locationBadge ml-1"
             >
-              5
+              2
+            </span>
+          </button>
+          <button
+            className="list-group-item list-group-item-action locationButton"
+            data-testid="hierarchical-locations-view-button"
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              className="locationName"
+              title="file2.txt"
+            >
+              <span
+                className="locationNameText"
+              >
+                <span
+                  className=""
+                >
+                   
+                  <span>
+                    file2.txt
+                  </span>
+                </span>
+              </span>
+            </span>
+            <span
+              className="locationBadge ml-1"
+            >
+              3
             </span>
           </button>
         </div>


### PR DESCRIPTION
## Changes

- Reverted `groupsToDisplay.filter(Boolean)`, which was added during the redesign and caused `groupsToDisplay` indexes to be out of sync with `groups`, that's why _some_ locations were not shown.

Fixes https://github.com/sourcegraph/sourcegraph/issues/22316.