### PR TITLE
batches: add mutation to set the UI publication state when applying a batch spec

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -110,7 +110,7 @@ type ApplyBatchChangeArgs struct {
 }
 
 type ChangesetSpecPublicationStateInput struct {
-	ChangesetSpecID  graphql.ID
+	ChangesetSpec    graphql.ID
 	PublicationState batches.PublishedValue
 }
 

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -106,6 +106,12 @@ type CreateBatchChangeArgs struct {
 type ApplyBatchChangeArgs struct {
 	BatchSpec         graphql.ID
 	EnsureBatchChange *graphql.ID
+	PublicationStates *[]ChangesetSpecPublicationStateInput
+}
+
+type ChangesetSpecPublicationStateInput struct {
+	ChangesetSpecID  graphql.ID
+	PublicationState batches.PublishedValue
 }
 
 type ListBatchChangesArgs struct {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2011,6 +2011,17 @@ extend type Mutation {
         deleted). The returned error has the error code ErrEnsureBatchChangeFailed.
         """
         ensureBatchChange: ID
+
+        """
+        If set, these changeset specs will have their UI publication states set
+        to the given values. When updating an existing batch change, this will
+        overwrite existing publication states on the changesets.
+
+        An error will be returned if the same changeset spec ID is included
+        more than once in the array, or if a changeset spec ID is included with
+        a publication state set in its spec.
+        """
+        publicationStates: [ChangesetSpecPublicationStateInput!]
     ): BatchChange!
 
     """
@@ -2878,4 +2889,20 @@ type BatchSpecExecution implements Node {
     finished yet or if it failed.
     """
     batchSpec: BatchSpec
+}
+
+"""
+A ChangesetSpecPublicationStateInput is a tuple containing a changeset spec ID
+and its desired UI publication state.
+"""
+input ChangesetSpecPublicationStateInput {
+    """
+    The changeset spec ID.
+    """
+    changesetSpecID: ID!
+
+    """
+    The desired publication state.
+    """
+    publicationState: PublishedValue!
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2899,7 +2899,7 @@ input ChangesetSpecPublicationStateInput {
     """
     The changeset spec ID.
     """
-    changesetSpecID: ID!
+    changesetSpec: ID!
 
     """
     The desired publication state.

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -468,7 +468,7 @@ func (r *Resolver) ApplyBatchChange(ctx context.Context, args *graphqlbackend.Ap
 	if args.PublicationStates != nil && *args.PublicationStates != nil {
 		var errs *multierror.Error
 		for _, state := range *args.PublicationStates {
-			id, err := unmarshalChangesetSpecID(state.ChangesetSpecID)
+			id, err := unmarshalChangesetSpecID(state.ChangesetSpec)
 			if err != nil {
 				return nil, err
 			}

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -460,6 +461,24 @@ func (r *Resolver) ApplyBatchChange(ctx context.Context, args *graphqlbackend.Ap
 	if args.EnsureBatchChange != nil {
 		opts.EnsureBatchChangeID, err = unmarshalBatchChangeID(*args.EnsureBatchChange)
 		if err != nil {
+			return nil, err
+		}
+	}
+
+	if args.PublicationStates != nil && *args.PublicationStates != nil {
+		var errs *multierror.Error
+		for _, state := range *args.PublicationStates {
+			id, err := unmarshalChangesetSpecID(state.ChangesetSpecID)
+			if err != nil {
+				return nil, err
+			}
+
+			if err := opts.PublicationStates.Add(id, state.PublicationState); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		}
+
+		if err := errs.ErrorOrNil(); err != nil {
 			return nil, err
 		}
 	}

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -529,35 +529,35 @@ func TestApplyBatchChange(t *testing.T) {
 		for name, states := range map[string][]map[string]interface{}{
 			"other batch spec": {
 				{
-					"changesetSpecID":  marshalChangesetSpecRandID(otherChangesetSpec.RandID),
+					"changesetSpec":    marshalChangesetSpecRandID(otherChangesetSpec.RandID),
 					"publicationState": true,
 				},
 			},
 			"duplicate batch specs": {
 				{
-					"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+					"changesetSpec":    marshalChangesetSpecRandID(changesetSpec.RandID),
 					"publicationState": true,
 				},
 				{
-					"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+					"changesetSpec":    marshalChangesetSpecRandID(changesetSpec.RandID),
 					"publicationState": true,
 				},
 			},
 			"invalid publication state": {
 				{
-					"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+					"changesetSpec":    marshalChangesetSpecRandID(changesetSpec.RandID),
 					"publicationState": "foo",
 				},
 			},
 			"invalid changeset spec ID": {
 				{
-					"changesetSpecID":  "foo",
+					"changesetSpec":    "foo",
 					"publicationState": true,
 				},
 			},
 			"changeset spec with a published state": {
 				{
-					"changesetSpecID":  marshalChangesetSpecRandID(publishedChangesetSpec.RandID),
+					"changesetSpec":    marshalChangesetSpecRandID(publishedChangesetSpec.RandID),
 					"publicationState": true,
 				},
 			},
@@ -573,7 +573,7 @@ func TestApplyBatchChange(t *testing.T) {
 		// Finally, let's actually make a legit apply.
 		input["publicationStates"] = []map[string]interface{}{
 			{
-				"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+				"changesetSpec":    marshalChangesetSpecRandID(changesetSpec.RandID),
 				"publicationState": true,
 			},
 		}

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -487,14 +487,130 @@ func TestApplyBatchChange(t *testing.T) {
 	if len(errs) == 0 {
 		t.Fatalf("expected errors, got none")
 	}
+
+	t.Run("publication states", func(t *testing.T) {
+		// Service.ApplyBatchChange() (rightly) early returns if it's called
+		// with the same batch spec, so we need to create a new batch spec here.
+		batchSpec := ct.CreateBatchSpec(t, ctx, cstore, "batch-spec", userID)
+		changesetSpec := ct.CreateChangesetSpec(t, ctx, cstore, ct.TestSpecOpts{
+			User:      userID,
+			Repo:      repo.ID,
+			BatchSpec: batchSpec.ID,
+			HeadRef:   "main",
+		})
+
+		// We need a couple more changeset specs to make this useful: we need to
+		// be able to test that changeset specs attached to other batch specs
+		// cannot be modified, and that changeset specs with explicit published
+		// fields cause errors.
+		otherBatchSpec := ct.CreateBatchSpec(t, ctx, cstore, "other-batch-spec", userID)
+		otherChangesetSpec := ct.CreateChangesetSpec(t, ctx, cstore, ct.TestSpecOpts{
+			User:      userID,
+			Repo:      repo.ID,
+			BatchSpec: otherBatchSpec.ID,
+			HeadRef:   "main",
+		})
+
+		publishedChangesetSpec := ct.CreateChangesetSpec(t, ctx, cstore, ct.TestSpecOpts{
+			User:      userID,
+			Repo:      repo.ID,
+			BatchSpec: batchSpec.ID,
+			HeadRef:   "main",
+			Published: true,
+		})
+
+		// Reset input to a known state.
+		input := map[string]interface{}{
+			"batchSpec": string(marshalBatchSpecRandID(batchSpec.RandID)),
+		}
+
+		// Handle the interesting error cases for different publicationStates
+		// inputs.
+		for name, states := range map[string][]map[string]interface{}{
+			"other batch spec": {
+				{
+					"changesetSpecID":  marshalChangesetSpecRandID(otherChangesetSpec.RandID),
+					"publicationState": true,
+				},
+			},
+			"duplicate batch specs": {
+				{
+					"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+					"publicationState": true,
+				},
+				{
+					"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+					"publicationState": true,
+				},
+			},
+			"invalid publication state": {
+				{
+					"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+					"publicationState": "foo",
+				},
+			},
+			"invalid changeset spec ID": {
+				{
+					"changesetSpecID":  "foo",
+					"publicationState": true,
+				},
+			},
+			"changeset spec with a published state": {
+				{
+					"changesetSpecID":  marshalChangesetSpecRandID(publishedChangesetSpec.RandID),
+					"publicationState": true,
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				input["publicationStates"] = states
+				if errs := apitest.Exec(actorCtx, t, s, input, &response, mutationApplyBatchChange); len(errs) == 0 {
+					t.Fatalf("expected errors, got none")
+				}
+			})
+		}
+
+		// Finally, let's actually make a legit apply.
+		input["publicationStates"] = []map[string]interface{}{
+			{
+				"changesetSpecID":  marshalChangesetSpecRandID(changesetSpec.RandID),
+				"publicationState": true,
+			},
+		}
+		apitest.MustExec(actorCtx, t, s, input, &response, mutationApplyBatchChange)
+		have := response.ApplyBatchChange
+		want := apitest.BatchChange{
+			ID:          have.ID,
+			Name:        batchSpec.Spec.Name,
+			Description: batchSpec.Spec.Description,
+			Namespace: apitest.UserOrg{
+				ID:         userAPIID,
+				DatabaseID: userID,
+				SiteAdmin:  true,
+			},
+			InitialApplier: apiUser,
+			LastApplier:    apiUser,
+			LastAppliedAt:  marshalDateTime(t, now),
+			Changesets: apitest.ChangesetConnection{
+				Nodes: []apitest.Changeset{
+					{Typename: "ExternalChangeset", State: string(btypes.ChangesetStateProcessing)},
+					{Typename: "ExternalChangeset", State: string(btypes.ChangesetStateProcessing)},
+				},
+				TotalCount: 2,
+			},
+		}
+		if diff := cmp.Diff(want, have); diff != "" {
+			t.Errorf("unexpected response (-want +have):\n%s", diff)
+		}
+	})
 }
 
 const mutationApplyBatchChange = `
 fragment u on User { id, databaseID, siteAdmin }
 fragment o on Org  { id, name }
 
-mutation($batchSpec: ID!, $ensureBatchChange: ID){
-  applyBatchChange(batchSpec: $batchSpec, ensureBatchChange: $ensureBatchChange) {
+mutation($batchSpec: ID!, $ensureBatchChange: ID, $publicationStates: [ChangesetSpecPublicationStateInput!]){
+  applyBatchChange(batchSpec: $batchSpec, ensureBatchChange: $ensureBatchChange, publicationStates: $publicationStates) {
     id, name, description
     initialApplier    { ...u }
     lastApplier       { ...u }

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -135,7 +135,7 @@ func (s *Service) ApplyBatchChange(ctx context.Context, opts ApplyBatchChangeOpt
 
 	// Prepare the UI publication states. We need to do this within the
 	// transaction to avoid conflicting writes to the changeset specs.
-	if err := opts.PublicationStates.prepareAndValidate(ctx, tx, batchChange.BatchSpecID); err != nil {
+	if err := opts.PublicationStates.prepareAndValidate(mappings); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -34,6 +34,8 @@ type ApplyBatchChangeOpts struct {
 	// When FailIfBatchChangeExists is true, ApplyBatchChange will fail if a batch change
 	// matching the given batch spec already exists.
 	FailIfBatchChangeExists bool
+
+	PublicationStates UiPublicationStates
 }
 
 func (o ApplyBatchChangeOpts) String() string {
@@ -131,8 +133,18 @@ func (s *Service) ApplyBatchChange(ctx context.Context, opts ApplyBatchChangeOpt
 		return nil, err
 	}
 
+	// Prepare the UI publication states. We need to do this within the
+	// transaction to avoid conflicting writes to the changeset specs.
+	if err := opts.PublicationStates.prepare(ctx, tx, batchChange.BatchSpecID); err != nil {
+		return nil, err
+	}
+
 	// Upsert all changesets.
 	for _, changeset := range changesets {
+		if state := opts.PublicationStates.get(changeset.CurrentSpecID); state != nil {
+			changeset.UiPublicationState = state
+		}
+
 		if err := tx.UpsertChangeset(ctx, changeset); err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -135,7 +135,7 @@ func (s *Service) ApplyBatchChange(ctx context.Context, opts ApplyBatchChangeOpt
 
 	// Prepare the UI publication states. We need to do this within the
 	// transaction to avoid conflicting writes to the changeset specs.
-	if err := opts.PublicationStates.prepare(ctx, tx, batchChange.BatchSpecID); err != nil {
+	if err := opts.PublicationStates.prepareAndValidate(ctx, tx, batchChange.BatchSpecID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/batches/service/ui_publication_states.go
+++ b/enterprise/internal/batches/service/ui_publication_states.go
@@ -15,15 +15,15 @@ import (
 // applyBatchChange mutation, and applies the required validation and processing
 // logic.
 //
-// External users must call Add() to add changeset specs to the struct, then
-// process() must be called before publication states can be retrieved using
-// get().
+// External users must call Add() to add changeset spec random IDs to the
+// struct, then process() must be called before publication states can be
+// retrieved using get().
 type UiPublicationStates struct {
 	rand map[string]batches.PublishedValue
 	id   map[int64]*btypes.ChangesetUiPublicationState
 }
 
-// Add adds a changeset spec to the publication states.
+// Add adds a changeset spec random ID to the publication states.
 func (ps *UiPublicationStates) Add(rand string, value batches.PublishedValue) error {
 	if ps.rand == nil {
 		ps.rand = map[string]batches.PublishedValue{rand: value}

--- a/enterprise/internal/batches/service/ui_publication_states.go
+++ b/enterprise/internal/batches/service/ui_publication_states.go
@@ -51,10 +51,10 @@ type ListChangesetSpeccer interface {
 
 var _ ListChangesetSpeccer = &store.Store{}
 
-// prepare looks up the random changeset spec IDs, and ensures that the
+// prepareAndValidate looks up the random changeset spec IDs, and ensures that the
 // changeset specs are attached to the batch spec and are eligible for a UI
 // publication state.
-func (ps *UiPublicationStates) prepare(ctx context.Context, s ListChangesetSpeccer, batchSpecID int64) error {
+func (ps *UiPublicationStates) prepareAndValidate(ctx context.Context, s ListChangesetSpeccer, batchSpecID int64) error {
 	// If there are no publication states -- which is the normal case -- there's
 	// nothing to do here, and we can bail early.
 	if len(ps.rand) == 0 {

--- a/enterprise/internal/batches/service/ui_publication_states.go
+++ b/enterprise/internal/batches/service/ui_publication_states.go
@@ -1,19 +1,16 @@
 package service
 
 import (
-	"context"
-
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
 // UiPublicationStates takes the publicationStates input from the
 // applyBatchChange mutation, and applies the required validation and processing
-// logic.
+// logic to calculate the eventual publication state for each changeset spec.
 //
 // External users must call Add() to add changeset spec random IDs to the
 // struct, then process() must be called before publication states can be
@@ -45,16 +42,10 @@ func (ps *UiPublicationStates) get(id int64) *btypes.ChangesetUiPublicationState
 	return nil
 }
 
-type ListChangesetSpeccer interface {
-	ListChangesetSpecs(context.Context, store.ListChangesetSpecsOpts) (btypes.ChangesetSpecs, int64, error)
-}
-
-var _ ListChangesetSpeccer = &store.Store{}
-
-// prepareAndValidate looks up the random changeset spec IDs, and ensures that the
-// changeset specs are attached to the batch spec and are eligible for a UI
-// publication state.
-func (ps *UiPublicationStates) prepareAndValidate(ctx context.Context, s ListChangesetSpeccer, batchSpecID int64) error {
+// prepareAndValidate looks up the random changeset spec IDs, and ensures that
+// the changeset specs are included in the current rewirer mappings and are
+// eligible for a UI publication state.
+func (ps *UiPublicationStates) prepareAndValidate(mappings btypes.RewirerMappings) error {
 	// If there are no publication states -- which is the normal case -- there's
 	// nothing to do here, and we can bail early.
 	if len(ps.rand) == 0 {
@@ -62,41 +53,37 @@ func (ps *UiPublicationStates) prepareAndValidate(ctx context.Context, s ListCha
 		return nil
 	}
 
-	// Fetch the changeset specs, being careful to only look at the current
-	// batch spec.
-	randIDs := make([]string, 0, len(ps.rand))
-	for id := range ps.rand {
-		randIDs = append(randIDs, id)
-	}
-
-	specs, _, err := s.ListChangesetSpecs(ctx, store.ListChangesetSpecsOpts{
-		BatchSpecID: batchSpecID,
-		RandIDs:     randIDs,
-	})
-	if err != nil {
-		return err
+	// Fetch the changeset specs from the rewirer mappings and key them by
+	// random ID, since that's the input we have.
+	specs := map[string]*btypes.ChangesetSpec{}
+	for _, mapping := range mappings {
+		if mapping.ChangesetSpecID != 0 {
+			specs[mapping.ChangesetSpec.RandID] = mapping.ChangesetSpec
+		}
 	}
 
 	// Handle the specs. We'll drain ps.rand while we add entries to ps.id,
 	// which means we can ensure that all the given changeset spec IDs mapped to
 	// a changeset spec.
-	ps.id = map[int64]*btypes.ChangesetUiPublicationState{}
 	var errs *multierror.Error
-	for _, spec := range specs {
-		if !spec.Spec.Published.Nil() {
-			// If the changeset spec has an explicit published field, we cannot
-			// override the publication state in the UI.
-			errs = multierror.Append(errs, errors.Newf("changeset spec %q has the published field set in its spec", spec.RandID))
-		} else {
-			ps.id[spec.ID] = btypes.ChangesetUiPublicationStateFromPublishedValue(ps.rand[spec.RandID])
-			delete(ps.rand, spec.RandID)
+	ps.id = map[int64]*btypes.ChangesetUiPublicationState{}
+	for rid, pv := range ps.rand {
+		if spec, ok := specs[rid]; ok {
+			if !spec.Spec.Published.Nil() {
+				// If the changeset spec has an explicit published field, we cannot
+				// override the publication state in the UI.
+				errs = multierror.Append(errs, errors.Newf("changeset spec %q has the published field set in its spec", rid))
+			} else {
+				ps.id[spec.ID] = btypes.ChangesetUiPublicationStateFromPublishedValue(pv)
+				delete(ps.rand, spec.RandID)
+			}
 		}
 	}
 
 	// If there are any changeset spec IDs remaining, let's turn them into
 	// errors.
-	for id := range ps.rand {
-		errs = multierror.Append(errs, errors.Newf("changeset spec %q not found", id))
+	for rid := range ps.rand {
+		errs = multierror.Append(errs, errors.Newf("changeset spec %q not found", rid))
 	}
 
 	return errs.ErrorOrNil()

--- a/enterprise/internal/batches/service/ui_publication_states.go
+++ b/enterprise/internal/batches/service/ui_publication_states.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/lib/batches"
+)
+
+// UiPublicationStates takes the publicationStates input from the
+// applyBatchChange mutation, and applies the required validation and processing
+// logic.
+//
+// External users must call Add() to add changeset specs to the struct, then
+// process() must be called before publication states can be retrieved using
+// get().
+type UiPublicationStates struct {
+	rand map[string]batches.PublishedValue
+	id   map[int64]*btypes.ChangesetUiPublicationState
+}
+
+// Add adds a changeset spec to the publication states.
+func (ps *UiPublicationStates) Add(rand string, value batches.PublishedValue) error {
+	if ps.rand == nil {
+		ps.rand = map[string]batches.PublishedValue{rand: value}
+		return nil
+	}
+
+	if _, ok := ps.rand[rand]; ok {
+		return errors.Newf("duplicate changeset spec: %s", rand)
+	}
+
+	ps.rand[rand] = value
+	return nil
+}
+
+func (ps *UiPublicationStates) get(id int64) *btypes.ChangesetUiPublicationState {
+	if ps.id != nil {
+		return ps.id[id]
+	}
+	return nil
+}
+
+type ListChangesetSpeccer interface {
+	ListChangesetSpecs(context.Context, store.ListChangesetSpecsOpts) (btypes.ChangesetSpecs, int64, error)
+}
+
+var _ ListChangesetSpeccer = &store.Store{}
+
+// prepare looks up the random changeset spec IDs, and ensures that the
+// changeset specs are attached to the batch spec and are eligible for a UI
+// publication state.
+func (ps *UiPublicationStates) prepare(ctx context.Context, s ListChangesetSpeccer, batchSpecID int64) error {
+	// If there are no publication states -- which is the normal case -- there's
+	// nothing to do here, and we can bail early.
+	if len(ps.rand) == 0 {
+		ps.id = nil
+		return nil
+	}
+
+	// Fetch the changeset specs, being careful to only look at the current
+	// batch spec.
+	randIDs := make([]string, 0, len(ps.rand))
+	for id := range ps.rand {
+		randIDs = append(randIDs, id)
+	}
+
+	specs, _, err := s.ListChangesetSpecs(ctx, store.ListChangesetSpecsOpts{
+		BatchSpecID: batchSpecID,
+		RandIDs:     randIDs,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Handle the specs. We'll drain ps.rand while we add entries to ps.id,
+	// which means we can ensure that all the given changeset spec IDs mapped to
+	// a changeset spec.
+	ps.id = map[int64]*btypes.ChangesetUiPublicationState{}
+	var errs *multierror.Error
+	for _, spec := range specs {
+		if !spec.Spec.Published.Nil() {
+			// If the changeset spec has an explicit published field, we cannot
+			// override the publication state in the UI.
+			errs = multierror.Append(errs, errors.Newf("changeset spec %q has the published field set in its spec", spec.RandID))
+		} else {
+			ps.id[spec.ID] = btypes.ChangesetUiPublicationStateFromPublishedValue(ps.rand[spec.RandID])
+			delete(ps.rand, spec.RandID)
+		}
+	}
+
+	// If there are any changeset spec IDs remaining, let's turn them into
+	// errors.
+	for id := range ps.rand {
+		errs = multierror.Append(errs, errors.Newf("changeset spec %q not found", id))
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/enterprise/internal/batches/service/ui_publication_states_test.go
+++ b/enterprise/internal/batches/service/ui_publication_states_test.go
@@ -112,12 +112,12 @@ func TestUiPublicationStates_prepareAndValidate(t *testing.T) {
 		}{
 			"spec not in mappings": {
 				changesetUIs: map[string]batches.PublishedValue{
-					changesetUnwired.RandID: batches.PublishedValue{Val: true},
+					changesetUnwired.RandID: {Val: true},
 				},
 			},
 			"spec with published field": {
 				changesetUIs: map[string]batches.PublishedValue{
-					changesetPublished.RandID: batches.PublishedValue{Val: true},
+					changesetPublished.RandID: {Val: true},
 				},
 			},
 		} {

--- a/enterprise/internal/batches/service/ui_publication_states_test.go
+++ b/enterprise/internal/batches/service/ui_publication_states_test.go
@@ -127,7 +127,7 @@ func TestUiPublicationStates_prepare(t *testing.T) {
 				var ps UiPublicationStates
 				tc.setup(&ps)
 
-				if err := ps.prepare(ctx, bstore, tc.batchSpecID); err == nil {
+				if err := ps.prepareAndValidate(ctx, bstore, tc.batchSpecID); err == nil {
 					t.Error("unexpected nil error")
 				}
 			})
@@ -138,7 +138,7 @@ func TestUiPublicationStates_prepare(t *testing.T) {
 		var ps UiPublicationStates
 
 		ps.Add(changesetSpecA.RandID, batches.PublishedValue{Val: true})
-		if err := ps.prepare(ctx, &brokenListChangesetSpeccer{}, batchSpecA.ID); err == nil {
+		if err := ps.prepareAndValidate(ctx, &brokenListChangesetSpeccer{}, batchSpecA.ID); err == nil {
 			t.Error("unexpected nil error")
 		}
 	})
@@ -147,7 +147,7 @@ func TestUiPublicationStates_prepare(t *testing.T) {
 		var ps UiPublicationStates
 
 		ps.Add(changesetSpecA.RandID, batches.PublishedValue{Val: true})
-		if err := ps.prepare(ctx, bstore, batchSpecA.ID); err != nil {
+		if err := ps.prepareAndValidate(ctx, bstore, batchSpecA.ID); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(ps.rand) != 0 {
@@ -171,7 +171,7 @@ func TestUiPublicationStates_prepareEmpty(t *testing.T) {
 		"empty": {rand: map[string]batches.PublishedValue{}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if err := ps.prepare(ctx, nil, 0); err != nil {
+			if err := ps.prepareAndValidate(ctx, nil, 0); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})

--- a/enterprise/internal/batches/service/ui_publication_states_test.go
+++ b/enterprise/internal/batches/service/ui_publication_states_test.go
@@ -20,7 +20,7 @@ import (
 func TestUiPublicationStates_Add(t *testing.T) {
 	var ps UiPublicationStates
 
-	// Add a single changeset spec, ensuring that ps.rand is initialised.
+	// Add a single publication state, ensuring that ps.rand is initialised.
 	if err := ps.Add("foo", batches.PublishedValue{Val: true}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestUiPublicationStates_Add(t *testing.T) {
 		t.Errorf("unexpected number of elements: %d", len(ps.rand))
 	}
 
-	// Add another changeset spec.
+	// Add another publication state.
 	if err := ps.Add("bar", batches.PublishedValue{Val: true}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestUiPublicationStates_Add(t *testing.T) {
 		t.Errorf("unexpected number of elements: %d", len(ps.rand))
 	}
 
-	// Try to add a duplicate changeset spec.
+	// Try to add a duplicate publication state.
 	if err := ps.Add("bar", batches.PublishedValue{Val: true}); err == nil {
 		t.Error("unexpected nil error")
 	}

--- a/enterprise/internal/batches/service/ui_publication_states_test.go
+++ b/enterprise/internal/batches/service/ui_publication_states_test.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/lib/batches"
+)
+
+func TestUiPublicationStates_Add(t *testing.T) {
+	var ps UiPublicationStates
+
+	// Add a single changeset spec, ensuring that ps.rand is initialised.
+	if err := ps.Add("foo", batches.PublishedValue{Val: true}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(ps.rand) != 1 {
+		t.Errorf("unexpected number of elements: %d", len(ps.rand))
+	}
+
+	// Add another changeset spec.
+	if err := ps.Add("bar", batches.PublishedValue{Val: true}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(ps.rand) != 2 {
+		t.Errorf("unexpected number of elements: %d", len(ps.rand))
+	}
+
+	// Try to add a duplicate changeset spec.
+	if err := ps.Add("bar", batches.PublishedValue{Val: true}); err == nil {
+		t.Error("unexpected nil error")
+	}
+	if len(ps.rand) != 2 {
+		t.Errorf("unexpected number of elements: %d", len(ps.rand))
+	}
+}
+
+func TestUiPublicationStates_get(t *testing.T) {
+	var ps UiPublicationStates
+
+	// Verify that an uninitialised UiPublicationStates can have get() called
+	// without panicking.
+	ps.get(0)
+
+	ps.id = map[int64]*btypes.ChangesetUiPublicationState{
+		1: &btypes.ChangesetUiPublicationStateDraft,
+		2: &btypes.ChangesetUiPublicationStateUnpublished,
+		3: nil,
+	}
+
+	for id, want := range map[int64]*btypes.ChangesetUiPublicationState{
+		1: &btypes.ChangesetUiPublicationStateDraft,
+		2: &btypes.ChangesetUiPublicationStateUnpublished,
+		3: nil,
+		4: nil,
+	} {
+		t.Run(strconv.FormatInt(id, 10), func(t *testing.T) {
+			if have := ps.get(id); have != want {
+				t.Errorf("unexpected result: have=%v want=%v", have, want)
+			}
+		})
+	}
+}
+
+func TestUiPublicationStates_prepare(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	db := dbtest.NewDB(t, "")
+
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
+	bstore := store.NewWithClock(db, nil, clock)
+
+	repos, _ := bt.CreateGitHubSSHTestRepos(t, ctx, db, 1)
+	repo := repos[0]
+	userID := bt.CreateTestUser(t, db, true).ID
+
+	batchSpecA := bt.CreateBatchSpec(t, ctx, bstore, "a", userID)
+	batchSpecB := bt.CreateBatchSpec(t, ctx, bstore, "b", userID)
+
+	changesetSpecA := bt.CreateChangesetSpec(t, ctx, bstore, bt.TestSpecOpts{
+		User:      userID,
+		Repo:      repo.ID,
+		BatchSpec: batchSpecA.ID,
+		HeadRef:   "main",
+	})
+	changesetSpecB := bt.CreateChangesetSpec(t, ctx, bstore, bt.TestSpecOpts{
+		User:      userID,
+		Repo:      repo.ID,
+		BatchSpec: batchSpecB.ID,
+		HeadRef:   "main",
+		Published: true,
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			batchSpecID int64
+			setup       func(ps *UiPublicationStates)
+		}{
+			"incorrect batch spec": {
+				batchSpecID: batchSpecB.ID,
+				setup: func(ps *UiPublicationStates) {
+					ps.Add(changesetSpecA.RandID, batches.PublishedValue{Val: true})
+				},
+			},
+			"spec with published field": {
+				batchSpecID: batchSpecB.ID,
+				setup: func(ps *UiPublicationStates) {
+					ps.Add(changesetSpecB.RandID, batches.PublishedValue{Val: true})
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				var ps UiPublicationStates
+				tc.setup(&ps)
+
+				if err := ps.prepare(ctx, bstore, tc.batchSpecID); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+
+	t.Run("database error", func(t *testing.T) {
+		var ps UiPublicationStates
+
+		ps.Add(changesetSpecA.RandID, batches.PublishedValue{Val: true})
+		if err := ps.prepare(ctx, &brokenListChangesetSpeccer{}, batchSpecA.ID); err == nil {
+			t.Error("unexpected nil error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		var ps UiPublicationStates
+
+		ps.Add(changesetSpecA.RandID, batches.PublishedValue{Val: true})
+		if err := ps.prepare(ctx, bstore, batchSpecA.ID); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(ps.rand) != 0 {
+			t.Errorf("unexpected elements remaining in ps.rand: %+v", ps.rand)
+		}
+
+		want := map[int64]*btypes.ChangesetUiPublicationState{
+			changesetSpecA.ID: &btypes.ChangesetUiPublicationStatePublished,
+		}
+		if diff := cmp.Diff(want, ps.id); diff != "" {
+			t.Errorf("unexpected ps.id (-want +have):\n%s", diff)
+		}
+	})
+}
+
+func TestUiPublicationStates_prepareEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	for name, ps := range map[string]UiPublicationStates{
+		"nil":   {},
+		"empty": {rand: map[string]batches.PublishedValue{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := ps.prepare(ctx, nil, 0); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type brokenListChangesetSpeccer struct{}
+
+var _ ListChangesetSpeccer = &brokenListChangesetSpeccer{}
+
+func (*brokenListChangesetSpeccer) ListChangesetSpecs(context.Context, store.ListChangesetSpecsOpts) (btypes.ChangesetSpecs, int64, error) {
+	return nil, 0, errors.New("database error")
+}

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
 // ChangesetState defines the possible states of a Changeset.
@@ -84,11 +85,22 @@ func (s ChangesetPublicationState) Unpublished() bool {
 
 type ChangesetUiPublicationState string
 
-const (
+var (
 	ChangesetUiPublicationStateUnpublished ChangesetUiPublicationState = "UNPUBLISHED"
 	ChangesetUiPublicationStateDraft       ChangesetUiPublicationState = "DRAFT"
 	ChangesetUiPublicationStatePublished   ChangesetUiPublicationState = "PUBLISHED"
 )
+
+func ChangesetUiPublicationStateFromPublishedValue(value batches.PublishedValue) *ChangesetUiPublicationState {
+	if value.True() {
+		return &ChangesetUiPublicationStatePublished
+	} else if value.Draft() {
+		return &ChangesetUiPublicationStateDraft
+	} else if !value.Nil() {
+		return &ChangesetUiPublicationStateUnpublished
+	}
+	return nil
+}
 
 func (s ChangesetUiPublicationState) Valid() bool {
 	switch s {

--- a/lib/batches/published.go
+++ b/lib/batches/published.go
@@ -2,7 +2,6 @@ package batches
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 

--- a/lib/batches/published.go
+++ b/lib/batches/published.go
@@ -87,7 +87,7 @@ func (p *PublishedValue) UnmarshalYAML(unmarshal func(interface{}) error) error 
 func (p *PublishedValue) UnmarshalGraphQL(input interface{}) error {
 	p.Val = input
 	if !p.Valid() {
-		return errors.New("invalid PublishedValue")
+		return fmt.Errorf("invalid PublishedValue: %v", input)
 	}
 	return nil
 }

--- a/lib/batches/published.go
+++ b/lib/batches/published.go
@@ -2,6 +2,7 @@ package batches
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -85,6 +86,9 @@ func (p *PublishedValue) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 func (p *PublishedValue) UnmarshalGraphQL(input interface{}) error {
 	p.Val = input
+	if !p.Valid() {
+		return errors.New("invalid PublishedValue")
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is part 4 of #18277. (Next up is putting a UI on top of this.)

This adds an optional input parameter to `applyBatchChange()` that provides the initial UI publication state for some or all of the changeset specs attached to the batch spec. About two thirds of this diff is tests: there's some overlap between the new resolver tests and the new unit tests for the service option type, but it felt important to test at both layers.