### PR TITLE
search-blitz: tracing and monitoring improvements

### DIFF
--- a/internal/cmd/search-blitz/client.go
+++ b/internal/cmd/search-blitz/client.go
@@ -59,7 +59,6 @@ func (s *client) search(ctx context.Context, query, queryName string) (*metrics,
 
 	start := time.Now()
 	resp, err := s.client.Do(req)
-
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +77,13 @@ func (s *client) search(ctx context.Context, query, queryName string) (*metrics,
 		return nil, err
 	}
 
-	durationMs := time.Since(start).Milliseconds()
+	duration := time.Since(start)
 
 	return &metrics{
-		took:          durationMs,
-		firstResultMs: durationMs,
-		matchCount:    respDec.Data.Search.Results.ResultCount,
-		trace:         resp.Header.Get("x-trace"),
+		took:        duration,
+		firstResult: duration,
+		matchCount:  respDec.Data.Search.Results.ResultCount,
+		trace:       resp.Header.Get("x-trace"),
 	}, nil
 }
 

--- a/internal/cmd/search-blitz/prometheus.go
+++ b/internal/cmd/search-blitz/prometheus.go
@@ -1,15 +1,26 @@
 package main
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
 
-var UserLatencyBuckets = []float64{100, 200, 300, 400, 500, 1000, 2000, 5000, 10000, 30000}
+var Buckets = []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 30, 45, 60, 80, 100}
 
-var durationSearchHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "search_blitz_duration_ms",
+var durationSearchSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "search_blitz_duration_seconds",
 	Help:    "e2e duration search-blitz where search_type is either stream or batch",
-	Buckets: UserLatencyBuckets,
+	Buckets: Buckets,
 }, []string{"group", "query_name", "client"})
 
-func init() {
-	prometheus.MustRegister(durationSearchHistogram)
-}
+var firstResultSearchSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "search_blitz_first_result_seconds",
+	Help:    "e2e time to first result search-blitz where search_type is either stream or batch",
+	Buckets: Buckets,
+}, []string{"group", "query_name", "client"})
+
+var fetchDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "search_blitz_trace_fetch_seconds",
+	Help:    "The time taken to fetch a trace from Jaeger",
+	Buckets: Buckets,
+}, []string{"error", "attempts"})

--- a/internal/cmd/search-blitz/protocol.go
+++ b/internal/cmd/search-blitz/protocol.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 type rawResult struct {
 	Data   result        `json:"data,omitempty"`
 	Errors []interface{} `json:"errors,omitempty"`
@@ -36,8 +38,8 @@ type searchResultsAlert struct {
 }
 
 type metrics struct {
-	took          int64
-	firstResultMs int64
-	matchCount    int
-	trace         string
+	took        time.Duration
+	firstResult time.Duration
+	matchCount  int
+	trace       string
 }

--- a/internal/cmd/search-blitz/stream_client.go
+++ b/internal/cmd/search-blitz/stream_client.go
@@ -58,7 +58,7 @@ func (s *streamClient) search(ctx context.Context, query, queryName string) (*me
 	dec := streamhttp.Decoder{
 		OnMatches: func(matches []streamhttp.EventMatch) {
 			if first && len(matches) > 0 {
-				m.firstResultMs = time.Since(start).Milliseconds()
+				m.firstResult = time.Since(start)
 				first = false
 			}
 		},
@@ -71,13 +71,13 @@ func (s *streamClient) search(ctx context.Context, query, queryName string) (*me
 		return nil, err
 	}
 
-	m.took = time.Since(start).Milliseconds()
+	m.took = time.Since(start)
 	m.trace = resp.Header.Get("x-trace")
 
 	// If we have no results, we use the total time taken for first result
 	// time.
 	if first {
-		m.firstResultMs = m.took
+		m.firstResult = m.took
 	}
 
 	return &m, nil

--- a/internal/cmd/search-blitz/trace.go
+++ b/internal/cmd/search-blitz/trace.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // traceStore fetches jaeger traces and stores them gzipped locally for future
@@ -59,9 +58,17 @@ func (t *traceStore) Fetch(ctx context.Context, traceURL string) (err error) {
 		attempts = 1
 	}
 
-	defer t.observeFetch()(&attempts, &err)
+	began := time.Now()
+	attempt := 0
 
-	for i := 0; i < attempts; i++ {
+	defer func() {
+		fetchDurationSeconds.WithLabelValues(
+			strconv.FormatBool(err != nil),
+			strconv.FormatInt(int64(attempt), 10),
+		).Observe(time.Since(began).Seconds())
+	}()
+
+	for ; attempt < attempts; attempt++ {
 		if err = t.fetch(ctx, traceURL); err != nil {
 			time.Sleep(time.Second)
 			continue
@@ -124,11 +131,11 @@ func (t *traceStore) fetch(ctx context.Context, traceURL string) (err error) {
 	}
 
 	dst := filepath.Join(t.Dir, traceID+".json.gz")
-	if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil && !os.IsExist(err) {
 		return err
 	}
 
-	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -148,30 +155,6 @@ func (t *traceStore) fetch(ctx context.Context, traceURL string) (err error) {
 	}
 
 	return f.Close()
-}
-
-func (t *traceStore) initMetrics() {
-	t.metrics.Do(func() {
-		t.metrics.fetchHist = promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: "src",
-			Subsystem: "search_blitz",
-			Name:      "trace_fetch_seconds",
-			Help:      "The time taken to fetch a trace from Jaeger",
-			Buckets:   prometheus.DefBuckets,
-		}, []string{"error", "attempts"})
-	})
-}
-
-func (t *traceStore) observeFetch() func(*int, *error) {
-	t.initMetrics()
-	began := time.Now()
-	return func(attempts *int, err *error) {
-		duration := time.Since(began)
-		t.metrics.fetchHist.WithLabelValues(
-			strconv.FormatBool(err != nil && *err != nil),
-			strconv.FormatInt(int64(*attempts), 10),
-		).Observe(duration.Seconds())
-	}
 }
 
 // CleanupLoop periodically will remove old traces from disk such that we are

--- a/internal/cmd/search-blitz/trace.go
+++ b/internal/cmd/search-blitz/trace.go
@@ -43,12 +43,6 @@ type traceStore struct {
 	// internally access jaeger-query instead of needing an admin access token
 	// + the jaeger proxy. Environment variable we use is JAEGER_SERVER_URL.
 	JaegerServerURL string
-
-	// unexported Prometheus metrics, lazily initiated by calls to t.initMetrics
-	metrics struct {
-		sync.Once
-		fetchHist *prometheus.HistogramVec
-	}
 }
 
 // Fetch and store the trace.

--- a/internal/cmd/search-blitz/trace.go
+++ b/internal/cmd/search-blitz/trace.go
@@ -13,11 +13,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/inconshreveable/log15"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // traceStore fetches jaeger traces and stores them gzipped locally for future


### PR DESCRIPTION
1. Adds time to first result Prometheus histogram.
2. Makes the used buckets for Prometheus histograms appropriate to the
   search latency distributions we're seeing.
3. Delays trace fetching until qc.Interval / 2.
4. Records seconds rather than milliseconds, since that's closer to the scale
   we're working with. It's still easy to read 0.1s for a 100ms query.
5. Simplifies the trace observability code to be less lazy.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
