### PR TITLE
search: require 'repo:' for 'rev:' filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Backend Code Insights only fills historical data frames that have changed to reduce the number of searches required. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
 - Backend Code Insights displays data points for a fixed 6 months period in 2 week intervals, and will carry observations forward that are missing. [#22298](https://github.com/sourcegraph/sourcegraph/pull/22298)
 - Backend Code Insights now aggregate over 26 weeks instead of 6 months. [#22527](https://github.com/sourcegraph/sourcegraph/pull/22527)
+- Search queries now disallow specifying `rev:` without `repo:`. Note that to search across potentially multiple revisions, a query like `repo:.* rev:<revision>` remains valid. [#22705](https://github.com/sourcegraph/sourcegraph/pull/22705)
 
 ### Fixed
 

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -72,6 +72,14 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			want:  "invalid syntax. You specified both @ and rev: for a repo: filter and I don't know how to interpret this. Remove either @ or rev: and try again",
 		},
 		{
+			input: "rev:this is a good channel",
+			want:  "invalid syntax. The query contains `rev:` without `repo:`. Add a `repo:` filter and try again",
+		},
+		{
+			input: `repo:'' rev:bedge`,
+			want:  "invalid syntax. The query contains `rev:` without `repo:`. Add a `repo:` filter and try again",
+		},
+		{
 			input: "repo:foo author:rob@saucegraph.com",
 			want:  `your query contains the field 'author', which requires type:commit or type:diff in the query`,
 		},


### PR DESCRIPTION
Fixes #22693.

As noted in that issue, this does not fix whatever the backend logic is doing that causes us to return results for an empty repo value and a non-empty revision. In particular, this validation does not solve the cases where you may specify, e.g.,:

- `repo:^$hash`

This one is a bit silly to validate and it's unlikely that a user tries this. I did add logic for another way to trigger this, which is `repo:"" stuff`, but I think it's super unlikely that a user actually tries this one as well, so the value is a little dubious. 