### PR TITLE
UserArea: Fix E2E tests

### DIFF
--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -145,7 +145,7 @@ export const UserArea: React.FunctionComponent<UserAreaProps> = ({
     },
     ...props
 }) => {
-    const { data, error, loading } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(
+    const { data, error, loading, previousData } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(
         USER_AREA_USER_PROFILE,
         {
             variables: { username, siteAdmin: Boolean(props.authenticatedUser?.siteAdmin) },
@@ -165,15 +165,16 @@ export const UserArea: React.FunctionComponent<UserAreaProps> = ({
         )
     )
 
-    if (loading) {
+    // Accept stale data if recently updated, avoids unmounting components due to a brief lack of data
+    const user = data?.user ?? previousData?.user
+
+    if (loading && !user) {
         return null
     }
 
     if (error) {
         throw new Error(error.message)
     }
-
-    const user = data?.user
 
     if (!user) {
         throw new Error(`User not found: ${JSON.stringify(username)}`)


### PR DESCRIPTION
Maintains the previous behavior.

The problem was that a mutation could update `User` which would trigger a full refetch of user data here. `data` would be undefined whilst `loading` new data, so the edit user form would unmount and users would not see the success message.

Longer term solution will be to break this query down so smaller components fetch only the data they need, rather than fetching everything at once and passing it down to each settings area