### PR TITLE
insights: refactor insight setting loader out of telemetry package

### DIFF
--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -1,0 +1,154 @@
+package insights
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+)
+
+// GetSettings returns all settings on the Sourcegraph installation that can be filtered by a type. This is useful for
+// generating aggregates for code insights which are currently stored in the settings.
+// 🚨 SECURITY: This method bypasses any user permissions to fetch a list of all settings on the Sourcegraph installation.
+//It is used for generating aggregated analytics that require an accurate view across all settings, such as for code insights🚨
+func GetSettings(ctx context.Context, db dbutil.DB, filter SettingFilter, prefix string) ([]*api.Settings, error) {
+	settingStore := database.Settings(db)
+	settings, err := settingStore.ListAll(ctx, prefix)
+	if err != nil {
+		return []*api.Settings{}, err
+	}
+	filtered := make([]*api.Settings, 0)
+
+	for _, setting := range settings {
+		if setting.Subject.Org != nil && filter == Org {
+			filtered = append(filtered, setting)
+		} else if setting.Subject.User != nil && filter == User {
+			filtered = append(filtered, setting)
+		} else if filter == All {
+			filtered = append(filtered, setting)
+		}
+	}
+
+	return filtered, nil
+}
+
+// FilterSettingJson will return a json map that only contains keys that match a prefix string, mapped to the keyed contents.
+func FilterSettingJson(settingJson string, prefix string) (map[string]json.RawMessage, error) {
+	var raw map[string]json.RawMessage
+
+	if err := jsonc.Unmarshal(settingJson, &raw); err != nil {
+		return map[string]json.RawMessage{}, err
+	}
+
+	filtered := make(map[string]json.RawMessage)
+	for key, val := range raw {
+		if strings.HasPrefix(key, prefix) {
+			filtered[key] = val
+		}
+	}
+
+	return filtered, nil
+}
+
+func GetSearchInsights(ctx context.Context, db dbutil.DB, filter SettingFilter) ([]SearchInsight, error) {
+	prefix := "searchInsights."
+	settings, err := GetSettings(ctx, db, filter, prefix)
+	if err != nil {
+		return []SearchInsight{}, err
+	}
+
+	var raw map[string]json.RawMessage
+	results := make([]SearchInsight, 0)
+
+	for _, setting := range settings {
+		raw, err = FilterSettingJson(setting.Contents, prefix)
+		if err != nil {
+			return []SearchInsight{}, err
+		}
+
+		var temp SearchInsight
+
+		for id, body := range raw {
+			temp.ID = id
+			if err := json.Unmarshal(body, &temp); err != nil {
+				// a deprecated schema collides with this field name, so skip any deserialization errors
+				continue
+			}
+			results = append(results, temp)
+		}
+	}
+	return results, nil
+}
+
+func GetLangStatsInsights(ctx context.Context, db dbutil.DB, filter SettingFilter) ([]LangStatsInsight, error) {
+	prefix := "codeStatsInsights."
+
+	settings, err := GetSettings(ctx, db, filter, prefix)
+	if err != nil {
+		return []LangStatsInsight{}, err
+	}
+
+	var raw map[string]json.RawMessage
+	results := make([]LangStatsInsight, 0)
+
+	for _, setting := range settings {
+		raw, err = FilterSettingJson(setting.Contents, prefix)
+		if err != nil {
+			return []LangStatsInsight{}, err
+		}
+
+		var temp LangStatsInsight
+
+		for id, body := range raw {
+			temp.ID = id
+			if err := json.Unmarshal(body, &temp); err != nil {
+				// a deprecated schema collides with this field name, so skip any deserialization errors
+				continue
+			}
+			results = append(results, temp)
+		}
+	}
+	return results, nil
+}
+
+type TimeSeries struct {
+	Name   string
+	Stroke string
+	Query  string
+}
+
+type Interval struct {
+	Years  *int
+	Months *int
+	Weeks  *int
+	Days   *int
+	Hours  *int
+}
+
+type SearchInsight struct {
+	ID           string
+	Title        string
+	Repositories []string
+	Series       []TimeSeries
+	Step         Interval
+	Visibility   string
+}
+
+type LangStatsInsight struct {
+	ID             string
+	Title          string
+	Repository     string
+	OtherThreshold float32
+}
+
+type SettingFilter string
+
+const (
+	Org  SettingFilter = "org"
+	User SettingFilter = "user"
+	All  SettingFilter = "all"
+)

--- a/internal/insights/insights_test.go
+++ b/internal/insights/insights_test.go
@@ -1,0 +1,67 @@
+package insights
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+)
+
+func TestGetSearchInsights(t *testing.T) {
+	ctx := context.Background()
+
+	db := dbtesting.GetDB(t)
+	_, err := db.Exec(`INSERT INTO orgs(id, name) VALUES (1, 'first-org'), (2, 'second-org');`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`
+
+			INSERT INTO settings (id, org_id, contents, created_at, user_id, author_user_id)
+			VALUES  (1, 1, $1, CURRENT_TIMESTAMP, NULL, NULL)`, insightSettingSimple)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetSearchInsights(ctx, db, All)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	weeks := 2
+
+	want := []SearchInsight{{
+		ID:           "searchInsights.insight.global.simple",
+		Title:        "my insight",
+		Repositories: []string{"github.com/sourcegraph/sourcegraph"},
+		Series: []TimeSeries{{
+			Name:   "Redis",
+			Stroke: "var(--oc-red-7)",
+			Query:  "redis",
+		}},
+		Step: Interval{
+			Weeks: &weeks,
+		},
+	}}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatched search insight want/got: %v", diff)
+	}
+}
+
+const insightSettingSimple = `{"searchInsights.insight.global.simple": {
+    "title": "my insight",
+    "repositories": ["github.com/sourcegraph/sourcegraph"],
+    "series": [
+      {
+        "name": "Redis",
+        "query": "redis",
+        "stroke": "var(--oc-red-7)"
+      }
+    ],
+    "step": {
+      "weeks": 2
+    }
+  }}`

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/insights"
+
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 
 	"github.com/google/go-cmp/cmp"
@@ -161,7 +163,7 @@ func TestFilterSettingJson(t *testing.T) {
 	}
 
 	input := insightInlineSettingStr
-	got, err := FilterSettingJson(input, "searchInsights.")
+	got, err := insights.FilterSettingJson(input, "searchInsights.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,46 +197,46 @@ func TestGetSearchInsights(t *testing.T) {
 	}
 
 	step := 2
-	want := []SearchInsight{
+	want := []insights.SearchInsight{
 		{
 			ID:           "searchInsights.insight.global.first",
 			Title:        "my insight",
 			Repositories: []string{"github.com/sourcegraph/sourcegraph"},
-			Series: []TimeSeries{{
+			Series: []insights.TimeSeries{{
 				Name:   "Redis",
 				Stroke: "var(--oc-red-7)",
 				Query:  "redis",
 			}},
-			Step:       Interval{Weeks: &step},
+			Step:       insights.Interval{Weeks: &step},
 			Visibility: "",
 		},
 		{
 			ID:           "searchInsights.insight.global.second",
 			Title:        "my insight",
 			Repositories: []string{"github.com/sourcegraph/sourcegraph"},
-			Series: []TimeSeries{{
+			Series: []insights.TimeSeries{{
 				Name:   "Redis",
 				Stroke: "var(--oc-red-7)",
 				Query:  "redis",
 			}},
-			Step:       Interval{Weeks: &step},
+			Step:       insights.Interval{Weeks: &step},
 			Visibility: "",
 		},
 		{
 			ID:           "searchInsights.insight.global.simple",
 			Title:        "my insight",
 			Repositories: []string{"github.com/sourcegraph/sourcegraph"},
-			Series: []TimeSeries{{
+			Series: []insights.TimeSeries{{
 				Name:   "Redis",
 				Stroke: "var(--oc-red-7)",
 				Query:  "redis",
 			}},
-			Step:       Interval{Weeks: &step},
+			Step:       insights.Interval{Weeks: &step},
 			Visibility: "",
 		},
 	}
 
-	got, err := GetSearchInsights(ctx, db, All)
+	got, err := insights.GetSearchInsights(ctx, db, insights.All)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +272,7 @@ func TestGetLangStatsInsights(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []LangStatsInsight{
+	want := []insights.LangStatsInsight{
 		{
 			ID:             "codeStatsInsights.insight.global.lang1",
 			Title:          "my insight",
@@ -279,7 +281,7 @@ func TestGetLangStatsInsights(t *testing.T) {
 		},
 	}
 
-	got, err := GetLangStatsInsights(ctx, db, All)
+	got, err := insights.GetLangStatsInsights(ctx, db, insights.All)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #22263, Closes #22064


Upcoming insights work will need to make use of the setting loaders, so performing a refactor into an internal package and out of usage_stats.