### PR TITLE
Implement very simple first version of create batch spec execution page

### DIFF
--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -1,0 +1,26 @@
+import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
+
+import { requestGraphQL } from '../../../backend/graphql'
+import {
+    BatchSpecExecutionFields,
+    CreateBatchSpecExecutionResult,
+    CreateBatchSpecExecutionVariables,
+} from '../../../graphql-operations'
+
+export async function createBatchSpecExecution(spec: string): Promise<BatchSpecExecutionFields> {
+    const result = await requestGraphQL<CreateBatchSpecExecutionResult, CreateBatchSpecExecutionVariables>(
+        gql`
+            mutation CreateBatchSpecExecution($spec: String!) {
+                createBatchSpecExecution(spec: $spec) {
+                    ...BatchSpecExecutionFields
+                }
+            }
+
+            fragment BatchSpecExecutionFields on BatchSpecExecution {
+                id
+            }
+        `,
+        { spec }
+    ).toPromise()
+    return dataOrThrowErrors(result).createBatchSpecExecution
+}

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "batch_spec.schema.json#",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "BatchSpec",
   "description": "A batch specification, which describes the batch change and what kinds of changes to make (or what existing changesets to track).",


### PR DESCRIPTION
So far this is just a simpler entry point to passing a spec file to the backend.

![image](https://user-images.githubusercontent.com/19534377/124496199-68b03a00-ddb9-11eb-9b2f-684e2556928c.png)
