### PR TITLE
Trim spaces from license tags

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -97,7 +97,7 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                         return generateProductLicenseForSubscription({
                             productSubscriptionID: subscriptionID,
                             license: {
-                                tags: formData.tags ? formData.tags.split(',') : [],
+                                tags: formData.tags ? formData.tags.split(',').map(tag => tag.trim()) : [],
                                 userCount: formData.userCount,
                                 expiresAt: Math.ceil(formData.expiresAt / 1000),
                             },

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -100,7 +100,7 @@ func (r *productLicense) CreatedAt() graphqlbackend.DateTime {
 
 func generateProductLicenseForSubscription(ctx context.Context, db dbutil.DB, subscriptionID string, input *graphqlbackend.ProductLicenseInput) (id string, err error) {
 	licenseKey, err := licensing.GenerateProductLicenseKey(license.Info{
-		Tags:      input.Tags,
+		Tags:      license.SanitizeTagsList(input.Tags),
 		UserCount: uint(input.UserCount),
 		ExpiresAt: time.Unix(int64(input.ExpiresAt), 0),
 	})

--- a/enterprise/internal/license/license.go
+++ b/enterprise/internal/license/license.go
@@ -69,10 +69,19 @@ func ParseTagsInput(tagsStr string) []string {
 		return nil
 	}
 	tags := strings.Split(tagsStr, ",")
-	for i, tag := range tags {
-		tags[i] = strings.TrimSpace(tag)
+	return SanitizeTagsList(tags)
+}
+
+// SanitizeTagsList removes whitespace around tags and removes empty tags before
+// returning the list of tags.
+func SanitizeTagsList(tags []string) []string {
+	sTags := make([]string, 0)
+	for _, tag := range tags {
+		if tag := strings.TrimSpace(tag); tag != "" {
+			sTags = append(sTags, tag)
+		}
 	}
-	return tags
+	return sTags
 }
 
 type encodedInfo struct {

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -3,6 +3,7 @@ package licensing
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 
@@ -41,8 +42,13 @@ func checkFeature(info *Info, feature Feature) error {
 
 	// Check if the feature is explicitly allowed via license tag.
 	hasFeature := func(want Feature) bool {
+		wantTrimmed := strings.TrimSpace(string(want))
 		for _, t := range info.Tags {
-			if Feature(t) == want {
+			// We have been issuing licenses with trailing spaces in the tags for a while.
+			// Eventually we should be able to remove these `TrimSpace` calls again,
+			// as we now guard against that while generating licenses, but there
+			// are quite a few "wrong" licenses out there as of today (2021-07-19).
+			if strings.TrimSpace(t) == wantTrimmed {
 				return true
 			}
 		}

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -40,21 +40,23 @@ func checkFeature(info *Info, feature Feature) error {
 		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.", feature))
 	}
 
+	featureTrimmed := Feature(strings.TrimSpace(string(feature)))
+
 	// Check if the feature is explicitly allowed via license tag.
 	hasFeature := func(want Feature) bool {
-		wantTrimmed := strings.TrimSpace(string(want))
 		for _, t := range info.Tags {
 			// We have been issuing licenses with trailing spaces in the tags for a while.
 			// Eventually we should be able to remove these `TrimSpace` calls again,
 			// as we now guard against that while generating licenses, but there
 			// are quite a few "wrong" licenses out there as of today (2021-07-19).
-			if strings.TrimSpace(t) == wantTrimmed {
+			if Feature(strings.TrimSpace(t)) == want {
+				fmt.Printf("fuck yeah feature %q is on\n", want)
 				return true
 			}
 		}
 		return false
 	}
-	if !info.Plan().HasFeature(feature) && !hasFeature(feature) {
+	if !info.Plan().HasFeature(featureTrimmed) && !hasFeature(featureTrimmed) {
 		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.", feature))
 	}
 	return nil // feature is activated for current license


### PR DESCRIPTION
When entering license tags in the web UI, it was easy to put spaces in between them. We didn't strip those out, though and hence the license tags didn't match. `"batch-changes" != " batch-changes"`.
