### PR TITLE
API docs: web: only include exported symbols for now 

### DIFF
--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -8,7 +8,7 @@ import { useScrollToLocationHash } from '../../components/useScrollToLocationHas
 import { RepositoryFields } from '../../graphql-operations'
 import { toDocumentationURL } from '../../util/url'
 
-import { GQLDocumentationNode } from './DocumentationNode'
+import { GQLDocumentationNode, isExcluded, Tag } from './DocumentationNode'
 
 interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec {
     repo: RepositoryFields
@@ -30,6 +30,9 @@ interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec {
 
     /** If true, render content index only */
     contentOnly: boolean
+
+    /** A list of documentation tags, a section will not be rendered if it matches one of these. */
+    excludingTags: Tag[]
 }
 
 export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, depth, ...props }) => {
@@ -43,7 +46,10 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, d
     let path = hashIndex !== -1 ? node.pathID.slice(0, hashIndex) : node.pathID
     path = path === '/' ? '' : path
     const thisPage = toDocumentationURL({ ...repoRevision, pathID: path + '#' + hash })
-
+    const excluded = isExcluded(node, props.excludingTags);
+    if (excluded) {
+        return null
+    }
     if (props.subpagesOnly) {
         return (
             <div className="documentation-index-node">

--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -46,7 +46,7 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, d
     let path = hashIndex !== -1 ? node.pathID.slice(0, hashIndex) : node.pathID
     path = path === '/' ? '' : path
     const thisPage = toDocumentationURL({ ...repoRevision, pathID: path + '#' + hash })
-    const excluded = isExcluded(node, props.excludingTags);
+    const excluded = isExcluded(node, props.excludingTags)
     if (excluded) {
         return null
     }

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -31,12 +31,45 @@ export interface MarkupContent {
 export type MarkupKind = 'plaintext' | 'markdown'
 
 export interface Documentation {
-    slug: string
+    identifier: string
     newPage: boolean
-    tags: DocumentationTag[]
+    searchKey: string
+    tags: Tag[]
 }
 
-export type DocumentationTag = 'exported' | 'unexported' | 'deprecated'
+export type Tag = 'private'
+    | 'deprecated'
+    | 'test'
+    | 'benchmark'
+    | 'example'
+    | 'license'
+    | 'owner'
+    | 'file'
+    | 'module'
+    | 'namespace'
+    | 'package'
+    | 'class'
+    | 'method'
+    | 'property'
+    | 'field'
+    | 'constructor'
+    | 'enum'
+    | 'interface'
+    | 'function'
+    | 'variable'
+    | 'constant'
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'array'
+    | 'object'
+    | 'key'
+    | 'null'
+    | 'enumNumber'
+    | 'struct'
+    | 'event'
+    | 'operator'
+    | 'typeParameter'
 
 export interface DocumentationNodeChild {
     node?: GQLDocumentationNode
@@ -48,8 +81,14 @@ interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec, BreadcrumbS
 
     history: H.History
     location: H.Location
+
+    /** The documentation node to render */
     node: GQLDocumentationNode
+
+    /** How far deep we are in the tree of documentation nodes */
     depth: number
+
+    /** The pathID of the page containing this documentation node */
     pagePathID: string
 }
 

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -1,6 +1,4 @@
 import * as H from 'history'
-import CancelIcon from 'mdi-react/CancelIcon'
-import LockIcon from 'mdi-react/LockIcon'
 import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -37,7 +35,8 @@ export interface Documentation {
     tags: Tag[]
 }
 
-export type Tag = 'private'
+export type Tag =
+    | 'private'
     | 'deprecated'
     | 'test'
     | 'benchmark'
@@ -77,7 +76,7 @@ export interface DocumentationNodeChild {
 }
 
 export function isExcluded(node: GQLDocumentationNode, excludingTags: Tag[]): boolean {
-    return node.documentation.tags.filter(tag => excludingTags.includes(tag)).length > 0;
+    return node.documentation.tags.filter(tag => excludingTags.includes(tag)).length > 0
 }
 
 interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec, BreadcrumbSetters {
@@ -132,7 +131,8 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
 
             {node.children?.map(
                 (child, index) =>
-                    child.node && !isExcluded(child.node, props.excludingTags) && (
+                    child.node &&
+                    !isExcluded(child.node, props.excludingTags) && (
                         <DocumentationNode
                             key={`${depth}-${index}`}
                             {...props}

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -119,16 +119,10 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
         )
     )
 
-    const tagIcons = {
-        exported: null,
-        unexported: <LockIcon className="icon-inline" data-tooltip="Unexported" />,
-        deprecated: <CancelIcon className="icon-inline" data-tooltip="Deprecated" />,
-    }
     return (
         <div className="documentation-node">
             <Link className={`h${depth + 1 < 4 ? depth + 1 : 4}`} id={hash} to={thisPage}>
                 {node.label.value}
-                {node.documentation.tags?.map(tag => tagIcons[tag])}
             </Link>
             {node.detail.value !== '' && (
                 <div className="px-2 pt-2">

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -76,6 +76,10 @@ export interface DocumentationNodeChild {
     pathID?: string
 }
 
+export function isExcluded(node: GQLDocumentationNode, excludingTags: Tag[]): boolean {
+    return node.documentation.tags.filter(tag => excludingTags.includes(tag)).length > 0;
+}
+
 interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec, BreadcrumbSetters {
     repo: RepositoryFields
 
@@ -90,6 +94,9 @@ interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec, BreadcrumbS
 
     /** The pathID of the page containing this documentation node */
     pagePathID: string
+
+    /** A list of documentation tags, a section will not be rendered if it matches one of these. */
+    excludingTags: Tag[]
 }
 
 export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrumb, node, depth, ...props }) => {
@@ -131,7 +138,7 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
 
             {node.children?.map(
                 (child, index) =>
-                    child.node && (
+                    child.node && !isExcluded(child.node, props.excludingTags) && (
                         <DocumentationNode
                             key={`${depth}-${index}`}
                             {...props}

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -172,6 +172,7 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ us
                                 node={page.tree}
                                 pagePathID={pagePathID}
                                 depth={0}
+                                excludingTags={['private']}
                             />
                         </div>
                     </div>

--- a/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
@@ -85,6 +85,7 @@ export const RepositoryDocumentationSidebar: React.FunctionComponent<Props> = ({
                             depth={0}
                             subpagesOnly={false}
                             contentOnly={false}
+                            excludingTags={['private']}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Exclude private symbols for now; we'll add this ability back later among other
filters via some UI toggle buttons.

Fixes #21934

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>