### PR TITLE
migrations: Add settings_user_id_idx

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1611,6 +1611,7 @@ Contains security-relevant events with a long time horizon for storage.
 Indexes:
     "settings_pkey" PRIMARY KEY, btree (id)
     "settings_org_id_idx" btree (org_id)
+    "settings_user_id_idx" btree (user_id)
 Foreign-key constraints:
     "settings_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
     "settings_references_orgs" FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE RESTRICT

--- a/migrations/frontend/1528395842_add_settings_user_id_index.down.sql
+++ b/migrations/frontend/1528395842_add_settings_user_id_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS settings_user_id_idx;
+
+COMMIT;

--- a/migrations/frontend/1528395842_add_settings_user_id_index.up.sql
+++ b/migrations/frontend/1528395842_add_settings_user_id_index.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS settings_user_id_idx ON settings USING BTREE (user_id);
+
+COMMIT;


### PR DESCRIPTION
This commit adds an index to the user_id column of the settings table.
This shaves off ~80ms in the critical search code path in `decodedViewerFinalSettings`.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
