### PR TITLE
add repo rev to predicate evaluation

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1257,9 +1257,14 @@ func searchResultsToRepoNodes(matches []result.Match) ([]query.Node, error) {
 			return nil, errors.Errorf("expected type %T, but got %T", &result.RepoMatch{}, match)
 		}
 
+		repoFieldValue := "^" + regexp.QuoteMeta(string(repoMatch.Name)) + "$"
+		if repoMatch.Rev != "" {
+			repoFieldValue += "@" + repoMatch.Rev
+		}
+
 		nodes = append(nodes, query.Parameter{
 			Field: query.FieldRepo,
-			Value: "^" + regexp.QuoteMeta(string(repoMatch.Name)) + "$",
+			Value: repoFieldValue,
 		})
 	}
 
@@ -1276,6 +1281,11 @@ func searchResultsToFileNodes(matches []result.Match) ([]query.Node, error) {
 			return nil, errors.Errorf("expected type %T, but got %T", &result.FileMatch{}, match)
 		}
 
+		repoFieldValue := "^" + regexp.QuoteMeta(string(fileMatch.Repo.Name)) + "$"
+		if fileMatch.InputRev != nil {
+			repoFieldValue += "@" + *fileMatch.InputRev
+		}
+
 		// We create AND nodes to match both the repo and the file at the same time so
 		// we don't get files of the same name from different repositories.
 		nodes = append(nodes, query.Operator{
@@ -1283,7 +1293,7 @@ func searchResultsToFileNodes(matches []result.Match) ([]query.Node, error) {
 			Operands: []query.Node{
 				query.Parameter{
 					Field: query.FieldRepo,
-					Value: "^" + regexp.QuoteMeta(string(fileMatch.Repo.Name)) + "$",
+					Value: repoFieldValue,
 				},
 				query.Parameter{
 					Field: query.FieldFile,

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -964,3 +964,89 @@ func TestIsContextError(t *testing.T) {
 		})
 	}
 }
+
+func Test_searchResultsToRepoNodes(t *testing.T) {
+	cases := []struct {
+		matches []result.Match
+		res     string
+		err     string
+	}{{
+		matches: []result.Match{
+			&result.RepoMatch{Name: "repo_a"},
+		},
+		res: `"repo:^repo_a$"`,
+	}, {
+		matches: []result.Match{
+			&result.RepoMatch{Name: "repo_a", Rev: "main"},
+		},
+		res: `"repo:^repo_a$@main"`,
+	}, {
+		matches: []result.Match{
+			&result.FileMatch{},
+		},
+		err: "expected type",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.res, func(t *testing.T) {
+			nodes, err := searchResultsToRepoNodes(tc.matches)
+			if err != nil {
+				require.Contains(t, err.Error(), tc.err)
+				return
+			}
+			require.Equal(t, tc.res, query.Q(nodes).String())
+		})
+	}
+}
+
+func Test_searchResultsToFileNodes(t *testing.T) {
+	cases := []struct {
+		matches []result.Match
+		res     string
+		err     string
+	}{{
+		matches: []result.Match{
+			&result.FileMatch{
+				File: result.File{
+					Repo: types.MinimalRepo{
+						Name: "repo_a",
+					},
+					Path: "my/file/path.txt",
+				},
+			},
+		},
+		res: `(and "repo:^repo_a$" "file:^my/file/path\\.txt$")`,
+	}, {
+		matches: []result.Match{
+			&result.FileMatch{
+				File: result.File{
+					Repo: types.MinimalRepo{
+						Name: "repo_a",
+					},
+					InputRev: func() *string { s := "main"; return &s }(),
+					Path:     "my/file/path1.txt",
+				},
+			},
+			&result.FileMatch{
+				File: result.File{
+					Repo: types.MinimalRepo{
+						Name: "repo_b",
+					},
+					Path: "my/file/path2.txt",
+				},
+			},
+		},
+		res: `(and "repo:^repo_a$@main" "file:^my/file/path1\\.txt$") (and "repo:^repo_b$" "file:^my/file/path2\\.txt$")`,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.res, func(t *testing.T) {
+			nodes, err := searchResultsToFileNodes(tc.matches)
+			if err != nil {
+				require.Contains(t, err.Error(), tc.err)
+				return
+			}
+			require.Equal(t, tc.res, query.Q(nodes).String())
+		})
+	}
+}


### PR DESCRIPTION
Previously, if a predicate evaluated to a match with a specific repo
rev, the rev would not be added to the expanded query. In practice, 
I don't think this could ever be hit because, if a repo rev was specified, 
the rev filter would apply after the predicate was evaluated as well, 
returning only results that matched the predicate-evaluated repo and 
the original revision-narrowed repo.

That said, there may be cases in the future where predicates can
evaluate to specific revisions of a repo, and fixing this now will save
some headaches down the road.

RE: https://github.com/sourcegraph/sourcegraph/pull/22666#discussion_r666037596
