### PR TITLE
internal/search: order results by repository priority (star count)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210702141945-8d81c47cc161
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210716091742-3a4373318324
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1323,8 +1323,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210702141945-8d81c47cc161 h1:FY1OIQCYQPRC00Jw6jU7HS0YR5uc5ybxO9+Z2oS21yg=
-github.com/sourcegraph/zoekt v0.0.0-20210702141945-8d81c47cc161/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
+github.com/sourcegraph/zoekt v0.0.0-20210716091742-3a4373318324 h1:ZDGoTN1/Aomg7g3gS3bXjxLQBi5uPRPLCtdTB1ZoR1g=
+github.com/sourcegraph/zoekt v0.0.0-20210716091742-3a4373318324/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
This makes result pages more stable and useful.

This commit takes the partially-ordered stream of results from the zoekt
backends and merges them using two new pieces of information added to
the API: the priority of the shard that a zoekt.SearchResult comes from,
and the maximum shard priority that the backend has not yet returned
results for.

This is a much better way to implement this feature than #22108, with less code, lower latencies, correctness guarantees, and no magic buffer size or latency goal numbers.

This requires sourcegraph/zoekt#104 for the two new fields in zoekt.SearchResult that it uses.

TODO: update changelog