### PR TITLE
flake: disable `TestMaxMatches` test

### DIFF
--- a/cmd/searcher/search/search_regex_test.go
+++ b/cmd/searcher/search/search_regex_test.go
@@ -422,6 +422,8 @@ func TestReadAll(t *testing.T) {
 }
 
 func TestMaxMatches(t *testing.T) {
+	t.Skip("TODO: Disabled because it's flaky. See: https://github.com/sourcegraph/sourcegraph/issues/22560")
+
 	pattern := "foo"
 
 	// Create a zip archive which contains our limits + 1


### PR DESCRIPTION
Observed this test failing on an unrelated change, let me know if you'd like to proceed some other way. 🙂

See #22560 
