### PR TITLE
chore: Fix error checking in codeintel source

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler.go
@@ -12,10 +12,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
-	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
 type IndexScheduler struct {
@@ -122,7 +122,7 @@ func (s *IndexScheduler) Handle(ctx context.Context) error {
 		}
 
 		if err := s.indexEnqueuer.QueueIndexesForRepository(ctx, repositoryID); err != nil {
-			if errors.Is(err, &vcs.RepoNotExistError{}) {
+			if gitserver.IsRevisionNotFound(err) {
 				continue
 			}
 

--- a/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -32,7 +32,7 @@ func TestUnknownCommitsJanitor(t *testing.T) {
 func TestUnknownCommitsJanitorUnknownCommit(t *testing.T) {
 	resolveRevisionFunc := func(commit string) error {
 		if commit == "foo-y" || commit == "bar-x" || commit == "baz-z" {
-			return &basegitserver.RevisionNotFoundError{}
+			return &gitserver.RevisionNotFoundError{}
 		}
 
 		return nil

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -62,7 +62,7 @@ func (c *Client) Head(ctx context.Context, repositoryID int) (_ string, revision
 
 	revision, err := c.execGitCommand(ctx, repositoryID, "rev-parse", "HEAD")
 	if err != nil {
-		if isRevisionNotFound(err) {
+		if gitserver.IsRevisionNotFound(err) {
 			err = nil
 		}
 
@@ -436,8 +436,4 @@ func (c *Client) repositoryIDToRepo(ctx context.Context, repositoryID int) (api.
 	}
 
 	return api.RepoName(repoName), nil
-}
-
-func isRevisionNotFound(err error) bool {
-	return errors.Is(err, &gitserver.RevisionNotFoundError{})
 }

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -1,7 +1,6 @@
 package gitserver
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -35,9 +34,7 @@ func newOperations(observationContext *observation.Context) *operations {
 			Name:         fmt.Sprintf("codeintel.gitserver.%s", name),
 			MetricLabels: []string{name},
 			Metrics:      metrics,
-			ErrorFilter: func(err error) bool {
-				return errors.Is(err, &gitserver.RevisionNotFoundError{})
-			},
+			ErrorFilter:  gitserver.IsRevisionNotFound,
 		})
 	}
 

--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
@@ -104,7 +104,7 @@ func (m *committedAtMigrator) handleSourcedCommits(ctx context.Context, tx *dbst
 func (m *committedAtMigrator) handleCommit(ctx context.Context, tx *dbstore.Store, repositoryID int, repositoryName, commit string) error {
 	var commitDateString string
 	if commitDate, err := m.gitserverClient.CommitDate(ctx, repositoryID, commit); err != nil {
-		if !errors.Is(err, &vcs.RepoNotExistError{}) && !errors.Is(err, &basegitserver.RevisionNotFoundError{}) {
+		if !vcs.IsRepoNotExist(err) && !gitserver.IsRevisionNotFound(err) {
 			return errors.Wrap(err, "gitserver.CommitDate")
 		}
 

--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
@@ -238,7 +238,7 @@ func TestCommittedAtMigratorUnknownCommits(t *testing.T) {
 	gitserverClient.CommitDateFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit string) (time.Time, error) {
 		if i := len(gitserverClient.CommitDateFunc.History()); i < n {
 			if i%3 == 0 {
-				return time.Time{}, &basegitserver.RevisionNotFoundError{}
+				return time.Time{}, &gitserver.RevisionNotFoundError{}
 			}
 
 			return allDates[i], nil

--- a/internal/gitserver/errors.go
+++ b/internal/gitserver/errors.go
@@ -1,6 +1,7 @@
 package gitserver
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/internal/gitserver/errors.go
+++ b/internal/gitserver/errors.go
@@ -26,6 +26,9 @@ func (RevisionNotFoundError) NotFound() bool {
 
 // IsRevisionNotFound reports if err is a RevisionNotFoundError.
 func IsRevisionNotFound(err error) bool {
-	_, ok := err.(*RevisionNotFoundError)
-	return ok
+	// Note we use As instead of Is here to ensure that we do not try
+	// compare struct fields for equality; we only care that the type
+	// of the error value matches.
+	var e *RevisionNotFoundError
+	return errors.As(err, &e)
 }

--- a/internal/vcs/errors.go
+++ b/internal/vcs/errors.go
@@ -1,6 +1,10 @@
 package vcs
 
-import "github.com/sourcegraph/sourcegraph/internal/api"
+import (
+	"errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
 
 // RepoNotExistError is an error that reports a repository doesn't exist.
 type RepoNotExistError struct {
@@ -24,15 +28,16 @@ func (e *RepoNotExistError) Error() string {
 
 // IsRepoNotExist reports if err is a RepoNotExistError.
 func IsRepoNotExist(err error) bool {
-	_, ok := err.(*RepoNotExistError)
-	return ok
+	// Note we use As instead of Is here to ensure that we do not try
+	// compare struct fields for equality; we only care that the type
+	// of the error value matches.
+	var e *RepoNotExistError
+	return errors.As(err, &e)
 }
 
 // IsCloneInProgress reports if err is a RepoNotExistError which has a clone
 // in progress.
 func IsCloneInProgress(err error) bool {
-	if e, ok := err.(*RepoNotExistError); ok {
-		return e.CloneInProgress
-	}
-	return false
+	var e *RepoNotExistError
+	return errors.As(err, &e) && e.CloneInProgress
 }


### PR DESCRIPTION
This updates two shared error helper methods:

- vcs.IsRepoNotExist
- gitserver.IsRevisionNotFound

Both methods now unwrap their arguments to check for _type_ equality.

The remaining changes are updates to codeintel usage of error checking. See https://github.com/sourcegraph/sourcegraph/pull/22657 for context on a previous attempt.