### PR TITLE
repo-updater: Reduce allocations caused by scheduler syncing

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -463,7 +463,7 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 			log15.Error("Listing default repos", "error", err)
 			return
 		} else {
-			// Ensure that uncloned repos are known to the scheduler
+			// Ensure that uncloned indexable repos are known to the scheduler
 			sched.EnsureScheduled(u)
 		}
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -406,10 +406,13 @@ type scheduler interface {
 	// UpdateFromDiff updates the scheduled and queued repos from the given sync diff.
 	UpdateFromDiff(repos.Diff)
 
-	// SetCloned ensures uncloned repos are given priority in the scheduler.
-	SetCloned([]string)
+	// SetUncloned ensures uncloned repos are given priority in the scheduler.
+	SetUncloned([]string)
 
-	// EnsureScheduled ensures that all the repos provided are known to the scheduler
+	// ListRepos lists all the repos managed by the scheduler.
+	ListRepos() []string
+
+	// EnsureScheduled ensures that all the repos provided are known to the scheduler.
 	EnsureScheduled([]types.RepoName)
 }
 
@@ -453,7 +456,7 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 			return
 		}
 
-		// Fetch ALL default repos that are NOT cloned so that we can add them to the
+		// Fetch ALL indexable repos that are NOT cloned so that we can add them to the
 		// scheduler
 		opts := database.ListIndexableReposOptions{
 			OnlyUncloned:   true,
@@ -467,17 +470,21 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 			sched.EnsureScheduled(u)
 		}
 
-		// TODO: Now that we store sync state in the DB maybe we should query from there
-		// instead of gitserver?
-		cloned, err := gitserverClient.ListCloned(ctx)
+		// Next, move any repos managed by the scheduler that are uncloned to the front
+		// of the queue
+		managed := sched.ListRepos()
+
+		uncloned, err := baseRepoStore.ListRepoNames(ctx, database.ReposListOptions{Names: managed, NoCloned: true})
 		if err != nil {
-			log15.Warn("failed to fetch list of cloned repositories", "error", err)
+			log15.Warn("failed to fetch list of uncloned repositories", "error", err)
 			return
 		}
+		names := make([]string, len(uncloned))
+		for i := range uncloned {
+			names[i] = string(uncloned[i].Name)
+		}
 
-		// Ensure that any uncloned repos are moved to the front of the schedule
-		// TODO: Could we change this to send through only the uncloned repos?
-		sched.SetCloned(cloned)
+		sched.SetUncloned(names)
 	}
 
 	for ctx.Err() == nil {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -406,8 +406,8 @@ type scheduler interface {
 	// UpdateFromDiff updates the scheduled and queued repos from the given sync diff.
 	UpdateFromDiff(repos.Diff)
 
-	// SetUncloned ensures uncloned repos are given priority in the scheduler.
-	SetUncloned([]string)
+	// PrioritiseUncloned ensures uncloned repos are given priority in the scheduler.
+	PrioritiseUncloned([]string)
 
 	// ListRepos lists all the repos managed by the scheduler.
 	ListRepos() []string
@@ -484,7 +484,7 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 			names[i] = string(uncloned[i].Name)
 		}
 
-		sched.SetUncloned(names)
+		sched.PrioritiseUncloned(names)
 	}
 
 	for ctx.Err() == nil {

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -300,13 +300,13 @@ func (s *updateScheduler) UpdateFromDiff(diff Diff) {
 	}
 }
 
-// SetUncloned will treat any repos listed in names as uncloned, which in effect
+// PrioritiseUncloned will treat any repos listed in names as uncloned, which in effect
 // will move them to the front of he queue for updating ASAP.
 //
 // This method should be called periodically with the list of all repositories
 // managed by the scheduler that are not cloned on gitserver.
-func (s *updateScheduler) SetUncloned(names []string) {
-	s.schedule.setUncloned(names)
+func (s *updateScheduler) PrioritiseUncloned(names []string) {
+	s.schedule.prioritiseUncloned(names)
 }
 
 // EnsureScheduled ensures that all repos in repos exist in the scheduler.
@@ -690,7 +690,7 @@ func (s *schedule) upsert(repo configuredRepo) (updated bool) {
 	return false
 }
 
-func (s *schedule) setUncloned(names []string) {
+func (s *schedule) prioritiseUncloned(names []string) {
 	// Set of names created outside of lock for fast checking.
 	uncloned := make(map[string]struct{}, len(names))
 	for _, n := range names {

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -300,19 +300,30 @@ func (s *updateScheduler) UpdateFromDiff(diff Diff) {
 	}
 }
 
-// SetCloned will ensure only repos in names are treated as cloned. All other
-// repositories in the scheduler will be marked as uncloned.
+// SetUncloned will treat any repos listed in names as uncloned, which in effect
+// will move them to the front of he queue for updating ASAP.
 //
 // This method should be called periodically with the list of all repositories
-// cloned on gitserver. This ensures the scheduler treats uncloned
-// repositories with a higher priority.
-func (s *updateScheduler) SetCloned(names []string) {
-	s.schedule.setCloned(names)
+// managed by the scheduler that are not cloned on gitserver.
+func (s *updateScheduler) SetUncloned(names []string) {
+	s.schedule.setUncloned(names)
 }
 
 // EnsureScheduled ensures that all repos in repos exist in the scheduler.
 func (s *updateScheduler) EnsureScheduled(repos []types.RepoName) {
 	s.schedule.insertNew(repos)
+}
+
+// ListRepos list all repos managed by the scheduler
+func (s *updateScheduler) ListRepos() []string {
+	s.schedule.mu.Lock()
+	defer s.schedule.mu.Unlock()
+
+	names := make([]string, len(s.schedule.heap))
+	for i := range s.schedule.heap {
+		names[i] = string(s.schedule.heap[i].Repo.Name)
+	}
+	return names
 }
 
 // upsert adds r to the scheduler for periodic updates. If r.ID is already in
@@ -679,11 +690,11 @@ func (s *schedule) upsert(repo configuredRepo) (updated bool) {
 	return false
 }
 
-func (s *schedule) setCloned(names []string) {
+func (s *schedule) setUncloned(names []string) {
 	// Set of names created outside of lock for fast checking.
-	cloned := make(map[string]struct{}, len(names))
+	uncloned := make(map[string]struct{}, len(names))
 	for _, n := range names {
-		cloned[strings.ToLower(n)] = struct{}{}
+		uncloned[strings.ToLower(n)] = struct{}{}
 	}
 
 	// All non-cloned repos will be due for cloning as if they are newly added
@@ -698,7 +709,8 @@ func (s *schedule) setCloned(names []string) {
 	// heap.
 	rescheduleTimer := false
 	for _, repoUpdate := range s.index {
-		if _, ok := cloned[strings.ToLower(string(repoUpdate.Repo.Name))]; ok {
+		if _, ok := uncloned[strings.ToLower(string(repoUpdate.Repo.Name))]; !ok {
+			// It not in the uncloned list, skip
 			continue
 		}
 		if repoUpdate.Due.After(notClonedDue) {

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -802,7 +802,7 @@ func TestSchedule_upsert(t *testing.T) {
 	}
 }
 
-func TestUpdateQueue_SetUncloned(t *testing.T) {
+func TestUpdateQueue_PrioritiseUncloned(t *testing.T) {
 	cloned1 := configuredRepo{ID: 1, Name: "cloned1"}
 	cloned2 := configuredRepo{ID: 2, Name: "CLONED2"}
 	notcloned := configuredRepo{ID: 3, Name: "notcloned"}
@@ -828,10 +828,10 @@ func TestUpdateQueue_SetUncloned(t *testing.T) {
 
 	assertFront(cloned1.Name)
 
-	// Reset the time to now and do setUncloned. We then verify that notcloned
+	// Reset the time to now and do prioritiseUncloned. We then verify that notcloned
 	// is now at the front of the queue.
 	mockTime(defaultTime)
-	s.schedule.setUncloned([]string{"notcloned"})
+	s.schedule.prioritiseUncloned([]string{"notcloned"})
 
 	assertFront(notcloned.Name)
 }

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -7,16 +7,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/schema"
-
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	gitserverprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 var defaultTime = time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
@@ -72,7 +71,6 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 		repo     configuredRepo
 		priority priority
 	}
-
 	tests := []struct {
 		name                  string
 		calls                 []*enqueueCall
@@ -804,7 +802,7 @@ func TestSchedule_upsert(t *testing.T) {
 	}
 }
 
-func TestUpdateQueue_setCloned(t *testing.T) {
+func TestUpdateQueue_SetUncloned(t *testing.T) {
 	cloned1 := configuredRepo{ID: 1, Name: "cloned1"}
 	cloned2 := configuredRepo{ID: 2, Name: "CLONED2"}
 	notcloned := configuredRepo{ID: 3, Name: "notcloned"}
@@ -830,10 +828,10 @@ func TestUpdateQueue_setCloned(t *testing.T) {
 
 	assertFront(cloned1.Name)
 
-	// Reset the time to now and do setCloned. We then verify that notcloned
+	// Reset the time to now and do setUncloned. We then verify that notcloned
 	// is now at the front of the queue.
 	mockTime(defaultTime)
-	s.schedule.setCloned([]string{"CLONED1", "cloned2", "notscheduled"})
+	s.schedule.setUncloned([]string{"notcloned"})
 
 	assertFront(notcloned.Name)
 }


### PR DESCRIPTION
Our syncScheduler loop has two jobs:

1. Ensure all indexable repos are in the scheduler
2. Ensure that any uncloned repos in the scheduler are moved to the
   front of the queue

For 2, we used to fetch ALL cloned repos and send that entire list to
the scheduler which would then compare it's internal state and move any
repo NOT in the cloned list to the front of the queue. This caused a
large number of allocations in repo-updater.

Instead, we now fetch only uncloned repos managed by the scheduler from
the database which will be a much smaller list and can then send this to
the scheduler instead.