### PR TITLE
Make it clear windows support is experimental

### DIFF
--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -28,7 +28,6 @@ In order to create batch changes we need to [install the Sourcegraph CLI](../cli
     curl -L https://YOUR-SOURCEGRAPH-INSTANCE/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src
     chmod +x /usr/local/bin/src
     ```
-    **Windows**: see ["Sourcegraph CLI for Windows"](../cli/explanations/windows.md)
 2. Authenticate `src` with your Sourcegraph instance by running **`src login`** and following the instructions:
 
     ```

--- a/doc/batch_changes/references/requirements.md
+++ b/doc/batch_changes/references/requirements.md
@@ -32,7 +32,8 @@ Batch Changes makes it possible to create changesets in tens, hundreds, or thous
 ## Requirements for batch change creators
 
 * Latest version of the [Sourcegraph CLI `src`](../../cli/index.md)
-  * `src` is supported on Linux or Intel macOS; Windows and ARM (eg M1) macOS support is experimental
+  * `src` is supported on Linux or Intel macOS
+  * <span class="badge badge-experimental">Experimental</span> Windows and ARM (eg. M1) macOS support are experimental
 * Docker
   * MacOS:
       * If using Docker 3.x, ensure your version is at least 3.0.1


### PR DESCRIPTION
Clarify that windows support is experimental after customers had expectations that it was fully supported.