### PR TITLE
search: inline determineRepos for cleaner call chain

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1467,7 +1467,11 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	tr.LazyPrintf("searching %d repos, %d missing", len(resolved.RepoRevs), len(resolved.MissingRepoRevs))
 	if len(resolved.RepoRevs) == 0 {
-		return nil, r.errorForNoResolvedRepos(ctx, args.Query)
+		localErr := r.errorForNoResolvedRepos(ctx, args.Query)
+		if alert, err := errorToAlert(localErr); alert != nil {
+			return alert.wrapResults(), err
+		}
+		return nil, localErr
 	}
 
 	if len(resolved.MissingRepoRevs) > 0 {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1354,23 +1354,6 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 	return args
 }
 
-// determineRepos wraps resolveRepositories. It interprets the response and
-// error to see if an alert needs to be returned. Only one of the return
-// values will be non-nil.
-func (r *searchResolver) determineRepos(ctx context.Context, q query.Q, tr *trace.Trace, start time.Time) (*searchrepos.Resolved, error) {
-	repoOptions := r.toRepoOptions(q, resolveRepositoriesOpts{})
-	resolved, err := r.resolveRepositories(ctx, repoOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	tr.LazyPrintf("searching %d repos, %d missing", len(resolved.RepoRevs), len(resolved.MissingRepoRevs))
-	if len(resolved.RepoRevs) == 0 {
-		return nil, r.errorForNoResolvedRepos(ctx, q)
-	}
-	return &resolved, nil
-}
-
 // isGlobalSearch returns true if the query does not contain repo, repogroup, or
 // repohasfile filters. For structural queries, queries with version context,
 // and queries with non-global search context, isGlobalSearch always return false.
@@ -1473,13 +1456,20 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		}
 	}
 
-	resolved, err := r.determineRepos(ctx, args.Query, tr, start)
+	repoOptions := r.toRepoOptions(args.Query, resolveRepositoriesOpts{})
+	resolved, err := r.resolveRepositories(ctx, repoOptions)
 	if err != nil {
 		if alert, err := errorToAlert(err); alert != nil {
 			return alert.wrapResults(), err
 		}
 		return nil, err
 	}
+
+	tr.LazyPrintf("searching %d repos, %d missing", len(resolved.RepoRevs), len(resolved.MissingRepoRevs))
+	if len(resolved.RepoRevs) == 0 {
+		return nil, r.errorForNoResolvedRepos(ctx, args.Query)
+	}
+
 	if len(resolved.MissingRepoRevs) > 0 {
 		agg.Error(&missingRepoRevsError{Missing: resolved.MissingRepoRevs})
 	}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22824.

Semantics preserving. We can inline `determineRepos` because it simplifies logic. The motivation behind this was to lift `r.toRepoOptions` higher up the call chain, but we can just remove one call entirely by inlining.

By the way, `repoOptions` is just our current best-effort internal query for repos, that will become part of the query plan. I wanted to integrate it into our `internal/search/types.go` but there are many potential circular dependencies to take care of before I can do that. Eventually:

-  the type of  `repoOptions` will be something like `search.RepoQuery`
- `r.toRepoOptions` will not depend on the resolver `r`, and will be a conversion routine for generating a query plan

---

PS @stefanhengl following our conversation on slack, you should use the `repoOptions` within `doResults` to power any additional logic around resolving repos / filtering forks and not (need to) introspect the query or parse tree.