### PR TITLE
all: update zoekt to include ListOptions

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -32,13 +32,13 @@ type repositoryTextSearchIndexResolver struct {
 }
 
 type repoLister interface {
-	List(ctx context.Context, q zoektquery.Q) (*zoekt.RepoList, error)
+	List(ctx context.Context, q zoektquery.Q, opts *zoekt.ListOptions) (*zoekt.RepoList, error)
 }
 
 func (r *repositoryTextSearchIndexResolver) resolve(ctx context.Context) (*zoekt.RepoListEntry, error) {
 	r.once.Do(func() {
 		q := &zoektquery.RepoBranches{Set: map[string][]string{r.repo.Name(): {"HEAD"}}}
-		repoList, err := r.client.List(ctx, q)
+		repoList, err := r.client.List(ctx, q, nil)
 		if err != nil {
 			r.err = err
 			return

--- a/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
@@ -18,7 +18,7 @@ import (
 
 type repoListerMock struct{}
 
-func (r repoListerMock) List(ctx context.Context, q zoektquery.Q) (*zoekt.RepoList, error) {
+func (r repoListerMock) List(ctx context.Context, q zoektquery.Q, opts *zoekt.ListOptions) (*zoekt.RepoList, error) {
 	zoektRepo := []*zoekt.RepoListEntry{{
 		Repository: zoekt.Repository{
 			Name: string("alice/repo"),

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210622031536-099907aa573a
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210702090744-1ca29d10c3c2
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -784,7 +784,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -990,7 +989,6 @@ github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkB
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1171,7 +1169,6 @@ github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtb
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
-github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1345,26 +1342,22 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210622031536-099907aa573a h1:IxUdGEzDWYzh+yaVof6QSBh4p0epg6mtSAzStBFCmvA=
-github.com/sourcegraph/zoekt v0.0.0-20210622031536-099907aa573a/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
+github.com/sourcegraph/zoekt v0.0.0-20210702090744-1ca29d10c3c2 h1:IMzdbiIq54c23sBirDxsJG/Yo5ir5yY/Ru+0/DW32JI=
+github.com/sourcegraph/zoekt v0.0.0-20210702090744-1ca29d10c3c2/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.1.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
-github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1377,7 +1370,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
-github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
@@ -1401,7 +1393,6 @@ github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPr
 github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
-github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -2020,7 +2011,6 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=

--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -29,7 +29,7 @@ func (ss *FakeSearcher) StreamSearch(ctx context.Context, q zoektquery.Q, opts *
 	return (&StreamSearchAdapter{ss}).StreamSearch(ctx, q, opts, z)
 }
 
-func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q) (*zoekt.RepoList, error) {
+func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q, opt *zoekt.ListOptions) (*zoekt.RepoList, error) {
 	return &zoekt.RepoList{Repos: ss.Repos}, nil
 }
 

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -92,7 +92,7 @@ func AggregateStreamSearch(ctx context.Context, streamSearch func(context.Contex
 }
 
 // List aggregates list over every endpoint in Map.
-func (s *HorizontalSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
+func (s *HorizontalSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListOptions) (*zoekt.RepoList, error) {
 	clients, err := s.searchers()
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoLi
 	results := make(chan result, len(clients))
 	for _, c := range clients {
 		go func(c zoekt.Streamer) {
-			rl, err := c.List(ctx, q)
+			rl, err := c.List(ctx, q, opts)
 			results <- result{rl: rl, err: err}
 		}(c)
 	}

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -87,7 +87,7 @@ func TestHorizontalSearcher(t *testing.T) {
 		}
 
 		// Our list results should be one per server
-		rle, err := searcher.List(context.Background(), nil)
+		rle, err := searcher.List(context.Background(), nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -307,7 +307,7 @@ func backgroundSearch(searcher zoekt.Searcher) func(t *testing.T) {
 				errC <- err
 				return
 			}
-			_, err = searcher.List(context.Background(), nil)
+			_, err = searcher.List(context.Background(), nil, nil)
 			if err != nil {
 				errC <- err
 				return
@@ -353,7 +353,7 @@ func (s *mockSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.
 	return (&StreamSearchAdapter{s}).StreamSearch(ctx, q, opts, streamer)
 }
 
-func (s *mockSearcher) List(context.Context, query.Q) (*zoekt.RepoList, error) {
+func (s *mockSearcher) List(context.Context, query.Q, *zoekt.ListOptions) (*zoekt.RepoList, error) {
 	return s.listResult, s.listError
 }
 

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -185,7 +185,7 @@ func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 	return AggregateStreamSearch(ctx, m.StreamSearch, q, opts)
 }
 
-func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
+func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListOptions) (*zoekt.RepoList, error) {
 	start := time.Now()
 
 	var cat string
@@ -202,8 +202,9 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList,
 	}
 
 	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q), tags...)
+	tr.LogFields(trace.Stringer("opts", opts))
 
-	zsl, err := m.Streamer.List(ctx, q)
+	zsl, err := m.Streamer.List(ctx, q, opts)
 
 	code := "200"
 	if err != nil {

--- a/internal/search/backend/text.go
+++ b/internal/search/backend/text.go
@@ -82,7 +82,7 @@ func (c *Zoekt) Enabled() bool {
 }
 
 func (c *Zoekt) list(ctx context.Context) (map[string]*zoekt.Repository, error) {
-	resp, err := c.Client.List(ctx, &zoektquery.Const{Value: true})
+	resp, err := c.Client.List(ctx, &zoektquery.Const{Value: true}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -109,7 +109,7 @@ func reposAtEndpoint(ctx context.Context, endpoint string) map[string]struct{} {
 	cl := rpc.Client(endpoint)
 	defer cl.Close()
 
-	resp, err := cl.List(ctx, &query.Const{Value: true})
+	resp, err := cl.List(ctx, &query.Const{Value: true}, nil)
 	if err != nil {
 		return map[string]struct{}{}
 	}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -527,7 +527,7 @@ func bufferedSender(cap int, sender zoekt.Sender) (zoekt.Sender, func()) {
 // only for the repos that contain matches for the query. This is a performance optimization,
 // and not required for proper function of select:repo.
 func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoektquery.Q, c streaming.Sender, getRepoRevMap func() map[string]*search.RepositoryRevisions) error {
-	repoList, err := client.List(ctx, query)
+	repoList, err := client.List(ctx, query, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -47,7 +47,7 @@ func GetRepositories(ctx context.Context) (*Repositories, error) {
 		total.GitDirBytes += uint64(stat.GitDirBytes)
 	}
 
-	repos, err := search.Indexed().Client.List(ctx, &query.Const{Value: true})
+	repos, err := search.Indexed().Client.List(ctx, &query.Const{Value: true}, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit updates Zoekt. We now pass in ListOptions to all List calls.

Commits included:
- https://github.com/sourcegraph/zoekt/commit/1ca29d1 Revert "add back subrepo branch validation"
- https://github.com/sourcegraph/zoekt/commit/0776897 matchtree: use predicate support in docMatchTree
- https://github.com/sourcegraph/zoekt/commit/32fedb7 Merge remote-tracking branch 'gerrit/master'
- https://github.com/sourcegraph/zoekt/commit/57d69c7 docMatchTree: compute document ids lazily
- https://github.com/sourcegraph/zoekt/commit/c09f4eb add back subrepo branch validation
- https://github.com/sourcegraph/zoekt/commit/0358cc5 indexserver: write public.txt
- https://github.com/sourcegraph/zoekt/commit/3f1b0d3 BenchmarkMinimalRepoListEncodings on a larger size
- https://github.com/sourcegraph/zoekt/commit/b8b0a64 all: implement minimal repo listing
- https://github.com/sourcegraph/zoekt/commit/09cdd44 stats: support multiple repos
- https://github.com/sourcegraph/zoekt/commit/1fd10b7 indexdata: remove simple shard special casing
- https://github.com/sourcegraph/zoekt/commit/ffbfd13 indexdata: support List with non-constant query on compound shard
