### PR TITLE
security: Insert events for role change attempts

### DIFF
--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -176,7 +176,7 @@ func (r *schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {
 	// the lifetime of this function when we have all the details required for eventArgs, especially
 	// eventArgs.By which is used as the UserID in database.SecurityEvent - a required argument to
 	// write an entry into the database.
-	var eventName = database.SecurityEventNameRoleChangeDenied
+	eventName := database.SecurityEventNameRoleChangeDenied
 	defer logRoleChangeAttempt(ctx, r.db, &eventName, &eventArgs, &err)
 
 	if err = backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -135,11 +135,9 @@ type roleChangeEventArgs struct {
 func (r *schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {
 	UserID    graphql.ID
 	SiteAdmin bool
-}) (*EmptyResponse, error) {
+}) (response *EmptyResponse, err error) {
 	// 🚨 SECURITY: Only site admins can promote other users to site admin (or demote from site
 	// admin).
-
-	var err error
 
 	// Set default values for event args.
 	eventArgs := roleChangeEventArgs{
@@ -184,10 +182,7 @@ func (r *schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {
 	}
 
 	if userResolver.ID() == args.UserID {
-		// err is passed as an argument to logRoleChangeAttempt. Returning errors.New directly will
-		// mean that this error is not logged in the reason for the security event.
-		err = errors.New("refusing to set current user site admin status")
-		return nil, err
+		return nil, errors.New("refusing to set current user site admin status")
 	}
 
 	if err = database.Users(r.db).SetIsSiteAdmin(ctx, affectedUserID, args.SiteAdmin); err != nil {

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -121,11 +121,15 @@ func (r *schemaResolver) DeleteOrganization(ctx context.Context, args *struct {
 }
 
 type roleChangeEventArgs struct {
-	By     int32  `json:"by"`
-	For    int32  `json:"for"`
-	From   string `json:"from"`
-	To     string `json:"to"`
-	Reason string `json:"reason,omitempty"`
+	By   int32  `json:"by"`
+	For  int32  `json:"for"`
+	From string `json:"from"`
+	To   string `json:"to"`
+
+	// Reason will be present only if the RoleChangeDenied event is logged, but will be set to an
+	// empty string in other cases for a consistent experience of the clients that consume this
+	// data.
+	Reason string `json:"reason"`
 }
 
 func (r *schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -2,14 +2,18 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
@@ -116,33 +120,102 @@ func (r *schemaResolver) DeleteOrganization(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
+type roleChangeEventArgs struct {
+	By     int32  `json:"by"`
+	For    int32  `json:"for"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Reason string `json:"reason,omitempty"`
+}
+
 func (r *schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {
 	UserID    graphql.ID
 	SiteAdmin bool
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can promote other users to site admin (or demote from site
 	// admin).
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
-		return nil, err
+
+	var err error
+
+	// Set default values for event args.
+	eventArgs := roleChangeEventArgs{
+		From: "role_user",
+		To:   "role_site_admin",
 	}
 
-	user, err := CurrentUser(ctx, r.db)
+	// Correct the values based on the value of SiteAdmin in the GraphQL mutation.
+	if !args.SiteAdmin {
+		eventArgs.From = "role_site_admin"
+		eventArgs.To = "role_user"
+	}
+
+	affectedUserID, err := UnmarshalUserID(args.UserID)
 	if err != nil {
 		return nil, err
 	}
-	if user.ID() == args.UserID {
-		return nil, errors.New("refusing to set current user site admin status")
-	}
 
-	userID, err := UnmarshalUserID(args.UserID)
+	eventArgs.For = affectedUserID
+
+	userResolver, err := CurrentUser(ctx, r.db)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := database.Users(r.db).SetIsSiteAdmin(ctx, userID, args.SiteAdmin); err != nil {
+	eventArgs.By = userResolver.user.ID
+
+	// At the moment, we log only two types of events:
+	// - RoleChangeDenied
+	// - RoleChangeGranted
+	//
+	// Unless we want to log another event for RoleChangeAttempted as well, invoking
+	// logRoleChangeAttempt before this point does not make sense since this is the first time in
+	// the lifetime of this function when we have all the details required for eventArgs, especially
+	// eventArgs.By which is used as the UserID in database.SecurityEvent - a required argument to
+	// write an entry into the database.
+	var eventName = database.SecurityEventNameRoleChangeDenied
+	defer logRoleChangeAttempt(ctx, r.db, &eventName, &eventArgs, &err)
+
+	if err = backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
+
+	if userResolver.ID() == args.UserID {
+		// err is passed as an argument to logRoleChangeAttempt. Returning errors.New directly will
+		// mean that this error is not logged in the reason for the security event.
+		err = errors.New("refusing to set current user site admin status")
+		return nil, err
+	}
+
+	if err = database.Users(r.db).SetIsSiteAdmin(ctx, affectedUserID, args.SiteAdmin); err != nil {
+		return nil, err
+	}
+
+	eventName = database.SecurityEventNameRoleChangeGranted
 	return &EmptyResponse{}, nil
+}
+
+func logRoleChangeAttempt(ctx context.Context, db dbutil.DB, name *database.SecurityEventName, eventArgs *roleChangeEventArgs, parentErr *error) {
+	// To avoid a panic, it's important to check for a nil parentErr before we dereference it.
+	if parentErr != nil && *parentErr != nil {
+		eventArgs.Reason = (*parentErr).Error()
+	}
+
+	args, err := json.Marshal(eventArgs)
+	if err != nil {
+		log15.Error("logRoleChangeAttempt: failed to marshal JSON", "eventArgs", eventArgs)
+	}
+
+	event := &database.SecurityEvent{
+		Name:            *name,
+		URL:             "",
+		UserID:          uint32(eventArgs.By),
+		AnonymousUserID: "",
+		Argument:        args,
+		Source:          "BACKEND",
+		Timestamp:       time.Now(),
+	}
+
+	database.SecurityEventLogs(db).LogEvent(ctx, event)
 }
 
 func (r *schemaResolver) InvalidateSessionsByID(ctx context.Context, args *struct {

--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
-	golang.org/x/tools v0.1.4
+	golang.org/x/tools v0.1.5
 	google.golang.org/api v0.46.0
 	google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -1857,8 +1857,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.4 h1:cVngSRcfgyZCzys3KYOpCFa+4dqX/Oub9tAq00ttGVs=
-golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -35,6 +35,9 @@ const (
 	SecurityEventNamePasswordChanged       SecurityEventName = "PasswordChanged"
 
 	SecurityEventNameEmailVerified SecurityEventName = "EmailVerified"
+
+	SecurityEventNameRoleChangeDenied  SecurityEventName = "RoleChangeDenied"
+	SecurityEventNameRoleChangeGranted SecurityEventName = "RoleChangeGranted"
 )
 
 // SecurityEvent contains information needed for logging a security-relevant event.


### PR DESCRIPTION
This commit adds two new security event types:
- RoleChangeDenied
- RoleChangeGranted

At the moment, if a user sends an API request to change a user's role
to admin for example, while they are **already** an admin, we will
still end up recording an event for RoleChangeGranted (provided that
all checks pass and the write to the database is successful). This is
because we make no initial checks for current state before writing the
new expected state to the database. The fact that we want to add this
check or not remains outside the scope of this commit and subject to
further deliberation.

## Test Results

Following are the database entries in the `security_event_logs` table from using the `SiteUserIsSiteAdmin` API locally:

```
localhost sourcegraph@sourcegraph=# select * from security_event_logs order by id DESC limit 3;
┌─────┬───────────────────┬─────┬─────────┬───────────────────┬─────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────┬──────────────────────────────────┐
│ id  │       name        │ url │ user_id │ anonymous_user_id │ source  │                                                           argument                                                            │  version  │            timestamp             │
├─────┼───────────────────┼─────┼─────────┼───────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────┼──────────────────────────────────┤
│ 129 │ RoleChangeDenied  │     │       1 │                   │ BACKEND │ {"by": 1, "to": "role_user", "for": 1, "from": "role_site_admin", "reason": "refusing to set current user site admin status"} │ 0.0.0+dev │ 2021-07-14 13:12:15.650317+05:30 │
│ 128 │ RoleChangeGranted │     │       1 │                   │ BACKEND │ {"by": 1, "to": "role_user", "for": 2, "from": "role_site_admin", "reason": ""}                                               │ 0.0.0+dev │ 2021-07-14 13:11:53.84756+05:30  │
│ 127 │ RoleChangeGranted │     │       1 │                   │ BACKEND │ {"by": 1, "to": "role_site_admin", "for": 2, "from": "role_user", "reason": ""}                                               │ 0.0.0+dev │ 2021-07-14 13:11:35.156653+05:30 │
└─────┴───────────────────┴─────┴─────────┴───────────────────┴─────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────┴──────────────────────────────────┘
(3 rows)

Time: 0.193 ms
```

And the local timestamp when this was tested:

```
$ date
Wed Jul 14 01:12:34 PM IST 2021
```

COREAPP-100
COREAPP-140


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
