### PR TITLE
Add RandID to BatchSpecExecutions and use it resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2846,7 +2846,13 @@ A batch spec execution describes one server-side run of a batch change yaml inpu
 """
 type BatchSpecExecution implements Node {
     """
-    The unique ID for the batch spec execution.
+    The unique ID for a batch spec execution.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential).
+    Consider a batch change to fix a security vulnerability: the batch change
+    author may prefer to prepare the batch change in private so that the window
+    between revealing the problem and merging the fixes is as short as
+    possible.
     """
     id: ID!
 

--- a/enterprise/internal/batches/resolvers/batch_spec_execution.go
+++ b/enterprise/internal/batches/resolvers/batch_spec_execution.go
@@ -14,11 +14,11 @@ import (
 
 const batchSpecExecutionIDKind = "BatchSpecExecution"
 
-func marshalBatchSpecExecutionID(id int64) graphql.ID {
+func marshalBatchSpecExecutionRandID(id string) graphql.ID {
 	return relay.MarshalID(batchSpecExecutionIDKind, id)
 }
 
-func unmarshalBatchSpecExecutionID(id graphql.ID) (batchSpecExecutionID int64, err error) {
+func unmarshalBatchSpecExecutionRandID(id graphql.ID) (batchSpecExecutionID string, err error) {
 	err = relay.UnmarshalSpec(id, &batchSpecExecutionID)
 	return
 }
@@ -32,7 +32,7 @@ type batchSpecExecutionResolver struct {
 var _ graphqlbackend.BatchSpecExecutionResolver = &batchSpecExecutionResolver{}
 
 func (r *batchSpecExecutionResolver) ID() graphql.ID {
-	return marshalBatchSpecExecutionID(r.spec.ID)
+	return marshalBatchSpecExecutionRandID(r.spec.RandID)
 }
 
 func (r *batchSpecExecutionResolver) InputSpec() string {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -370,16 +370,16 @@ func (r *Resolver) batchSpecExecutionByID(ctx context.Context, id graphql.ID) (g
 		return nil, err
 	}
 
-	dbID, err := unmarshalBatchSpecExecutionID(id)
+	randID, err := unmarshalBatchSpecExecutionRandID(id)
 	if err != nil {
 		return nil, err
 	}
 
-	if dbID == 0 {
+	if randID == "" {
 		return nil, nil
 	}
 
-	spec, err := r.store.GetBatchSpecExecution(ctx, store.GetBatchSpecExecutionOpts{ID: dbID})
+	spec, err := r.store.GetBatchSpecExecution(ctx, store.GetBatchSpecExecutionOpts{RandID: randID})
 	if err != nil {
 		if err == store.ErrNoResults {
 			return nil, nil
@@ -1399,7 +1399,7 @@ func (r *Resolver) CreateBatchSpecExecution(ctx context.Context, args *graphqlba
 		return nil, err
 	}
 
-	return r.batchSpecExecutionByID(ctx, marshalBatchSpecExecutionID(exec.ID))
+	return r.batchSpecExecutionByID(ctx, marshalBatchSpecExecutionRandID(exec.RandID))
 }
 
 func parseBatchChangeState(s *string) (btypes.BatchChangeState, error) {

--- a/enterprise/internal/batches/store/batch_spec_execution_test.go
+++ b/enterprise/internal/batches/store/batch_spec_execution_test.go
@@ -35,6 +35,7 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 			have := exec
 			want := &btypes.BatchSpecExecution{
 				ID:              have.ID,
+				RandID:          have.RandID,
 				CreatedAt:       clock.Now(),
 				UpdatedAt:       clock.Now(),
 				State:           btypes.BatchSpecExecutionStateQueued,
@@ -47,6 +48,10 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 				t.Fatal("ID should not be zero")
 			}
 
+			if have.RandID == "" {
+				t.Fatal("RandID should not be empty")
+			}
+
 			if diff := cmp.Diff(have, want); diff != "" {
 				t.Fatal(diff)
 			}
@@ -54,18 +59,35 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 	})
 
 	t.Run("Get", func(t *testing.T) {
-		for i, exec := range execs {
-			t.Run(strconv.Itoa(i), func(t *testing.T) {
-				have, err := s.GetBatchSpecExecution(ctx, GetBatchSpecExecutionOpts{ID: exec.ID})
-				if err != nil {
-					t.Fatal(err)
-				}
+		t.Run("GetByID", func(t *testing.T) {
+			for i, exec := range execs {
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					have, err := s.GetBatchSpecExecution(ctx, GetBatchSpecExecutionOpts{ID: exec.ID})
+					if err != nil {
+						t.Fatal(err)
+					}
 
-				if diff := cmp.Diff(have, exec); diff != "" {
-					t.Fatal(diff)
-				}
-			})
-		}
+					if diff := cmp.Diff(have, exec); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+			}
+		})
+
+		t.Run("GetByRandID", func(t *testing.T) {
+			for i, exec := range execs {
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					have, err := s.GetBatchSpecExecution(ctx, GetBatchSpecExecutionOpts{RandID: exec.RandID})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if diff := cmp.Diff(have, exec); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+			}
+		})
 
 		t.Run("NoResults", func(t *testing.T) {
 			opts := GetBatchSpecExecutionOpts{ID: 0xdeadbeef}

--- a/enterprise/internal/batches/types/batch_spec_execution.go
+++ b/enterprise/internal/batches/types/batch_spec_execution.go
@@ -18,6 +18,7 @@ const (
 
 type BatchSpecExecution struct {
 	ID              int64
+	RandID          string
 	State           BatchSpecExecutionState
 	FailureMessage  *string
 	StartedAt       *time.Time

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -97,7 +97,7 @@ Indexes:
  user_id           | integer                  |           |          | 
  namespace_user_id | integer                  |           |          | 
  namespace_org_id  | integer                  |           |          | 
- rand_id           | text                     |           |          | 
+ rand_id           | text                     |           | not null | 
 Indexes:
     "batch_spec_executions_pkey" PRIMARY KEY, btree (id)
     "batch_spec_executions_rand_id" btree (rand_id)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -97,8 +97,10 @@ Indexes:
  user_id           | integer                  |           |          | 
  namespace_user_id | integer                  |           |          | 
  namespace_org_id  | integer                  |           |          | 
+ rand_id           | text                     |           |          | 
 Indexes:
     "batch_spec_executions_pkey" PRIMARY KEY, btree (id)
+    "batch_spec_executions_rand_id" btree (rand_id)
 Check constraints:
     "batch_spec_executions_has_1_namespace" CHECK ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))
 Foreign-key constraints:

--- a/migrations/frontend/1528395848_add_rand_id_to_batch_spec_executions.down.sql
+++ b/migrations/frontend/1528395848_add_rand_id_to_batch_spec_executions.down.sql
@@ -1,0 +1,8 @@
+
+BEGIN;
+
+DROP INDEX IF EXISTS batch_spec_executions_rand_id;
+
+ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS rand_id;
+
+COMMIT;

--- a/migrations/frontend/1528395848_add_rand_id_to_batch_spec_executions.down.sql
+++ b/migrations/frontend/1528395848_add_rand_id_to_batch_spec_executions.down.sql
@@ -1,4 +1,3 @@
-
 BEGIN;
 
 DROP INDEX IF EXISTS batch_spec_executions_rand_id;

--- a/migrations/frontend/1528395848_add_rand_id_to_batch_spec_executions.up.sql
+++ b/migrations/frontend/1528395848_add_rand_id_to_batch_spec_executions.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS batch_spec_executions ADD COLUMN IF NOT EXISTS rand_id text NOT NULL;
+
+CREATE INDEX batch_spec_executions_rand_id ON batch_spec_executions USING btree (rand_id);
+
+COMMIT;


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/22550.

This brings `batch_spec_executions` up to date with the pattern we use for `batch_specs` and `changeset_specs` too.

Note: we need to delete all batch_spec_executions before running this migration since I added a non-null constraint. Should be fine since only Erik and I have those on our machine. But we need to delete them on k8s.sgdev.org before we merge this.