### PR TITLE
search: intersect repository matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Listing Github Entreprise org repos now returns internal repos as well. [#22339](https://github.com/sourcegraph/sourcegraph/pull/22339)
 - Jaeger works in Docker-compose deployments again. [#22691](https://github.com/sourcegraph/sourcegraph/pull/22691)
 - A bug where the pattern `)` makes the browser unresponsive. [#22738](https://github.com/sourcegraph/sourcegraph/pull/22738)
+- An issue where using `select:repo` in conjunction with `and` patterns did not yield expected repo results. [#22743](https://github.com/sourcegraph/sourcegraph/pull/22743)
 
 ### Removed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1151,6 +1151,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query:  `type:diff repo:go-diff file:contains(after_success)`, // matches .travis.yml and its 10 commits
 				counts: counts{Commit: 10},
 			},
+			{
+				name:   `select repo on 'and' operation`,
+				query:  `repo:^github\.com/sgtest/go-diff$ (func and main) select:repo`,
+				counts: counts{Repo: 1},
+			},
 		}
 
 		for _, test := range tests {

--- a/internal/search/result/merge.go
+++ b/internal/search/result/merge.go
@@ -17,12 +17,12 @@ func Union(left, right []Match) []Match {
 // Intersect performs a merge of match results, merging line matches for files
 // contained in both result sets.
 func Intersect(left, right []Match) []Match {
-	rightMap := make(map[Key]Match)
+	rightMap := make(map[Key]Match, len(right))
 	for _, r := range right {
 		rightMap[r.Key()] = r
 	}
 
-	var merged []Match
+	merged := left[:0]
 	for _, l := range left {
 		r := rightMap[l.Key()]
 		if r == nil {

--- a/internal/search/result/merge.go
+++ b/internal/search/result/merge.go
@@ -14,30 +14,24 @@ func Union(left, right []Match) []Match {
 	return dedup.Results()
 }
 
-// Intersect performs a merge of file match results, merging line matches
-// for files contained in both result sets.
+// Intersect performs a merge of match results, merging line matches for files
+// contained in both result sets.
 func Intersect(left, right []Match) []Match {
-	rightFileMatches := make(map[Key]*FileMatch)
-	for _, m := range right {
-		if fileMatch, ok := m.(*FileMatch); ok {
-			rightFileMatches[fileMatch.Key()] = fileMatch
-		}
+	rightMap := make(map[Key]Match)
+	for _, r := range right {
+		rightMap[r.Key()] = r
 	}
 
 	var merged []Match
-	for _, m := range left {
-		leftFileMatch, ok := m.(*FileMatch)
-		if !ok {
+	for _, l := range left {
+		r := rightMap[l.Key()]
+		if r == nil {
 			continue
 		}
-
-		rightFileMatch := rightFileMatches[leftFileMatch.Key()]
-		if rightFileMatch == nil {
-			continue
+		if leftFileMatch, ok := l.(*FileMatch); ok {
+			leftFileMatch.AppendMatches(r.(*FileMatch)) // key matches, so we know it's a file match
 		}
-
-		leftFileMatch.AppendMatches(rightFileMatch)
-		merged = append(merged, m)
+		merged = append(merged, l)
 	}
 	return merged
 }


### PR DESCRIPTION
Fixes #22651.

Previously, the intersect operation only applied to `FileMatches` and other result types would just not satisfy intersect.

Adjacent concern: we don't actually support proper intersect operations on commit results, and `type:diff (foo and bar)` does not highlight matches of both terms. We need an analogous `AppendMatches` operation for matches within commit messages/diffs for this to work. Intersect on these operations were unsupported before this PR, at least now we intersect by key, which is quite nice.

We should implement that `AppendMatches` operation for `type:diff`/`type:commit`, but I haven't looked into it. If it turns out too tricky for a quick fix, I'll add a stopgap validate `type:diff`/`type:commit` against expressions