### PR TITLE
executor: Allow inheriting env vars if on host or in Docker

### DIFF
--- a/enterprise/cmd/executor-queue/internal/queues/batches/transform.go
+++ b/enterprise/cmd/executor-queue/internal/queues/batches/transform.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
@@ -47,10 +46,6 @@ func transformRecord(ctx context.Context, db dbutil.DB, exec *btypes.BatchSpecEx
 	cliEnv := []string{
 		fmt.Sprintf("SRC_ENDPOINT=%s", srcEndpoint),
 		fmt.Sprintf("SRC_ACCESS_TOKEN=%s", token),
-
-		// TODO: This is wrong here, it should be set on the executor machine
-		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	}
 
 	var namespaceName string
@@ -80,8 +75,9 @@ func transformRecord(ctx context.Context, db dbutil.DB, exec *btypes.BatchSpecEx
 					"-text-only",
 					"-n", namespaceName,
 				},
-				Dir: ".",
-				Env: cliEnv,
+				Dir:             ".",
+				Env:             cliEnv,
+				InheritLocalEnv: []string{"HOME", "PATH"},
 			},
 		},
 		RedactedValues: map[string]string{

--- a/enterprise/cmd/executor-queue/internal/queues/batches/transform_test.go
+++ b/enterprise/cmd/executor-queue/internal/queues/batches/transform_test.go
@@ -2,7 +2,6 @@ package batches
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,14 +20,6 @@ func TestTransformRecord(t *testing.T) {
 		return 1234, accessToken, nil
 	}
 	t.Cleanup(func() { database.Mocks.AccessTokens.Create = nil })
-
-	overwriteEnv := func(k, v string) {
-		old := os.Getenv(k)
-		os.Setenv(k, v)
-		t.Cleanup(func() { os.Setenv(k, old) })
-	}
-	overwriteEnv("HOME", "/home/the-test-user")
-	overwriteEnv("PATH", "/home/the-test-user/bin")
 
 	testBatchSpec := `batchSpec: yeah`
 	index := &btypes.BatchSpecExecution{
@@ -74,9 +65,8 @@ func TestTransformRecord(t *testing.T) {
 				Env: []string{
 					"SRC_ENDPOINT=https://test%2A:hunter2@test.io",
 					"SRC_ACCESS_TOKEN=" + accessToken,
-					"HOME=/home/the-test-user",
-					"PATH=/home/the-test-user/bin",
 				},
+				InheritLocalEnv: []string{"HOME", "PATH"},
 			},
 		},
 		RedactedValues: map[string]string{

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -82,9 +82,9 @@ func TestFormatRawOrDockerCommandDockerCommand(t *testing.T) {
 
 	actual := formatRawOrDockerCommand(
 		CommandSpec{
-			Command: []string{"ls", "-a"},
-			Dir:     "subdir",
-			Env:     []string{"TEST=true"},
+			Command:         []string{"ls", "-a"},
+			Dir:             "subdir",
+			Env:             []string{"TEST=true"},
 			InheritLocalEnv: []string{"TEST2"},
 		},
 		"/proj/src",

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -1,18 +1,28 @@
 package command
 
 import (
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
+func overwriteEnv(t *testing.T, k, v string) {
+	old := os.Getenv(k)
+	os.Setenv(k, v)
+	t.Cleanup(func() { os.Setenv(k, old) })
+}
+
 func TestFormatRawOrDockerCommandRaw(t *testing.T) {
+	overwriteEnv(t, "TEST2", "testing")
+
 	actual := formatRawOrDockerCommand(
 		CommandSpec{
-			Command:   []string{"ls", "-a"},
-			Dir:       "subdir",
-			Env:       []string{"TEST=true"},
-			Operation: makeTestOperation(),
+			Command:         []string{"ls", "-a"},
+			Dir:             "subdir",
+			Env:             []string{"TEST=true"},
+			InheritLocalEnv: []string{"TEST2"},
+			Operation:       makeTestOperation(),
 		},
 		"/proj/src",
 		Options{},
@@ -21,7 +31,7 @@ func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 	expected := command{
 		Command: []string{"ls", "-a"},
 		Dir:     "/proj/src/subdir",
-		Env:     []string{"TEST=true"},
+		Env:     []string{"TEST=true", "TEST2=testing"},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
 		t.Errorf("unexpected command (-want +got):\n%s", diff)
@@ -31,11 +41,12 @@ func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 	actual := formatRawOrDockerCommand(
 		CommandSpec{
-			Image:      "alpine:latest",
-			ScriptPath: "myscript.sh",
-			Dir:        "subdir",
-			Env:        []string{"TEST=true"},
-			Operation:  makeTestOperation(),
+			Image:           "alpine:latest",
+			ScriptPath:      "myscript.sh",
+			Dir:             "subdir",
+			Env:             []string{"TEST=true"},
+			InheritLocalEnv: []string{"TEST2"},
+			Operation:       makeTestOperation(),
 		},
 		"/proj/src",
 		Options{
@@ -54,6 +65,7 @@ func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 			"-v", "/proj/src:/data",
 			"-w", "/data/subdir",
 			"-e", "TEST=true",
+			"-e", "TEST2",
 			"--entrypoint",
 			"/bin/sh",
 			"alpine:latest",
@@ -66,11 +78,14 @@ func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 }
 
 func TestFormatRawOrDockerCommandDockerCommand(t *testing.T) {
+	overwriteEnv(t, "TEST2", "testing")
+
 	actual := formatRawOrDockerCommand(
 		CommandSpec{
 			Command: []string{"ls", "-a"},
 			Dir:     "subdir",
 			Env:     []string{"TEST=true"},
+			InheritLocalEnv: []string{"TEST2"},
 		},
 		"/proj/src",
 		Options{},
@@ -80,7 +95,7 @@ func TestFormatRawOrDockerCommandDockerCommand(t *testing.T) {
 		Command: []string{
 			"ls", "-a",
 		},
-		Env: []string{"TEST=true"},
+		Env: []string{"TEST=true", "TEST2=testing"},
 		Dir: "/proj/src/subdir",
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -37,6 +37,11 @@ var commonFirecrackerFlags = []string{
 // also been the name supplied to a successful invocation of setupFirecracker. Additionally,
 // the virtual machine must not yet have been torn down (via teardownFirecracker).
 func formatFirecrackerCommand(spec CommandSpec, name, repoDir string, options Options) command {
+	// Since we're executing in a Firecracker VM we can't simply inherit from
+	// the local machine without breaking things (e.g. a HOME set outside the
+	// VM might break things inside the VM), so we ignore the field altogether.
+	spec.InheritLocalEnv = []string{}
+
 	rawOrDockerCommand := formatRawOrDockerCommand(spec, firecrackerContainerDir, options)
 
 	innerCommand := strings.Join(rawOrDockerCommand.Command, " ")

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -14,10 +14,11 @@ import (
 func TestFormatFirecrackerCommandRaw(t *testing.T) {
 	actual := formatFirecrackerCommand(
 		CommandSpec{
-			Command:   []string{"ls", "-a"},
-			Dir:       "subdir",
-			Env:       []string{"TEST=true"},
-			Operation: makeTestOperation(),
+			Command:         []string{"ls", "-a"},
+			Dir:             "subdir",
+			Env:             []string{"TEST=true"},
+			InheritLocalEnv: []string{"TEST2"},
+			Operation:       makeTestOperation(),
 		},
 		"deadbeef",
 		"/proj/src",
@@ -38,11 +39,12 @@ func TestFormatFirecrackerCommandRaw(t *testing.T) {
 func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 	actual := formatFirecrackerCommand(
 		CommandSpec{
-			Image:      "alpine:latest",
-			ScriptPath: "myscript.sh",
-			Dir:        "subdir",
-			Env:        []string{"TEST=true"},
-			Operation:  makeTestOperation(),
+			Image:           "alpine:latest",
+			ScriptPath:      "myscript.sh",
+			Dir:             "subdir",
+			Env:             []string{"TEST=true"},
+			InheritLocalEnv: []string{"TEST2"},
+			Operation:       makeTestOperation(),
 		},
 		"deadbeef",
 		"/proj/src",
@@ -78,9 +80,10 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 func TestFormatFirecrackerCommandDockerCommand(t *testing.T) {
 	actual := formatFirecrackerCommand(
 		CommandSpec{
-			Command: []string{"ls", "-a"},
-			Dir:     "subdir",
-			Env:     []string{"TEST=true"},
+			Command:         []string{"ls", "-a"},
+			Dir:             "subdir",
+			Env:             []string{"TEST=true"},
+			InheritLocalEnv: []string{"TEST2"},
 		},
 		"deadbeef",
 		"/proj/src",

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -25,13 +25,14 @@ type Runner interface {
 // is the host, in a virtual machine, or in a docker container. If an image is
 // supplied, then the command will be run in a one-shot docker container.
 type CommandSpec struct {
-	Key        string
-	Image      string
-	ScriptPath string
-	Command    []string
-	Dir        string
-	Env        []string
-	Operation  *observation.Operation
+	Key             string
+	Image           string
+	ScriptPath      string
+	Command         []string
+	Dir             string
+	Env             []string
+	InheritLocalEnv []string
+	Operation       *observation.Operation
 }
 
 type Options struct {

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -186,12 +186,12 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 		log15.Info(fmt.Sprintf("Running src-cli step #%d", i), "jobID", job.ID, "repositoryName", job.RepositoryName, "commit", job.Commit)
 
 		cliStepCommand := command.CommandSpec{
-			Key:     fmt.Sprintf("step.src.%d", i),
-			Command: append([]string{"src"}, cliStep.Commands...),
-			Dir:     cliStep.Dir,
-			// TODO: We need $HOME/$PATH from the machine on which this is executed
+			Key:       fmt.Sprintf("step.src.%d", i),
+			Command:   append([]string{"src"}, cliStep.Commands...),
+			Dir:       cliStep.Dir,
 			Env:       cliStep.Env,
 			Operation: h.operations.Exec,
+			InheritLocalEnv: cliStep.InheritLocalEnv,
 		}
 
 		if err := runner.Run(ctx, cliStepCommand); err != nil {

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -186,11 +186,11 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 		log15.Info(fmt.Sprintf("Running src-cli step #%d", i), "jobID", job.ID, "repositoryName", job.RepositoryName, "commit", job.Commit)
 
 		cliStepCommand := command.CommandSpec{
-			Key:       fmt.Sprintf("step.src.%d", i),
-			Command:   append([]string{"src"}, cliStep.Commands...),
-			Dir:       cliStep.Dir,
-			Env:       cliStep.Env,
-			Operation: h.operations.Exec,
+			Key:             fmt.Sprintf("step.src.%d", i),
+			Command:         append([]string{"src"}, cliStep.Commands...),
+			Dir:             cliStep.Dir,
+			Env:             cliStep.Env,
+			Operation:       h.operations.Exec,
 			InheritLocalEnv: cliStep.InheritLocalEnv,
 		}
 

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -63,6 +63,11 @@ type CliStep struct {
 
 	// Env specifies a set of NAME=value pairs to supply to the src command.
 	Env []string `json:"env"`
+
+	// InheritLocalEnv specifies a set of environment variables the src command
+	// should inherit, **if** it is executed locally, not inside a Docker
+	// container or Firecracker VM.
+	InheritLocalEnv []string `json:"inheritLocalEnv"`
 }
 
 type DequeueRequest struct {


### PR DESCRIPTION
When executing `src` as part of a batch spec execution we need `PATH`
and `HOME` to be set so that we can create temp/caching directories and
find `git` in the `PATH`.

This works without anything from our side when executing `src` inside
Firecracker since `ignite exec` will SSH into the VM and env vars get.

But when executing `src` on the host (as is the case when running the
executor on macOS) then its environment only contains the values we set,
since that's how Go's `exec.Command` works: if `cmd.Env` is nil then the
command inherits the environment, otherwise only the given values are
set.

What this PR attempts is to introduce an `InheritLocalEnv` option that
contains a list of environment variables that the given command should
inherit from its environment, but **only outside Firecracker**.

That exception makes the code a bit ugly, since there's shared code
between the Docker and the Firecracker runner and I had to introduce an
exception.

But I'm also not sure how to not make it a special case.

Ideas welcome!



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
