### PR TITLE
Don't pass invalid arguments to ignite stop/remove

### DIFF
--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -170,7 +170,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 func teardownFirecracker(ctx context.Context, runner commandRunner, logger *Logger, name string, options Options, operations *Operations) error {
 	stopCommand := command{
 		Key:       "teardown.firecracker.stop",
-		Command:   flatten("ignite", "stop", commonFirecrackerFlags, name),
+		Command:   flatten("ignite", "stop", name),
 		Operation: operations.TeardownFirecrackerStop,
 	}
 	if err := runner.RunCommand(ctx, stopCommand, logger); err != nil {
@@ -179,7 +179,7 @@ func teardownFirecracker(ctx context.Context, runner commandRunner, logger *Logg
 
 	removeCommand := command{
 		Key:       "teardown.firecracker.remove",
-		Command:   flatten("ignite", "rm", "-f", commonFirecrackerFlags, name),
+		Command:   flatten("ignite", "rm", "-f", name),
 		Operation: operations.TeardownFirecrackerRemove,
 	}
 	if err := runner.RunCommand(ctx, removeCommand, logger); err != nil {

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -172,8 +172,8 @@ func TestTeardownFirecracker(t *testing.T) {
 	}
 
 	expected := []string{
-		"ignite stop --runtime docker --network-plugin docker-bridge deadbeef",
-		"ignite rm -f --runtime docker --network-plugin docker-bridge deadbeef",
+		"ignite stop deadbeef",
+		"ignite rm -f deadbeef",
 	}
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Errorf("unexpected commands (-want +got):\n%s", diff)


### PR DESCRIPTION
These arguments are not understood by either of these commands. In a newer version of ignite, this fails with an unknown flag error.

