### PR TITLE
security: Log AccountCreated event

### DIFF
--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -269,6 +269,9 @@ func (s *UserExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 	}
 
 	err = tx.insert(ctx, createdUser.ID, spec, data)
+	if err == nil {
+		logAccountCreatedEvent(ctx, s.Handle().DB(), createdUser, spec.ServiceType)
+	}
 	return createdUser.ID, err
 }
 

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -25,6 +25,8 @@ const (
 	SecurityEventNameSignInAttempted SecurityEventName = "SignInAttempted"
 	SecurityEventNameSignInFailed    SecurityEventName = "SignInFailed"
 	SecurityEventNameSignInSucceeded SecurityEventName = "SignInSucceeded"
+
+	SecurityEventNameAccountCreated SecurityEventName = "AccountCreated"
 )
 
 // SecurityEvent contains information needed for logging a security-relevant event.

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"sync"
@@ -194,7 +195,11 @@ func (u *UserStore) Create(ctx context.Context, info NewUser) (newUser *types.Us
 		return nil, err
 	}
 	defer func() { err = tx.Done(err) }()
-	return tx.create(ctx, info)
+	newUser, err = tx.create(ctx, info)
+	if err == nil {
+		logAccountCreatedEvent(ctx, u.Handle().DB(), newUser, "")
+	}
+	return newUser, err
 }
 
 // maxPasswordRunes is the maximum number of UTF-8 runes that a password can contain.
@@ -368,20 +373,29 @@ func (u *UserStore) create(ctx context.Context, info NewUser) (newUser *types.Us
 				return nil, errors.Wrap(err, "after create user hook")
 			}
 		}
-
-		logAccountCreatedEvent(ctx, u.Handle().DB(), id)
 	}
 
 	return user, nil
 }
 
-func logAccountCreatedEvent(ctx context.Context, db dbutil.DB, id int32) {
+func logAccountCreatedEvent(ctx context.Context, db dbutil.DB, u *types.User, serviceType string) {
+	a := actor.FromContext(ctx)
+	arg, _ := json.Marshal(struct {
+		Creator     int32  `json:"creator,omitempty"`
+		SiteAdmin   bool   `json:"site_admin,omitempty"`
+		ServiceType string `json:"service_type,omitempty"`
+	}{
+		Creator:     a.UID,
+		SiteAdmin:   u.SiteAdmin,
+		ServiceType: serviceType,
+	})
+
 	event := &SecurityEvent{
 		Name:            SecurityEventNameAccountCreated,
 		URL:             "",
-		UserID:          uint32(id),
+		UserID:          uint32(u.ID),
 		AnonymousUserID: "",
-		Argument:        nil,
+		Argument:        arg,
 		Source:          "BACKEND",
 		Timestamp:       time.Now(),
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -381,9 +381,9 @@ func (u *UserStore) create(ctx context.Context, info NewUser) (newUser *types.Us
 func logAccountCreatedEvent(ctx context.Context, db dbutil.DB, u *types.User, serviceType string) {
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
-		Creator     int32  `json:"creator,omitempty"`
-		SiteAdmin   bool   `json:"site_admin,omitempty"`
-		ServiceType string `json:"service_type,omitempty"`
+		Creator     uint32 `json:"creator"`
+		SiteAdmin   bool   `json:"site_admin"`
+		ServiceType string `json:"service_type"`
 	}{
 		Creator:     a.UID,
 		SiteAdmin:   u.SiteAdmin,

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -381,7 +381,7 @@ func (u *UserStore) create(ctx context.Context, info NewUser) (newUser *types.Us
 func logAccountCreatedEvent(ctx context.Context, db dbutil.DB, u *types.User, serviceType string) {
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
-		Creator     uint32 `json:"creator"`
+		Creator     int32  `json:"creator"`
 		SiteAdmin   bool   `json:"site_admin"`
 		ServiceType string `json:"service_type"`
 	}{


### PR DESCRIPTION
We include the following metadata:

`creator`: The id of user requesting creation 
`site_admin`: Is the new user a site admin?
`service_type`: Was the user created via an external account, eg `github`