### PR TITLE
search: send fields "fork" and "archived" to zoekt indexserver

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -218,6 +218,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 			RepoID:     int32(repo.ID),
 			Public:     !repo.Private,
 			Priority:   priority,
+			Fork:       repo.Fork,
 			GetVersion: getVersion,
 		}, nil
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -219,6 +219,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 			Public:     !repo.Private,
 			Priority:   priority,
 			Fork:       repo.Fork,
+			Archived:   repo.Archived,
 			GetVersion: getVersion,
 		}, nil
 	}

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -23,6 +23,9 @@ type zoektIndexOptions struct {
 	// filtering.
 	Public bool
 
+	// Fork is true if the repository is a fork.
+	Fork bool
+
 	// LargeFiles is a slice of glob patterns where matching file paths should
 	// be indexed regardless of their size. The pattern syntax can be found
 	// here: https://golang.org/pkg/path/filepath/#Match.
@@ -53,6 +56,9 @@ type RepoIndexOptions struct {
 
 	// Priority indicates ranking in results, higher first.
 	Priority float64
+
+	// Fork is true if the repository is a fork.
+	Fork bool
 
 	// GetVersion is used to resolve revisions for a repo. If it fails, the
 	// error is encoded in the body. If the revision is missing, an empty
@@ -105,6 +111,7 @@ func getIndexOptions(
 		RepoID:     opts.RepoID,
 		Public:     opts.Public,
 		Priority:   opts.Priority,
+		Fork:       opts.Fork,
 		LargeFiles: c.SearchLargeFiles,
 		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
 	}

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -26,6 +26,9 @@ type zoektIndexOptions struct {
 	// Fork is true if the repository is a fork.
 	Fork bool
 
+	// Archived is true if the repository is archived.
+	Archived bool
+
 	// LargeFiles is a slice of glob patterns where matching file paths should
 	// be indexed regardless of their size. The pattern syntax can be found
 	// here: https://golang.org/pkg/path/filepath/#Match.
@@ -59,6 +62,9 @@ type RepoIndexOptions struct {
 
 	// Fork is true if the repository is a fork.
 	Fork bool
+
+	// Archived is true if the repository is archived.
+	Archived bool
 
 	// GetVersion is used to resolve revisions for a repo. If it fails, the
 	// error is encoded in the body. If the revision is missing, an empty
@@ -112,6 +118,7 @@ func getIndexOptions(
 		Public:     opts.Public,
 		Priority:   opts.Priority,
 		Fork:       opts.Fork,
+		Archived:   opts.Archived,
 		LargeFiles: c.SearchLargeFiles,
 		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
 	}

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -75,6 +75,18 @@ func TestGetIndexOptions(t *testing.T) {
 			},
 		},
 	}, {
+		name: "archived",
+		conf: schema.SiteConfiguration{},
+		repo: "archived",
+		want: zoektIndexOptions{
+			RepoID:   7,
+			Archived: true,
+			Symbols:  true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+			},
+		},
+	}, {
 		name: "nosymbols",
 		conf: schema.SiteConfiguration{
 			SearchIndexSymbolsEnabled: boolPtr(false)},
@@ -233,7 +245,7 @@ func TestGetIndexOptions(t *testing.T) {
 
 	getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
 		repoID := int32(1)
-		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority", "public", "fork"} {
+		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority", "public", "fork", "archived"} {
 			if r == repo {
 				break
 			}
@@ -247,6 +259,7 @@ func TestGetIndexOptions(t *testing.T) {
 			RepoID:   repoID,
 			Public:   repo == "public",
 			Fork:     repo == "fork",
+			Archived: repo == "archived",
 			Priority: priority,
 			GetVersion: func(branch string) (string, error) {
 				return "!" + branch, nil

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -63,6 +63,18 @@ func TestGetIndexOptions(t *testing.T) {
 			},
 		},
 	}, {
+		name: "fork",
+		conf: schema.SiteConfiguration{},
+		repo: "fork",
+		want: zoektIndexOptions{
+			RepoID:  6,
+			Fork:    true,
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+			},
+		},
+	}, {
 		name: "nosymbols",
 		conf: schema.SiteConfiguration{
 			SearchIndexSymbolsEnabled: boolPtr(false)},
@@ -221,7 +233,7 @@ func TestGetIndexOptions(t *testing.T) {
 
 	getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
 		repoID := int32(1)
-		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority", "public"} {
+		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority", "public", "fork"} {
 			if r == repo {
 				break
 			}
@@ -234,6 +246,7 @@ func TestGetIndexOptions(t *testing.T) {
 		return &RepoIndexOptions{
 			RepoID:   repoID,
 			Public:   repo == "public",
+			Fork:     repo == "fork",
 			Priority: priority,
 			GetVersion: func(branch string) (string, error) {
 				return "!" + branch, nil


### PR DESCRIPTION
With this change we add fields `Fork` and `Archived` to zoektIndexOptions. 
This lays the groundwork for enabling queries targeting both fields in Zoekt.

We want to maintain this kind of information in Zoekt so that we can 
skip db lookups in Sourcegraph on the critical path.