### PR TITLE
search frontend: don't show monaco status bar on hover

### DIFF
--- a/client/web/src/search/input/MonacoQueryInput.scss
+++ b/client/web/src/search/input/MonacoQueryInput.scss
@@ -15,7 +15,7 @@
             border: none;
         }
 
-        .monaco-editor-hover-content {
+        .monaco-hover-content {
             padding: 0.25rem;
             .status-bar {
                 display: none;


### PR DESCRIPTION
The monaco style class changed which means we weren't suppressing the render of this status bar/menu:


https://user-images.githubusercontent.com/888624/124688399-8b128800-de8b-11eb-8582-2d807c7f8e4f.mp4



This fixes it so we only show the diagnostic message. I can't really control where it's rendered though, so it renders above the text. This is luckily consistent with where our normal hovers render:

![Screen Shot 2021-07-06 at 6 52 43 PM](https://user-images.githubusercontent.com/888624/124688416-949bf000-de8b-11eb-91af-b2fe904419a6.png)


Aside, since I looked into this, I've been playing around adding quickfix suggestions for real, will see if I can hack on this later.

