### PR TITLE
doc(admin): move monitoring FAQ to admin FAQ, refresh monitoring guide

### DIFF
--- a/doc/admin/faq.md
+++ b/doc/admin/faq.md
@@ -113,9 +113,57 @@ If you are running Sourcegraph as a Kubernetes cluster, you have two additional 
 We leave the choice of which external HTTP check monitor up to our users. What we provide out-of-the-box is extensive metrics monitoring through Prometheus and Grafana, with builtin alert thresholds and dashboards, and Kubernetes/Docker HTTP health checks which verify that the server is running. Sourcegraph's frontend has a default health check at
 https://$SOURCEGRAPH_BASE_URL/healthz. Some users choose to set up their own external HTTP health checker which tests if the homepage loads, a repository page loads, and if a search GraphQL request returns successfully. 
 
+## Monitoring
 
+Please visit our [Observability Docs](https://docs.sourcegraph.com/admin/observability) for more in-depth information about observability in Sourcegraph.
 
-## Can I consume Sourcegraph's metrics in my own monitoring system (Datadog, New Relic, etc.)?
+### What should I look at when my instance is having performance issues?
+
+Sourcegraph comes with built-in monitoring in the form of [Grafana](https://docs.sourcegraph.com/admin/observability/metrics#grafana), connected to [Prometheus](https://docs.sourcegraph.com/admin/observability/metrics#prometheus) for metrics and alerting.
+
+Generally, Grafana should be the first stop you make when experiencing a system performance issue. From there you can look for system alerts or metrics that would provide you with more insights on what’s causing the performance issue. You can learn more about [accessing Grafana here](https://docs.sourcegraph.com/admin/observability/metrics#grafana).
+
+### What are the key values/alerts to look for when looking at the Grafana Dashboard?
+
+Please refer to the [Dashboards](https://docs.sourcegraph.com/admin/observability/metrics#dashboards) guide for more on how to use our Grafana dashboards.
+
+Please refer to [Understanding alerts](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts) for examples and suggested actions for alerts.
+
+### How do I know when more resources are needed for a specified service?
+
+All resource dashboards contain a section called `Provisioning indicators` that provide information about the current resource usage of containers. These can be used to determine if a scale-up is needed ([example panel](https://docs.sourcegraph.com/admin/observability/dashboards#frontend-provisioning-container-cpu-usage-long-term)).
+
+More information on each available panel in the dashboards is available in the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards).
+
+### What does this `<ALERT-MESSAGE>` mean?
+
+See [Alert solutions](https://docs.sourcegraph.com/admin/observability/alert_solutions) to learn about each alert and their possible solutions.
+
+### What’s the threshold for each resource?
+
+All resources dashboards contain a section called `Container monitoring` that indicate thresholds at which alerts will fire for each resource ([example alert](https://docs.sourcegraph.com/admin/observability/alert_solutions#frontend-container-cpu-usage)).
+
+More information on each available panel in the dashboards is available in the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards).
+
+### How much resources should I add after receiving alerts about running out of resources?
+
+You should make the decision based on the metrics from the relevant Grafana dashboard linked in each alert.
+  
+### What are some of the important alerts that I should be aware of?
+
+We recommend paying closer attention to [critical alerts](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts).
+
+### How do I set up alerts?
+
+Please refer to our guide on [setting up alerting](https://docs.sourcegraph.com/admin/observability/alerting#setting-up-alerting).
+
+### How do I create a custom alert?
+
+Creating a custom alert is not recommended and currently not supported by Sourcegraph. However, please provide feedback on the monitoring dashboards and alerts if you find anything could be improved via our issue tracker.
+
+More advanced users can also refer to [our FAQ item about custom consumption of Sourcegraph metrics](#can-i-consume-sourcegraph-s-metrics-in-my-own-monitoring-system-datadog-new-relic-etc).
+
+### Can I consume Sourcegraph's metrics in my own monitoring system (Datadog, New Relic, etc.)?
 
 Sourcegraph provides [high-level alerting metrics](./observability/metrics.md#high-level-alerting-metrics) which you can integrate into your own monitoring system - see the [alerting custom consumption guide](./observability/alerting_custom_consumption.md) for more details.
 
@@ -125,4 +173,4 @@ Other monitoring systems that support Prometheus scraping (for example, Datadog 
 
 ## Troubleshooting
 
-Content moved to a [dedicated troubleshooting page](troubleshooting.md).
+Please refer to our [dedicated troubleshooting page](troubleshooting.md).

--- a/doc/admin/how-to/monitoring-guide.md
+++ b/doc/admin/how-to/monitoring-guide.md
@@ -6,50 +6,13 @@ Please visit our [Observability Docs](https://docs.sourcegraph.com/admin/observa
 
 This document assumes that you are a [site administrator](https://docs.sourcegraph.com/admin).
 
+## Set up monitoring
+
+1. Familiarize yourself with [Sourcegraph's monitoring dashboards and metrics](../observability/metrics.md).
+   1. Also see our [full dashboards reference](../observability/dashboards.md).
+1. [Set up alerting](../observability/alerting.md#setting-up-alerting) and [learn about how to respond to alerts](../observability/alerting.md#understanding-alerts).
+   1. Also see our [full alert solutions reference](../observability/alert_solutions.md).
+
 ## FAQs
 
-### What should I look at when my instance is having performance issues?
-
-Sourcegraph comes with built-in monitoring in the form of [Grafana](https://docs.sourcegraph.com/admin/observability/metrics#grafana), connected to [Prometheus](https://docs.sourcegraph.com/admin/observability/metrics#prometheus) for metrics and alerting.
-
-Generally, Grafana should be the first stop you make when experiencing a system performance issue. From there you can look for system alerts or metrics that would provide you with more insights on what’s causing the performance issue. You can learn more about [accessing Grafana here](https://docs.sourcegraph.com/admin/observability/metrics#grafana).
-
-### What are the key values/alerts to look for when looking at the Grafana Dashboard?
-
-Please refer to the [Dashboards](https://docs.sourcegraph.com/admin/observability/metrics#dashboards) guide for more on how to use our Grafana dashboards.
-
-Please refer to [Understanding alerts](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts) for examples and suggested actions for alerts.
-
-### How do I know when more resources are needed for a specified service?
-
-All resource dashboards contain a section called `Provisioning indicators` that provide information about the current resource usage of containers. These can be used to determine if a scale-up is needed ([example panel](https://docs.sourcegraph.com/admin/observability/dashboards#frontend-provisioning-container-cpu-usage-long-term)).
-
-More information on each available panel in the dashboards is available in the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards).
-
-### What does this `<ALERT-MESSAGE>` mean?
-
-See [Alert solutions](https://docs.sourcegraph.com/admin/observability/alert_solutions) to learn about each alert and their possible solutions.
-
-### What’s the threshold for each resource?
-
-All resources dashboards contain a section called `Container monitoring` that indicate thresholds at which alerts will fire for each resource ([example alert](https://docs.sourcegraph.com/admin/observability/alert_solutions#frontend-container-cpu-usage)).
-
-More information on each available panel in the dashboards is available in the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards).
-
-### How much resources should I add after receiving alerts about running out of resources?
-
-You should make the decision based on the metrics from the relevant Grafana dashboard linked in each alert.
-  
-### What are some of the important alerts that I should be aware of?
-
-We recommend paying closer attention to [critical alerts](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts).
-
-### How do I set up alerts?
-
-Please refer to our guide on [setting up alerting](https://docs.sourcegraph.com/admin/observability/alerting#setting-up-alerting).
-
-### How do I create a custom alert?
-
-Creating a custom alert is not recommended and currently not supported by Sourcegraph. However, please provide feedback on the monitoring dashboards and alerts if you find anything could be improved via our issue tracker.
-
-More advanced users can also refer to [our FAQ item about custom consumption of Sourcegraph metrics](https://docs.sourcegraph.com/admin/faq#can-i-consume-sourcegraph-s-metrics-in-my-own-monitoring-system-datadog-new-relic-etc).
+See the [monitoring section of our FAQ](./../faq.md#monitoring).


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/22663

Move monitoring FAQ to a subsection in the admin FAQ, and simplify the guide to just "look at dashboards" and then "set up alerts"

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
