### PR TITLE
search frontend: fix hovers on cursor

### DIFF
--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -14,66 +14,39 @@ const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSucce
 describe('getHoverResult()', () => {
     test('returns hover contents for filters', () => {
         const scannedQuery = toSuccess(scanSearchQuery('repo:sourcegraph file:code_intelligence'))
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 4 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "Matches the string \`sourcegraph\`."
-                },
-                {
-                  "value": "Include only results from files matching the given search pattern."
-                },
-                {
-                  "value": "Matches the string \`code_intelligence\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 23,
-                "endColumn": 40
+                "startColumn": 1,
+                "endColumn": 6
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 18 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "Matches the string \`sourcegraph\`."
-                },
-                {
                   "value": "Include only results from files matching the given search pattern."
-                },
-                {
-                  "value": "Matches the string \`code_intelligence\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 23,
-                "endColumn": 40
+                "startColumn": 18,
+                "endColumn": 23
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 30 })).toMatchInlineSnapshot(`
             {
               "contents": [
-                {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "Matches the string \`sourcegraph\`."
-                },
-                {
-                  "value": "Include only results from files matching the given search pattern."
-                },
                 {
                   "value": "Matches the string \`code_intelligence\`."
                 }
@@ -90,51 +63,33 @@ describe('getHoverResult()', () => {
 
     test('returns hover contents for fields and regexp values', () => {
         const scannedQuery = toSuccess(scanSearchQuery('repo:^hey$'))
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 3 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`hey\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 10,
-                "endColumn": 11
+                "startColumn": 1,
+                "endColumn": 6
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 6 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
                   "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`hey\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 10,
-                "endColumn": 11
+                "startColumn": 6,
+                "endColumn": 7
               }
             }
         `)
@@ -142,114 +97,69 @@ describe('getHoverResult()', () => {
 
     test('returns hover contents regexp patterns', () => {
         const scannedQuery = toSuccess(scanSearchQuery('\\b.*?', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 1 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
-                },
-                {
-                  "value": "**Dot**. Match any character except a line break."
-                },
-                {
-                  "value": "**Zero or more**. Match zero or more of the previous expression."
-                },
-                {
-                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 5,
-                "endColumn": 6
+                "startColumn": 1,
+                "endColumn": 3
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 2 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
-                },
-                {
-                  "value": "**Dot**. Match any character except a line break."
-                },
-                {
-                  "value": "**Zero or more**. Match zero or more of the previous expression."
-                },
-                {
-                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 5,
-                "endColumn": 6
+                "startColumn": 1,
+                "endColumn": 3
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 3 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
-                },
-                {
                   "value": "**Dot**. Match any character except a line break."
-                },
-                {
-                  "value": "**Zero or more**. Match zero or more of the previous expression."
-                },
-                {
-                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 5,
-                "endColumn": 6
+                "startColumn": 3,
+                "endColumn": 4
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 4 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
-                },
-                {
-                  "value": "**Dot**. Match any character except a line break."
-                },
-                {
                   "value": "**Zero or more**. Match zero or more of the previous expression."
-                },
-                {
-                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 5,
-                "endColumn": 6
+                "startColumn": 4,
+                "endColumn": 5
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 5 })).toMatchInlineSnapshot(`
             {
               "contents": [
-                {
-                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
-                },
-                {
-                  "value": "**Dot**. Match any character except a line break."
-                },
-                {
-                  "value": "**Zero or more**. Match zero or more of the previous expression."
-                },
                 {
                   "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
                 }
@@ -266,66 +176,39 @@ describe('getHoverResult()', () => {
 
     test('regexp group range encloses pattern', () => {
         const scannedQuery = toSuccess(scanSearchQuery('(abcd){1,3}', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 1 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Group**. Groups together multiple expressions to match."
-                },
-                {
-                  "value": "Matches the string \`abcd\`."
-                },
-                {
-                  "value": "**Group**. Groups together multiple expressions to match."
-                },
-                {
-                  "value": "**Range**. Match between 1 and 3 of the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 7,
-                "endColumn": 12
+                "startColumn": 1,
+                "endColumn": 7
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 2 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "**Group**. Groups together multiple expressions to match."
-                },
-                {
                   "value": "Matches the string \`abcd\`."
-                },
-                {
-                  "value": "**Group**. Groups together multiple expressions to match."
-                },
-                {
-                  "value": "**Range**. Match between 1 and 3 of the previous expression."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 7,
-                "endColumn": 12
+                "startColumn": 2,
+                "endColumn": 6
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 8 })).toMatchInlineSnapshot(`
             {
               "contents": [
-                {
-                  "value": "**Group**. Groups together multiple expressions to match."
-                },
-                {
-                  "value": "Matches the string \`abcd\`."
-                },
-                {
-                  "value": "**Group**. Groups together multiple expressions to match."
-                },
                 {
                   "value": "**Range**. Match between 1 and 3 of the previous expression."
                 }
@@ -342,129 +225,69 @@ describe('getHoverResult()', () => {
 
     test('regexp escape characters', () => {
         const scannedQuery = toSuccess(scanSearchQuery('\\q\\r\\n\\.\\\\', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 1 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Escaped Character**. The character \`q\` is escaped."
-                },
-                {
-                  "value": "**Escaped Character**. Match a carriage return."
-                },
-                {
-                  "value": "**Escaped Character**. Match a new line."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`.\`."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 9,
-                "endColumn": 11
+                "startColumn": 1,
+                "endColumn": 3
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 3 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "**Escaped Character**. The character \`q\` is escaped."
-                },
-                {
                   "value": "**Escaped Character**. Match a carriage return."
-                },
-                {
-                  "value": "**Escaped Character**. Match a new line."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`.\`."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 9,
-                "endColumn": 11
+                "startColumn": 3,
+                "endColumn": 5
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 5 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "**Escaped Character**. The character \`q\` is escaped."
-                },
-                {
-                  "value": "**Escaped Character**. Match a carriage return."
-                },
-                {
                   "value": "**Escaped Character**. Match a new line."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`.\`."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 9,
-                "endColumn": 11
+                "startColumn": 5,
+                "endColumn": 7
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 7 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "**Escaped Character**. The character \`q\` is escaped."
-                },
-                {
-                  "value": "**Escaped Character**. Match a carriage return."
-                },
-                {
-                  "value": "**Escaped Character**. Match a new line."
-                },
-                {
                   "value": "**Escaped Character**. Match the character \`.\`."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 9,
-                "endColumn": 11
+                "startColumn": 7,
+                "endColumn": 9
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 9 })).toMatchInlineSnapshot(`
             {
               "contents": [
-                {
-                  "value": "**Escaped Character**. The character \`q\` is escaped."
-                },
-                {
-                  "value": "**Escaped Character**. Match a carriage return."
-                },
-                {
-                  "value": "**Escaped Character**. Match a new line."
-                },
-                {
-                  "value": "**Escaped Character**. Match the character \`.\`."
-                },
                 {
                   "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
@@ -481,79 +304,25 @@ describe('getHoverResult()', () => {
 
     test('ordinary and negated character class', () => {
         const scannedQuery = toSuccess(scanSearchQuery('[^a-z][0-9]', false, SearchPatternType.regexp))
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 2 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
                   "value": "**Negated character class**. Match any character _not_ inside the square brackets."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`a-z\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`a-z\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`a-z\`."
-                },
-                {
-                  "value": "**Character class**. Match any character inside the square brackets."
-                },
-                {
-                  "value": "**Character class**. Match any character inside the square brackets."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`0-9\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`0-9\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`0-9\`."
-                },
-                {
-                  "value": "**Character class**. Match any character inside the square brackets."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 7,
-                "endColumn": 12
+                "startColumn": 1,
+                "endColumn": 7
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 7 })).toMatchInlineSnapshot(`
             {
               "contents": [
-                {
-                  "value": "**Negated character class**. Match any character _not_ inside the square brackets."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`a-z\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`a-z\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`a-z\`."
-                },
-                {
-                  "value": "**Character class**. Match any character inside the square brackets."
-                },
-                {
-                  "value": "**Character class**. Match any character inside the square brackets."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`0-9\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`0-9\`."
-                },
-                {
-                  "value": "**Character range**. Match a character in the range \`0-9\`."
-                },
                 {
                   "value": "**Character class**. Match any character inside the square brackets."
                 }
@@ -570,7 +339,7 @@ describe('getHoverResult()', () => {
 
     test('literal search interprets parentheses as patterns', () => {
         const scannedQuery = toSuccess(scanSearchQuery('(abcd)', false, SearchPatternType.literal))
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 1 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
@@ -585,7 +354,7 @@ describe('getHoverResult()', () => {
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 2 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
@@ -611,285 +380,57 @@ describe('getHoverResult()', () => {
             )
         )
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 11 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`foo\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
-                },
-                {
                   "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                },
-                {
-                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 61,
-                "endColumn": 61
+                "startColumn": 11,
+                "endColumn": 12
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 12 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`foo\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                },
-                {
                   "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 61,
-                "endColumn": 61
+                "startColumn": 12,
+                "endColumn": 16
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 16 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`foo\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                },
-                {
-                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                },
-                {
                   "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 61,
-                "endColumn": 61
+                "startColumn": 16,
+                "endColumn": 17
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 17 })).toMatchInlineSnapshot(`
             {
               "contents": [
-                {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`foo\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                },
-                {
-                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
                 {
                   "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
@@ -897,227 +438,56 @@ describe('getHoverResult()', () => {
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 61,
-                "endColumn": 61
+                "startColumn": 17,
+                "endColumn": 21
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 26 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`foo\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                },
-                {
-                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
                   "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 61,
-                "endColumn": 61
+                "startColumn": 26,
+                "endColumn": 27
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 27 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`foo\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                },
-                {
-                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
                   "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 61,
-                "endColumn": 61
+                "startColumn": 27,
+                "endColumn": 38
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 41 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Include only results from repositories matching the given search pattern."
-                },
-                {
-                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "Matches the string \`foo\`."
-                },
-                {
-                  "value": "**End anchor**. Match the end of a string. Typically used to match a string suffix, as in \`suffix$\`. Also often used with the start anchor to match an exact string, as in \`^exact$\`."
-                },
-                {
-                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
-                },
-                {
-                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "Search a revision (branch, commit hash, or tag) instead of the default branch."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
-                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
-                },
-                {
                   "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
-                },
-                {
-                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
-                },
-                {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
-                },
-                {
-                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 61,
-                "endColumn": 61
+                "startColumn": 40,
+                "endColumn": 42
               }
             }
         `)
@@ -1126,214 +496,88 @@ describe('getHoverResult()', () => {
     test('returns hover contents for structural syntax', () => {
         const scannedQuery = toSuccess(scanSearchQuery(':[var~\\w+] ...', false, SearchPatternType.structural))
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 1 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Matches the character \`\`."
-                },
-                {
                   "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
-                },
-                {
-                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
-                },
-                {
-                  "value": "**Word**. Match any word character. "
-                },
-                {
-                  "value": "**One or more**. Match one or more of the previous expression."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 12,
-                "endColumn": 15
+                "startColumn": 1,
+                "endColumn": 11
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 3 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Matches the character \`\`."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
                   "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
-                },
-                {
-                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
-                },
-                {
-                  "value": "**Word**. Match any word character. "
-                },
-                {
-                  "value": "**One or more**. Match one or more of the previous expression."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 12,
-                "endColumn": 15
+                "startColumn": 3,
+                "endColumn": 6
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 6 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Matches the character \`\`."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
-                },
-                {
                   "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
-                },
-                {
-                  "value": "**Word**. Match any word character. "
-                },
-                {
-                  "value": "**One or more**. Match one or more of the previous expression."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 12,
-                "endColumn": 15
+                "startColumn": 6,
+                "endColumn": 7
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 9 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Matches the character \`\`."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
-                },
-                {
-                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
-                },
-                {
-                  "value": "**Word**. Match any word character. "
-                },
-                {
                   "value": "**One or more**. Match one or more of the previous expression."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 12,
-                "endColumn": 15
+                "startColumn": 9,
+                "endColumn": 10
               }
             }
         `)
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 10 })).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
-                  "value": "Matches the character \`\`."
-                },
-                {
                   "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
-                },
-                {
-                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
-                },
-                {
-                  "value": "**Word**. Match any word character. "
-                },
-                {
-                  "value": "**One or more**. Match one or more of the previous expression."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 12,
-                "endColumn": 15
+                "startColumn": 1,
+                "endColumn": 11
               }
             }
         `)
 
-        expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, { column: 12 })).toMatchInlineSnapshot(`
             {
               "contents": [
-                {
-                  "value": "Matches the character \`\`."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
-                {
-                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
-                },
-                {
-                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
-                },
-                {
-                  "value": "**Word**. Match any word character. "
-                },
-                {
-                  "value": "**One or more**. Match one or more of the previous expression."
-                },
-                {
-                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
-                },
                 {
                   "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
                 }
@@ -1352,27 +596,18 @@ describe('getHoverResult()', () => {
 test('returns hover contents for select', () => {
     const scannedQuery = toSuccess(scanSearchQuery('select:repo repo:foo', false, SearchPatternType.literal))
 
-    expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+    expect(getHoverResult(scannedQuery, { column: 8 })).toMatchInlineSnapshot(`
         {
           "contents": [
             {
-              "value": "Selects the kind of result to display."
-            },
-            {
               "value": "Select and display distinct repository paths from search results."
-            },
-            {
-              "value": "Include only results from repositories matching the given search pattern."
-            },
-            {
-              "value": "Matches the string \`foo\`."
             }
           ],
           "range": {
             "startLineNumber": 1,
             "endLineNumber": 1,
-            "startColumn": 18,
-            "endColumn": 21
+            "startColumn": 8,
+            "endColumn": 12
           }
         }
     `)
@@ -1381,27 +616,9 @@ test('returns hover contents for select', () => {
 test('returns repo:contains hovers', () => {
     const scannedQuery = toSuccess(scanSearchQuery('repo:contains.file(foo)', false, SearchPatternType.literal))
 
-    expect(getHoverResult(scannedQuery)).toMatchInlineSnapshot(`
+    expect(getHoverResult(scannedQuery, { column: 8 })).toMatchInlineSnapshot(`
         {
           "contents": [
-            {
-              "value": "Include only results from repositories matching the given search pattern."
-            },
-            {
-              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
-            },
-            {
-              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
-            },
-            {
-              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
-            },
-            {
-              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
-            },
-            {
-              "value": "Matches the string \`foo\`."
-            },
             {
               "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
             }

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -193,11 +193,17 @@ const toHover = (token: DecoratedToken): string => {
     return ''
 }
 
+const inside = (column: number) => ({ range }: Pick<Token | DecoratedToken, 'range'>): boolean =>
+    range.start + 1 <= column && range.end >= column
+
 /**
  * Returns the hover result for a hovered search token in the Monaco query input.
  */
-export const getHoverResult = (tokens: Token[]): Monaco.languages.Hover | null => {
-    const tokensAtCursor = tokens.flatMap(decorate)
+export const getHoverResult = (
+    tokens: Token[],
+    { column }: Pick<Monaco.Position, 'column'>
+): Monaco.languages.Hover | null => {
+    const tokensAtCursor = tokens.flatMap(decorate).filter(inside(column))
     if (tokensAtCursor.length === 0) {
         return null
     }

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -83,7 +83,9 @@ export function getProviders(
                 scannedQueries
                     .pipe(
                         first(),
-                        map(({ scanned }) => (scanned.type === 'error' ? null : getHoverResult(scanned.term))),
+                        map(({ scanned }) =>
+                            scanned.type === 'error' ? null : getHoverResult(scanned.term, position)
+                        ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )
                     .toPromise(),


### PR DESCRIPTION
I was overzealous in https://github.com/sourcegraph/sourcegraph/pull/22415 and deleted code that I thought was no longer needed to show hovers at the cursor position. Right now all hovers show at any cursor position, so this PR fixes the regression + tests.