### PR TITLE
search: avoid duplicate deduplication with select

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
-	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -116,12 +115,6 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	if searchType == query.SearchTypeStructural {
 		// Set a lower max result count until structural search supports true streaming.
 		defaultLimit = defaultMaxSearchResults
-	}
-
-	if sp, _ := plan.ToParseTree().StringValue(query.FieldSelect); sp != "" && args.Stream != nil {
-		// Invariant: error already checked
-		selectPath, _ := filter.SelectPathFromString(sp)
-		args.Stream = streaming.WithSelect(args.Stream, selectPath)
 	}
 
 	return &searchResolver{

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -895,6 +895,11 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 		}
 		return srr, err
 	}
+	if sp, _ := r.Plan.ToParseTree().StringValue(query.FieldSelect); sp != "" {
+		// Ensure downstream events sent on the stream are processed by `select:`.
+		selectPath, _ := filter.SelectPathFromString(sp) // Invariant: error already checked
+		r.stream = streaming.WithSelect(r.stream, selectPath)
+	}
 	sr, err := r.resultsRecursive(ctx, r.Plan)
 	srr := r.resultsToResolver(sr)
 	return srr, err


### PR DESCRIPTION
Previously it was possible that adding `select:` to the query would deduplicate results at two points during code execution. This because `stream` unconditionally processed results `WithSelect` logic. However, some queries (expressions) are "streamingIncompatible", meaning we perform batch search and then send those results on stream. The batch logic already performs `select` deduplication for any `union` operation, which would then also be processed/deduplicated by `WithSelect` on stream. 

This PR moves the unconditional `WithSelect` processing to only conditionally process those results which come from true streaming-compatible queries (i.e., queries whose results are sent directly to the stream by individual backends like commit search/zoekt/etc.). 

There was no harm in doing this before, except for the extra work, but the real issue is that adding a (minor) side-effect to `select` would break if that side-effect triggers twice. See up the stack https://github.com/sourcegraph/sourcegraph/pull/22449.