### PR TITLE
add file:contains.content predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A new bulk operation to close many changesets at once has been added to Batch Changes. [#22547](https://github.com/sourcegraph/sourcegraph/pull/22547)
 - Backend Code Insights will aggregate viewable repositories based on the authenticated user. [#22471](https://github.com/sourcegraph/sourcegraph/pull/22471)
 - Added support for highlighting .frugal files as Thrift syntax.
+- Added `file:contains.content(regexp)` predicate, which filters only to files that contain matches of the given pattern. [#22666](https://github.com/sourcegraph/sourcegraph/pull/22666)
 
 ### Changed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1148,7 +1148,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:   `file contains content predicate type diff`,
-				query:  `type:diff repo:go-diff file:contains.content(after_success)`, // matches .travis.yml and its 8 commits
+				query:  `type:diff repo:go-diff file:contains(after_success)`, // matches .travis.yml and its 8 commits
 				counts: counts{Commit: 8},
 			},
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1086,6 +1086,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{File: 1},
 			},
 			{
+				name:   `file contains content predicate`, // should be the same as the `select file` test
+				query:  `repo:go-diff patterntype:literal file:contains.content(HunkNoChunkSize)`,
+				counts: counts{File: 1},
+			},
+			{
 				name:   `or statement merges file`,
 				query:  `repo:go-diff HunkNoChunksize or ParseHunksAndPrintHunks select:file`,
 				counts: counts{File: 1},

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1086,11 +1086,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{File: 1},
 			},
 			{
-				name:   `file contains content predicate`, // should be the same as the `select file` test
-				query:  `repo:go-diff patterntype:literal file:contains.content(HunkNoChunkSize)`,
-				counts: counts{File: 1},
-			},
-			{
 				name:   `or statement merges file`,
 				query:  `repo:go-diff HunkNoChunksize or ParseHunksAndPrintHunks select:file`,
 				counts: counts{File: 1},
@@ -1145,6 +1140,16 @@ func testSearchClient(t *testing.T, client searchClient) {
 				name:   `select diffs with removed lines containing pattern`,
 				query:  `repo:go-diff patterntype:literal type:diff select:commit.diff.removed sample_binary_inline`,
 				counts: counts{Commit: 0},
+			},
+			{
+				name:   `file contains content predicate`, // equivalent to the `select file` test
+				query:  `repo:go-diff patterntype:literal file:contains.content(HunkNoChunkSize)`,
+				counts: counts{File: 1},
+			},
+			{
+				name:   `file contains content predicate type diff`,
+				query:  `type:diff repo:go-diff file:contains.content(after_success)`, // matches .travis.yml and its 8 commits
+				counts: counts{Commit: 8},
 			},
 		}
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1148,8 +1148,8 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:   `file contains content predicate type diff`,
-				query:  `type:diff repo:go-diff file:contains(after_success)`, // matches .travis.yml and its 8 commits
-				counts: counts{Commit: 8},
+				query:  `type:diff repo:go-diff file:contains(after_success)`, // matches .travis.yml and its 10 commits
+				counts: counts{Commit: 10},
 			},
 		}
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -266,6 +266,9 @@ func (f *FileContainsContentPredicate) Plan(parent Basic) (Plan, error) {
 	nodes = append(nodes, Parameter{
 		Field: FieldCount,
 		Value: "99999",
+	}, Parameter{
+		Field: FieldType,
+		Value: "file",
 	}, Pattern{
 		Value:      f.Pattern,
 		Annotation: Annotation{Labels: Regexp},

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -32,6 +32,9 @@ var DefaultPredicateRegistry = predicateRegistry{
 		"contains.content":      func() Predicate { return &RepoContainsContentPredicate{} },
 		"contains.commit.after": func() Predicate { return &RepoContainsCommitAfterPredicate{} },
 	},
+	FieldFile: {
+		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
+	},
 }
 
 type predicateRegistry map[string]map[string]func() Predicate
@@ -233,6 +236,38 @@ func (f *RepoContainsCommitAfterPredicate) Plan(parent Basic) (Plan, error) {
 	}, Parameter{
 		Field: FieldRepoHasCommitAfter,
 		Value: f.TimeRef,
+	})
+
+	nodes = append(nodes, nonPredicateRepos(parent)...)
+	return ToPlan(Dnf(nodes))
+}
+
+type FileContainsContentPredicate struct {
+	Pattern string
+}
+
+func (f *FileContainsContentPredicate) ParseParams(params string) error {
+	if _, err := regexp.Compile(params); err != nil {
+		return fmt.Errorf("file:contains.content argument: %w", err)
+	}
+	if params == "" {
+		return fmt.Errorf("file:contains.content argument should not be empty")
+	}
+	f.Pattern = params
+	return nil
+}
+
+func (f FileContainsContentPredicate) Field() string { return FieldFile }
+func (f FileContainsContentPredicate) Name() string  { return "contains.content" }
+
+func (f *FileContainsContentPredicate) Plan(parent Basic) (Plan, error) {
+	nodes := make([]Node, 0, 3)
+	nodes = append(nodes, Parameter{
+		Field: FieldCount,
+		Value: "99999",
+	}, Pattern{
+		Value:      f.Pattern,
+		Annotation: Annotation{Labels: Regexp},
 	})
 
 	nodes = append(nodes, nonPredicateRepos(parent)...)

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -34,6 +34,7 @@ var DefaultPredicateRegistry = predicateRegistry{
 	},
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
+		"contains":         func() Predicate { return &FileContainsContentPredicate{} },
 	},
 }
 


### PR DESCRIPTION
This adds a file predicate to filter to only files that contain content
matching the given pattern.

In textsearch cases, it's usually simpler to just use an "and" operator.
For example, `file:contains.content(q1) q2` is equivalent to `q1 and
q1`.

However, for non-file results, that's not possible. Consider "find diffs
that modify files that contain q1". With this change, that query can be
written as `type:diff file:contains.content(q1)` whereas that would
previously be unrepresentible in our query language.

This is specifically for a [customer request](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1625660806268500). 