### PR TITLE
modify sg service role migration

### DIFF
--- a/migrations/frontend/1528395840_create_sg_service_role.up.sql
+++ b/migrations/frontend/1528395840_create_sg_service_role.up.sql
@@ -10,10 +10,13 @@ BEGIN
     GRANT USAGE ON SCHEMA public TO sg_service;
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO sg_service;
     GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO sg_service;
-EXCEPTION WHEN duplicate_object THEN
+EXCEPTION 
+	WHEN duplicate_object THEN
     -- Roles are cluster-wide, which makes them visible to both real and test
     -- code. The test runners may effectively execute this code multiple times,
     -- so if the role happens to exist, we just ignore it.
+	WHEN unique_violation THEN
+    -- Same as above.
 END;
 $$;
 


### PR DESCRIPTION
This migration was causing issues when running tests in parallel because
it would occasionally throw a unique_violation exception. This commit
modifies an existing migration because we want to ignore an additional
exception when running the migration, but this change does not affect
any already-migrated databases.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
