### PR TITLE
Add Code Insights Dashboard page UI

### DIFF
--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -47,7 +47,7 @@ export interface InsightDashboard extends InsightDashboardConfiguration {
      * "All" - all insights that dashboard have all users by default
      *
      * "Personal" - all personal insights from personal settings (also all users
-     * it have by default)
+     * have it by default)
      *
      * "Organizations level" - all organizations act as insights dashboard
      */

--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -24,7 +24,7 @@ export enum InsightsDashboardType {
 }
 
 /**
- * Extended custom insights dashboard. A user can have they own dashboards created
+ * Extended custom insights dashboard. A user can have their own dashboards created
  * by insights dashboard creation UI.
  */
 export interface InsightDashboard extends InsightDashboardConfiguration {

--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -7,28 +7,43 @@ export type InsightDashboard = InsightBuiltInDashboard | InsightCustomDashboard
  */
 export enum InsightsDashboardType {
     /**
-     * A built in dashboard that all users have as a default and non-removable
-     * dashboards like "all insights", "personal", "org level dashboard".
+     * A dashboard that includes all insights from the personal and organization
+     * level dashboards.
      */
-    BuiltIn = 'built-in',
+    All = 'all',
 
     /**
-     * A Custom dashboard that a user created by dashboard creation UI.
-     * These dashboard types can be deleted or moved from user personal settings
-     * to org setting scope and vice versa.
+     * A dashboard that includes insights from personal settings or from
+     * dashboards that are stored in personal settings (personal dashboard)
      */
-    Custom = 'custom',
+    Personal = 'personal',
+
+    /**
+     * A dashboard that includes insights from organization settings or from
+     * dashboards that are stored in organization settings (org dashboard)
+     */
+    Organization = 'organization',
 }
 
 /**
- * An extended custom insights dashboard configuration.
+ * An Owner of dashboard. It can be user subject (a personal dashboard), org subject
+ * (an org level dashboard)
+ */
+export interface InsightDashboardOwner {
+    id: string | null
+    name: string
+}
+
+/**
+ * An extended custom insights dashboard. A user can have they own dashboards created
+ * by insights dashboard creation UI.
  */
 export interface InsightCustomDashboard extends InsightDashboardConfiguration {
     /**
-     * All dashboards that were created in users settings explicitly are
+     * All dashboards that were created in users or org settings explicitly are
      * custom dashboards.
      */
-    type: InsightsDashboardType.Custom
+    type: InsightsDashboardType.Personal | InsightsDashboardType.Organization
 
     /**
      * Subject that has a particular dashboard, it can be personal setting
@@ -37,16 +52,13 @@ export interface InsightCustomDashboard extends InsightDashboardConfiguration {
     owner: InsightDashboardOwner
 }
 
-export interface InsightDashboardOwner {
-    id: string | null
-    name: string
-}
-
 /**
- * A built in insights dashboard.
+ * A built-in insights dashboard. Currently we have 3 type of built-in dashboards.
+ * All users have "All Insights" dashboard and "Personal Insights" dashboard
+ * Also users who were included in org have built-in org level dashboard by default.
  */
 export interface InsightBuiltInDashboard {
-    type: InsightsDashboardType.BuiltIn
+    type: InsightsDashboardType
 
     /**
      * Title of insights dashboards ("All insights", "Personal", ...)
@@ -68,5 +80,10 @@ export interface InsightBuiltInDashboard {
  */
 export const ALL_INSIGHTS_DASHBOARD: InsightBuiltInDashboard = {
     title: 'All',
-    type: InsightsDashboardType.BuiltIn,
+    type: InsightsDashboardType.All,
 }
+
+/**
+ * The key for accessing  insights dashboards in the subject settings.
+ */
+export const INSIGHTS_DASHBOARDS_SETTINGS_KEY = 'insights.dashboards'

--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -1,7 +1,5 @@
 import { InsightDashboard as InsightDashboardConfiguration } from '../../../schema/settings.schema'
 
-export type InsightDashboard = InsightBuiltInDashboard | InsightCustomDashboard
-
 /**
  * All insights dashboards are separated on two categories.
  */
@@ -26,19 +24,10 @@ export enum InsightsDashboardType {
 }
 
 /**
- * An Owner of dashboard. It can be user subject (a personal dashboard), org subject
- * (an org level dashboard)
- */
-export interface InsightDashboardOwner {
-    id: string | null
-    name: string
-}
-
-/**
  * An extended custom insights dashboard. A user can have they own dashboards created
  * by insights dashboard creation UI.
  */
-export interface InsightCustomDashboard extends InsightDashboardConfiguration {
+export interface InsightDashboard extends InsightDashboardConfiguration {
     /**
      * All dashboards that were created in users or org settings explicitly are
      * custom dashboards.
@@ -50,37 +39,28 @@ export interface InsightCustomDashboard extends InsightDashboardConfiguration {
      * or organization setting subject.
      */
     owner: InsightDashboardOwner
+
+    /**
+     * Property to distinguish between real user-created dashboard and virtual
+     * built-in dashboard. Currently we support 3 types of built-in dashboard.
+     *
+     * "All" - all insights that dashboard have all users by default
+     *
+     * "Personal" - all personal insights from personal settings (also all users
+     * it have by default)
+     *
+     * "Organizations level" - all organizations act as insights dashboard
+     */
+    builtIn?: boolean
 }
 
 /**
- * A built-in insights dashboard. Currently we have 3 type of built-in dashboards.
- * All users have "All Insights" dashboard and "Personal Insights" dashboard
- * Also users who were included in org have built-in org level dashboard by default.
+ * An Owner of dashboard. It can be user subject (a personal dashboard), org subject
+ * (an org level dashboard)
  */
-export interface InsightBuiltInDashboard {
-    type: InsightsDashboardType
-
-    /**
-     * Title of insights dashboards ("All insights", "Personal", ...)
-     */
-    title?: string
-
-    /**
-     * Possible owner of dashboard. That might be equal to undefined when
-     * this dashboard is "all insights" dashboard.
-     */
-    owner?: InsightDashboardOwner
-
-    insightIds?: string[]
-}
-
-/**
- * A built-in type of dashboard that contains all insights from all settings level
- * like organizations level and personal settings.
- */
-export const ALL_INSIGHTS_DASHBOARD: InsightBuiltInDashboard = {
-    title: 'All',
-    type: InsightsDashboardType.All,
+export interface InsightDashboardOwner {
+    id: string
+    name: string
 }
 
 /**

--- a/client/web/src/insights/core/types/dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard.ts
@@ -5,26 +5,26 @@ import { InsightDashboard as InsightDashboardConfiguration } from '../../../sche
  */
 export enum InsightsDashboardType {
     /**
-     * A dashboard that includes all insights from the personal and organization
+     * Dashboard that includes all insights from the personal and organization
      * level dashboards.
      */
     All = 'all',
 
     /**
-     * A dashboard that includes insights from personal settings or from
+     * Dashboard that includes insights from personal settings or from
      * dashboards that are stored in personal settings (personal dashboard)
      */
     Personal = 'personal',
 
     /**
-     * A dashboard that includes insights from organization settings or from
+     * Dashboard that includes insights from organization settings or from
      * dashboards that are stored in organization settings (org dashboard)
      */
     Organization = 'organization',
 }
 
 /**
- * An extended custom insights dashboard. A user can have they own dashboards created
+ * Extended custom insights dashboard. A user can have they own dashboards created
  * by insights dashboard creation UI.
  */
 export interface InsightDashboard extends InsightDashboardConfiguration {
@@ -55,7 +55,7 @@ export interface InsightDashboard extends InsightDashboardConfiguration {
 }
 
 /**
- * An Owner of dashboard. It can be user subject (a personal dashboard), org subject
+ * Info about dashboard owner. It can be user subject (a personal dashboard), org subject
  * (an org level dashboard)
  */
 export interface InsightDashboardOwner {
@@ -64,6 +64,6 @@ export interface InsightDashboardOwner {
 }
 
 /**
- * The key for accessing  insights dashboards in the subject settings.
+ * The key for accessing insights dashboards in the subject settings.
  */
 export const INSIGHTS_DASHBOARDS_SETTINGS_KEY = 'insights.dashboards'

--- a/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
@@ -16,6 +16,7 @@ import { CodeInsightsIcon, InsightsViewGrid, InsightsViewGridProps } from '../..
 import { InsightsApiContext } from '../../core/backend/api-provider'
 
 import { useDashboards } from './hooks/use-dashboards/use-dashboards'
+import { DashboardSelect } from './components/dashboard-select/DashboardSelect'
 
 export interface DashboardsPageProps
     extends Omit<InsightsViewGridProps, 'views' | 'settingsCascade'>,
@@ -77,6 +78,8 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
                 }
                 className="mb-3"
             />
+
+            <DashboardSelect />
             {views === undefined ? (
                 <div className="d-flex w-100">
                     <LoadingSpinner className="my-4" />

--- a/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
@@ -15,8 +15,8 @@ import { Settings } from '../../../schema/settings.schema'
 import { CodeInsightsIcon, InsightsViewGrid, InsightsViewGridProps } from '../../components'
 import { InsightsApiContext } from '../../core/backend/api-provider'
 
-import { useDashboards } from './hooks/use-dashboards/use-dashboards'
 import { DashboardSelect } from './components/dashboard-select/DashboardSelect'
+import { useDashboards } from './hooks/use-dashboards/use-dashboards'
 
 export interface DashboardsPageProps
     extends Omit<InsightsViewGridProps, 'views' | 'settingsCascade'>,

--- a/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/DashboardsPage.tsx
@@ -79,7 +79,7 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
                 className="mb-3"
             />
 
-            <DashboardSelect />
+            <DashboardSelect dashboards={dashboards} />
             {views === undefined ? (
                 <div className="d-flex w-100">
                     <LoadingSpinner className="my-4" />

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
@@ -1,0 +1,65 @@
+@import '~@reach/listbox/styles.css';
+
+.listbox-button {
+    display: flex;
+    width: 22.8125rem;
+    padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+    background: var(--input-bg);
+    border-radius: var(--border-radius);
+    border-color: var(--border-color);
+
+    &:focus {
+        border-color: var(--focus-outline-color);
+    }
+}
+
+.listbox-list {
+    display: block;
+    position: static;
+    width: 22.8125rem;
+    overflow: hidden;
+
+    &:focus {
+        // Reach-ui implicitly reset box-shadow to none if list element is focused
+        // to preserve visual state we have to explicitly set box shadow value to
+        // our standard --dropdown-shadow value
+        box-shadow: var(--dropdown-shadow);
+    }
+}
+
+.listbox-popover {
+    // Reset reach-ui styles for popover element.
+    outline: none !important;
+    box-shadow: none !important;
+    border: none;
+    background: none;
+}
+
+.listbox-group-label {
+    font-weight: normal;
+    font-size: 0.75rem;
+
+    border-top: 1px solid var(--border-color);
+
+    padding: 0.5rem 0.75rem 0;
+}
+
+.listbox-option {
+    display: flex;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    padding: 0.5rem 0.75rem;
+
+    & + & {
+        margin-top: -0.25rem;
+    }
+}
+
+.listbox-option-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+.listbox-badge {
+    margin-left: 0.5rem;
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
@@ -31,9 +31,7 @@
     }
 
     &__option {
-        &--simple-text {
-            padding: 0.5rem 0.75rem;
-        }
+        margin: 0.25rem 0;
 
         & + & {
             margin-top: -0.25rem;

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
@@ -46,20 +46,5 @@
 
 .listbox-option {
     display: flex;
-    text-overflow: ellipsis;
-    overflow: hidden;
     padding: 0.5rem 0.75rem;
-
-    & + & {
-        margin-top: -0.25rem;
-    }
-}
-
-.listbox-option-text {
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-
-.listbox-badge {
-    margin-left: 0.5rem;
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
@@ -1,10 +1,15 @@
 @import '~@reach/listbox/styles.css';
 
 .listbox {
+    &__button {
+        max-width: 22.75rem;
+    }
+
     &__list {
         display: block;
         position: static;
-        width: 22.8125rem;
+        max-width: 22.75rem;
+        width: 100%;
         overflow: hidden;
 
         &:focus {

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
@@ -1,50 +1,42 @@
 @import '~@reach/listbox/styles.css';
 
-.listbox-button {
-    display: flex;
-    width: 22.8125rem;
-    padding: 0.5rem 0.5rem 0.5rem 0.75rem;
-    background: var(--input-bg);
-    border-radius: var(--border-radius);
-    border-color: var(--border-color);
+.listbox {
+    &__list {
+        display: block;
+        position: static;
+        width: 22.8125rem;
+        overflow: hidden;
 
-    &:focus {
-        border-color: var(--focus-outline-color);
+        &:focus {
+            // Reach-ui implicitly reset box-shadow to none if list element is focused
+            // to preserve visual state we have to explicitly set a box shadow value to
+            // our standard --dropdown-shadow
+            box-shadow: var(--dropdown-shadow);
+        }
     }
-}
 
-.listbox-list {
-    display: block;
-    position: static;
-    width: 22.8125rem;
-    overflow: hidden;
-
-    &:focus {
-        // Reach-ui implicitly reset box-shadow to none if list element is focused
-        // to preserve visual state we have to explicitly set box shadow value to
-        // our standard --dropdown-shadow value
-        box-shadow: var(--dropdown-shadow);
+    &__popover {
+        // Reset reach-ui styles for popover element.
+        outline: none !important;
+        box-shadow: none !important;
+        border: none;
+        background: none;
     }
-}
 
-.listbox-popover {
-    // Reset reach-ui styles for popover element.
-    outline: none !important;
-    box-shadow: none !important;
-    border: none;
-    background: none;
-}
+    &__group-label {
+        font-weight: normal;
+        font-size: 0.75rem;
+        border-top: 1px solid var(--border-color);
+        padding: 0.5rem 0.75rem 0;
+    }
 
-.listbox-group-label {
-    font-weight: normal;
-    font-size: 0.75rem;
+    &__option {
+        &--simple-text {
+            padding: 0.5rem 0.75rem;
+        }
 
-    border-top: 1px solid var(--border-color);
-
-    padding: 0.5rem 0.75rem 0;
-}
-
-.listbox-option {
-    display: flex;
-    padding: 0.5rem 0.75rem;
+        & + & {
+            margin-top: -0.25rem;
+        }
+    }
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.module.scss
@@ -1,45 +1,43 @@
 @import '~@reach/listbox/styles.css';
 
-.listbox {
-    &__button {
-        max-width: 22.75rem;
+.select-button {
+    max-width: 22.75rem;
+}
+
+.list {
+    display: block;
+    position: static;
+    max-width: 22.75rem;
+    width: 100%;
+    overflow: hidden;
+
+    &:focus {
+        // Reach-ui implicitly reset box-shadow to none if list element is focused
+        // to preserve visual state we have to explicitly set a box shadow value to
+        // our standard --dropdown-shadow
+        box-shadow: var(--dropdown-shadow);
     }
+}
 
-    &__list {
-        display: block;
-        position: static;
-        max-width: 22.75rem;
-        width: 100%;
-        overflow: hidden;
+.popover {
+    // Reset reach-ui styles for popover element.
+    outline: none !important;
+    box-shadow: none !important;
+    border: none;
+    background: none;
+}
 
-        &:focus {
-            // Reach-ui implicitly reset box-shadow to none if list element is focused
-            // to preserve visual state we have to explicitly set a box shadow value to
-            // our standard --dropdown-shadow
-            box-shadow: var(--dropdown-shadow);
-        }
-    }
+.group-label {
+    font-weight: normal;
+    font-size: 0.75rem;
+    border-top: 1px solid var(--border-color);
+    padding: 0.5rem 0.75rem 0;
+}
 
-    &__popover {
-        // Reset reach-ui styles for popover element.
-        outline: none !important;
-        box-shadow: none !important;
-        border: none;
-        background: none;
-    }
+.option {
+    margin: 0.25rem 0;
 
-    &__group-label {
-        font-weight: normal;
-        font-size: 0.75rem;
-        border-top: 1px solid var(--border-color);
-        padding: 0.5rem 0.75rem 0;
-    }
-
-    &__option {
-        margin: 0.25rem 0;
-
-        & + & {
-            margin-top: -0.25rem;
-        }
+    & + & {
+        margin-top: -0.25rem;
     }
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.story.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.story.tsx
@@ -1,0 +1,82 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { WebStory } from '../../../../../components/WebStory'
+import { InsightDashboard, InsightsDashboardType } from '../../../../core/types'
+
+import { DashboardSelect } from './DashboardSelect'
+
+const { add } = storiesOf('web/insights/DashboardSelect', module)
+    .addDecorator(story => <WebStory>{() => story()}</WebStory>)
+    .addParameters({
+        chromatic: {
+            viewports: [576, 1440],
+        },
+    })
+
+const DASHBOARDS: InsightDashboard[] = [
+    {
+        type: InsightsDashboardType.Personal,
+        id: '101',
+        title: 'Personal',
+        builtIn: true,
+        insightIds: [],
+        owner: {
+            id: '101',
+            name: 'Pesonal',
+        },
+    },
+    {
+        type: InsightsDashboardType.Personal,
+        id: '102',
+        title: 'Code Insights dashboard',
+        insightIds: [],
+        owner: {
+            id: '101',
+            name: 'Pesonal',
+        },
+    },
+    {
+        type: InsightsDashboardType.Personal,
+        id: '103',
+        title: 'Experimental Insights dashboard',
+        insightIds: [],
+        owner: {
+            id: '101',
+            name: 'Pesonal',
+        },
+    },
+    {
+        type: InsightsDashboardType.Organization,
+        id: '104',
+        title: 'Sourcegraph',
+        builtIn: true,
+        insightIds: [],
+        owner: {
+            id: '104',
+            name: 'Sourcegraph',
+        },
+    },
+    {
+        type: InsightsDashboardType.Organization,
+        id: '105',
+        title: 'Loooong looo0000ong name of dashboard',
+        insightIds: [],
+        owner: {
+            id: '104',
+            name: 'Sourcegraph',
+        },
+    },
+    {
+        type: InsightsDashboardType.Organization,
+        id: '106',
+        title: 'Loooong looo0000ong name of dashboard',
+        insightIds: [],
+        owner: {
+            id: '104',
+            name: 'Extended Sourcegraph space',
+        },
+    },
+]
+
+add('DashboardSelect', () => <DashboardSelect dashboards={DASHBOARDS} />)

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -1,7 +1,7 @@
 import { ListboxGroup, ListboxGroupLabel, ListboxInput, ListboxList, ListboxPopover } from '@reach/listbox'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classnames from 'classnames'
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 
 import { InsightDashboard, InsightsDashboardType } from '../../../../core/types'
 
@@ -27,7 +27,7 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
         setSelectedDashboard(value)
     }
 
-    const organizationGroups = useMemo(() => getDashboardOrganizationsGroups(dashboards), [dashboards])
+    const organizationGroups = getDashboardOrganizationsGroups(dashboards)
 
     return (
         <div>

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -1,11 +1,4 @@
-import {
-    ListboxGroup,
-    ListboxGroupLabel,
-    ListboxInput,
-    ListboxList,
-    ListboxOption,
-    ListboxPopover,
-} from '@reach/listbox'
+import { ListboxGroup, ListboxGroupLabel, ListboxInput, ListboxList, ListboxPopover } from '@reach/listbox'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classnames from 'classnames'
 import React, { useMemo, useState } from 'react'
@@ -13,7 +6,7 @@ import React, { useMemo, useState } from 'react'
 import { InsightDashboard, InsightsDashboardType } from '../../../../core/types'
 
 import { MenuButton } from './components/menu-button/MenuButton'
-import { SelectOption } from './components/select-option/SelectOption'
+import { SelectDashboardOption, SelectOption } from './components/select-option/SelectOption'
 import styles from './DashboardSelect.module.scss'
 
 const LABEL_ID = 'insights-dashboards--select'
@@ -45,12 +38,11 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
 
                 <ListboxPopover className={classnames(styles.listboxPopover)} portal={true}>
                     <ListboxList className={classnames(styles.listboxList, 'dropdown-menu')}>
-                        <ListboxOption
-                            className={classnames(styles.listboxOption, styles.listboxOptionSimpleText)}
+                        <SelectOption
                             value={InsightsDashboardType.All}
-                        >
-                            All Insights
-                        </ListboxOption>
+                            label="All Insights"
+                            className={styles.listboxOption}
+                        />
 
                         <ListboxGroup>
                             <ListboxGroupLabel className={classnames(styles.listboxGroupLabel, 'text-muted')}>
@@ -60,7 +52,7 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
                             {dashboards
                                 .filter(dashboard => dashboard.type === InsightsDashboardType.Personal)
                                 .map(dashboard => (
-                                    <SelectOption
+                                    <SelectDashboardOption
                                         key={dashboard.id}
                                         dashboard={dashboard}
                                         className={styles.listboxOption}
@@ -75,7 +67,7 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
                                 </ListboxGroupLabel>
 
                                 {group.dashboards.map(dashboard => (
-                                    <SelectOption
+                                    <SelectDashboardOption
                                         key={dashboard.id}
                                         dashboard={dashboard}
                                         className={styles.listboxOption}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -34,7 +34,7 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
             <VisuallyHidden id={LABEL_ID}>Choose a dashboard</VisuallyHidden>
 
             <ListboxInput value={value} onChange={handleChange}>
-                <MenuButton dashboards={dashboards} />
+                <MenuButton dashboards={dashboards} className={styles.listboxButton} />
 
                 <ListboxPopover className={classnames(styles.listboxPopover)} portal={true}>
                     <ListboxList className={classnames(styles.listboxList, 'dropdown-menu')}>

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -1,0 +1,104 @@
+import {
+    ListboxOption,
+    ListboxInput,
+    ListboxButton,
+    ListboxPopover,
+    ListboxList,
+    ListboxGroup,
+    ListboxGroupLabel,
+} from '@reach/listbox'
+import { VisuallyHidden } from '@reach/visually-hidden'
+import classnames from 'classnames'
+import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
+import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
+import React, { useState } from 'react'
+
+import styles from './DashboardSelect.module.scss'
+
+const LABEL_ID = 'insights-dashboards--select'
+
+export interface DashboardSelectProps {}
+
+export const DashboardSelect: React.FunctionComponent = props => {
+    const {} = props
+
+    const [value, setValue] = useState()
+
+    const handleChange = (value: string) => {}
+
+    return (
+        <div>
+            <VisuallyHidden id={LABEL_ID}>Choose a dashboard</VisuallyHidden>
+
+            <ListboxInput value={value} onChange={handleChange}>
+                <ListboxButton className={styles.listboxButton}>
+                    {({ value, label, isExpanded }) => (
+                        <>
+                            <span>{value} </span>
+
+                            {isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+                        </>
+                    )}
+                </ListboxButton>
+
+                <ListboxPopover className={classnames(styles.listboxPopover)} portal={true}>
+                    <ListboxList className={classnames(styles.listboxList, 'dropdown-menu')}>
+                        <ListboxOption className={styles.listboxOption} value="all">
+                            All Insights
+                        </ListboxOption>
+
+                        <ListboxGroup>
+                            <ListboxGroupLabel className={classnames(styles.listboxGroupLabel, 'text-muted')}>
+                                Private
+                            </ListboxGroupLabel>
+                            <ListboxOption className={styles.listboxOption} value="vova">
+                                Vova Kulikov Insights
+                            </ListboxOption>
+                            <ListboxOption className={styles.listboxOption} value="okr">
+                                OKRs 2022
+                            </ListboxOption>
+                        </ListboxGroup>
+
+                        <ListboxGroup>
+                            <ListboxGroupLabel className={classnames(styles.listboxGroupLabel, 'text-muted')}>
+                                Org 1
+                            </ListboxGroupLabel>
+                            <ListboxOption className={styles.listboxOption} value="org1">
+                                Org 1 Insights
+                            </ListboxOption>
+                            <ListboxOption className={styles.listboxOption} value="migration">
+                                Migrations
+                            </ListboxOption>
+                        </ListboxGroup>
+
+                        <ListboxGroup>
+                            <ListboxGroupLabel className={classnames(styles.listboxGroupLabel, 'text-muted')}>
+                                Sourcegraph
+                            </ListboxGroupLabel>
+                            <ListboxOption className={styles.listboxOption} value="sg">
+                                Sourcegraph Insights
+                                <span className={classnames('badge badge-secondary', styles.listboxBadge)}>
+                                    Sourcegraph
+                                </span>
+                            </ListboxOption>
+                            <ListboxOption className={styles.listboxOption} value="code-search">
+                                Code Search
+                            </ListboxOption>
+                            <ListboxOption className={styles.listboxOption} value="long">
+                                <span className={styles.listboxOptionText}>
+                                    Very looooooong insight dashboard name that doesn't fit
+                                </span>
+                                <span className={classnames('badge badge-secondary', styles.listboxBadge)}>
+                                    Sourcegraph
+                                </span>
+                            </ListboxOption>
+                            <ListboxOption className={styles.listboxOption} value="ext">
+                                Extensibility
+                            </ListboxOption>
+                        </ListboxGroup>
+                    </ListboxList>
+                </ListboxPopover>
+            </ListboxInput>
+        </div>
+    )
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -25,9 +25,11 @@ export interface DashboardSelectProps {
 export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = props => {
     const { dashboards } = props
 
-    const [value, setValue] = useState()
+    const [value, setValue] = useState<string>()
 
-    const handleChange = (value: string) => {}
+    const handleChange = (value: string): void => {
+        setValue(value)
+    }
 
     const organizationGroups = useMemo(() => getDashboardOrganizationsGroups(dashboards), [dashboards])
 

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -21,10 +21,10 @@ export interface DashboardSelectProps {
 export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = props => {
     const { dashboards } = props
 
-    const [value, setValue] = useState<string>()
+    const [selectedDashboard, setSelectedDashboard] = useState<string>()
 
     const handleChange = (value: string): void => {
-        setValue(value)
+        setSelectedDashboard(value)
     }
 
     const organizationGroups = useMemo(() => getDashboardOrganizationsGroups(dashboards), [dashboards])
@@ -33,7 +33,7 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
         <div>
             <VisuallyHidden id={LABEL_ID}>Choose a dashboard</VisuallyHidden>
 
-            <ListboxInput value={value} onChange={handleChange}>
+            <ListboxInput value={selectedDashboard} onChange={handleChange}>
                 <MenuButton dashboards={dashboards} className={styles.listboxButton} />
 
                 <ListboxPopover className={classnames(styles.listboxPopover)} portal={true}>

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -34,18 +34,18 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
             <VisuallyHidden id={LABEL_ID}>Choose a dashboard</VisuallyHidden>
 
             <ListboxInput value={selectedDashboard} onChange={handleChange}>
-                <MenuButton dashboards={dashboards} className={styles.listboxButton} />
+                <MenuButton dashboards={dashboards} className={styles.selectButton} />
 
-                <ListboxPopover className={classnames(styles.listboxPopover)} portal={true}>
-                    <ListboxList className={classnames(styles.listboxList, 'dropdown-menu')}>
+                <ListboxPopover className={classnames(styles.popover)} portal={true}>
+                    <ListboxList className={classnames(styles.list, 'dropdown-menu')}>
                         <SelectOption
                             value={InsightsDashboardType.All}
                             label="All Insights"
-                            className={styles.listboxOption}
+                            className={styles.option}
                         />
 
                         <ListboxGroup>
-                            <ListboxGroupLabel className={classnames(styles.listboxGroupLabel, 'text-muted')}>
+                            <ListboxGroupLabel className={classnames(styles.groupLabel, 'text-muted')}>
                                 Private
                             </ListboxGroupLabel>
 
@@ -55,14 +55,14 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
                                     <SelectDashboardOption
                                         key={dashboard.id}
                                         dashboard={dashboard}
-                                        className={styles.listboxOption}
+                                        className={styles.option}
                                     />
                                 ))}
                         </ListboxGroup>
 
                         {organizationGroups.map(group => (
                             <ListboxGroup key={group.id}>
-                                <ListboxGroupLabel className={classnames(styles.listboxGroupLabel, 'text-muted')}>
+                                <ListboxGroupLabel className={classnames(styles.groupLabel, 'text-muted')}>
                                     {group.name}
                                 </ListboxGroupLabel>
 
@@ -70,7 +70,7 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
                                     <SelectDashboardOption
                                         key={dashboard.id}
                                         dashboard={dashboard}
-                                        className={styles.listboxOption}
+                                        className={styles.option}
                                     />
                                 ))}
                             </ListboxGroup>

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/DashboardSelect.tsx
@@ -22,6 +22,9 @@ export interface DashboardSelectProps {
     dashboards: InsightDashboard[]
 }
 
+/**
+ * Renders dashboard select component for code insights dashboard page selection UI.
+ */
 export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = props => {
     const { dashboards } = props
 
@@ -42,7 +45,10 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
 
                 <ListboxPopover className={classnames(styles.listboxPopover)} portal={true}>
                     <ListboxList className={classnames(styles.listboxList, 'dropdown-menu')}>
-                        <ListboxOption className={styles.listboxOption} value={InsightsDashboardType.All}>
+                        <ListboxOption
+                            className={classnames(styles.listboxOption, styles.listboxOptionSimpleText)}
+                            value={InsightsDashboardType.All}
+                        >
                             All Insights
                         </ListboxOption>
 
@@ -54,7 +60,11 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
                             {dashboards
                                 .filter(dashboard => dashboard.type === InsightsDashboardType.Personal)
                                 .map(dashboard => (
-                                    <SelectOption key={dashboard.id} dashboard={dashboard} />
+                                    <SelectOption
+                                        key={dashboard.id}
+                                        dashboard={dashboard}
+                                        className={styles.listboxOption}
+                                    />
                                 ))}
                         </ListboxGroup>
 
@@ -65,7 +75,11 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
                                 </ListboxGroupLabel>
 
                                 {group.dashboards.map(dashboard => (
-                                    <SelectOption key={dashboard.id} dashboard={dashboard} />
+                                    <SelectOption
+                                        key={dashboard.id}
+                                        dashboard={dashboard}
+                                        className={styles.listboxOption}
+                                    />
                                 ))}
                             </ListboxGroup>
                         ))}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/badge/Badge.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/badge/Badge.tsx
@@ -1,0 +1,15 @@
+import classnames from 'classnames'
+import React from 'react'
+
+import { TruncatedText } from '../trancated-text/TrancatedText'
+
+interface BadgeProps {
+    value: string
+    className?: string
+}
+
+export const Badge: React.FunctionComponent<BadgeProps> = props => {
+    const { value, className } = props
+
+    return <TruncatedText className={classnames('badge badge-secondary', className)}>{value}</TruncatedText>
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/badge/Badge.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/badge/Badge.tsx
@@ -11,5 +11,9 @@ interface BadgeProps {
 export const Badge: React.FunctionComponent<BadgeProps> = props => {
     const { value, className } = props
 
-    return <TruncatedText className={classnames('badge badge-secondary', className)}>{value}</TruncatedText>
+    return (
+        <TruncatedText title={value} className={classnames('badge badge-secondary', className)}>
+            {value}
+        </TruncatedText>
+    )
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
@@ -4,7 +4,6 @@
     &[data-reach-listbox-button] {
         display: flex;
         justify-content: flex-start;
-        width: 22.8125rem;
         cursor: pointer;
         padding: 0.25rem 0.5rem 0.25rem 0.75rem;
         background: var(--input-bg);

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
@@ -1,0 +1,42 @@
+/*
+ A special selector to increase the specificity in order to override reach ui styles
+ for list-box button element.
+*/
+.listbox-button[data-reach-listbox-button] {
+    display: flex;
+    justify-content: flex-start;
+    width: 22.8125rem;
+    padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+    background: var(--input-bg);
+    border-radius: var(--border-radius);
+    /* Reset reach ui border value */
+    border: 1px solid var(--border-color);
+
+    &:focus {
+        border-color: var(--focus-outline-color);
+    }
+}
+
+.listbox-button-text {
+    display: flex;
+    align-items: baseline;
+
+    /*
+        Without min-width with value, the flex child containing the other text elements
+        won’t narrow past the “implied width” of those text elements.
+
+        More info (https://css-tricks.com/flexbox-truncated-text/)
+    */
+    min-width: 0;
+    white-space: nowrap;
+}
+
+.listbox-button-badge {
+    max-width: 8rem;
+    flex-shrink: 0;
+}
+
+.listbox-button-icon {
+    color: var(--color-bg-6);
+    margin-left: auto;
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
@@ -1,42 +1,44 @@
-/*
- A special selector to increase the specificity in order to override reach ui styles
- for list-box button element.
-*/
-.listbox-button[data-reach-listbox-button] {
-    display: flex;
-    justify-content: flex-start;
-    width: 22.8125rem;
-    padding: 0.25rem 0.5rem 0.25rem 0.75rem;
-    background: var(--input-bg);
-    border-radius: var(--border-radius);
-    /* Reset reach ui border value */
-    border: 1px solid var(--border-color);
+.listbox-button {
+    // A special selector to increase the specificity in order to override reach ui styles
+    // for the list-box button element.
+    &[data-reach-listbox-button] {
+        display: flex;
+        justify-content: flex-start;
+        width: 22.8125rem;
+        cursor: pointer;
+        padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+        background: var(--input-bg);
+        border-radius: var(--border-radius);
 
-    &:focus {
-        border-color: var(--focus-outline-color);
+        /* Reset reach ui border value */
+        border: 1px solid var(--border-color);
+
+        &:focus {
+            border-color: var(--focus-outline-color);
+        }
     }
-}
 
-.listbox-button-text {
-    display: flex;
-    align-items: baseline;
+    &__text {
+        display: flex;
+        align-items: baseline;
 
-    /*
-        Without min-width with value, the flex child containing the other text elements
-        won’t narrow past the “implied width” of those text elements.
+        /*
+            Without min-width with value, the flex child containing the other text elements
+            won’t narrow past the “implied width” of those text elements.
 
-        More info (https://css-tricks.com/flexbox-truncated-text/)
-    */
-    min-width: 0;
-    white-space: nowrap;
-}
+            More info (https://css-tricks.com/flexbox-truncated-text/)
+        */
+        min-width: 0;
+        white-space: nowrap;
+    }
 
-.listbox-button-badge {
-    max-width: 8rem;
-    flex-shrink: 0;
-}
+    &__badge {
+        max-width: 8rem;
+        flex-shrink: 0;
+    }
 
-.listbox-button-icon {
-    color: var(--color-bg-6);
-    margin-left: auto;
+    &__icon {
+        color: var(--color-bg-6);
+        margin-left: auto;
+    }
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
@@ -1,43 +1,41 @@
-.listbox-button {
-    // A special selector to increase the specificity in order to override reach ui styles
-    // for the list-box button element.
-    &[data-reach-listbox-button] {
-        display: flex;
-        justify-content: flex-start;
-        cursor: pointer;
-        padding: 0.25rem 0.5rem 0.25rem 0.75rem;
-        background: var(--input-bg);
-        border-radius: var(--border-radius);
+// Special reach-ui selector to increase the specificity in order to override reach ui styles
+// for the list-box button element.
+.button[data-reach-listbox-button] {
+    display: flex;
+    justify-content: flex-start;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+    background: var(--input-bg);
+    border-radius: var(--border-radius);
 
-        /* Reset reach ui border value */
-        border: 1px solid var(--border-color);
+    /* Reset reach ui border value */
+    border: 1px solid var(--border-color);
 
-        &:focus {
-            border-color: var(--focus-outline-color);
-        }
+    &:focus {
+        border-color: var(--focus-outline-color);
     }
+}
 
-    &__text {
-        display: flex;
-        align-items: baseline;
+.text {
+    display: flex;
+    align-items: baseline;
 
-        /*
-            Without min-width with value, the flex child containing the other text elements
-            won’t narrow past the “implied width” of those text elements.
+    /*
+        Without min-width with value, the flex child containing the other text elements
+        won’t narrow past the “implied width” of those text elements.
 
-            More info (https://css-tricks.com/flexbox-truncated-text/)
-        */
-        min-width: 0;
-        white-space: nowrap;
-    }
+        More info (https://css-tricks.com/flexbox-truncated-text/)
+    */
+    min-width: 0;
+    white-space: nowrap;
+}
 
-    &__badge {
-        max-width: 8rem;
-        flex-shrink: 0;
-    }
+.badge {
+    max-width: 8rem;
+    flex-shrink: 0;
+}
 
-    &__icon {
-        color: var(--color-bg-6);
-        margin-left: auto;
-    }
+.expanded-icon {
+    color: var(--color-bg-6);
+    margin-left: auto;
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.module.scss
@@ -31,6 +31,7 @@
 }
 
 .badge {
+    // This badge max-width value should be synced with select option badge max-width
     max-width: 8rem;
     flex-shrink: 0;
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -55,6 +55,7 @@ interface MenuButtonContentProps {
 
 const MenuButtonContent: React.FunctionComponent<MenuButtonContentProps> = props => {
     const { title, isExpanded, badge } = props
+    const ListboxButtonIcon = isExpanded ? ChevronUpIcon : ChevronDownIcon
 
     return (
         <>
@@ -63,11 +64,7 @@ const MenuButtonContent: React.FunctionComponent<MenuButtonContentProps> = props
                 {badge && <Badge value={badge} className={classnames('ml-1 mr-1', styles.listboxButtonBadge)} />}
             </span>
 
-            {isExpanded ? (
-                <ChevronUpIcon className={styles.listboxButtonIcon} />
-            ) : (
-                <ChevronDownIcon className={styles.listboxButtonIcon} />
-            )}
+            <ListboxButtonIcon className={styles.listboxButtonIcon} />
         </>
     )
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -58,13 +58,15 @@ const MenuButtonContent: React.FunctionComponent<MenuButtonContentProps> = props
     return (
         <>
             <span className={styles.listboxButtonText}>
-                <TruncatedText>{title}</TruncatedText>
+                <TruncatedText title={title}>{title}</TruncatedText>
                 {badge && <Badge value={badge} className={classnames('ml-1 mr-1', styles.listboxButtonBadge)} />}
             </span>
 
-            {isExpanded
-                ? <ChevronUpIcon className={styles.listboxButtonIcon} />
-                : <ChevronDownIcon className={styles.listboxButtonIcon}  />}
+            {isExpanded ? (
+                <ChevronUpIcon className={styles.listboxButtonIcon} />
+            ) : (
+                <ChevronDownIcon className={styles.listboxButtonIcon} />
+            )}
         </>
     )
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -1,0 +1,70 @@
+import { ListboxButton } from '@reach/listbox'
+import classnames from 'classnames'
+import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
+import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
+import React from 'react'
+
+import { InsightDashboard, InsightsDashboardType } from '../../../../../../core/types'
+import { getDashboardOwnerName, getDashboardTitle } from '../../helpers/get-dashboard-title'
+import { Badge } from '../badge/Badge'
+import { TruncatedText } from '../trancated-text/TrancatedText'
+
+import styles from './MenuButton.module.scss'
+
+interface MenuButtonProps {
+    dashboards: InsightDashboard[]
+}
+
+/**
+ * Renders ListBox menu button for dashboard select component.
+ */
+export const MenuButton: React.FunctionComponent<MenuButtonProps> = props => {
+    const { dashboards } = props
+
+    return (
+        <ListboxButton className={styles.listboxButton}>
+            {({ value, isExpanded }) => {
+                if (value === InsightsDashboardType.All) {
+                    return <MenuButtonContent title="All Insights" isExpanded={isExpanded} />
+                }
+
+                const dashboard = dashboards.find(dashboard => dashboard.id === value)
+
+                if (!dashboard) {
+                    return <MenuButtonContent title="Unknown value" isExpanded={isExpanded} />
+                }
+
+                return (
+                    <MenuButtonContent
+                        title={getDashboardTitle(dashboard)}
+                        badge={getDashboardOwnerName(dashboard)}
+                        isExpanded={isExpanded}
+                    />
+                )
+            }}
+        </ListboxButton>
+    )
+}
+
+interface MenuButtonContentProps {
+    title: string
+    isExpanded: boolean
+    badge?: string
+}
+
+const MenuButtonContent: React.FunctionComponent<MenuButtonContentProps> = props => {
+    const { title, isExpanded, badge } = props
+
+    return (
+        <>
+            <span className={styles.listboxButtonText}>
+                <TruncatedText>{title}</TruncatedText>
+                {badge && <Badge value={badge} className={classnames('ml-1 mr-1', styles.listboxButtonBadge)} />}
+            </span>
+
+            {isExpanded
+                ? <ChevronUpIcon className={styles.listboxButtonIcon} />
+                : <ChevronDownIcon className={styles.listboxButtonIcon}  />}
+        </>
+    )
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -23,7 +23,7 @@ export const MenuButton: React.FunctionComponent<MenuButtonProps> = props => {
     const { dashboards, className } = props
 
     return (
-        <ListboxButton className={classnames(styles.listboxButton, className)}>
+        <ListboxButton className={classnames(styles.button, className)}>
             {({ value, isExpanded }) => {
                 if (value === InsightsDashboardType.All) {
                     return <MenuButtonContent title="All Insights" isExpanded={isExpanded} />
@@ -59,12 +59,12 @@ const MenuButtonContent: React.FunctionComponent<MenuButtonContentProps> = props
 
     return (
         <>
-            <span className={styles.listboxButtonText}>
+            <span className={styles.text}>
                 <TruncatedText title={title}>{title}</TruncatedText>
-                {badge && <Badge value={badge} className={classnames('ml-1 mr-1', styles.listboxButtonBadge)} />}
+                {badge && <Badge value={badge} className={classnames('ml-1 mr-1', styles.badge)} />}
             </span>
 
-            <ListboxButtonIcon className={styles.listboxButtonIcon} />
+            <ListboxButtonIcon className={styles.expandedIcon} />
         </>
     )
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -13,16 +13,17 @@ import styles from './MenuButton.module.scss'
 
 interface MenuButtonProps {
     dashboards: InsightDashboard[]
+    className?: string
 }
 
 /**
  * Renders ListBox menu button for dashboard select component.
  */
 export const MenuButton: React.FunctionComponent<MenuButtonProps> = props => {
-    const { dashboards } = props
+    const { dashboards, className } = props
 
     return (
-        <ListboxButton className={styles.listboxButton}>
+        <ListboxButton className={classnames(styles.listboxButton, className)}>
             {({ value, isExpanded }) => {
                 if (value === InsightsDashboardType.All) {
                     return <MenuButtonContent title="All Insights" isExpanded={isExpanded} />

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
@@ -1,30 +1,28 @@
-.listbox-option {
-    // A special selector to increase the specificity in order to override reach ui styles
-    // for the list-box button element.
-    &[data-reach-listbox-option] {
-        display: flex;
-        align-items: baseline;
-        padding: 0.25rem 0.75rem;
-        justify-content: space-between;
-        cursor: pointer;
+// A special selector to increase the specificity in order to override reach ui styles
+// for the list-box button element.
+.option[data-reach-listbox-option] {
+    display: flex;
+    align-items: baseline;
+    padding: 0.25rem 0.75rem;
+    justify-content: space-between;
+    cursor: pointer;
 
-        &[data-current] {
-            font-weight: normal;
-            background-color: var(--color-bg-2);
-        }
-
-        &[aria-selected] {
-            background-color: var(--link-color);
-            color: var(--light-text);
-        }
+    &[data-current] {
+        font-weight: normal;
+        background-color: var(--color-bg-2);
     }
 
-    &__text {
-        padding-right: 0.5rem;
+    &[aria-selected] {
+        background-color: var(--link-color);
+        color: var(--light-text);
     }
+}
 
-    &__badge {
-        max-width: 8rem;
-        flex-shrink: 0;
-    }
+.text {
+    padding-right: 0.5rem;
+}
+
+.badge {
+    max-width: 8rem;
+    flex-shrink: 0;
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
@@ -4,9 +4,19 @@
     &[data-reach-listbox-option] {
         display: flex;
         align-items: baseline;
-        padding: 0.5rem 0.75rem;
+        padding: 0.25rem 0.75rem;
         justify-content: space-between;
         cursor: pointer;
+
+        &[data-current] {
+            font-weight: normal;
+            background-color: var(--color-bg-2);
+        }
+
+        &[aria-selected] {
+            background-color: var(--link-color);
+            color: var(--light-text);
+        }
     }
 
     &__text {

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
@@ -1,0 +1,18 @@
+.listbox-option {
+    display: flex;
+    padding: 0.5rem 0.75rem;
+    justify-content: space-between;
+
+    & + & {
+        margin-top: -0.25rem;
+    }
+}
+
+.listbox-option-text {
+    padding-right: 0.5rem;
+}
+
+.listbox-option-badge {
+    max-width: 8rem;
+    flex-shrink: 0;
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
@@ -1,19 +1,20 @@
-.listbox-option[data-reach-listbox-option] {
-    display: flex;
-    align-items: baseline;
-    padding: 0.5rem 0.75rem;
-    justify-content: space-between;
-
-    & + & {
-        margin-top: -0.25rem;
+.listbox-option {
+    // A special selector to increase the specificity in order to override reach ui styles
+    // for the list-box button element.
+    &[data-reach-listbox-option] {
+        display: flex;
+        align-items: baseline;
+        padding: 0.5rem 0.75rem;
+        justify-content: space-between;
+        cursor: pointer;
     }
-}
 
-.listbox-option-text {
-    padding-right: 0.5rem;
-}
+    &__text {
+        padding-right: 0.5rem;
+    }
 
-.listbox-option-badge {
-    max-width: 8rem;
-    flex-shrink: 0;
+    &__badge {
+        max-width: 8rem;
+        flex-shrink: 0;
+    }
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
@@ -23,6 +23,7 @@
 }
 
 .badge {
+    // This badge max-width value should be synced with menu button badge max-width
     max-width: 8rem;
     flex-shrink: 0;
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.module.scss
@@ -1,5 +1,6 @@
-.listbox-option {
+.listbox-option[data-reach-listbox-option] {
     display: flex;
+    align-items: baseline;
     padding: 0.5rem 0.75rem;
     justify-content: space-between;
 

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
@@ -29,11 +29,11 @@ export const SelectOption: React.FunctionComponent<SelectOptionProps> = props =>
     const { value, label, badge, className } = props
 
     return (
-        <ListboxOption className={classnames(styles.listboxOption, className)} value={value}>
-            <TruncatedText title={label} className={styles.listboxOptionText}>
+        <ListboxOption className={classnames(styles.option, className)} value={value}>
+            <TruncatedText title={label} className={styles.text}>
                 {label}
             </TruncatedText>
-            {badge && <Badge value={badge} className={styles.listboxOptionBadge} />}
+            {badge && <Badge value={badge} className={styles.badge} />}
         </ListboxOption>
     )
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
@@ -1,0 +1,24 @@
+import { ListboxOption } from '@reach/listbox'
+import React from 'react'
+
+import { InsightDashboard } from '../../../../../../core/types'
+import { getDashboardOwnerName, getDashboardTitle } from '../../helpers/get-dashboard-title'
+import { Badge } from '../badge/Badge'
+import { TruncatedText } from '../trancated-text/TrancatedText'
+
+import styles from './SelectOption.module.scss'
+
+interface SelectOptionProps {
+    dashboard: InsightDashboard
+}
+
+export const SelectOption: React.FunctionComponent<SelectOptionProps> = props => {
+    const { dashboard } = props
+
+    return (
+        <ListboxOption className={styles.listboxOption} value={dashboard.id}>
+            <TruncatedText className={styles.listboxOptionText}>{getDashboardTitle(dashboard)}</TruncatedText>
+            <Badge value={getDashboardOwnerName(dashboard)} className={styles.listboxOptionBadge} />
+        </ListboxOption>
+    )
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
@@ -1,4 +1,5 @@
 import { ListboxOption } from '@reach/listbox'
+import classnames from 'classnames'
 import React from 'react'
 
 import { InsightDashboard } from '../../../../../../core/types'
@@ -10,14 +11,19 @@ import styles from './SelectOption.module.scss'
 
 interface SelectOptionProps {
     dashboard: InsightDashboard
+    className?: string
 }
 
 export const SelectOption: React.FunctionComponent<SelectOptionProps> = props => {
-    const { dashboard } = props
+    const { dashboard, className } = props
+
+    const optionText = getDashboardTitle(dashboard)
 
     return (
-        <ListboxOption className={styles.listboxOption} value={dashboard.id}>
-            <TruncatedText className={styles.listboxOptionText}>{getDashboardTitle(dashboard)}</TruncatedText>
+        <ListboxOption className={classnames(styles.listboxOption, className)} value={dashboard.id}>
+            <TruncatedText title={optionText} className={styles.listboxOptionText}>
+                {optionText}
+            </TruncatedText>
             <Badge value={getDashboardOwnerName(dashboard)} className={styles.listboxOptionBadge} />
         </ListboxOption>
     )

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/select-option/SelectOption.tsx
@@ -9,22 +9,52 @@ import { TruncatedText } from '../trancated-text/TrancatedText'
 
 import styles from './SelectOption.module.scss'
 
-interface SelectOptionProps {
+export interface SelectOptionProps {
+    /** Value for the list-option element */
+    value: string
+
+    /** List-box label text */
+    label: string
+
+    /** Badge text */
+    badge?: string
+
+    className?: string
+}
+
+/**
+ * Displays simple text (label) list select (list-box) option.
+ */
+export const SelectOption: React.FunctionComponent<SelectOptionProps> = props => {
+    const { value, label, badge, className } = props
+
+    return (
+        <ListboxOption className={classnames(styles.listboxOption, className)} value={value}>
+            <TruncatedText title={label} className={styles.listboxOptionText}>
+                {label}
+            </TruncatedText>
+            {badge && <Badge value={badge} className={styles.listboxOptionBadge} />}
+        </ListboxOption>
+    )
+}
+
+interface SelectDashboardOptionProps {
     dashboard: InsightDashboard
     className?: string
 }
 
-export const SelectOption: React.FunctionComponent<SelectOptionProps> = props => {
+/**
+ * Displays select dashboard list-box options.
+ */
+export const SelectDashboardOption: React.FunctionComponent<SelectDashboardOptionProps> = props => {
     const { dashboard, className } = props
 
-    const optionText = getDashboardTitle(dashboard)
-
     return (
-        <ListboxOption className={classnames(styles.listboxOption, className)} value={dashboard.id}>
-            <TruncatedText title={optionText} className={styles.listboxOptionText}>
-                {optionText}
-            </TruncatedText>
-            <Badge value={getDashboardOwnerName(dashboard)} className={styles.listboxOptionBadge} />
-        </ListboxOption>
+        <SelectOption
+            value={dashboard.id}
+            label={getDashboardTitle(dashboard)}
+            badge={getDashboardOwnerName(dashboard)}
+            className={className}
+        />
     )
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/trancated-text/TrancatedText.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/trancated-text/TrancatedText.tsx
@@ -3,8 +3,10 @@ import React, { PropsWithChildren } from 'react'
 
 import styles from './TruncatedText.module.scss'
 
-export const TruncatedText: React.FunctionComponent<PropsWithChildren<{ className?: string }>> = props => {
-    const { children, className } = props
+export const TruncatedText: React.FunctionComponent<
+    PropsWithChildren<React.HTMLAttributes<HTMLSpanElement>>
+> = props => {
+    const { className, ...otherProps } = props
 
-    return <span className={classnames(className, styles.truncatedText)}>{children}</span>
+    return <span className={classnames(className, styles.truncatedText)} {...otherProps} />
 }

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/trancated-text/TrancatedText.tsx
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/trancated-text/TrancatedText.tsx
@@ -1,0 +1,10 @@
+import classnames from 'classnames'
+import React, { PropsWithChildren } from 'react'
+
+import styles from './TruncatedText.module.scss'
+
+export const TruncatedText: React.FunctionComponent<PropsWithChildren<{ className?: string }>> = props => {
+    const { children, className } = props
+
+    return <span className={classnames(className, styles.truncatedText)}>{children}</span>
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/components/trancated-text/TruncatedText.module.scss
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/components/trancated-text/TruncatedText.module.scss
@@ -1,0 +1,4 @@
+.truncated-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+}

--- a/client/web/src/insights/pages/dashboards/components/dashboard-select/helpers/get-dashboard-title.ts
+++ b/client/web/src/insights/pages/dashboards/components/dashboard-select/helpers/get-dashboard-title.ts
@@ -1,0 +1,27 @@
+import { InsightDashboard, InsightsDashboardType } from '../../../../../core/types'
+
+/**
+ * Get formatted dashboard title for the dashboard select option.
+ */
+export const getDashboardTitle = (dashboard: InsightDashboard): string => {
+    const { builtIn } = dashboard
+
+    if (builtIn) {
+        return `${dashboard.owner.name} Insights`
+    }
+
+    return dashboard.title
+}
+
+/**
+ * Get formatted dashboard owner name. Used for list option badge element.
+ */
+export const getDashboardOwnerName = (dashboard: InsightDashboard): string => {
+    const { type } = dashboard
+
+    if (type === InsightsDashboardType.Personal) {
+        return 'Private'
+    }
+
+    return dashboard.owner.name
+}

--- a/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
+++ b/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
@@ -1,4 +1,4 @@
-import { ALL_INSIGHTS_DASHBOARD } from '../../../../core/types'
+import { ALL_INSIGHTS_DASHBOARD, InsightsDashboardType } from '../../../../core/types'
 
 import { getInsightsDashboards } from './use-dashboards'
 
@@ -16,6 +16,27 @@ describe('getInsightsDashboards', () => {
                             __typename: 'User',
                             id: '101',
                             username: 'emirkusturica',
+                            displayName: 'Emir Kusturica',
+                            viewerCanAdminister: true,
+                        },
+                        settings: new Error(),
+                        lastID: null,
+                    },
+                ])
+            ).toStrictEqual([
+                // Even with empty or errored value of user settings we still have
+                // generic built in insights dashboard - "All"
+                ALL_INSIGHTS_DASHBOARD,
+            ])
+        })
+
+        test('with unsupported types of settings cascade subject', () => {
+            expect(
+                getInsightsDashboards([
+                    {
+                        subject: {
+                            __typename: 'Client',
+                            id: '101',
                             displayName: 'Emir Kusturica',
                             viewerCanAdminister: true,
                         },
@@ -61,7 +82,7 @@ describe('getInsightsDashboards', () => {
             ).toStrictEqual([
                 ALL_INSIGHTS_DASHBOARD,
                 {
-                    type: 'built-in',
+                    type: InsightsDashboardType.Organization,
                     insightIds: [],
                     owner: {
                         id: '102',
@@ -69,7 +90,7 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: 'built-in',
+                    type: InsightsDashboardType.Personal,
                     insightIds: [],
                     owner: {
                         id: '101',
@@ -110,7 +131,7 @@ describe('getInsightsDashboards', () => {
             ).toStrictEqual([
                 ALL_INSIGHTS_DASHBOARD,
                 {
-                    type: 'built-in',
+                    type: InsightsDashboardType.Personal,
                     insightIds: [],
                     owner: {
                         id: '101',
@@ -118,7 +139,7 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: 'custom',
+                    type: InsightsDashboardType.Personal,
                     id: '001',
                     title: 'Test Dashboard',
                     insightIds: ['insightID1', 'insightID2'],
@@ -128,7 +149,7 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: 'custom',
+                    type: InsightsDashboardType.Personal,
                     id: '002',
                     title: 'Another Test Dashboard',
                     insightIds: ['insightID3', 'insightID4'],
@@ -185,7 +206,7 @@ describe('getInsightsDashboards', () => {
             ).toStrictEqual([
                 ALL_INSIGHTS_DASHBOARD,
                 {
-                    type: 'built-in',
+                    type: InsightsDashboardType.Organization,
                     insightIds: [],
                     owner: {
                         id: '102',
@@ -193,15 +214,7 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: 'built-in',
-                    insightIds: [],
-                    owner: {
-                        id: '101',
-                        name: 'Emir Kusturica',
-                    },
-                },
-                {
-                    type: 'custom',
+                    type: InsightsDashboardType.Organization,
                     id: '001',
                     title: 'Test Dashboard',
                     insightIds: ['insightID1', 'insightID2'],
@@ -211,7 +224,15 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: 'custom',
+                    type: InsightsDashboardType.Personal,
+                    insightIds: [],
+                    owner: {
+                        id: '101',
+                        name: 'Emir Kusturica',
+                    },
+                },
+                {
+                    type: InsightsDashboardType.Personal,
                     id: '002',
                     title: 'Another Test Dashboard',
                     insightIds: ['insightID3', 'insightID4'],

--- a/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
+++ b/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboard.test.ts
@@ -1,4 +1,4 @@
-import { ALL_INSIGHTS_DASHBOARD, InsightsDashboardType } from '../../../../core/types'
+import { InsightsDashboardType } from '../../../../core/types'
 
 import { getInsightsDashboards } from './use-dashboards'
 
@@ -23,11 +23,7 @@ describe('getInsightsDashboards', () => {
                         lastID: null,
                     },
                 ])
-            ).toStrictEqual([
-                // Even with empty or errored value of user settings we still have
-                // generic built in insights dashboard - "All"
-                ALL_INSIGHTS_DASHBOARD,
-            ])
+            ).toStrictEqual([])
         })
 
         test('with unsupported types of settings cascade subject', () => {
@@ -44,11 +40,7 @@ describe('getInsightsDashboards', () => {
                         lastID: null,
                     },
                 ])
-            ).toStrictEqual([
-                // Even with empty or errored value of user settings we still have
-                // generic built in insights dashboard - "All"
-                ALL_INSIGHTS_DASHBOARD,
-            ])
+            ).toStrictEqual([])
         })
     })
 
@@ -80,9 +72,11 @@ describe('getInsightsDashboards', () => {
                     },
                 ])
             ).toStrictEqual([
-                ALL_INSIGHTS_DASHBOARD,
                 {
                     type: InsightsDashboardType.Organization,
+                    builtIn: true,
+                    id: '102',
+                    title: 'Sourcegraph',
                     insightIds: [],
                     owner: {
                         id: '102',
@@ -91,6 +85,9 @@ describe('getInsightsDashboards', () => {
                 },
                 {
                     type: InsightsDashboardType.Personal,
+                    builtIn: true,
+                    title: 'Emir Kusturica',
+                    id: '101',
                     insightIds: [],
                     owner: {
                         id: '101',
@@ -129,9 +126,11 @@ describe('getInsightsDashboards', () => {
                     },
                 ])
             ).toStrictEqual([
-                ALL_INSIGHTS_DASHBOARD,
                 {
                     type: InsightsDashboardType.Personal,
+                    title: 'Emir Kusturica',
+                    builtIn: true,
+                    id: '101',
                     insightIds: [],
                     owner: {
                         id: '101',
@@ -204,9 +203,11 @@ describe('getInsightsDashboards', () => {
                     },
                 ])
             ).toStrictEqual([
-                ALL_INSIGHTS_DASHBOARD,
                 {
                     type: InsightsDashboardType.Organization,
+                    builtIn: true,
+                    id: '102',
+                    title: 'Sourcegraph',
                     insightIds: [],
                     owner: {
                         id: '102',
@@ -225,6 +226,9 @@ describe('getInsightsDashboards', () => {
                 },
                 {
                     type: InsightsDashboardType.Personal,
+                    id: '101',
+                    title: 'Emir Kusturica',
+                    builtIn: true,
                     insightIds: [],
                     owner: {
                         id: '101',

--- a/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboards.ts
+++ b/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboards.ts
@@ -11,9 +11,6 @@ import { isDefined } from '@sourcegraph/shared/src/util/types'
 
 import { Settings } from '../../../../../schema/settings.schema'
 import {
-    ALL_INSIGHTS_DASHBOARD,
-    InsightBuiltInDashboard,
-    InsightCustomDashboard,
     InsightDashboard,
     InsightDashboardOwner,
     INSIGHTS_DASHBOARDS_SETTINGS_KEY,
@@ -47,16 +44,6 @@ export function getInsightsDashboards(subjects: ConfiguredSubjectOrError<Setting
         return []
     }
 
-    return [ALL_INSIGHTS_DASHBOARD, ...getSubjectsDashboards(subjects)]
-}
-
-/**
- * Returns all reachable insights dashboards from all available subjects
- * Basically we have insights only in organization based subject or personal subject
- *
- * @param subjects - array of all subject from settings cascade
- */
-function getSubjectsDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): InsightDashboard[] {
     return subjects.flatMap(configuredSubject => {
         const { settings, subject } = configuredSubject
 
@@ -75,15 +62,18 @@ function getSubjectsDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): 
 function getSubjectDashboards(subject: SupportedSubject, settings: Settings): InsightDashboard[] {
     const { dashboardType, ...owner } = getDashboardOwnerInfo(subject)
 
-    const subjectBuiltInDashboard: InsightBuiltInDashboard = {
+    const subjectBuiltInDashboard: InsightDashboard = {
         owner,
+        id: owner.id,
+        builtIn: true,
+        title: owner.name,
         type: dashboardType,
         insightIds: Object.keys(settings).filter(isInsightSettingKey),
     }
 
     // Find all personal insights dashboards
     const subjectDashboards = Object.keys(settings[INSIGHTS_DASHBOARDS_SETTINGS_KEY] ?? {})
-        .map<InsightCustomDashboard | undefined>(dashboardKey => {
+        .map<InsightDashboard | undefined>(dashboardKey => {
             // Select dashboard configuration from the subject settings
             const dashboardSettings = settings[INSIGHTS_DASHBOARDS_SETTINGS_KEY]?.[dashboardKey]
 

--- a/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboards.ts
+++ b/client/web/src/insights/pages/dashboards/hooks/use-dashboards/use-dashboards.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { IOrg, IUser } from '@sourcegraph/shared/src/graphql/schema'
 import {
     ConfiguredSubjectOrError,
     SettingsCascadeOrError,
@@ -10,14 +11,24 @@ import { isDefined } from '@sourcegraph/shared/src/util/types'
 
 import { Settings } from '../../../../../schema/settings.schema'
 import {
-    InsightDashboard,
+    ALL_INSIGHTS_DASHBOARD,
     InsightBuiltInDashboard,
     InsightCustomDashboard,
+    InsightDashboard,
     InsightDashboardOwner,
+    INSIGHTS_DASHBOARDS_SETTINGS_KEY,
     InsightsDashboardType,
     isInsightSettingKey,
-    ALL_INSIGHTS_DASHBOARD,
 } from '../../../../core/types'
+
+/**
+ * Currently we support only two types of subject that can have insights dashboard.
+ */
+type SupportedSubject = IUser | IOrg
+
+const SUPPORTED_TYPES_OF_SUBJECT = new Set<SettingsSubject['__typename']>(['User', 'Org'])
+const isSubjectSupported = (subject: SettingsSubject): subject is SupportedSubject =>
+    SUPPORTED_TYPES_OF_SUBJECT.has(subject.__typename)
 
 /**
  * React hook that returns all valid and available insights dashboards.
@@ -36,88 +47,84 @@ export function getInsightsDashboards(subjects: ConfiguredSubjectOrError<Setting
         return []
     }
 
-    const builtInDashboards = getBuiltInDashboards(subjects)
-    const customDashboards = getCustomDashboards(subjects)
-
-    return [...builtInDashboards, ...customDashboards]
+    return [ALL_INSIGHTS_DASHBOARD, ...getSubjectsDashboards(subjects)]
 }
 
 /**
- * Returns built in types of insights dashboards (all, personal, org level dashboards).
+ * Returns all reachable insights dashboards from all available subjects
+ * Basically we have insights only in organization based subject or personal subject
+ *
+ * @param subjects - array of all subject from settings cascade
  */
-function getBuiltInDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): InsightBuiltInDashboard[] {
-    const subjectDashboards = subjects.reduce<InsightBuiltInDashboard[]>((dashboards, configuredSubject) => {
+function getSubjectsDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): InsightDashboard[] {
+    return subjects.flatMap(configuredSubject => {
         const { settings, subject } = configuredSubject
 
-        if (isErrorLike(settings) || settings === null) {
-            return dashboards
+        if (isErrorLike(settings) || !settings || !isSubjectSupported(subject)) {
+            return []
         }
 
-        const dashboardOwner = getDashboardOwner(subject)
-        const subjectInsightIds = Object.keys(settings).filter(isInsightSettingKey)
-
-        const subjectDashboard: InsightBuiltInDashboard = {
-            type: InsightsDashboardType.BuiltIn,
-            owner: dashboardOwner,
-            insightIds: subjectInsightIds,
-        }
-
-        return [...dashboards, subjectDashboard]
-    }, [])
-
-    return [ALL_INSIGHTS_DASHBOARD, ...subjectDashboards]
+        return getSubjectDashboards(subject, settings)
+    })
 }
 
 /**
- * Returns list of custom insights dashboards generated from settings cascade subjects.
+ * Returns all subject dashboards and one special (built-in) dashboard that includes
+ * all insights from subject settings.
  */
-function getCustomDashboards(subjects: ConfiguredSubjectOrError<Settings>[]): InsightCustomDashboard[] {
-    return subjects.reduce<InsightCustomDashboard[]>((dashboards, configuredSubject) => {
-        const { settings, subject } = configuredSubject
+function getSubjectDashboards(subject: SupportedSubject, settings: Settings): InsightDashboard[] {
+    const { dashboardType, ...owner } = getDashboardOwnerInfo(subject)
 
-        if (isErrorLike(settings) || settings === null) {
-            return dashboards
-        }
+    const subjectBuiltInDashboard: InsightBuiltInDashboard = {
+        owner,
+        type: dashboardType,
+        insightIds: Object.keys(settings).filter(isInsightSettingKey),
+    }
 
-        const subjectDashboards = Object.keys(settings['insights.dashboards'] ?? {})
-            .map<InsightCustomDashboard | undefined>(dashboardKey => {
-                // Select dashboard configuration from the subject settings
-                const dashboardSettings = settings['insights.dashboards']?.[dashboardKey]
+    // Find all personal insights dashboards
+    const subjectDashboards = Object.keys(settings[INSIGHTS_DASHBOARDS_SETTINGS_KEY] ?? {})
+        .map<InsightCustomDashboard | undefined>(dashboardKey => {
+            // Select dashboard configuration from the subject settings
+            const dashboardSettings = settings[INSIGHTS_DASHBOARDS_SETTINGS_KEY]?.[dashboardKey]
 
-                if (!dashboardSettings) {
-                    return undefined
-                }
+            if (!dashboardSettings) {
+                return undefined
+            }
 
-                // Extend settings dashboard configuration with owner info
-                return {
-                    type: InsightsDashboardType.Custom,
-                    owner: getDashboardOwner(subject),
-                    ...dashboardSettings,
-                }
-            })
-            .filter(isDefined)
+            return {
+                owner,
+                type: dashboardType,
+                ...dashboardSettings,
+            }
+        })
+        .filter(isDefined)
 
-        return [...dashboards, ...subjectDashboards]
-    }, [])
+    return [subjectBuiltInDashboard, ...subjectDashboards]
 }
 
-function getDashboardOwner(subject: SettingsSubject): InsightDashboardOwner {
-    if (subject.__typename === 'User') {
-        return {
-            id: subject.id,
-            name: subject.displayName ?? subject.username,
-        }
-    }
+interface DashboardOwnerInfo extends InsightDashboardOwner {
+    /** Currently we support only two types of subject that can have insights dashboard. */
+    dashboardType: InsightsDashboardType.Personal | InsightsDashboardType.Organization
+}
+/**
+ * Return dashboard owner info by subject configuration
+ *
+ * @param subject - subject settings (User, Organization, Site, Client)
+ */
+function getDashboardOwnerInfo(subject: SupportedSubject): DashboardOwnerInfo {
+    switch (subject.__typename) {
+        case 'Org':
+            return {
+                id: subject.id,
+                name: subject.displayName ?? subject.name,
+                dashboardType: InsightsDashboardType.Organization,
+            }
 
-    if (subject.__typename === 'Org') {
-        return {
-            id: subject.id,
-            name: subject.displayName ?? subject.name,
-        }
-    }
-
-    return {
-        id: null,
-        name: 'UNKNOWN SUBJECT',
+        case 'User':
+            return {
+                id: subject.id,
+                name: subject.displayName ?? subject.username,
+                dashboardType: InsightsDashboardType.Personal,
+            }
     }
 }

--- a/package.json
+++ b/package.json
@@ -312,6 +312,7 @@
     "@reach/listbox": "^0.10.1",
     "@reach/menu-button": "0.10.2",
     "@reach/tabs": "^0.13.0",
+    "@reach/visually-hidden": "^0.15.2",
     "@sentry/browser": "^5.19.0",
     "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2914,6 +2914,14 @@
     tslib "^1.11.2"
     warning "^4.0.3"
 
+"@reach/visually-hidden@^0.15.2":
+  version "0.15.2"
+  resolved "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.15.2.tgz#07794cb53f4bd23a9452d53a0ad7778711ee323f"
+  integrity sha512-suDSCuKKuqiEB4UDgwWHbrPRxNwrusZ3ImXr85kfsQXGmKptMogaq22xoaHn32NC++lzZXxdWtAJriieszzFXw==
+  dependencies:
+    prop-types "^15.7.2"
+    tslib "^2.3.0"
+
 "@react-spring/animated@^9.0.0":
   version "9.0.0"
   resolved "https://registry.npmjs.org/@react-spring/animated/-/animated-9.0.0.tgz#5c4704965b959412accf1f565bc25b282d983c35"
@@ -22472,6 +22480,11 @@ tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tsutils-etc@^1.0.0, tsutils-etc@^1.2.2:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22471,20 +22471,15 @@ tslib@^1, tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.11.2, tslib@^1.8.
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@~2.0.0, tslib@~2.0.1:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
-
-tslib@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
-
-tslib@^2.3.0:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@~2.0.0, tslib@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tsutils-etc@^1.0.0, tsutils-etc@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22225

### Background

**Adding dashboard UI** implies implementation of select/listbox UI, without dashboard creation UI. Users should be able to switch between different dashboards (All, personal, org level dashboards) via select dashboard UI. [You can find designs for this UI here](https://www.figma.com/file/g5lSlPBnHt00wCogjRFnt5/RFC-398%3A-Easily-Viewing-and-Sharing-Code-Insights-WIP?node-id=275%3A1628)

![Group 356](https://user-images.githubusercontent.com/18492575/123830137-b2a5a580-d90b-11eb-9cf9-b696747e8d40.png)


What have been done 
- [x] Change built-in dashboards paradigm on dashboards levels 
Example:
        - **All**
        - **Personal**
              - Built-in personal dashboard with all insights
              - Custom personal dashboards
        - **Organization 1**
           - Built-in Organization 1 dashboard with all insights withing this org
           - Custom Organization 1 dashboards
        - **Organization N**
           ...
- [x] Imlement listbox dashboard component

The following two points will be resolved in the next PR, so as not to increase the size of this PR https://github.com/sourcegraph/sourcegraph/pull/22474
- [ ] Connect UI logic and dashboard data 
- [ ] Connect UI logic to URL routes and sync active dashboard with insights route URL

