### PR TITLE
dx: Fix test cockroachdb/errors

### DIFF
--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -157,7 +156,7 @@ func TestRepos_ResolveRev_commitIDSpecified_failsToResolve(t *testing.T) {
 	defer git.ResetMocks()
 
 	_, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
-	if !reflect.DeepEqual(err, want) {
+	if !errors.Is(err, want) {
 		t.Fatalf("got err %v, want %v", err, want)
 	}
 	if calledRepoLookup {

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -52,7 +51,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
 			return &types.User{ID: 1, SiteAdmin: false}, nil
 		}
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 				Schema:  mustParseGraphQLSchema(t),
@@ -117,7 +116,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		}
 		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 				Schema:  mustParseGraphQLSchema(t),
@@ -150,7 +149,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		}
 		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: differentSiteAdminUID}),
 				Schema:  mustParseGraphQLSchema(t),
@@ -163,7 +162,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 				}
 			`,
 				ExpectedResult: `null`,
-				ExpectedErrors: []*errors.QueryError{
+				ExpectedErrors: []*gqlerrors.QueryError{
 					{
 						Path:          []interface{}{"createAccessToken"},
 						Message:       "Must be authenticated as user with id 1",
@@ -186,7 +185,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		conf.Get().AuthAccessTokens = &schema.AuthAccessTokens{Allow: string(conf.AccessTokensAdmin)}
 		defer func() { conf.Get().AuthAccessTokens = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: differentSiteAdminUID}),
 				Schema:  mustParseGraphQLSchema(t),
@@ -304,7 +303,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
 			return &types.User{ID: 1, SiteAdmin: false}, nil
 		}
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
 				Schema:  mustParseGraphQLSchema(t),
@@ -335,7 +334,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		}
 		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: differentSiteAdminUID}),
 				Schema:  mustParseGraphQLSchema(t),

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -10,8 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -229,7 +228,7 @@ func TestAddExternalService(t *testing.T) {
 		database.Mocks.ExternalServices = database.MockExternalServices{}
 	})
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -417,7 +416,7 @@ func TestUpdateExternalService(t *testing.T) {
 		database.Mocks.ExternalServices = database.MockExternalServices{}
 	})
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -553,7 +552,7 @@ func TestDeleteExternalService(t *testing.T) {
 		database.Mocks.ExternalServices = database.MockExternalServices{}
 	})
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -688,7 +687,7 @@ func TestExternalServices(t *testing.T) {
 	}()
 
 	// NOTE: all these tests run as site admin
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		// Read all external services
 		{
 			Schema: mustParseGraphQLSchema(t),
@@ -721,7 +720,7 @@ func TestExternalServices(t *testing.T) {
 				}
 			}
 		`,
-			ExpectedErrors: []*errors.QueryError{
+			ExpectedErrors: []*gqlerrors.QueryError{
 				{
 					Path:          []interface{}{"externalServices"},
 					Message:       errNoAccessExternalService.Error(),

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/graph-gophers/graphql-go/gqltesting"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -131,7 +130,7 @@ func TestGitCommitFileNames(t *testing.T) {
 
 	defer git.ResetMocks()
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -58,7 +56,7 @@ func TestGitTree(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -52,7 +51,7 @@ func BenchmarkPrometheusFieldName(b *testing.B) {
 func TestRepository(t *testing.T) {
 	resetMocks()
 	database.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -231,7 +230,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 		UID: 1,
 	})
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Context: ctx,
 			Schema:  mustParseGraphQLSchema(t),
@@ -280,7 +279,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 		UID: 2,
 	})
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Context: ctx,
 			Schema:  mustParseGraphQLSchema(t),
@@ -333,7 +332,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 		}, nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Context: ctx,
 			Schema:  mustParseGraphQLSchema(t),

--- a/cmd/frontend/graphqlbackend/namespaces_test.go
+++ b/cmd/frontend/graphqlbackend/namespaces_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -23,7 +22,7 @@ func TestNamespace(t *testing.T) {
 			}
 			return &types.User{ID: wantUserID, Username: "alice"}, nil
 		}
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -55,7 +54,7 @@ func TestNamespace(t *testing.T) {
 			}
 			return &types.Org{ID: wantOrgID, Name: "acme"}, nil
 		}
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -84,7 +83,7 @@ func TestNamespace(t *testing.T) {
 		invalidID := "aW52YWxpZDoz"
 		wantErr := InvalidNamespaceIDErr{id: graphql.ID(invalidID)}
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: fmt.Sprintf(`
@@ -101,8 +100,8 @@ func TestNamespace(t *testing.T) {
 			`,
 				ExpectedErrors: []*gqlerrors.QueryError{
 					{
-						Message:       wantErr.Error(),
 						Path:          []interface{}{"namespace"},
+						Message:       wantErr.Error(),
 						ResolverError: wantErr,
 					},
 				},
@@ -130,7 +129,7 @@ func TestNamespaceByName(t *testing.T) {
 			}
 			return &types.User{ID: wantUserID, Username: wantName}, nil
 		}
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -171,7 +170,7 @@ func TestNamespaceByName(t *testing.T) {
 			}
 			return &types.Org{ID: wantOrgID, Name: "acme"}, nil
 		}
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -199,7 +198,7 @@ func TestNamespaceByName(t *testing.T) {
 		database.Mocks.Namespaces.GetByName = func(ctx context.Context, name string) (*database.Namespace, error) {
 			return nil, database.ErrNamespaceNotFound
 		}
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -16,7 +14,7 @@ func TestOrganization(t *testing.T) {
 		return &types.Org{ID: 1, Name: "acme"}, nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -41,7 +39,7 @@ func TestNode_Org(t *testing.T) {
 	resetMocks()
 	database.Mocks.Orgs.MockGetByID_Return(t, &types.Org{ID: 1, Name: "acme"}, nil)
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -19,7 +17,7 @@ func TestOrgs(t *testing.T) {
 		return []*types.Org{{Name: "org1"}, {Name: "org2"}}, nil
 	}
 	database.Mocks.Orgs.Count = func(context.Context, database.OrgsListOptions) (int, error) { return 2, nil }
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -2,11 +2,10 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/errors"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -43,7 +42,7 @@ func TestRepositories(t *testing.T) {
 		}, nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -86,7 +85,7 @@ func TestRepositories(t *testing.T) {
 		}, nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -245,7 +244,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 		}
 		defer func() { database.Mocks.Repos.List = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -282,7 +281,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 		}
 		defer func() { database.Mocks.Repos.List = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -319,7 +318,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 		}
 		defer func() { database.Mocks.Repos.List = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -356,7 +355,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 		}
 		defer func() { database.Mocks.Repos.List = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -397,7 +396,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 		}
 		defer func() { database.Mocks.Repos.List = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -432,7 +431,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 		}
 		defer func() { database.Mocks.Repos.List = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -450,9 +449,9 @@ func TestRepositories_CursorPagination(t *testing.T) {
 				ExpectedResult: "null",
 				ExpectedErrors: []*gqlerrors.QueryError{
 					{
-						ResolverError: errors.New(`cannot unmarshal repository cursor type: ""`),
-						Message:       `cannot unmarshal repository cursor type: ""`,
 						Path:          []interface{}{"repositories"},
+						Message:       `cannot unmarshal repository cursor type: ""`,
+						ResolverError: fmt.Errorf(`cannot unmarshal repository cursor type: ""`),
 					},
 				},
 			},

--- a/cmd/frontend/graphqlbackend/repository_mirror_test.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror_test.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -40,7 +38,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 		}
 		defer func() { gitserver.MockIsRepoCloneable = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -81,7 +79,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 		}
 		defer func() { gitserver.MockIsRepoCloneable = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `
@@ -199,7 +197,7 @@ func TestCheckMirrorRepositoryRemoteURL(t *testing.T) {
 			}
 			defer func() { repoupdater.MockRepoLookup = nil }()
 
-			gqltesting.RunTests(t, []*gqltesting.Test{
+			RunTests(t, []*Test{
 				{
 					Schema: mustParseGraphQLSchema(t),
 					Query: `

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -34,7 +33,7 @@ func TestRepository_Commit(t *testing.T) {
 	}
 	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &git.Commit{ID: exampleCommitSHA1})
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -84,7 +82,7 @@ func TestSetExternalServiceRepos(t *testing.T) {
 		repoupdater.DefaultClient.HTTPClient = oldClient
 	}()
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Context: ctx,
 			Schema:  mustParseGraphQLSchema(t),

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -34,7 +32,7 @@ func TestSettingsMutation_EditSettings(t *testing.T) {
 		return &api.Settings{ID: 2, Contents: contents}, nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 			Schema:  mustParseGraphQLSchema(t),
@@ -81,7 +79,7 @@ func TestSettingsMutation_OverwriteSettings(t *testing.T) {
 		return &api.Settings{ID: 2, Contents: contents}, nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 			Schema:  mustParseGraphQLSchema(t),

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/gqltesting"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -116,11 +115,11 @@ func TestDeleteUser(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		gqlTests []*gqltesting.Test
+		gqlTests []*Test
 	}{
 		{
 			name: "soft delete a user",
-			gqlTests: []*gqltesting.Test{
+			gqlTests: []*Test{
 				{
 					Schema: mustParseGraphQLSchema(t),
 					Query: `
@@ -142,7 +141,7 @@ func TestDeleteUser(t *testing.T) {
 		},
 		{
 			name: "hard delete a user",
-			gqlTests: []*gqltesting.Test{
+			gqlTests: []*Test{
 				{
 					Schema: mustParseGraphQLSchema(t),
 					Query: `
@@ -165,7 +164,7 @@ func TestDeleteUser(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gqltesting.RunTests(t, test.gqlTests)
+			RunTests(t, test.gqlTests)
 		})
 	}
 }

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
@@ -66,7 +64,7 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { repos.MockStatusMessages = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query:  graphqlQuery,
@@ -118,7 +116,7 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { repos.MockStatusMessages = nil }()
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query:  graphqlQuery,

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/errors"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 )
 
 var (
@@ -47,7 +47,7 @@ type Test struct {
 	OperationName  string
 	Variables      map[string]interface{}
 	ExpectedResult string
-	ExpectedErrors []*errors.QueryError
+	ExpectedErrors []*gqlerrors.QueryError
 }
 
 // RunTests runs the given GraphQL test cases as subtests.
@@ -112,19 +112,19 @@ func formatJSON(data []byte) ([]byte, error) {
 	return formatted, nil
 }
 
-func checkErrors(t *testing.T, want, got []*errors.QueryError) {
+func checkErrors(t *testing.T, want, got []*gqlerrors.QueryError) {
 	t.Helper()
 
 	sortErrors(want)
 	sortErrors(got)
 
 	// Compare without caring about the concrete type of the error returned
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(errors.QueryError{}, "ResolverError")); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(gqlerrors.QueryError{}, "ResolverError")); diff != "" {
 		t.Fatal(diff)
 	}
 }
 
-func sortErrors(errors []*errors.QueryError) {
+func sortErrors(errors []*gqlerrors.QueryError) {
 	if len(errors) <= 1 {
 		return
 	}

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -23,7 +22,7 @@ func TestUser(t *testing.T) {
 	t.Run("by username", func(t *testing.T) {
 		checkUserByUsername := func(t *testing.T) {
 			t.Helper()
-			gqltesting.RunTests(t, []*gqltesting.Test{
+			RunTests(t, []*Test{
 				{
 					Schema: mustParseGraphQLSchema(t),
 					Query: `
@@ -77,7 +76,7 @@ func TestUser(t *testing.T) {
 		t.Run("disallowed on Sourcegraph.com", func(t *testing.T) {
 			checkUserByEmailError := func(t *testing.T, wantErr string) {
 				t.Helper()
-				gqltesting.RunTests(t, []*gqltesting.Test{
+				RunTests(t, []*Test{
 					{
 						Schema: mustParseGraphQLSchema(t),
 						Query: `
@@ -88,7 +87,13 @@ func TestUser(t *testing.T) {
 				}
 			`,
 						ExpectedResult: `{"user": null}`,
-						ExpectedErrors: []*gqlerrors.QueryError{{Message: wantErr, Path: []interface{}{"user"}, ResolverError: errors.New(wantErr)}},
+						ExpectedErrors: []*gqlerrors.QueryError{
+							{
+								Path:          []interface{}{"user"},
+								Message:       wantErr,
+								ResolverError: errors.New(wantErr),
+							},
+						},
 					},
 				})
 			}
@@ -112,7 +117,7 @@ func TestUser(t *testing.T) {
 		})
 
 		t.Run("allowed on non-Sourcegraph.com", func(t *testing.T) {
-			gqltesting.RunTests(t, []*gqltesting.Test{
+			RunTests(t, []*Test{
 				{
 					Schema: mustParseGraphQLSchema(t),
 					Query: `
@@ -139,7 +144,7 @@ func TestNode_User(t *testing.T) {
 	resetMocks()
 	database.Mocks.Users.MockGetByID_Return(t, &types.User{ID: 1, Username: "alice"}, nil)
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `
@@ -265,7 +270,7 @@ func TestUpdateUser(t *testing.T) {
 			database.Mocks.Users = database.MockUsers{}
 		})
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 				Schema:  mustParseGraphQLSchema(t),
@@ -307,7 +312,7 @@ func TestUpdateUser(t *testing.T) {
 			database.Mocks.Users = database.MockUsers{}
 		})
 
-		gqltesting.RunTests(t, []*gqltesting.Test{
+		RunTests(t, []*Test{
 			{
 				Schema: mustParseGraphQLSchema(t),
 				Query: `

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -3,8 +3,6 @@ package graphqlbackend
 import (
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -19,7 +17,7 @@ func TestUser_UsageStatistics(t *testing.T) {
 		}, nil
 	}
 	defer func() { usagestatsdeprecated.MockGetByUserID = nil }()
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/users_create_test.go
+++ b/cmd/frontend/graphqlbackend/users_create_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -25,7 +23,7 @@ func TestCreateUser(t *testing.T) {
 		return nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/gqltesting"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -19,7 +17,7 @@ func TestUsers(t *testing.T) {
 		return []*types.User{{Username: "user1"}, {Username: "user2"}}, nil
 	}
 	database.Mocks.Users.Count = func(context.Context, *database.UsersListOptions) (int, error) { return 2, nil }
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/internal/sysreq/sysreq.go
+++ b/internal/sysreq/sysreq.go
@@ -2,9 +2,10 @@
 package sysreq
 
 import (
+	"context"
 	"strings"
 
-	"context"
+	"github.com/cockroachdb/errors"
 )
 
 // Status describes the status of a system requirement.
@@ -14,6 +15,13 @@ type Status struct {
 	Fix     string // if non-empty, how to fix the problem
 	Err     error  // if non-nil, the error encountered
 	Skipped bool   // if true, indicates this check was skipped
+}
+
+// Equals returns true if other has the same fields as the receiver.
+// Used for testing as we don't want to DeepEqual or cmp.Diff structs
+// holding error values.
+func (s Status) Equals(other Status) bool {
+	return s.Name == other.Name && s.Problem == other.Problem && s.Fix == other.Fix && errors.Is(s.Err, other.Err) && s.Skipped == other.Skipped
 }
 
 // OK is whether the component is present, has no errors, and was not

--- a/internal/sysreq/sysreq_test.go
+++ b/internal/sysreq/sysreq_test.go
@@ -2,7 +2,6 @@ package sysreq
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -18,9 +17,13 @@ func TestCheck(t *testing.T) {
 		},
 	}
 	st := Check(context.Background(), nil)
-	want := []Status{{Name: "a", Err: errors.New("foo")}}
-	if !reflect.DeepEqual(st, want) {
-		t.Errorf("got %v, want %v", st, want)
+	if len(st) != 1 {
+		t.Fatalf("unexpected number of statuses. want=%d have=%d", 1, len(st))
+	}
+
+	want := Status{Name: "a", Err: errors.New("foo")}
+	if !st[0].Equals(want) {
+		t.Errorf("got %v, want %v", st[0], want)
 	}
 }
 
@@ -34,8 +37,12 @@ func TestCheck_skip(t *testing.T) {
 		},
 	}
 	st := Check(context.Background(), []string{"A"})
-	want := []Status{{Name: "a", Skipped: true}}
-	if !reflect.DeepEqual(st, want) {
-		t.Errorf("got %v, want %v", st, want)
+	if len(st) != 1 {
+		t.Fatalf("unexpected number of statuses. want=%d have=%d", 1, len(st))
+	}
+
+	want := Status{Name: "a", Skipped: true}
+	if !st[0].Equals(want) {
+		t.Errorf("got %v, want %v", st[0], want)
 	}
 }


### PR DESCRIPTION
Fixes unit tests that incorrectly compared error values. The `graphqlbackend` package had an internal copy of the gqltesting library we used (with the proper fix), so we can just use that everywhere.