### PR TITLE
dev(sg): add support for checking version of any deployment

### DIFF
--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -40,9 +40,9 @@
 - [Principles](#principles)
 - [Inspiration](#inspiration)
 - [Ideas](#ideas)
-  - [Generators](#generators)
-  - [Edit configuration files](#edit-configuration-files)
-  - [Tail logs](#tail-logs)
+    - [Generators](#generators)
+    - [Edit configuration files](#edit-configuration-files)
+    - [Tail logs](#tail-logs)
 
 ## Quickstart
 
@@ -138,9 +138,12 @@ sg doctor
 ### `sg live` - See currently deployed version
 
 ```bash
-# See which version is deployed on an environment
+# See which version is deployed on a preset environment
 sg live dot-com
 sg live k8s
+
+# See which version is deployed on a custom environment
+sg live https://demo.sourcegraph.com
 
 # List environments:
 sg live -help

--- a/dev/sg/go.mod
+++ b/dev/sg/go.mod
@@ -5,11 +5,12 @@ go 1.16
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cockroachdb/errors v1.8.4
-	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/go-cmp v0.5.5
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/rjeczalik/notify v0.9.2
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-00010101000000-000000000000
+	golang.org/x/mod v0.4.2
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/dev/sg/go.sum
+++ b/dev/sg/go.sum
@@ -259,6 +259,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/mod/semver"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -56,9 +57,19 @@ func printDeployedVersion(e environment) error {
 		return err
 	}
 
-	elems := strings.Split(string(body), "_")
+	bodyStr := string(body)
+	elems := strings.Split(bodyStr, "_")
 	if len(elems) != 3 {
-		return errors.Errorf("unknown format of /__version response: %q", body)
+		if semver.IsValid("v" + bodyStr) {
+			out.WriteLine(output.Linef(
+				output.EmojiLightbulb, output.StyleLogo,
+				"Live on %q: v%s",
+				e.Name, bodyStr,
+			))
+			return nil
+		} else {
+			return errors.Errorf("unknown format of /__version response: %q", body)
+		}
 	}
 
 	buildDate := elems[1]

--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -58,18 +58,17 @@ func printDeployedVersion(e environment) error {
 	}
 
 	bodyStr := string(body)
+	if semver.IsValid("v" + bodyStr) {
+		out.WriteLine(output.Linef(
+			output.EmojiLightbulb, output.StyleLogo,
+			"Live on %q: v%s",
+			e.Name, bodyStr,
+		))
+		return nil
+	}
 	elems := strings.Split(bodyStr, "_")
 	if len(elems) != 3 {
-		if semver.IsValid("v" + bodyStr) {
-			out.WriteLine(output.Linef(
-				output.EmojiLightbulb, output.StyleLogo,
-				"Live on %q: v%s",
-				e.Name, bodyStr,
-			))
-			return nil
-		} else {
-			return errors.Errorf("unknown format of /__version response: %q", body)
-		}
+		return errors.Errorf("unknown format of /__version response: %q", body)
 	}
 
 	buildDate := elems[1]

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -352,8 +353,12 @@ func liveExec(ctx context.Context, args []string) error {
 
 	e, ok := getEnvironment(args[0])
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: environment %q not found :(\n", args[0]))
-		return flag.ErrHelp
+		if customURL, err := url.Parse(args[0]); err == nil {
+			e = environment{Name: customURL.Host, URL: customURL.String()}
+		} else {
+			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: environment %q not found, or is not a valid URL :(\n", args[0]))
+			return flag.ErrHelp
+		}
 	}
 
 	return printDeployedVersion(e)
@@ -632,9 +637,9 @@ func printLiveUsage(c *ffcli.Command) string {
 	var out strings.Builder
 
 	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg live <environment>\n")
+	fmt.Fprintf(&out, "  sg live <environment|url>\n")
 	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE ENVIRONMENTS\n")
+	fmt.Fprintf(&out, "AVAILABLE PRESET ENVIRONMENTS\n")
 
 	for _, name := range environmentNames() {
 		fmt.Fprintf(&out, "  %s\n", name)


### PR DESCRIPTION
Adds support for checking the version of any deployment:

```sh
❯ sg live -help                       
USAGE
  sg live <environment|url>

AVAILABLE PRESET ENVIRONMENTS
  dot-com
  k8s

❯ sg live https://demo.sourcegraph.com
✅ Done
💡 Live on "demo.sourcegraph.com": v3.29.0
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
