### PR TITLE
add file:contains.content() predicate

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -32,6 +32,9 @@ var DefaultPredicateRegistry = predicateRegistry{
 		"contains.content":      func() Predicate { return &RepoContainsContentPredicate{} },
 		"contains.commit.after": func() Predicate { return &RepoContainsCommitAfterPredicate{} },
 	},
+	FieldFile: {
+		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
+	},
 }
 
 type predicateRegistry map[string]map[string]func() Predicate
@@ -233,6 +236,38 @@ func (f *RepoContainsCommitAfterPredicate) Plan(parent Basic) (Plan, error) {
 	}, Parameter{
 		Field: FieldRepoHasCommitAfter,
 		Value: f.TimeRef,
+	})
+
+	nodes = append(nodes, nonPredicateRepos(parent)...)
+	return ToPlan(Dnf(nodes))
+}
+
+type FileContainsContentPredicate struct {
+	Pattern string
+}
+
+func (f *FileContainsContentPredicate) ParseParams(params string) error {
+	if _, err := regexp.Compile(params); err != nil {
+		return fmt.Errorf("file:contains.content argument: %w", err)
+	}
+	if params == "" {
+		return fmt.Errorf("file:contains.content argument should not be empty")
+	}
+	f.Pattern = params
+	return nil
+}
+
+func (f FileContainsContentPredicate) Field() string { return FieldFile }
+func (f FileContainsContentPredicate) Name() string  { return "contains.content" }
+
+func (f *FileContainsContentPredicate) Plan(parent Basic) (Plan, error) {
+	nodes := make([]Node, 0, 3)
+	nodes = append(nodes, Parameter{
+		Field: FieldCount,
+		Value: "99999",
+	}, Pattern{
+		Value:      f.Pattern,
+		Annotation: Annotation{Labels: Regexp},
 	})
 
 	nodes = append(nodes, nonPredicateRepos(parent)...)


### PR DESCRIPTION
This adds a file predicate to filter to only files that contain content
matching the given pattern.

In textsearch cases, it's usually simpler to just use an "and" operator.
For example, `file:contains.content(q1) q2` is equivalent to `q1 and
q1`.

However, for non-file results, that's not possible. Consider "find diffs
that modify files that contain q1". With this change, that query can be
written as `type:diff file:contains.content(q1)` whereas that would
previously be unrepresentible in our query language.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
