### PR TITLE
extensbility: fix GitLab merge request ID regex

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/scrape.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/scrape.ts
@@ -95,7 +95,14 @@ export function getFilePageInfo(): GitLabFileInfo {
  * Finds the merge request ID from the URL.
  */
 export const getMergeRequestID = (): string => {
-    const matches = window.location.pathname.match(/merge_requests\/(.*?)\/diffs/)
+    let matches = window.location.pathname.match(/merge_requests\/(.*?)\/diffs/)
+
+    // If /diffs hasn't been added to the path as a result of clicking the "Changes" tab (a known GitLab bug),
+    // check if the "Changes" tab is active. If so, try to find the merge request ID again.
+    if (!matches && !!document.querySelector('.diffs-tab.active')) {
+        // Matches with and without trailing slash (merge_requests/151 or merge_requests/151/)
+        matches = window.location.pathname.match(/merge_requests\/(.*?)((\/)|$)/)
+    }
     if (!matches) {
         throw new Error('Unable to determine merge request ID')
     }


### PR DESCRIPTION
Closes #22418.

We originally expected that clicking on the "Changes" tab on a GitLab merge request would add `/diffs` to the path. This is inconsistent, and the regex we use to capture the merge request ID assumes that `/diffs` is always present. We can work around GitLab not consistently adding `/diffs` when clicking on the diffs tab by checking that it is the active tab and executing an alternative regex.

<details>
<summary>GIF of extension working despite bad routing</summary>
<img src="https://user-images.githubusercontent.com/37420160/125114755-5fc0b080-e0b8-11eb-82bd-666cd29a3cb1.gif" />
</details>
