### PR TITLE
Implement close bulk operation for changesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - An `sg_service` Postgres role has been introduced, as well as an `sg_repo_access_policy` policy on the `repo` table that restricts access to that role. The role that owns the `repo` table will continue to get unrestricted access. [#22303](https://github.com/sourcegraph/sourcegraph/pull/22303)
 - Every service that connects to the database (i.e. Postgres) now has a "Database connections" monitoring section in its Grafana dashboard. [#22570](https://github.com/sourcegraph/sourcegraph/pull/22570)
 - A new bulk operation to close many changesets at once has been added to Batch Changes. [#XX](https://github.com/sourcegraph/sourcegraph/pull/XX)
+- A new bulk operation to close many changesets at once has been added to Batch Changes. [#22547](https://github.com/sourcegraph/sourcegraph/pull/22547)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added support for `select:file.directory` in search queries, which returns unique directory paths for results that satisfy the query. [#22449](https://github.com/sourcegraph/sourcegraph/pull/22449)
 - An `sg_service` Postgres role has been introduced, as well as an `sg_repo_access_policy` policy on the `repo` table that restricts access to that role. The role that owns the `repo` table will continue to get unrestricted access. [#22303](https://github.com/sourcegraph/sourcegraph/pull/22303)
 - Every service that connects to the database (i.e. Postgres) now has a "Database connections" monitoring section in its Grafana dashboard. [#22570](https://github.com/sourcegraph/sourcegraph/pull/22570)
+- A new bulk operation to close many changesets at once has been added to Batch Changes. [#XX](https://github.com/sourcegraph/sourcegraph/pull/XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Added support for `select:file.directory` in search queries, which returns unique directory paths for results that satisfy the query. [#22449](https://github.com/sourcegraph/sourcegraph/pull/22449)
 - An `sg_service` Postgres role has been introduced, as well as an `sg_repo_access_policy` policy on the `repo` table that restricts access to that role. The role that owns the `repo` table will continue to get unrestricted access. [#22303](https://github.com/sourcegraph/sourcegraph/pull/22303)
 - Every service that connects to the database (i.e. Postgres) now has a "Database connections" monitoring section in its Grafana dashboard. [#22570](https://github.com/sourcegraph/sourcegraph/pull/22570)
-- A new bulk operation to close many changesets at once has been added to Batch Changes. [#XX](https://github.com/sourcegraph/sourcegraph/pull/XX)
 - A new bulk operation to close many changesets at once has been added to Batch Changes. [#22547](https://github.com/sourcegraph/sourcegraph/pull/22547)
 
 ### Changed

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -43,6 +43,8 @@ import {
     ReenqueueChangesetsVariables,
     MergeChangesetsResult,
     MergeChangesetsVariables,
+    CloseChangesetsResult,
+    CloseChangesetsVariables,
 } from '../../../graphql-operations'
 
 const changesetsStatsFragment = gql`
@@ -687,6 +689,20 @@ export async function mergeChangesets(
             }
         `,
         { batchChange, changesets, squash }
+    ).toPromise()
+    dataOrThrowErrors(result)
+}
+
+export async function closeChangesets(batchChange: Scalars['ID'], changesets: Scalars['ID'][]): Promise<void> {
+    const result = await requestGraphQL<CloseChangesetsResult, CloseChangesetsVariables>(
+        gql`
+            mutation CloseChangesets($batchChange: ID!, $changesets: [ID!]!) {
+                closeChangesets(batchChange: $batchChange, changesets: $changesets) {
+                    id
+                }
+            }
+        `,
+        { batchChange, changesets }
     ).toPromise()
     dataOrThrowErrors(result)
 }

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -39,6 +39,11 @@ const OPERATION_TITLES: Record<BulkOperationType, JSX.Element> = {
             <SourceBranchIcon className="icon-inline text-muted" /> Merge changesets
         </>
     ),
+    CLOSE: (
+        <>
+            <SourceBranchIcon className="icon-inline text-danger" /> Close changesets
+        </>
+    ),
 }
 
 export interface BulkOperationNodeProps {

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -10,6 +10,7 @@ import { eventLogger } from '../../../../tracking/eventLogger'
 import { queryAllChangesetIDs } from '../backend'
 
 import styles from './ChangesetSelectRow.module.scss'
+import { CloseChangesetsModal } from './CloseChangesetsModal'
 import { CreateCommentModal } from './CreateCommentModal'
 import { DetachChangesetsModal } from './DetachChangesetsModal'
 import { MergeChangesetsModal } from './MergeChangesetsModal'
@@ -103,6 +104,22 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
         isAvailable: ({ state }) => state === ChangesetState.OPEN,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
             <MergeChangesetsModal
+                batchChangeID={batchChangeID}
+                changesetIDs={changesetIDs}
+                afterCreate={onDone}
+                onCancel={onCancel}
+            />
+        ),
+    },
+    {
+        type: 'close',
+        buttonLabel: 'Close changesets',
+        dropdownTitle: 'Close changesets',
+        dropdownDescription:
+            'Attempt to close all selected changesets on the code hosts. The changesets will remain part of the batch change.',
+        isAvailable: ({ state }) => state === ChangesetState.OPEN || state === ChangesetState.DRAFT,
+        onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
+            <CloseChangesetsModal
                 batchChangeID={batchChangeID}
                 changesetIDs={changesetIDs}
                 afterCreate={onDone}

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
@@ -1,0 +1,33 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+
+import { CloseChangesetsModal } from './CloseChangesetsModal'
+
+const { add } = storiesOf('web/batches/details/CloseChangesetsModal', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
+const closeChangesets = () => {
+    action('CloseChangesets')
+    return Promise.resolve()
+}
+
+add('Confirmation', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CloseChangesetsModal
+                {...props}
+                afterCreate={noop}
+                batchChangeID="test-123"
+                changesetIDs={changesetIDsFunction}
+                onCancel={noop}
+                closeChangesets={closeChangesets}
+            />
+        )}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
@@ -45,7 +45,7 @@ export const CloseChangesetsModal: React.FunctionComponent<CloseChangesetsModalP
             aria-labelledby={MODAL_LABEL_ID}
         >
             <h3 id={MODAL_LABEL_ID}>Close changesets</h3>
-            <p className="mb-4">Are you sure you want to attempt to close all the selected changesets?</p>
+            <p className="mb-4">Are you sure you want to close all the selected changesets on the code hosts?</p>
             {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
             <div className="d-flex justify-content-end">
                 <button

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
@@ -1,0 +1,68 @@
+import Dialog from '@reach/dialog'
+import React, { useCallback, useState } from 'react'
+
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { ErrorAlert } from '../../../../components/alerts'
+import { Scalars } from '../../../../graphql-operations'
+import { closeChangesets as _closeChangesets } from '../backend'
+
+export interface CloseChangesetsModalProps {
+    onCancel: () => void
+    afterCreate: () => void
+    batchChangeID: Scalars['ID']
+    changesetIDs: () => Promise<Scalars['ID'][]>
+
+    /** For testing only. */
+    closeChangesets?: typeof _closeChangesets
+}
+
+export const CloseChangesetsModal: React.FunctionComponent<CloseChangesetsModalProps> = ({
+    onCancel,
+    afterCreate,
+    batchChangeID,
+    changesetIDs,
+    closeChangesets = _closeChangesets,
+}) => {
+    const [isLoading, setIsLoading] = useState<boolean | Error>(false)
+
+    const onSubmit = useCallback<React.FormEventHandler>(async () => {
+        setIsLoading(true)
+        try {
+            const ids = await changesetIDs()
+            await closeChangesets(batchChangeID, ids)
+            afterCreate()
+        } catch (error) {
+            setIsLoading(asError(error))
+        }
+    }, [changesetIDs, closeChangesets, batchChangeID, afterCreate])
+
+    return (
+        <Dialog
+            className="modal-body modal-body--top-third p-4 rounded border"
+            onDismiss={onCancel}
+            aria-labelledby={MODAL_LABEL_ID}
+        >
+            <h3 id={MODAL_LABEL_ID}>Close changesets</h3>
+            <p className="mb-4">Are you sure you want to attempt to close all the selected changesets?</p>
+            {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
+            <div className="d-flex justify-content-end">
+                <button
+                    type="button"
+                    disabled={isLoading === true}
+                    className="btn btn-outline-secondary mr-2"
+                    onClick={onCancel}
+                >
+                    Cancel
+                </button>
+                <button type="button" onClick={onSubmit} disabled={isLoading === true} className="btn btn-primary">
+                    {isLoading === true && <LoadingSpinner className="icon-inline" />}
+                    Close
+                </button>
+            </div>
+        </Dialog>
+    )
+}
+
+const MODAL_LABEL_ID = 'close-changesets-modal-title'

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -234,7 +234,6 @@ type CreateBatchSpecExecutionArgs struct {
 
 type CloseChangesetsArgs struct {
 	BulkOperationBaseArgs
-	Squash bool
 }
 
 type BatchChangesResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -232,6 +232,11 @@ type CreateBatchSpecExecutionArgs struct {
 	Spec string
 }
 
+type CloseChangesetsArgs struct {
+	BulkOperationBaseArgs
+	Squash bool
+}
+
 type BatchChangesResolver interface {
 	//
 	// MUTATIONS
@@ -263,6 +268,7 @@ type BatchChangesResolver interface {
 	ReenqueueChangesets(ctx context.Context, args *ReenqueueChangesetsArgs) (BulkOperationResolver, error)
 	MergeChangesets(ctx context.Context, args *MergeChangesetsArgs) (BulkOperationResolver, error)
 	CreateBatchSpecExecution(ctx context.Context, args *CreateBatchSpecExecutionArgs) (BatchSpecExecutionResolver, error)
+	CloseChangesets(ctx context.Context, args *CloseChangesetsArgs) (BulkOperationResolver, error)
 
 	// Queries
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2099,6 +2099,13 @@ extend type Mutation {
     mergeChangesets(batchChange: ID!, changesets: [ID!]!, squash: Boolean = false): BulkOperation!
 
     """
+    Close multiple changesets.
+
+    Experimental: This API is likely to change in the future.
+    """
+    closeChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
+
+    """
     Creates a new batch spec execution from a given batch spec yaml file input.
     The execution will be queued for processing by an executor. If some are available
     for work, they will pick this up eventually.
@@ -2386,6 +2393,10 @@ enum BulkOperationType {
     Bulk merge changesets.
     """
     MERGE
+    """
+    Bulk close changesets.
+    """
+    CLOSE
 }
 
 """

--- a/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
+++ b/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
@@ -24,6 +24,7 @@ Bulk operations allow a single action to be performed across many changesets in 
 - Detach: Only available in the archived tab. Detach a selection of changesets from the batch change to remove them from the archived tab.
 - Re-enqueue: Only available if filtering by state `failed`. Re-enqueues the pending changes for all selected changesets that failed.
 - <span class="badge badge-experimental">Experimental</span> Merge: Only available if filtering by state `open`. Tries to merge the selected changesets on the code hosts. Due to the nature of changesets, there are many states in which a changeset is not mergeable. This won't break the entire bulk operation, but single changesets may not be merged after the run for this reason. The bulk operations tab lists those where merging failed below the bulk operation in that case. In the confirmation modal, you can select to merge using the squash merge strategy. This is supported on both GitHub and GitLab, but not on Bitbucket Server. In this case, regular merges are always used for merging the changesets.
+- Close: Only available if filtering by state `open` or `draft`. Tries to close the selected changesets on the code hosts.
 
 _More types coming soon._
 

--- a/enterprise/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation.go
@@ -117,6 +117,8 @@ func changesetJobTypeToBulkOperationType(t btypes.ChangesetJobType) (string, err
 		return "REENQUEUE", nil
 	case btypes.ChangesetJobTypeMerge:
 		return "MERGE", nil
+	case btypes.ChangesetJobTypeClose:
+		return "CLOSE", nil
 	default:
 		return "", fmt.Errorf("invalid job type %q", t)
 	}

--- a/enterprise/internal/batches/resolvers/changeset_connection.go
+++ b/enterprise/internal/batches/resolvers/changeset_connection.go
@@ -64,7 +64,7 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 func (r *changesetsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	count, err := r.store.CountChangesets(ctx, store.CountChangesetsOpts{
 		BatchChangeID:        r.opts.BatchChangeID,
-		ExternalState:        r.opts.ExternalState,
+		ExternalStates:       r.opts.ExternalStates,
 		ExternalReviewState:  r.opts.ExternalReviewState,
 		ExternalCheckState:   r.opts.ExternalCheckState,
 		ReconcilerStates:     r.opts.ReconcilerStates,

--- a/enterprise/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/internal/batches/resolvers/permissions_test.go
@@ -748,6 +748,12 @@ func TestPermissionLevels(t *testing.T) {
 					return fmt.Sprintf(`mutation { mergeChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
 				},
 			},
+			{
+				name: "closeChangesets",
+				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+					return fmt.Sprintf(`mutation { closeChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
+				},
+			},
 		}
 
 		for _, m := range mutations {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -778,31 +778,31 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 		case btypes.ChangesetStateOpen:
 			externalState := btypes.ChangesetExternalStateOpen
 			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalState = &externalState
+			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
 			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
 			opts.PublicationState = &publicationState
 		case btypes.ChangesetStateDraft:
 			externalState := btypes.ChangesetExternalStateDraft
 			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalState = &externalState
+			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
 			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
 			opts.PublicationState = &publicationState
 		case btypes.ChangesetStateClosed:
 			externalState := btypes.ChangesetExternalStateClosed
 			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalState = &externalState
+			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
 			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
 			opts.PublicationState = &publicationState
 		case btypes.ChangesetStateMerged:
 			externalState := btypes.ChangesetExternalStateMerged
 			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalState = &externalState
+			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
 			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
 			opts.PublicationState = &publicationState
 		case btypes.ChangesetStateDeleted:
 			externalState := btypes.ChangesetExternalStateDeleted
 			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalState = &externalState
+			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
 			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
 			opts.PublicationState = &publicationState
 		case btypes.ChangesetStateUnpublished:
@@ -1305,7 +1305,7 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 		store.ListChangesetsOpts{
 			PublicationState: &published,
 			ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
-			ExternalState:    &openState,
+			ExternalStates:   []btypes.ChangesetExternalState{openState},
 		},
 	)
 	if err != nil {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1358,6 +1358,7 @@ func (r *Resolver) CreateBatchSpecExecution(ctx context.Context, args *graphqlba
 		tr.SetError(err)
 		tr.Finish()
 	}()
+
 	if err := batchChangesEnabled(ctx, r.store.DB()); err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -85,6 +85,8 @@ func TestNullIDResilience(t *testing.T) {
 		fmt.Sprintf(`mutation { reenqueueChangesets(batchChange: %q, changesets: [%q]) { id } }`, marshalBatchChangeID(1), marshalChangesetID(0)),
 		fmt.Sprintf(`mutation { mergeChangesets(batchChange: %q, changesets: []) { id } }`, marshalBatchChangeID(0)),
 		fmt.Sprintf(`mutation { mergeChangesets(batchChange: %q, changesets: [%q]) { id } }`, marshalBatchChangeID(1), marshalChangesetID(0)),
+		fmt.Sprintf(`mutation { closeChangesets(batchChange: %q, changesets: []) { id } }`, marshalBatchChangeID(0)),
+		fmt.Sprintf(`mutation { closeChangesets(batchChange: %q, changesets: [%q]) { id } }`, marshalBatchChangeID(1), marshalChangesetID(0)),
 	}
 
 	for _, m := range mutations {
@@ -1431,6 +1433,117 @@ mutation($spec: String!) {
 		placeInQueue
 		batchSpec { id }
 	}
+}
+`
+
+func TestCloseChangesets(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	db := dbtest.NewDB(t, "")
+	cstore := store.New(db, nil)
+
+	userID := ct.CreateTestUser(t, db, true).ID
+	batchSpec := ct.CreateBatchSpec(t, ctx, cstore, "test-close", userID)
+	otherBatchSpec := ct.CreateBatchSpec(t, ctx, cstore, "test-close-other", userID)
+	batchChange := ct.CreateBatchChange(t, ctx, cstore, "test-close", userID, batchSpec.ID)
+	otherBatchChange := ct.CreateBatchChange(t, ctx, cstore, "test-close-other", userID, otherBatchSpec.ID)
+	repos, _ := ct.CreateTestRepos(t, context.Background(), db, 1)
+	repo := repos[0]
+	changeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+		Repo:             repo.ID,
+		BatchChange:      batchChange.ID,
+		PublicationState: btypes.ChangesetPublicationStatePublished,
+		ReconcilerState:  btypes.ReconcilerStateCompleted,
+		ExternalState:    btypes.ChangesetExternalStateOpen,
+	})
+	otherChangeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+		Repo:             repo.ID,
+		BatchChange:      otherBatchChange.ID,
+		PublicationState: btypes.ChangesetPublicationStatePublished,
+		ReconcilerState:  btypes.ReconcilerStateCompleted,
+		ExternalState:    btypes.ChangesetExternalStateOpen,
+	})
+	mergedChangeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+		Repo:             repo.ID,
+		BatchChange:      otherBatchChange.ID,
+		PublicationState: btypes.ChangesetPublicationStatePublished,
+		ReconcilerState:  btypes.ReconcilerStateCompleted,
+		ExternalState:    btypes.ChangesetExternalStateMerged,
+	})
+
+	r := &Resolver{store: cstore}
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	generateInput := func() map[string]interface{} {
+		return map[string]interface{}{
+			"batchChange": marshalBatchChangeID(batchChange.ID),
+			"changesets":  []string{string(marshalChangesetID(changeset.ID))},
+		}
+	}
+
+	var response struct {
+		CloseChangesets apitest.BulkOperation
+	}
+	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+
+	t.Run("0 changesets fails", func(t *testing.T) {
+		input := generateInput()
+		input["changesets"] = []string{}
+		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCloseChangesets)
+
+		if len(errs) != 1 {
+			t.Fatalf("expected single errors, but got none")
+		}
+		if have, want := errs[0].Message, "specify at least one changeset"; have != want {
+			t.Fatalf("wrong error. want=%q, have=%q", want, have)
+		}
+	})
+
+	t.Run("changeset in different batch change fails", func(t *testing.T) {
+		input := generateInput()
+		input["changesets"] = []string{string(marshalChangesetID(otherChangeset.ID))}
+		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCloseChangesets)
+
+		if len(errs) != 1 {
+			t.Fatalf("expected single errors, but got none")
+		}
+		if have, want := errs[0].Message, "some changesets could not be found"; have != want {
+			t.Fatalf("wrong error. want=%q, have=%q", want, have)
+		}
+	})
+
+	t.Run("merged changeset fails", func(t *testing.T) {
+		input := generateInput()
+		input["changesets"] = []string{string(marshalChangesetID(mergedChangeset.ID))}
+		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCloseChangesets)
+
+		if len(errs) != 1 {
+			t.Fatalf("expected single errors, but got none")
+		}
+		if have, want := errs[0].Message, "some changesets could not be found"; have != want {
+			t.Fatalf("wrong error. want=%q, have=%q", want, have)
+		}
+	})
+
+	t.Run("runs successfully", func(t *testing.T) {
+		input := generateInput()
+		apitest.MustExec(actorCtx, t, s, input, &response, mutationCloseChangesets)
+
+		if response.CloseChangesets.ID == "" {
+			t.Fatalf("expected bulk operation to be created, but was not")
+		}
+	})
+}
+
+const mutationCloseChangesets = `
+mutation($batchChange: ID!, $changesets: [ID!]!) {
+    closeChangesets(batchChange: $batchChange, changesets: $changesets) { id }
 }
 `
 

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -722,7 +722,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			},
 			wantSafe: true,
 			wantParsed: store.ListChangesetsOpts{
-				ExternalState:    &wantExternalStates[0],
+				ExternalStates:   wantExternalStates[0:1],
 				PublicationState: &wantPublicationStates[0],
 				ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
 			},

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1002,6 +1002,68 @@ func TestService(t *testing.T) {
 				}
 			})
 		})
+
+		t.Run("CloseChangesets", func(t *testing.T) {
+			spec := testBatchSpec(admin.ID)
+			if err := s.CreateBatchSpec(ctx, spec); err != nil {
+				t.Fatal(err)
+			}
+
+			batchChange := testBatchChange(admin.ID, spec)
+			if err := s.CreateBatchChange(ctx, batchChange); err != nil {
+				t.Fatal(err)
+			}
+			published := btypes.ChangesetPublicationStatePublished
+			openState := btypes.ChangesetExternalStateOpen
+			t.Run("open changeset", func(t *testing.T) {
+				changeset := ct.CreateChangeset(t, adminCtx, s, ct.TestChangesetOpts{
+					Repo:             rs[0].ID,
+					ReconcilerState:  btypes.ReconcilerStateCompleted,
+					ExternalState:    btypes.ChangesetExternalStateOpen,
+					PublicationState: btypes.ChangesetPublicationStatePublished,
+					BatchChange:      batchChange.ID,
+					IsArchived:       false,
+				})
+				_, err := svc.CreateChangesetJobs(
+					adminCtx,
+					batchChange.ID,
+					[]int64{changeset.ID},
+					btypes.ChangesetJobTypeClose,
+					btypes.ChangesetJobClosePayload{},
+					store.ListChangesetsOpts{
+						PublicationState: &published,
+						ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
+						ExternalState:    &openState},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+			t.Run("closed changeset", func(t *testing.T) {
+				closedChangeset := ct.CreateChangeset(t, adminCtx, s, ct.TestChangesetOpts{
+					Repo:             rs[0].ID,
+					ReconcilerState:  btypes.ReconcilerStateCompleted,
+					ExternalState:    btypes.ChangesetExternalStateClosed,
+					PublicationState: btypes.ChangesetPublicationStatePublished,
+					BatchChange:      batchChange.ID,
+				})
+				_, err := svc.CreateChangesetJobs(
+					adminCtx,
+					batchChange.ID,
+					[]int64{closedChangeset.ID},
+					btypes.ChangesetJobTypeClose,
+					btypes.ChangesetJobClosePayload{},
+					store.ListChangesetsOpts{
+						PublicationState: &published,
+						ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
+						ExternalState:    &openState,
+					},
+				)
+				if err != ErrChangesetsForJobNotFound {
+					t.Fatalf("wrong error. want=%s, got=%s", ErrChangesetsForJobNotFound, err)
+				}
+			})
+		})
 	})
 }
 

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -971,7 +971,8 @@ func TestService(t *testing.T) {
 					store.ListChangesetsOpts{
 						PublicationState: &published,
 						ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
-						ExternalState:    &openState},
+						ExternalStates:   []btypes.ChangesetExternalState{openState},
+					},
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -994,7 +995,7 @@ func TestService(t *testing.T) {
 					store.ListChangesetsOpts{
 						PublicationState: &published,
 						ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
-						ExternalState:    &openState,
+						ExternalStates:   []btypes.ChangesetExternalState{openState},
 					},
 				)
 				if err != ErrChangesetsForJobNotFound {
@@ -1033,7 +1034,8 @@ func TestService(t *testing.T) {
 					store.ListChangesetsOpts{
 						PublicationState: &published,
 						ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
-						ExternalState:    &openState},
+						ExternalStates:   []btypes.ChangesetExternalState{openState},
+					},
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -1056,7 +1058,7 @@ func TestService(t *testing.T) {
 					store.ListChangesetsOpts{
 						PublicationState: &published,
 						ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
-						ExternalState:    &openState,
+						ExternalStates:   []btypes.ChangesetExternalState{openState},
 					},
 				)
 				if err != ErrChangesetsForJobNotFound {

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -186,6 +186,8 @@ func scanChangesetJob(c *btypes.ChangesetJob, s scanner) error {
 		c.Payload = new(btypes.ChangesetJobReenqueuePayload)
 	case btypes.ChangesetJobTypeMerge:
 		c.Payload = new(btypes.ChangesetJobMergePayload)
+	case btypes.ChangesetJobTypeClose:
+		c.Payload = new(btypes.ChangesetJobClosePayload)
 	default:
 		return fmt.Errorf("unknown job type %q", c.JobType)
 	}

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -224,7 +224,7 @@ type CountChangesetsOpts struct {
 	BatchChangeID        int64
 	OnlyArchived         bool
 	IncludeArchived      bool
-	ExternalState        *btypes.ChangesetExternalState
+	ExternalStates       []btypes.ChangesetExternalState
 	ExternalReviewState  *btypes.ChangesetReviewState
 	ExternalCheckState   *btypes.ChangesetCheckState
 	ReconcilerStates     []btypes.ReconcilerState
@@ -268,8 +268,12 @@ func countChangesetsQuery(opts *CountChangesetsOpts, authzConds *sqlf.Query) *sq
 	if opts.PublicationState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.publication_state = %s", *opts.PublicationState))
 	}
-	if opts.ExternalState != nil {
-		preds = append(preds, sqlf.Sprintf("changesets.external_state = %s", *opts.ExternalState))
+	if len(opts.ExternalStates) > 0 {
+		states := make([]*sqlf.Query, len(opts.ExternalStates))
+		for i, externalState := range opts.ExternalStates {
+			states[i] = sqlf.Sprintf("%s", externalState)
+		}
+		preds = append(preds, sqlf.Sprintf("changesets.external_state IN (%s)", sqlf.Join(states, ",")))
 	}
 	if opts.ExternalReviewState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.external_review_state = %s", *opts.ExternalReviewState))
@@ -477,7 +481,6 @@ type ListChangesetsOpts struct {
 	IDs                  []int64
 	PublicationState     *btypes.ChangesetPublicationState
 	ReconcilerStates     []btypes.ReconcilerState
-	ExternalState        *btypes.ChangesetExternalState
 	ExternalStates       []btypes.ChangesetExternalState
 	ExternalReviewState  *btypes.ChangesetReviewState
 	ExternalCheckState   *btypes.ChangesetCheckState
@@ -557,9 +560,6 @@ func listChangesetsQuery(opts *ListChangesetsOpts, authzConds *sqlf.Query) *sqlf
 			states[i] = sqlf.Sprintf("%s", reconcilerState.ToDB())
 		}
 		preds = append(preds, sqlf.Sprintf("changesets.reconciler_state IN (%s)", sqlf.Join(states, ",")))
-	}
-	if opts.ExternalState != nil {
-		preds = append(preds, sqlf.Sprintf("changesets.external_state = %s", *opts.ExternalState))
 	}
 	if len(opts.ExternalStates) > 0 {
 		states := make([]*sqlf.Query, len(opts.ExternalStates))

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -478,6 +478,7 @@ type ListChangesetsOpts struct {
 	PublicationState     *btypes.ChangesetPublicationState
 	ReconcilerStates     []btypes.ReconcilerState
 	ExternalState        *btypes.ChangesetExternalState
+	ExternalStates       []btypes.ChangesetExternalState
 	ExternalReviewState  *btypes.ChangesetReviewState
 	ExternalCheckState   *btypes.ChangesetCheckState
 	OwnedByBatchChangeID int64
@@ -559,6 +560,13 @@ func listChangesetsQuery(opts *ListChangesetsOpts, authzConds *sqlf.Query) *sqlf
 	}
 	if opts.ExternalState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.external_state = %s", *opts.ExternalState))
+	}
+	if len(opts.ExternalStates) > 0 {
+		states := make([]*sqlf.Query, len(opts.ExternalStates))
+		for i, externalState := range opts.ExternalStates {
+			states[i] = sqlf.Sprintf("%s", externalState)
+		}
+		preds = append(preds, sqlf.Sprintf("changesets.external_state IN (%s)", sqlf.Join(states, ",")))
 	}
 	if opts.ExternalReviewState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.external_review_state = %s", *opts.ExternalReviewState))

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -740,6 +740,24 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			},
 			{
 				opts: ListChangesetsOpts{
+					ExternalStates: []btypes.ChangesetExternalState{stateOpen},
+				},
+				wantCount: 3,
+			},
+			{
+				opts: ListChangesetsOpts{
+					ExternalStates: []btypes.ChangesetExternalState{stateClosed},
+				},
+				wantCount: 0,
+			},
+			{
+				opts: ListChangesetsOpts{
+					ExternalStates: []btypes.ChangesetExternalState{stateOpen, stateClosed},
+				},
+				wantCount: 3,
+			},
+			{
+				opts: ListChangesetsOpts{
 					ExternalReviewState: &stateApproved,
 				},
 				wantCount: 3,

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -728,18 +728,6 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			},
 			{
 				opts: ListChangesetsOpts{
-					ExternalState: &stateOpen,
-				},
-				wantCount: 3,
-			},
-			{
-				opts: ListChangesetsOpts{
-					ExternalState: &stateClosed,
-				},
-				wantCount: 0,
-			},
-			{
-				opts: ListChangesetsOpts{
 					ExternalStates: []btypes.ChangesetExternalState{stateOpen},
 				},
 				wantCount: 3,
@@ -782,14 +770,14 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			},
 			{
 				opts: ListChangesetsOpts{
-					ExternalState:      &stateOpen,
+					ExternalStates:     []btypes.ChangesetExternalState{stateOpen},
 					ExternalCheckState: &stateFailed,
 				},
 				wantCount: 0,
 			},
 			{
 				opts: ListChangesetsOpts{
-					ExternalState:       &stateOpen,
+					ExternalStates:      []btypes.ChangesetExternalState{stateOpen},
 					ExternalReviewState: &stateChangesRequested,
 				},
 				wantCount: 0,

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -45,6 +45,7 @@ var (
 	ChangesetJobTypeDetach    ChangesetJobType = "detach"
 	ChangesetJobTypeReenqueue ChangesetJobType = "reenqueue"
 	ChangesetJobTypeMerge     ChangesetJobType = "merge"
+	ChangesetJobTypeClose     ChangesetJobType = "close"
 )
 
 type ChangesetJobCommentPayload struct {
@@ -58,6 +59,8 @@ type ChangesetJobReenqueuePayload struct{}
 type ChangesetJobMergePayload struct {
 	Squash bool `json:"squash,omitempty"`
 }
+
+type ChangesetJobClosePayload struct{}
 
 // ChangesetJob describes a one-time action to be taken on a changeset.
 type ChangesetJob struct {


### PR DESCRIPTION
This PR implements yet another type of bulk operation: CLOSE!
Turns out this was actually easier to do than I expected, because I forgot we already have close implemented as a reconciler operation. So we can just recycle the source methods :) 

Closes https://github.com/sourcegraph/sourcegraph/issues/20866