### PR TITLE
search: factor out result merge logic

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -467,24 +467,6 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResults, er
 	return r.resultsWithTimeoutSuggestion(ctx)
 }
 
-// unionMerge performs a merge of file match results, merging line matches when
-// they occur in the same file.
-func unionMerge(left, right *SearchResults) *SearchResults {
-	dedup := result.NewDeduper()
-
-	// Add results to maps for deduping
-	for _, leftResult := range left.Matches {
-		dedup.Add(leftResult)
-	}
-	for _, rightResult := range right.Matches {
-		dedup.Add(rightResult)
-	}
-
-	left.Matches = dedup.Results()
-	left.Stats.Update(&right.Stats)
-	return left
-}
-
 // union returns the union of two sets of search results and merges common search data.
 func union(left, right *SearchResults) *SearchResults {
 	if right == nil {
@@ -495,40 +477,12 @@ func union(left, right *SearchResults) *SearchResults {
 	}
 
 	if left.Matches != nil && right.Matches != nil {
-		return unionMerge(left, right)
+		left.Matches = result.Union(left.Matches, right.Matches)
+		left.Stats.Update(&right.Stats)
+		return left
 	} else if right.Matches != nil {
 		return right
 	}
-	return left
-}
-
-// intersectMerge performs a merge of file match results, merging line matches
-// for files contained in both result sets, and updating counts.
-func intersectMerge(left, right *SearchResults) *SearchResults {
-	rightFileMatches := make(map[result.Key]*result.FileMatch)
-	for _, r := range right.Matches {
-		if fileMatch, ok := r.(*result.FileMatch); ok {
-			rightFileMatches[fileMatch.Key()] = fileMatch
-		}
-	}
-
-	var merged []result.Match
-	for _, leftMatch := range left.Matches {
-		leftFileMatch, ok := leftMatch.(*result.FileMatch)
-		if !ok {
-			continue
-		}
-
-		rightFileMatch := rightFileMatches[leftFileMatch.Key()]
-		if rightFileMatch == nil {
-			continue
-		}
-
-		leftFileMatch.AppendMatches(rightFileMatch)
-		merged = append(merged, leftMatch)
-	}
-	left.Matches = merged
-	left.Stats.Update(&right.Stats)
 	return left
 }
 
@@ -538,7 +492,9 @@ func intersect(left, right *SearchResults) *SearchResults {
 	if left == nil || right == nil {
 		return nil
 	}
-	return intersectMerge(left, right)
+	left.Matches = result.Intersect(left.Matches, right.Matches)
+	left.Stats.Update(&right.Stats)
+	return left
 }
 
 // evaluateAnd performs set intersection on result sets. It collects results for

--- a/internal/search/result/merge.go
+++ b/internal/search/result/merge.go
@@ -1,0 +1,43 @@
+package result
+
+// Union performs a merge of results, merging line matches when they occur in
+// the same file.
+func Union(left, right []Match) []Match {
+	dedup := NewDeduper()
+	// Add results to maps for deduping
+	for _, result := range left {
+		dedup.Add(result)
+	}
+	for _, result := range right {
+		dedup.Add(result)
+	}
+	return dedup.Results()
+}
+
+// Intersect performs a merge of file match results, merging line matches
+// for files contained in both result sets.
+func Intersect(left, right []Match) []Match {
+	rightFileMatches := make(map[Key]*FileMatch)
+	for _, m := range right {
+		if fileMatch, ok := m.(*FileMatch); ok {
+			rightFileMatches[fileMatch.Key()] = fileMatch
+		}
+	}
+
+	var merged []Match
+	for _, m := range left {
+		leftFileMatch, ok := m.(*FileMatch)
+		if !ok {
+			continue
+		}
+
+		rightFileMatch := rightFileMatches[leftFileMatch.Key()]
+		if rightFileMatch == nil {
+			continue
+		}
+
+		leftFileMatch.AppendMatches(rightFileMatch)
+		merged = append(merged, m)
+	}
+	return merged
+}

--- a/internal/search/result/merge_test.go
+++ b/internal/search/result/merge_test.go
@@ -1,0 +1,175 @@
+package result
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+func commitResult(repo, commit string) *CommitMatch {
+	return &CommitMatch{
+		Repo: types.RepoName{Name: api.RepoName(repo)},
+		Commit: git.Commit{
+			ID: api.CommitID(commit),
+		},
+	}
+}
+
+func diffResult(repo, commit string) *CommitMatch {
+	return &CommitMatch{
+		DiffPreview: &HighlightedString{},
+		Repo:        types.RepoName{Name: api.RepoName(repo)},
+		Commit: git.Commit{
+			ID: api.CommitID(commit),
+		},
+	}
+}
+
+func repoResult(name string) *RepoMatch {
+	return &RepoMatch{
+		Name: api.RepoName(name),
+	}
+}
+
+func fileResult(repo string, lineMatches []*LineMatch, symbolMatches []*SymbolMatch) *FileMatch {
+	return &FileMatch{
+		File: File{
+			Repo: types.RepoName{Name: api.RepoName(repo)},
+		},
+		Symbols:     symbolMatches,
+		LineMatches: lineMatches,
+	}
+}
+
+func resultsToString(matches []Match) string {
+	toString := func(match Match) string {
+		switch v := match.(type) {
+		case *FileMatch:
+			symbols := []string{}
+			for _, symbol := range v.Symbols {
+				symbols = append(symbols, symbol.Symbol.Name)
+			}
+			lines := []string{}
+			for _, line := range v.LineMatches {
+				lines = append(lines, line.Preview)
+			}
+			return fmt.Sprintf("File{url:%s/%s,symbols:[%s],lineMatches:[%s]}", v.Repo.Name, v.Path, strings.Join(symbols, ","), strings.Join(lines, ","))
+		case *CommitMatch:
+			if v.DiffPreview != nil {
+				return fmt.Sprintf("Diff:%s", v.URL())
+			}
+			return fmt.Sprintf("Commit:%s", v.URL())
+		case *RepoMatch:
+			return fmt.Sprintf("Repo:%s", v.URL())
+		}
+		return ""
+	}
+
+	var searchResultStrings []string
+	for _, srr := range matches {
+		searchResultStrings = append(searchResultStrings, toString(srr))
+	}
+	return strings.Join(searchResultStrings, ", ")
+}
+
+func TestUnionMerge(t *testing.T) {
+	cases := []struct {
+		left  []Match
+		right []Match
+		want  autogold.Value
+	}{
+		{
+			left: []Match{
+				diffResult("a", "a"),
+				commitResult("a", "a"),
+				repoResult("a"),
+				fileResult("a", nil, nil),
+			},
+			right: []Match{},
+			want:  autogold.Want("LeftOnly", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a"),
+		},
+		{
+			left: []Match{
+				diffResult("a", "a"),
+				commitResult("a", "a"),
+				repoResult("a"),
+				fileResult("a", nil, nil),
+			},
+			want: autogold.Want("RightOnly", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a"),
+		},
+		{
+			left: []Match{
+				diffResult("a", "a"),
+				commitResult("a", "a"),
+				repoResult("a"),
+				fileResult("a", nil, nil),
+			},
+			right: []Match{
+				diffResult("b", "b"),
+				commitResult("b", "b"),
+				repoResult("b"),
+				fileResult("b", nil, nil),
+			},
+			want: autogold.Want("MergeAllDifferent", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a, File{url:b/,symbols:[],lineMatches:[]}, Repo:/b, Commit:/b/-/commit/b, Diff:/b/-/commit/b"),
+		},
+		{
+			left: []Match{
+				fileResult("b", []*LineMatch{
+					{Preview: "a"},
+					{Preview: "b"},
+				}, nil),
+			},
+			right: []Match{
+				fileResult("b", []*LineMatch{
+					{Preview: "c"},
+					{Preview: "d"},
+				}, nil),
+			},
+			want: autogold.Want("MergeFileLineMatches", "File{url:b/,symbols:[],lineMatches:[a,b,c,d]}"),
+		},
+		{
+			left: []Match{
+				fileResult("a", []*LineMatch{
+					{Preview: "a"},
+					{Preview: "b"},
+				}, nil),
+			},
+			right: []Match{
+				fileResult("b", []*LineMatch{
+					{Preview: "c"},
+					{Preview: "d"},
+				}, nil),
+			},
+			want: autogold.Want("NoMergeFileSymbols", "File{url:a/,symbols:[],lineMatches:[a,b]}, File{url:b/,symbols:[],lineMatches:[c,d]}"),
+		},
+		{
+			left: []Match{
+				fileResult("a", nil, []*SymbolMatch{
+					{Symbol: Symbol{Name: "a"}},
+					{Symbol: Symbol{Name: "b"}},
+				}),
+			},
+			right: []Match{
+				fileResult("a", nil, []*SymbolMatch{
+					{Symbol: Symbol{Name: "c"}},
+					{Symbol: Symbol{Name: "d"}},
+				}),
+			},
+			want: autogold.Want("MergeFileSymbols", "File{url:a/,symbols:[a,b,c,d],lineMatches:[]}"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			got := Union(tc.left, tc.right)
+			sort.Sort(Matches(got))
+			tc.want.Equal(t, resultsToString(got))
+		})
+	}
+}


### PR DESCRIPTION
- `unionMerge` -> `result.Union`
- `intersectMerge` -> `result.Intersect`
- Moves these to a `merge.go` function in the `result` package, out of graphqlbackend (debloating `search_results.go` ftw)

The reason these functions existed previously was because we didn't have dedicated result types to factor out, so this is thanks to @camdencheek's changes 🙂 

(At time of review this already passed backend integration tests but had to rerun for lint)