### PR TITLE
batches/scheduler: remove flaky assertions

### DIFF
--- a/enterprise/internal/batches/scheduler/ticker_test.go
+++ b/enterprise/internal/batches/scheduler/ticker_test.go
@@ -50,10 +50,6 @@ func TestTickerGoBrrr(t *testing.T) {
 	// Also read from the now-closed `done` to synchronize, since closing a
 	// channel is non-blocking.
 	<-ticker.done
-	// Now make sure that the channel is closed.
-	if c := <-ticker.C; c != nil {
-		t.Errorf("unexpected non-nil channel: %v", c)
-	}
 }
 
 func TestTickerRateLimited(t *testing.T) {
@@ -86,10 +82,6 @@ func TestTickerRateLimited(t *testing.T) {
 	// Also read from the now-closed `done` to synchronize, since closing a
 	// channel is non-blocking.
 	<-ticker.done
-	// Now make sure that the channel is closed.
-	if c := <-ticker.C; c != nil {
-		t.Errorf("unexpected non-nil channel: %v", c)
-	}
 }
 
 func TestTickerZero(t *testing.T) {


### PR DESCRIPTION
As identified by @rvantonder in #22445, two specific assertions in `ticker_test.go` could result in test failures. Although `ticker.stop()` closes `ticker.done`, just draining that channel doesn't mean that `ticker.C` has been closed, as that happens asynchronously.

We _could_ make `ticker.stop()` block until `ticker.C` is closed, but I don't think that's necessary or useful here: if the ticker's core goroutine is blocked waiting to send to another channel, this might take a while or — worse — cause a deadlock. `ticker.stop()` having lazy, asynchronous cleanup semantics seems reasonable to me.

(I did audit the other uses of `stop()`, but while there's a similar test construction in `TestTickerZero`, I don't believe it suffers from this problem, as there's no specific timing expected for `ticker.C` being closed.)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
