### PR TITLE
app/ui: Show blocked error message instead of 500

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -202,7 +202,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 				serveError(w, r, err, http.StatusNotFound)
 				return nil, nil
 			}
-			if errcode.IsNotFound(err) {
+			if errcode.IsNotFound(err) || errcode.IsBlocked(err) {
 				// Repo does not exist.
 				serveError(w, r, err, http.StatusNotFound)
 				return nil, nil

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -541,7 +541,7 @@ func TestRepoStore_Blocking(t *testing.T) {
 		}
 
 		_, err = rs.GetByName(ctx, repos[1].Name)
-		if have, want := fmt.Sprint(err), `bar has been blocked. reason: too big`; have != want {
+		if have, want := fmt.Sprint(err), `repository bar has been blocked. reason: too big`; have != want {
 			t.Errorf("error, have: %q, want: %q", have, want)
 		}
 	})
@@ -553,7 +553,7 @@ func TestRepoStore_Blocking(t *testing.T) {
 		}
 
 		_, err = rs.GetByName(ctx, api.RepoName(repos[1].URI))
-		if have, want := fmt.Sprint(err), `bar has been blocked. reason: too big`; have != want {
+		if have, want := fmt.Sprint(err), `repository bar has been blocked. reason: too big`; have != want {
 			t.Errorf("error, have: %q, want: %q", have, want)
 		}
 	})

--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -170,6 +170,17 @@ func IsTemporary(err error) bool {
 	})
 }
 
+// IsBlocked will check if err or one of its causes is a blocked error.
+func IsBlocked(err error) bool {
+	type blocker interface {
+		Blocked() bool
+	}
+	return isErrorPredicate(err, func(err error) bool {
+		e, ok := err.(blocker)
+		return ok && e.Blocked()
+	})
+}
+
 // IsTimeout will check if err or one of its causes is a timeout. Many errors
 // in the go stdlib implement the timeout interface.
 func IsTimeout(err error) bool {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -98,10 +98,23 @@ func (r *Repo) ExternalServiceIDs() []int64 {
 	return ids
 }
 
+// BlockedRepoError is returned by a Repo IsBlocked method.
+type BlockedRepoError struct {
+	Name   api.RepoName
+	Reason string
+}
+
+func (e BlockedRepoError) Error() string {
+	return fmt.Sprintf("repository %s has been blocked. reason: %s", e.Name, e.Reason)
+}
+
+// Blocked implements the blocker interface in the errcode package.
+func (e BlockedRepoError) Blocked() bool { return true }
+
 // IsBlocked returns a non nil error if the repo has been blocked.
 func (r *Repo) IsBlocked() error {
 	if r.Blocked != nil {
-		return fmt.Errorf("%s has been blocked. reason: %s", r.Name, r.Blocked.Reason)
+		return &BlockedRepoError{Name: r.Name, Reason: r.Blocked.Reason}
 	}
 	return nil
 }


### PR DESCRIPTION
This commit makes it so we show the reason for a repository being blocked in the UI.

Before:
<img width="928" alt="Screen Shot 2021-06-30 at 18 03 16" src="https://user-images.githubusercontent.com/67471/123994314-8e120200-d9cd-11eb-8d6b-f20923481622.png">


After:

<img width="928" alt="Screen Shot 2021-06-30 at 18 03 37" src="https://user-images.githubusercontent.com/67471/123994317-8fdbc580-d9cd-11eb-84da-9d2d96e41814.png">

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
