### PR TITLE
chore: Fix usage of errors

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -562,8 +562,11 @@ func errorToAlert(err error) (*searchAlert, error) {
 		return multierrorToAlert(me)
 	}
 
-	if errors.Is(err, authz.ErrStalePermissions{}) {
-		return alertForStalePermissions(), nil
+	{
+		e := authz.ErrStalePermissions{}
+		if errors.As(err, &e) {
+			return alertForStalePermissions(), nil
+		}
 	}
 
 	{

--- a/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler.go
@@ -122,7 +122,7 @@ func (s *IndexScheduler) Handle(ctx context.Context) error {
 		}
 
 		if err := s.indexEnqueuer.QueueIndexesForRepository(ctx, repositoryID); err != nil {
-			if errors.Is(err, &vcs.RepoNotExistError{}) {
+			if vcs.IsRepoNotExist(err) {
 				continue
 			}
 

--- a/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -104,15 +104,19 @@ func (j *unknownCommitJanitor) handleSourcedCommits(ctx context.Context, tx DBSt
 }
 
 func (j *unknownCommitJanitor) handleCommit(ctx context.Context, tx DBStore, repositoryID int, repositoryName, commit string) error {
-	shouldDelete := true
+	var shouldDelete bool
 	_, err := git.ResolveRevision(ctx, api.RepoName(repositoryName), commit, git.ResolveRevisionOptions{})
-	if err == nil || errors.Is(err, &vcs.RepoNotExistError{}) {
+	if err == nil {
 		// If we have no error then the commit is resolvable and we shouldn't touch it.
+		shouldDelete = false
+	} else if vcs.IsRepoNotExist(err) {
+		shouldDelete = false
 		// If we have a repository not found error, then we'll just update the timestamp
 		// of the record so we can move on to other data; we deleted records associated
 		// with deleted repositories in a separate janitor process.
-		shouldDelete = false
-	} else if !errors.Is(err, &basegitserver.RevisionNotFoundError{}) {
+	} else if gitserver.IsRevisionNotFound(err) {
+		shouldDelete = true
+	} else {
 		return errors.Wrap(err, "git.ResolveRevision")
 	}
 

--- a/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -32,7 +32,7 @@ func TestUnknownCommitsJanitor(t *testing.T) {
 func TestUnknownCommitsJanitorUnknownCommit(t *testing.T) {
 	resolveRevisionFunc := func(commit string) error {
 		if commit == "foo-y" || commit == "bar-x" || commit == "baz-z" {
-			return &basegitserver.RevisionNotFoundError{}
+			return &gitserver.RevisionNotFoundError{}
 		}
 
 		return nil

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -62,7 +62,7 @@ func (c *Client) Head(ctx context.Context, repositoryID int) (_ string, revision
 
 	revision, err := c.execGitCommand(ctx, repositoryID, "rev-parse", "HEAD")
 	if err != nil {
-		if isRevisionNotFound(err) {
+		if gitserver.IsRevisionNotFound(err) {
 			err = nil
 		}
 
@@ -436,8 +436,4 @@ func (c *Client) repositoryIDToRepo(ctx context.Context, repositoryID int) (api.
 	}
 
 	return api.RepoName(repoName), nil
-}
-
-func isRevisionNotFound(err error) bool {
-	return errors.Is(err, &gitserver.RevisionNotFoundError{})
 }

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -1,7 +1,6 @@
 package gitserver
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -35,9 +34,7 @@ func newOperations(observationContext *observation.Context) *operations {
 			Name:         fmt.Sprintf("codeintel.gitserver.%s", name),
 			MetricLabels: []string{name},
 			Metrics:      metrics,
-			ErrorFilter: func(err error) bool {
-				return errors.Is(err, &gitserver.RevisionNotFoundError{})
-			},
+			ErrorFilter:  gitserver.IsRevisionNotFound,
 		})
 	}
 

--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
@@ -98,13 +98,12 @@ func (m *committedAtMigrator) handleSourcedCommits(ctx context.Context, tx *dbst
 	}
 
 	return nil
-
 }
 
 func (m *committedAtMigrator) handleCommit(ctx context.Context, tx *dbstore.Store, repositoryID int, repositoryName, commit string) error {
 	var commitDateString string
 	if commitDate, err := m.gitserverClient.CommitDate(ctx, repositoryID, commit); err != nil {
-		if !errors.Is(err, &vcs.RepoNotExistError{}) && !errors.Is(err, &basegitserver.RevisionNotFoundError{}) {
+		if !vcs.IsRepoNotExist(err) && !gitserver.IsRevisionNotFound(err) {
 			return errors.Wrap(err, "gitserver.CommitDate")
 		}
 

--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
@@ -238,7 +238,7 @@ func TestCommittedAtMigratorUnknownCommits(t *testing.T) {
 	gitserverClient.CommitDateFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit string) (time.Time, error) {
 		if i := len(gitserverClient.CommitDateFunc.History()); i < n {
 			if i%3 == 0 {
-				return time.Time{}, &basegitserver.RevisionNotFoundError{}
+				return time.Time{}, &gitserver.RevisionNotFoundError{}
 			}
 
 			return allDates[i], nil

--- a/internal/gitserver/errors.go
+++ b/internal/gitserver/errors.go
@@ -3,6 +3,8 @@ package gitserver
 import (
 	"fmt"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
@@ -26,6 +28,6 @@ func (RevisionNotFoundError) NotFound() bool {
 
 // IsRevisionNotFound reports if err is a RevisionNotFoundError.
 func IsRevisionNotFound(err error) bool {
-	_, ok := err.(*RevisionNotFoundError)
-	return ok
+	var e *RevisionNotFoundError
+	return errors.As(err, &e)
 }

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -277,7 +277,8 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 				if errors.Is(err, context.DeadlineExceeded) {
 					return Resolved{}, context.DeadlineExceeded
 				}
-				if errors.As(err, &git.BadCommitError{}) {
+				var e git.BadCommitError
+				if errors.As(err, &e) {
 					return Resolved{}, err
 				}
 				if gitserver.IsRevisionNotFound(err) {

--- a/internal/vcs/errors.go
+++ b/internal/vcs/errors.go
@@ -1,6 +1,10 @@
 package vcs
 
-import "github.com/sourcegraph/sourcegraph/internal/api"
+import (
+	"github.com/cockroachdb/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
 
 // RepoNotExistError is an error that reports a repository doesn't exist.
 type RepoNotExistError struct {
@@ -24,15 +28,13 @@ func (e *RepoNotExistError) Error() string {
 
 // IsRepoNotExist reports if err is a RepoNotExistError.
 func IsRepoNotExist(err error) bool {
-	_, ok := err.(*RepoNotExistError)
-	return ok
+	var e *RepoNotExistError
+	return errors.As(err, &e)
 }
 
 // IsCloneInProgress reports if err is a RepoNotExistError which has a clone
 // in progress.
 func IsCloneInProgress(err error) bool {
-	if e, ok := err.(*RepoNotExistError); ok {
-		return e.CloneInProgress
-	}
-	return false
+	var e *RepoNotExistError
+	return errors.As(err, &e) && e.CloneInProgress
 }


### PR DESCRIPTION
There are several places where I used `errors.Is(err, &want)` that are illegal, where `want` is not something that can be successfully compared. This PR gets rid of these illegal uses.

Consistency check:

- use `errors.Is(...)` to compare an `err` value against a known constant error
- use `errors.As(...)` to cast an `err` value into a specific type of known struct or interface (structs with fields, etc)