### PR TITLE
prometheus: add default string templates for alertmanager priority and tags

### DIFF
--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -64,7 +64,7 @@ var (
 
 	priorityTemplateDefault = `{{ if eq .CommonLabels.level "critical"}}P1{{else if eq .CommonLabels.level "warning"}}P2{{else if eq .CommonLabels.level "info"}}P3{{else}}P4{{end}}`
 
-	tagsTemplateDefault = "{{ range $index, $element := .CommonLabels }}{{if $index}},{{end}}{{$element}}{{end}}"
+	tagsTemplateDefault = "{{ range $key, $value := .CommonLabels }}{{$key}}={{$value}},{{end}}"
 )
 
 // newRoutesAndReceivers converts the given alerts from Sourcegraph site configuration into Alertmanager receivers

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -64,7 +64,7 @@ var (
 
 	priorityTemplateDefault = `{{ range .Alerts }}{{ if eq .Labels.severity "critical"}}P1{{else if eq .Labels.severity "warning"}}P2{{else if eq .Labels.severity "info"}}P3{{else}}P4{{end}}{{end}}`
 
-	tagsTemplateDefault = "{{ range $index, $element := .Labels}}{{if $index}},{{end}}{{$element}}{{end}}"
+	tagsTemplateDefault = "{{ range $index, $element := $labels}}{{if $index}},{{end}}{{$element}}{{end}}"
 )
 
 // newRoutesAndReceivers converts the given alerts from Sourcegraph site configuration into Alertmanager receivers

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -62,8 +62,6 @@ var (
 	resolvedTitleTemplate     = "[RESOLVED] {{ .CommonLabels.description }}"
 	notificationTitleTemplate = fmt.Sprintf(`{{ if eq .Status "firing" }}%s{{ else }}%s{{ end }}`, firingTitleTemplate, resolvedTitleTemplate)
 
-	priorityTemplateDefault = `{{ if eq .CommonLabels.level "critical"}}P1{{else if eq .CommonLabels.level "warning"}}P2{{else if eq .CommonLabels.level "info"}}P3{{else}}P4{{end}}`
-
 	tagsTemplateDefault = "{{ range $key, $value := .CommonLabels }}{{$key}}={{$value}},{{end}}"
 )
 
@@ -230,7 +228,19 @@ For more details, please refer to the service dashboard: %s`, firingBodyTemplate
 				}
 			}
 
-			priority := priorityTemplateDefault
+			var priority string
+
+			switch alert.Level {
+			case "critical":
+				priority = "P1"
+			case "warning":
+				priority = "P2"
+			case "info":
+				priority = "P3"
+			default:
+				priority = "P4"
+			}
+
 			if notifier.Opsgenie.Priority != "" {
 				priority = notifier.Opsgenie.Priority
 			}

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -61,6 +61,10 @@ var (
 	firingTitleTemplate       = "[{{ .CommonLabels.level | toUpper }}] {{ .CommonLabels.description }}"
 	resolvedTitleTemplate     = "[RESOLVED] {{ .CommonLabels.description }}"
 	notificationTitleTemplate = fmt.Sprintf(`{{ if eq .Status "firing" }}%s{{ else }}%s{{ end }}`, firingTitleTemplate, resolvedTitleTemplate)
+
+	priorityTemplateDefault = `{{ range .Alerts }}{{ if eq .Labels.severity "critical"}}P1{{else if eq .Labels.severity "warning"}}P2{{else if eq .Labels.severity "info"}}P3{{else}}P4{{end}}{{end}}`
+
+	tagsTemplateDefault = "{{ range $index, $element := .Labels}}{{if $index}},{{end}}{{$element}}{{end}}"
 )
 
 // newRoutesAndReceivers converts the given alerts from Sourcegraph site configuration into Alertmanager receivers
@@ -226,8 +230,15 @@ For more details, please refer to the service dashboard: %s`, firingBodyTemplate
 				}
 			}
 
-			priority := notifier.Opsgenie.Priority
-			tags := notifier.Opsgenie.Tags
+			priority := priorityTemplateDefault
+			if notifier.Opsgenie.Priority != "" {
+				priority = notifier.Opsgenie.Priority
+			}
+
+			tags := tagsTemplateDefault
+			if notifier.Opsgenie.Tags != "" {
+				tags = notifier.Opsgenie.Tags
+			}
 
 			receiver.OpsGenieConfigs = append(receiver.OpsGenieConfigs, &amconfig.OpsGenieConfig{
 				APIKey: apiKEY,

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -62,9 +62,9 @@ var (
 	resolvedTitleTemplate     = "[RESOLVED] {{ .CommonLabels.description }}"
 	notificationTitleTemplate = fmt.Sprintf(`{{ if eq .Status "firing" }}%s{{ else }}%s{{ end }}`, firingTitleTemplate, resolvedTitleTemplate)
 
-	priorityTemplateDefault = `{{ range .Alerts }}{{ if eq .Labels.severity "critical"}}P1{{else if eq .Labels.severity "warning"}}P2{{else if eq .Labels.severity "info"}}P3{{else}}P4{{end}}{{end}}`
+	priorityTemplateDefault = `{{ if eq .CommonLabels.level "critical"}}P1{{else if eq .CommonLabels.level "warning"}}P2{{else if eq .CommonLabels.level "info"}}P3{{else}}P4{{end}}`
 
-	tagsTemplateDefault = "{{ range $index, $element := $labels}}{{if $index}},{{end}}{{$element}}{{end}}"
+	tagsTemplateDefault = "{{ range $index, $element := .CommonLabels }}{{if $index}},{{end}}{{$element}}{{end}}"
 )
 
 // newRoutesAndReceivers converts the given alerts from Sourcegraph site configuration into Alertmanager receivers

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -955,13 +955,15 @@ type NotifierEmail struct {
 
 // NotifierOpsGenie description: OpsGenie notifier
 type NotifierOpsGenie struct {
-	ApiKey   string `json:"apiKey,omitempty"`
-	ApiUrl   string `json:"apiUrl,omitempty"`
+	ApiKey string `json:"apiKey,omitempty"`
+	ApiUrl string `json:"apiUrl,omitempty"`
+	// Priority description: Defines the importance of an alert. Allowed values are P1, P2, P3, P4, P5 - or a Go template that resolves to one of those values. By default, Sourcegraph will fill this in for you if a value isn't specified here.
 	Priority string `json:"priority,omitempty"`
 	// Responders description: List of responders responsible for notifications.
 	Responders []*Responders `json:"responders,omitempty"`
-	Tags       string        `json:"tags,omitempty"`
-	Type       string        `json:"type"`
+	// Tags description: Comma separated list of tags attached to the notifications - or a Go template that produces such a list. Sourcegraph provides some default ones if this value isn't specified.
+	Tags string `json:"tags,omitempty"`
+	Type string `json:"type"`
 }
 
 // NotifierPagerduty description: PagerDuty notifier

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1445,7 +1445,7 @@
           "type": "string"
         },
         "priority": {
-          "description": "Defines the importance of an alert. Allowed values are P1, P2, P3, P4, P5 - or a Go template that resolves to one of those values. By default, Sourcegraph will fill this in for you if a value isn't specified here. ",
+          "description": "Defines the importance of an alert. Allowed values are P1, P2, P3, P4, P5 - or a Go template that resolves to one of those values. By default, Sourcegraph will fill this in for you if a value isn't specified here.",
           "type": "string"
         },
         "responders": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1441,9 +1441,11 @@
         "apiKey": { "type": "string" },
         "apiUrl": { "type": "string" },
         "tags": {
+          "description": "Comma separated list of tags attached to the notifications - or a Go template that produces such a list. Sourcegraph provides some default ones if this value isn't specified.",
           "type": "string"
         },
         "priority": {
+          "description": "Defines the importance of an alert. Allowed values are P1, P2, P3, P4, P5 - or a Go template that resolves to one of those values. By default, Sourcegraph will fill this in for you if a value isn't specified here. ",
           "type": "string"
         },
         "responders": {


### PR DESCRIPTION
Part of #12138 

When you embed go-template expressions inside the site configuration, you'll have to escape any nested quotes. You'll also have to potentially copy the template strings multiple times depending on how many alert definitions you have. Both of these made me realize it was just easier to change our prom-wrapper to automatically insert these expressions if they weren't already provided.

See the screenshot below for what our new alerts look like now (they have proper `priority` and `tag` fields now).

![Screen Shot 2021-07-08 at 3 33 52 PM](https://user-images.githubusercontent.com/9022011/124999230-8b815f00-e002-11eb-9254-37c84fd349e4.png)
