### PR TITLE
users: Disallow new users with existing verified email

### DIFF
--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -308,8 +308,17 @@ func (u *UserStore) create(ctx context.Context, info NewUser) (newUser *types.Us
 	}
 
 	if info.Email != "" {
+		// We don't allow adding a new user with an email address that has already been
+		// verified by another user.
+		exists, _, err := basestore.ScanFirstBool(u.Query(ctx, sqlf.Sprintf("SELECT TRUE WHERE EXISTS (SELECT FROM user_emails where email = %s AND verified_at IS NOT NULL)", info.Email)))
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			return nil, errCannotCreateUser{errorCodeEmailExists}
+		}
+
 		// The first email address added should be their primary
-		var err error
 		if info.EmailIsVerified {
 			err = u.Exec(ctx, sqlf.Sprintf("INSERT INTO user_emails(user_id, email, verified_at, is_primary) VALUES (%s, %s, now(), true)", id, info.Email))
 		} else {

--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -91,6 +91,23 @@ func TestUsers_BuiltinAuth(t *testing.T) {
 	if isPassword, err := Users(db).IsPassword(ctx, usr.ID, "right-password"); err == nil && isPassword {
 		t.Fatal("old password still works")
 	}
+
+	// Creating a new user with an already verified email address should fail
+	_, err = Users(db).Create(ctx, NewUser{
+		Email:                 "foo@bar.com",
+		Username:              "another",
+		DisplayName:           "another",
+		Password:              "right-password",
+		EmailVerificationCode: "email-code",
+	})
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	}
+	want := "cannot create user: err_email_exists"
+	if err.Error() != want {
+		t.Fatalf("Want %q, got %q", want, err.Error())
+	}
+
 }
 
 func TestUsers_BuiltinAuth_VerifiedEmail(t *testing.T) {


### PR DESCRIPTION
We should not allow new users to sign up with an email address that is
already verified and assigned to another user.

We chose not to add a new constraint as it would require a migration
and it's not obvious what to do with existing accounts that would now
be considered invalid. It's simpler to just not allow this moving forward.

Fixes: https://github.com/sourcegraph/sourcegraph/issues/22447