### PR TITLE
Do not abort ID extraction on invalid input, ignore instead

### DIFF
--- a/enterprise/internal/batches/background/executor_store.go
+++ b/enterprise/internal/batches/background/executor_store.go
@@ -138,7 +138,8 @@ func extractBatchSpecRandID(logs []workerutil.ExecutionLogEntry) (string, error)
 
 		var e srcCLILogLine
 		if err := json.Unmarshal([]byte(jsonPart), &e); err != nil {
-			return "", ErrNoBatchSpecRandID
+			// If we can't unmarshal the line as JSON we skip it
+			continue
 		}
 
 		if e.Operation == operationCreatingBatchSpec && e.Status == "SUCCESS" {

--- a/enterprise/internal/batches/background/executor_store_test.go
+++ b/enterprise/internal/batches/background/executor_store_test.go
@@ -187,6 +187,19 @@ stdout: {HORSE}
 			},
 			wantErr: ErrNoBatchSpecRandID,
 		},
+
+		{
+			name: "non-json output inbetween valid json",
+			entries: []workerutil.ExecutionLogEntry{
+				{
+					Key: "step.src.0",
+					Out: `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-12T12:25:33.965Z","status":"STARTED"}
+stdout: No changeset specs created
+stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-12T12:26:01.165Z","status":"SUCCESS","message":"https://example.com/users/erik/batch-changes/apply/QmF0Y2hTcGVjOiI5cFZPcHJyTUhNQiI="}`,
+				},
+			},
+			wantRandID: "9pVOprrMHMB",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This fixes an error message we ran into on k8s.sgdev.org even though a batch spec was created.
