### PR TITLE
remove chan from sender and incrementally send structural results

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -71,21 +71,17 @@ func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
 	return matches
 }
 
-func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) {
-	for _, m := range combyMatches {
-		var lineMatches []protocol.LineMatch
-		for _, r := range m.Matches {
-			lineMatches = append(lineMatches, highlightMultipleLines(&r)...)
-		}
-		matches = append(matches,
-			protocol.FileMatch{
-				Path:        m.URI,
-				LineMatches: lineMatches,
-				MatchCount:  len(m.Matches),
-				LimitHit:    false,
-			})
+func toFileMatch(combyMatch comby.FileMatch) protocol.FileMatch {
+	var lineMatches []protocol.LineMatch
+	for _, r := range combyMatch.Matches {
+		lineMatches = append(lineMatches, highlightMultipleLines(&r)...)
 	}
-	return matches
+	return protocol.FileMatch{
+		Path:        combyMatch.URI,
+		LineMatches: lineMatches,
+		MatchCount:  len(combyMatch.Matches),
+		LimitHit:    false,
+	}
 }
 
 var isValidMatcher = lazyregexp.New(`\.(s|sh|bib|c|cs|css|dart|clj|elm|erl|ex|f|fsx|go|html|hs|java|js|json|jl|kt|tex|lisp|nim|md|ml|org|pas|php|py|re|rb|rs|rst|scala|sql|swift|tex|txt|ts)$`)
@@ -180,7 +176,7 @@ func lookupMatcher(language string) string {
 }
 
 // filteredStructuralSearch filters the list of files with a regex search before passing the zip to comby
-func filteredStructuralSearch(ctx context.Context, zipPath string, zipFile *store.ZipFile, p *protocol.PatternInfo, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
+func filteredStructuralSearch(ctx context.Context, zipPath string, zipFile *store.ZipFile, p *protocol.PatternInfo, repo api.RepoName, sender MatchSender) (limitHit bool, err error) {
 	// Make a copy of the pattern info to modify it to work for a regex search
 	rp := *p
 	rp.Pattern = comby.StructuralPatToRegexpQuery(p.Pattern, false)
@@ -188,12 +184,12 @@ func filteredStructuralSearch(ctx context.Context, zipPath string, zipFile *stor
 	rp.IsRegExp = true
 	rg, err := compile(&rp)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 
 	fileMatches, _, err := regexSearchBatch(ctx, rg, zipFile, p.FileMatchLimit, true, false, false)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 
 	matchedPaths := make([]string, 0, len(fileMatches))
@@ -206,7 +202,7 @@ func filteredStructuralSearch(ctx context.Context, zipPath string, zipFile *stor
 		extensionHint = filepath.Ext(matchedPaths[0])
 	}
 
-	return structuralSearch(ctx, zipPath, Subset(matchedPaths), extensionHint, p.Pattern, p.CombyRule, p.Languages, repo)
+	return structuralSearch(ctx, zipPath, Subset(matchedPaths), extensionHint, p.Pattern, p.CombyRule, p.Languages, repo, sender)
 }
 
 // toMatcher returns the matcher that parameterizes structural search. It
@@ -244,7 +240,7 @@ type Subset []string
 
 var All UniversalSet = struct{}{}
 
-func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
+func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName, sender MatchSender) (limitHit bool, err error) {
 	log15.Info("structural search", "repo", string(repo))
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
@@ -269,17 +265,16 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 
 	combyMatches, err := comby.Matches(ctx, args)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 
-	matches = ToFileMatch(combyMatches)
-	if err != nil {
-		return nil, false, err
+	for _, combyMatch := range combyMatches {
+		sender.Send(toFileMatch(combyMatch))
 	}
-	return matches, false, err
+	return false, err
 }
 
-func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender matchSender) (limitHit, deadlineHit bool, err error) {
+func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender MatchSender) (limitHit, deadlineHit bool, err error) {
 	// Since we are returning file content, limit the number of file matches
 	// until streaming from Zoekt is implemented
 	fileMatchLimit := p.FileMatchLimit
@@ -336,9 +331,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender 
 		extensionHint = filepath.Ext(filename)
 	}
 
-	matches, limitHit, err := structuralSearch(ctx, zipFile.Name(), All, extensionHint, p.Pattern, p.CombyRule, p.Languages, p.Repo)
-	sender.Send(matches)
-
+	limitHit, err = structuralSearch(ctx, zipFile.Name(), All, extensionHint, p.Pattern, p.CombyRule, p.Languages, p.Repo, sender)
 	return limitHit, false, err
 }
 


### PR DESCRIPTION
This PR propagates sender down into structural search so we can incrementally send structural results as well.

While working on that, I realized that the current sender pattern with channels is super unnecesssary, and was forcing me to do some weird channel stuff. Instead, I just put it behind an interface, and made a `collectingSender` that just collects all the results sent to it. This can be swapped out for a streaming sender when we convert to streaming over the wire. 