### PR TITLE
API docs: LSIF: prevent `null` lists in GraphQL responses

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
@@ -55,7 +55,7 @@ func (r *QueryResolver) DocumentationPathInfo(ctx context.Context, args *gql.LSI
 		if pathInfo == nil {
 			return nil, nil
 		}
-		var children []DocumentationPathInfoResult
+		children := []DocumentationPathInfoResult{}
 		if depth < maxDepth {
 			if !ignoreIndex || ignoreIndex && !pathInfo.IsIndex {
 				depth++
@@ -101,5 +101,5 @@ type DocumentationPathInfoResult struct {
 	IsIndex bool `json:"isIndex"`
 
 	// Children is a list of the children page paths immediately below this one.
-	Children []DocumentationPathInfoResult `json:"children,omitempty"`
+	Children []DocumentationPathInfoResult `json:"children"`
 }

--- a/lib/codeintel/lsif/conversion/correlate_documentation.go
+++ b/lib/codeintel/lsif/conversion/correlate_documentation.go
@@ -13,6 +13,12 @@ func correlateDocumentationResult(state *wrappedState, element Element) error {
 		return ErrUnexpectedPayload
 	}
 
+	if payload.Tags == nil {
+		// don't encode "null", instead encode an empty list. Null is forbidden for tags,
+		// but it can crop up in some languages (e.g. Go) due to JSON encoders so we handle
+		// it gracefully.
+		payload.Tags = []protocol.Tag{}
+	}
 	state.DocumentationResultsData[element.ID] = payload
 	return nil
 }


### PR DESCRIPTION
Prior to this change, children and tag arrays could sometimes be `null` in our GraphQL
JSON response data. This was sometimes incorrect (in the case of tags), and other times
just annoying to deal with. This change makes us do our best to prevent `null` lists
from appearing in our data, preventing a myriad of bugs.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
