### PR TITLE
search-blitz: fetch traces from in cluster jaeger

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -150,7 +150,7 @@ func (t *tsvLogger) Log(a ...interface{}) {
 		t.buf.WriteByte('\t')
 		_, _ = fmt.Fprintf(&t.buf, "%v", v)
 	}
-	t.buf.WriteByte('\t')
+	t.buf.WriteByte('\n')
 	_, _ = t.buf.WriteTo(t.w)
 }
 
@@ -186,6 +186,7 @@ func main() {
 	traces = &traceStore{
 		Dir:                filepath.Join(logDir, "traces"),
 		Token:              os.Getenv(envToken),
+		JaegerServerURL:    os.Getenv("JAEGER_SERVER_URL"),
 		MaxTotalTraceBytes: 1024 * 1024 * 1024, // 1 GiB
 	}
 	go traces.CleanupLoop(ctx)


### PR DESCRIPTION
This is how I originally wrote the service. I then changed it to using
token so that I could more easily run search-blitz locally. However, the
token we use in practice is not an admin. So I support both paths now.