### PR TITLE
extsvc/github: Fix isArchived and isLocked field fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Jaeger works in Docker-compose deployments again. [#22691](https://github.com/sourcegraph/sourcegraph/pull/22691)
 - A bug where the pattern `)` makes the browser unresponsive. [#22738](https://github.com/sourcegraph/sourcegraph/pull/22738)
 - An issue where using `select:repo` in conjunction with `and` patterns did not yield expected repo results. [#22743](https://github.com/sourcegraph/sourcegraph/pull/22743)
-- The `isLocked` and `isDisabled` fields of GitHub repositories are now fetched correctly from the GraphQL API of GitHub Enterprise instances. Users that rely on the `repos` config in GitHub code host connections should update so that locked and disabled repositories defined in that list are actually skipped.
+- The `isLocked` and `isDisabled` fields of GitHub repositories are now fetched correctly from the GraphQL API of GitHub Enterprise instances. Users that rely on the `repos` config in GitHub code host connections should update so that locked and disabled repositories defined in that list are actually skipped. [#22788](https://github.com/sourcegraph/sourcegraph/pull/22788)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Jaeger works in Docker-compose deployments again. [#22691](https://github.com/sourcegraph/sourcegraph/pull/22691)
 - A bug where the pattern `)` makes the browser unresponsive. [#22738](https://github.com/sourcegraph/sourcegraph/pull/22738)
 - An issue where using `select:repo` in conjunction with `and` patterns did not yield expected repo results. [#22743](https://github.com/sourcegraph/sourcegraph/pull/22743)
+- The `isLocked` and `isDisabled` fields of GitHub repositories are now fetched correctly from the GraphQL API of GitHub Enterprise instances. Users that rely on the `repos` config in GitHub code host connections should update so that locked and disabled repositories defined in that list are actually skipped.
 
 ### Removed
 

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -976,7 +976,7 @@ func (c *V4Client) MergePullRequest(ctx context.Context, pr *PullRequest, squash
 		} `json:"mergePullRequest"`
 	}
 
-	var mergeMethod = "MERGE"
+	mergeMethod := "MERGE"
 	if squash {
 		mergeMethod = "SQUASH"
 	}
@@ -1074,9 +1074,11 @@ func abbreviateRef(ref string) string {
 // timelineItemTypes contains all the types requested via GraphQL from the timelineItems connection on a pull request.
 const timelineItemTypesFmtStr = `ASSIGNED_EVENT, CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW, PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT, REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT, READY_FOR_REVIEW_EVENT`
 
-var ghe220Semver, _ = semver.NewConstraint("~2.20.0")
-var ghe221PlusOrDotComSemver, _ = semver.NewConstraint(">= 2.21.0")
-var ghe300PlusOrDotComSemver, _ = semver.NewConstraint(">= 3.0.0")
+var (
+	ghe220Semver, _             = semver.NewConstraint("~2.20.0")
+	ghe221PlusOrDotComSemver, _ = semver.NewConstraint(">= 2.21.0")
+	ghe300PlusOrDotComSemver, _ = semver.NewConstraint(">= 3.0.0")
+)
 
 func timelineItemTypes(version *semver.Version) (string, error) {
 	if ghe220Semver.Check(version) {
@@ -1633,8 +1635,8 @@ type Repository struct {
 	IsPrivate     bool   // whether the repository is private
 	IsFork        bool   // whether the repository is a fork of another repository
 	IsArchived    bool   // whether the repository is archived on the code host
-	IsLocked      bool   `json:"-"` // whether the repository is locked on the code host
-	IsDisabled    bool   `json:"-"` // whether the repository is disabled on the code host
+	IsLocked      bool   // whether the repository is locked on the code host
+	IsDisabled    bool   // whether the repository is disabled on the code host
 	// This field will always be blank on repos stored in our database because the value will be different
 	// depending on which token was used to fetch it
 	ViewerPermission string // ADMIN, WRITE, READ, or empty if unknown. Only the graphql api populates this. https://developer.github.com/v4/enum/repositorypermission/

--- a/internal/extsvc/github/common_test.go
+++ b/internal/extsvc/github/common_test.go
@@ -168,7 +168,8 @@ func TestClient_ListOrgRepositories(t *testing.T) {
     "fork": false
   }
 ]
-`}
+`,
+	}
 
 	c := newTestClient(t, &mock)
 	wantRepos := []*Repository{
@@ -362,6 +363,7 @@ func TestClient_GetReposByNameWithOwner(t *testing.T) {
 		IsPrivate:        true,
 		IsFork:           false,
 		IsArchived:       true,
+		IsLocked:         true,
 		ViewerPermission: "ADMIN",
 	}
 
@@ -374,6 +376,7 @@ func TestClient_GetReposByNameWithOwner(t *testing.T) {
 		IsPrivate:        true,
 		IsFork:           false,
 		IsArchived:       true,
+		IsDisabled:       true,
 		ViewerPermission: "ADMIN",
 	}
 
@@ -398,6 +401,7 @@ func TestClient_GetReposByNameWithOwner(t *testing.T) {
       "isPrivate": true,
       "isFork": false,
       "isArchived": true,
+      "isLocked": true,
       "viewerPermission": "ADMIN"
     },
     "repo_sourcegraph_clojure_grapher": {
@@ -409,6 +413,7 @@ func TestClient_GetReposByNameWithOwner(t *testing.T) {
       "isPrivate": true,
       "isFork": false,
       "isArchived": true,
+      "isDisabled": true,
       "viewerPermission": "ADMIN"
     }
   }
@@ -430,6 +435,7 @@ func TestClient_GetReposByNameWithOwner(t *testing.T) {
       "isPrivate": true,
       "isFork": false,
       "isArchived": true,
+      "isLocked": true,
       "viewerPermission": "ADMIN"
     },
     "repo_sourcegraph_clojure_grapher": null
@@ -495,9 +501,6 @@ func TestClient_GetReposByNameWithOwner(t *testing.T) {
 				t.Errorf("error:\nhave: %v\nwant: %v", have, want)
 			}
 
-			if mock.count != 1 {
-				t.Errorf("mock.count == %d", mock.count)
-			}
 			if want, have := len(tc.wantRepos), len(repos); want != have {
 				t.Errorf("wrong number of repos. want=%d, have=%d", want, have)
 			}

--- a/internal/repos/testdata/golden/GithubSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/GithubSource_makeRepo_path-pattern
@@ -30,6 +30,8 @@
     "IsPrivate": false,
     "IsFork": false,
     "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
     "ViewerPermission": ""
    }
   },
@@ -64,6 +66,8 @@
     "IsPrivate": true,
     "IsFork": false,
     "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
     "ViewerPermission": ""
    }
   }

--- a/internal/repos/testdata/golden/GithubSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/GithubSource_makeRepo_simple
@@ -30,6 +30,8 @@
     "IsPrivate": false,
     "IsFork": false,
     "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
     "ViewerPermission": ""
    }
   },
@@ -64,6 +66,8 @@
     "IsPrivate": true,
     "IsFork": false,
     "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
     "ViewerPermission": ""
    }
   }

--- a/internal/repos/testdata/golden/GithubSource_makeRepo_ssh
+++ b/internal/repos/testdata/golden/GithubSource_makeRepo_ssh
@@ -30,6 +30,8 @@
     "IsPrivate": false,
     "IsFork": false,
     "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
     "ViewerPermission": ""
    }
   },
@@ -64,6 +66,8 @@
     "IsPrivate": true,
     "IsFork": false,
     "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
     "ViewerPermission": ""
    }
   }


### PR DESCRIPTION
I noticed this when working on streaming repo syncing. Because of the
JSON tags we set in those fields in order to avoid updating test
fixtures, we ended up not unmarshalling those fields from actual GraphQL
API requests.

REST API requests were not affected because we convert a restRepository
to a Repository.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
