### PR TITLE
dbconn: Close connections by idle time

### DIFF
--- a/internal/database/dbconn/dbconn.go
+++ b/internal/database/dbconn/dbconn.go
@@ -280,7 +280,7 @@ func open(cfg *pgx.ConnConfig) (*sql.DB, error) {
 	}
 	db.SetMaxOpenConns(maxOpen)
 	db.SetMaxIdleConns(maxOpen)
-	db.SetConnMaxLifetime(time.Minute)
+	db.SetConnMaxIdleTime(time.Minute)
 
 	return db, nil
 }
@@ -386,5 +386,5 @@ func configureConnectionPool(db *sql.DB) {
 	}
 	db.SetMaxOpenConns(maxOpen)
 	db.SetMaxIdleConns(maxOpen)
-	db.SetConnMaxLifetime(time.Minute)
+	db.SetConnMaxIdleTime(time.Minute)
 }


### PR DESCRIPTION
This commit replaces our usage of SetConnMaxLifetime with
SetConnMaxIdleTime which was later added to the standard library and
beter captures our intent when we introduced the former.

This might also improve the connection wait time being reported. The
theory is that because connections get closed lazily with
SetConnMaxLifetime, some connection requests can wait longer when an
underlying connection expires.

Only closing idle connections should address this.

