### PR TITLE
web: add `location.search` to the new tab URL

### DIFF
--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -122,7 +122,7 @@ export const Panel = React.memo<Props>(props => {
 
     const [tabIndex, setTabIndex] = useState(0)
     const location = useLocation()
-    const { hash, pathname } = location
+    const { hash, pathname, search } = location
     const history = useHistory()
     const handlePanelClose = useCallback(() => history.replace(pathname), [history, pathname])
     const [currentTabLabel, currentTabID] = hash.split('=')
@@ -214,9 +214,9 @@ export const Panel = React.memo<Props>(props => {
 
     const handleActiveTab = useCallback(
         (index: number): void => {
-            history.replace(`${pathname}${currentTabLabel}=${items[index].id}`)
+            history.replace(`${pathname}${search}${currentTabLabel}=${items[index].id}`)
         },
-        [currentTabLabel, history, items, pathname]
+        [currentTabLabel, history, items, pathname, search]
     )
 
     useEffect(() => {


### PR DESCRIPTION
## Context

Missing query parameters caused `Panel` to lose focus on a specific code symbol. 
That's why tabs disappeared on any tab switch — there was no symbol to generate tabs for.

Fixes https://github.com/sourcegraph/sourcegraph/issues/22490.

## Changes

- Added `location.search` to the new tab URL.