### PR TITLE
repos: Add blocking support

### DIFF
--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2,10 +2,12 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -406,6 +408,15 @@ func TestListIndexableRepos(t *testing.T) {
 			Name:  "github.com/foo/bar4",
 			Stars: 10, // Not enough stars
 		},
+		{
+			ID:    api.RepoID(5),
+			Name:  "github.com/foo/bar5",
+			Stars: 400,
+			Blocked: &types.RepoBlock{
+				At:     time.Now().UTC(),
+				Reason: "Failed to index too many times.",
+			},
+		},
 	}
 
 	ctx := context.Background()
@@ -418,7 +429,15 @@ func TestListIndexableRepos(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, r := range reposToAdd {
-		if _, err := db.ExecContext(ctx, `INSERT INTO repo(id, name, stars, private) VALUES ($1, $2, $3, $4)`, r.ID, r.Name, r.Stars, r.Private); err != nil {
+		blocked, err := json.Marshal(r.Blocked)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO repo(id, name, stars, private, blocked) VALUES ($1, $2, $3, $4, NULLIF($5, 'null'::jsonb))`,
+			r.ID, r.Name, r.Stars, r.Private, blocked,
+		)
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -477,4 +496,77 @@ func TestListIndexableRepos(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRepoStore_Blocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+	db := dbtest.NewDB(t, "")
+	rs := Repos(db)
+
+	ctx := context.Background()
+
+	repos := []*types.Repo{
+		{
+			ID:      1,
+			Name:    "foo",
+			URI:     "foo-uri",
+			Sources: map[string]*types.SourceInfo{},
+		},
+		{
+			ID:      2,
+			Name:    "bar",
+			URI:     "bar-uri",
+			Sources: map[string]*types.SourceInfo{},
+		},
+	}
+
+	err := rs.Create(ctx, repos...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rs.Block(ctx, "too big", repos[1].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("GetByName_Name", func(t *testing.T) {
+		_, err := rs.GetByName(ctx, repos[0].Name)
+		if have, want := fmt.Sprint(err), "<nil>"; have != want {
+			t.Errorf("error, have: %q, want: %q", have, want)
+		}
+
+		_, err = rs.GetByName(ctx, repos[1].Name)
+		if have, want := fmt.Sprint(err), `bar has been blocked. reason: too big`; have != want {
+			t.Errorf("error, have: %q, want: %q", have, want)
+		}
+	})
+
+	t.Run("GetByName_URI", func(t *testing.T) {
+		_, err := rs.GetByName(ctx, api.RepoName(repos[0].URI))
+		if have, want := fmt.Sprint(err), "<nil>"; have != want {
+			t.Errorf("error, have: %q, want: %q", have, want)
+		}
+
+		_, err = rs.GetByName(ctx, api.RepoName(repos[1].URI))
+		if have, want := fmt.Sprint(err), `bar has been blocked. reason: too big`; have != want {
+			t.Errorf("error, have: %q, want: %q", have, want)
+		}
+	})
+
+	t.Run("List", func(t *testing.T) {
+		have, err := rs.List(ctx, ReposListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := repos[:1]
+		if !cmp.Equal(have, want) {
+			t.Errorf("mismatch: (-have, +want):\n:%s", cmp.Diff(have, want))
+		}
+	})
 }

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -413,7 +413,7 @@ func TestListIndexableRepos(t *testing.T) {
 			Name:  "github.com/foo/bar5",
 			Stars: 400,
 			Blocked: &types.RepoBlock{
-				At:     time.Now().UTC(),
+				At:     time.Now().UTC().Unix(),
 				Reason: "Failed to index too many times.",
 			},
 		},

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1405,10 +1405,11 @@ Indexes:
     "repo_external_unique_idx" UNIQUE, btree (external_service_type, external_service_id, external_id)
     "repo_name_unique" UNIQUE CONSTRAINT, btree (name) DEFERRABLE
     "repo_archived" btree (archived)
+    "repo_blocked_idx" btree ((blocked IS NOT NULL))
     "repo_cloned" btree (cloned)
     "repo_created_at" btree (created_at)
     "repo_fork" btree (fork)
-    "repo_is_blocked_idx" btree ((blocked IS NOT NULL))
+    "repo_is_not_blocked_idx" btree ((blocked IS NULL))
     "repo_metadata_gin_idx" gin (metadata)
     "repo_name_idx" btree (lower(name::text) COLLATE "C")
     "repo_name_trgm" gin (lower(name::text) gin_trgm_ops)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1399,6 +1399,7 @@ Referenced by:
  private               | boolean                  |           | not null | false
  cloned                | boolean                  |           | not null | false
  stars                 | integer                  |           |          | 
+ blocked               | jsonb                    |           |          | 
 Indexes:
     "repo_pkey" PRIMARY KEY, btree (id)
     "repo_external_unique_idx" UNIQUE, btree (external_service_type, external_service_id, external_id)
@@ -1407,6 +1408,7 @@ Indexes:
     "repo_cloned" btree (cloned)
     "repo_created_at" btree (created_at)
     "repo_fork" btree (fork)
+    "repo_is_blocked_idx" btree ((blocked IS NOT NULL))
     "repo_metadata_gin_idx" gin (metadata)
     "repo_name_idx" btree (lower(name::text) COLLATE "C")
     "repo_name_trgm" gin (lower(name::text) gin_trgm_ops)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -3,7 +3,6 @@ package types
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -71,36 +70,8 @@ type Repo struct {
 
 // RepoBlock contains data about a repo that has been blocked. Blocked repos aren't returned by store methods by default.
 type RepoBlock struct {
-	At     time.Time
+	At     int64 // Unix timestamp
 	Reason string
-}
-
-func (b *RepoBlock) UnmarshalJSON(data []byte) error {
-	var v struct {
-		At     int64
-		Reason string
-	}
-
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-
-	b.At = time.Unix(v.At, 0)
-	b.Reason = v.Reason
-
-	return nil
-}
-
-func (b RepoBlock) MarshalJSON() ([]byte, error) {
-	var v struct {
-		At     int64
-		Reason string
-	}
-
-	v.At = b.At.UTC().Unix()
-	v.Reason = b.Reason
-
-	return json.Marshal(v)
 }
 
 // CloneURLs returns all the clone URLs this repo is clonable from.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -66,7 +66,7 @@ type Repo struct {
 	// Metadata contains the raw source code host JSON metadata.
 	Metadata interface{}
 	// Blocked contains the reason this repository was blocked and the timestamp of when it happened.
-	Blocked *RepoBlock
+	Blocked *RepoBlock `json:",omitempty"`
 }
 
 // RepoBlock contains data about a repo that has been blocked. Blocked repos aren't returned by store methods by default.

--- a/migrations/frontend/1528395838_add_blocked_column_to_repo_table.down.sql
+++ b/migrations/frontend/1528395838_add_blocked_column_to_repo_table.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP INDEX IF EXISTS repo_is_blocked_idx;
+
+DROP FUNCTION IF EXISTS block_repo;
+
+ALTER TABLE IF EXISTS repo DROP COLUMN IF EXISTS blocked;
+
+COMMIT;

--- a/migrations/frontend/1528395838_add_blocked_column_to_repo_table.down.sql
+++ b/migrations/frontend/1528395838_add_blocked_column_to_repo_table.down.sql
@@ -1,8 +1,9 @@
 BEGIN;
 
 DROP INDEX IF EXISTS repo_is_blocked_idx;
+DROP INDEX IF EXISTS repo_is_not_blocked_idx;
 
-DROP FUNCTION IF EXISTS block_repo;
+DROP FUNCTION IF EXISTS repo_block;
 
 ALTER TABLE IF EXISTS repo DROP COLUMN IF EXISTS blocked;
 

--- a/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
+++ b/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS repo ADD COLUMN blocked jsonb DEFAULT NULL;
+
+CREATE OR REPLACE FUNCTION repo_block(reason text, at timestamptz) RETURNS jsonb AS
+$$
+SELECT jsonb_build_object(
+    'reason', reason,
+    'at', extract(epoch from timezone('utc', at))::bigint
+);
+$$ LANGUAGE SQL STRICT IMMUTABLE LEAKPROOF;
+
+CREATE INDEX repo_is_blocked_idx ON repo USING BTREE ((blocked IS NOT NULL));
+
+COMMIT;

--- a/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
+++ b/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-ALTER TABLE IF EXISTS repo ADD COLUMN blocked jsonb DEFAULT NULL;
+ALTER TABLE IF EXISTS repo ADD COLUMN blocked jsonb;
 
 CREATE OR REPLACE FUNCTION repo_block(reason text, at timestamptz) RETURNS jsonb AS
 $$
@@ -8,7 +8,7 @@ SELECT jsonb_build_object(
     'reason', reason,
     'at', extract(epoch from timezone('utc', at))::bigint
 );
-$$ LANGUAGE SQL STRICT IMMUTABLE LEAKPROOF;
+$$ LANGUAGE SQL STRICT IMMUTABLE;
 
 CREATE INDEX repo_is_blocked_idx ON repo USING BTREE ((blocked IS NOT NULL));
 

--- a/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
+++ b/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
@@ -10,6 +10,7 @@ SELECT jsonb_build_object(
 );
 $$ LANGUAGE SQL STRICT IMMUTABLE;
 
-CREATE INDEX repo_is_blocked_idx ON repo USING BTREE ((blocked IS NOT NULL));
+CREATE INDEX repo_blocked_idx ON repo USING BTREE ((blocked IS NOT NULL));
+CREATE INDEX repo_is_not_blocked_idx ON repo USING BTREE ((blocked IS NULL));
 
 COMMIT;


### PR DESCRIPTION
This change set implements support for blocking specific repositories in Sourcegraph. This grew out of the need to block poison pill repositories such as https://github.com/Katee/git-bomb or https://github.com/cdnjs/cdnjs which gitserver or zoekt don't handle well.

For now, we'll be manually blocking repos using a direct SQL query in production. In the future, we expect to automate this process based on certain heuristics that we'll find over time. Manual and automatic blocking of repos is also a useful feature for large customers which have numerous corrupt, unindexable or uncloneable repos that aren't straightforward to filter out in the external service configuration.

I chose to add a column to `repo` for performance reasons — adding yet another join to these core queries would be detrimental to latency and it can be avoided with this little bit of denormalization. If someone feels strongly against this, I'm open to investigate the alternatives in more detail and provide data, but we need this functionality sooner rather than later to handle these poison pill repos in production.