### PR TITLE
add in new date to cut release branch

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -16,7 +16,7 @@
     "previousRelease": "3.29.1",
     "upcomingRelease": "3.30.0",
     // Release dates
-    "oneWorkingDayAfterRelease": "19 July 2021 10:00 PST",
+    "oneWorkingDayBeforeRelease": "19 July 2021 10:00 PST",
     "releaseDate": "20 July 2021 10:00 PST",
     "oneWorkingDayAfterRelease": "21 July 2021 10:00 PST",
     // Channel where messages from the tooling are posted

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -16,6 +16,7 @@
     "previousRelease": "3.29.1",
     "upcomingRelease": "3.30.0",
     // Release dates
+    "oneWorkingDayAfterRelease": "19 July 2021 10:00 PST",
     "releaseDate": "20 July 2021 10:00 PST",
     "oneWorkingDayAfterRelease": "21 July 2021 10:00 PST",
     // Channel where messages from the tooling are posted

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -17,6 +17,7 @@ export interface Config {
     previousRelease: string
     upcomingRelease: string
 
+    oneWorkingDayBeforeRelease: string
     releaseDate: string
     oneWorkingDayAfterRelease: string
 

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -106,7 +106,15 @@ const steps: Step[] = [
             const name = releaseName(release)
             const events: EventOptions[] = [
                 {
-                    title: `Cut and release Sourcegraph ${name}`,
+                    title: `Cut Sourcegraph ${name}`,
+                    description: '(This is not an actual event to attend, just a calendar marker.)',
+                    anyoneCanAddSelf: true,
+                    attendees: [config.teamEmail],
+                    transparency: 'transparent',
+                    ...calendarTime(config.oneWorkingDayBeforeRelease),
+                },
+                {
+                    title: `Release Sourcegraph ${name}`,
                     description: '(This is not an actual event to attend, just a calendar marker.)',
                     anyoneCanAddSelf: true,
                     attendees: [config.teamEmail],
@@ -141,6 +149,7 @@ const steps: Step[] = [
             const {
                 releaseDate,
                 captainGitHubUsername,
+                oneWorkingDayBeforeRelease,
                 oneWorkingDayAfterRelease,
                 captainSlackUsername,
                 slackAnnounceChannel,
@@ -154,6 +163,7 @@ const steps: Step[] = [
                 version: release,
                 assignees: [captainGitHubUsername],
                 releaseDate: date,
+                oneWorkingDayBeforeRelease: new Date(oneWorkingDayBeforeRelease),
                 oneWorkingDayAfterRelease: new Date(oneWorkingDayAfterRelease),
                 dryRun: dryRun.trackingIssues || false,
             })


### PR DESCRIPTION
This adds in the param for the calendar event to cut the release branch, as discussed in our sync and [here](https://github.com/sourcegraph/about/pull/3719)