### PR TITLE
wip: support visibility queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210702141945-8d81c47cc161
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210712151521-8b5ec2f88fb7
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1342,8 +1342,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210702141945-8d81c47cc161 h1:FY1OIQCYQPRC00Jw6jU7HS0YR5uc5ybxO9+Z2oS21yg=
-github.com/sourcegraph/zoekt v0.0.0-20210702141945-8d81c47cc161/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
+github.com/sourcegraph/zoekt v0.0.0-20210712151521-8b5ec2f88fb7 h1:uSlVUDIPy0M0IxUz5lmBU6j+nc5g7VeDU/E9OsJKiaA=
+github.com/sourcegraph/zoekt v0.0.0-20210712151521-8b5ec2f88fb7/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -130,10 +131,12 @@ type TextParameters struct {
 	ResultTypes result.Types
 	Timeout     time.Duration
 
-	// Performance optimization: For global queries, resolving repositories and
-	// querying zoekt happens concurrently.
+	// deprecated
 	RepoPromise *RepoPromise
-	Mode        GlobalSearchMode
+
+	// perf: For global queries, we only resolve private repos.
+	UserPrivateRepos []types.RepoName
+	Mode             GlobalSearchMode
 
 	// Query is the parsed query from the user. You should be using Pattern
 	// instead, but Query is useful for checking extra fields that are set and

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -302,11 +302,22 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 	}, nil
 }
 
+type queryRepoRevFunc struct {
+	q           zoektquery.Q
+	repoRevFunc repoRevFunc
+}
+
 // zoektSearchGlobal searches the entire universe of indexed repositories.
-func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, typ IndexedRequestType, since func(t time.Time) time.Duration, c streaming.Sender) error {
+//
+// zoektSearchGlobal only needs to search "HEAD", because global queries, per
+// definition, don't have a repo: filter and consequently no rev: filter, too.
+// This makes the code a bit simpler because we don't have to resolve revisions
+// before sending off the request to Zoekt.
+func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, typ IndexedRequestType, c streaming.Sender) error {
 	if args == nil {
 		return nil
 	}
+
 	if args.Mode != search.ZoektGlobalSearch {
 		return fmt.Errorf("zoektSearchGlobal called with args.Mode %d instead of %d", args.Mode, search.ZoektGlobalSearch)
 	}
@@ -319,116 +330,88 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, typ Ind
 		return err
 	}
 
-	finalQuery := zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, queryExceptRepos)
-	// for globalSearches we set k = 1.
-	searchOpts := SearchOpts(ctx, 1, args.PatternInfo)
+	g := errgroup.Group{}
 
-	// Start event stream.
-	t0 := time.Now()
-
-	// We use reposResolved to synchronize repo resolution and event processing.
-	reposResolved := make(chan struct{})
-	var getRepoInputRev repoRevFunc
-	var repoRevMap map[api.RepoID]*search.RepositoryRevisions
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		defer close(reposResolved)
-		repos, err := args.RepoPromise.Get(ctx)
-		if err != nil {
-			return err
-		}
-		repoRevMap = make(map[api.RepoID]*search.RepositoryRevisions, len(repos))
-		for _, r := range repos {
-			repoRevMap[r.Repo.ID] = r
-		}
-		getRepoInputRev = func(file *zoekt.FileMatch) (repo types.RepoName, revs []string, ok bool) {
-			if repoRev, ok := repoRevMap[api.RepoID(file.RepositoryID)]; ok {
-				return repoRev.Repo, repoRev.RevSpecs(), true
+	// We always send a "public" query. In case the user has access to indexed
+	// private repos, we send a second query for those repos, too. For each query, we
+	// also define a specific repoRevFunc.
+	qs := []queryRepoRevFunc{{
+		q: zoektquery.NewAnd(&zoektquery.Visibility{Value: "public"}, &zoektquery.Branch{Pattern: "HEAD", Exact: true}, queryExceptRepos),
+		// For public queries, we don't validate ID or repo name.
+		repoRevFunc: func(file *zoekt.FileMatch) (types.RepoName, []string, bool) {
+			repo := types.RepoName{
+				ID:   api.RepoID(file.RepositoryID),
+				Name: api.RepoName(file.Repository),
 			}
-			return types.RepoName{}, nil, false
+			return repo, []string{""}, true
+		},
+	}}
+	if len(args.UserPrivateRepos) > 0 {
+		privateRepoSet := make(map[string][]string, len(args.UserPrivateRepos))
+		head := []string{"HEAD"}
+		for _, r := range args.UserPrivateRepos {
+			privateRepoSet[string(r.Name)] = head
 		}
-		return nil
-	})
-
-	foundResults := atomic.Bool{}
-	g.Go(func() error {
-		ctx := ctx
-		if deadline, ok := ctx.Deadline(); ok {
-			// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
-			searchOpts.MaxWallTime = time.Until(deadline)
-			if searchOpts.MaxWallTime < 0 {
-				return ctx.Err()
-			}
-			// We don't want our context's deadline to cut off zoekt so that we can get the results
-			// found before the deadline.
-			//
-			// We'll create a new context that gets cancelled if the other context is cancelled for any
-			// reason other than the deadline being exceeded. This essentially means the deadline for the new context
-			// will be `deadline + time for zoekt to cancel + network latency`.
-			var cancel context.CancelFunc
-			ctx, cancel = contextWithoutDeadline(ctx)
-			defer cancel()
-		}
-
-		// PERF: if we are going to be selecting to repo results only anyways, we can just ask
-		// zoekt for only results of type repo.
-		if args.PatternInfo.Select.Root() == filter.Repository {
-			return zoektSearchReposOnly(ctx, args.Zoekt.Client, finalQuery, c, func() map[api.RepoID]*search.RepositoryRevisions {
-				<-reposResolved
-				// getRepoInputRev is nil only if we encountered an error during repo resolution.
-				if getRepoInputRev == nil {
-					return nil
+		qs = append(qs, queryRepoRevFunc{
+			q: zoektquery.NewAnd(&zoektquery.RepoBranches{Set: privateRepoSet}, queryExceptRepos),
+			repoRevFunc: func(file *zoekt.FileMatch) (types.RepoName, []string, bool) {
+				// Validate whether the repo names we receive match the repo names in the query.
+				if _, ok := privateRepoSet[file.Repository]; !ok {
+					return types.RepoName{}, nil, false
 				}
-				return repoRevMap
-			})
-		}
+				repo := types.RepoName{
+					ID:   api.RepoID(file.RepositoryID),
+					Name: api.RepoName(file.Repository),
+				}
+				return repo, []string{""}, true
+			},
+		})
+	}
 
-		// The buffered backend.ZoektStreamFunc allows us to consume events from Zoekt
-		// while we wait for repo resolution.
-		bufSender, cleanup := bufferedSender(240, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
-			foundResults.CAS(false, event.FileCount != 0 || event.MatchCount != 0)
+	for _, q := range qs {
+		q2 := q
+		g.Go(func() error {
+			// select:repo
+			if args.PatternInfo.Select.Root() == filter.Repository {
+				fmt.Printf(">>>>>>>>>>>>>>>>> calling zoekt.Client.List: %+v\n", q2.q)
+				repoList, err := args.Zoekt.Client.List(ctx, q2.q, nil)
+				if err != nil {
+					return err
+				}
 
-			files := event.Files
-			limitHit := event.FilesSkipped+event.ShardsSkipped > 0
+				matches := make([]result.Match, 0, len(repoList.Repos))
+				for _, repo := range repoList.Repos {
+					matches = append(matches, &result.RepoMatch{
+						Name: api.RepoName(repo.Repository.Name),
+						ID:   api.RepoID(repo.Repository.ID),
+					})
+				}
 
-			if len(files) == 0 {
 				c.Send(streaming.SearchEvent{
-					Stats: streaming.Stats{IsLimitHit: limitHit},
+					Results: matches,
+					Stats:   streaming.Stats{}, // TODO
 				})
-				return
+				return nil
 			}
 
-			<-reposResolved
-			// getRepoInputRev is nil only if we encountered an error during repo resolution.
-			if getRepoInputRev == nil {
-				return
-			}
+			searchOpts := SearchOpts(ctx, 1, args.PatternInfo)
+			return args.Zoekt.Client.StreamSearch(ctx, q2.q, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+				files := event.Files
+				limitHit := event.FilesSkipped+event.ShardsSkipped > 0
 
-			sendMatches(files, getRepoInputRev, typ, c, limitHit)
-		}))
-		defer cleanup()
+				if len(files) == 0 {
+					c.Send(streaming.SearchEvent{
+						Stats: streaming.Stats{IsLimitHit: limitHit},
+					})
+					return
+				}
 
-		return args.Zoekt.Client.StreamSearch(ctx, finalQuery, &searchOpts, bufSender)
-	})
-
-	if err := g.Wait(); err != nil {
-		return err
+				sendMatches(files, q2.repoRevFunc, typ, c, limitHit)
+			}))
+		})
 	}
 
-	if !foundResults.Load() && since(t0) >= searchOpts.MaxWallTime {
-		var statusMap search.RepoStatusMap
-		repos, err := args.RepoPromise.Get(ctx)
-		if err != nil {
-			return nil
-		}
-		for _, r := range repos {
-			statusMap.Update(r.Repo.ID, search.RepoStatusTimedout)
-		}
-		c.Send(streaming.SearchEvent{Stats: streaming.Stats{Status: statusMap}})
-	}
-	return nil
+	return g.Wait()
 }
 
 // zoektSearch searches repositories using zoekt.
@@ -438,7 +421,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *Indexe
 	}
 
 	if args.Mode == search.ZoektGlobalSearch {
-		return zoektSearchGlobal(ctx, args, typ, since, c)
+		return zoektSearchGlobal(ctx, args, typ, c)
 	}
 
 	if len(repos.repoRevs) == 0 {


### PR DESCRIPTION
This changes how we treat global queries for indexed search.

Before:
We resolved repos and searched Zoekt concurrenty. Once the repos
were resolved, we filtered the results coming back from Zoekt before
streaming them back to the user. This approach was performant but still
had the caveat of having to resolve all public repos (O(#index)).

Now:
We send 2 queries to Zoekt: One query targeting public repositories
and one query targeting all private repos a user has access to. Since we
know that results from the first query only contain public results, we
can stream them back immediately without authorization check, which will
improve the "time to first result".

Why?
Repo resolution is a major bottleneck for our efforts to increase the
the number of indexed repos. With this change we can avoid large
repo lists and remove repoPromises (future PR) we introduced earlier.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
