### PR TITLE
database: Add ~175k repos to the indexed corpus

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -925,7 +925,7 @@ const listIndexableReposQuery = `
 WITH s AS (
 	SELECT id as repo_id
 	FROM repo
-	WHERE stars >= 20
+	WHERE stars >= 12
 
 	UNION ALL
 


### PR DESCRIPTION
This commit increases the indexed corpus size by ~175k repos to a total of ~851k indexed repos.