### PR TITLE
search: don't show "Repository match" or "Path match" text

### DIFF
--- a/client/shared/src/components/FileMatch.story.tsx
+++ b/client/shared/src/components/FileMatch.story.tsx
@@ -1,0 +1,73 @@
+import { storiesOf } from '@storybook/react'
+import { createBrowserHistory } from 'history'
+import FileIcon from 'mdi-react/FileIcon'
+import * as React from 'react'
+import _VisibilitySensor from 'react-visibility-sensor'
+import sinon from 'sinon'
+
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
+
+import { SymbolKind } from '../graphql/schema'
+import { HIGHLIGHTED_FILE_LINES_REQUEST, NOOP_SETTINGS_CASCADE } from '../util/searchTestHelpers'
+
+import { FileMatch } from './FileMatch'
+
+const defaultProps: Omit<React.ComponentProps<typeof FileMatch>, 'result'> = {
+    location: createBrowserHistory().location,
+    icon: FileIcon,
+    onSelect: sinon.spy(),
+    expanded: true,
+    showAllMatches: true,
+    isLightTheme: true,
+    fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_REQUEST,
+    settingsCascade: NOOP_SETTINGS_CASCADE,
+}
+
+// The FileMatch component lives in `shared`, but show it in the `web` storybook group so it's
+// alongside the other search result component storybooks.
+const { add } = storiesOf('web/search/results/FileMatch', module)
+    .addParameters({
+        chromatic: { viewports: [800] },
+    })
+    .addDecorator(story => (
+        <>
+            <div className="p-4">{story()}</div>
+            <style>{webStyles}</style>
+        </>
+    ))
+
+add('file/line matches', () => (
+    <FileMatch
+        {...defaultProps}
+        result={{
+            type: 'file',
+            repository: 'a/b',
+            name: '.foo.yml',
+            lineMatches: [{ line: '', lineNumber: 1, offsetAndLengths: [[1, 1]] }],
+        }}
+    />
+))
+
+add('file/symbol matches', () => (
+    <FileMatch
+        {...defaultProps}
+        result={{
+            type: 'symbol',
+            repository: 'a/b',
+            name: '.foo.yml',
+            symbols: [{ containerName: 'Cat', name: 'meow', kind: SymbolKind.METHOD, url: '/meow' }],
+        }}
+    />
+))
+
+add('file/path match', () => (
+    <FileMatch
+        {...defaultProps}
+        result={{
+            type: 'file',
+            repository: 'a/b',
+            name: '.foo.yml',
+            lineMatches: [],
+        }}
+    />
+))

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -141,55 +141,51 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         grouped.length === 0 && (result.type !== 'symbol' || !result.symbols || result.symbols.length === 0)
 
     return (
-        <div className="file-match-children">
-            {/* No symbols or line matches means that this is a path match */}
-            {noMatches && (
-                <div className="file-match-children__item">
-                    <small>Path match</small>
-                </div>
-            )}
-
-            {/* Symbols */}
-            {((result.type === 'symbol' && result.symbols) || []).map(symbol => (
-                <Link
-                    to={symbol.url}
-                    className="file-match-children__item test-file-match-children-item"
-                    key={`symbol:${symbol.name}${String(symbol.containerName)}${symbol.url}`}
-                >
-                    <SymbolIcon kind={symbol.kind} className="icon-inline mr-1" />
-                    <code>
-                        {symbol.name}{' '}
-                        {symbol.containerName && <span className="text-muted">{symbol.containerName}</span>}
-                    </code>
-                </Link>
-            ))}
-
-            {/* Line matches */}
-            {grouped.map((group, index) => (
-                <div
-                    key={`linematch:${getFileMatchUrl(result)}${group.position.line}:${group.position.character}`}
-                    className="file-match-children__item-code-wrapper test-file-match-children-item-wrapper"
-                >
+        // No symbols or line matches means that this is a path match
+        noMatches ? null : (
+            <div className="file-match-children">
+                {/* Symbols */}
+                {((result.type === 'symbol' && result.symbols) || []).map(symbol => (
                     <Link
-                        to={createCodeExcerptLink(group)}
-                        className="file-match-children__item file-match-children__item-clickable test-file-match-children-item"
-                        onClick={props.onSelect}
+                        to={symbol.url}
+                        className="file-match-children__item test-file-match-children-item"
+                        key={`symbol:${symbol.name}${String(symbol.containerName)}${symbol.url}`}
                     >
-                        <CodeExcerpt
-                            repoName={result.repository}
-                            commitID={result.version || ''}
-                            filePath={result.name}
-                            startLine={group.startLine}
-                            endLine={group.endLine}
-                            highlightRanges={group.matches}
-                            className="file-match-children__item-code-excerpt"
-                            isLightTheme={isLightTheme}
-                            fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
-                            isFirst={index === 0}
-                        />
+                        <SymbolIcon kind={symbol.kind} className="icon-inline mr-1" />
+                        <code>
+                            {symbol.name}{' '}
+                            {symbol.containerName && <span className="text-muted">{symbol.containerName}</span>}
+                        </code>
                     </Link>
-                </div>
-            ))}
-        </div>
+                ))}
+
+                {/* Line matches */}
+                {grouped.map((group, index) => (
+                    <div
+                        key={`linematch:${getFileMatchUrl(result)}${group.position.line}:${group.position.character}`}
+                        className="file-match-children__item-code-wrapper test-file-match-children-item-wrapper"
+                    >
+                        <Link
+                            to={createCodeExcerptLink(group)}
+                            className="file-match-children__item file-match-children__item-clickable test-file-match-children-item"
+                            onClick={props.onSelect}
+                        >
+                            <CodeExcerpt
+                                repoName={result.repository}
+                                commitID={result.version || ''}
+                                filePath={result.name}
+                                startLine={group.startLine}
+                                endLine={group.endLine}
+                                highlightRanges={group.matches}
+                                className="file-match-children__item-code-excerpt"
+                                isLightTheme={isLightTheme}
+                                fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
+                                isFirst={index === 0}
+                            />
+                        </Link>
+                    </div>
+                ))}
+            </div>
+        )
     )
 }

--- a/client/web/src/components/SearchResult.scss
+++ b/client/web/src/components/SearchResult.scss
@@ -13,11 +13,6 @@
         height: 1rem;
         margin: 0 0.5rem;
     }
-    &__divider-vertical {
-        border-bottom: 1px solid var(--border-color-2);
-        width: 100%;
-        margin: 0.5rem 0;
-    }
     &__match-type {
         white-space: nowrap;
     }
@@ -29,6 +24,7 @@
         margin-right: 0.25rem;
     }
     &__icon {
+        margin-left: 0.25rem;
         margin-right: 0.25rem;
     }
 }

--- a/client/web/src/components/SearchResult.story.tsx
+++ b/client/web/src/components/SearchResult.story.tsx
@@ -1,0 +1,118 @@
+import { storiesOf } from '@storybook/react'
+import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
+import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
+import React from 'react'
+
+import { SearchResult } from './SearchResult'
+import { WebStory } from './WebStory'
+
+const defaultProps: Omit<React.ComponentProps<typeof SearchResult>, 'result' | 'icon'> = {
+    isLightTheme: true,
+    repoName: 'a/b',
+}
+
+const { add } = storiesOf('web/search/results/SearchResult', module).addParameters({
+    chromatic: { viewports: [800] },
+})
+
+add('repository/source', () => (
+    <WebStory>
+        {() => (
+            <SearchResult {...defaultProps} icon={SourceRepositoryIcon} result={{ type: 'repo', repository: 'a/b' }} />
+        )}
+    </WebStory>
+))
+
+add('repository/github', () => (
+    <WebStory>
+        {() => (
+            <SearchResult
+                {...defaultProps}
+                icon={SourceRepositoryIcon}
+                repoName="github.com/a/b"
+                result={{ type: 'repo', repository: 'github.com/a/b' }}
+            />
+        )}
+    </WebStory>
+))
+
+add('repository/github stars', () => (
+    <WebStory>
+        {() => (
+            <SearchResult
+                {...defaultProps}
+                icon={SourceRepositoryIcon}
+                repoName="github.com/a/b"
+                result={{ type: 'repo', repository: 'github.com/a/b', repoStars: 123 }}
+            />
+        )}
+    </WebStory>
+))
+
+add('repository/fork', () => (
+    <WebStory>
+        {() => (
+            <SearchResult
+                {...defaultProps}
+                icon={SourceRepositoryIcon}
+                result={{ type: 'repo', repository: 'a/b', fork: true }}
+            />
+        )}
+    </WebStory>
+))
+
+add('repository/archived', () => (
+    <WebStory>
+        {() => (
+            <SearchResult
+                {...defaultProps}
+                icon={SourceRepositoryIcon}
+                result={{ type: 'repo', repository: 'a/b', archived: true }}
+            />
+        )}
+    </WebStory>
+))
+
+add('repository/fork archived', () => (
+    <WebStory>
+        {() => (
+            <SearchResult
+                {...defaultProps}
+                icon={SourceRepositoryIcon}
+                result={{ type: 'repo', repository: 'a/b', fork: true, archived: true }}
+            />
+        )}
+    </WebStory>
+))
+
+add('repository/stars fork archived', () => (
+    <WebStory>
+        {() => (
+            <SearchResult
+                {...defaultProps}
+                icon={SourceRepositoryIcon}
+                result={{ type: 'repo', repository: 'a/b', repoStars: 123, fork: true, archived: true }}
+            />
+        )}
+    </WebStory>
+))
+
+add('commit', () => (
+    <WebStory>
+        {() => (
+            <SearchResult
+                {...defaultProps}
+                icon={SourceCommitIcon}
+                result={{
+                    type: 'commit',
+                    label: 'title',
+                    detail: 'detail',
+                    url: '/u',
+                    content: 'abc',
+                    ranges: [],
+                    repository: 'a/b',
+                }}
+            />
+        )}
+    </WebStory>
+))

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -38,6 +38,22 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, icon, isL
                 {result.type === 'commit' && result.detail && formattedRepositoryStarCount && (
                     <div className="search-result__divider" />
                 )}
+                {result.type === 'repo' && (
+                    <>
+                        {result.fork && (
+                            <SourceForkIcon
+                                className="search-result__icon icon-inline flex-shrink-0 text-muted"
+                                data-tooltip="Fork"
+                            />
+                        )}
+                        {result.archived && (
+                            <ArchiveIcon
+                                className="search-result__icon icon-inline flex-shrink-0 text-muted"
+                                data-tooltip="Archive"
+                            />
+                        )}
+                    </>
+                )}
                 {formattedRepositoryStarCount && (
                     <>
                         <StarIcon className="search-result__star" />
@@ -48,51 +64,15 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, icon, isL
         )
     }
 
-    const renderBody = (): JSX.Element => {
+    const renderBody = (): JSX.Element | undefined => {
         if (result.type === 'repo') {
-            return (
-                <div>
-                    <div className="search-result-match p-2 flex-column">
-                        <div className="d-flex align-items-center flex-row">
-                            <div className="search-result__match-type">
-                                <small>Repository match</small>
-                            </div>
-                            {result.fork && (
-                                <>
-                                    <div className="search-result__divider" />
-                                    <div>
-                                        <SourceForkIcon className="search-result__icon icon-inline flex-shrink-0 text-muted" />
-                                    </div>
-                                    <div>
-                                        <small>Fork</small>
-                                    </div>
-                                </>
-                            )}
-                            {result.archived && (
-                                <>
-                                    <div className="search-result__divider" />
-                                    <div>
-                                        <ArchiveIcon className="search-result__icon icon-inline flex-shrink-0 text-muted" />
-                                    </div>
-                                    <div>
-                                        <small>Archived</small>
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                        {result.description && (
-                            <>
-                                <div className="search-result__divider-vertical" />
-                                <div className="search-result__description">
-                                    <small>
-                                        <em>{result.description}</em>
-                                    </small>
-                                </div>
-                            </>
-                        )}
-                    </div>
+            return result.description ? (
+                <div className="search-result-match p-2 flex-column">
+                    <small>
+                        <em>{result.description}</em>
+                    </small>
                 </div>
-            )
+            ) : undefined
         }
 
         return <CommitSearchResultMatch key={result.url} item={result} isLightTheme={isLightTheme} />


### PR DESCRIPTION
When searching repositories, each repository match will show a large, clunky text box saying `Repository match`. When searching files, each file whose path matches likewise says `Path match`. These text labels take up space and feel clunky (obviously it's a match--that's why it's shown as a result).

This commit removes those text labels. This means that some matches now have no "box" below them (such as if a matched repository has no description, and all path-matched files). It also means that the archived and fork labels needed to be moved elsewhere, so they are now next to the repository stars count (or otherwise on the right-hand side of the result).

Also adds storybooks for repository, commit, file, symbol, and path matches.