### PR TITLE
dbtest: remove statement_timeout

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -59,7 +59,7 @@ func NewDB(t testing.TB, dsn string) *sql.DB {
 	var err error
 	var config *url.URL
 	if dsn == "" {
-		config, err = url.Parse("postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC&statement_timeout=30s")
+		config, err = url.Parse("postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC")
 		if err != nil {
 			t.Fatalf("failed to parse dsn %q: %s", dsn, err)
 		}


### PR DESCRIPTION
#22756 added `statement_timeout` to the DSN we use when connecting to test databases, which has then caused our CI to often fail because we have many tests that can take more than 30 seconds when cloning new test databases when our test environment is under load.

This PR removes that parameter.

Note that CI is currently failing on this PR due to the unrelated issue fixed by #22806. :facepalm: 