### PR TITLE
update alpine packages

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -10,14 +10,14 @@
  */
  {
     // Captain information
-    "captainSlackUsername": "dave",
-    "captainGitHubUsername": "davejrt",
+    "captainSlackUsername": "dax",
+    "captainGitHubUsername": "daxmc99",
     // Release versions
-    "previousRelease": "3.29.0",
-    "upcomingRelease": "3.29.1",
+    "previousRelease": "3.29.1",
+    "upcomingRelease": "3.30.0",
     // Release dates
-    "releaseDate": "25 June 2021 10:00 PST",
-    "oneWorkingDayAfterRelease": "26 June 2021 10:00 PST",
+    "releaseDate": "20 July 2021 10:00 PST",
+    "oneWorkingDayAfterRelease": "21 July 2021 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "dev-announce",
     // Email for preparing calendar events

--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -1,0 +1,4 @@
+FROM timescale/timescaledb:2.0.0-pg12-oss
+
+# hadolint ignore=DL3017
+RUN apk -U upgrade

--- a/docker-images/codeinsights-db/build.sh
+++ b/docker-images/codeinsights-db/build.sh
@@ -3,6 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# This merely re-tags the image to match our official Sourcegraph versioning andimage naming scheme.
-docker pull timescale/timescaledb:2.0.0-pg12-oss@sha256:08ea7cda3b6891c1815af449493c322969d8d9cf283a7af501ce22c6672b51a1
-docker tag timescale/timescaledb:2.0.0-pg12-oss@sha256:08ea7cda3b6891c1815af449493c322969d8d9cf283a7af501ce22c6672b51a1 "$IMAGE"
+docker build -t "${IMAGE:-sourcegraph/codeinsights-db}" .


### PR DESCRIPTION
The upstream timescale image is built on a slightly older version of alpine and is not patched during the build process. In order to remediate a number of CVE's this PR patches the affected packages found as part of https://github.com/sourcegraph/security-issues/issues/151