### PR TITLE
search: double zoekt buffer size

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -411,7 +411,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 
 		// The buffered backend.ZoektStreamFunc allows us to consume events from Zoekt
 		// while we wait for repo resolution.
-		bufSender, cleanup := bufferedSender(120, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+		bufSender, cleanup := bufferedSender(240, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 
 			foundResults.CAS(false, event.FileCount != 0 || event.MatchCount != 0)
 


### PR DESCRIPTION
We buffer to avoid causing back pressure on zoekt while resolving
repositories. Since we increased the corpus size we have noticed far
more contention on zoekt's streaming writer. This is a sign of more back
pressure. So increasing the amount of buffering we do should alleviate
this.

Co-authored-by: @tsenart 
Co-authored-by: @stefanhengl 