### PR TITLE
search frontend: terminate heuristic scanning on single ')'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The Batch Changes user and site credential encryption migrators added in Sourcegraph 3.28 could report zero progress when encryption was disabled, even though they had nothing to do. This has been fixed, and progress will now be correctly reported. [#22277](https://github.com/sourcegraph/sourcegraph/issues/22277)
 - Listing Github Entreprise org repos now returns internal repos as well. [#22339](https://github.com/sourcegraph/sourcegraph/pull/22339)
 - Jaeger works in Docker-compose deployments again. [#22691](https://github.com/sourcegraph/sourcegraph/pull/22691)
+- A bug where the pattern `)` makes the browser unresponsive. [#22738](https://github.com/sourcegraph/sourcegraph/pull/22738)
 
 ### Removed
 

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -69,6 +69,12 @@ describe('scanBalancedPattern()', () => {
             '{"type":"error","expected":"no unbalanced parentheses","at":4}'
         )
     })
+
+    test('single unbalanced paren', () => {
+        expect(scanSearchQuery(')', false, SearchPatternType.regexp)).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"closingParen","range":{"start":0,"end":1}}]}'
+        )
+    })
 })
 
 describe('scanSearchQuery() for literal search', () => {

--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -233,7 +233,7 @@ export const scanBalancedLiteral: Scanner<Literal> = (input, start) => {
             result.push(current)
         } else if (current === ')') {
             balanced -= 1
-            if (balanced < 0) {
+            if (balanced < 0 && adjustedStart > 1) {
                 // This paren is an unmatched closing paren, so we stop treating it as a potential
                 // pattern here--it might be closing a group.
                 adjustedStart -= 1 // Backtrack.


### PR DESCRIPTION
Fixes #22714

Fixes non termination for the specific pattern `)` in a frontend scanner heuristic routine when it attempts to backtrack and recognize balanced groups `(...)` .

---

Trivia:

- The backend parser doesn't have this problem because it preempts this heuristic scanning for this kind of pattern.
- We have a frontend parser scanner but I may have last run it before introducing this frontend part--would probably have caught this very quickly. Maybe time to set up frontend fuzzer...