### PR TITLE
remove stable reference FIXME

### DIFF
--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -158,15 +158,6 @@ const searchReferenceInfo: SearchReferenceInfo[] = [
             'Shows only query results for a given type. For example, `select:repo` displays only distinct reopsitory paths from search results. See [language definition](https://docs.sourcegraph.com/code_search/reference/language#select) for possible values.',
         examples: ['fmt.Errorf select:repo'],
     },
-    /*
-     * FIXME: Doesn't exist as filter type?
-    {
-        type: FilterType.stable,
-        placeholder: parsePlaceholder('{yes}'),
-        description:
-            'Ensures a deterministic result order. Applies only to file contents. Limited to at max `count:5000` results. Note this field should be removed if you’re using the pagination API, which already ensures deterministic results.',
-    },
-    */
     {
         type: FilterType.type,
         placeholder: parsePlaceholder('{diff//commit/...}'),


### PR DESCRIPTION
The experimental `stable` field was removed in #22537 when we removed
the pagination API.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
