### PR TITLE
Fix #22672: Scroll parent of RepositoryCommitPage

### DIFF
--- a/client/web/src/repo/commit/RepositoryCommitPage.scss
+++ b/client/web/src/repo/commit/RepositoryCommitPage.scss
@@ -1,5 +1,4 @@
 .repository-commit-page {
-    overflow-y: auto;
     width: 100%;
     position: relative; // For HoverOverlay positioning
 


### PR DESCRIPTION
Fix #21662: Make the diff view page scroll in the same way as the other repository subpages (e.g. Branches, Tags, etc.)

**Old behavior:**

https://user-images.githubusercontent.com/17293/124911312-e5772a00-dfec-11eb-9ec6-7375caa91523.mp4

**New behavior:**

https://user-images.githubusercontent.com/17293/124911174-bfea2080-dfec-11eb-829a-3ad6368dc5a3.mp4


