### PR TITLE
Generalize ExecutionLogEntry and expose entries on BatchSpecExecutions

### DIFF
--- a/client/web/src/components/ExecutionLogEntry.tsx
+++ b/client/web/src/components/ExecutionLogEntry.tsx
@@ -1,0 +1,123 @@
+import classNames from 'classnames'
+import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
+import ErrorIcon from 'mdi-react/ErrorIcon'
+import React from 'react'
+
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
+
+import { Collapsible } from './Collapsible'
+import { Timestamp } from './time/Timestamp'
+
+interface ExecutionLogEntryProps extends React.PropsWithChildren<{}> {
+    logEntry: {
+        key: string
+        command: string[]
+        startTime: string
+        exitCode: number
+        out: string
+        durationMilliseconds: number
+    }
+    now?: () => Date
+}
+
+export const ExecutionLogEntry: React.FunctionComponent<ExecutionLogEntryProps> = ({ logEntry, children, now }) => (
+    <div className="card mb-3">
+        <div className="card-body">
+            <LogOutput text={logEntry.command.join(' ')} className="mb-3" />
+
+            <div>
+                {logEntry.exitCode === 0 ? (
+                    <CheckCircleIcon className="text-success" />
+                ) : (
+                    <ErrorIcon className="text-danger" />
+                )}
+
+                <span className="ml-2">
+                    <span className="text-muted">Started</span>{' '}
+                    <Timestamp date={logEntry.startTime} now={now} noAbout={true} />
+                    <span className="text-muted">, ran for</span> {formatMilliseconds(logEntry.durationMilliseconds)}
+                </span>
+            </div>
+
+            {children}
+        </div>
+
+        <div className="p-2">
+            {logEntry.out ? (
+                <Collapsible title="Log output" titleAtStart={true} buttonClassName="p-2">
+                    <LogOutput text={logEntry.out} />
+                </Collapsible>
+            ) : (
+                <div className="p-2">
+                    <span className="text-muted">No log output available.</span>
+                </div>
+            )}
+        </div>
+    </div>
+)
+
+interface LogOutputProps {
+    text: string
+    className?: string
+}
+
+const LogOutput: React.FunctionComponent<LogOutputProps> = React.memo(({ text, className }) => (
+    <pre className={classNames('bg-code rounded p-3 mb-0', className)}>
+        {
+            // Use index as key because log lines may not be unique. This is OK
+            // here because this list will not be updated during this component's
+            // lifetime (note: it's also memoized).
+            /* eslint-disable react/no-array-index-key */
+            text.split('\n').map((line, index) => (
+                <code key={index} className={classNames('d-block', line.startsWith('stderr:') ? 'text-danger' : '')}>
+                    {line.replace(/^std(out|err): /, '')}
+                </code>
+            ))
+        }
+    </pre>
+))
+
+const timeOrders: [number, string][] = [
+    [1000 * 60 * 60 * 24, 'day'],
+    [1000 * 60 * 60, 'hour'],
+    [1000 * 60, 'minute'],
+    [1000, 'second'],
+    [1, 'millisecond'],
+]
+
+/**
+ * This is essentially to date-fns/formatDistance with support for milliseconds.
+ * The output of this function has the following properties:
+ *
+ * - Consists of one unit (e.g. `x days`) or two units (e.g. `x days and y hours`).
+ * - If there are more than one unit, they are adjacent (e.g. never `x days and y minutes`).
+ * - If there is a greater unit, the value will not exceed the next threshold (e.g. `2 minutes and 5 seconds`, never `125 seconds`).
+ *
+ * @param milliseconds The number of milliseconds elapsed.
+ */
+const formatMilliseconds = (milliseconds: number): string => {
+    const parts: string[] = []
+
+    // Construct a list of parts like `1 day` or `7 hours` in descending
+    // order. If the value is zero, an empty string is added to the list.`
+    timeOrders.reduce((msRemaining, [denominator, suffix]) => {
+        // Determine how many units can fit into the current value
+        const part = Math.floor(msRemaining / denominator)
+        // Format this part (pluralize if value is more than one)
+        parts.push(part > 0 ? `${part} ${pluralize(suffix, part)}` : '')
+        // Remove this order's contribution to the current value
+        return msRemaining - part * denominator
+    }, milliseconds)
+
+    return (
+        parts
+            // Trim leading zero-valued parts
+            .slice(parts.findIndex(part => part !== ''))
+            // Keep only two consecutive non-zero parts
+            .slice(0, 2)
+            // Re-filter zero-valued parts
+            .filter(part => part !== '')
+            // If there are two parts, join them
+            .join(' and ')
+    )
+}

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -1,5 +1,8 @@
-import { isEqual } from 'lodash'
+import { parseISO } from 'date-fns'
+import { formatDistance } from 'date-fns/esm'
+import { isArray, isEqual } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import CheckIcon from 'mdi-react/CheckIcon'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import ProgressClockIcon from 'mdi-react/ProgressClockIcon'
@@ -16,9 +19,10 @@ import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
 import { ErrorAlert } from '../../../components/alerts'
+import { ExecutionLogEntry } from '../../../components/ExecutionLogEntry'
 import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
-import { Timeline } from '../../../components/Timeline'
+import { Timeline, TimelineStage } from '../../../components/Timeline'
 import { BatchSpecExecutionFields, Scalars } from '../../../graphql-operations'
 import { BatchSpec } from '../BatchSpec'
 
@@ -124,11 +128,186 @@ const ExecutionTimeline: React.FunctionComponent<ExecutionTimelineProps> = ({ ex
                 className: 'bg-success',
             },
 
+            setupStage(execution, now),
+            batchPreviewStage(execution, now),
+            teardownStage(execution, now),
+
             execution.state === BatchSpecExecutionState.COMPLETED
                 ? { icon: <CheckIcon />, text: 'Finished', date: execution.finishedAt, className: 'bg-success' }
                 : { icon: <ErrorIcon />, text: 'Failed', date: execution.finishedAt, className: 'bg-danger' },
         ],
-        [execution]
+        [execution, now]
     )
     return <Timeline stages={stages.filter(isDefined)} now={now} className={className} />
+}
+
+const setupStage = (execution: BatchSpecExecutionFields, now?: () => Date): TimelineStage | undefined =>
+    execution.steps.setup.length === 0
+        ? undefined
+        : {
+              text: 'Setup',
+              details: execution.steps.setup.map(logEntry => (
+                  <ExecutionLogEntry key={logEntry.key} logEntry={logEntry} now={now} />
+              )),
+              ...genericStage(execution.steps.setup),
+          }
+
+const batchPreviewStage = (execution: BatchSpecExecutionFields, now?: () => Date): TimelineStage | undefined =>
+    !execution.steps.srcPreview
+        ? undefined
+        : {
+              text: 'Create batch spec preview',
+              details: (
+                  <ExecutionLogEntry logEntry={execution.steps.srcPreview} now={now}>
+                      {execution.steps.srcPreview.out && <ParsedJsonOutput out={execution.steps.srcPreview.out} />}
+                  </ExecutionLogEntry>
+              ),
+              ...genericStage(execution.steps.srcPreview),
+          }
+
+const teardownStage = (execution: BatchSpecExecutionFields, now?: () => Date): TimelineStage | undefined =>
+    execution.steps.teardown.length === 0
+        ? undefined
+        : {
+              text: 'Teardown',
+              details: execution.steps.teardown.map(logEntry => (
+                  <ExecutionLogEntry key={logEntry.key} logEntry={logEntry} now={now} />
+              )),
+              ...genericStage(execution.steps.teardown),
+          }
+
+const genericStage = <E extends { startTime: string; exitCode: number }>(
+    value: E | E[]
+): Pick<TimelineStage, 'icon' | 'date' | 'className' | 'expanded'> => {
+    const success = isArray(value) ? value.every(logEntry => logEntry.exitCode === 0) : value.exitCode === 0
+
+    return {
+        icon: success ? <CheckIcon /> : <ErrorIcon />,
+        date: isArray(value) ? value[0].startTime : value.startTime,
+        className: success ? 'bg-success' : 'bg-danger',
+        expanded: !success,
+    }
+}
+
+enum JSONLogLineOperation {
+    PARSING_BATCH_SPEC = 'PARSING_BATCH_SPEC',
+    RESOLVING_NAMESPACE = 'RESOLVING_NAMESPACE',
+    PREPARING_DOCKER_IMAGES = 'PREPARING_DOCKER_IMAGES',
+    DETERMINING_WORKSPACE_TYPE = 'DETERMINING_WORKSPACE_TYPE',
+    RESOLVING_REPOSITORIES = 'RESOLVING_REPOSITORIES',
+    DETERMINING_WORKSPACES = 'DETERMINING_WORKSPACES',
+    CHECKING_CACHE = 'CHECKING_CACHE',
+    EXECUTING_TASKS = 'EXECUTING_TASKS',
+    UPLOADING_CHANGESET_SPECS = 'UPLOADING_CHANGESET_SPECS',
+    CREATING_BATCH_SPEC = 'CREATING_BATCH_SPEC',
+}
+
+const prettyOperationNames: Record<JSONLogLineOperation, string> = {
+    PARSING_BATCH_SPEC: 'Parsing batch spec',
+    RESOLVING_NAMESPACE: 'Resolving namespace',
+    PREPARING_DOCKER_IMAGES: 'Preparing docker images',
+    DETERMINING_WORKSPACE_TYPE: 'Determining workspace type',
+    RESOLVING_REPOSITORIES: 'Resolving repositories',
+    DETERMINING_WORKSPACES: 'Determining workspaces',
+    CHECKING_CACHE: 'Checking cache',
+    EXECUTING_TASKS: 'Executing tasks',
+    UPLOADING_CHANGESET_SPECS: 'Uploading changeset specs',
+    CREATING_BATCH_SPEC: 'Creating batch spec',
+}
+
+enum JSONLogLineStatus {
+    STARTED = 'STARTED',
+    PROGRESS = 'PROGRESS',
+    SUCCESS = 'SUCCESS',
+    FAILED = 'FAILED',
+}
+
+interface JSONLogLine {
+    operation: JSONLogLineOperation
+    timestamp: string
+    status: JSONLogLineStatus
+    message?: string
+}
+
+const ParsedJsonOutput: React.FunctionComponent<{ out: string }> = ({ out }) => {
+    const parsed = useMemo<JSONLogLine[]>(
+        () =>
+            out
+                .split('\n')
+                .map(line => line.replace(/^std(out|err): /, ''))
+                .map(line => {
+                    try {
+                        return JSON.parse(line) as JSONLogLine
+                    } catch (error) {
+                        return String(error)
+                    }
+                })
+                .filter((line): line is JSONLogLine => typeof line !== 'string')
+                // Don't consider these lines for now.
+                .filter(line => line.status !== JSONLogLineStatus.PROGRESS),
+        [out]
+    )
+
+    return (
+        <ul className="list-group w-100 mt-3">
+            {Object.values<JSONLogLineOperation>(JSONLogLineOperation).map(operation => {
+                const tuple = findLogLineTuple(parsed, operation)
+                if (tuple === undefined) {
+                    return null
+                }
+                const completionStatus = tuple[1]?.status
+                return (
+                    <li className="list-group-item p-2" key={operation}>
+                        <div className="d-flex justify-content-between">
+                            <p>
+                                {completionStatus === JSONLogLineStatus.SUCCESS && (
+                                    <CheckCircleIcon className="icon-inline text-success mr-1" />
+                                )}
+                                {completionStatus === JSONLogLineStatus.FAILED && (
+                                    <ErrorIcon className="icon-inline text-danger mr-1" />
+                                )}
+                                {prettyOperationNames[tuple[0].operation]}
+                            </p>
+                            <span>
+                                {formatDistance(
+                                    parseISO(tuple[0].timestamp),
+                                    parseISO(tuple[1]?.timestamp ?? new Date().toISOString()),
+                                    { includeSeconds: true }
+                                )}
+                            </span>
+                        </div>
+                        <code className="d-block">
+                            {[tuple[0].message, tuple[1]?.message].filter(line => !!line).join('\n')}
+                        </code>
+                    </li>
+                )
+            })}
+        </ul>
+    )
+}
+
+function findLogLine(
+    lines: JSONLogLine[],
+    operation: JSONLogLineOperation,
+    status: JSONLogLineStatus
+): JSONLogLine | undefined {
+    return lines.find(line => line.operation === operation && line.status === status)
+}
+
+function findLogLineTuple(
+    lines: JSONLogLine[],
+    operation: JSONLogLineOperation
+): [JSONLogLine] | [JSONLogLine, JSONLogLine] | undefined {
+    const start = findLogLine(lines, operation, JSONLogLineStatus.STARTED)
+    if (!start) {
+        return undefined
+    }
+    let end = findLogLine(lines, operation, JSONLogLineStatus.SUCCESS)
+    if (!end) {
+        end = findLogLine(lines, operation, JSONLogLineStatus.FAILED)
+    }
+    if (end) {
+        return [start, end]
+    }
+    return [start]
 }

--- a/client/web/src/enterprise/batches/execution/backend.ts
+++ b/client/web/src/enterprise/batches/execution/backend.ts
@@ -20,6 +20,17 @@ const batchSpecExecutionFieldsFragment = gql`
         startedAt
         finishedAt
         failure
+        steps {
+            setup {
+                ...BatchSpecExecutionLogEntryFields
+            }
+            srcPreview {
+                ...BatchSpecExecutionLogEntryFields
+            }
+            teardown {
+                ...BatchSpecExecutionLogEntryFields
+            }
+        }
         placeInQueue
         batchSpec {
             applyURL
@@ -34,6 +45,15 @@ const batchSpecExecutionFieldsFragment = gql`
             url
             namespaceName
         }
+    }
+
+    fragment BatchSpecExecutionLogEntryFields on ExecutionLogEntry {
+        key
+        command
+        startTime
+        exitCode
+        durationMilliseconds
+        out
     }
 `
 

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelIndexTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelIndexTimeline.tsx
@@ -1,17 +1,13 @@
-import classNames from 'classnames'
 import { isArray } from 'lodash'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import CheckIcon from 'mdi-react/CheckIcon'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import ProgressClockIcon from 'mdi-react/ProgressClockIcon'
 import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import React, { FunctionComponent, useMemo } from 'react'
 
-import { pluralize } from '@sourcegraph/shared/src/util/strings'
 import { isDefined } from '@sourcegraph/shared/src/util/types'
 
-import { Collapsible } from '../../../components/Collapsible'
-import { Timestamp } from '../../../components/time/Timestamp'
+import { ExecutionLogEntry } from '../../../components/ExecutionLogEntry'
 import { Timeline, TimelineStage } from '../../../components/Timeline'
 import { LsifIndexFields, LSIFIndexState } from '../../../graphql-operations'
 
@@ -65,15 +61,15 @@ const indexPreIndexStage = (index: LsifIndexFields, now?: () => Date): TimelineS
                   step =>
                       step.logEntry && (
                           <div key={`${step.image}${step.root}${step.commands.join(' ')}}`}>
-                              <ExecutionLogEntry
-                                  logEntry={step.logEntry}
-                                  now={now}
-                                  meta={{
-                                      image: step.image,
-                                      commands: step.commands,
-                                      root: step.root,
-                                  }}
-                              />
+                              <ExecutionLogEntry logEntry={step.logEntry} now={now}>
+                                  <ExecutionMetaInformation
+                                      {...{
+                                          image: step.image,
+                                          commands: step.commands,
+                                          root: step.root,
+                                      }}
+                                  />
+                              </ExecutionLogEntry>
                           </div>
                       )
               ),
@@ -88,15 +84,15 @@ const indexIndexStage = (index: LsifIndexFields, now?: () => Date): TimelineStag
               text: 'Index',
               details: (
                   <>
-                      <ExecutionLogEntry
-                          logEntry={index.steps.index.logEntry}
-                          now={now}
-                          meta={{
-                              image: index.inputIndexer,
-                              commands: index.steps.index.indexerArgs,
-                              root: index.inputRoot,
-                          }}
-                      />
+                      <ExecutionLogEntry logEntry={index.steps.index.logEntry} now={now}>
+                          <ExecutionMetaInformation
+                              {...{
+                                  image: index.inputIndexer,
+                                  commands: index.steps.index.indexerArgs,
+                                  root: index.inputRoot,
+                              }}
+                          />
+                      </ExecutionLogEntry>
                   </>
               ),
               ...genericStage(index.steps.index.logEntry),
@@ -135,138 +131,25 @@ const genericStage = <E extends { startTime: string; exitCode: number }>(
     }
 }
 
-interface ExecutionLogEntryProps {
-    logEntry: {
-        key: string
-        command: string[]
-        startTime: string
-        exitCode: number
-        out: string
-        durationMilliseconds: number
-    }
-    meta?: {
-        image: string
-        commands: string[]
-        root: string
-    }
-    now?: () => Date
-}
-
-const ExecutionLogEntry: FunctionComponent<ExecutionLogEntryProps> = ({ logEntry, meta, now }) => (
-    <div className="card mb-3">
-        <div className="card-body">
-            <LogOutput text={logEntry.command.join(' ')} className="mb-3" />
-
-            <div>
-                {logEntry.exitCode === 0 ? (
-                    <CheckCircleIcon className="text-success" />
-                ) : (
-                    <ErrorIcon className="text-danger" />
-                )}
-
-                <span className="ml-2">
-                    <span className="text-muted">Started</span>{' '}
-                    <Timestamp date={logEntry.startTime} now={now} noAbout={true} />
-                    <span className="text-muted">, ran for</span> {formatMilliseconds(logEntry.durationMilliseconds)}
-                </span>
-            </div>
-
-            {meta && (
-                <div className="pt-3">
-                    <div className="docker-command-spec py-2 border-top pl-2">
-                        <strong className="docker-command-spec__header">Image</strong>
-                        <div>{meta.image}</div>
-                    </div>
-                    <div className="docker-command-spec py-2 border-top pl-2">
-                        <strong className="docker-command-spec__header">Commands</strong>
-                        <div>
-                            <code>{meta.commands.join(' ')}</code>
-                        </div>
-                    </div>
-                    <div className="docker-command-spec py-2 border-top pl-2">
-                        <strong className="docker-command-spec__header">Root</strong>
-                        <div>/{meta.root}</div>
-                    </div>
-                </div>
-            )}
+const ExecutionMetaInformation: React.FunctionComponent<{ image: string; commands: string[]; root: string }> = ({
+    image,
+    commands,
+    root,
+}) => (
+    <div className="pt-3">
+        <div className="docker-command-spec py-2 border-top pl-2">
+            <strong className="docker-command-spec__header">Image</strong>
+            <div>{image}</div>
         </div>
-
-        <div className="p-2">
-            {logEntry.out ? (
-                <Collapsible title="Log output" titleAtStart={true} buttonClassName="p-2">
-                    <LogOutput text={logEntry.out} />
-                </Collapsible>
-            ) : (
-                <div className="p-2">
-                    <span className="text-muted">No log output available.</span>
-                </div>
-            )}
+        <div className="docker-command-spec py-2 border-top pl-2">
+            <strong className="docker-command-spec__header">Commands</strong>
+            <div>
+                <code>{commands.join(' ')}</code>
+            </div>
+        </div>
+        <div className="docker-command-spec py-2 border-top pl-2">
+            <strong className="docker-command-spec__header">Root</strong>
+            <div>/{root}</div>
         </div>
     </div>
 )
-
-interface LogOutputProps {
-    text: string
-    className?: string
-}
-
-const LogOutput: FunctionComponent<LogOutputProps> = React.memo(({ text, className }) => (
-    <pre className={classNames('bg-code rounded p-3 mb-0', className)}>
-        {
-            // Use index as key because log lines may not be unique. This is OK
-            // here because this list will not be updated during this component's
-            // lifetime (note: it's also memoized).
-            /* eslint-disable react/no-array-index-key */
-            text.split('\n').map((line, index) => (
-                <code key={index} className={classNames('d-block', line.startsWith('stderr:') ? 'text-danger' : '')}>
-                    {line.replace(/^std(out|err): /, '')}
-                </code>
-            ))
-        }
-    </pre>
-))
-
-const timeOrders: [number, string][] = [
-    [1000 * 60 * 60 * 24, 'day'],
-    [1000 * 60 * 60, 'hour'],
-    [1000 * 60, 'minute'],
-    [1000, 'second'],
-    [1, 'millisecond'],
-]
-
-/**
- * This is essentially to date-fns/formatDistance with support for milliseconds.
- * The output of this function has the following properties:
- *
- * - Consists of one unit (e.g. `x days`) or two units (e.g. `x days and y hours`).
- * - If there are more than one unit, they are adjacent (e.g. never `x days and y minutes`).
- * - If there is a greater unit, the value will not exceed the next threshold (e.g. `2 minutes and 5 seconds`, never `125 seconds`).
- *
- * @param milliseconds The number of milliseconds elapsed.
- */
-const formatMilliseconds = (milliseconds: number): string => {
-    const parts: string[] = []
-
-    // Construct a list of parts like `1 day` or `7 hours` in descending
-    // order. If the value is zero, an empty string is added to the list.`
-    timeOrders.reduce((msRemaining, [denominator, suffix]) => {
-        // Determine how many units can fit into the current value
-        const part = Math.floor(msRemaining / denominator)
-        // Format this part (pluralize if value is more than one)
-        parts.push(part > 0 ? `${part} ${pluralize(suffix, part)}` : '')
-        // Remove this order's contribution to the current value
-        return msRemaining - part * denominator
-    }, milliseconds)
-
-    return (
-        parts
-            // Trim leading zero-valued parts
-            .slice(parts.findIndex(part => part !== ''))
-            // Keep only two consecutive non-zero parts
-            .slice(0, 2)
-            // Re-filter zero-valued parts
-            .filter(part => part !== '')
-            // If there are two parts, join them
-            .join(' and ')
-    )
-}

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -717,8 +717,15 @@ type BatchSpecExecutionResolver interface {
 	StartedAt() *DateTime
 	FinishedAt() *DateTime
 	Failure() *string
+	Steps() BatchSpecExecutionStepsResolver
 	PlaceInQueue() *int32
 	BatchSpec(ctx context.Context) (BatchSpecResolver, error)
 	Initiator(ctx context.Context) (*UserResolver, error)
 	Namespace(ctx context.Context) (*NamespaceResolver, error)
+}
+
+type BatchSpecExecutionStepsResolver interface {
+	Setup() []ExecutionLogEntryResolver
+	SrcPreview() ExecutionLogEntryResolver
+	Teardown() []ExecutionLogEntryResolver
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2887,8 +2887,10 @@ type BatchSpecExecution implements Node {
     """
     failure: String
 
-    ### TODO(eseliger): We want to provide more information here. Take inspiration
-    # steps: IndexSteps!
+    """
+    The configuration and execution summary (if completed or errored) of this execution.
+    """
+    steps: BatchSpecExecutionSteps!
 
     """
     The rank of this execution in the queue. The value of this field is null if the
@@ -2913,6 +2915,27 @@ type BatchSpecExecution implements Node {
     namespace.
     """
     namespace: Namespace!
+}
+
+"""
+Configuration and execution summary of a batch spec execution.
+"""
+type BatchSpecExecutionSteps {
+    """
+    Execution log entries related to setting up the workspace.
+    """
+    setup: [ExecutionLogEntry!]!
+
+    """
+    Execution log entry related to running src batch preview.
+    This field is null, if the step had not been executed.
+    """
+    srcPreview: ExecutionLogEntry
+
+    """
+    Execution log entries related to tearing down the workspace.
+    """
+    teardown: [ExecutionLogEntry!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -112,15 +112,6 @@ type IndexStepResolver interface {
 	LogEntry() ExecutionLogEntryResolver
 }
 
-type ExecutionLogEntryResolver interface {
-	Key() string
-	Command() []string
-	StartTime() DateTime
-	ExitCode() int32
-	Out(ctx context.Context) (string, error)
-	DurationMilliseconds() int32
-}
-
 type LSIFIndexConnectionResolver interface {
 	Nodes(ctx context.Context) ([]LSIFIndexResolver, error)
 	TotalCount(ctx context.Context) (*int32, error)

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -699,41 +699,6 @@ type IndexStep {
 }
 
 """
-A description of a command run inside the executor to during processing of the parent record.
-"""
-type ExecutionLogEntry {
-    """
-    An internal tag used to correlate this log entry with other records.
-    """
-    key: String!
-
-    """
-    The arguments of the command run inside the executor.
-    """
-    command: [String!]!
-
-    """
-    The date when this command started.
-    """
-    startTime: DateTime!
-
-    """
-    The exit code of the command.
-    """
-    exitCode: Int!
-
-    """
-    The combined stdout and stderr logs of the command.
-    """
-    out: String!
-
-    """
-    The duration in milliseconds of the command.
-    """
-    durationMilliseconds: Int!
-}
-
-"""
 A list of LSIF indexes.
 """
 type LSIFIndexConnection {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6320,3 +6320,38 @@ type CodeHostRepository {
     """
     private: Boolean!
 }
+
+"""
+A description of a command run inside the executor to during processing of the parent record.
+"""
+type ExecutionLogEntry {
+    """
+    An internal tag used to correlate this log entry with other records.
+    """
+    key: String!
+
+    """
+    The arguments of the command run inside the executor.
+    """
+    command: [String!]!
+
+    """
+    The date when this command started.
+    """
+    startTime: DateTime!
+
+    """
+    The exit code of the command.
+    """
+    exitCode: Int!
+
+    """
+    The combined stdout and stderr logs of the command.
+    """
+    out: String!
+
+    """
+    The duration in milliseconds of the command.
+    """
+    durationMilliseconds: Int!
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps.go
@@ -6,6 +6,7 @@ import (
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -50,7 +51,7 @@ func (r *indexStepsResolver) Index() gql.IndexStepResolver {
 
 func (r *indexStepsResolver) Upload() gql.ExecutionLogEntryResolver {
 	if entry, ok := r.findExecutionLogEntry("step.src.0"); ok {
-		return &executionLogEntryResolver{entry: entry}
+		return gql.NewExecutionLogEntryResolver(dbconn.Global, entry)
 	}
 
 	return nil
@@ -76,10 +77,8 @@ func (r *indexStepsResolver) executionLogEntryResolversWithPrefix(prefix string)
 		if !strings.HasPrefix(entry.Key, prefix) {
 			continue
 		}
-
-		resolvers = append(resolvers, &executionLogEntryResolver{
-			entry: entry,
-		})
+		r := gql.NewExecutionLogEntryResolver(dbconn.Global, entry)
+		resolvers = append(resolvers, r)
 	}
 
 	return resolvers

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_index.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_index.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -18,7 +19,7 @@ func (r *indexStepResolver) Outfile() *string      { return strPtr(r.index.Outfi
 
 func (r *indexStepResolver) LogEntry() gql.ExecutionLogEntryResolver {
 	if r.entry != nil {
-		return &executionLogEntryResolver{entry: *r.entry}
+		return gql.NewExecutionLogEntryResolver(dbconn.Global, *r.entry)
 	}
 
 	return nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_preindex.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_preindex.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -19,7 +20,7 @@ func (r *preIndexStepResolver) Commands() []string { return r.step.Commands }
 
 func (r *preIndexStepResolver) LogEntry() gql.ExecutionLogEntryResolver {
 	if r.entry != nil {
-		return &executionLogEntryResolver{entry: *r.entry}
+		return gql.NewExecutionLogEntryResolver(dbconn.Global, *r.entry)
 	}
 
 	return nil

--- a/enterprise/internal/batches/resolvers/batch_spec_execution.go
+++ b/enterprise/internal/batches/resolvers/batch_spec_execution.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
 const batchSpecExecutionIDKind = "BatchSpecExecution"
@@ -25,44 +26,51 @@ func unmarshalBatchSpecExecutionRandID(id graphql.ID) (batchSpecExecutionID stri
 
 type batchSpecExecutionResolver struct {
 	store *store.Store
-	spec  *btypes.BatchSpecExecution
+	exec  *btypes.BatchSpecExecution
 }
 
 // Type guard.
 var _ graphqlbackend.BatchSpecExecutionResolver = &batchSpecExecutionResolver{}
 
 func (r *batchSpecExecutionResolver) ID() graphql.ID {
-	return marshalBatchSpecExecutionRandID(r.spec.RandID)
+	return marshalBatchSpecExecutionRandID(r.exec.RandID)
 }
 
 func (r *batchSpecExecutionResolver) InputSpec() string {
-	return r.spec.BatchSpec
+	return r.exec.BatchSpec
 }
 
 func (r *batchSpecExecutionResolver) State() string {
-	return strings.ToUpper(string(r.spec.State))
+	return strings.ToUpper(string(r.exec.State))
 }
 
 func (r *batchSpecExecutionResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.spec.CreatedAt}
+	return graphqlbackend.DateTime{Time: r.exec.CreatedAt}
 }
 
 func (r *batchSpecExecutionResolver) StartedAt() *graphqlbackend.DateTime {
-	if r.spec.StartedAt == nil {
+	if r.exec.StartedAt == nil {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: *r.spec.StartedAt}
+	return &graphqlbackend.DateTime{Time: *r.exec.StartedAt}
 }
 
 func (r *batchSpecExecutionResolver) FinishedAt() *graphqlbackend.DateTime {
-	if r.spec.FinishedAt == nil {
+	if r.exec.FinishedAt == nil {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: *r.spec.FinishedAt}
+	return &graphqlbackend.DateTime{Time: *r.exec.FinishedAt}
 }
 
 func (r *batchSpecExecutionResolver) Failure() *string {
-	return r.spec.FailureMessage
+	return r.exec.FailureMessage
+}
+
+func (r *batchSpecExecutionResolver) Steps() graphqlbackend.BatchSpecExecutionStepsResolver {
+	return &batchSpecExecutionStepsResolver{
+		store: r.store,
+		exec:  r.exec,
+	}
 }
 
 func (r *batchSpecExecutionResolver) PlaceInQueue() *int32 {
@@ -71,10 +79,10 @@ func (r *batchSpecExecutionResolver) PlaceInQueue() *int32 {
 }
 
 func (r *batchSpecExecutionResolver) BatchSpec(ctx context.Context) (graphqlbackend.BatchSpecResolver, error) {
-	if r.spec.BatchSpecID == 0 {
+	if r.exec.BatchSpecID == 0 {
 		return nil, nil
 	}
-	spec, err := r.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{ID: r.spec.BatchSpecID})
+	spec, err := r.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{ID: r.exec.BatchSpecID})
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +90,7 @@ func (r *batchSpecExecutionResolver) BatchSpec(ctx context.Context) (graphqlback
 }
 
 func (r *batchSpecExecutionResolver) Initiator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	return graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.spec.UserID)
+	return graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.exec.UserID)
 }
 
 func (r *batchSpecExecutionResolver) Namespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
@@ -90,18 +98,64 @@ func (r *batchSpecExecutionResolver) Namespace(ctx context.Context) (*graphqlbac
 		namespace graphqlbackend.NamespaceResolver
 		err       error
 	)
-	if r.spec.NamespaceUserID != 0 {
+	if r.exec.NamespaceUserID != 0 {
 		namespace.Namespace, err = graphqlbackend.UserByIDInt32(
 			ctx,
 			r.store.DB(),
-			r.spec.NamespaceUserID,
+			r.exec.NamespaceUserID,
 		)
 		return &namespace, err
 	}
 	namespace.Namespace, err = graphqlbackend.OrgByIDInt32(
 		ctx,
 		r.store.DB(),
-		r.spec.NamespaceOrgID,
+		r.exec.NamespaceOrgID,
 	)
 	return &namespace, err
+}
+
+type batchSpecExecutionStepsResolver struct {
+	store *store.Store
+	exec  *btypes.BatchSpecExecution
+}
+
+var _ graphqlbackend.BatchSpecExecutionStepsResolver = &batchSpecExecutionStepsResolver{}
+
+func (r *batchSpecExecutionStepsResolver) Setup() []graphqlbackend.ExecutionLogEntryResolver {
+	return r.executionLogEntryResolversWithPrefix("setup.")
+}
+
+func (r *batchSpecExecutionStepsResolver) SrcPreview() graphqlbackend.ExecutionLogEntryResolver {
+	if entry, ok := r.findExecutionLogEntry("step.src.0"); ok {
+		return graphqlbackend.NewExecutionLogEntryResolver(r.store.DB(), entry)
+	}
+
+	return nil
+}
+
+func (r *batchSpecExecutionStepsResolver) Teardown() []graphqlbackend.ExecutionLogEntryResolver {
+	return r.executionLogEntryResolversWithPrefix("teardown.")
+}
+
+func (r *batchSpecExecutionStepsResolver) findExecutionLogEntry(key string) (workerutil.ExecutionLogEntry, bool) {
+	for _, entry := range r.exec.ExecutionLogs {
+		if entry.Key == key {
+			return entry, true
+		}
+	}
+
+	return workerutil.ExecutionLogEntry{}, false
+}
+
+func (r *batchSpecExecutionStepsResolver) executionLogEntryResolversWithPrefix(prefix string) []graphqlbackend.ExecutionLogEntryResolver {
+	var resolvers []graphqlbackend.ExecutionLogEntryResolver
+	for _, entry := range r.exec.ExecutionLogs {
+		if !strings.HasPrefix(entry.Key, prefix) {
+			continue
+		}
+		r := graphqlbackend.NewExecutionLogEntryResolver(r.store.DB(), entry)
+		resolvers = append(resolvers, r)
+	}
+
+	return resolvers
 }

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -386,7 +386,7 @@ func (r *Resolver) batchSpecExecutionByID(ctx context.Context, id graphql.ID) (g
 		}
 		return nil, err
 	}
-	return &batchSpecExecutionResolver{store: r.store, spec: spec}, nil
+	return &batchSpecExecutionResolver{store: r.store, exec: spec}, nil
 }
 
 func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.CreateBatchChangeArgs) (graphqlbackend.BatchChangeResolver, error) {


### PR DESCRIPTION
This PR shares the execution log entry resolver, and exposes log entries on the BatchSpecExecutionResolver.
In addition, we render them in the UI and do some parsing of the json logs to get a prettier overview.

Expands the timeline to something like this:
![image](https://user-images.githubusercontent.com/19534377/124940405-3e08f000-e00a-11eb-941a-1060f7de89d1.png)

This is not supposed to be a fully fledged UI, or anything user friendly, for now this just serves the purpose so we can better look into the state of an execution, without reading unparseable json from a database column in `psql`.