### PR TITLE
doc(dev): add quickstart step with additional resources, including sg

### DIFF
--- a/doc/dev/getting-started/index.md
+++ b/doc/dev/getting-started/index.md
@@ -10,3 +10,4 @@ Have a look around, our code is on [GitHub](https://sourcegraph.com/github.com/s
 - [Step 4: Get the code](quickstart_4_clone_repository.md)
 - [Step 5: Configure HTTPS reverse proxy](quickstart_5_configure_https_reverse_proxy.md)
 - [Step 6: Start the server](quickstart_6_start_server.md)
+- [Step 7: Additional resources](quickstart_7_additional_resources.md)

--- a/doc/dev/getting-started/quickstart_6_start_server.md
+++ b/doc/dev/getting-started/quickstart_6_start_server.md
@@ -65,4 +65,4 @@ After the initial setup you can `cd` into `sourcegraph` and run `enterprise/dev/
 
 The environment variables `SITE_CONFIG_FILE`, `EXTSVC_CONFIG_FILE` and `GLOBAL_SETTINGS_FILE` are paths that are read at startup. The content of the files will overwrite the respective setting. `start.sh` will set these files to point into `dev-private`. To avoid overwriting configuration changes done in Sourcegraph, you can set the environment variable `DEV_NO_CONFIG=1`.
 
-[< Previous](quickstart_5_configure_https_reverse_proxy.md) | [Next >](../how-to/troubleshooting_local_development.md)
+[< Previous](quickstart_5_configure_https_reverse_proxy.md) | [Next >](quickstart_7_additional_resources.md)

--- a/doc/dev/getting-started/quickstart_7_additional_resources.md
+++ b/doc/dev/getting-started/quickstart_7_additional_resources.md
@@ -1,0 +1,11 @@
+# Quickstart step 7: Additional resources
+
+Congratulations on making it to the end of the quickstart guide!
+Here are some additional resources to help you go further:
+
+- [Install `sg`: the Sourcegraph Developer Tool](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md)
+- [How-to guides](../how-to/index.md), particularly:
+  - [Troubleshooting local development](../how-to/troubleshooting_local_development.md)
+- [Background information](../background-information/index.md) for more context
+
+[< Previous](quickstart_6_start_server.md) | [Back to Quickstart index >](./index.md)

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -17,6 +17,7 @@ A hands-on introduction for setting up your local development environment.
 - [Step 4: Get the code](getting-started/quickstart_4_clone_repository.md)
 - [Step 5: Configure HTTPS reverse proxy](getting-started/quickstart_5_configure_https_reverse_proxy.md)
 - [Step 6: Start the server](getting-started/quickstart_6_start_server.md)
+- [Step 7: Additional resources](getting-started/quickstart_7_additional_resources.md)
 
 ## [How-to guides](how-to/index.md)
 


### PR DESCRIPTION
I [spied a Slack message that used this fancy `sg live` command](https://sourcegraph.slack.com/archives/C07KZF47K/p1626133334278600?thread_ts=1626129120.273500&cid=C07KZF47K) that I've never seen before, which lead me to finding the [Sourcegraph developer tool](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md)!

This seems super handy, but there doesn't seem to be very many mentions of it ([search](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%401d77d20+dev/sg/README.md&patternType=literal)), so I added a quickstart step that can include some "next step" resources and added this tool there

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
