### PR TITLE
Code insights: Dashboard product clean up 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Repository syncing can now be done in a streaming mode via the `ENABLE_STREAMING_REPOS_SYNCER` environment variable in `repo-updater`. Customers with many repositories should notice code host updates much faster when this is enabled. It will become default in the next release. [#22756](https://github.com/sourcegraph/sourcegraph/pull/22756)
 - Added "Groovy" to the initial `lang:` filter suggestions in the search bar. [#22755](https://github.com/sourcegraph/sourcegraph/pull/22755)
 - The `lang:` filter suggestions now show all supported, matching languages as the user types a language name. [#22765](https://github.com/sourcegraph/sourcegraph/pull/22765)
-- Added the code insights dashboards functionality. Now you can divide insights into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
+- Code Insights can now be grouped into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Repository syncing can now be done in a streaming mode via the `ENABLE_STREAMING_REPOS_SYNCER` environment variable in `repo-updater`. Customers with many repositories should notice code host updates much faster when this is enabled. It will become default in the next release. [#22756](https://github.com/sourcegraph/sourcegraph/pull/22756)
 - Added "Groovy" to the initial `lang:` filter suggestions in the search bar. [#22755](https://github.com/sourcegraph/sourcegraph/pull/22755)
 - The `lang:` filter suggestions now show all supported, matching languages as the user types a language name. [#22765](https://github.com/sourcegraph/sourcegraph/pull/22765)
+- Added the code insights dashboards functionality. Now you can divide insights into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
 
 ### Changed
 
@@ -45,7 +46,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - The experimental paginated search feature (the `stable:` keyword) has been removed, to be replaced with streaming search. [#22428](https://github.com/sourcegraph/sourcegraph/pull/22428)
-- The experimental extensions view page [#22565](https://github.com/sourcegraph/sourcegraph/pull/22565)
+- The experimental extensions view page has been removed. [#22565](https://github.com/sourcegraph/sourcegraph/pull/22565)
 
 ### API docs (experimental)
 

--- a/client/web/src/insights/InsightsRouter.tsx
+++ b/client/web/src/insights/InsightsRouter.tsx
@@ -14,7 +14,6 @@ import { lazyComponent } from '../util/lazyComponent'
 
 import { DashboardsRoutes } from './pages/dashboards/DasbhoardsRoutes'
 import { CreationRoutes } from './pages/insights/creation/CreationRoutes'
-import { getExperimentalFeatures } from './utils/get-experimental-features'
 
 const InsightsLazyPage = lazyComponent(() => import('./pages/insights/insights-page/InsightsPage'), 'InsightsPage')
 const EditInsightLazyPage = lazyComponent(
@@ -48,7 +47,6 @@ export const InsightsRouter = withAuthenticatedUser<InsightsRouterProps>(props =
     const { platformContext, settingsCascade, telemetryService, extensionsController, authenticatedUser } = props
 
     const match = useRouteMatch()
-    const { codeInsightsDashboards } = getExperimentalFeatures(settingsCascade)
 
     return (
         <Switch>
@@ -82,15 +80,13 @@ export const InsightsRouter = withAuthenticatedUser<InsightsRouterProps>(props =
                 )}
             />
 
-            {codeInsightsDashboards && (
-                <DashboardsRoutes
-                    authenticatedUser={authenticatedUser}
-                    telemetryService={telemetryService}
-                    extensionsController={extensionsController}
-                    platformContext={platformContext}
-                    settingsCascade={settingsCascade}
-                />
-            )}
+            <DashboardsRoutes
+                authenticatedUser={authenticatedUser}
+                telemetryService={telemetryService}
+                extensionsController={extensionsController}
+                platformContext={platformContext}
+                settingsCascade={settingsCascade}
+            />
 
             <Route component={NotFoundPage} key="hardcoded-key" />
         </Switch>

--- a/client/web/src/insights/components/form/form-group/FormGroup.tsx
+++ b/client/web/src/insights/components/form/form-group/FormGroup.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import React, { PropsWithChildren, RefObject } from 'react'
+import React, { PropsWithChildren, ReactNode, RefObject } from 'react'
 
 interface FormGroupProps {
     /** Name attr value for root fieldset element. */
@@ -7,11 +7,11 @@ interface FormGroupProps {
     /** Title on top of group. */
     title: string
     /** Subtitle of group. */
-    subtitle?: string
+    subtitle?: ReactNode
     /** Error message for field group. */
     error?: string
     /** Description text, renders below of content inputs of group. */
-    description?: string
+    description?: ReactNode
     /** Custom class name for root fieldset element. */
     className?: string
     /** Custom class name for label element of the group. */

--- a/client/web/src/insights/components/form/form-radio-input/FormRadioInput.tsx
+++ b/client/web/src/insights/components/form/form-radio-input/FormRadioInput.tsx
@@ -22,7 +22,7 @@ export const FormRadioInput: React.FunctionComponent<RadioInputProps> = props =>
         <label
             data-placement={labelTooltipPosition}
             data-tooltip={labelTooltipText}
-            className={classnames('d-flex flex-wrap align-items-center w-100', className, {
+            className={classnames('d-flex flex-wrap align-items-center', className, {
                 'text-muted': otherProps.disabled,
             })}
         >

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent } from 'react'
+import { Link } from 'react-router-dom';
 
 import { SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
 
@@ -53,7 +54,10 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
         <FormGroup
             name="visibility"
             title="Visibility"
-            description="This insight will be always displayed in the ‘All Insights’ dashboard by default"
+            subtitle={
+                <span>This insight will be always displayed in the {' '}
+                    <Link to='/insights/dashboards/all'>‘All Insights’ dashboard</Link>{' '} by default</span>
+            }
             className="mb-0 mt-4"
             labelClassName={labelClassName}
             contentClassName="d-flex flex-wrap mb-n2"
@@ -64,7 +68,7 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
                 title="Personal"
                 description="only you"
                 checked={value === userSubject.id}
-                className="mr-3"
+                className="mr-3 w-100"
                 onChange={handleChange}
             />
 
@@ -77,7 +81,7 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
                     description={`all users in ${org.displayName ?? org.name} organization`}
                     checked={value === org.id}
                     onChange={handleChange}
-                    className="mr-3"
+                    className="mr-3 w-100"
                 />
             ))}
 
@@ -88,7 +92,7 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
                     disabled={true}
                     title="Organization"
                     description="all users in your organization"
-                    className="mr-3"
+                    className="mr-3 w-100"
                     labelTooltipText="Create or join the Organization to share code insights with others!"
                 />
             )}
@@ -100,7 +104,7 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
                 description="visible to everyone on your Sourcegraph instance"
                 checked={value === globalSubject.id}
                 disabled={!canGlobalSubjectBeEdited}
-                className="mr-3"
+                className="mr-3 w-100"
                 onChange={handleChange}
             />
         </FormGroup>

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -67,7 +67,7 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
             <FormRadioInput
                 name="visibility"
                 value={userSubject.id}
-                title="Personal"
+                title="Private"
                 description="only you"
                 checked={value === userSubject.id}
                 className="mr-3 w-100"

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react'
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom'
 
 import { SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
 
@@ -55,8 +55,10 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
             name="visibility"
             title="Visibility"
             subtitle={
-                <span>This insight will be always displayed in the {' '}
-                    <Link to='/insights/dashboards/all'>‘All Insights’ dashboard</Link>{' '} by default</span>
+                <span>
+                    This insight will be always displayed in the{' '}
+                    <Link to="/insights/dashboards/all">‘All Insights’ dashboard</Link> by default
+                </span>
             }
             className="mb-0 mt-4"
             labelClassName={labelClassName}

--- a/client/web/src/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -73,6 +73,17 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
 
             <PageHeader path={[{ icon: CodeInsightsIcon }, { text: 'Add new dashboard' }]} />
 
+            <span className="text-muted d-block mt-2">
+                Dashboards group your insights and let you share them with others.{' '}
+                <a
+                    href="https://docs.sourcegraph.com/code_insights/explanations/viewing_code_insights"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    Learn more.
+                </a>
+            </span>
+
             <Container className="mt-4">
                 <InsightsDashboardCreationContent
                     dashboardsSettings={finalSettings}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
@@ -60,20 +60,7 @@ export const AddInsightModal: React.FunctionComponent<AddInsightModalProps> = pr
                 <CloseIcon />
             </button>
 
-            <h2 className="">
-                Add insight to the <span className="font-italic">"{dashboard.title}"</span> dashboard
-            </h2>
-
-            <span className="text-muted d-block mb-4">
-                Dashboards group your insights and let you share them with others.{' '}
-                <a
-                    href="https://docs.sourcegraph.com/code_insights/explanations/viewing_code_insights"
-                    target="_blank"
-                    rel="noopener"
-                >
-                    Learn more.
-                </a>
-            </span>
+            <h2 className="mb-3">Add insight to the ’{dashboard.title}’</h2>
 
             {!insights.length && <span>There are no insights for this dashboard.</span>}
 

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
@@ -60,7 +60,9 @@ export const AddInsightModal: React.FunctionComponent<AddInsightModalProps> = pr
                 <CloseIcon />
             </button>
 
-            <h2 className="mb-3">Add insight to the ’{dashboard.title}’</h2>
+            <h2 className="mb-3">
+                Add insight to <q>{dashboard.title}</q>
+            </h2>
 
             {!insights.length && <span>There are no insights for this dashboard.</span>}
 

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
@@ -46,14 +46,13 @@ export const AddInsightModalContent: React.FunctionComponent<AddInsightModalCont
         <form ref={ref} onSubmit={handleSubmit}>
             <FormInput
                 autoFocus={true}
-                title="Filter your insights"
                 description={
                     <span className="">
                         Don't see an insight? Check the insight's visibility settings or{' '}
                         <Link to="/insights/create">create a new insight</Link>
                     </span>
                 }
-                placeholder="Example: My GraphQL migration insight"
+                placeholder="Search Insights..."
                 {...searchInput.input}
             />
 

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
@@ -52,7 +52,7 @@ export const AddInsightModalContent: React.FunctionComponent<AddInsightModalCont
                         <Link to="/insights/create">create a new insight</Link>
                     </span>
                 }
-                placeholder="Search Insights..."
+                placeholder="Search insights..."
                 {...searchInput.input}
             />
 

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -21,13 +21,14 @@ export enum DashboardMenuAction {
 }
 
 export interface DashboardMenuProps extends SettingsCascadeProps<Settings> {
+    innerRef: React.Ref<HTMLButtonElement>
     dashboard?: InsightDashboard
     onSelect?: (action: DashboardMenuAction) => void
     tooltipText?: string
 }
 
 export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props => {
-    const { dashboard, settingsCascade, onSelect = () => {}, tooltipText } = props
+    const { innerRef, dashboard, settingsCascade, onSelect = () => {}, tooltipText } = props
 
     const hasDashboard = dashboard !== undefined
     const permissions = useDashboardPermissions(dashboard, settingsCascade)
@@ -35,6 +36,7 @@ export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props 
     return (
         <Menu>
             <MenuButton
+                ref={innerRef}
                 data-tooltip={tooltipText}
                 data-placement="right"
                 className={classnames(styles.triggerButton, 'btn btn-icon')}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -23,17 +23,22 @@ export enum DashboardMenuAction {
 export interface DashboardMenuProps extends SettingsCascadeProps<Settings> {
     dashboard?: InsightDashboard
     onSelect?: (action: DashboardMenuAction) => void
+    tooltipText?: string
 }
 
 export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props => {
-    const { dashboard, settingsCascade, onSelect = () => {} } = props
+    const { dashboard, settingsCascade, onSelect = () => {}, tooltipText } = props
 
     const hasDashboard = dashboard !== undefined
     const permissions = useDashboardPermissions(dashboard, settingsCascade)
 
     return (
         <Menu>
-            <MenuButton className={classnames(styles.triggerButton, 'btn btn-icon')}>
+            <MenuButton
+                data-tooltip={tooltipText}
+                data-placement="right"
+                className={classnames(styles.triggerButton, 'btn btn-icon')}
+            >
                 <DotsVerticalIcon size={16} />
             </MenuButton>
 

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.tsx
@@ -57,33 +57,37 @@ export const DashboardSelect: React.FunctionComponent<DashboardSelectProps> = pr
                             className={styles.option}
                         />
 
-                        <ListboxGroup>
-                            <ListboxGroupLabel className={classnames(styles.groupLabel, 'text-muted')}>
-                                Private
-                            </ListboxGroupLabel>
+                        {dashboards.some(isPersonalDashboard) && (
+                            <ListboxGroup>
+                                <ListboxGroupLabel className={classnames(styles.groupLabel, 'text-muted')}>
+                                    Private
+                                </ListboxGroupLabel>
 
-                            {dashboards.filter(isPersonalDashboard).map(dashboard => (
-                                <SelectDashboardOption
-                                    key={dashboard.id}
-                                    dashboard={dashboard}
-                                    className={styles.option}
-                                />
-                            ))}
-                        </ListboxGroup>
+                                {dashboards.filter(isPersonalDashboard).map(dashboard => (
+                                    <SelectDashboardOption
+                                        key={dashboard.id}
+                                        dashboard={dashboard}
+                                        className={styles.option}
+                                    />
+                                ))}
+                            </ListboxGroup>
+                        )}
 
-                        <ListboxGroup>
-                            <ListboxGroupLabel className={classnames(styles.groupLabel, 'text-muted')}>
-                                Global
-                            </ListboxGroupLabel>
+                        {dashboards.some(isGlobalDashboard) && (
+                            <ListboxGroup>
+                                <ListboxGroupLabel className={classnames(styles.groupLabel, 'text-muted')}>
+                                    Global
+                                </ListboxGroupLabel>
 
-                            {dashboards.filter(isGlobalDashboard).map(dashboard => (
-                                <SelectDashboardOption
-                                    key={dashboard.id}
-                                    dashboard={dashboard}
-                                    className={styles.option}
-                                />
-                            ))}
-                        </ListboxGroup>
+                                {dashboards.filter(isGlobalDashboard).map(dashboard => (
+                                    <SelectDashboardOption
+                                        key={dashboard.id}
+                                        dashboard={dashboard}
+                                        className={styles.option}
+                                    />
+                                ))}
+                            </ListboxGroup>
+                        )}
 
                         {organizationGroups.map(group => (
                             <ListboxGroup key={group.id}>

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -22,7 +22,7 @@ import { DashboardInsights } from './components/dashboard-inisghts/DashboardInsi
 import styles from './DashboardsContent.module.scss'
 import { useCopyURLHandler } from './hooks/use-copy-url-handler'
 import { useDashboardSelectHandler } from './hooks/use-dashboard-select-handler'
-import { findDashboardByURLId } from './utils/find-dashboard-by-url-id'
+import { findDashboardByUrlId } from './utils/find-dashboard-by-url-id'
 import { isDashboardConfigurable } from './utils/is-dashboard-configurable'
 
 export interface DashboardsContentProps
@@ -49,10 +49,10 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     const [isAddInsightOpen, setAddInsightsState] = useState<boolean>(false)
     const [isDeleteDashboardActive, setDeleteDashboardActive] = useState<boolean>(false)
 
-    const currentDashboard = findDashboardByURLId(dashboards, dashboardID)
+    const currentDashboard = findDashboardByUrlId(dashboards, dashboardID)
     const handleDashboardSelect = useDashboardSelectHandler()
     const [copyURL, isCopied] = useCopyURLHandler()
-    const menuReference = useRef<HTMLButtonElement|null>(null)
+    const menuReference = useRef<HTMLButtonElement | null>(null)
 
     const handleSelect = (action: DashboardMenuAction): void => {
         switch (action) {

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -52,6 +52,7 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     const currentDashboard = findDashboardByURLId(dashboards, dashboardID)
     const handleDashboardSelect = useDashboardSelectHandler()
     const [copyURL, isCopied] = useCopyURLHandler()
+    const menuReference = useRef<HTMLButtonElement|null>(null)
 
     const handleSelect = (action: DashboardMenuAction): void => {
         switch (action) {
@@ -71,6 +72,14 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
             }
             case DashboardMenuAction.CopyLink: {
                 copyURL()
+
+                // Re-trigger trigger tooltip event catching logic to activate
+                // copied tooltip appearance
+                requestAnimationFrame(() => {
+                    menuReference.current?.blur()
+                    menuReference.current?.focus()
+                })
+
                 return
             }
         }
@@ -89,6 +98,7 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
                 />
 
                 <DashboardMenu
+                    innerRef={menuReference}
                     tooltipText={isCopied ? 'Copied!' : undefined}
                     dashboard={currentDashboard}
                     settingsCascade={settingsCascade}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -1,19 +1,15 @@
 import classnames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import React, { useContext, useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
-import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { HeroPage } from '../../../../../../components/HeroPage'
 import { Settings } from '../../../../../../schema/settings.schema'
-import { InsightsViewGrid } from '../../../../../components'
-import { InsightsApiContext } from '../../../../../core/backend/api-provider'
 import { InsightDashboard, isVirtualDashboard } from '../../../../../core/types'
 import { isSettingsBasedInsightsDashboard } from '../../../../../core/types/dashboard/real-dashboard'
 import { useDashboards } from '../../../../../hooks/use-dashboards/use-dashboards'
@@ -22,6 +18,7 @@ import { DashboardMenu, DashboardMenuAction } from '../dashboard-menu/DashboardM
 import { DashboardSelect } from '../dashboard-select/DashboardSelect'
 import { DeleteDashboardModal } from '../delete-dashboard-modal/DeleteDashboardModal'
 
+import { DashboardInsights } from './components/dashboard-inisghts/DashboardInsights'
 import styles from './DashboardsContent.module.scss'
 import { isDashboardConfigurable } from './utils/is-dashboard-configurable'
 
@@ -148,41 +145,6 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
                     platformContext={platformContext}
                     onClose={() => setDeleteDashboardActive(false)}
                 />
-            )}
-        </div>
-    )
-}
-
-interface DashboardInsightsProps extends ExtensionsControllerProps, TelemetryProps {
-    /**
-     * Dashboard specific insight ids.
-     */
-    insightIds?: string[]
-}
-
-/**
- * Renders code insight view grid.
- */
-const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> = props => {
-    const { telemetryService, extensionsController, insightIds } = props
-    const { getInsightCombinedViews } = useContext(InsightsApiContext)
-
-    const views = useObservable(
-        useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, insightIds), [
-            insightIds,
-            extensionsController,
-            getInsightCombinedViews,
-        ])
-    )
-
-    return (
-        <div>
-            {views === undefined ? (
-                <div className="d-flex w-100">
-                    <LoadingSpinner className="my-4" />
-                </div>
-            ) : (
-                <InsightsViewGrid views={views} hasContextMenu={true} telemetryService={telemetryService} />
             )}
         </div>
     )

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -1,0 +1,66 @@
+import PuzzleIcon from 'mdi-react/PuzzleIcon'
+import React, { useContext, useMemo } from 'react'
+
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/features'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+
+import { InsightsViewGrid } from '../../../../../../../components'
+import { InsightsApiContext } from '../../../../../../../core/backend/api-provider'
+import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
+
+interface DashboardInsightsProps extends ExtensionsControllerProps, TelemetryProps {
+    /**
+     * Dashboard specific insight ids.
+     */
+    insightIds?: string[]
+}
+
+export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> = props => {
+    const { telemetryService, extensionsController, insightIds } = props
+    const { getInsightCombinedViews } = useContext(InsightsApiContext)
+
+    const views = useObservable(
+        useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, insightIds), [
+            insightIds,
+            extensionsController,
+            getInsightCombinedViews,
+        ])
+    )
+
+    // Ensures that we don't show a misleading empty state when extensions haven't loaded yet.
+    const areExtensionsReady = useObservable(
+        useMemo(() => haveInitialExtensionsLoaded(props.extensionsController.extHostAPI), [props.extensionsController])
+    )
+
+    if (!areExtensionsReady) {
+        return (
+            <div className="d-flex justify-content-center align-items-center pt-5">
+                <LoadingSpinner />
+                <span className="mx-2">Loading Sourcegraph extensions</span>
+                <PuzzleIcon className="icon-inline" />
+            </div>
+        )
+    }
+
+    if (views === undefined) {
+        return (
+            <div className="d-flex w-100">
+                <LoadingSpinner className="my-4" />
+                <span className="mx-2">Loading Code Insights</span>
+            </div>
+        )
+    }
+
+    return (
+        <div>
+            {views.length > 0 ? (
+                <InsightsViewGrid views={views} hasContextMenu={true} telemetryService={telemetryService} />
+            ) : (
+                <EmptyInsightDashboard />
+            )}
+        </div>
+    )
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -7,7 +7,7 @@ import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/co
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
-import { InsightsViewGrid } from '../../../../../../../components'
+import { CodeInsightsIcon, InsightsViewGrid } from '../../../../../../../components'
 import { InsightsApiContext } from '../../../../../../../core/backend/api-provider'
 import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
 
@@ -38,7 +38,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     if (!areExtensionsReady) {
         return (
             <div className="d-flex justify-content-center align-items-center pt-5">
-                <LoadingSpinner />
+                <LoadingSpinner/>
                 <span className="mx-2">Loading Sourcegraph extensions</span>
                 <PuzzleIcon className="icon-inline" />
             </div>
@@ -47,9 +47,10 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
 
     if (views === undefined) {
         return (
-            <div className="d-flex w-100">
-                <LoadingSpinner className="my-4" />
+            <div className="d-flex justify-content-center align-items-center pt-5">
+                <LoadingSpinner/>
                 <span className="mx-2">Loading Code Insights</span>
+                <CodeInsightsIcon className="icon-inline" />
             </div>
         )
     }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -38,7 +38,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     if (!areExtensionsReady) {
         return (
             <div className="d-flex justify-content-center align-items-center pt-5">
-                <LoadingSpinner/>
+                <LoadingSpinner />
                 <span className="mx-2">Loading Sourcegraph extensions</span>
                 <PuzzleIcon className="icon-inline" />
             </div>
@@ -48,8 +48,8 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     if (views === undefined) {
         return (
             <div className="d-flex justify-content-center align-items-center pt-5">
-                <LoadingSpinner/>
-                <span className="mx-2">Loading Code Insights</span>
+                <LoadingSpinner />
+                <span className="mx-2">Loading code insights</span>
                 <CodeInsightsIcon className="icon-inline" />
             </div>
         )

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.module.scss
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.module.scss
@@ -1,0 +1,18 @@
+.empty-section {
+    max-width: 22.75rem;
+}
+
+.item-card {
+    min-height: 20rem;
+    height: 0;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-color);
+
+    &:hover {
+        background: var(--link-hover-bg-color);
+        text-decoration: none;
+    }
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -1,0 +1,22 @@
+import classnames from 'classnames'
+import PlusIcon from 'mdi-react/PlusIcon'
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+import styles from './EmptyInsightDashboard.module.scss'
+
+export const EmptyInsightDashboard: React.FunctionComponent = () => (
+    <div>
+        <section className={styles.emptySection}>
+            <Link to="/insights/create" className={classnames(styles.itemCard, 'card')}>
+                <PlusIcon size="2rem" />
+                <span>Create new Insight</span>
+            </Link>
+            <span className="d-flex justify-content-center mt-3">
+                <span>
+                    ...or add existing Insights from <Link to="/insights/dashboards/all">All Insights</Link>
+                </span>
+            </span>
+        </section>
+    </div>
+)

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -10,11 +10,11 @@ export const EmptyInsightDashboard: React.FunctionComponent = () => (
         <section className={styles.emptySection}>
             <Link to="/insights/create" className={classnames(styles.itemCard, 'card')}>
                 <PlusIcon size="2rem" />
-                <span>Create new Insight</span>
+                <span>Create new insight</span>
             </Link>
             <span className="d-flex justify-content-center mt-3">
                 <span>
-                    ...or add existing Insights from <Link to="/insights/dashboards/all">All Insights</Link>
+                    ...or add existing insights from <Link to="/insights/dashboards/all">All Insights</Link>
                 </span>
             </span>
         </section>

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-copy-url-handler.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-copy-url-handler.ts
@@ -1,0 +1,34 @@
+import copy from 'copy-to-clipboard'
+import { useCallback } from 'react'
+import { merge, Observable, of } from 'rxjs'
+import { delay, startWith, switchMapTo, tap } from 'rxjs/operators'
+
+import { Tooltip } from '@sourcegraph/branded/src/components/tooltip/Tooltip'
+import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable'
+
+type useCopiedHandlerReturn = [() => void, boolean | undefined]
+
+/**
+ * Provide logic for copy dashboard URL logic.
+ * Returns handler to copy a dashboard URL and as the second parameter copied tooltip state
+ */
+export function useCopyURLHandler(): useCopiedHandlerReturn {
+    const copyDashboardURL = useCallback((): void => {
+        copy(window.location.href)
+    }, [])
+
+    return useEventObservable(
+        useCallback(
+            (clicks: Observable<void>) =>
+                clicks.pipe(
+                    tap(copyDashboardURL),
+                    delay(0),
+                    tap(() => Tooltip.forceUpdate()),
+                    switchMapTo(merge(of(true), of(false).pipe(delay(2000)))),
+                    tap(() => Tooltip.forceUpdate()),
+                    startWith(false)
+                ),
+            [copyDashboardURL]
+        )
+    )
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-copy-url-handler.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-copy-url-handler.ts
@@ -22,8 +22,6 @@ export function useCopyURLHandler(): useCopiedHandlerReturn {
             (clicks: Observable<void>) =>
                 clicks.pipe(
                     tap(copyDashboardURL),
-                    delay(0),
-                    tap(() => Tooltip.forceUpdate()),
                     switchMapTo(merge(of(true), of(false).pipe(delay(2000)))),
                     tap(() => Tooltip.forceUpdate()),
                     startWith(false)

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
@@ -1,0 +1,28 @@
+import { useHistory } from 'react-router-dom'
+
+import { InsightDashboard, isVirtualDashboard } from '../../../../../../core/types'
+import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
+
+/**
+ * Hook for managing URL of the dashboard page whenever the user picks
+ * another dashboard via dashboard select
+ */
+export function useDashboardSelectHandler() {
+    const history = useHistory()
+
+    return (dashboard: InsightDashboard): void => {
+        if (isVirtualDashboard(dashboard)) {
+            history.push(`/insights/dashboards/${dashboard.type}`)
+
+            return
+        }
+
+        if (isSettingsBasedInsightsDashboard(dashboard)) {
+            history.push(`/insights/dashboards/${dashboard.settingsKey}`)
+
+            return
+        }
+
+        history.push(`/insights/dashboards/${dashboard.id}`)
+    }
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
@@ -3,11 +3,13 @@ import { useHistory } from 'react-router-dom'
 import { InsightDashboard, isVirtualDashboard } from '../../../../../../core/types'
 import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
 
+type SelectHandler = (dashboard: InsightDashboard) => void
+
 /**
  * Hook for managing URL of the dashboard page whenever the user picks
  * another dashboard via dashboard select
  */
-export function useDashboardSelectHandler() {
+export function useDashboardSelectHandler(): SelectHandler {
     const history = useHistory()
 
     return (dashboard: InsightDashboard): void => {

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
@@ -1,0 +1,28 @@
+import { InsightDashboard, isVirtualDashboard } from '../../../../../../core/types'
+import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
+
+/**
+ * Returns dashboard configurations by URL query param - dashboardID.
+ *
+ * @param dashboards - list of all reachable dashboards
+ * @param dashboardID - possible dashboard id from the URL query param.
+ */
+export function findDashboardByURLId(
+    dashboards: InsightDashboard[],
+    dashboardID: string
+): InsightDashboard | undefined {
+    return dashboards.find(dashboard => {
+        if (isVirtualDashboard(dashboard)) {
+            return (
+                dashboard.id === dashboardID.toLowerCase() || dashboard.type.toLowerCase() === dashboardID.toLowerCase()
+            )
+        }
+
+        return (
+            dashboard.id === dashboardID ||
+            dashboard.title.toLowerCase() === dashboardID?.toLowerCase() ||
+            (isSettingsBasedInsightsDashboard(dashboard) &&
+                dashboard.settingsKey.toLowerCase() === dashboardID?.toLowerCase())
+        )
+    })
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
@@ -7,7 +7,7 @@ import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/d
  * @param dashboards - list of all reachable dashboards
  * @param dashboardID - possible dashboard id from the URL query param.
  */
-export function findDashboardByURLId(
+export function findDashboardByUrlId(
     dashboards: InsightDashboard[],
     dashboardID: string
 ): InsightDashboard | undefined {

--- a/client/web/src/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -103,6 +103,17 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
 
             <PageHeader path={[{ icon: CodeInsightsIcon }, { text: 'Configure dashboard' }]} />
 
+            <span className="text-muted d-block mt-2">
+                Dashboards group your insights and let you share them with others.{' '}
+                <a
+                    href="https://docs.sourcegraph.com/code_insights/explanations/viewing_code_insights"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    Learn more.
+                </a>
+            </span>
+
             <Container className="mt-4">
                 <InsightsDashboardCreationContent
                     initialValues={dashboardInitialValues}

--- a/client/web/src/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -61,7 +61,9 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
                 // Clear initial values if user successfully created search insight
                 setInitialFormValues(undefined)
                 telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')
-                history.push('/insights')
+
+                // Navigate user to the dashboard page with new created dashboard
+                history.push(`/insights/dashboards/${insight.visibility}`)
             } catch (error) {
                 return { [FORM_ERROR]: asError(error) }
             }
@@ -75,7 +77,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
         // Clear initial values if user successfully created search insight
         setInitialFormValues(undefined)
         telemetryService.log('CodeInsightsCodeStatsCreationPageCancelClick')
-        history.push('/insights')
+        history.push('/insights/dashboards/all')
     }, [history, setInitialFormValues, telemetryService])
 
     const handleChange = (event: FormChangeEvent<LangStatsCreationFormFields>): void => {

--- a/client/web/src/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
@@ -58,7 +58,9 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
 
                 // Clear initial values if user successfully created search insight
                 setLocalStorageFormValues(undefined)
-                history.push('/insights')
+
+                // Navigate user to the dashboard page with new created dashboard
+                history.push(`/insights/dashboards/${insight.visibility}`)
             } catch (error) {
                 return { [FORM_ERROR]: asError(error) }
             }
@@ -82,7 +84,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
     const handleCancel = useCallback(() => {
         telemetryService.log('CodeInsightsSearchBasedCreationPageCancelClick')
         setLocalStorageFormValues(undefined)
-        history.push('/insights')
+        history.push('/insights/dashboards/all')
     }, [history, setLocalStorageFormValues, telemetryService])
 
     return (

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
@@ -10,6 +10,7 @@ import { createMockInsightAPI } from '../../../../../../core/backend/insights-ap
 import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
 
 import { SearchInsightCreationContent, SearchInsightCreationContentProps } from './SearchInsightCreationContent'
+import { MemoryRouter } from 'react-router-dom'
 
 const USER_TEST_SUBJECT: SupportedInsightSubject = {
     __typename: 'User' as const,
@@ -33,9 +34,11 @@ describe('CreateInsightContent', () => {
 
     const renderWithProps = (props: SearchInsightCreationContentProps): RenderResult =>
         render(
-            <InsightsApiContext.Provider value={mockAPI}>
-                <SearchInsightCreationContent {...props} subjects={[USER_TEST_SUBJECT, SITE_TEST_SUBJECT]} />
-            </InsightsApiContext.Provider>
+            <MemoryRouter>
+                <InsightsApiContext.Provider value={mockAPI}>
+                    <SearchInsightCreationContent {...props} subjects={[USER_TEST_SUBJECT, SITE_TEST_SUBJECT]} />
+                </InsightsApiContext.Provider>
+            </MemoryRouter>
         )
     const onSubmitMock = sinon.spy()
 
@@ -47,7 +50,7 @@ describe('CreateInsightContent', () => {
         const repoGroup = getByRole('group', { name: /list of repositories/i })
         const repositories = within(repoGroup).getByRole('combobox')
 
-        const personalVisibility = getByRole('radio', { name: /personal/i })
+        const personalVisibility = getByRole('radio', { name: /private/i })
         const organisationVisibility = getByRole('radio', { name: /organization/i })
 
         const dataSeriesGroup = getByRole('group', { name: /data series/i })

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
@@ -1,5 +1,6 @@
 import { render, RenderResult, act, within, BoundFunction, GetByRole, cleanup, fireEvent } from '@testing-library/react'
 import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import sinon from 'sinon'
 
 import { asError } from '@sourcegraph/shared/src/util/errors'
@@ -10,7 +11,6 @@ import { createMockInsightAPI } from '../../../../../../core/backend/insights-ap
 import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
 
 import { SearchInsightCreationContent, SearchInsightCreationContentProps } from './SearchInsightCreationContent'
-import { MemoryRouter } from 'react-router-dom'
 
 const USER_TEST_SUBJECT: SupportedInsightSubject = {
     __typename: 'User' as const,

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.module.scss
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.module.scss
@@ -14,9 +14,5 @@
     // visual behavior of legend label (reset font size and weight)
     &__group-label {
         font-size: 0.875rem;
-
-        // Important needed here to override bootstrap helper font-weight-bold
-        // on group label element.
-        font-weight: normal !important;
     }
 }

--- a/client/web/src/insights/pages/insights/edit-insight/hooks/use-handle-submit.ts
+++ b/client/web/src/insights/pages/insights/edit-insight/hooks/use-handle-submit.ts
@@ -60,7 +60,8 @@ export function useHandleSubmit(props: UseHandleSubmitProps): useHandleSubmitOut
 
             await Promise.all(subjectUpdateRequests)
 
-            history.push('/insights')
+            // Navigate user to the dashboard page with new created dashboard
+            history.push(`/insights/dashboards/${newInsight.visibility}`)
         } catch (error) {
             return { [FORM_ERROR]: asError(error) }
         }

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -257,7 +257,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         {props.showBatchChanges && <BatchChangesNavItem isSourcegraphDotCom={isSourcegraphDotCom} />}
                         {codeInsights && (
                             <NavItem icon={BarChartIcon}>
-                                <NavLink to="/insights">Insights</NavLink>
+                                <NavLink to="/insights/dashboards/all">Insights</NavLink>
                             </NavItem>
                         )}
                         <NavItem icon={PuzzleOutlineIcon}>

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -77,7 +77,7 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
                     child.node &&
                     !isExcluded(child.node, props.excludingTags) && (
                         <DocumentationNode
-                            key={`${depth}-${child.node!.pathID}`}
+                            key={`${depth}-${child.node.pathID}`}
                             {...props}
                             node={child.node}
                             depth={depth + 1}


### PR DESCRIPTION
### Context
Final dashboard clean-up PR for the 3.30 release. Part of https://github.com/sourcegraph/sourcegraph/issues/22215

This PR adds and fixes a number of things that were not fulfilled in previous PRs of this tracking issues/story https://github.com/sourcegraph/sourcegraph/issues/22215. 

### What have been done
- [x] Remove feature flag for the dashboard routes
- [x] Update all insights-related links (from `/insights` to `insights/dashboards`)
- [x] Add initial states for the empty dashboard and update not found visual state 
- [x] Add copy link item to the dashboard context menu
- [x] Update add insight to dashboard UI according to last changes from Figma designs  
- [x] Update changelog 