### PR TITLE
search-blitz: jitter sleep instead of ticker

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -56,8 +56,6 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		if qc.Interval == 0 {
 			qc.Interval = time.Minute
 		}
-		ticker := time.NewTicker(qc.Interval)
-		defer ticker.Stop()
 
 		// Randomize start to a random time in the initial interval so our
 		// queries aren't all scheduled at the same time.
@@ -67,6 +65,9 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 			return
 		case <-time.After(randomStart):
 		}
+
+		ticker := time.NewTicker(qc.Interval)
+		defer ticker.Stop()
 
 		for {
 


### PR DESCRIPTION
Using a ticker means a query will always run at a specific moment every
minute. By introducing jitter we avoid predictable behaviour. We jitter
by 25% between each query. In practice this means we sleep for 45s ->
1m15s between each request.

The other change here is how long we sleep is affected by how slow the
query we run is. This seems fine, since most queries are very fast and
the jitter is much larger than the query runtime.

A reason against doing this change is we are now less predictable. IE we
can't rule out bad luck (all queries running at the same time). This be
a very good reason to not do this change.