### PR TITLE
web: add unit test to cover `Panel` location change

### DIFF
--- a/client/branded/src/components/panel/Panel.fixtures.ts
+++ b/client/branded/src/components/panel/Panel.fixtures.ts
@@ -1,0 +1,86 @@
+import { noop } from 'lodash'
+import { EMPTY, NEVER, of } from 'rxjs'
+
+import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
+import { PanelViewData } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
+import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHelpers'
+
+export const panels: PanelViewData[] = [
+    {
+        id: 'panel_1',
+        title: 'Panel 1',
+        content: 'Panel 1',
+        priority: 3,
+        component: null,
+    },
+    {
+        id: 'panel_2',
+        title: 'Panel 2',
+        content: 'Panel 2',
+        priority: 2,
+        component: null,
+    },
+    {
+        id: 'panel_3',
+        title: 'Panel 3',
+        content: 'Panel 3',
+        priority: 1,
+        component: null,
+    },
+]
+
+export const panelActions = [
+    {
+        id: 'a',
+        actionItem: {
+            label: 'Action A',
+            description: 'This is Action A',
+        },
+        command: 'open',
+        commandArguments: ['https://example.com'],
+    },
+    {
+        id: 'b',
+        actionItem: {
+            label: 'Action B',
+            description: 'This is Action B',
+        },
+        command: 'updateConfiguration',
+        commandArguments: [],
+    },
+]
+
+export const panelMenus = {
+    'panel/toolbar': [
+        {
+            action: 'a',
+        },
+        {
+            action: 'b',
+        },
+    ],
+}
+
+export const panelProps = {
+    repoName: 'git://github.com/foo/bar',
+    fetchHighlightedFileLineRanges: () => of([]),
+    isLightTheme: true,
+    versionContext: undefined,
+    platformContext: {} as any,
+    settingsCascade: { subjects: null, final: null },
+    telemetryService: NOOP_TELEMETRY_SERVICE,
+    extensionsController: {
+        ...extensionsController,
+        extHostAPI: Promise.resolve(
+            pretendRemote<FlatExtensionHostAPI>({
+                getContributions: () => pretendProxySubscribable(NEVER),
+                registerContributions: () => pretendProxySubscribable(EMPTY).subscribe(noop as any),
+                haveInitialExtensionsLoaded: () => pretendProxySubscribable(of(true)),
+                getPanelViews: () => pretendProxySubscribable(of(panels)),
+                getActiveCodeEditorPosition: () => pretendProxySubscribable(NEVER),
+            })
+        ),
+    },
+}

--- a/client/branded/src/components/panel/Panel.story.tsx
+++ b/client/branded/src/components/panel/Panel.story.tsx
@@ -1,42 +1,17 @@
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 import React from 'react'
-import { EMPTY, NEVER, of } from 'rxjs'
+import { EMPTY, of } from 'rxjs'
 
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
-import { PanelViewData } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
-import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHelpers'
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { BrandedStory } from '../BrandedStory'
 
 import { Panel } from './Panel'
-
-const panels: PanelViewData[] = [
-    {
-        id: 'panel_1',
-        title: 'Panel 1',
-        content: 'Panel 1',
-        priority: 3,
-        component: null,
-    },
-    {
-        id: 'panel_2',
-        title: 'Panel 2',
-        content: 'Panel 2',
-        priority: 2,
-        component: null,
-    },
-    {
-        id: 'panel_3',
-        title: 'Panel 3',
-        content: 'Panel 3',
-        priority: 1,
-        component: null,
-    },
-]
+import { panels, panelProps, panelActions, panelMenus } from './Panel.fixtures'
 
 const { add } = storiesOf('branded/Panel', module)
     .addDecorator(story => (
@@ -49,60 +24,6 @@ const { add } = storiesOf('branded/Panel', module)
             viewports: [320, 576, 978, 1440],
         },
     })
-
-const panelActions = [
-    {
-        id: 'a',
-        actionItem: {
-            label: 'Action A',
-            description: 'This is Action A',
-        },
-        command: 'open',
-        commandArguments: ['https://example.com'],
-    },
-    {
-        id: 'b',
-        actionItem: {
-            label: 'Action B',
-            description: 'This is Action B',
-        },
-        command: 'updateConfiguration',
-        commandArguments: [],
-    },
-]
-
-const panelMenus = {
-    'panel/toolbar': [
-        {
-            action: 'a',
-        },
-        {
-            action: 'b',
-        },
-    ],
-}
-
-const panelProps = {
-    repoName: 'git://github.com/foo/bar',
-    fetchHighlightedFileLineRanges: () => of([]),
-    isLightTheme: true,
-    versionContext: undefined,
-    platformContext: {} as any,
-    settingsCascade: { subjects: null, final: null },
-    telemetryService: NOOP_TELEMETRY_SERVICE,
-    extensionsController: {
-        ...extensionsController,
-        extHostAPI: Promise.resolve(
-            pretendRemote<FlatExtensionHostAPI>({
-                getContributions: () => pretendProxySubscribable(NEVER),
-                registerContributions: () => pretendProxySubscribable(EMPTY).subscribe(noop as any),
-                haveInitialExtensionsLoaded: () => pretendProxySubscribable(of(true)),
-                getPanelViews: () => pretendProxySubscribable(of(panels)),
-                getActiveCodeEditorPosition: () => pretendProxySubscribable(NEVER),
-            })
-        ),
-    },
-}
 
 add('Simple', () => <Panel {...panelProps} />)
 

--- a/client/branded/src/components/panel/Panel.test.tsx
+++ b/client/branded/src/components/panel/Panel.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+import { renderWithRouter } from '@sourcegraph/shared/src/testing/render-wth-router'
+
+import { Panel } from './Panel'
+import { panels, panelProps } from './Panel.fixtures'
+
+describe('Panel', () => {
+    const location = {
+        pathname: `/${panelProps.repoName}`,
+        search: '?L4:7',
+        hash: `#tab=${panels[0].id}`,
+    }
+    const route = `${location.pathname}${location.search}${location.hash}`
+
+    afterEach(cleanup)
+
+    it('preserves `location.pathname` and `location.hash` on tab change', async () => {
+        const renderResult = renderWithRouter(<Panel {...panelProps} />, { route })
+
+        const panelToSelect = panels[2]
+        const panelButton = await renderResult.findByRole('tab', { name: panelToSelect.title })
+        fireEvent.click(panelButton)
+
+        expect(renderResult.history.location.pathname).toEqual(location.pathname)
+        expect(renderResult.history.location.search).toEqual(location.search)
+        expect(renderResult.history.location.hash).toEqual(`#tab=${panelToSelect.id}`)
+    })
+})

--- a/client/branded/src/components/panel/Panel.test.tsx
+++ b/client/branded/src/components/panel/Panel.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent } from '@testing-library/react'
 import React from 'react'
 
-import { renderWithRouter } from '@sourcegraph/shared/src/testing/render-wth-router'
+import { renderWithRouter } from '@sourcegraph/shared/src/testing/render-with-router'
 
 import { Panel } from './Panel'
 import { panels, panelProps } from './Panel.fixtures'

--- a/client/shared/src/testing/render-with-router.tsx
+++ b/client/shared/src/testing/render-with-router.tsx
@@ -3,14 +3,14 @@ import { MemoryHistory, createMemoryHistory } from 'history'
 import React, { ReactNode } from 'react'
 import { Router } from 'react-router-dom'
 
-export interface RenderWithRouterReturn extends RenderResult {
+export interface RenderWithRouterResult extends RenderResult {
     history: MemoryHistory
 }
 
 export function renderWithRouter(
     children: ReactNode,
     { route = '/', history = createMemoryHistory({ initialEntries: [route] }) } = {}
-): RenderWithRouterReturn {
+): RenderWithRouterResult {
     return {
         ...render(<Router history={history}>{children}</Router>),
         history,

--- a/client/shared/src/testing/render-wth-router.tsx
+++ b/client/shared/src/testing/render-wth-router.tsx
@@ -1,0 +1,18 @@
+import { RenderResult, render } from '@testing-library/react'
+import { MemoryHistory, createMemoryHistory } from 'history'
+import React, { ReactNode } from 'react'
+import { Router } from 'react-router-dom'
+
+export interface RenderWithRouterReturn extends RenderResult {
+    history: MemoryHistory
+}
+
+export function renderWithRouter(
+    children: ReactNode,
+    { route = '/', history = createMemoryHistory({ initialEntries: [route] }) } = {}
+): RenderWithRouterReturn {
+    return {
+        ...render(<Router history={history}>{children}</Router>),
+        history,
+    }
+}


### PR DESCRIPTION
## Changes

- Added unit test to cover location mutation on tab change in the `Panel` component.

Follow up for https://github.com/sourcegraph/sourcegraph/pull/22600.