### PR TITLE
Add user_id to batch_spec_executions table

### DIFF
--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1331,8 +1331,11 @@ func (r *Resolver) CreateBatchSpecExecution(ctx context.Context, args *graphqlba
 		return nil, err
 	}
 
+	actor := actor.FromContext(ctx)
+
 	exec := &btypes.BatchSpecExecution{
 		BatchSpec: args.Spec,
+		UserID:    actor.UID,
 	}
 
 	if err := r.store.CreateBatchSpecExecution(ctx, exec); err != nil {

--- a/enterprise/internal/batches/store/batch_spec_execution.go
+++ b/enterprise/internal/batches/store/batch_spec_execution.go
@@ -29,10 +29,12 @@ var BatchSpecExecutionColumns = []*sqlf.Query{
 	sqlf.Sprintf(`batch_spec_executions.updated_at`),
 	sqlf.Sprintf(`batch_spec_executions.batch_spec`),
 	sqlf.Sprintf(`batch_spec_executions.batch_spec_id`),
+	sqlf.Sprintf(`batch_spec_executions.user_id`),
 }
 
 var batchSpecExecutionInsertColumns = []*sqlf.Query{
 	sqlf.Sprintf("batch_spec"),
+	sqlf.Sprintf("user_id"),
 	sqlf.Sprintf("created_at"),
 	sqlf.Sprintf("updated_at"),
 }
@@ -57,7 +59,7 @@ func (s *Store) CreateBatchSpecExecution(ctx context.Context, b *btypes.BatchSpe
 var createBatchSpecExecutionQueryFmtstr = `
 -- source: enterprise/internal/batches/store/batch_spec_executions.go:CreateBatchSpecExecution
 INSERT INTO batch_spec_executions (%s)
-VALUES (%s, %s, %s)
+VALUES (%s, %s, %s, %s)
 RETURNING %s`
 
 func createBatchSpecExecutionQuery(c *btypes.BatchSpecExecution) (*sqlf.Query, error) {
@@ -65,6 +67,7 @@ func createBatchSpecExecutionQuery(c *btypes.BatchSpecExecution) (*sqlf.Query, e
 		createBatchSpecExecutionQueryFmtstr,
 		sqlf.Join(batchSpecExecutionInsertColumns, ", "),
 		c.BatchSpec,
+		c.UserID,
 		c.CreatedAt,
 		c.UpdatedAt,
 		sqlf.Join(BatchSpecExecutionColumns, ", "),
@@ -132,6 +135,7 @@ func scanBatchSpecExecution(b *btypes.BatchSpecExecution, sc scanner) error {
 		&b.UpdatedAt,
 		&b.BatchSpec,
 		&dbutil.NullInt64{N: &b.BatchSpecID},
+		&b.UserID,
 	); err != nil {
 		return err
 	}

--- a/enterprise/internal/batches/store/batch_spec_execution_test.go
+++ b/enterprise/internal/batches/store/batch_spec_execution_test.go
@@ -38,7 +38,7 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 				UpdatedAt: clock.Now(),
 				State:     btypes.BatchSpecExecutionStateQueued,
 				BatchSpec: testBatchSpec,
-				UserID:          have.UserID,
+				UserID:    have.UserID,
 			}
 
 			if have.ID == 0 {

--- a/enterprise/internal/batches/store/batch_spec_execution_test.go
+++ b/enterprise/internal/batches/store/batch_spec_execution_test.go
@@ -19,6 +19,7 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 		c := &btypes.BatchSpecExecution{
 			State:     btypes.BatchSpecExecutionStateQueued,
 			BatchSpec: testBatchSpec,
+			UserID:    int32(i + 123),
 		}
 
 		execs = append(execs, c)
@@ -37,6 +38,7 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 				UpdatedAt: clock.Now(),
 				State:     btypes.BatchSpecExecutionStateQueued,
 				BatchSpec: testBatchSpec,
+				UserID:          have.UserID,
 			}
 
 			if have.ID == 0 {

--- a/enterprise/internal/batches/types/batch_spec_execution.go
+++ b/enterprise/internal/batches/types/batch_spec_execution.go
@@ -31,6 +31,7 @@ type BatchSpecExecution struct {
 	UpdatedAt      time.Time
 	BatchSpec      string
 	BatchSpecID    int64
+	UserID         int32
 }
 
 func (i BatchSpecExecution) RecordID() int {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -94,10 +94,12 @@ Indexes:
  updated_at      | timestamp with time zone |           | not null | now()
  batch_spec      | text                     |           | not null | 
  batch_spec_id   | integer                  |           |          | 
+ user_id         | integer                  |           |          | 
 Indexes:
     "batch_spec_executions_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
     "batch_spec_executions_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id)
+    "batch_spec_executions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
 
 ```
 
@@ -1832,6 +1834,7 @@ Referenced by:
     TABLE "batch_changes" CONSTRAINT "batch_changes_initial_applier_id_fkey" FOREIGN KEY (initial_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_last_applier_id_fkey" FOREIGN KEY (last_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
+    TABLE "batch_spec_executions" CONSTRAINT "batch_spec_executions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
     TABLE "batch_specs" CONSTRAINT "batch_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "changeset_specs" CONSTRAINT "changeset_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE

--- a/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.down.sql
+++ b/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.down.sql
@@ -1,0 +1,6 @@
+
+BEGIN;
+
+ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS user_id;
+
+COMMIT;

--- a/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.down.sql
+++ b/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.down.sql
@@ -1,4 +1,3 @@
-
 BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS user_id;

--- a/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.up.sql
+++ b/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.up.sql
@@ -1,4 +1,3 @@
-
 BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions ADD COLUMN IF NOT EXISTS user_id int REFERENCES users(id) DEFERRABLE;

--- a/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.up.sql
+++ b/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.up.sql
@@ -1,0 +1,6 @@
+
+BEGIN;
+
+ALTER TABLE IF EXISTS batch_spec_executions ADD COLUMN IF NOT EXISTS user_id int REFERENCES users(id) DEFERRABLE;
+
+COMMIT;


### PR DESCRIPTION
Turns out we need this column so we can do things on behalf of the user that wants to execute the batch spec. Immediate example: we need to create an access token on behalf of the user.