### PR TITLE
clean up leftover resolver naming crumbs

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1000,14 +1000,14 @@ func (r *searchResolver) resultsRecursive(ctx context.Context, plan query.Plan) 
 func searchResultsToRepoNodes(matches []result.Match) ([]query.Node, error) {
 	nodes := make([]query.Node, 0, len(matches))
 	for _, match := range matches {
-		repoResolver, ok := match.(*result.RepoMatch)
+		repoMatch, ok := match.(*result.RepoMatch)
 		if !ok {
-			return nil, fmt.Errorf("expected type %T, but got %T", &RepositoryResolver{}, match)
+			return nil, fmt.Errorf("expected type %T, but got %T", &result.RepoMatch{}, match)
 		}
 
 		nodes = append(nodes, query.Parameter{
 			Field: query.FieldRepo,
-			Value: "^" + regexp.QuoteMeta(string(repoResolver.Name)) + "$",
+			Value: "^" + regexp.QuoteMeta(string(repoMatch.Name)) + "$",
 		})
 	}
 


### PR DESCRIPTION
This commit just changes some variable names that still reference
resolvers to be more correct.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
