### PR TITLE
vscode: exclude *.scss.d.ts (generated) files from explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,9 @@
     "doc/_resources/assets": true,
     "**/.eslintcache": true,
   },
+  "files.exclude": {
+    "**/*.scss.d.ts": true,
+  },
   "files.associations": {
     "**/dev/critical-config.json": "jsonc",
     "**/dev/site-config.json": "jsonc",


### PR DESCRIPTION
These files are auto-generated and just add noise to the VS Code explorer.