### PR TITLE
search: lift search limits out of repo package into search package

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1259,7 +1259,7 @@ var (
 
 func withTimeout(ctx context.Context, q query.Q) (context.Context, context.CancelFunc, error) {
 	d := defaultTimeout
-	maxTimeout := time.Duration(searchrepos.SearchLimits().MaxTimeoutSeconds) * time.Second
+	maxTimeout := time.Duration(search.SearchLimits().MaxTimeoutSeconds) * time.Second
 	timeout := q.Timeout()
 	if timeout != nil {
 		d = *timeout

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -46,7 +46,7 @@ func assertEqual(t *testing.T, got, want interface{}) {
 func TestSearchResults(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	limitOffset := &database.LimitOffset{Limit: searchrepos.SearchLimits().MaxRepos + 1}
+	limitOffset := &database.LimitOffset{Limit: search.SearchLimits().MaxRepos + 1}
 
 	getResults := func(t *testing.T, query, version string) []string {
 		r, err := (&schemaResolver{db: db}).Search(context.Background(), &SearchArgs{Query: query, Version: version})

--- a/internal/search/constants.go
+++ b/internal/search/constants.go
@@ -1,6 +1,0 @@
-package search
-
-const (
-	DefaultMaxSearchResults          = 30
-	DefaultMaxSearchResultsStreaming = 500
-)

--- a/internal/search/limits.go
+++ b/internal/search/limits.go
@@ -1,0 +1,42 @@
+package search
+
+import (
+	"math"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+const (
+	DefaultMaxSearchResults          = 30
+	DefaultMaxSearchResultsStreaming = 500
+)
+
+func SearchLimits() schema.SearchLimits {
+	// Our configuration reader does not set defaults from schema. So we rely
+	// on Go default values to mean defaults.
+	withDefault := func(x *int, def int) {
+		if *x <= 0 {
+			*x = def
+		}
+	}
+
+	c := conf.Get()
+
+	var limits schema.SearchLimits
+	if c.SearchLimits != nil {
+		limits = *c.SearchLimits
+	}
+
+	// If MaxRepos unset use deprecated value
+	if limits.MaxRepos == 0 {
+		limits.MaxRepos = c.MaxReposToSearch
+	}
+
+	withDefault(&limits.MaxRepos, math.MaxInt32>>1)
+	withDefault(&limits.CommitDiffMaxRepos, 50)
+	withDefault(&limits.CommitDiffWithTimeFilterMaxRepos, 10000)
+	withDefault(&limits.MaxTimeoutSeconds, 60)
+
+	return limits
+}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -3,7 +3,6 @@ package repos
 import (
 	"context"
 	"fmt"
-	"math"
 	"regexp"
 	regexpsyntax "regexp/syntax"
 	"sort"
@@ -71,7 +70,7 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 
 	limit := op.Limit
 	if limit == 0 {
-		limit = SearchLimits().MaxRepos
+		limit = search.SearchLimits().MaxRepos
 	}
 
 	// If any repo groups are specified, take the intersection of the repo
@@ -381,35 +380,6 @@ func (op *Options) String() string {
 	}
 
 	return b.String()
-}
-
-func SearchLimits() schema.SearchLimits {
-	// Our configuration reader does not set defaults from schema. So we rely
-	// on Go default values to mean defaults.
-	withDefault := func(x *int, def int) {
-		if *x <= 0 {
-			*x = def
-		}
-	}
-
-	c := conf.Get()
-
-	var limits schema.SearchLimits
-	if c.SearchLimits != nil {
-		limits = *c.SearchLimits
-	}
-
-	// If MaxRepos unset use deprecated value
-	if limits.MaxRepos == 0 {
-		limits.MaxRepos = c.MaxReposToSearch
-	}
-
-	withDefault(&limits.MaxRepos, math.MaxInt32>>1)
-	withDefault(&limits.CommitDiffMaxRepos, 50)
-	withDefault(&limits.CommitDiffWithTimeFilterMaxRepos, 10000)
-	withDefault(&limits.MaxTimeoutSeconds, 60)
-
-	return limits
 }
 
 // ExactlyOneRepo returns whether exactly one repo: literal field is specified and

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
-	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
@@ -196,7 +195,7 @@ func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameter
 		hasTimeFilter = true
 	}
 
-	limits := searchrepos.SearchLimits()
+	limits := search.SearchLimits()
 	if max := limits.CommitDiffMaxRepos; !hasTimeFilter && len(repos) > max {
 		return &RepoLimitError{ResultType: resultType, Max: max}
 	}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22710.

Semantics preserving and moves `SearchLimits()` computed from the schema out of the `repo` package and into the `search` package. This because future me wants to compute query timeout values but will run into a cyclic dependency where `query` -> `repos` and `repos` -> `query`. Because of this relationship between query/search/limits, I think it's a strong indicator that it lives better in the `search` package. Also gets rid of yucky `searchrepos` import in graphqlbackend.


Changes:

- `constants.go` -> `limits.go` which contains static and dynamic limits for search
- moves `SearchLimits` to `limits.go`


