### PR TITLE
database: Drop unused default_repos table

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -160,7 +160,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 }
 
 // ListIndexable calls database.IndexableRepos.List, with tracing. It lists ALL
-// default repos which could include private user added repos.
+// indexable repos which could include private user added repos.
 func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err error) {
 	ctx, done := trace(ctx, "Repos", "ListIndexable", nil, &err)
 	defer func() {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -463,7 +463,7 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 			IncludePrivate: true,
 		}
 		if u, err := baseRepoStore.ListIndexableRepos(ctx, opts); err != nil {
-			log15.Error("Listing default repos", "error", err)
+			log15.Error("Listing indexable repos", "error", err)
 			return
 		} else {
 			// Ensure that uncloned indexable repos are known to the scheduler

--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -61,7 +61,7 @@ func (a *AllReposIterator) ForEach(ctx context.Context, forEach func(repoName st
 			a.cachedRepoNames = a.cachedRepoNames[:0]
 
 			// We shouldn't try to fill historical data for ALL repos on Sourcegraph.com, it would take
-			// forever. Instead, we use the same list of default repositories used when you do a global
+			// forever. Instead, we use the same list of indexable repositories used when you do a global
 			// search on Sourcegraph.com.
 			res, err := a.IndexableReposLister.List(ctx)
 			if err != nil {

--- a/internal/database/dbcache/cached_indexable_repos.go
+++ b/internal/database/dbcache/cached_indexable_repos.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// indexableReposMaxAge is how long we cache the list of default repos. The list
+// indexableReposMaxAge is how long we cache the list of indexable repos. The list
 // changes very rarely, so we can cache for a while.
 const indexableReposMaxAge = time.Minute
 
@@ -40,7 +40,7 @@ func NewIndexableReposLister(store *database.RepoStore) *IndexableReposLister {
 	}
 }
 
-// IndexableReposLister holds the list of default repos which are cached for
+// IndexableReposLister holds the list of indexable repos which are cached for
 // indexableReposMaxAge.
 type IndexableReposLister struct {
 	store *database.RepoStore
@@ -50,8 +50,8 @@ type IndexableReposLister struct {
 	mu               sync.Mutex
 }
 
-// List lists ALL default repos. These include anything in the default_repos
-// table, user added repos (both public and private) as well as any repos added
+// List lists ALL indexable repos. These include all repos with a minimum number of stars,
+// user added repos (both public and private) as well as any repos added
 // to the user_public_repos table.
 //
 // The values are cached for up to indexableReposMaxAge. If the cache has expired, we return
@@ -89,7 +89,7 @@ func (s *IndexableReposLister) list(ctx context.Context, onlyPublic bool) (resul
 
 		_, err := s.refreshCache(newCtx, onlyPublic)
 		if err != nil {
-			log15.Error("Refreshing default repos cache", "error", err)
+			log15.Error("Refreshing indexable repos cache", "error", err)
 		}
 	}()
 	return repos, nil
@@ -117,7 +117,7 @@ func (s *IndexableReposLister) refreshCache(ctx context.Context, onlyPublic bool
 	}
 	repos, err := s.store.ListIndexableRepos(ctx, opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "querying for default repos")
+		return nil, errors.Wrap(err, "querying for indexable repos")
 	}
 
 	cache.Store(&cachedRepos{

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -103,7 +103,7 @@ func TestListIndexableRepos(t *testing.T) {
 			}
 		})
 
-		t.Run("List only public default repos", func(t *testing.T) {
+		t.Run("List only public indexable repos", func(t *testing.T) {
 			repos, err := NewIndexableReposLister(database.Repos(db)).ListPublic(ctx)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -859,7 +859,7 @@ SELECT repo_id as id FROM user_public_repos WHERE user_id = %d
 `
 
 type ListIndexableReposOptions struct {
-	// If true, will only include uncloned default repos
+	// If true, will only include uncloned indexable repos
 	OnlyUncloned bool
 	// If true, we include user added private repos
 	IncludePrivate bool
@@ -903,19 +903,19 @@ func (s *RepoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableRe
 
 	rows, err := s.Query(ctx, q)
 	if err != nil {
-		return nil, errors.Wrap(err, "querying for indexed repos")
+		return nil, errors.Wrap(err, "querying indexable repos")
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var r types.RepoName
 		if err := rows.Scan(&r.ID, &r.Name); err != nil {
-			return nil, errors.Wrap(err, "scanning row from default_repos table")
+			return nil, errors.Wrap(err, "scanning indexable repos")
 		}
 		results = append(results, r)
 	}
 	if err = rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "scanning rows for default repos")
+		return nil, errors.Wrap(err, "scanning indexable repos")
 	}
 
 	return results, nil

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -454,18 +454,6 @@ Indexes:
 
 ```
 
-# Table "public.default_repos"
-```
- Column  |  Type   | Collation | Nullable | Default 
----------+---------+-----------+----------+---------
- repo_id | integer |           | not null | 
-Indexes:
-    "default_repos_pkey" PRIMARY KEY, btree (repo_id)
-Foreign-key constraints:
-    "default_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
-
-```
-
 # Table "public.discussion_comments"
 ```
      Column     |           Type           | Collation | Nullable |                     Default                     
@@ -600,7 +588,6 @@ Check constraints:
  user_id             | integer |           |          | 
 Indexes:
     "external_service_repos_repo_id_external_service_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_service_id)
-    "external_service_repos_external_service_id" btree (external_service_id)
     "external_service_repos_idx" btree (external_service_id, repo_id)
     "external_service_user_repos_idx" btree (user_id, repo_id) WHERE user_id IS NOT NULL
 Foreign-key constraints:
@@ -1486,7 +1473,6 @@ Check constraints:
 Referenced by:
     TABLE "changeset_specs" CONSTRAINT "changeset_specs_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE
     TABLE "changesets" CONSTRAINT "changesets_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
-    TABLE "default_repos" CONSTRAINT "default_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "discussion_threads_target_repo" CONSTRAINT "discussion_threads_target_repo_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
     TABLE "gitserver_repos" CONSTRAINT "gitserver_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -129,11 +129,11 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 		start := time.Now()
 		searchableRepos, err = searchableRepositories(ctx, r.SearchableReposFunc, r.Zoekt, excludePatterns)
 		if err != nil {
-			return Resolved{}, errors.Wrap(err, "getting list of default repos")
+			return Resolved{}, errors.Wrap(err, "getting list of indexable repos")
 		}
 		tr.LazyPrintf("searchableRepos: took %s to add %d repos", time.Since(start), len(searchableRepos))
 
-		// Search all default repos since indexed search is fast.
+		// Search all indexable repos since indexed search is fast.
 		if len(searchableRepos) > limit {
 			limit = len(searchableRepos)
 		}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -379,7 +379,7 @@ func TestSearchableRepositories(t *testing.T) {
 				drNames = append(drNames, string(dr.Name))
 			}
 			if !reflect.DeepEqual(drNames, tc.want) {
-				t.Errorf("names of default repos = %v, want %v", drNames, tc.want)
+				t.Errorf("names of indexable repos = %v, want %v", drNames, tc.want)
 			}
 		})
 	}
@@ -425,8 +425,8 @@ func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 		name              string
 		searchContextSpec string
 	}{
-		{name: "use default repos if missing search context", searchContextSpec: ""},
-		{name: "use default repos with global search context", searchContextSpec: "global"},
+		{name: "use indexable repos if missing search context", searchContextSpec: ""},
+		{name: "use indexable repos with global search context", searchContextSpec: "global"},
 	}
 
 	for _, tt := range tests {
@@ -445,7 +445,7 @@ func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 				repoNames = append(repoNames, string(repoRev.Repo.Name))
 			}
 			if !reflect.DeepEqual(repoNames, wantIndexableRepos) {
-				t.Errorf("names of default repos = %v, want %v", repoNames, wantIndexableRepos)
+				t.Errorf("names of indexable repos = %v, want %v", repoNames, wantIndexableRepos)
 			}
 		})
 	}

--- a/migrations/frontend/1528395848_drop_default_repos.down.sql
+++ b/migrations/frontend/1528395848_drop_default_repos.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE TABLE default_repos (
+    repo_id integer NOT NULL
+);
+
+COMMIT;

--- a/migrations/frontend/1528395848_drop_default_repos.up.sql
+++ b/migrations/frontend/1528395848_drop_default_repos.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS default_repos;
+
+COMMIT;

--- a/migrations/frontend/1528395849_drop_unused_indexes.down.sql
+++ b/migrations/frontend/1528395849_drop_unused_indexes.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX external_service_repos_external_service_id ON external_service_repos USING btree (external_service_id);
+
+COMMIT;

--- a/migrations/frontend/1528395849_drop_unused_indexes.up.sql
+++ b/migrations/frontend/1528395849_drop_unused_indexes.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- Covered by external_service_repos_idx (external_service_id, repo_id)
+DROP INDEX IF EXISTS external_service_repos_external_service_id;
+
+COMMIT;


### PR DESCRIPTION
We replaced the default_repos table with selecting all repos with a
minimum number of stars. This commit drops that table and removes any
dangling references to the term.

In addition to that, we drop an unused index I noticed being reported in
PGHero.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
