### PR TITLE
security: Log user deletion events

### DIFF
--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -25,6 +25,9 @@ const (
 	SecurityEventNameSignInAttempted SecurityEventName = "SignInAttempted"
 	SecurityEventNameSignInFailed    SecurityEventName = "SignInFailed"
 	SecurityEventNameSignInSucceeded SecurityEventName = "SignInSucceeded"
+
+	SecurityEventNameAccountDeleted SecurityEventName = "AccountDeleted"
+	SecurityEventNameAccountNuked   SecurityEventName = "AccountNuked"
 )
 
 // SecurityEvent contains information needed for logging a security-relevant event.

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -588,7 +588,7 @@ func logUserDeletionEvent(ctx context.Context, db dbutil.DB, id int32, name Secu
 	// admin
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
-		Deleter int32 `json:"Deleter"`
+		Deleter int32 `json:"deleter"`
 	}{
 		Deleter: a.UID,
 	})


### PR DESCRIPTION
Since a user can be deleted by another user, we included the `deleter` field on the payload