### PR TITLE
codeintel: Do not delete reachable uploads

### DIFF
--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.story.tsx
@@ -118,6 +118,26 @@ add('Errored', () => (
     </EnterpriseWebStory>
 ))
 
+add('Deleting', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CodeIntelUploadPage
+                {...props}
+                fetchLsifUpload={fetch({
+                    state: LSIFUploadState.DELETING,
+                    uploadedAt: '2020-06-15T12:20:30+00:00',
+                    startedAt: '2020-06-15T12:25:30+00:00',
+                    finishedAt: '2020-06-15T12:30:30+00:00',
+                    failure: null,
+                    placeInQueue: null,
+                    associatedIndex: null,
+                })}
+                now={now}
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
 add('Failed Upload', () => (
     <EnterpriseWebStory>
         {props => (

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
@@ -123,7 +123,11 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                             },
                         ]}
                         actions={
-                            <CodeIntelDeleteUpload deleteUpload={deleteUpload} deletionOrError={deletionOrError} />
+                            <CodeIntelDeleteUpload
+                                state={uploadOrError.state}
+                                deleteUpload={deleteUpload}
+                                deletionOrError={deletionOrError}
+                            />
                         }
                         className="mb-3"
                     />
@@ -160,19 +164,31 @@ function shouldReload(upload: LsifUploadFields | ErrorLike | null | undefined): 
 }
 
 interface CodeIntelDeleteUploadProps {
+    state: LSIFUploadState
     deleteUpload: () => Promise<void>
     deletionOrError?: 'loading' | 'deleted' | ErrorLike
 }
 
-const CodeIntelDeleteUpload: FunctionComponent<CodeIntelDeleteUploadProps> = ({ deleteUpload, deletionOrError }) => (
-    <button
-        type="button"
-        className="btn btn-outline-danger"
-        onClick={deleteUpload}
-        disabled={deletionOrError === 'loading'}
-        aria-describedby="upload-delete-button-help"
-        data-tooltip="Deleting this upload makes it immediately unavailable to answer code intelligence queries."
-    >
-        <DeleteIcon className="icon-inline" /> Delete upload
-    </button>
-)
+const CodeIntelDeleteUpload: FunctionComponent<CodeIntelDeleteUploadProps> = ({
+    state,
+    deleteUpload,
+    deletionOrError,
+}) =>
+    state === LSIFUploadState.DELETING ? (
+        <></>
+    ) : (
+        <button
+            type="button"
+            className="btn btn-outline-danger"
+            onClick={deleteUpload}
+            disabled={deletionOrError === 'loading'}
+            aria-describedby="upload-delete-button-help"
+            data-tooltip={
+                state === LSIFUploadState.COMPLETED
+                    ? 'Deleting this upload will make it unavailable to answer code intelligence queries the next time the repository commit graph is refreshed.'
+                    : 'Delete this upload immediately'
+            }
+        >
+            <DeleteIcon className="icon-inline" /> Delete upload
+        </button>
+    )

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
@@ -170,6 +170,16 @@ const fetchLsifUploads = fetch(
         failure: 'Whoops! The server encountered a boo-boo handling this input.',
         placeInQueue: null,
         associatedIndex: null,
+    },
+    {
+        id: '6',
+        state: LSIFUploadState.DELETING,
+        uploadedAt: '2020-06-15T12:20:30+00:00',
+        startedAt: '2020-06-15T12:25:30+00:00',
+        finishedAt: '2020-06-15T12:30:30+00:00',
+        failure: null,
+        placeInQueue: null,
+        associatedIndex: null,
     }
 )
 

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
@@ -77,6 +77,12 @@ const filters: FilteredConnectionFilter[] = [
                 tooltip: 'Show uploading uploads only',
                 args: { state: LSIFUploadState.UPLOADING },
             },
+            {
+                label: 'Deleting',
+                value: 'deleting',
+                tooltip: 'Show uploads queued for deletion',
+                args: { state: LSIFUploadState.DELETING },
+            },
         ],
     },
 ]

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelStateDescription.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelStateDescription.tsx
@@ -23,6 +23,8 @@ export const CodeIntelStateDescription: FunctionComponent<CodeIntelStateDescript
 }) =>
     state === LSIFUploadState.UPLOADING ? (
         <span className={className}>Still uploading...</span>
+    ) : state === LSIFUploadState.DELETING ? (
+        <span className={className}>Upload is queued for deletion.</span>
     ) : state === LSIFUploadState.QUEUED || state === LSIFIndexState.QUEUED ? (
         <span className={className}>
             {upperFirst(typeName)} is queued.{' '}

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelStateIcon.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelStateIcon.tsx
@@ -17,6 +17,8 @@ export interface CodeIntelStateIconProps {
 export const CodeIntelStateIcon: FunctionComponent<CodeIntelStateIconProps> = ({ state, className }) =>
     state === LSIFUploadState.UPLOADING ? (
         <FileUploadIcon className={className} />
+    ) : state === LSIFUploadState.DELETING ? (
+        <CheckCircleIcon className={classNames('text-muted', className)} />
     ) : state === LSIFUploadState.QUEUED || state === LSIFIndexState.QUEUED ? (
         <TimerSandIcon className={className} />
     ) : state === LSIFUploadState.PROCESSING || state === LSIFIndexState.PROCESSING ? (

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelStateLabel.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelStateLabel.tsx
@@ -14,6 +14,8 @@ const labelClassNames = 'codeintel-state__label text-muted'
 export const CodeIntelStateLabel: FunctionComponent<CodeIntelStateLabelProps> = ({ state, placeInQueue, className }) =>
     state === LSIFUploadState.UPLOADING ? (
         <span className={classNames(labelClassNames, className)}>Uploading</span>
+    ) : state === LSIFUploadState.DELETING ? (
+        <span className={classNames(labelClassNames, className)}>Deleting</span>
     ) : state === LSIFUploadState.QUEUED || state === LSIFIndexState.QUEUED ? (
         <span className={classNames(labelClassNames, className)}>
             Queued <CodeIntelStateLabelPlaceInQueue placeInQueue={placeInQueue} />

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -432,6 +432,15 @@ enum LSIFUploadState {
     This upload is currently being transferred to Sourcegraph.
     """
     UPLOADING
+
+    """
+    This upload is queued for deletion. This upload was previously in the
+    COMPLETED state and evicted, replaced by a newer upload, or deleted by
+    a user. This upload is able to answer code intelligence queries until
+    the commit graph of the upload's repository is next calculated, at which
+    point the upload will become unreachable.
+    """
+    DELETING
 }
 
 """

--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -276,6 +276,13 @@ func (s *Store) CalculateVisibleUploads(
 		}
 	}
 
+	// All completed uploads are now visible. Mark any uploads queued for deletion as deleted as
+	// they are no longer reachable from the commit graph and cannot be used to fulfill any API
+	// requests.
+	if err := tx.Store.Exec(ctx, sqlf.Sprintf(calculateVisibleUploadsDeletedUploadsQuery, repositoryID)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -287,6 +294,23 @@ SELECT id, commit, md5(root || ':' || indexer) as token, 0 as distance FROM lsif
 const calculateVisibleUploadsDirtyRepositoryQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/commits.go:CalculateVisibleUploads
 UPDATE lsif_dirty_repositories SET update_token = GREATEST(update_token, %s), updated_at = %s WHERE repository_id = %s
+`
+
+const calculateVisibleUploadsDeletedUploadsQuery = `
+-- source: enterprise/internal/codeintel/stores/dbstore/commits.go:CalculateVisibleUploads
+WITH
+candidates AS (
+	SELECT u.id
+	FROM lsif_uploads u
+	WHERE u.state = 'deleting' AND u.repository_id = %s
+
+	-- Lock these rows in a deterministic order so that we don't
+	-- deadlock with other processes updating the lsif_uploads table.
+	ORDER BY u.id FOR UPDATE
+)
+UPDATE lsif_uploads
+SET state = 'deleted'
+WHERE id IN (SELECT id FROM candidates)
 `
 
 // refineRetentionConfiguration returns the maximum age for no-stale branches and tags, effectively, as configured

--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -397,8 +397,8 @@ candidates AS (
 	ORDER BY u.id FOR UPDATE
 ),
 updated AS (
-	UPDATE lsif_uploads u
-	SET state = 'deleted'
+	UPDATE lsif_uploads
+	SET state = 'deleting'
 	WHERE id IN (SELECT id FROM candidates)
 	RETURNING 1
 )

--- a/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
@@ -721,7 +721,7 @@ func TestDeleteOverlappingDumps(t *testing.T) {
 	// Ensure record was deleted
 	if states, err := getUploadStates(db, 1); err != nil {
 		t.Fatalf("unexpected error getting states: %s", err)
-	} else if diff := cmp.Diff(map[int]string{1: "deleted"}, states); diff != "" {
+	} else if diff := cmp.Diff(map[int]string{1: "deleting"}, states); diff != "" {
 		t.Errorf("unexpected dump (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -360,7 +360,7 @@ func (s *Store) IsQueued(ctx context.Context, repositoryID int, commit string) (
 const isQueuedQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/indexes.go:IsQueued
 SELECT COUNT(*) WHERE EXISTS (
-	SELECT id FROM lsif_uploads_with_repository_name WHERE state != 'deleted' AND repository_id = %s AND commit = %s
+	SELECT id FROM lsif_uploads_with_repository_name WHERE repository_id = %s AND commit = %s AND state NOT IN ('deleted', 'deleting')
 	UNION
 	SELECT id FROM lsif_indexes_with_repository_name WHERE repository_id = %s AND commit = %s
 )

--- a/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
@@ -84,6 +84,7 @@ func TestRefreshCommitResolvability(t *testing.T) {
 		Upload{ID: 3, RepositoryID: 51, Commit: makeCommit(4)},
 		Upload{ID: 4, RepositoryID: 51, Commit: makeCommit(5)},
 		Upload{ID: 5, RepositoryID: 52, Commit: makeCommit(7)},
+		Upload{ID: 6, RepositoryID: 52, Commit: makeCommit(7), State: "uploading"},
 	)
 	insertIndexes(t, db,
 		Index{ID: 1, RepositoryID: 50, Commit: makeCommit(3)},
@@ -108,14 +109,14 @@ func TestRefreshCommitResolvability(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error refreshing commit resolvability")
 	}
-	if uploadsUpdated != 1 {
+	if uploadsUpdated != 2 {
 		t.Fatalf("unexpected uploads updated. want=%d have=%d", 1, uploadsUpdated)
 	}
 	if indexesUpdated != 1 {
 		t.Fatalf("unexpected indexes updated. want=%d have=%d", 1, indexesUpdated)
 	}
 
-	uploadStates, err := getUploadStates(db, 1, 2, 3, 4, 5)
+	uploadStates, err := getUploadStates(db, 1, 2, 3, 4, 5, 6)
 	if err != nil {
 		t.Fatalf("unexpected error fetching upload states: %s", err)
 	}
@@ -124,7 +125,8 @@ func TestRefreshCommitResolvability(t *testing.T) {
 		2: "completed",
 		3: "completed",
 		4: "completed",
-		5: "deleted",
+		5: "deleting",
+		6: "deleted",
 	}
 	if diff := cmp.Diff(expectedUploadStates, uploadStates); diff != "" {
 		t.Errorf("unexpected upload states (-want +got):\n%s", diff)
@@ -137,7 +139,7 @@ func TestRefreshCommitResolvability(t *testing.T) {
 	expectedIndexStates := map[int]string{
 		1: "completed",
 		2: "completed",
-		3: "deleted",
+		3: "deleting",
 		4: "completed",
 		5: "completed",
 	}

--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -24,6 +24,7 @@ type operations struct {
 	dirtyRepositories                      *observation.Operation
 	findClosestDumps                       *observation.Operation
 	findClosestDumpsFromGraphFragment      *observation.Operation
+	getAutoindexDisabledRepositories       *observation.Operation
 	getDumpsByIDs                          *observation.Operation
 	getIndexByID                           *observation.Operation
 	getIndexConfigurationByRepositoryID    *observation.Operation
@@ -31,7 +32,6 @@ type operations struct {
 	getIndexesByIDs                        *observation.Operation
 	getOldestCommitDate                    *observation.Operation
 	getRepositoriesWithIndexConfiguration  *observation.Operation
-	getAutoindexDisabledRepositories       *observation.Operation
 	getUploadByID                          *observation.Operation
 	getUploads                             *observation.Operation
 	getUploadsByIDs                        *observation.Operation
@@ -112,6 +112,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		dirtyRepositories:                      op("DirtyRepositories"),
 		findClosestDumps:                       op("FindClosestDumps"),
 		findClosestDumpsFromGraphFragment:      op("FindClosestDumpsFromGraphFragment"),
+		getAutoindexDisabledRepositories:       op("getAutoindexDisabledRepositories"),
 		getDumpsByIDs:                          op("GetDumpsByIDs"),
 		getIndexByID:                           op("GetIndexByID"),
 		getIndexConfigurationByRepositoryID:    op("GetIndexConfigurationByRepositoryID"),
@@ -119,7 +120,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		getIndexesByIDs:                        op("GetIndexesByIDs"),
 		getOldestCommitDate:                    op("GetOldestCommitDate"),
 		getRepositoriesWithIndexConfiguration:  op("GetRepositoriesWithIndexConfiguration"),
-		getAutoindexDisabledRepositories:       op("getAutoindexDisabledRepositories"),
 		getUploadByID:                          op("GetUploadByID"),
 		getUploads:                             op("GetUploads"),
 		getUploadsByIDs:                        op("GetUploadsByIDs"),

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2045,7 +2045,7 @@ Triggers:
     u.associated_index_id,
     u.finished_at AS processed_at
    FROM lsif_uploads u
-  WHERE (u.state = 'completed'::text);
+  WHERE ((u.state = 'completed'::text) OR (u.state = 'deleting'::text));
 ```
 
 # View "public.lsif_dumps_with_repository_name"

--- a/migrations/frontend/1528395853_add_deleting_state.down.sql
+++ b/migrations/frontend/1528395853_add_deleting_state.down.sql
@@ -1,0 +1,47 @@
+BEGIN;
+
+DROP VIEW lsif_dumps_with_repository_name;
+DROP VIEW lsif_dumps;
+
+CREATE VIEW lsif_dumps AS SELECT u.id,
+    u.commit,
+    u.root,
+    u.uploaded_at,
+    u.state,
+    u.failure_message,
+    u.started_at,
+    u.finished_at,
+    u.repository_id,
+    u.indexer,
+    u.num_parts,
+    u.uploaded_parts,
+    u.process_after,
+    u.num_resets,
+    u.upload_size,
+    u.num_failures,
+    u.associated_index_id,
+    u.finished_at AS processed_at
+FROM lsif_uploads u WHERE u.state = 'completed'::text;
+
+CREATE VIEW lsif_dumps_with_repository_name AS SELECT u.id,
+    u.commit,
+    u.root,
+    u.uploaded_at,
+    u.state,
+    u.failure_message,
+    u.started_at,
+    u.finished_at,
+    u.repository_id,
+    u.indexer,
+    u.num_parts,
+    u.uploaded_parts,
+    u.process_after,
+    u.num_resets,
+    u.upload_size,
+    u.num_failures,
+    u.associated_index_id,
+    u.processed_at,
+    r.name AS repository_name
+FROM lsif_dumps u JOIN repo r ON r.id = u.repository_id WHERE r.deleted_at IS NULL;
+
+COMMIT;

--- a/migrations/frontend/1528395853_add_deleting_state.up.sql
+++ b/migrations/frontend/1528395853_add_deleting_state.up.sql
@@ -1,0 +1,50 @@
+BEGIN;
+
+DROP VIEW lsif_dumps_with_repository_name;
+DROP VIEW lsif_dumps;
+
+CREATE VIEW lsif_dumps AS SELECT u.id,
+    u.commit,
+    u.root,
+    u.uploaded_at,
+    u.state,
+    u.failure_message,
+    u.started_at,
+    u.finished_at,
+    u.repository_id,
+    u.indexer,
+    u.num_parts,
+    u.uploaded_parts,
+    u.process_after,
+    u.num_resets,
+    u.upload_size,
+    u.num_failures,
+    u.associated_index_id,
+    u.finished_at AS processed_at
+FROM lsif_uploads u
+WHERE u.state = 'completed'::text OR u.state = 'deleting';
+
+CREATE VIEW lsif_dumps_with_repository_name AS SELECT u.id,
+    u.commit,
+    u.root,
+    u.uploaded_at,
+    u.state,
+    u.failure_message,
+    u.started_at,
+    u.finished_at,
+    u.repository_id,
+    u.indexer,
+    u.num_parts,
+    u.uploaded_parts,
+    u.process_after,
+    u.num_resets,
+    u.upload_size,
+    u.num_failures,
+    u.associated_index_id,
+    u.processed_at,
+    r.name AS repository_name
+FROM lsif_dumps u
+JOIN repo r ON r.id = u.repository_id
+WHERE r.deleted_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
This PR adds a `deleting` state to LSIF upload records. This state acts as an intermediate between `completed` and `deleted` states.

A problem currently arises when deleting visible uploads, as the deletion of the record does not force an (immediate) recalculation of the commit graph. If a record is deleted, the code intelligence resolvers will attempt to use these indexes (as they are still referenced in the nearest uploads table), but won't be able to fetch them as they have a state filtered out by all fetch queries.k

Instead of jumping directly to deleted for these records, we mark them as _queued for deletion_. Then, the next time the commit graph is calculated for the owning repository, all deleting records are marked as deleted (which is fine as it's now unreachable from the commit graph).

Summary of other changes:
- Update lsif_dumps view to include both completed and deleting records
- Update queries to include deleting records where completed records are used
- All queries that mark an upload as deleted now mark it as deleting if it's currently completed
- Update help text for delete button in UI
- Do not show delete button in UI if it's already marked

<img width="1011" alt="Screen Shot 2021-07-19 at 8 14 15 AM" src="https://user-images.githubusercontent.com/103087/126166686-5521d365-645b-48d2-83a2-f2af22fb9b99.png">
<img width="1011" alt="Screen Shot 2021-07-19 at 8 22 46 AM" src="https://user-images.githubusercontent.com/103087/126166690-2784f32b-311e-4fc9-9131-96f28f759bc7.png">
<img width="1011" alt="Screen Shot 2021-07-19 at 8 22 51 AM" src="https://user-images.githubusercontent.com/103087/126166693-55349048-f918-4de3-9940-1f2ebee9f445.png">
<img width="1011" alt="Screen Shot 2021-07-19 at 8 23 00 AM" src="https://user-images.githubusercontent.com/103087/126166699-672cf501-4c42-4784-8cd8-ae6f6f650afb.png">
