### PR TITLE
indexed search: refactor zoektSearch

### DIFF
--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -143,7 +143,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, repoBranches
 	}
 
 	// Choose sensible values for k when we generalize this.
-	k := zoektutil.ResultCountFactor(len(repoBranches), args.FileMatchLimit, false)
+	k := zoektutil.ResultCountFactor(len(repoBranches), args.FileMatchLimit)
 	searchOpts := zoektutil.SearchOpts(ctx, k, args)
 	searchOpts.Whole = true
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -543,7 +543,6 @@ func sendMatches(files []zoekt.FileMatch, getRepoInputRev repoRevFunc, typ Index
 			if typ == SymbolRequest {
 				symbols = zoektFileMatchToSymbolResults(repo, inputRev, &file)
 			}
-			// TODO: Why do we always set LimitHit to false?
 			fm := result.FileMatch{
 				LineMatches: lines,
 				Symbols:     symbols,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -321,6 +321,7 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, typ Ind
 	}
 
 	finalQuery := zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, queryExceptRepos)
+	// for globalSearches we set k = 1.
 	searchOpts := SearchOpts(ctx, 1, args.PatternInfo)
 
 	// Start event stream.
@@ -500,7 +501,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 
 	finalQuery := zoektquery.NewAnd(&zoektquery.RepoBranches{Set: repos.repoBranches}, queryExceptRepos)
 
-	k := ResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, false)
+	k := ResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit)
 	searchOpts := SearchOpts(ctx, k, args.PatternInfo)
 
 	// Start event stream.

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -409,11 +409,10 @@ func TestZoektIndexedRepos(t *testing.T) {
 
 func TestZoektResultCountFactor(t *testing.T) {
 	cases := []struct {
-		name         string
-		numRepos     int
-		globalSearch bool
-		pattern      *search.TextPatternInfo
-		want         int
+		name     string
+		numRepos int
+		pattern  *search.TextPatternInfo
+		want     int
 	}{
 		{
 			name:     "One repo implies max scaling factor",
@@ -439,24 +438,10 @@ func TestZoektResultCountFactor(t *testing.T) {
 			pattern:  &search.TextPatternInfo{FileMatchLimit: 100},
 			want:     10,
 		},
-		{
-			name:         "for global searches, k should be 1",
-			numRepos:     0,
-			globalSearch: true,
-			pattern:      &search.TextPatternInfo{},
-			want:         1,
-		},
-		{
-			name:         "for global searches, k should be 1, adjusted by the FileMatchLimit",
-			numRepos:     0,
-			globalSearch: true,
-			pattern:      &search.TextPatternInfo{FileMatchLimit: 100},
-			want:         10,
-		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ResultCountFactor(tt.numRepos, tt.pattern.FileMatchLimit, tt.globalSearch)
+			got := ResultCountFactor(tt.numRepos, tt.pattern.FileMatchLimit)
 			if tt.want != got {
 				t.Fatalf("Want scaling factor %d but got %d", tt.want, got)
 			}

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -90,30 +90,24 @@ func SearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt
 	return searchOpts
 }
 
-func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k int) {
-	if globalSearch {
-		// for globalSearch, numRepos = 0, but effectively we are searching over all
-		// indexed repos, hence k should be 1
+func ResultCountFactor(numRepos int, fileMatchLimit int32) (k int) {
+	// If we're only searching a small number of repositories, return more
+	// comprehensive results. This is arbitrary.
+	switch {
+	case numRepos <= 5:
+		k = 100
+	case numRepos <= 10:
+		k = 10
+	case numRepos <= 25:
+		k = 8
+	case numRepos <= 50:
+		k = 5
+	case numRepos <= 100:
+		k = 3
+	case numRepos <= 500:
+		k = 2
+	default:
 		k = 1
-	} else {
-		// If we're only searching a small number of repositories, return more
-		// comprehensive results. This is arbitrary.
-		switch {
-		case numRepos <= 5:
-			k = 100
-		case numRepos <= 10:
-			k = 10
-		case numRepos <= 25:
-			k = 8
-		case numRepos <= 50:
-			k = 5
-		case numRepos <= 100:
-			k = 3
-		case numRepos <= 500:
-			k = 2
-		default:
-			k = 1
-		}
 	}
 	if fileMatchLimit > search.DefaultMaxSearchResults {
 		k = int(float64(k) * 3 * float64(fileMatchLimit) / float64(search.DefaultMaxSearchResults))


### PR DESCRIPTION
This is a refactor of indexed_search.zoektSearch to
make upcoming changes to zoektSearch easier.

Currenty zoektSearch handles 4 cases:
1. scoped search w/ select:repo
2. scoped search w/o select:repo
3. global search w/ select:repo
4. global search w/o select:repo

This refactor splits zoektSearch into 2 separate functions, one
for scoped search and one for global search, zoektSearchGlobal.

In a next PR, we will rewrite the new zoektSearchGlobal completely
to leverage Zoekt's new visibility queries.