### PR TITLE
monitoring: Fix dbconn wait monitoring

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -432,17 +432,9 @@ This panel indicates idle.
 
 <br />
 
-#### frontend: waited_for
+#### frontend: mean_blocked_seconds_per_conn_request
 
-This panel indicates waited for.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: blocked_seconds
-
-This panel indicates blocked seconds.
+This panel indicates mean blocked seconds per conn request.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -982,17 +974,9 @@ This panel indicates idle.
 
 <br />
 
-#### gitserver: waited_for
+#### gitserver: mean_blocked_seconds_per_conn_request
 
-This panel indicates waited for.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### gitserver: blocked_seconds
-
-This panel indicates blocked seconds.
+This panel indicates mean blocked seconds per conn request.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -1653,17 +1637,9 @@ This panel indicates idle.
 
 <br />
 
-#### precise-code-intel-worker: waited_for
+#### precise-code-intel-worker: mean_blocked_seconds_per_conn_request
 
-This panel indicates waited for.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### precise-code-intel-worker: blocked_seconds
-
-This panel indicates blocked seconds.
+This panel indicates mean blocked seconds per conn request.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -2191,17 +2167,9 @@ This panel indicates idle.
 
 <br />
 
-#### worker: waited_for
+#### worker: mean_blocked_seconds_per_conn_request
 
-This panel indicates waited for.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### worker: blocked_seconds
-
-This panel indicates blocked seconds.
+This panel indicates mean blocked seconds per conn request.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -2767,17 +2735,9 @@ This panel indicates idle.
 
 <br />
 
-#### repo-updater: waited_for
+#### repo-updater: mean_blocked_seconds_per_conn_request
 
-This panel indicates waited for.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### repo-updater: blocked_seconds
-
-This panel indicates blocked seconds.
+This panel indicates mean blocked seconds per conn request.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -3948,17 +3908,9 @@ This panel indicates idle.
 
 <br />
 
-#### executor-queue: waited_for
+#### executor-queue: mean_blocked_seconds_per_conn_request
 
-This panel indicates waited for.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### executor-queue: blocked_seconds
-
-This panel indicates blocked seconds.
+This panel indicates mean blocked seconds per conn request.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -442,7 +442,7 @@ This panel indicates waited for.
 
 #### frontend: blocked_seconds
 
-This panel indicates blocked seconds (99th percentile).
+This panel indicates blocked seconds.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -992,7 +992,7 @@ This panel indicates waited for.
 
 #### gitserver: blocked_seconds
 
-This panel indicates blocked seconds (99th percentile).
+This panel indicates blocked seconds.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -1663,7 +1663,7 @@ This panel indicates waited for.
 
 #### precise-code-intel-worker: blocked_seconds
 
-This panel indicates blocked seconds (99th percentile).
+This panel indicates blocked seconds.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -2201,7 +2201,7 @@ This panel indicates waited for.
 
 #### worker: blocked_seconds
 
-This panel indicates blocked seconds (99th percentile).
+This panel indicates blocked seconds.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -2777,7 +2777,7 @@ This panel indicates waited for.
 
 #### repo-updater: blocked_seconds
 
-This panel indicates blocked seconds (99th percentile).
+This panel indicates blocked seconds.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -3958,7 +3958,7 @@ This panel indicates waited for.
 
 #### executor-queue: blocked_seconds
 
-This panel indicates blocked seconds (99th percentile).
+This panel indicates blocked seconds.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 

--- a/internal/database/dbconn/metrics.go
+++ b/internal/database/dbconn/metrics.go
@@ -18,10 +18,10 @@ type metricsCollector struct {
 	inUseDesc             *prometheus.Desc
 	idleDesc              *prometheus.Desc
 	waitedForDesc         *prometheus.Desc
+	blockedSecondsDesc    *prometheus.Desc
 	closedMaxIdleDesc     *prometheus.Desc
 	closedMaxLifetimeDesc *prometheus.Desc
 	closedMaxIdleTimeDesc *prometheus.Desc
-	blockedSecondsHist    prometheus.Histogram
 }
 
 func newMetricsCollector(db *sql.DB, dbname, app string) *metricsCollector {
@@ -67,6 +67,12 @@ func newMetricsCollector(db *sql.DB, dbname, app string) *metricsCollector {
 			nil,
 			labels,
 		),
+		blockedSecondsDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "blocked_seconds"),
+			"The total time blocked waiting for a new connection.",
+			nil,
+			labels,
+		),
 		closedMaxIdleDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "closed_max_idle"),
 			"The total number of connections closed due to SetMaxIdleConns.",
@@ -85,14 +91,6 @@ func newMetricsCollector(db *sql.DB, dbname, app string) *metricsCollector {
 			nil,
 			labels,
 		),
-		blockedSecondsHist: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace:   namespace,
-			Subsystem:   subsystem,
-			Name:        "blocked_seconds",
-			Help:        "The total time blocked waiting for a new connection.",
-			ConstLabels: labels,
-			Buckets:     prometheus.DefBuckets,
-		}),
 	}
 }
 
@@ -103,10 +101,10 @@ func (c metricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.inUseDesc
 	ch <- c.idleDesc
 	ch <- c.waitedForDesc
+	ch <- c.blockedSecondsDesc
 	ch <- c.closedMaxIdleDesc
 	ch <- c.closedMaxLifetimeDesc
 	ch <- c.closedMaxIdleTimeDesc
-	c.blockedSecondsHist.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -139,6 +137,11 @@ func (c metricsCollector) Collect(ch chan<- prometheus.Metric) {
 		float64(stats.WaitCount),
 	)
 	ch <- prometheus.MustNewConstMetric(
+		c.blockedSecondsDesc,
+		prometheus.CounterValue,
+		stats.WaitDuration.Seconds(),
+	)
+	ch <- prometheus.MustNewConstMetric(
 		c.closedMaxIdleDesc,
 		prometheus.CounterValue,
 		float64(stats.MaxIdleClosed),
@@ -153,7 +156,4 @@ func (c metricsCollector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.CounterValue,
 		float64(stats.MaxIdleTimeClosed),
 	)
-
-	c.blockedSecondsHist.Observe(stats.WaitDuration.Seconds())
-	c.blockedSecondsHist.Collect(ch)
 }

--- a/monitoring/definitions/shared/dbconns.go
+++ b/monitoring/definitions/shared/dbconns.go
@@ -63,8 +63,8 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 			},
 			{
 				Name:           "blocked_seconds",
-				Description:    "blocked seconds (99th percentile)",
-				Query:          fmt.Sprintf(`histogram_quantile(0.99, sum by (app_name, db_name, le) (rate(src_pgsql_conns_blocked_seconds_bucket{app_name=%q}[1m])))`, app),
+				Description:    "blocked seconds",
+				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name=%q}[1m]))`, app),
 				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}").Unit(monitoring.Seconds),
 				NoAlert:        true,
 				Owner:          monitoring.ObservableOwnerCoreApplication,

--- a/monitoring/definitions/shared/dbconns.go
+++ b/monitoring/definitions/shared/dbconns.go
@@ -53,18 +53,14 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 		},
 		{
 			{
-				Name:           "waited_for",
-				Description:    "waited for",
-				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name=%q}[5m]))`, app),
-				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}"),
-				NoAlert:        true,
-				Owner:          monitoring.ObservableOwnerCoreApplication,
-				Interpretation: "none",
-			},
-			{
-				Name:           "blocked_seconds",
-				Description:    "blocked seconds",
-				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name=%q}[5m]))`, app),
+				// The stats produced by the database/sql package don't allow us to maintain a histogram of blocked
+				// durations. The best we can do with two ever increasing counters is an average / mean, which alright
+				// to detect trends, although it doesn't give us a good sense of outliers (which we'd want to use high
+				// percentiles for).
+				Name:        "mean_blocked_seconds_per_conn_request",
+				Description: "mean blocked seconds per conn request",
+				Query: fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name=%q}[5m])) / `+
+					`sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name=%q}[5m]))`, app, app),
 				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}").Unit(monitoring.Seconds),
 				NoAlert:        true,
 				Owner:          monitoring.ObservableOwnerCoreApplication,

--- a/monitoring/definitions/shared/dbconns.go
+++ b/monitoring/definitions/shared/dbconns.go
@@ -55,7 +55,7 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 			{
 				Name:           "waited_for",
 				Description:    "waited for",
-				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name=%q}[1m]))`, app),
+				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name=%q}[5m]))`, app),
 				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}"),
 				NoAlert:        true,
 				Owner:          monitoring.ObservableOwnerCoreApplication,
@@ -64,7 +64,7 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 			{
 				Name:           "blocked_seconds",
 				Description:    "blocked seconds",
-				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name=%q}[1m]))`, app),
+				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name=%q}[5m]))`, app),
 				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}").Unit(monitoring.Seconds),
 				NoAlert:        true,
 				Owner:          monitoring.ObservableOwnerCoreApplication,
@@ -75,7 +75,7 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 			{
 				Name:           "closed_max_idle",
 				Description:    "closed by SetMaxIdleConns",
-				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name=%q}[1m]))`, app),
+				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name=%q}[5m]))`, app),
 				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}"),
 				NoAlert:        true,
 				Owner:          monitoring.ObservableOwnerCoreApplication,
@@ -84,7 +84,7 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 			{
 				Name:           "closed_max_lifetime",
 				Description:    "closed by SetConnMaxLifetime",
-				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name=%q}[1m]))`, app),
+				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name=%q}[5m]))`, app),
 				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}"),
 				NoAlert:        true,
 				Owner:          monitoring.ObservableOwnerCoreApplication,
@@ -93,7 +93,7 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 			{
 				Name:           "closed_max_idle_time",
 				Description:    "closed by SetConnMaxIdleTime",
-				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name=%q}[1m]))`, app),
+				Query:          fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name=%q}[5m]))`, app),
 				Panel:          monitoring.Panel().LegendFormat("dbname={{db_name}}"),
 				NoAlert:        true,
 				Owner:          monitoring.ObservableOwnerCoreApplication,


### PR DESCRIPTION
Yesterday I introduced a completely bogus change. The stats that `db.Stats()` returns doesn't permit us recording a histogram of blocked durations because it only keeps ever increasing counters. The best we can do is compute a mean / avg over time, which should be good enough to spot trends, but not good enough to spot major outliers (which we'd want to use a high percentile for).