### PR TITLE
API docs: web: fix various margin/padding issues

### DIFF
--- a/client/web/src/repo/docs/RepositoryDocumentationPage.scss
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.scss
@@ -1,31 +1,34 @@
+@import './RepositoryDocumentationSidebar';
+
 .repository-docs-page {
     width: 100%;
     display: flex;
     overflow: hidden;
-    &__sidebar {
-        padding: 1rem;
-    }
     &__container {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
         overflow: auto;
         width: 100%;
-        padding: 1rem;
-        &--sidebar-visible {
-            justify-content: unset;
-        }
         &-content {
             width: 60rem;
+            padding-left: 2rem;
+            padding-bottom: 3rem;
+            margin: auto;
+            &--sidebar-visible {
+                margin: unset;
+            }
         }
-        &-feedback {
-            display: flex;
-            position: absolute;
-            top: 0;
-            right: 1rem;
-            padding: 1rem;
+    }
+    &__feedback-container {
+        width: 0;
+        height: 0;
+        &-content {
+            display: block;
+            width: 19rem;
+            float: right;
             .btn {
                 background-color: var(--color-bg-1);
+            }
+            .feedback-prompt {
+                display: inline-block;
             }
         }
     }

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -155,18 +155,15 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ us
                 <>
                     <RepositoryDocumentationSidebar
                         {...props}
-                        className="repository-docs-page__sidebar"
                         onToggle={handleSidebarVisible}
                         node={page.tree}
                         pagePathID={pagePathID}
                         depth={0}
                     />
-                    <div
-                        className={`repository-docs-page__container${
-                            sidebarVisible ? ' repository-docs-page__container--sidebar-visible' : ''
-                        }`}
-                    >
-                        <div className="repository-docs-page__container-content">
+                    <div className="repository-docs-page__container">
+                        <div className={`repository-docs-page__container-content${
+                            sidebarVisible ? ' repository-docs-page__container-content--sidebar-visible' : ''
+                        }`}>
                             <DocumentationNode
                                 {...props}
                                 useBreadcrumb={useBreadcrumb}
@@ -175,7 +172,9 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ us
                                 depth={0}
                             />
                         </div>
-                        <div className="repository-docs-page__container-feedback">
+                    </div>
+                    <div className="repository-docs-page__feedback-container">
+                        <div className="repository-docs-page__feedback-container-content">
                             <Badge status="experimental" className="text-uppercase mr-2" />
                             <a
                                 // eslint-disable-next-line react/jsx-no-target-blank

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -161,9 +161,11 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ us
                         depth={0}
                     />
                     <div className="repository-docs-page__container">
-                        <div className={`repository-docs-page__container-content${
-                            sidebarVisible ? ' repository-docs-page__container-content--sidebar-visible' : ''
-                        }`}>
+                        <div
+                            className={`repository-docs-page__container-content${
+                                sidebarVisible ? ' repository-docs-page__container-content--sidebar-visible' : ''
+                            }`}
+                        >
                             <DocumentationNode
                                 {...props}
                                 useBreadcrumb={useBreadcrumb}

--- a/client/web/src/repo/docs/RepositoryDocumentationSidebar.scss
+++ b/client/web/src/repo/docs/RepositoryDocumentationSidebar.scss
@@ -1,0 +1,5 @@
+.repository-documentation-sidebar {
+    &-scroller:last-child {
+        padding-bottom: 3rem;
+    }
+}

--- a/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
@@ -15,7 +15,6 @@ import { GQLDocumentationNode } from './DocumentationNode'
 
 interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec {
     repo: RepositoryFields
-    className: string
     history: H.History
     location: H.Location
     onToggle: (visible: boolean) => void
@@ -65,9 +64,8 @@ export const RepositoryDocumentationSidebar: React.FunctionComponent<Props> = ({
             defaultSize={384}
             handlePosition="right"
             storageKey={SIZE_STORAGE_KEY}
-            className={props.className}
             element={
-                <div className="d-flex flex-column w-100 border-right">
+                <div className="repository-documentation-sidebar d-flex flex-column w-100 border-right">
                     <div className="d-flex flex-0 mx-3">
                         <Button
                             onClick={handleSidebarToggle}
@@ -79,7 +77,7 @@ export const RepositoryDocumentationSidebar: React.FunctionComponent<Props> = ({
                             <ChevronDoubleLeftIcon className="icon-inline" />
                         </Button>
                     </div>
-                    <div aria-hidden={true} className="d-flex explorer overflow-auto px-3">
+                    <div aria-hidden={true} className="repository-documentation-sidebar-scroller overflow-auto px-3">
                         <DocumentationIndexNode
                             {...props}
                             node={props.node}


### PR DESCRIPTION
* Fixes an issue where the `Experimental | Learn more | Feedback` buttons would
  overlap with the extensions panel when expanded, and the vertical scrollbar when
  visible.
* Fixes an issue in Chrome where the bottom padding of the page and API docs sidebar
  would be non-existant. It's now consistent across Chrome/FF.
* Fixes an issue where the sidebar had more padding than intended.

Fixes #22440

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
