### PR TITLE
sg: Make `sg start` boot up enterprise environment

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -499,7 +499,7 @@ checks:
 commandsets:
   # TODO: Should we be able to define "env" vars _per set_?
 
-  default:
+  oss:
     - frontend
     - worker
     - repo-updater
@@ -517,7 +517,7 @@ commandsets:
     - zoekt-webserver-0
     - zoekt-webserver-1
 
-  enterprise:
+  enterprise: &enterprise_set
     - enterprise-frontend
     - enterprise-worker
     - enterprise-repo-updater
@@ -535,6 +535,8 @@ commandsets:
     - zoekt-webserver-0
     - zoekt-webserver-1
     - executor-queue
+
+  default: *enterprise_set
 
   enterprise-codeintel:
     - enterprise-frontend


### PR DESCRIPTION
The people on Slack [have spoken](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1626167506183100) and we all want the same thing:

`sg start` should boot up the enterprise environment.

`sg run-set oss` will boot up the open-source environment.
