### PR TITLE
search: move search argument construction up the call chain

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -37,7 +37,12 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		results, err := srs.sr.doResults(ctx, result.TypeEmpty)
+		args, err := srs.sr.toTextParameters(srs.sr.Query)
+		if err != nil {
+			srs.srsErr = err
+			return
+		}
+		results, err := srs.sr.doResults(ctx, args)
 		if err != nil {
 			srs.srsErr = err
 			return

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -476,7 +476,12 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
 		if len(r.Query.Values(query.FieldDefault)) > 0 {
-			results, err := r.doResults(ctx, result.TypeFile) // only "file" result type
+			searchArgs, err := r.toTextParameters(r.Query)
+			if err != nil {
+				return nil, err
+			}
+			searchArgs.ResultTypes = result.TypeFile // only "file" result type
+			results, err := r.doResults(ctx, searchArgs)
 			if err == context.DeadlineExceeded {
 				err = nil // don't log as error below
 			}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22632.

Semantics preserving and lifts out the logic that creates `search.TextParameters` to a method `toTextParameters` before `doResults` instead of inside it. `search.TextParameters` is currently the closest type we have to an internal query representation that our backend understands. The role of this function will evolve to generate better types for our internal representation so that we can generate and run, for example, native Zoekt queries and not this currently generic `search.TextParameters` representation.