### PR TITLE
batches: refactor `DiffStat` API to support independent composition of stats + squares

### DIFF
--- a/client/web/src/components/diff/DiffStat.scss
+++ b/client/web/src/components/diff/DiffStat.scss
@@ -2,10 +2,9 @@
     display: inline-flex;
     align-items: center;
 
-    &__total {
-        padding-right: 0.125rem;
-        // stylelint-disable-next-line declaration-property-unit-whitelist
-        margin-bottom: -1px;
+    &__squares {
+        display: flex;
+        flex-wrap: nowrap;
     }
 
     &__square {

--- a/client/web/src/components/diff/DiffStat.story.tsx
+++ b/client/web/src/components/diff/DiffStat.story.tsx
@@ -1,32 +1,36 @@
+import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
 import { WebStory } from '../WebStory'
 
-import { DiffStat, DiffStatStack } from './DiffStat'
+import { DiffStat, DiffStatSquares, DiffStatStack } from './DiffStat'
+
+const getSharedKnobs = () => ({
+    added: number('Added', 10),
+    changed: number('Changed', 4),
+    deleted: number('Deleted', 8),
+})
 
 const { add } = storiesOf('web/diffs/DiffStat', module).addDecorator(story => (
     <div className="p-3 container">{story()}</div>
 ))
 
-add('Collapsed', () => (
-    <WebStory>
-        {() => (
-            <div>
-                <DiffStat added={10} changed={4} deleted={8} />
-            </div>
-        )}
-    </WebStory>
-))
+add('Collapsed counts', () => {
+    const stats = getSharedKnobs()
+    return <WebStory>{() => <DiffStat {...stats} />}</WebStory>
+})
 
-add('Expanded', () => (
-    <WebStory>
-        {() => (
-            <div>
-                <DiffStat added={10} changed={4} deleted={8} expandedCounts={true} />
-            </div>
-        )}
-    </WebStory>
-))
+add('Expanded counts', () => {
+    const stats = getSharedKnobs()
+    return <WebStory>{() => <DiffStat {...stats} expandedCounts={true} />}</WebStory>
+})
 
-add('DiffStatStack', () => <WebStory>{() => <DiffStatStack added={10} changed={4} deleted={8} />}</WebStory>)
+add('DiffStatSquares', () => {
+    const stats = getSharedKnobs()
+    return <WebStory>{() => <DiffStatSquares {...stats} />}</WebStory>
+})
+add('DiffStatStack', () => {
+    const stats = getSharedKnobs()
+    return <WebStory>{() => <DiffStatStack {...stats} />}</WebStory>
+})

--- a/client/web/src/components/diff/DiffStat.story.tsx
+++ b/client/web/src/components/diff/DiffStat.story.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { WebStory } from '../WebStory'
 
-import { DiffStat } from './DiffStat'
+import { DiffStat, DiffStatStack } from './DiffStat'
 
 const { add } = storiesOf('web/diffs/DiffStat', module).addDecorator(story => (
     <div className="p-3 container">{story()}</div>
@@ -29,12 +29,4 @@ add('Expanded', () => (
     </WebStory>
 ))
 
-add('Separate lines', () => (
-    <WebStory>
-        {() => (
-            <div>
-                <DiffStat added={10} changed={4} deleted={8} expandedCounts={true} separateLines={true} />
-            </div>
-        )}
-    </WebStory>
-))
+add('DiffStatStack', () => <WebStory>{() => <DiffStatStack added={10} changed={4} deleted={8} />}</WebStory>)

--- a/client/web/src/components/diff/DiffStat.test.tsx
+++ b/client/web/src/components/diff/DiffStat.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 
-import { DiffStat } from './DiffStat'
+import { DiffStat, DiffStatSquares, DiffStatStack } from './DiffStat'
 
 describe('DiffStat', () => {
     test('standard', () =>
@@ -12,3 +12,9 @@ describe('DiffStat', () => {
             renderer.create(<DiffStat added={1} changed={2} deleted={3} expandedCounts={true} />).toJSON()
         ).toMatchSnapshot())
 })
+
+test('DiffStatSquares', () =>
+    expect(renderer.create(<DiffStatSquares added={1} changed={2} deleted={3} />).toJSON()).toMatchSnapshot())
+
+test('DiffStatStack', () =>
+    expect(renderer.create(<DiffStatStack added={1} changed={2} deleted={3} />).toJSON()).toMatchSnapshot())

--- a/client/web/src/components/diff/FileDiffNode.scss
+++ b/client/web/src/components/diff/FileDiffNode.scss
@@ -48,9 +48,6 @@
                 font-size: 0.875rem;
             }
         }
-        &-stat {
-            margin-right: 0.5rem;
-        }
 
         &-actions {
             // unset from .card-header

--- a/client/web/src/components/diff/FileDiffNode.tsx
+++ b/client/web/src/components/diff/FileDiffNode.tsx
@@ -15,7 +15,7 @@ import { FileDiffFields } from '../../graphql-operations'
 import { DiffMode } from '../../repo/commit/RepositoryCommitPage'
 import { dirname } from '../../util/path'
 
-import { DiffStat } from './DiffStat'
+import { DiffStat, DiffStatSquares } from './DiffStat'
 import { ExtensionInfo } from './FileDiffConnection'
 import { FileDiffHunks } from './FileDiffHunks'
 
@@ -81,15 +81,13 @@ export const FileDiffNode: React.FunctionComponent<FileDiffNodeProps> = ({
     if (node.oldFile?.binary || node.newFile?.binary) {
         const sizeChange = (node.newFile?.byteSize ?? 0) - (node.oldFile?.byteSize ?? 0)
         const className = sizeChange >= 0 ? 'text-success' : 'text-danger'
-        stat = <strong className={classnames(className, 'mr-2 code')}>{prettyBytes(sizeChange)}</strong>
+        stat = <strong className={classnames(className, 'code')}>{prettyBytes(sizeChange)}</strong>
     } else {
         stat = (
-            <DiffStat
-                added={node.stat.added}
-                changed={node.stat.changed}
-                deleted={node.stat.deleted}
-                className="file-diff-node__header-stat"
-            />
+            <>
+                <DiffStat className="mr-1" {...node.stat} />
+                <DiffStatSquares {...node.stat} />
+            </>
         )
     }
 
@@ -118,7 +116,7 @@ export const FileDiffNode: React.FunctionComponent<FileDiffNodeProps> = ({
                             </span>
                         )}
                         {stat}
-                        <Link to={{ ...location, hash: anchor }} className="file-diff-node__header-path">
+                        <Link to={{ ...location, hash: anchor }} className="file-diff-node__header-path ml-2">
                             {path}
                         </Link>
                     </div>

--- a/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
@@ -5,45 +5,24 @@ exports[`DiffStat expandedCounts 1`] = `
   className="diff-stat"
   data-tooltip="1 addition, 2 changes, 3 deletions"
 >
-  <span
-    className="diff-stat__total font-weight-bold"
+  <strong
+    className="text-success mr-1"
   >
-    <span
-      className="text-success mr-1"
-    >
-      +
-      1
-    </span>
-    <span
-      className="text-warning mr-1"
-    >
-      •
-      2
-    </span>
-    <span
-      className="text-danger mr-1"
-    >
-      −
-      3
-    </span>
-  </span>
-  <div>
-    <div
-      className="diff-stat__square bg-success"
-    />
-    <div
-      className="diff-stat__square bg-warning"
-    />
-    <div
-      className="diff-stat__square bg-danger"
-    />
-    <div
-      className="diff-stat__square bg-danger"
-    />
-    <div
-      className="diff-stat__square bg-danger"
-    />
-  </div>
+    +
+    1
+  </strong>
+  <strong
+    className="text-warning mr-1"
+  >
+    •
+    2
+  </strong>
+  <strong
+    className="text-danger"
+  >
+    −
+    3
+  </strong>
 </div>
 `;
 
@@ -52,12 +31,64 @@ exports[`DiffStat standard 1`] = `
   className="diff-stat"
   data-tooltip="1 addition, 2 changes, 3 deletions"
 >
-  <small
-    className="diff-stat__total"
-  >
+  <small>
     8
   </small>
-  <div>
+</div>
+`;
+
+exports[`DiffStatSquares 1`] = `
+<div
+  className="diff-stat__squares"
+>
+  <div
+    className="diff-stat__square bg-success"
+  />
+  <div
+    className="diff-stat__square bg-warning"
+  />
+  <div
+    className="diff-stat__square bg-danger"
+  />
+  <div
+    className="diff-stat__square bg-danger"
+  />
+  <div
+    className="diff-stat__square bg-danger"
+  />
+</div>
+`;
+
+exports[`DiffStatStack 1`] = `
+<div
+  className="d-flex flex-column align-items-center"
+>
+  <div
+    className="diff-stat pb-1"
+    data-tooltip="1 addition, 2 changes, 3 deletions"
+  >
+    <strong
+      className="text-success mr-1"
+    >
+      +
+      1
+    </strong>
+    <strong
+      className="text-warning mr-1"
+    >
+      •
+      2
+    </strong>
+    <strong
+      className="text-danger"
+    >
+      −
+      3
+    </strong>
+  </div>
+  <div
+    className="diff-stat__squares"
+  >
     <div
       className="diff-stat__square bg-success"
     />

--- a/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.tsx
+++ b/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.tsx
@@ -12,7 +12,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { ErrorAlert } from '../../../components/alerts'
-import { DiffStat } from '../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { ExternalChangesetFields } from '../../../graphql-operations'
 import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
 import { ChangesetCheckStatusCell } from '../detail/changesets/ChangesetCheckStatusCell'
@@ -87,7 +87,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
             >
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} className="mr-3" />}
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             <span className="d-none d-md-inline">
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}
@@ -96,7 +96,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}
             </span>
             <div className="d-none d-md-flex justify-content-center">
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             {/* The button for expanding the information used on xs devices. */}
             <button

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
-import { DiffStat } from '../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { BatchChangeFields, ChangesetsStatsFields, DiffStatFields } from '../../../graphql-operations'
 
 import { BatchChangeStateBadge } from './BatchChangeStateBadge'
@@ -61,12 +61,7 @@ export const BatchChangeStatsCard: React.FunctionComponent<BatchChangeStatsCardP
                     </span>
                 </div>
                 <div className={classNames(styles.batchChangeStatsCardDivider, 'd-none d-md-block mx-3')} />
-                <DiffStat
-                    {...diff}
-                    expandedCounts={true}
-                    separateLines={true}
-                    className={styles.batchChangeStatsCardDiffStat}
-                />
+                <DiffStatStack className={styles.batchChangeStatsCardDiffStat} {...diff} />
                 <div className="d-flex flex-wrap justify-content-end flex-grow-1">
                     <BatchChangeStatsTotalAction count={stats.total} />
                     <ChangesetStatusUnpublished

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -15,7 +15,7 @@ import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { ErrorAlert, ErrorMessage } from '../../../../components/alerts'
-import { DiffStat } from '../../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../../components/diff/DiffStat'
 import { ChangesetSpecType, ExternalChangesetFields } from '../../../../graphql-operations'
 import {
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
@@ -125,7 +125,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
             >
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} className="mr-3" />}
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             <span
                 className={classNames(
@@ -149,7 +149,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                     node.diffStat && 'p-2'
                 )}
             >
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
+                {node.diffStat && <DiffStatStack {...node.diffStat} />}
             </div>
             {/* The button for expanding the information used on xs devices. */}
             <button

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React from 'react'
 
-import { DiffStat } from '../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { BatchSpecFields } from '../../../graphql-operations'
 
 import styles from './BatchChangePreviewStatsBar.module.scss'
@@ -32,12 +32,7 @@ export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePrev
             <span className="badge badge-info text-uppercase mb-0">Preview</span>
         </h2>
         <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-sm-block mx-3')} />
-        <DiffStat
-            {...batchSpec.diffStat}
-            separateLines={true}
-            expandedCounts={true}
-            className={styles.batchChangePreviewStatsBarDiff}
-        />
+        <DiffStatStack className={styles.batchChangePreviewStatsBarDiff} {...batchSpec.diffStat} />
         <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-sm-none my-3')} />
         <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'mx-3 d-none d-sm-block d-md-none')} />
         <div className={classNames(styles.batchChangePreviewStatsBarMetrics, 'flex-grow-1 d-flex justify-content-end')}>

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -12,7 +12,7 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { Maybe } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { DiffStat } from '../../../../components/diff/DiffStat'
+import { DiffStatStack } from '../../../../components/diff/DiffStat'
 import { FileDiffConnection } from '../../../../components/diff/FileDiffConnection'
 import { FileDiffNode } from '../../../../components/diff/FileDiffNode'
 import { FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
@@ -531,7 +531,7 @@ const ApplyDiffStat: React.FunctionComponent<{ spec: VisibleChangesetApplyPrevie
     } else {
         diffStat = spec.targets.changesetSpec.description.diffStat
     }
-    return <DiffStat {...diffStat} expandedCounts={true} separateLines={true} />
+    return <DiffStatStack {...diffStat} />
 }
 
 const VisibleChangesetApplyPreviewNodeStatusCell: React.FunctionComponent<


### PR DESCRIPTION
Pulled out a minor refactor from #22372 of the `DiffStat` component API that made it easier to leverage this component on the new repo batch changes page, in order to make it easier for reviewing. 🙂 While we don't technically own this component, we're *almost* the sole users of it.

This component has proven very versatile in a bunch of different places, so this PR attempts to elevate it to the NEXT LEVEL™.

This PR:
- Separates `DiffStat` into two pieces: `DiffStat` (the actual stats numbers) and `DiffStatSquares` (the visual representation of the stats)
- Removes CSS controlling the container's layout, padding, and margin from the `DiffStat` components themselves, leaving them up to the implementers
- Removes the `separateLines` prop for the same reason, and to prevent combining `separateLines: true` with `expandedCounts: false` into a form that wasn't technically supported
- Adds `DiffStatStack` as a specific, commonly-used composition of `DiffStat` and `DiffStatSquares` that produces the two-line stack we're most familiar with in the batch changes area:
	<img width="97" alt="Screen Shot 2021-07-08 at 3 11 44 PM" src="https://user-images.githubusercontent.com/8942601/124997034-d13c2880-dffe-11eb-9bc7-f9f5c9967e32.png">
- Improves the stories for this set of components, including adding knobs!

This work inadvertently fixed two minor visual problems, as well. 😅

Before | After
:-----:|:-----:
![image](https://user-images.githubusercontent.com/8942601/124998305-06e21100-e001-11eb-8cd3-ca00943eb113.png) (squares kinda low) | ![image](https://user-images.githubusercontent.com/8942601/124998341-16615a00-e001-11eb-8439-c05349235cc6.png) (squares juuuussst right)

At some point I saw the expanded counts diff stat wrap onto a second line when it was too long, which also was no good. I can't remember where I was when I saw that, and I can't seem to repro it now that I am *trying* to, but this PR prevents that from happening, now, too.

I don't know if we still use snapshot tests around here (I seem to remember some discussion of getting rid of them), but I updated those just in case.