### PR TITLE
search: revert to old k-factor

### DIFF
--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -141,7 +141,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, repoBranches
 	}
 
 	// Choose sensible values for k when we generalize this.
-	k := zoektutil.ResultCountFactor(len(repoBranches), args.FileMatchLimit)
+	k := zoektutil.ResultCountFactor(len(repoBranches), args.FileMatchLimit, false)
 	searchOpts := zoektutil.SearchOpts(ctx, k, args)
 	searchOpts.Whole = true
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -320,8 +320,8 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, typ Ind
 	}
 
 	finalQuery := zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, queryExceptRepos)
-	// for globalSearches we set k = 1.
-	searchOpts := SearchOpts(ctx, 1, args.PatternInfo)
+	k := ResultCountFactor(0, args.PatternInfo.FileMatchLimit, true)
+	searchOpts := SearchOpts(ctx, k, args.PatternInfo)
 
 	// Start event stream.
 	t0 := time.Now()
@@ -455,7 +455,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 
 	finalQuery := zoektquery.NewAnd(&zoektquery.RepoBranches{Set: repos.repoBranches}, queryExceptRepos)
 
-	k := ResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit)
+	k := ResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, false)
 	searchOpts := SearchOpts(ctx, k, args.PatternInfo)
 
 	// Start event stream.

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -410,10 +410,11 @@ func TestZoektIndexedRepos(t *testing.T) {
 
 func TestZoektResultCountFactor(t *testing.T) {
 	cases := []struct {
-		name     string
-		numRepos int
-		pattern  *search.TextPatternInfo
-		want     int
+		name         string
+		numRepos     int
+		globalSearch bool
+		pattern      *search.TextPatternInfo
+		want         int
 	}{
 		{
 			name:     "One repo implies max scaling factor",
@@ -439,10 +440,24 @@ func TestZoektResultCountFactor(t *testing.T) {
 			pattern:  &search.TextPatternInfo{FileMatchLimit: 100},
 			want:     10,
 		},
+		{
+			name:         "for global searches, k should be 1",
+			numRepos:     0,
+			globalSearch: true,
+			pattern:      &search.TextPatternInfo{},
+			want:         1,
+		},
+		{
+			name:         "for global searches, k should be 1, adjusted by the FileMatchLimit",
+			numRepos:     0,
+			globalSearch: true,
+			pattern:      &search.TextPatternInfo{FileMatchLimit: 100},
+			want:         10,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ResultCountFactor(tt.numRepos, tt.pattern.FileMatchLimit)
+			got := ResultCountFactor(tt.numRepos, tt.pattern.FileMatchLimit, tt.globalSearch)
 			if tt.want != got {
 				t.Fatalf("Want scaling factor %d but got %d", tt.want, got)
 			}

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -90,24 +90,30 @@ func SearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt
 	return searchOpts
 }
 
-func ResultCountFactor(numRepos int, fileMatchLimit int32) (k int) {
-	// If we're only searching a small number of repositories, return more
-	// comprehensive results. This is arbitrary.
-	switch {
-	case numRepos <= 5:
-		k = 100
-	case numRepos <= 10:
-		k = 10
-	case numRepos <= 25:
-		k = 8
-	case numRepos <= 50:
-		k = 5
-	case numRepos <= 100:
-		k = 3
-	case numRepos <= 500:
-		k = 2
-	default:
+func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k int) {
+	if globalSearch {
+		// for globalSearch, numRepos = 0, but effectively we are searching over all
+		// indexed repos, hence k should be 1
 		k = 1
+	} else {
+		// If we're only searching a small number of repositories, return more
+		// comprehensive results. This is arbitrary.
+		switch {
+		case numRepos <= 5:
+			k = 100
+		case numRepos <= 10:
+			k = 10
+		case numRepos <= 25:
+			k = 8
+		case numRepos <= 50:
+			k = 5
+		case numRepos <= 100:
+			k = 3
+		case numRepos <= 500:
+			k = 2
+		default:
+			k = 1
+		}
 	}
 	if fileMatchLimit > search.DefaultMaxSearchResults {
 		k = int(float64(k) * 3 * float64(fileMatchLimit) / float64(search.DefaultMaxSearchResults))


### PR DESCRIPTION
fixes #22777

The regression was introduced because I changed how the magic k-factor
is calculated for global queries.

I will come up with a proposal to change this logic to something less
ad-hoc in another PR. For now, let's just revert to the old logic.

The screenshots show that the counts behave as expected with this fix.

<img width="1200" alt="Screenshot 2021-07-13 at 09 54 09" src="https://user-images.githubusercontent.com/26413131/125414922-74a3d3e9-ceae-48dd-aa48-f15de1f6b26b.png">

<img width="1200" alt="Screenshot 2021-07-13 at 09 54 21" src="https://user-images.githubusercontent.com/26413131/125414928-78ae05f1-1e9d-4ba0-91f4-d1e767430232.png">

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
