### PR TITLE
search-blitz: include name and client type in logs

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -59,7 +59,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		ticker := time.NewTicker(qc.Interval)
 		defer ticker.Stop()
 
-		log := log15.New("group", group, "query", qc.Query)
+		log := log15.New("group", group, "name", qc.Name, "query", qc.Query, "type", c.clientType())
 
 		// Randomize start to a random time in the initial interval so our
 		// queries aren't all scheduled at the same time.
@@ -77,7 +77,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 				log.Error(err.Error())
 			} else {
 				log.Info("metrics", "trace", m.trace, "duration_ms", m.took)
-				durationSearchHistogram.WithLabelValues(group, c.clientType()).Observe(float64(m.took))
+				durationSearchHistogram.WithLabelValues(group, qc.Name, c.clientType()).Observe(float64(m.took))
 			}
 
 			select {

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -59,6 +59,8 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		ticker := time.NewTicker(qc.Interval)
 		defer ticker.Stop()
 
+		log := log15.New("group", group, "query", qc.Query)
+
 		// Randomize start to a random time in the initial interval so our
 		// queries aren't all scheduled at the same time.
 		randomStart := time.Duration(int64(float64(qc.Interval) * rand.Float64()))
@@ -72,9 +74,9 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 
 			m, err := c.search(ctx, qc.Query, qc.Name)
 			if err != nil {
-				log15.Error(err.Error())
+				log.Error(err.Error())
 			} else {
-				log15.Info("metrics", "group", group, "query", qc.Query, "trace", m.trace, "duration_ms", m.took)
+				log.Info("metrics", "trace", m.trace, "duration_ms", m.took)
 				durationSearchHistogram.WithLabelValues(group, c.clientType()).Observe(float64(m.took))
 			}
 

--- a/internal/cmd/search-blitz/prometheus.go
+++ b/internal/cmd/search-blitz/prometheus.go
@@ -8,7 +8,7 @@ var durationSearchHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpt
 	Name:    "search_blitz_duration_ms",
 	Help:    "e2e duration search-blitz where search_type is either stream or batch",
 	Buckets: UserLatencyBuckets,
-}, []string{"type", "search_type"})
+}, []string{"group", "query_name", "client"})
 
 func init() {
 	prometheus.MustRegister(durationSearchHistogram)


### PR DESCRIPTION
Additionally we also include all the contextual information when we do error logs.

We also change the prometheus metric to include name. I don't think anyone consumes this at the moment, so safe to change.