### PR TITLE
search-blitz: cleanup queries after loading from YAML

### DIFF
--- a/internal/cmd/search-blitz/config.go
+++ b/internal/cmd/search-blitz/config.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Config struct {
-	Groups []QueryGroupConfig
+	Groups []*QueryGroupConfig
 }
 
 type QueryGroupConfig struct {
 	Name    string
-	Queries []QueryConfig
+	Queries []*QueryConfig
 }
 
 type QueryConfig struct {

--- a/internal/cmd/search-blitz/io.go
+++ b/internal/cmd/search-blitz/io.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -15,5 +16,22 @@ func loadQueries(path string) (*Config, error) {
 	dec := yaml.NewDecoder(f)
 	var config Config
 	err = dec.Decode(&config)
-	return &config, err
+	if err != nil {
+		return nil, err
+	}
+	massageYaml(&config)
+	return &config, nil
+}
+
+func massageYaml(c *Config) {
+	for _, group := range c.Groups {
+		for _, q := range group.Queries {
+			// Remove newlines and extra space from "readable" yaml
+			parts := strings.Split(q.Query, "\n")
+			for i := range parts {
+				parts[i] = strings.TrimSpace(parts[i])
+			}
+			q.Query = strings.TrimSpace(strings.Join(parts, " "))
+		}
+	}
 }

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -52,7 +52,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		return nil
 	}
 
-	loopSearch := func(ctx context.Context, c genericClient, group string, qc QueryConfig) {
+	loopSearch := func(ctx context.Context, c genericClient, group string, qc *QueryConfig) {
 		if qc.Interval == 0 {
 			qc.Interval = time.Minute
 		}
@@ -86,7 +86,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		}
 	}
 
-	scheduleQuery := func(ctx context.Context, group string, qc QueryConfig) {
+	scheduleQuery := func(ctx context.Context, group string, qc *QueryConfig) {
 		if len(qc.Protocols) == 0 {
 			qc.Protocols = allProtocols
 		}


### PR DESCRIPTION
Noticed we were passing in newlines to sourcegraph in the query. Unsure
what the implications are of that, so cleaning it up.