### PR TITLE
search: mock to not depend on repo options

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -26,7 +26,7 @@ import (
 
 // This file contains the root resolver for search. It currently has a lot of
 // logic that spans out into all the other search_* files.
-var mockResolveRepositories func(effectiveRepoFieldValues []string) (resolved searchrepos.Resolved, err error)
+var mockResolveRepositories func() (resolved searchrepos.Resolved, err error)
 
 type SearchArgs struct {
 	Version        string
@@ -263,7 +263,7 @@ type resolveRepositoriesOpts struct {
 // where opts.effectiveRepoFieldValues == nil.
 func (r *searchResolver) resolveRepositories(ctx context.Context, q query.Q, opts resolveRepositoriesOpts) (resolved searchrepos.Resolved, err error) {
 	if mockResolveRepositories != nil {
-		return mockResolveRepositories(opts.effectiveRepoFieldValues)
+		return mockResolveRepositories()
 	}
 
 	tr, ctx := trace.New(ctx, "graphql.resolveRepositories", fmt.Sprintf("opts: %+v", opts))

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -249,7 +249,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	}
 
 	setMockResolveRepositories := func(numRepos int) {
-		mockResolveRepositories = func(effectiveRepoFieldValues []string) (resolved searchrepos.Resolved, err error) {
+		mockResolveRepositories = func() (resolved searchrepos.Resolved, err error) {
 			return searchrepos.Resolved{
 				RepoRevs:        generateRepoRevs(numRepos),
 				MissingRepoRevs: make([]*search.RepositoryRevisions, 0),
@@ -405,7 +405,7 @@ func TestCapFirst(t *testing.T) {
 func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	mockResolveRepositories = func(effectiveRepoFieldValues []string) (resolved searchrepos.Resolved, err error) {
+	mockResolveRepositories = func() (resolved searchrepos.Resolved, err error) {
 		return searchrepos.Resolved{
 			RepoRevs:        []*search.RepositoryRevisions{},
 			MissingRepoRevs: make([]*search.RepositoryRevisions, 0),


### PR DESCRIPTION
Set up for changing the `resolveRepositories` function signature.