### PR TITLE
search: remove excessive resolver methods

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -219,11 +219,6 @@ func (r *searchResolver) rawQuery() string {
 	return r.OriginalQuery
 }
 
-func (r *searchResolver) countIsSet() bool {
-	count := r.Query.Count()
-	return count != nil
-}
-
 // protocol returns what type of search we are doing (batch, stream,
 // paginated).
 func (r *searchResolver) protocol() search.Protocol {
@@ -397,7 +392,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 		PatternInfo:     p,
 		RepoPromise:     (&search.RepoPromise{}).Resolve(resolved.RepoRevs),
 		Query:           r.Query,
-		UseFullDeadline: r.searchTimeoutFieldSet(),
+		UseFullDeadline: r.Query.Timeout() != nil || r.Query.Count() != nil,
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1210,18 +1210,13 @@ var (
 	defaultTimeout = 20 * time.Second
 )
 
-func (r *searchResolver) searchTimeoutFieldSet() bool {
-	timeout := r.Query.Timeout()
-	return timeout != nil || r.countIsSet()
-}
-
 func (r *searchResolver) withTimeout(ctx context.Context) (context.Context, context.CancelFunc, error) {
 	d := defaultTimeout
 	maxTimeout := time.Duration(searchrepos.SearchLimits().MaxTimeoutSeconds) * time.Second
 	timeout := r.Query.Timeout()
 	if timeout != nil {
 		d = *timeout
-	} else if r.countIsSet() {
+	} else if r.Query.Count() != nil {
 		// If `count:` is set but `timeout:` is not explicitly set, use the max timeout
 		d = maxTimeout
 	}
@@ -1337,7 +1332,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 		Query:       r.Query,
 
 		// UseFullDeadline if timeout: set or we are streaming.
-		UseFullDeadline: r.searchTimeoutFieldSet() || r.stream != nil,
+		UseFullDeadline: r.Query.Timeout() != nil || r.Query.Count() != nil || r.stream != nil,
 
 		Zoekt:        r.zoekt,
 		SearcherURLs: r.searcherURLs,


### PR DESCRIPTION
Starting to fix up backend query logic things. Preface: I want to promote logic that processes queries earlier (i.e., for statically-known properties), so we can have dedicated types for our backend components. To do that promotion requires breaking dependencies on some methods/objects, like `searchResolver` methods. 

This PR removes two `searchResolver` methods that are little used and inlines the logic which only depends on query properties instead. What this does is later allows me to pass just `r.Query` earlier to a function that processes it for those static properties (e.g., computing `UseFullDeadline`), without needing access to resolver methods `r.countIsSet` or `r.searchTimeoutFieldSet`, for example.