### PR TITLE
Add batches executorStore to provide custom MarkComplete method

### DIFF
--- a/enterprise/cmd/executor-queue/internal/queues/batches/transform.go
+++ b/enterprise/cmd/executor-queue/internal/queues/batches/transform.go
@@ -31,6 +31,7 @@ func transformRecord(ctx context.Context, db dbutil.DB, exec *btypes.BatchSpecEx
 					"batch",
 					"preview",
 					"-f", "spec.yml",
+					"-text-only",
 				},
 				Dir: ".",
 				Env: []string{

--- a/enterprise/cmd/executor-queue/internal/queues/batches/transform_test.go
+++ b/enterprise/cmd/executor-queue/internal/queues/batches/transform_test.go
@@ -37,7 +37,7 @@ func TestTransformRecord(t *testing.T) {
 		CliSteps: []apiclient.CliStep{
 			{
 				Commands: []string{
-					"batch", "preview", "-f", "spec.yml",
+					"batch", "preview", "-f", "spec.yml", "-text-only",
 				},
 				Dir: ".",
 				Env: []string{"SRC_ENDPOINT=https://test%2A:hunter2@test.io"},

--- a/enterprise/internal/batches/background/executor_store.go
+++ b/enterprise/internal/batches/background/executor_store.go
@@ -95,7 +95,7 @@ func (s *executorStore) Dequeue(ctx context.Context, workerHostname string, cond
 }
 
 func loadAndExtractBatchSpecRandID(ctx context.Context, s *store.Store, id int64) (string, error) {
-	exec, err := s.GetBatchSpecExecution(ctx, store.GetBatchSpecExecutionOpts{ID: int64(id)})
+	exec, err := s.GetBatchSpecExecution(ctx, store.GetBatchSpecExecutionOpts{ID: id})
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/internal/batches/background/executor_store.go
+++ b/enterprise/internal/batches/background/executor_store.go
@@ -1,9 +1,14 @@
 package background
 
 import (
+	"context"
 	"database/sql"
+	"encoding/json"
+	"strings"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -39,7 +44,97 @@ var executorWorkerStoreOptions = dbworkerstore.Options{
 // NewExecutorStore creates a dbworker store that wraps the batch_spec_executions
 // table.
 func NewExecutorStore(s basestore.ShareableStore, observationContext *observation.Context) dbworkerstore.Store {
-	return dbworkerstore.NewWithMetrics(s.Handle(), executorWorkerStoreOptions, observationContext)
+	return &executorStore{wrapped: dbworkerstore.NewWithMetrics(s.Handle(), executorWorkerStoreOptions, observationContext)}
+}
+
+var _ dbworkerstore.Store = &executorStore{}
+
+type executorStore struct {
+	wrapped dbworkerstore.Store
+}
+
+const markCompleteQuery = `
+UPDATE batch_spec_executions
+SET state = 'completed', finished_at = clock_timestamp(), batch_spec_id = (SELECT id FROM batch_specs WHERE rand_id = %s)
+WHERE id = %s AND state = 'processing'
+RETURNING id
+`
+
+func (s *executorStore) MarkComplete(ctx context.Context, id int) (_ bool, err error) {
+	batchesStore := store.New(s.wrapped.Handle().DB(), nil)
+
+	exec, err := batchesStore.GetBatchSpecExecution(ctx, store.GetBatchSpecExecutionOpts{ID: int64(id)})
+
+	lines := strings.Split(strings.ReplaceAll(exec.ExecutionLogs[0].Out, "stdout: ", ""), "\n")
+
+	type batchesLogEvent struct {
+		Operation string `json:"operation"` // "PREPARING_DOCKER_IMAGES"
+
+		Timestamp time.Time `json:"timestamp"`
+
+		Status  string `json:"status"`            // "STARTED", "PROGRESS", "SUCCESS", "FAILURE"
+		Message string `json:"message,omitempty"` // "70% done"
+	}
+
+	var batchSpecRandID string
+	for _, l := range lines {
+		var e batchesLogEvent
+
+		if err := json.Unmarshal([]byte(l), &e); err != nil {
+			return false, err
+		}
+
+		if e.Operation == "CREATING_BATCH_SPEC" && e.Status == "SUCCESS" {
+			parts := strings.Split(e.Message, "/")
+			batchSpecGraphQLID := graphql.ID(parts[len(parts)-1])
+
+			if err := relay.UnmarshalSpec(batchSpecGraphQLID, &batchSpecRandID); err != nil {
+				return false, err
+			}
+			break
+		}
+	}
+
+	h := basestore.NewWithHandle(s.wrapped.Handle())
+	_, ok, err := basestore.ScanFirstInt(h.Query(ctx, sqlf.Sprintf(markCompleteQuery, batchSpecRandID, id)))
+
+	return ok, err
+}
+
+func (s *executorStore) DequeueWithIndependentTransactionContext(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (workerutil.Record, dbworkerstore.Store, bool, error) {
+	r, wrapped, b, err := s.wrapped.DequeueWithIndependentTransactionContext(ctx, workerHostname, conditions)
+
+	return r, &executorStore{wrapped: wrapped}, b, err
+}
+
+func (s *executorStore) Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (record workerutil.Record, tx dbworkerstore.Store, exists bool, err error) {
+	r, wrapped, b, err := s.wrapped.Dequeue(ctx, workerHostname, conditions)
+
+	return r, &executorStore{wrapped: wrapped}, b, err
+}
+func (s *executorStore) Handle() *basestore.TransactableHandle {
+	return s.wrapped.Handle()
+}
+func (s *executorStore) Done(err error) error {
+	return s.wrapped.Done(err)
+}
+func (s *executorStore) QueuedCount(ctx context.Context, conditions []*sqlf.Query) (int, error) {
+	return s.wrapped.QueuedCount(ctx, conditions)
+}
+func (s *executorStore) Requeue(ctx context.Context, id int, after time.Time) error {
+	return s.wrapped.Requeue(ctx, id, after)
+}
+func (s *executorStore) AddExecutionLogEntry(ctx context.Context, id int, entry workerutil.ExecutionLogEntry) error {
+	return s.wrapped.AddExecutionLogEntry(ctx, id, entry)
+}
+func (s *executorStore) MarkErrored(ctx context.Context, id int, failureMessage string) (bool, error) {
+	return s.wrapped.MarkErrored(ctx, id, failureMessage)
+}
+func (s *executorStore) MarkFailed(ctx context.Context, id int, failureMessage string) (bool, error) {
+	return s.wrapped.MarkFailed(ctx, id, failureMessage)
+}
+func (s *executorStore) ResetStalled(ctx context.Context) (resetIDs, erroredIDs []int, err error) {
+	return s.wrapped.ResetStalled(ctx)
 }
 
 // scanFirstExecutionRecord scans a slice of batch change executions and returns the first.

--- a/enterprise/internal/batches/background/executor_store_test.go
+++ b/enterprise/internal/batches/background/executor_store_test.go
@@ -1,0 +1,163 @@
+package background
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+)
+
+func TestLoadAndExtractBatchSpecRandID(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+	user := ct.CreateTestUser(t, db, true)
+
+	s := store.New(db, nil)
+	workStore := dbworkerstore.NewWithMetrics(s.Handle(), executorWorkerStoreOptions, &observation.TestContext)
+
+	t.Run("success", func(t *testing.T) {
+		specExec := &btypes.BatchSpecExecution{
+			State:         btypes.BatchSpecExecutionStateProcessing,
+			BatchSpec:     `name: testing`,
+			UserID:        user.ID,
+			ExecutionLogs: []workerutil.ExecutionLogEntry{},
+		}
+
+		if err := s.CreateBatchSpecExecution(context.Background(), specExec); err != nil {
+			t.Fatal(err)
+		}
+
+		logEntry := workerutil.ExecutionLogEntry{
+			Key:       "step.src.0",
+			Command:   []string{"src", "batch", "preview", "-f", "spec.yml", "-text-only"},
+			StartTime: time.Now().Add(-5 * time.Second),
+			ExitCode:  0,
+			Out: `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
+stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"SUCCESS"}
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.528Z","status":"STARTED"}
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.535Z","status":"SUCCESS","message":"http://USERNAME_REMOVED:PASSWORD_REMOVED@localhost:3080/users/mrnugget/batch-changes/apply/QmF0Y2hTcGVjOiJBZFBMTDU5SXJmWCI="}
+`,
+			DurationMs: 200,
+		}
+
+		err := workStore.AddExecutionLogEntry(context.Background(), int(specExec.ID), logEntry)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := "AdPLL59IrfX"
+		have, err := loadAndExtractBatchSpecRandID(context.Background(), s, specExec.ID)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if have != want {
+			t.Fatalf("wrong rand id extracted. want=%s, have=%s", want, have)
+		}
+	})
+
+	t.Run("without log entry", func(t *testing.T) {
+		specExec := &btypes.BatchSpecExecution{
+			State:         btypes.BatchSpecExecutionStateProcessing,
+			BatchSpec:     `name: testing`,
+			UserID:        user.ID,
+			ExecutionLogs: []workerutil.ExecutionLogEntry{},
+		}
+
+		if err := s.CreateBatchSpecExecution(context.Background(), specExec); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := loadAndExtractBatchSpecRandID(context.Background(), s, specExec.ID)
+		if err == nil {
+			t.Fatalf("expected error but got none")
+		}
+
+		if err.Error() != "no execution logs" {
+			t.Fatalf("wrong error: %q", err.Error())
+		}
+	})
+}
+
+func TestExtractBatchSpecRandID(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// Reduced log output because we don't care about _all_ lines
+		executionLogOut := `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
+stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"SUCCESS"}
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.528Z","status":"STARTED"}
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.535Z","status":"SUCCESS","message":"http://USERNAME_REMOVED:PASSWORD_REMOVED@localhost:3080/users/mrnugget/batch-changes/apply/QmF0Y2hTcGVjOiJBZFBMTDU5SXJmWCI="}
+`
+		// Run `echo "QmF0Y2hTcGVjOiJBZFBMTDU5SXJmWCI=" |base64 -d` to get this
+		want := "AdPLL59IrfX"
+
+		have, err := extractBatchSpecRandID(executionLogOut)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have != want {
+			t.Fatalf("wrong batch spec rand id extracted. want=%q, have=%q", want, have)
+		}
+	})
+
+	t.Run("no url in the output", func(t *testing.T) {
+		executionLogOut := `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
+stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"SUCCESS"}
+`
+		_, err := extractBatchSpecRandID(executionLogOut)
+		if err != ErrNoBatchSpecRandID {
+			t.Fatalf("wrong error: %s", err)
+		}
+	})
+
+	t.Run("invalid url in the output", func(t *testing.T) {
+		executionLogOut := `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
+stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"SUCCESS"}
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.528Z","status":"STARTED"}
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.535Z","status":"SUCCESS","message":"http://horse.txt"}
+`
+		_, err := extractBatchSpecRandID(executionLogOut)
+		if err != ErrNoBatchSpecRandID {
+			t.Fatalf("wrong error: %s", err)
+		}
+	})
+
+	t.Run("additional text in log output", func(t *testing.T) {
+		executionLogOut := `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
+stderr: HORSE
+stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"SUCCESS"}
+stderr: HORSE
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.528Z","status":"STARTED"}
+stderr: HORSE
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.535Z","status":"SUCCESS","message":"http://USERNAME_REMOVED:PASSWORD_REMOVED@localhost:3080/users/mrnugget/batch-changes/apply/QmF0Y2hTcGVjOiJBZFBMTDU5SXJmWCI="}
+`
+		want := "AdPLL59IrfX"
+		have, err := extractBatchSpecRandID(executionLogOut)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have != want {
+			t.Fatalf("wrong batch spec rand id extracted. want=%q, have=%q", want, have)
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		executionLogOut := `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
+stdout: {HOOOORSE}
+stdout: {HORSE}
+stdout: {HORSE}
+`
+		_, err := extractBatchSpecRandID(executionLogOut)
+		if err != ErrNoBatchSpecRandID {
+			t.Fatalf("wrong error: %s", err)
+		}
+	})
+}


### PR DESCRIPTION
The `MarkComplete` method replaces the existing one so that we can
extract the batch spec ID from the output of the job and save it to a
database column.