### PR TITLE
search: lift query processing further up call chain

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -477,10 +477,10 @@ func (r *searchResolver) toTextParameters(q query.Q) (*search.TextParameters, er
 
 	args := search.TextParameters{
 		PatternInfo: p,
-		Query:       r.Query, // TODO(rvantonder) remove setQuery and use q here.
+		Query:       q,
 
 		// UseFullDeadline if timeout: set or we are streaming.
-		UseFullDeadline: r.Query.Timeout() != nil || r.Query.Count() != nil || r.stream != nil,
+		UseFullDeadline: q.Timeout() != nil || q.Count() != nil || r.stream != nil,
 
 		Zoekt:        r.zoekt,
 		SearcherURLs: r.searcherURLs,
@@ -495,14 +495,14 @@ func (r *searchResolver) toTextParameters(q query.Q) (*search.TextParameters, er
 
 // evaluateLeaf performs a single search operation and corresponds to the
 // evaluation of leaf expression in a query.
-func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResults, err error) {
+func (r *searchResolver) evaluateLeaf(ctx context.Context, args *search.TextParameters) (_ *SearchResults, err error) {
 	tr, ctx := trace.New(ctx, "evaluateLeaf", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	return r.resultsWithTimeoutSuggestion(ctx)
+	return r.resultsWithTimeoutSuggestion(ctx, args)
 }
 
 // union returns the union of two sets of search results and merges common search data.
@@ -701,12 +701,20 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, q query.
 		case query.Concat:
 			r.invalidateCache()
 			r.Query = q.ToParseTree()
-			return r.evaluateLeaf(ctx)
+			args, err := r.toTextParameters(q.ToParseTree())
+			if err != nil {
+				return &SearchResults{}, err
+			}
+			return r.evaluateLeaf(ctx, args)
 		}
 	case query.Pattern:
 		r.invalidateCache()
 		r.Query = q.ToParseTree()
-		return r.evaluateLeaf(ctx)
+		args, err := r.toTextParameters(q.ToParseTree())
+		if err != nil {
+			return &SearchResults{}, err
+		}
+		return r.evaluateLeaf(ctx, args)
 	case query.Parameter:
 		// evaluatePatternExpression does not process Parameter nodes.
 		return &SearchResults{}, nil
@@ -719,8 +727,12 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, q query.
 func (r *searchResolver) evaluate(ctx context.Context, q query.Basic) (*SearchResults, error) {
 	if q.Pattern == nil {
 		r.invalidateCache()
-		r.Query = query.ToNodes(q.Parameters)
-		return r.evaluateLeaf(ctx)
+		r.Query = q.ToParseTree()
+		args, err := r.toTextParameters(query.ToNodes(q.Parameters))
+		if err != nil {
+			return &SearchResults{}, err
+		}
+		return r.evaluateLeaf(ctx, args)
 	}
 	return r.evaluatePatternExpression(ctx, q)
 }
@@ -1003,12 +1015,8 @@ func searchResultsToFileNodes(matches []result.Match) ([]query.Node, error) {
 // resultsWithTimeoutSuggestion calls doResults, and in case of deadline
 // exceeded returns a search alert with a did-you-mean link for the same
 // query with a longer timeout.
-func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*SearchResults, error) {
+func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context, args *search.TextParameters) (*SearchResults, error) {
 	start := time.Now()
-	args, err := r.toTextParameters(r.Query)
-	if err != nil {
-		return nil, err
-	}
 	rr, err := r.doResults(ctx, args)
 
 	// If we encountered a context timeout, it indicates one of the many result


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22659.

Semantics preserving and lifts construction of `search.TextParameters` further up the call chain to the evaluation functions. This has the desirable effect of partially removing downstream dependencies on `r.Query`, and removes dependence of  `search.TextParameters` on `r.Query`. 

Recall that `search.TextParameters` is our "best" approximation of an internal query representation, and will change. We don't want this to depend on a resolver state at all eventually. The most important thing is that constructing `search.TextParameters` does not depend on a global query value in the resolver, which is what this PR does. Now, we construct this internal representation at the point where we have the subexpression we are ready to evaluate, and _conceptually_ never need to look at the parse tree again to run a search from here on. Only _conceptually_ because we still have a downstream dependency on [`r.Query` when resolving repos](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%5Cbr.Query+file:/search%5C.go%24&patternType=regexp&case=yes) which will be the next piece of state I will factor out.

At some point, our internal representation will be able to capture multiple subexpressions, but not yet, we're just inlining construction for now.