### PR TITLE
API docs: web: add 'Experimental' badge, feedback/docs buttons

### DIFF
--- a/client/web/src/repo/docs/RepositoryDocumentationPage.scss
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.scss
@@ -18,6 +18,16 @@
         &-content {
             width: 60rem;
         }
+        &-feedback {
+            display: flex;
+            position: absolute;
+            top: 0;
+            right: 1rem;
+            padding: 1rem;
+            .btn {
+                background-color: var(--color-bg-1);
+            }
+        }
     }
     a.h1,
     a.h2,

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -15,9 +15,12 @@ import { RevisionSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { requestGraphQL } from '../../backend/graphql'
+import { Badge } from '../../components/Badge'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { PageTitle } from '../../components/PageTitle'
 import { RepositoryFields, Scalars } from '../../graphql-operations'
+import { FeedbackPrompt } from '../../nav/Feedback/FeedbackPrompt'
+import { routes } from '../../routes'
 import { eventLogger } from '../../tracking/eventLogger'
 import { toDocumentationURL } from '../../util/url'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
@@ -171,6 +174,19 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ us
                                 pagePathID={pagePathID}
                                 depth={0}
                             />
+                        </div>
+                        <div className="repository-docs-page__container-feedback">
+                            <Badge status="experimental" className="text-uppercase mr-2" />
+                            <a
+                                // eslint-disable-next-line react/jsx-no-target-blank
+                                target="_blank"
+                                rel="noopener"
+                                href="https://docs.sourcegraph.com/code_intelligence/apidocs"
+                                className="mr-1 btn btn-sm text-decoration-none btn-link btn-outline-secondary"
+                            >
+                                Learn more
+                            </a>
+                            <FeedbackPrompt routes={routes} />
                         </div>
                     </div>
                 </>


### PR DESCRIPTION
This change adds a floating 'Experimental' badge to API docs pages, as well as feedback/learn-more buttons:

<img width="1350" alt="image" src="https://user-images.githubusercontent.com/3173176/123862992-df42c880-d8dd-11eb-8af6-f566c5945692.png">

The feedback button opens our feedback widget, and the buttons follow you as you e.g. are further down on the page:

<img width="1348" src="https://user-images.githubusercontent.com/3173176/123863254-35b00700-d8de-11eb-8285-658e19426249.png">

Fixes #21923

Fixes #22436

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
