### PR TITLE
Fix flaky tests: use `dbtest.NewDB` in insights store tests instead of `dbtesting.Get`

### DIFF
--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -26,7 +26,7 @@ func TestSeriesPoints(t *testing.T) {
 	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
 	defer cleanup()
 
-	postgres := dbtesting.GetDB(t)
+	postgres := dbtest.NewDB(t, "")
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(timescale, permStore, clock)
 
@@ -135,7 +135,7 @@ func TestCountData(t *testing.T) {
 	clock := timeutil.Now
 	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
 	defer cleanup()
-	postgres := dbtesting.GetDB(t)
+	postgres := dbtest.NewDB(t, "")
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(timescale, permStore, clock)
 
@@ -228,7 +228,7 @@ func TestRecordSeriesPoints(t *testing.T) {
 	clock := timeutil.Now
 	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
 	defer cleanup()
-	postgres := dbtesting.GetDB(t)
+	postgres := dbtest.NewDB(t, "")
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(timescale, permStore, clock)
 


### PR DESCRIPTION
This could help with test failures on Buildkite, such as this one: https://buildkite.com/sourcegraph/sourcegraph/builds/100916#f275b3b6-66f9-4d32-8443-038040fdce09 

Also see Slack discussion here: https://sourcegraph.slack.com/archives/C07KZF47K/p1625626347218700

Not sure what the performance impact of `dbtest.NewDB` is nowadays vs. `dbtesting.Get` (cc @camdencheek) though.