### PR TITLE
Insights: id filter argument in GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -3,6 +3,8 @@ package graphqlbackend
 import (
 	"context"
 
+	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 )
 
@@ -12,7 +14,11 @@ import (
 
 // InsightsResolver is the root resolver.
 type InsightsResolver interface {
-	Insights(ctx context.Context) (InsightConnectionResolver, error)
+	Insights(ctx context.Context, args *InsightsArgs) (InsightConnectionResolver, error)
+}
+
+type InsightsArgs struct {
+	Ids *[]graphql.ID
 }
 
 type InsightsDataPointResolver interface {
@@ -42,6 +48,7 @@ type InsightResolver interface {
 	Title() string
 	Description() string
 	Series() []InsightSeriesResolver
+	ID() string
 }
 
 type InsightConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -2,9 +2,7 @@ extend type Query {
     """
     EXPERIMENTAL: Queries code insights
     """
-
     insights(ids: [ID!]): InsightConnection
-
 }
 
 """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -1,8 +1,13 @@
 extend type Query {
     """
-    EXPERIMENTAL: Queries code insights
+    [Experimental] Query for all insights and return their aggregations.
     """
-    insights(ids: [ID!]): InsightConnection
+    insights(
+        """
+        An (optional) array of insight unique ids that will filter the results by the provided values. If omitted, all available insights will return.
+        """
+        ids: [ID!]
+    ): InsightConnection
 }
 
 """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -3,9 +3,6 @@ extend type Query {
     EXPERIMENTAL: Queries code insights
     """
 
-    """
-    Select only specific insight IDs.
-    """
     insights(ids: [ID!]): InsightConnection
 
 }

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -2,7 +2,12 @@ extend type Query {
     """
     EXPERIMENTAL: Queries code insights
     """
-    insights: InsightConnection
+
+    """
+    Select only specific insight IDs.
+    """
+    insights(ids: [ID!]): InsightConnection
+
 }
 
 """
@@ -43,6 +48,11 @@ type Insight {
     Data points over a time range (inclusive)
     """
     series: [InsightsSeries!]!
+
+    """
+    Unique identifier for this insight.
+    """
+    id: String!
 }
 
 """

--- a/enterprise/internal/insights/discovery/discovery_test.go
+++ b/enterprise/internal/insights/discovery/discovery_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/insights"
+
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -53,40 +55,40 @@ func TestDiscover(t *testing.T) {
 		return settingsExample, nil
 	})
 	ctx := context.Background()
-	insights, err := Discover(ctx, settingStore)
+	discovered, err := Discover(ctx, settingStore)
 	if err != nil {
 		t.Fatal(err)
 	}
-	autogold.Want("insights", []*schema.Insight{
-		{
+	autogold.Want("discovered", []insights.SearchInsight{
+		insights.SearchInsight{
+			Title:       "fmt usage",
 			Description: "fmt.Errorf/fmt.Printf usage",
-			Series: []*schema.InsightSeries{
-				{
-					Label:  "fmt.Errorf",
-					Search: "errorf",
+			Series: []insights.TimeSeries{
+				insights.TimeSeries{
+					Name:  "fmt.Errorf",
+					Query: "errorf",
 				},
-				{
-					Label:  "printf",
-					Search: "fmt.Printf",
+				insights.TimeSeries{
+					Name:  "printf",
+					Query: "fmt.Printf",
 				},
 			},
-			Title: "fmt usage",
 		},
-		{
+		insights.SearchInsight{
+			Title:       "gitserver usage",
 			Description: "gitserver exec & close usage",
-			Series: []*schema.InsightSeries{
-				{
-					Label:  "exec",
-					Search: "gitserver.Exec",
+			Series: []insights.TimeSeries{
+				insights.TimeSeries{
+					Name:  "exec",
+					Query: "gitserver.Exec",
 				},
-				{
-					Label:  "close",
-					Search: "gitserver.Close",
+				insights.TimeSeries{
+					Name:  "close",
+					Query: "gitserver.Close",
 				},
 			},
-			Title: "gitserver usage",
 		},
-	}).Equal(t, insights)
+	}).Equal(t, discovered)
 }
 
 func Test_parseUserSettings(t *testing.T) {

--- a/enterprise/internal/insights/discovery/discovery_test.go
+++ b/enterprise/internal/insights/discovery/discovery_test.go
@@ -60,29 +60,29 @@ func TestDiscover(t *testing.T) {
 		t.Fatal(err)
 	}
 	autogold.Want("discovered", []insights.SearchInsight{
-		insights.SearchInsight{
+		{
 			Title:       "fmt usage",
 			Description: "fmt.Errorf/fmt.Printf usage",
 			Series: []insights.TimeSeries{
-				insights.TimeSeries{
+				{
 					Name:  "fmt.Errorf",
 					Query: "errorf",
 				},
-				insights.TimeSeries{
+				{
 					Name:  "printf",
 					Query: "fmt.Printf",
 				},
 			},
 		},
-		insights.SearchInsight{
+		{
 			Title:       "gitserver usage",
 			Description: "gitserver exec & close usage",
 			Series: []insights.TimeSeries{
-				insights.TimeSeries{
+				{
 					Name:  "exec",
 					Query: "gitserver.Exec",
 				},
-				insights.TimeSeries{
+				{
 					Name:  "close",
 					Query: "gitserver.Close",
 				},

--- a/enterprise/internal/insights/discovery/series_id.go
+++ b/enterprise/internal/insights/discovery/series_id.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	"github.com/sourcegraph/sourcegraph/internal/insights"
+
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -23,6 +25,10 @@ func EncodeSeriesID(series *schema.InsightSeries) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid series %+v", series)
 	}
+}
+
+func Encode(series insights.TimeSeries) string {
+	return fmt.Sprintf("s:%s", sha256String(series.Query))
 }
 
 func sha256String(s string) string {

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -50,7 +50,6 @@ func (r *insightConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend
 }
 
 func (r *insightConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	log15.Info("total_count", "ids", r.ids)
 	results, _, err := r.compute(ctx)
 	return int32(len(results)), err
 }

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -83,7 +83,7 @@ type insightResolver struct {
 }
 
 func (r *insightResolver) ID() string {
-	return r.insight.Uuid
+	return r.insight.ID
 }
 
 func (r *insightResolver) Title() string { return r.insight.Title }

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -5,12 +5,15 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/sourcegraph/sourcegraph/internal/insights"
+
+	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 var _ graphqlbackend.InsightConnectionResolver = &insightConnectionResolver{}
@@ -20,9 +23,12 @@ type insightConnectionResolver struct {
 	workerBaseStore *basestore.Store
 	settingStore    discovery.SettingStore
 
+	// arguments from query
+	ids []string
+
 	// cache results because they are used by multiple fields
 	once     sync.Once
-	insights []*schema.Insight
+	insights []insights.SearchInsight
 	next     int64
 	err      error
 }
@@ -44,8 +50,9 @@ func (r *insightConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend
 }
 
 func (r *insightConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	insights, _, err := r.compute(ctx)
-	return int32(len(insights)), err
+	log15.Info("total_count", "ids", r.ids)
+	results, _, err := r.compute(ctx)
+	return int32(len(results)), err
 }
 
 func (r *insightConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
@@ -59,7 +66,7 @@ func (r *insightConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.
 	return graphqlutil.HasNextPage(false), nil
 }
 
-func (r *insightConnectionResolver) compute(ctx context.Context) ([]*schema.Insight, int64, error) {
+func (r *insightConnectionResolver) compute(ctx context.Context) ([]insights.SearchInsight, int64, error) {
 	r.once.Do(func() {
 		r.insights, r.err = discovery.Discover(ctx, r.settingStore)
 	})
@@ -73,7 +80,11 @@ var _ graphqlbackend.InsightResolver = &insightResolver{}
 type insightResolver struct {
 	insightsStore   store.Interface
 	workerBaseStore *basestore.Store
-	insight         *schema.Insight
+	insight         insights.SearchInsight
+}
+
+func (r *insightResolver) ID() string {
+	return r.insight.Uuid
 }
 
 func (r *insightResolver) Title() string { return r.insight.Title }
@@ -84,6 +95,7 @@ func (r *insightResolver) Series() []graphqlbackend.InsightSeriesResolver {
 	series := r.insight.Series
 	resolvers := make([]graphqlbackend.InsightSeriesResolver, 0, len(series))
 	for _, series := range series {
+		log15.Info("building series")
 		resolvers = append(resolvers, &insightSeriesResolver{
 			insightsStore:   r.insightsStore,
 			workerBaseStore: r.workerBaseStore,

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/insights"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
@@ -94,7 +92,6 @@ func (r *insightResolver) Series() []graphqlbackend.InsightSeriesResolver {
 	series := r.insight.Series
 	resolvers := make([]graphqlbackend.InsightSeriesResolver, 0, len(series))
 	for _, series := range series {
-		log15.Info("building series")
 		resolvers = append(resolvers, &insightSeriesResolver{
 			insightsStore:   r.insightsStore,
 			workerBaseStore: r.workerBaseStore,

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -93,7 +93,7 @@ func TestResolver_InsightConnection(t *testing.T) {
 		resolver := newWithClock(timescale, postgres, clock)
 
 		// Create the insights connection resolver.
-		conn, err := resolver.Insights(ctx)
+		conn, err := resolver.Insights(ctx, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -213,7 +213,7 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 	setUpTest := func(ctx context.Context, t *testing.T) graphqlbackend.InsightConnectionResolver {
 
 		resolver := newWithClock(timescale, postgres, clock)
-		conn, err := resolver.Insights(ctx)
+		conn, err := resolver.Insights(ctx, &graphqlbackend.InsightsArgs{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/insights"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -31,8 +29,6 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 	// Query data points only for the series we are representing.
 	seriesID := discovery.Encode(r.series)
 	opts.SeriesID = &seriesID
-
-	log15.Error("series_id", "series_id", seriesID)
 
 	if args.From == nil {
 		// Default to last 6mo of data.

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -38,7 +38,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 		resolver.insightsStore = mockStore
 
 		// Create the insights connection resolver and query series.
-		conn, err := resolver.Insights(ctx)
+		conn, err := resolver.Insights(ctx, nil)
 		if err != nil {
 			cleanup()
 			t.Fatal(err)

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -38,11 +38,18 @@ func newWithClock(timescale, postgres dbutil.DB, clock func() time.Time) *Resolv
 	}
 }
 
-func (r *Resolver) Insights(ctx context.Context) (graphqlbackend.InsightConnectionResolver, error) {
+func (r *Resolver) Insights(ctx context.Context, args *graphqlbackend.InsightsArgs) (graphqlbackend.InsightConnectionResolver, error) {
+	idList := make([]string, 0)
+	if args != nil && args.Ids != nil {
+		for _, id := range *args.Ids {
+			idList = append(idList, string(id))
+		}
+	}
 	return &insightConnectionResolver{
 		insightsStore:   r.insightsStore,
 		workerBaseStore: r.workerBaseStore,
 		settingStore:    r.settingStore,
+		ids:             idList,
 	}, nil
 }
 
@@ -54,6 +61,6 @@ func NewDisabledResolver(reason string) graphqlbackend.InsightsResolver {
 	return &disabledResolver{reason}
 }
 
-func (r *disabledResolver) Insights(ctx context.Context) (graphqlbackend.InsightConnectionResolver, error) {
+func (r *disabledResolver) Insights(ctx context.Context, args *graphqlbackend.InsightsArgs) (graphqlbackend.InsightConnectionResolver, error) {
 	return nil, errors.New(r.reason)
 }

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -39,10 +39,11 @@ func newWithClock(timescale, postgres dbutil.DB, clock func() time.Time) *Resolv
 }
 
 func (r *Resolver) Insights(ctx context.Context, args *graphqlbackend.InsightsArgs) (graphqlbackend.InsightConnectionResolver, error) {
-	idList := make([]string, 0)
+	var idList []string
 	if args != nil && args.Ids != nil {
-		for _, id := range *args.Ids {
-			idList = append(idList, string(id))
+		idList = make([]string, len(*args.Ids))
+		for i, id := range *args.Ids {
+			idList[i] = string(id)
 		}
 	}
 	return &insightConnectionResolver{

--- a/enterprise/internal/insights/resolvers/resolver_test.go
+++ b/enterprise/internal/insights/resolvers/resolver_test.go
@@ -30,7 +30,7 @@ func TestResolver_Insights(t *testing.T) {
 	postgres := dbtesting.GetDB(t)
 	resolver := newWithClock(timescale, postgres, clock)
 
-	insightsConnection, err := resolver.Insights(ctx)
+	insightsConnection, err := resolver.Insights(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -134,7 +134,6 @@ type SearchInsight struct {
 	Title        string
 	Description  string
 	Repositories []string
-	Uuid         string
 	Series       []TimeSeries
 	Step         Interval
 	Visibility   string

--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -132,7 +132,9 @@ type Interval struct {
 type SearchInsight struct {
 	ID           string
 	Title        string
+	Description  string
 	Repositories []string
+	Uuid         string
 	Series       []TimeSeries
 	Step         Interval
 	Visibility   string


### PR DESCRIPTION
Part of #22533

Adds a new argument to the Insights query in the GraphQL api. The argument doesn't do anything yet, but in an upcoming PR will filter insights if present.

This also refactors the internal model for insights to match the model used in the frontend extensions for a near future deprecation of the 'backend' settings model.