### PR TITLE
insights: aggregate insight data over 26 weeks instead of 6 months

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Backend Code Insights only fills historical data frames that have changed to reduce the number of searches required. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
 - Backend Code Insights displays data points for a fixed 6 months period in 2 week intervals, and will carry observations forward that are missing. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
+- Backend Code Insights now aggregate over 26 weeks instead of 6 months. [#22527](https://github.com/sourcegraph/sourcegraph/pull/22527)
 
 ### Fixed
 

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -119,7 +119,7 @@ func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]Seri
 // This query is a barebones implementation of per-repo per-series last-observation carried forward. Long term
 // this query is too expensive to run in real-time and should be moved to a materialized view.
 const lastObservationCarriedPointsSql = `select sub.series_id, sub.interval_time, sum(value) as value, null as metadata from (WITH target_times AS (SELECT *
-FROM GENERATE_SERIES(CURRENT_TIMESTAMP::date - INTERVAL '6 months', CURRENT_TIMESTAMP::date, '2 weeks') as interval_time)
+FROM GENERATE_SERIES(CURRENT_TIMESTAMP::date - INTERVAL '26 weeks', CURRENT_TIMESTAMP::date, '2 weeks') as interval_time)
 SELECT sub.series_id, sub.repo_id, sub.value, interval_time
 FROM (select distinct repo_id, series_id from series_points) as r
 cross join target_times tt

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -54,7 +54,7 @@ SELECT time,
     2,
     (SELECT id FROM repo_names WHERE name = 'github.com/gorilla/mux-renamed'),
     (SELECT id FROM repo_names WHERE name = 'github.com/gorilla/mux-original')
-	FROM GENERATE_SERIES(CURRENT_TIMESTAMP::date - INTERVAL '6 months', CURRENT_TIMESTAMP::date, '2 weeks') AS time;
+	FROM GENERATE_SERIES(CURRENT_TIMESTAMP::date - INTERVAL '30 weeks', CURRENT_TIMESTAMP::date, '2 weeks') AS time;
 `)
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +69,6 @@ SELECT time,
 	}
 
 	t.Run("all data points", func(t *testing.T) {
-		t.SkipNow() // TODO(insights): flaky test
 		// Confirm we get all data points.
 		points, err = store.SeriesPoints(ctx, SeriesPointsOpts{})
 		if err != nil {
@@ -197,7 +196,6 @@ func TestCountData(t *testing.T) {
 }
 
 func TestRecordSeriesPoints(t *testing.T) {
-	t.SkipNow() // TODO(insights): flaky test
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
Some tests are flaky because 6 month aggregations aren't consistently the same number of rows. This changes the insights aggregation to be over 26 weeks instead of 6 months.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
