### PR TITLE
search: remove parse tree dependency to resolve repos

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -309,7 +309,8 @@ func (r *searchResolver) errorForOverRepoLimit(ctx context.Context) *errOverRepo
 		return buildErr(proposedQueries, description)
 	}
 
-	resolved, _ := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{})
+	repoOptions := r.toRepoOptions(r.Query, resolveRepositoriesOpts{})
+	resolved, _ := r.resolveRepositories(ctx, repoOptions)
 	if len(resolved.RepoRevs) > 0 {
 		paths := make([]string, len(resolved.RepoRevs))
 		for i, repo := range resolved.RepoRevs {
@@ -338,9 +339,11 @@ func (r *searchResolver) errorForOverRepoLimit(ctx context.Context) *errOverRepo
 			repoFieldValues = append(repoFieldValues, repoParentPattern)
 			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
-			resolved, err := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{
-				effectiveRepoFieldValues: repoFieldValues,
-			})
+			repoOptions := r.toRepoOptions(r.Query,
+				resolveRepositoriesOpts{
+					effectiveRepoFieldValues: repoFieldValues,
+				})
+			resolved, err := r.resolveRepositories(ctx, repoOptions)
 			if ctx.Err() != nil {
 				continue
 			} else if err != nil {

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -268,11 +268,13 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
 
 		if len(effectiveRepoFieldValues) > 0 || hasSingleContextField {
-			resolved, err := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{
-				effectiveRepoFieldValues: effectiveRepoFieldValues,
-				limit:                    maxSearchSuggestions,
-			})
+			repoOptions := r.toRepoOptions(r.Query,
+				resolveRepositoriesOpts{
+					effectiveRepoFieldValues: effectiveRepoFieldValues,
+					limit:                    maxSearchSuggestions,
+				})
 
+			resolved, err := r.resolveRepositories(ctx, repoOptions)
 			resolvers := make([]SearchSuggestionResolver, 0, len(resolved.RepoRevs))
 			for i, rev := range resolved.RepoRevs {
 				resolvers = append(resolvers, repositorySuggestionResolver{
@@ -378,7 +380,8 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return mockShowSymbolMatches()
 		}
 
-		resolved, err := r.resolveRepositories(ctx, r.Query, resolveRepositoriesOpts{})
+		repoOptions := r.toRepoOptions(r.Query, resolveRepositoriesOpts{})
+		resolved, err := r.resolveRepositories(ctx, repoOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -506,7 +506,8 @@ func TestVersionContext(t *testing.T) {
 			}
 			defer git.ResetMocks()
 
-			gotResult, err := resolver.resolveRepositories(context.Background(), resolver.Query, resolveRepositoriesOpts{})
+			repoOptions := resolver.toRepoOptions(resolver.Query, resolveRepositoriesOpts{})
+			gotResult, err := resolver.resolveRepositories(context.Background(), repoOptions)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -332,6 +332,7 @@ type Options struct {
 	OnlyPublic         bool
 	Ranked             bool // Return results ordered by rank
 	Limit              int
+	CacheLookup        bool
 	Query              query.Q
 }
 


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22823. 

Semantics preserving modulo a small change to trace output. The PR changes the signature of `resolveRepositories`:

- `resolveRepositories(ctx, <parse tree>, <random options>)` to 
 `resolveRepositories(ctx, <processed-repo-options>)`

The effect is that `resolveRepositories` no longer depends on `<parse tree>` and can simply receive and use the `<processed-repo-options>`  it cares about. This is achieved by doing said processing before calling `resolveRepositories`. More inline comments to motivate why.