### PR TITLE
search: resolveRepositories does not depend on r.Query

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -261,7 +261,7 @@ type resolveRepositoriesOpts struct {
 
 // resolveRepositories calls ResolveRepositories, caching the result for the common case
 // where opts.effectiveRepoFieldValues == nil.
-func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRepositoriesOpts) (resolved searchrepos.Resolved, err error) {
+func (r *searchResolver) resolveRepositories(ctx context.Context, q query.Q, opts resolveRepositoriesOpts) (resolved searchrepos.Resolved, err error) {
 	if mockResolveRepositories != nil {
 		return mockResolveRepositories(opts.effectiveRepoFieldValues)
 	}
@@ -288,12 +288,12 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 		}()
 	}
 
-	repoFilters, minusRepoFilters := r.Query.Repositories()
+	repoFilters, minusRepoFilters := q.Repositories()
 	if opts.effectiveRepoFieldValues != nil {
 		repoFilters = opts.effectiveRepoFieldValues
 
 	}
-	repoGroupFilters, _ := r.Query.StringValues(query.FieldRepoGroup)
+	repoGroupFilters, _ := q.StringValues(query.FieldRepoGroup)
 
 	var settingForks, settingArchived bool
 	if v := r.UserSettings.SearchIncludeForks; v != nil {
@@ -310,7 +310,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 		// (2) user/org/global setting includes forks
 		fork = query.Yes
 	}
-	if setFork := r.Query.Fork(); setFork != nil {
+	if setFork := q.Fork(); setFork != nil {
 		fork = *setFork
 	}
 
@@ -321,15 +321,15 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 		// (2) user/org/global setting includes archives in all searches
 		archived = query.Yes
 	}
-	if setArchived := r.Query.Archived(); setArchived != nil {
+	if setArchived := q.Archived(); setArchived != nil {
 		archived = *setArchived
 	}
 
-	visibilityStr, _ := r.Query.StringValue(query.FieldVisibility)
+	visibilityStr, _ := q.StringValue(query.FieldVisibility)
 	visibility := query.ParseVisibility(visibilityStr)
 
-	commitAfter, _ := r.Query.StringValue(query.FieldRepoHasCommitAfter)
-	searchContextSpec, _ := r.Query.StringValue(query.FieldContext)
+	commitAfter, _ := q.StringValue(query.FieldRepoHasCommitAfter)
+	searchContextSpec, _ := q.StringValue(query.FieldContext)
 
 	var versionContextName string
 	if r.VersionContext != nil {
@@ -367,17 +367,6 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 }
 
 func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]SearchSuggestionResolver, error) {
-	resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
-	if err != nil {
-		return nil, err
-	}
-
-	if resolved.OverLimit {
-		// If we've exceeded the repo limit, then we may miss files from repos we care
-		// about, so don't bother searching filenames at all.
-		return nil, nil
-	}
-
 	q, err := query.ToBasicQuery(r.Query)
 	if err != nil {
 		return nil, err
@@ -390,7 +379,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 
 	args := search.TextParameters{
 		PatternInfo:     p,
-		RepoPromise:     (&search.RepoPromise{}).Resolve(resolved.RepoRevs),
+		RepoPromise:     &search.RepoPromise{}, // TODO(rvantonder) remove this field for this type.
 		Query:           r.Query,
 		UseFullDeadline: r.Query.Timeout() != nil || r.Query.Count() != nil,
 		Zoekt:           r.zoekt,
@@ -399,6 +388,19 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 	if err := args.PatternInfo.Validate(); err != nil {
 		return nil, err
 	}
+
+	resolved, err := r.resolveRepositories(ctx, args.Query, resolveRepositoriesOpts{})
+	if err != nil {
+		return nil, err
+	}
+
+	if resolved.OverLimit {
+		// If we've exceeded the repo limit, then we may miss files from repos we care
+		// about, so don't bother searching filenames at all.
+		return nil, nil
+	}
+
+	args.RepoPromise = (&search.RepoPromise{}).Resolve(resolved.RepoRevs)
 
 	fileMatches, _, err := unindexed.SearchFilesInReposBatch(ctx, &args)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -310,7 +310,7 @@ func (r *searchResolver) errorForOverRepoLimit(ctx context.Context) *errOverRepo
 		return buildErr(proposedQueries, description)
 	}
 
-	resolved, _ := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
+	resolved, _ := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{})
 	if len(resolved.RepoRevs) > 0 {
 		paths := make([]string, len(resolved.RepoRevs))
 		for i, repo := range resolved.RepoRevs {
@@ -339,7 +339,7 @@ func (r *searchResolver) errorForOverRepoLimit(ctx context.Context) *errOverRepo
 			repoFieldValues = append(repoFieldValues, repoParentPattern)
 			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
-			resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{
+			resolved, err := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{
 				effectiveRepoFieldValues: repoFieldValues,
 			})
 			if ctx.Err() != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1305,8 +1305,8 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 // determineRepos wraps resolveRepositories. It interprets the response and
 // error to see if an alert needs to be returned. Only one of the return
 // values will be non-nil.
-func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (*searchrepos.Resolved, error) {
-	resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
+func (r *searchResolver) determineRepos(ctx context.Context, q query.Q, tr *trace.Trace, start time.Time) (*searchrepos.Resolved, error) {
+	resolved, err := r.resolveRepositories(ctx, q, resolveRepositoriesOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -1423,7 +1423,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		}
 	}
 
-	resolved, err := r.determineRepos(ctx, tr, start)
+	resolved, err := r.determineRepos(ctx, args.Query, tr, start)
 	if err != nil {
 		if alert, err := errorToAlert(err); alert != nil {
 			return alert.wrapResults(), err

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -268,7 +268,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
 
 		if len(effectiveRepoFieldValues) > 0 || hasSingleContextField {
-			resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{
+			resolved, err := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{
 				effectiveRepoFieldValues: effectiveRepoFieldValues,
 				limit:                    maxSearchSuggestions,
 			})
@@ -378,7 +378,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return mockShowSymbolMatches()
 		}
 
-		resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
+		resolved, err := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -506,7 +506,7 @@ func TestVersionContext(t *testing.T) {
 			}
 			defer git.ResetMocks()
 
-			gotResult, err := resolver.resolveRepositories(context.Background(), resolveRepositoriesOpts{})
+			gotResult, err := resolver.resolveRepositories(context.Background(), resolver.Query, resolveRepositoriesOpts{})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22660.

Intended to be semantics preserving. This propagates the query data structure via `search.TextParameters` as an argument to `resolveRepositories`. This breaks the dependency of `r.Query` in `resolveRepositories`. Now, it _looks_ like I'm just passing previous state stored in the resolver via arguments, so if you're thinking:

> Rijnard, is your plan to just pass the members in the resolver as arguments everywhere?

Then the answer is: It looks that way but that's _not_ the point. The point is that the _type_ of the query will change here, so that it is, for example, a specific `Repo` query, containing only the values (internal representation) to conduct a repo search. The type will be split likewise for other kinds of searches, but it cannot be split while the definition is part of the resolver, because that will just bloat the resolver definition without simplifying control flow.