### PR TITLE
symbol: `GetMatchAtLineCharacter` should match if line and character are within symbol range

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -251,7 +251,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 		}
 
 		common.Metadata.ShowPreview = true
-		common.Metadata.PreviewImage = getBlobPreviewImageURL(envvar.OpenGraphPreviewServiceURL(), r.URL.Path, lineRange, symbolResult)
+		common.Metadata.PreviewImage = getBlobPreviewImageURL(envvar.OpenGraphPreviewServiceURL(), r.URL.Path, lineRange)
 		common.Metadata.Description = fmt.Sprintf("%s/%s", globals.ExternalURL(), mux.Vars(r)["Repo"])
 		common.Metadata.Title = getBlobPreviewTitle(blobPath, lineRange, symbolResult)
 	}

--- a/cmd/frontend/internal/app/ui/preview.go
+++ b/cmd/frontend/internal/app/ui/preview.go
@@ -77,16 +77,13 @@ func formatLineRange(lineRange *lineRange) string {
 	return formattedLineRange
 }
 
-func getBlobPreviewImageURL(previewServiceURL string, blobURLPath string, lineRange *lineRange, symbolResult *result.Symbol) string {
+func getBlobPreviewImageURL(previewServiceURL string, blobURLPath string, lineRange *lineRange) string {
 	blobPreviewImageURL := previewServiceURL + blobURLPath
 	formattedLineRange := formatLineRange(lineRange)
 
 	queryValues := url.Values{}
 	if formattedLineRange != "" {
 		queryValues.Add("range", formattedLineRange)
-	}
-	if symbolResult != nil {
-		queryValues.Add("type", "symbol")
 	}
 
 	encodedQueryValues := queryValues.Encode()

--- a/cmd/frontend/internal/app/ui/preview_test.go
+++ b/cmd/frontend/internal/app/ui/preview_test.go
@@ -37,19 +37,17 @@ func TestGetBlobPreviewImageURL(t *testing.T) {
 	previewServiceURL := "https://preview.sourcegraph.com"
 	blobURLPath := "/github.com/sourcegraph/sourcegraph/-/blob/client/browser/src/end-to-end/github.test.ts"
 	tests := []struct {
-		name         string
-		lineRange    *lineRange
-		symbolResult *result.Symbol
-		wantURL      string
+		name      string
+		lineRange *lineRange
+		wantURL   string
 	}{
 		{name: "empty line range", lineRange: nil, wantURL: fmt.Sprintf("%s%s", previewServiceURL, blobURLPath)},
 		{name: "single line", lineRange: &lineRange{StartLine: 123}, wantURL: fmt.Sprintf("%s%s?range=L123", previewServiceURL, blobURLPath)},
 		{name: "line range", lineRange: &lineRange{StartLine: 123, EndLine: 125}, wantURL: fmt.Sprintf("%s%s?range=L123-125", previewServiceURL, blobURLPath)},
-		{name: "line range with symbol", lineRange: &lineRange{StartLine: 123, EndLine: 125}, symbolResult: &result.Symbol{}, wantURL: fmt.Sprintf("%s%s?range=L123-125&type=symbol", previewServiceURL, blobURLPath)},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := getBlobPreviewImageURL(previewServiceURL, blobURLPath, test.lineRange, test.symbolResult)
+			got := getBlobPreviewImageURL(previewServiceURL, blobURLPath, test.lineRange)
 			if !reflect.DeepEqual(test.wantURL, got) {
 				t.Errorf("got %v, want %v", got, test.wantURL)
 			}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -380,8 +380,8 @@ func GetMatchAtLineCharacter(ctx context.Context, repo types.RepoName, commitID 
 	var match *result.SymbolMatch
 	for _, symbolMatch := range symbolMatches {
 		symbolRange := symbolMatch.Symbol.Range()
-		hasMatchingStartRange := symbolRange.Start.Line == line && symbolRange.Start.Character == character
-		if hasMatchingStartRange && (match == nil || len(symbolMatch.Symbol.Name) < len(match.Symbol.Name)) {
+		isWithinRange := line >= symbolRange.Start.Line && character >= symbolRange.Start.Character && line <= symbolRange.End.Line && character <= symbolRange.End.Character
+		if isWithinRange && (match == nil || len(symbolMatch.Symbol.Name) < len(match.Symbol.Name)) {
 			match = symbolMatch
 		}
 	}


### PR DESCRIPTION
This PR changes `GetMatchAtLineCharacter` symbol function to return a symbol match if the provided line and character are within the symbol range. Previously it returned a match if the line and character matched the symbol start line and character exactly. This allows for more flexibility when generating OpenGraph metadata.