### PR TITLE
dx: enable `problems` auto-fix mode for VS Code ESLint extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
   },
+  "eslint.codeActionsOnSave.mode": "problems",
   "eslint.options": { "cache": true },
   "eslint.workingDirectories": [
     "./dev/release",


### PR DESCRIPTION
## Context

Our VS Code ESLint auto-fix is [quite slow](https://sourcegraph.slack.com/archives/C07KZF47K/p1625525663189100) at the moment. We need to revisit our ESLint rules and consider disabling some of them to boost auto-fix perf. In the meantime, we can use faster auto-fix mode "problems":

> problems: fixes only the currently known fixable problems as long as their textual edits are non-overlapping. This mode is a lot faster but very likely only fixes parts of the problems.

It's an intermediate step. After bringing ESLint auto-fix time down to acceptable levels, we can switch back to "all" mode.

## Changes 

The auto-fix time on file save went down to 0.2-0.8s from 2-6s on my machine. 🎉
But sometimes, it's required to save files a couple of times to fix overlapping problems. 