### PR TITLE
stream in searcher up to API boundary

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -320,18 +320,18 @@ type matchSender struct {
 	sentCount atomic.Int64
 }
 
-func (m matchSender) Send(matches []protocol.FileMatch) {
+func (m *matchSender) Send(matches []protocol.FileMatch) {
 	m.sentCount.Add(int64(len(matches)))
 	m.c <- matches
 }
 
-func (m matchSender) SentCount() int {
+func (m *matchSender) SentCount() int {
 	return int(m.sentCount.Load())
 }
 
 // CollectTo reads from the sender's channel and collects the results into a single
 // slice, sending it down the channel passed to it
-func (m matchSender) CollectTo(dst chan<- []protocol.FileMatch) {
+func (m *matchSender) CollectTo(dst chan<- []protocol.FileMatch) {
 	collected := make([]protocol.FileMatch, 0)
 	for matches := range m.c {
 		collected = append(collected, matches...)
@@ -340,7 +340,7 @@ func (m matchSender) CollectTo(dst chan<- []protocol.FileMatch) {
 }
 
 // Close indicates that the sender will receive no more results, closing its channel.
-func (m matchSender) Close() {
+func (m *matchSender) Close() {
 	close(m.c)
 }
 

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -251,8 +251,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		sender.Send(matches)
 		return limitHit, false, err
 	} else {
-		matches, limitHit, err := regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
-		sender.Send(matches)
+		limitHit, err := regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated, sender)
 		return limitHit, false, err
 	}
 }

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
 
 	nettrace "golang.org/x/net/trace"
 
@@ -101,7 +102,13 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	matches, limitHit, deadlineHit, err := s.search(ctx, &p)
+	sender := newMatchSender(100)
+	matches := make(chan []protocol.FileMatch, 1) // size of 1 to avoid blocking goroutine
+	go func() {
+		matches <- sender.Collect()
+	}()
+
+	limitHit, deadlineHit, err := s.search(ctx, &p, sender)
 	if err != nil {
 		code := http.StatusInternalServerError
 		if isBadRequest(err) || ctx.Err() == context.Canceled {
@@ -114,14 +121,11 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), code)
 		return
 	}
-	if matches == nil {
-		// Return an empty list
-		matches = make([]protocol.FileMatch, 0)
-	}
+	sender.Close()
 
 	w.Header().Set("Content-Type", "application/json")
 	resp := protocol.Response{
-		Matches:     matches,
+		Matches:     <-matches,
 		LimitHit:    limitHit,
 		DeadlineHit: deadlineHit,
 	}
@@ -134,7 +138,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 const maxFileMatchLimit = 100
 
-func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []protocol.FileMatch, limitHit, deadlineHit bool, err error) {
+func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchSender) (limitHit, deadlineHit bool, err error) {
 	tr := nettrace.New("search", fmt.Sprintf("%s@%s", p.Repo, p.Commit))
 	tr.LazyPrintf("%s", p.Pattern)
 
@@ -182,21 +186,21 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 				code = "500"
 			}
 		}
-		tr.LazyPrintf("code=%s matches=%d limitHit=%v deadlineHit=%v", code, len(matches), limitHit, deadlineHit)
+		tr.LazyPrintf("code=%s matches=%d limitHit=%v deadlineHit=%v", code, sender.SentCount(), limitHit, deadlineHit)
 		tr.Finish()
 		requestTotal.WithLabelValues(code).Inc()
-		span.LogFields(otlog.Int("matches.len", len(matches)))
+		span.LogFields(otlog.Int("matches.len", sender.SentCount()))
 		span.SetTag("limitHit", limitHit)
 		span.SetTag("deadlineHit", deadlineHit)
 		span.Finish()
 		if s.Log != nil {
-			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "languages", p.Languages, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", len(matches), "code", code, "duration", time.Since(start), "indexerEndpoints", p.IndexerEndpoints, "err", err)
+			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "languages", p.Languages, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", sender.SentCount(), "code", code, "duration", time.Since(start), "indexerEndpoints", p.IndexerEndpoints, "err", err)
 		}
 	}(time.Now())
 
 	if p.IsStructuralPat && p.Indexed {
 		// Execute the new structural search path that directly calls Zoekt.
-		return structuralSearchWithZoekt(ctx, p)
+		return structuralSearchWithZoekt(ctx, p, sender)
 	}
 
 	// Compile pattern before fetching from store incase it is bad.
@@ -204,7 +208,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	if !p.IsStructuralPat {
 		rg, err = compile(&p.PatternInfo)
 		if err != nil {
-			return nil, false, false, badRequestError{err.Error()}
+			return false, false, badRequestError{err.Error()}
 		}
 	}
 
@@ -213,7 +217,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	}
 	fetchTimeout, err := time.ParseDuration(p.FetchTimeout)
 	if err != nil {
-		return nil, false, false, err
+		return false, false, err
 	}
 	prepareCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
@@ -229,7 +233,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 
 	zipPath, zf, err := store.GetZipFileWithRetry(getZf)
 	if err != nil {
-		return nil, false, false, errors.Wrap(err, "failed to get archive")
+		return false, false, errors.Wrap(err, "failed to get archive")
 	}
 	defer zf.Close()
 
@@ -243,11 +247,14 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	archiveSize.Observe(float64(bytes))
 
 	if p.IsStructuralPat {
-		matches, limitHit, err = filteredStructuralSearch(ctx, zipPath, zf, &p.PatternInfo, p.Repo)
+		matches, limitHit, err := filteredStructuralSearch(ctx, zipPath, zf, &p.PatternInfo, p.Repo)
+		sender.Send(matches)
+		return limitHit, false, err
 	} else {
-		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
+		matches, limitHit, err := regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
+		sender.Send(matches)
+		return limitHit, false, err
 	}
-	return matches, limitHit, false, err
 }
 
 func validateParams(p *protocol.Request) error {
@@ -307,4 +314,36 @@ func isTemporary(err error) bool {
 		Temporary() bool
 	})
 	return ok && e.Temporary()
+}
+
+type matchSender struct {
+	c         chan []protocol.FileMatch
+	sentCount atomic.Int64
+}
+
+func (m matchSender) Send(matches []protocol.FileMatch) {
+	m.sentCount.Add(int64(len(matches)))
+	m.c <- matches
+}
+
+func (m matchSender) SentCount() int {
+	return int(m.sentCount.Load())
+}
+
+func (m matchSender) Collect() []protocol.FileMatch {
+	res := make([]protocol.FileMatch, 0)
+	for matches := range m.c {
+		res = append(res, matches...)
+	}
+	return res
+}
+
+func (m matchSender) Close() {
+	close(m.c)
+}
+
+func newMatchSender(capacity int) matchSender {
+	return matchSender{
+		c: make(chan []protocol.FileMatch, capacity),
+	}
 }

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -368,6 +368,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 		wgErr         error
 		filesSkipped  uint32 // accessed atomically
 		filesSearched uint32 // accessed atomically
+		limitMu       sync.Mutex
 	)
 
 	// Start workers. They read from files and write to matches.
@@ -423,7 +424,9 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 					if sender.SentCount() < fileMatchLimit {
 						sender.Send([]protocol.FileMatch{fm})
 					} else {
+						limitMu.Lock()
 						limitHit = true
+						limitMu.Unlock()
 						cancel()
 					}
 				}

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -295,10 +295,7 @@ func (rg *readerGrep) FindZip(zf *store.ZipFile, f *store.SrcFile) (protocol.Fil
 
 func regexSearchBatch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMatchLimit int, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool) ([]protocol.FileMatch, bool, error) {
 	sender := newMatchSender(100)
-	matches := make(chan []protocol.FileMatch, 1)
-	go func() {
-		matches <- sender.Collect()
-	}()
+	matches := sender.Collect()
 	limitHit, err := regexSearch(ctx, rg, zf, fileMatchLimit, patternMatchesContent, patternMatchesPaths, isPatternNegated, sender)
 	sender.Close()
 	return <-matches, limitHit, err

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -295,7 +295,8 @@ func (rg *readerGrep) FindZip(zf *store.ZipFile, f *store.SrcFile) (protocol.Fil
 
 func regexSearchBatch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMatchLimit int, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool) ([]protocol.FileMatch, bool, error) {
 	sender := newMatchSender(100)
-	matches := sender.Collect()
+	matches := make(chan []protocol.FileMatch, 1)
+	go sender.CollectTo(matches)
 	limitHit, err := regexSearch(ctx, rg, zf, fileMatchLimit, patternMatchesContent, patternMatchesPaths, isPatternNegated, sender)
 	sender.Close()
 	return <-matches, limitHit, err

--- a/cmd/searcher/search/search_regex_test.go
+++ b/cmd/searcher/search/search_regex_test.go
@@ -264,7 +264,7 @@ func benchSearchRegex(b *testing.B, p *protocol.Request) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		_, _, err := regexSearch(ctx, rg, zf, 0, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
+		_, _, err := regexSearchBatch(ctx, rg, zf, 0, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -454,7 +454,7 @@ func TestMaxMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileMatches, limitHit, err := regexSearch(context.Background(), rg, zf, maxFileMatches, true, false, false)
+	fileMatches, limitHit, err := regexSearchBatch(context.Background(), rg, zf, maxFileMatches, true, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -506,7 +506,7 @@ func TestPathMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileMatches, _, err := regexSearch(context.Background(), rg, zf, 10, true, true, false)
+	fileMatches, _, err := regexSearchBatch(context.Background(), rg, zf, 10, true, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,7 +581,7 @@ func TestRegexSearch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFm, gotLimitHit, err := regexSearch(tt.args.ctx, tt.args.rg, tt.args.zf, tt.args.fileMatchLimit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths, false)
+			gotFm, gotLimitHit, err := regexSearchBatch(tt.args.ctx, tt.args.rg, tt.args.zf, tt.args.fileMatchLimit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("regexSearch() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -191,7 +191,7 @@ func filteredStructuralSearch(ctx context.Context, zipPath string, zipFile *stor
 		return nil, false, err
 	}
 
-	fileMatches, _, err := regexSearch(ctx, rg, zipFile, p.FileMatchLimit, true, false, false)
+	fileMatches, _, err := regexSearchBatch(ctx, rg, zipFile, p.FileMatchLimit, true, false, false)
 	if err != nil {
 		return nil, false, err
 	}

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -279,7 +279,7 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 	return matches, false, err
 }
 
-func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matches []protocol.FileMatch, limitHit, deadlineHit bool, err error) {
+func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender matchSender) (limitHit, deadlineHit bool, err error) {
 	// Since we are returning file content, limit the number of file matches
 	// until streaming from Zoekt is implemented
 	fileMatchLimit := p.FileMatchLimit
@@ -312,22 +312,22 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 	useFullDeadline := false
 	zoektMatches, limitHit, _, err := zoektSearch(ctx, patternInfo, repoBranches, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {
-		return nil, false, false, err
+		return false, false, err
 	}
 
 	if len(zoektMatches) == 0 {
-		return nil, false, false, nil
+		return false, false, nil
 	}
 
 	zipFile, err := os.CreateTemp("", "*.zip")
 	if err != nil {
-		return nil, false, false, err
+		return false, false, err
 	}
 	defer zipFile.Close()
 	defer os.Remove(zipFile.Name())
 
 	if err = writeZip(ctx, zipFile, zoektMatches); err != nil {
-		return nil, false, false, err
+		return false, false, err
 	}
 
 	var extensionHint string
@@ -336,8 +336,10 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 		extensionHint = filepath.Ext(filename)
 	}
 
-	matches, limitHit, err = structuralSearch(ctx, zipFile.Name(), All, extensionHint, p.Pattern, p.CombyRule, p.Languages, p.Repo)
-	return matches, limitHit, false, err
+	matches, limitHit, err := structuralSearch(ctx, zipFile.Name(), All, extensionHint, p.Pattern, p.CombyRule, p.Languages, p.Repo)
+	sender.Send(matches)
+
+	return limitHit, false, err
 }
 
 var requestTotalStructuralSearch = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
This PR is part of the effort to implement streaming for searcher. This PR adds a `matchSender` that is propagated through searcher's codepaths to stream results as they are matched. It currently does not stream across the network yet, that will be implemented in a separate PR. This PR should not introduce any change in behavior. 
