### PR TITLE
doc: add API docs docs

### DIFF
--- a/doc/code_intelligence/apidocs/CODENOTIFY
+++ b/doc/code_intelligence/apidocs/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @slimsag

--- a/doc/code_intelligence/apidocs/index.md
+++ b/doc/code_intelligence/apidocs/index.md
@@ -32,7 +32,7 @@ We're working hard to improve it rapidly, so your feedback will influence the fu
 
 | Language | LSIF indexer                              | Tutorial                                                 |
 |----------|-------------------------------------------|----------------------------------------------------------|
-| Go       | [lsif-go](github.com/sourcegraph/lsif-go) | [Index a Go repository](../how-to/index_a_go_repository.md) |
+| Go       | [lsif-go](https://github.com/sourcegraph/lsif-go) | [Index a Go repository](../how-to/index_a_go_repository.md) |
 
 
 ## ⏱️ Coming soon

--- a/doc/code_intelligence/apidocs/index.md
+++ b/doc/code_intelligence/apidocs/index.md
@@ -1,0 +1,43 @@
+# API docs for your code
+
+<p class="subtitle">Generated API documentation for all your code</p>
+
+<p class="lead">
+
+Sourcegraph uses [LSIF code intelligence](../index.md) to generate API documentation for all your code, giving you the ability to navigate and explore the APIs provided by repositories.
+
+</p>
+
+## 🚀 Try it out
+
+You can try out API docs on Sourcegraph.com here:
+
+* [sourcegraph.com/github.com/golang/go](https://sourcegraph.com/github.com/golang/go)
+* [sourcegraph.com/github.com/sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph)
+
+## ✨ Try API docs on your repository
+
+Tweet us your Go repository name to @slimsag @sourcegraph and we'll index and upload LSIF data for you, so you can try API docs on your repository! 🎉 -- or [do it yourself](../index.md).
+
+## ⚠️ Experimental status
+
+API docs is an experimental feature of Sourcegraph. If you like this idea, have any feedback, please reach out:
+
+* (lead engineer) twitter:@slimsag stephen@sourcegraph.com
+* (entire team) twitter:@sourcegraph support@sourcegraph.com
+
+We're working hard to improve it rapidly, so your feedback will influence the future direction a lot!
+
+## ✅ Supported languages
+
+| Language | LSIF indexer                              | Tutorial                                                 |
+|----------|-------------------------------------------|----------------------------------------------------------|
+| Go       | [lsif-go](github.com/sourcegraph/lsif-go) | [Index a Go repository](../how-to/index_a_go_repository.md) |
+
+
+## ⏱️ Coming soon
+
+If you're interested in any of the following topics, please reach out - we're still working on material for them as things are progressing quickly:
+
+* ...how to add support for API docs to an LSIF indexer
+* ...troubleshooting

--- a/doc/code_intelligence/index.md
+++ b/doc/code_intelligence/index.md
@@ -9,6 +9,7 @@ Code intelligence provides advanced code navigation features that let developers
 <div class="cta-group">
 <a class="btn btn-primary" href="explanations/introduction_to_code_intelligence">★ Introduction to code intelligence</a>
 <a class="btn" href="references/indexers">LSIF supported languages</a>
+<a class="btn" href="apidocs">📚 API docs for your code</a>
 </div>
 
 ## Getting started


### PR DESCRIPTION
Some initial docs for API docs that we can link to as documentation in the API docs section of the product.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>