### PR TITLE
search-blitz: start ticker after random sleep

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -56,8 +56,6 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		if qc.Interval == 0 {
 			qc.Interval = time.Minute
 		}
-		ticker := time.NewTicker(qc.Interval)
-		defer ticker.Stop()
 
 		// Randomize start to a random time in the initial interval so our
 		// queries aren't all scheduled at the same time.
@@ -67,6 +65,9 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 			return
 		case <-time.After(randomStart):
 		}
+
+		ticker := time.NewTicker(qc.Interval)
+		defer ticker.Stop()
 
 		for {
 


### PR DESCRIPTION
Previously all queries would do the first request at a random time, but
after that point every query would be running at the same time. Instead
we now start the ticker after the jitter.
