### PR TITLE
search-blitz: track first result time and match count in logs

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -77,7 +77,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 			if err != nil {
 				log.Error(err.Error())
 			} else {
-				log.Info("metrics", "trace", m.trace, "duration_ms", m.took)
+				log.Info("metrics", "trace", m.trace, "duration_ms", m.took, "first_result_ms", m.firstResultMs, "match_count", m.matchCount)
 				durationSearchHistogram.WithLabelValues(group, qc.Name, c.clientType()).Observe(float64(m.took))
 			}
 

--- a/internal/cmd/search-blitz/protocol.go
+++ b/internal/cmd/search-blitz/protocol.go
@@ -36,6 +36,8 @@ type searchResultsAlert struct {
 }
 
 type metrics struct {
-	took  int64
-	trace string
+	took          int64
+	firstResultMs int64
+	matchCount    int
+	trace         string
 }


### PR DESCRIPTION
Co-authored-by: Tomás Senart <tomas@sourcegraph.com>
Co-authored-by: Stefan Hengl <stefan@sourcegraph.com>
