### PR TITLE
search-blitz: increase trace storage to 10GiB

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -187,7 +187,7 @@ func main() {
 		Dir:                filepath.Join(logDir, "traces"),
 		Token:              os.Getenv(envToken),
 		JaegerServerURL:    os.Getenv("JAEGER_SERVER_URL"),
-		MaxTotalTraceBytes: 1024 * 1024 * 1024, // 1 GiB
+		MaxTotalTraceBytes: 10 * 1024 * 1024 * 1024, // 10 GiB
 	}
 	go traces.CleanupLoop(ctx)
 


### PR DESCRIPTION
At our current rate we will only store 1 days worth of traces. This
quick fix gives us 10 days. I would make it higher, but the disk is
currently 15GiB.