### PR TITLE
RepositoryDiffPage: prevent scroll bar from appearing over content

### DIFF
--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -243,7 +243,7 @@ class RepositoryCommitPageDetails extends React.Component<Props & { isRedesignEn
 
     public render(): JSX.Element | null {
         return (
-            <div className="repository-commit-page m-3" ref={this.nextRepositoryCommitPageElement}>
+            <div className="repository-commit-page p-3" ref={this.nextRepositoryCommitPageElement}>
                 <PageTitle
                     title={
                         this.state.commitOrError && !isErrorLike(this.state.commitOrError)


### PR DESCRIPTION
## Context

Addresses part of #21662.

The scroll bar on the diff view currently appears over top of the content, rather than over top of the margin between the diff page and the extension sidebar:

![CleanShot 2021-07-08 at 12 12 04](https://user-images.githubusercontent.com/17293/124908136-456bd180-dfe9-11eb-80e1-36e8576fd3cc.png)

The desired behavior is for it to appear slightly further to the right, over top of the margin:

![CleanShot 2021-07-08 at 12 14 54](https://user-images.githubusercontent.com/17293/124908123-41d84a80-dfe9-11eb-9161-b918e08fbcca.png)

## Changes

Change the _margin_ on RepositoryCommitPage to _padding_.
