### PR TITLE
search: add select:file.directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- Added support for `select:file.directory` in search queries, which returns unique directory paths for results that satisfy the query. [#22449](https://github.com/sourcegraph/sourcegraph/pull/22449)
 
 ### Changed
 

--- a/client/shared/src/search/query/selectFilter.ts
+++ b/client/shared/src/search/query/selectFilter.ts
@@ -11,6 +11,7 @@ export const SELECTORS: Access[] = [
     },
     {
         name: 'file',
+        fields: [{ name: 'directory' }, { name: 'path' }],
     },
     {
         name: 'content',

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
-	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -116,12 +115,6 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	if searchType == query.SearchTypeStructural {
 		// Set a lower max result count until structural search supports true streaming.
 		defaultLimit = defaultMaxSearchResults
-	}
-
-	if sp, _ := plan.ToParseTree().StringValue(query.FieldSelect); sp != "" && args.Stream != nil {
-		// Invariant: error already checked
-		selectPath, _ := filter.SelectPathFromString(sp)
-		args.Stream = streaming.WithSelect(args.Stream, selectPath)
 	}
 
 	return &searchResolver{

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -895,6 +895,11 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 		}
 		return srr, err
 	}
+	if sp, _ := r.Plan.ToParseTree().StringValue(query.FieldSelect); sp != "" {
+		// Ensure downstream events sent on the stream are processed by `select:`.
+		selectPath, _ := filter.SelectPathFromString(sp) // Invariant: error already checked
+		r.stream = streaming.WithSelect(r.stream, selectPath)
+	}
 	sr, err := r.resultsRecursive(ctx, r.Plan)
 	srr := r.resultsToResolver(sr)
 	return srr, err

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1110,6 +1110,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{File: 1},
 			},
 			{
+				name:   `select file.directory`,
+				query:  `repo:go-diff HunkNoChunksize or diffFile *os.File select:file.directory`,
+				counts: counts{File: 2},
+			},
+			{
 				name:   `select content`,
 				query:  `repo:go-diff patterntype:literal HunkNoChunksize select:content`,
 				counts: counts{Content: 1},

--- a/internal/search/filter/select.go
+++ b/internal/search/filter/select.go
@@ -38,8 +38,11 @@ var validSelectors = object{
 			"removed": nil,
 		},
 	},
-	Content:    nil,
-	File:       nil,
+	Content: nil,
+	File: {
+		"directory": nil,
+		"path":      nil,
+	},
 	Repository: nil,
 	Symbol: object{
 		/* cf. SymbolKind https://microsoft.github.io/language-server-protocol/specification */


### PR DESCRIPTION
Adds `select:file.directory` support to `select`. All this does is get `dirname` of the file paths of file path results, set it, and deduplicates. The frontend view works as expected when clicking on path links. This is a customer request, and I think ~campaigns~ batch changes would get use out of t.

This does make `select` potentially side-effecting. I think it is an OK side-effect for `file.directory`. We could separate out select functionality that is side-effect free, but I don't think there's a big benefit of doing that right now.