### PR TITLE
search-blitz: retry trace fetching

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -188,6 +188,7 @@ func main() {
 		Token:              os.Getenv(envToken),
 		JaegerServerURL:    os.Getenv("JAEGER_SERVER_URL"),
 		MaxTotalTraceBytes: 10 * 1024 * 1024 * 1024, // 10 GiB
+		MaxFetchAttempts:   10,
 	}
 	go traces.CleanupLoop(ctx)
 

--- a/internal/cmd/search-blitz/trace.go
+++ b/internal/cmd/search-blitz/trace.go
@@ -32,7 +32,7 @@ type traceStore struct {
 	MaxTotalTraceBytes int64
 
 	// MaxFetchAttempts is the maximum number of attempts to try fetching a trace
-	// before failing.
+	// before failing. Defaults to 1 when zero valued.
 	MaxFetchAttempts int
 
 	// JaegerServerURL if non-empty will be used as the non-path of the URL

--- a/internal/cmd/search-blitz/trace.go
+++ b/internal/cmd/search-blitz/trace.go
@@ -45,7 +45,7 @@ type traceStore struct {
 	// + the jaeger proxy. Environment variable we use is JAEGER_SERVER_URL.
 	JaegerServerURL string
 
-	// unexported Prometheus metrics, lazily initiated by calls to t.observe
+	// unexported Prometheus metrics, lazily initiated by calls to t.initMetrics
 	metrics struct {
 		sync.Once
 		fetchHist *prometheus.HistogramVec


### PR DESCRIPTION
Some searches are fast enough that Jaeger hasn't received the traces
yet. We introduce retries to address this.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
