### PR TITLE
repos: Remove cloud param from FetchStatusMessages

### DIFF
--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -23,7 +22,7 @@ func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageRe
 
 	// 🚨 SECURITY: Users will fetch status messages for any external services they
 	// own. In addition, site admins will also fetch site level external services.
-	messages, err := repos.FetchStatusMessages(ctx, r.db, currentUser, envvar.SourcegraphDotComMode())
+	messages, err := repos.FetchStatusMessages(ctx, r.db, currentUser)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -17,7 +17,7 @@ var MockStatusMessages func(context.Context, *types.User) ([]StatusMessage, erro
 // external service sync errors we'll fetch any external services owned by the
 // user. In addition, if the user is a site admin we'll also fetch site level
 // external services.
-func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User, cloud bool) ([]StatusMessage, error) {
+func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]StatusMessage, error) {
 	if MockStatusMessages != nil {
 		return MockStatusMessages(ctx, u)
 	}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -80,7 +80,6 @@ func TestStatusMessages(t *testing.T) {
 		user             *types.User
 		// maps repoName to external service
 		repoOwner map[api.RepoName]*types.ExternalService
-		cloud     bool
 		err       string
 	}{
 		{
@@ -359,7 +358,7 @@ func TestStatusMessages(t *testing.T) {
 				tc.err = "<nil>"
 			}
 
-			res, err := FetchStatusMessages(ctx, db, tc.user, tc.cloud)
+			res, err := FetchStatusMessages(ctx, db, tc.user)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("have err: %q, want: %q", have, want)
 			}


### PR DESCRIPTION
We no longer special case cloud as instead we simply don't look at
external services flagged as cloud_default
