### PR TITLE
search: factor out search timeout computation

### DIFF
--- a/internal/search/limits.go
+++ b/internal/search/limits.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"math"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -10,6 +11,9 @@ import (
 const (
 	DefaultMaxSearchResults          = 30
 	DefaultMaxSearchResultsStreaming = 500
+
+	// The default timeout to use for queries.
+	DefaultTimeout = 20 * time.Second
 )
 
 func SearchLimits() schema.SearchLimits {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -129,6 +129,19 @@ func (b Basic) GetCount() string {
 	return countStr
 }
 
+// GetTimeout returns the time.Duration value from the `timeout:` field.
+func (b Basic) GetTimeout() *time.Duration {
+	var timeout *time.Duration
+	VisitField(ToNodes(b.Parameters), FieldTimeout, func(value string, _ bool, _ Annotation) {
+		t, err := time.ParseDuration(value)
+		if err != nil {
+			panic(fmt.Sprintf("Value %q for timeout cannot be parsed as an duration: %s", value, err))
+		}
+		timeout = &t
+	})
+	return timeout
+}
+
 // MapCount returns a copy of a basic query with a count parameter set.
 func (b Basic) MapCount(count int) Basic {
 	parameters := MapParameter(ToNodes(b.Parameters), func(field, value string, negated bool, annotation Annotation) Node {

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-enry/go-enry/v2"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
@@ -149,4 +150,20 @@ func ToTextPatternInfo(q query.Basic, p Protocol, transform query.BasicPass) *Te
 		Index:                        q.Index(),
 		Select:                       selector,
 	}
+}
+
+func TimeoutDuration(b query.Basic) time.Duration {
+	d := DefaultTimeout
+	maxTimeout := time.Duration(SearchLimits().MaxTimeoutSeconds) * time.Second
+	timeout := b.GetTimeout()
+	if timeout != nil {
+		d = *timeout
+	} else if b.GetCount() != "" {
+		// If `count:` is set but `timeout:` is not explicitly set, use the max timeout
+		d = maxTimeout
+	}
+	if d > maxTimeout {
+		d = maxTimeout
+	}
+	return d
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -3,6 +3,7 @@ package search
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -127,6 +128,7 @@ func (m GlobalSearchMode) String() string {
 type TextParameters struct {
 	PatternInfo *TextPatternInfo
 	ResultTypes result.Types
+	Timeout     time.Duration
 
 	// Performance optimization: For global queries, resolving repositories and
 	// querying zoekt happens concurrently.


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22711.

Follow up of https://github.com/sourcegraph/sourcegraph/pull/22710#discussion_r666620367. This disentangles:

- (1) figuring out what limit we should place on a search based on query values (`count` and `timeout`) and
- (2) setting the runtime value of `ctx` for a search downstream, or when evaluating an expression.

We want to compute (1) from a so-called basic query, where we do not need to know or manipulate the runtime `ctx`.  Thus, in our evaluation functions:

- When we are ready to set the runtime value of `ctx` in our main line search code execution, we want to access the value from our internal representation `TextParameters` ( _not_ directly from parse tree).  

- When we evaluate `and`-expressions (which may execute multiple independent backend searches), we want to compute the `timeout` from the processed basic query that's already available in the argument (_not_ directly from the parse tree).

---

By the way all the previous stuff is towards getting rid of these 3 lines: https://github.com/sourcegraph/sourcegraph/pull/22708/files