### PR TITLE
doc(admin): remove outdated info, rely more on main observability docs

### DIFF
--- a/doc/admin/how-to/monitoring-guide.md
+++ b/doc/admin/how-to/monitoring-guide.md
@@ -1,5 +1,6 @@
 # Monitoring Guide
-Please visit our [Observability Docs](https://docs.sourcegraph.com/admin/observability) for more in-depth information about observability.
+
+Please visit our [Observability Docs](https://docs.sourcegraph.com/admin/observability) for more in-depth information about observability in Sourcegraph.
 
 ## Prerequisites
 
@@ -8,38 +9,47 @@ This document assumes that you are a [site administrator](https://docs.sourcegra
 ## FAQs
 
 ### What should I look at when my instance is having performance issues?
-Sourcegraph comes with built-in monitoring in the form of [Grafana](https://docs.sourcegraph.com/admin/observability/metrics#grafana), connected to [Prometheus](https://docs.sourcegraph.com/admin/observability/metrics#prometheus) for metrics and alerting. You can access Grafana by visiting `https://<your-sourcegraph-url>/-/debug/grafana` for monitoring purposes. Generally, Grafana should be the first stop you make when experiencing a system performance issue. From there you can look for system alerts or metrics that would provide you with more insights on what’s causing the performance issue.
 
+Sourcegraph comes with built-in monitoring in the form of [Grafana](https://docs.sourcegraph.com/admin/observability/metrics#grafana), connected to [Prometheus](https://docs.sourcegraph.com/admin/observability/metrics#prometheus) for metrics and alerting.
 
-### What are the key values / alerts to look for when looking at the Grafana Dashboard?
-All key values are defined as either warnings or critical. Please visit our [Observability Docs](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts) to 
-learn how they are defined. Warnings are typically not as important as critical but should be investigated. 
-All alerts turn red when they fire. Critical alerts should be investigated and reported if they are occurring repeatedly.
+Generally, Grafana should be the first stop you make when experiencing a system performance issue. From there you can look for system alerts or metrics that would provide you with more insights on what’s causing the performance issue. You can learn more about [accessing Grafana here](https://docs.sourcegraph.com/admin/observability/metrics#grafana).
 
+### What are the key values/alerts to look for when looking at the Grafana Dashboard?
 
-### How do I know when more resources is needed for a specified service?
-All resources contain a dashboard called `Provisioning indicators` that provide information about the current resource usage of containers. These can be used to determine if a scale-up is needed.
+Please refer to the [Dashboards](https://docs.sourcegraph.com/admin/observability/metrics#dashboards) guide for more on how to use our Grafana dashboards.
 
+Please refer to [Understanding alerts](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts) for examples and suggested actions for alerts.
+
+### How do I know when more resources are needed for a specified service?
+
+All resource dashboards contain a section called `Provisioning indicators` that provide information about the current resource usage of containers. These can be used to determine if a scale-up is needed ([example panel](https://docs.sourcegraph.com/admin/observability/dashboards#frontend-provisioning-container-cpu-usage-long-term)).
+
+More information on each available panel in the dashboards is available in the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards).
 
 ### What does this `<ALERT-MESSAGE>` mean?
-See [Alert solutions](https://docs.sourcegraph.com/admin/observability/alert_solutions) to learn about each alert and their possible solutions. 
 
-  
+See [Alert solutions](https://docs.sourcegraph.com/admin/observability/alert_solutions) to learn about each alert and their possible solutions.
+
 ### What’s the threshold for each resource?
-All resources have provisioning indicators that will fire up alerts when the container uses 80% of the container memory limit and 90% of the specified CPU limit.
 
-  
+All resources dashboards contain a section called `Container monitoring` that indicate thresholds at which alerts will fire for each resource ([example alert](https://docs.sourcegraph.com/admin/observability/alert_solutions#frontend-container-cpu-usage)).
+
+More information on each available panel in the dashboards is available in the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards).
+
 ### How much resources should I add after receiving alerts about running out of resources?
-You should make the decision based on the metrics from your Grafana Dashboard. 
 
+You should make the decision based on the metrics from the relevant Grafana dashboard linked in each alert.
   
 ### What are some of the important alerts that I should be aware of?
-We recommend paying closer attention to critical alerts, especially when they turn red as that indicates there are issues occurring continuously that require immediate actions.
 
-  
-### How to set up alerts?
-See our Observability Docs on [setting up alerting](https://docs.sourcegraph.com/admin/observability/alerting#setting-up-alerting).
+We recommend paying closer attention to [critical alerts](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts).
 
-  
-### How to create a custom alert?
-Creating a customer alert is not recommended and currently not supported by Sourcegraph. However, please provide feedback on the monitoring dashboards and alerts if you find anything could be improved.
+### How do I set up alerts?
+
+Please refer to our guide on [setting up alerting](https://docs.sourcegraph.com/admin/observability/alerting#setting-up-alerting).
+
+### How do I create a custom alert?
+
+Creating a custom alert is not recommended and currently not supported by Sourcegraph. However, please provide feedback on the monitoring dashboards and alerts if you find anything could be improved via our issue tracker.
+
+More advanced users can also refer to [our FAQ item about custom consumption of Sourcegraph metrics](https://docs.sourcegraph.com/admin/faq#can-i-consume-sourcegraph-s-metrics-in-my-own-monitoring-system-datadog-new-relic-etc).

--- a/doc/admin/observability/index.md
+++ b/doc/admin/observability/index.md
@@ -33,6 +33,7 @@ Sourcegraph is designed, and ships with, a number of observability tools and cap
 * [Logs](./logs.md)
 * [Health checks](./health_checks.md)
 * [Troubleshooting guide](troubleshooting.md)
+* [Monitoring guide](../how-to/monitoring-guide.md)
 
 ## Reference
 


### PR DESCRIPTION
There was mention of specific thresholds for some alerts here that was outdated, so I updated the guide to depend primarily on links to the main observability docs. Also adds a backlink from there.

I'm also wondering if we can migrate this entire page to the [administration FAQ](https://docs.sourcegraph.com/admin/faq) under a subsection to keep everything together and easier to update

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
