### PR TITLE
search: couple ResultType value with search args

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -9,6 +9,7 @@ import (
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -125,6 +126,7 @@ func (m GlobalSearchMode) String() string {
 // search. It defines behavior for text search on repository names, file names, and file content.
 type TextParameters struct {
 	PatternInfo *TextPatternInfo
+	ResultTypes result.Types
 
 	// Performance optimization: For global queries, resolving repositories and
 	// querying zoekt happens concurrently.


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22631.

Semantics preserving and changes the signature of `withResultTypes` to return a modified `search.TextParameters` that now contains the computed `resultType` value. We want this because currently the `resultTypes` value drives what kind of search to perform, but is disjoint from `search.TextParameters`, and intertwined with the logic in `doResults`. We want the logic that decides what search to perform to be self-contained. To start doing that we need to keep the state together. This change will make more sense if you look at the next PR in the stack #22634