### PR TITLE
searcher cleanup

### DIFF
--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -376,14 +376,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 	for i := 0; i < numWorkers; i++ {
 		rg := rg.Copy()
 		g.Go(func() error {
-			for {
-				// check whether we've been cancelled
-				select {
-				case <-ctx.Done():
-					return nil
-				default:
-				}
-
+			for ctx.Err() == nil {
 				// grab a file to work on
 				filesmu.Lock()
 				if len(files) == 0 {
@@ -424,6 +417,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 					}
 				}
 			}
+			return nil
 		})
 	}
 

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -303,7 +303,8 @@ func regexSearchBatch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fi
 }
 
 // regexSearch concurrently searches files in zr looking for matches using rg.
-func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMatchLimit int, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool, sender matchSender) (_ bool, err error) {
+func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMatchLimit int, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool, sender matchSender) (bool, error) {
+	var err error
 	span, ctx := ot.StartSpanFromContext(ctx, "RegexSearch")
 	ext.Component.Set(span, "regex_search")
 	if rg.re != nil {
@@ -388,10 +389,10 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 			for f := range fileFeeder {
 				// decide whether to process, record that decision
 				if !rg.matchPath.MatchPath(f.Name) {
-					filesSkipped.Add(1)
+					filesSkipped.Inc()
 					continue
 				}
-				filesSearched.Add(1)
+				filesSearched.Inc()
 
 				// process
 				var fm protocol.FileMatch

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -362,7 +362,6 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 	}
 
 	var (
-		done          = ctx.Done()
 		wg            sync.WaitGroup
 		wgErrOnce     sync.Once
 		wgErr         error
@@ -380,7 +379,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 			for {
 				// check whether we've been cancelled
 				select {
-				case <-done:
+				case <-ctx.Done():
 					return
 				default:
 				}

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -338,10 +338,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 	}
 	defer cancel()
 
-	var (
-		files = zf.Files
-	)
-
+	files := zf.Files
 	if rg.re == nil || (patternMatchesPaths && !patternMatchesContent) {
 		// Fast path for only matching file paths (or with a nil pattern, which matches all files,
 		// so is effectively matching only on file paths).


### PR DESCRIPTION
While working on converting searcher to streaming, I noticed a number of things that don't follow our standard practices, so I took a few minutes to clean it up. Each commit is pretty self-contained, but it mostly boils down to:
- Preferring `go.uber.org/atomic` to the stdlib atomics for clarity
- Using an errgroup rather than a mutex-protected error value and wait groups
- Feeding workers with a channel rather than locking a shared slice

Depends on #22466 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
