### PR TITLE
Repo sidebar: fix missing right margin on symbol panel

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -62,7 +62,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
             element={
                 <div className={classnames('d-flex w-100', !isRedesignEnabled && 'bg-2 border-right')}>
                     <Tabs
-                        className="w-100 test-repo-revision-sidebar mr-3"
+                        className="w-100 test-repo-revision-sidebar pr-3"
                         defaultIndex={tabIndex}
                         onChange={handleTabsChange}
                     >


### PR DESCRIPTION
Fixes a visual bug in the repo sidebar, where there is no space to the right of the symbol panel if the filenames are long.

**Before:**

![CleanShot 2021-07-02 at 13 59 14](https://user-images.githubusercontent.com/17293/124271736-1dd6be00-db3e-11eb-91c6-b254befc7ca7.png)

**After:**

![CleanShot 2021-07-02 at 13 58 45](https://user-images.githubusercontent.com/17293/124271404-b91b6380-db3d-11eb-955c-9c209b59e313.png)

