### PR TITLE
Code insights: Add BE insight creation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added "Groovy" to the initial `lang:` filter suggestions in the search bar. [#22755](https://github.com/sourcegraph/sourcegraph/pull/22755)
 - The `lang:` filter suggestions now show all supported, matching languages as the user types a language name. [#22765](https://github.com/sourcegraph/sourcegraph/pull/22765)
 - Code Insights can now be grouped into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
+- Added the code insights dashboards functionality. Now you can divide insights into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
 
 ### Changed
 

--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -198,6 +198,7 @@ export function mergeSettings<S extends Settings>(values: S[]): S | null {
         'search.savedQueries': (base: any, add: any) => [...base, ...add],
         'search.repositoryGroups': (base: any, add: any) => ({ ...base, ...add }),
         'insights.dashboards': (base: any, add: any) => ({ ...base, ...add }),
+        'insights.allrepos': (base: any, add: any) => ({ ...base, ...add }),
         quicklinks: (base: any, add: any) => [...base, ...add],
     }
     const target = cloneDeep(values[0])

--- a/client/web/src/insights/components/form/hooks/useInsightTitleValidator.ts
+++ b/client/web/src/insights/components/form/hooks/useInsightTitleValidator.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
-import { InsightTypePrefix } from '../../../core/types'
+import { INSIGHTS_ALL_REPOS_SETTINGS_KEY, InsightTypePrefix } from '../../../core/types'
 import { composeValidators, createRequiredValidator } from '../validators'
 
 import { Validator } from './useField'
@@ -24,11 +24,16 @@ export function useInsightTitleValidator(props: useTitleValidatorProps): Validat
     const { settings, insightType } = props
 
     return useMemo(() => {
+        const normalizedSettingsKeys = Object.keys(settings ?? DEFAULT_FINAL_SETTINGS)
+        const normalizedInsightAllReposKeys = Object.keys(
+            settings?.[INSIGHTS_ALL_REPOS_SETTINGS_KEY] ?? DEFAULT_FINAL_SETTINGS
+        )
+
         const existingInsightNames = new Set(
-            Object.keys(settings ?? DEFAULT_FINAL_SETTINGS)
+            [...normalizedSettingsKeys, ...normalizedInsightAllReposKeys]
                 // According to our convention about insights name <insight type>.insight.<insight name>
                 .filter(key => key.startsWith(`${insightType}`))
-                .map(key => camelCase(key.split('.').pop()))
+                .map(key => camelCase(key.split(`${insightType}.`).pop()))
         )
 
         return composeValidators<string>(createRequiredValidator('Title is a required field.'), value =>

--- a/client/web/src/insights/core/types/insight.ts
+++ b/client/web/src/insights/core/types/insight.ts
@@ -2,6 +2,8 @@ import { Duration } from 'date-fns'
 
 import { DataSeries } from '../backend/types'
 
+export const INSIGHTS_ALL_REPOS_SETTINGS_KEY = 'insights.allrepos'
+
 export enum InsightTypePrefix {
     search = 'searchInsights.insight',
     langStats = 'codeStatsInsights.insight',
@@ -31,12 +33,28 @@ export interface SyntheticInsightFields {
     visibility: InsightVisibility
 }
 
+export enum InsightType {
+    Extension = 'extension',
+    Backend = 'backend',
+}
+
+export interface SearchExtensionBasedInsight extends SearchBasedInsightSettings, SyntheticInsightFields {
+    type: InsightType.Extension
+}
+
+export interface SearchBackendBasedInsight extends SearchBasedInsightSettings, SyntheticInsightFields {
+    type: InsightType.Backend
+}
+
 /**
- * Extended Search Insight.
- * Some fields and settings (id, visibility) do not exist implicitly in user/org settings but
- * we have to have these to operate with insight properly.
- * */
-export interface SearchBasedInsight extends SearchBasedInsightSettings, SyntheticInsightFields {}
+ * Search based insight supports type types of configuration
+ *
+ * Extension based works via insight extension and lives in settings file on top level
+ * search "searchInsights.insight.<name>": {...config}
+ *
+ * Backend based works on BE and lives in "insights.allrepos": { "searchInsights.insight.<name>" : { ...config }}
+ */
+export type SearchBasedInsight = SearchExtensionBasedInsight | SearchBackendBasedInsight
 
 /**
  * See public API of search insight extension
@@ -54,7 +72,9 @@ export interface SearchBasedInsightSettings {
  * Some fields and settings (id, visibility) do not exist implicitly in user/org settings but
  * we have to have these to operate with insight properly.
  * */
-export interface LangStatsInsight extends LangStatsInsightSettings, SyntheticInsightFields {}
+export interface LangStatsInsight extends LangStatsInsightSettings, SyntheticInsightFields {
+    type: InsightType.Extension
+}
 
 /**
  * Lang stats insight as it is presented in user/org settings cascade.

--- a/client/web/src/insights/hooks/use-insight/use-insight.ts
+++ b/client/web/src/insights/hooks/use-insight/use-insight.ts
@@ -32,9 +32,9 @@ export function findInsightById(settingsCascade: SettingsCascadeOrError<Settings
         ({ settings }) =>
             settings &&
             !isErrorLike(settings) &&
-            (!!settings[insightId] ||
+            (settings[insightId] ||
                 // Also check insights all repos map as a second place if insights store
-                !!(settings[INSIGHTS_ALL_REPOS_SETTINGS_KEY] as Record<string, Insight>)?.[insightId])
+                (settings[INSIGHTS_ALL_REPOS_SETTINGS_KEY] as Record<string, Insight>)?.[insightId])
     )
 
     if (!subject?.settings || isErrorLike(subject.settings)) {
@@ -53,11 +53,12 @@ export function findInsightById(settingsCascade: SettingsCascadeOrError<Settings
         }
     }
 
-    const allReposInsights = (subject.settings[INSIGHTS_ALL_REPOS_SETTINGS_KEY] as Record<string, Insight>) ?? {}
+    const allReposInsights =
+        (subject.settings[INSIGHTS_ALL_REPOS_SETTINGS_KEY] as Record<string, SearchBasedInsightSettings>) ?? {}
 
     // Match in all repos object means that we are dealing with backend search based insight.
     if (allReposInsights[insightId]) {
-        const insightConfiguration = allReposInsights[insightId] as SearchBasedInsightSettings
+        const insightConfiguration = allReposInsights[insightId]
 
         return {
             id: insightId,

--- a/client/web/src/insights/hooks/use-insight/use-insight.ts
+++ b/client/web/src/insights/hooks/use-insight/use-insight.ts
@@ -4,7 +4,13 @@ import { SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/share
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { Settings } from '../../../schema/settings.schema'
-import { Insight, InsightConfiguration } from '../../core/types'
+import {
+    Insight,
+    InsightConfiguration,
+    INSIGHTS_ALL_REPOS_SETTINGS_KEY,
+    InsightType,
+    SearchBasedInsightSettings,
+} from '../../core/types'
 
 export interface UseInsightProps extends SettingsCascadeProps<Settings> {
     insightId: string
@@ -22,19 +28,46 @@ export function useInsight(props: UseInsightProps): Insight | null {
 export function findInsightById(settingsCascade: SettingsCascadeOrError<Settings>, insightId: string): Insight | null {
     const subjects = settingsCascade.subjects
 
-    const subject = subjects?.find(({ settings }) => settings && !isErrorLike(settings) && !!settings[insightId])
+    const subject = subjects?.find(
+        ({ settings }) =>
+            settings &&
+            !isErrorLike(settings) &&
+            (!!settings[insightId] ||
+                // Also check insights all repos map as a second place if insights store
+                !!(settings[INSIGHTS_ALL_REPOS_SETTINGS_KEY] as Record<string, Insight>)?.[insightId])
+    )
 
     if (!subject?.settings || isErrorLike(subject.settings)) {
         return null
     }
 
-    const insightConfiguration = subject.settings[insightId] as InsightConfiguration
+    // Top level match means we are dealing with extension based insights
+    if (subject.settings[insightId]) {
+        const insightConfiguration = subject.settings[insightId] as InsightConfiguration
 
-    return {
-        id: insightId,
-        visibility: subject.subject.id,
-        ...insightConfiguration,
+        return {
+            id: insightId,
+            visibility: subject.subject.id,
+            type: InsightType.Extension,
+            ...insightConfiguration,
+        }
     }
+
+    const allReposInsights = (subject.settings[INSIGHTS_ALL_REPOS_SETTINGS_KEY] as Record<string, Insight>) ?? {}
+
+    // Match in all repos object means that we are dealing with backend search based insight.
+    if (allReposInsights[insightId]) {
+        const insightConfiguration = allReposInsights[insightId] as SearchBasedInsightSettings
+
+        return {
+            id: insightId,
+            visibility: subject.subject.id,
+            type: InsightType.Backend,
+            ...insightConfiguration,
+        }
+    }
+
+    return null
 }
 
 interface InsightsInputs {
@@ -48,6 +81,7 @@ export function createInsightFromSettings(input: InsightsInputs): Insight {
 
     return {
         id: insightKey,
+        type: InsightType.Extension,
         visibility: ownerId,
         ...insightConfiguration,
     }

--- a/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/InsightsDashboardCreationContent.tsx
+++ b/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/InsightsDashboardCreationContent.tsx
@@ -62,8 +62,17 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsD
     })
 
     const nameValidator = useDashboardNameValidator({ settings: dashboardsSettings })
-    const name = useField('name', formAPI, { sync: nameValidator })
-    const visibility = useField('visibility', formAPI)
+
+    const name = useField({
+        name: 'name',
+        formApi: formAPI,
+        validators: { sync: nameValidator },
+    })
+
+    const visibility = useField({
+        name: 'visibility',
+        formApi: formAPI,
+    })
 
     // We always have user subject in our settings cascade
     const userSubject = getUserSubject(subjects)

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
@@ -34,7 +34,11 @@ export const AddInsightModalContent: React.FunctionComponent<AddInsightModalCont
         onSubmit,
     })
 
-    const searchInput = useField('searchInput', formAPI)
+    const searchInput = useField({
+        name: 'searchInput',
+        formApi: formAPI,
+    })
+
     const {
         input: { isChecked, onChange, onBlur },
     } = useCheckboxes('insightIds', formAPI)

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -38,7 +38,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     if (!areExtensionsReady) {
         return (
             <div className="d-flex justify-content-center align-items-center pt-5">
-                <LoadingSpinner/>
+                <LoadingSpinner />
                 <span className="mx-2">Loading Sourcegraph extensions</span>
                 <PuzzleIcon className="icon-inline" />
             </div>

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -38,7 +38,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     if (!areExtensionsReady) {
         return (
             <div className="d-flex justify-content-center align-items-center pt-5">
-                <LoadingSpinner />
+                <LoadingSpinner/>
                 <span className="mx-2">Loading Sourcegraph extensions</span>
                 <PuzzleIcon className="icon-inline" />
             </div>

--- a/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -72,13 +72,29 @@ export const LangStatsInsightCreationContent: React.FunctionComponent<LangStatsI
     // We can't have two or more insights with the same name, since we rely on name as on id of insights.
     const titleValidator = useInsightTitleValidator({ settings, insightType: InsightTypePrefix.langStats })
 
-    const repository = useField('repository', formAPI, {
-        sync: repositoriesFieldValidator,
-        async: repositoryFieldAsyncValidator,
+    const repository = useField({
+        name: 'repository',
+        formApi: formAPI,
+        validators: {
+            sync: repositoriesFieldValidator,
+            async: repositoryFieldAsyncValidator,
+        },
     })
-    const title = useField('title', formAPI, { sync: titleValidator })
-    const threshold = useField('threshold', formAPI, { sync: thresholdFieldValidator })
-    const visibility = useField('visibility', formAPI)
+    const title = useField({
+        name: 'title',
+        formApi: formAPI,
+        validators: { sync: titleValidator },
+    })
+
+    const threshold = useField({
+        name: 'threshold',
+        formApi: formAPI,
+        validators: { sync: thresholdFieldValidator },
+    })
+    const visibility = useField({
+        name: 'visibility',
+        formApi: formAPI,
+    })
 
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview

--- a/client/web/src/insights/pages/insights/creation/lang-stats/utils/insight-sanitizer.ts
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/utils/insight-sanitizer.ts
@@ -1,12 +1,13 @@
 import { camelCase } from 'lodash'
 
-import { InsightTypePrefix, LangStatsInsight } from '../../../../../core/types'
+import { InsightType, InsightTypePrefix, LangStatsInsight } from '../../../../../core/types'
 import { LangStatsCreationFormFields } from '../types'
 
 /**
  * Converter from creation UI form values to real insight object.
  * */
 export const getSanitizedLangStatsInsight = (values: LangStatsCreationFormFields): LangStatsInsight => ({
+    type: InsightType.Extension,
     // ID generated according to our naming insight convention
     // <Type of insight>.insight.<name of insight>
     id: `${InsightTypePrefix.langStats}.${camelCase(values.title)}`,

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -85,9 +85,22 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
         },
     })
 
-    const nameField = useField('seriesName', formAPI, { sync: requiredNameField })
-    const queryField = useField('seriesQuery', formAPI, { sync: validQuery })
-    const colorField = useField('seriesColor', formAPI)
+    const nameField = useField({
+        name: 'seriesName',
+        formApi: formAPI,
+        validators: { sync: requiredNameField },
+    })
+
+    const queryField = useField({
+        name: 'seriesQuery',
+        formApi: formAPI,
+        validators: { sync: validQuery },
+    })
+
+    const colorField = useField({
+        name: 'seriesColor',
+        formApi: formAPI,
+    })
 
     return (
         <div data-testid="series-form" ref={ref} className={classnames('d-flex flex-column', className)}>

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
@@ -11,7 +11,6 @@ import { createMockInsightAPI } from '../../../../../../core/backend/insights-ap
 import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
 
 import { SearchInsightCreationContent, SearchInsightCreationContentProps } from './SearchInsightCreationContent'
-import { MemoryRouter } from 'react-router-dom'
 
 const USER_TEST_SUBJECT: SupportedInsightSubject = {
     __typename: 'User' as const,

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
@@ -11,6 +11,7 @@ import { createMockInsightAPI } from '../../../../../../core/backend/insights-ap
 import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
 
 import { SearchInsightCreationContent, SearchInsightCreationContentProps } from './SearchInsightCreationContent'
+import { MemoryRouter } from 'react-router-dom'
 
 const USER_TEST_SUBJECT: SupportedInsightSubject = {
     __typename: 'User' as const,

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -4,25 +4,16 @@ import { noop } from 'rxjs'
 
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
-import { useField } from '../../../../../../components/form/hooks/useField'
-import { FormChangeEvent, SubmissionErrors, useForm } from '../../../../../../components/form/hooks/useForm'
-import { useInsightTitleValidator } from '../../../../../../components/form/hooks/useInsightTitleValidator'
-import { InsightTypePrefix } from '../../../../../../core/types'
-import { isUserSubject, SupportedInsightSubject } from '../../../../../../core/types/subjects'
+import { FormChangeEvent, SubmissionErrors } from '../../../../../../components/form/hooks/useForm'
+import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
 import { CreateInsightFormFields } from '../../types'
 import { getSanitizedRepositories } from '../../utils/insight-sanitizer'
 import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLivePreview'
 import { SearchInsightCreationForm } from '../search-insight-creation-form/SearchInsightCreationForm'
 
 import { useEditableSeries, createDefaultEditSeries } from './hooks/use-editable-series'
-import { INITIAL_INSIGHT_VALUES } from './initial-insight-values'
+import { useInsightCreationForm } from './hooks/use-insight-creation-form/use-insight-creation-form'
 import styles from './SearchInsightCreationContent.module.scss'
-import {
-    repositoriesExistValidator,
-    repositoriesFieldValidator,
-    requiredStepValueField,
-    seriesRequired,
-} from './validators'
 
 export interface SearchInsightCreationContentProps {
     /** This component might be used in edit or creation insight case. */
@@ -62,29 +53,23 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
 
     const isEditMode = mode === 'edit'
 
-    // Calculate initial value for visibility settings
-    const userSubjectID = subjects.find(isUserSubject)?.id ?? ''
-
-    const { values, formAPI, ref, handleSubmit } = useForm<CreateInsightFormFields>({
-        initialValues: initialValue ?? { ...INITIAL_INSIGHT_VALUES, visibility: userSubjectID },
-        onSubmit,
-        onChange,
+    const {
+        form: { values, formAPI, ref, handleSubmit },
+        title,
+        repositories,
+        series,
+        visibility,
+        step,
+        stepValue,
+        allReposMode,
+    } = useInsightCreationForm({
+        settings,
+        subjects,
+        initialValue,
         touched: isEditMode,
+        onChange,
+        onSubmit,
     })
-
-    // We can't have two or more insights with the same name, since we rely on name as on id of insights.
-    const titleValidator = useInsightTitleValidator({ settings, insightType: InsightTypePrefix.search })
-
-    const title = useField('title', formAPI, { sync: titleValidator })
-    const repositories = useField('repositories', formAPI, {
-        sync: repositoriesFieldValidator,
-        async: repositoriesExistValidator,
-    })
-    const visibility = useField('visibility', formAPI)
-
-    const series = useField('series', formAPI, { sync: seriesRequired })
-    const step = useField('step', formAPI)
-    const stepValue = useField('stepValue', formAPI, { sync: requiredStepValueField })
 
     const { editSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({
         series,
@@ -111,7 +96,9 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         (repositories.meta.validState === 'VALID' || repositories.meta.validState === 'CHECKING') &&
         repositoriesList.length > 0 &&
         (series.meta.validState === 'VALID' || validEditSeries.length) &&
-        stepValue.meta.validState === 'VALID'
+        stepValue.meta.validState === 'VALID' &&
+        // For all repos mode we are not able to show the live preview chart
+        !allReposMode.input.value
 
     const hasFilledValue =
         values.series?.some(line => line.name !== '' || line.query !== '') ||
@@ -130,6 +117,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 submitted={formAPI.submitted}
                 title={title}
                 repositories={repositories}
+                allReposMode={allReposMode}
                 visibility={visibility}
                 subjects={subjects}
                 series={series}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-insight-creation-form/use-insight-creation-form.ts
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-insight-creation-form/use-insight-creation-form.ts
@@ -1,0 +1,146 @@
+import { Settings } from '../../../../../../../../../schema/settings.schema'
+import { useField, useFieldAPI } from '../../../../../../../../components/form/hooks/useField'
+import { Form, FormChangeEvent, SubmissionErrors, useForm } from '../../../../../../../../components/form/hooks/useForm'
+import { useInsightTitleValidator } from '../../../../../../../../components/form/hooks/useInsightTitleValidator'
+import { InsightTypePrefix } from '../../../../../../../../core/types'
+import { isUserSubject, SupportedInsightSubject } from '../../../../../../../../core/types/subjects'
+import { CreateInsightFormFields, EditableDataSeries, InsightStep } from '../../../../types'
+import { INITIAL_INSIGHT_VALUES } from '../../initial-insight-values'
+import {
+    repositoriesExistValidator,
+    repositoriesFieldValidator,
+    requiredStepValueField,
+    seriesRequired,
+} from '../../validators'
+
+export interface UseInsightCreationFormProps {
+    /**
+     * Final (merged) settings cascade  objects
+     */
+    settings?: Settings | null
+
+    /**
+     * List of all supportable insight subjects
+     */
+    subjects?: SupportedInsightSubject[]
+
+    /**
+     * Initial value for all form fields
+     */
+    initialValue?: CreateInsightFormFields
+
+    /**
+     * Set initial touched state for all form fields.
+     */
+    touched?: boolean
+
+    /**
+     * Submit handler for form element.
+     */
+    onSubmit: (values: CreateInsightFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
+
+    /**
+     * Change handlers is called every time when user changed any field within the form.
+     */
+    onChange?: (event: FormChangeEvent<CreateInsightFormFields>) => void
+}
+
+export interface InsightCreationForm {
+    form: Form<CreateInsightFormFields>
+
+    title: useFieldAPI<string>
+    repositories: useFieldAPI<string>
+    visibility: useFieldAPI<string>
+    series: useFieldAPI<EditableDataSeries[]>
+    step: useFieldAPI<InsightStep>
+    stepValue: useFieldAPI<string>
+    allReposMode: useFieldAPI<boolean>
+}
+
+/**
+ * Hooks absorbs all insight creation form logic (field state managements, validations, fields dependencies)
+ */
+export function useInsightCreationForm(props: UseInsightCreationFormProps): InsightCreationForm {
+    const { subjects = [], initialValue, touched, settings, onSubmit, onChange } = props
+
+    // Calculate initial value for visibility settings
+    const userSubjectID = subjects.find(isUserSubject)?.id ?? ''
+
+    const form = useForm<CreateInsightFormFields>({
+        initialValues: initialValue ?? { ...INITIAL_INSIGHT_VALUES, visibility: userSubjectID },
+        onSubmit,
+        onChange,
+        touched,
+    })
+
+    const allReposMode = useField({
+        name: 'allRepos',
+        formApi: form.formAPI,
+        onChange: (checked: boolean) => {
+            // Reset form values in case if All repos mode was activated
+            if (checked) {
+                repositories.input.onChange('')
+                step.input.onChange('weeks')
+                stepValue.input.onChange('2')
+            }
+        },
+    })
+
+    const isAllReposMode = allReposMode.input.value
+
+    // We can't have two or more insights with the same name, since we rely on name as on id of insights.
+    const titleValidator = useInsightTitleValidator({ settings, insightType: InsightTypePrefix.search })
+    const title = useField({
+        name: 'title',
+        formApi: form.formAPI,
+        validators: { sync: titleValidator },
+    })
+
+    const repositories = useField({
+        name: 'repositories',
+        formApi: form.formAPI,
+        validators: {
+            // Turn off any validations for the repositories field in we are in all repos mode
+            sync: !isAllReposMode ? repositoriesFieldValidator : undefined,
+            async: !isAllReposMode ? repositoriesExistValidator : undefined,
+        },
+        disabled: isAllReposMode,
+    })
+
+    const visibility = useField({
+        name: 'visibility',
+        formApi: form.formAPI,
+    })
+
+    const series = useField({
+        name: 'series',
+        formApi: form.formAPI,
+        validators: { sync: seriesRequired },
+    })
+
+    const step = useField({
+        name: 'step',
+        formApi: form.formAPI,
+        disabled: isAllReposMode,
+    })
+    const stepValue = useField({
+        name: 'stepValue',
+        formApi: form.formAPI,
+        validators: {
+            // Turn off any validations if we are in all repos mode
+            sync: !isAllReposMode ? requiredStepValueField : undefined,
+        },
+        disabled: isAllReposMode,
+    })
+
+    return {
+        form,
+        title,
+        repositories,
+        visibility,
+        series,
+        step,
+        stepValue,
+        allReposMode,
+    }
+}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/initial-insight-values.ts
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/initial-insight-values.ts
@@ -12,4 +12,5 @@ export const INITIAL_INSIGHT_VALUES: CreateInsightFormFields = {
     stepValue: '2',
     title: '',
     repositories: '',
+    allRepos: false,
 }

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -30,6 +30,7 @@ interface CreationSearchInsightFormProps {
 
     title: useFieldAPI<CreateInsightFormFields['title']>
     repositories: useFieldAPI<CreateInsightFormFields['repositories']>
+    allReposMode: useFieldAPI<CreateInsightFormFields['allRepos']>
 
     visibility: useFieldAPI<CreateInsightFormFields['visibility']>
     subjects: SupportedInsightSubject[]
@@ -72,6 +73,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         submitted,
         title,
         repositories,
+        allReposMode,
         visibility,
         subjects,
         series,
@@ -116,6 +118,17 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                     {...repositories.input}
                     className="mb-0 d-flex flex-column"
                 />
+
+                <label className="d-flex align-items-center mb-2 mt-2 font-weight-normal">
+                    <input
+                        type="checkbox"
+                        {...allReposMode.input}
+                        value="all-repos-mode"
+                        checked={allReposMode.input.value}
+                    />
+
+                    <span className="pl-2">Run your insight over all your repositories</span>
+                </label>
             </FormGroup>
 
             <hr className={styles.creationInsightFormSeparator} />
@@ -185,6 +198,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                         value="hours"
                         checked={step.input.value === 'hours'}
                         onChange={step.input.onChange}
+                        disabled={step.input.disabled}
                         className="mr-3"
                     />
                     <FormRadioInput
@@ -193,6 +207,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                         value="days"
                         checked={step.input.value === 'days'}
                         onChange={step.input.onChange}
+                        disabled={step.input.disabled}
                         className="mr-3"
                     />
                     <FormRadioInput
@@ -201,6 +216,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                         value="weeks"
                         checked={step.input.value === 'weeks'}
                         onChange={step.input.onChange}
+                        disabled={step.input.disabled}
                         className="mr-3"
                     />
                     <FormRadioInput
@@ -209,6 +225,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                         value="months"
                         checked={step.input.value === 'months'}
                         onChange={step.input.onChange}
+                        disabled={step.input.disabled}
                         className="mr-3"
                     />
                     <FormRadioInput
@@ -217,6 +234,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                         value="years"
                         checked={step.input.value === 'years'}
                         onChange={step.input.onChange}
+                        disabled={step.input.disabled}
                         className="mr-3"
                     />
                 </FormGroup>

--- a/client/web/src/insights/pages/insights/creation/search-insight/types.ts
+++ b/client/web/src/insights/pages/insights/creation/search-insight/types.ts
@@ -9,21 +9,41 @@ export interface EditableDataSeries extends DataSeries {
     edit: boolean
 }
 
-/** Creation form fields. */
 export interface CreateInsightFormFields {
-    /** Code Insight series setting (name of line, line query, color) */
+    /**
+     * Code Insight series setting (name of line, line query, color)
+     */
     series: EditableDataSeries[]
-    /** Title of code insight*/
+
+    /**
+     * Title of code insight
+     */
     title: string
-    /** Repositories which to be used to get the info for code insights */
+
+    /**
+     * Repositories which to be used to get the info for code insights
+     */
     repositories: string
+
     /**
      * Visibility setting which responsible for where insight will appear.
      * possible value 'personal' | '<org id 1> ... | ... <org id N>'
-     * */
+     */
     visibility: InsightVisibility
-    /** Setting for set chart step - how often do we collect data. */
+
+    /**
+     * Setting for set chart step - how often do we collect data.
+     */
     step: InsightStep
-    /** Value for insight step setting */
+
+    /**
+     * Value for insight step setting
+     */
     stepValue: string
+
+    /**
+     * This settings stands for turn on/off all repos mode that means this insight
+     * will be run over all repos on BE (BE insight)
+     */
+    allRepos: boolean
 }

--- a/client/web/src/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
@@ -1,7 +1,7 @@
 import { camelCase } from 'lodash'
 
 import { DataSeries } from '../../../../../core/backend/types'
-import { InsightTypePrefix, SearchBasedInsight } from '../../../../../core/types'
+import { InsightType, InsightTypePrefix, SearchBasedInsight } from '../../../../../core/types'
 import { CreateInsightFormFields, EditableDataSeries } from '../types'
 
 export function getSanitizedRepositories(rawRepositories: string): string[] {
@@ -33,6 +33,8 @@ export function getSanitizedSeries(rawSeries: EditableDataSeries[]): DataSeries[
  */
 export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): SearchBasedInsight {
     return {
+        type: rawInsight.allRepos ? InsightType.Backend : InsightType.Extension,
+
         // ID generated according to our naming insight convention
         // <Type of insight>.insight.<name of insight>
         id: `${InsightTypePrefix.search}.${camelCase(rawInsight.title)}`,

--- a/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
+++ b/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
@@ -30,6 +30,7 @@ export const EditSearchBasedInsight: React.FunctionComponent<EditSearchBasedInsi
             series: insight.series.map(line => createDefaultEditSeries({ ...line, valid: true })),
             stepValue: Object.values(insight.step)[0]?.toString() ?? '3',
             step: Object.keys(insight.step)[0] as InsightStep,
+            allRepos: false,
         }),
         [insight]
     )

--- a/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
+++ b/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom'
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { SubmissionErrors } from '../../../../components/form/hooks/useForm'
-import { SearchBasedInsight } from '../../../../core/types'
+import { InsightType, SearchBasedInsight } from '../../../../core/types'
 import { SupportedInsightSubject } from '../../../../core/types/subjects'
 import { createDefaultEditSeries } from '../../creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series'
 import { SearchInsightCreationContent } from '../../creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent'
@@ -30,7 +30,7 @@ export const EditSearchBasedInsight: React.FunctionComponent<EditSearchBasedInsi
             series: insight.series.map(line => createDefaultEditSeries({ ...line, valid: true })),
             stepValue: Object.values(insight.step)[0]?.toString() ?? '3',
             step: Object.keys(insight.step)[0] as InsightStep,
-            allRepos: false,
+            allRepos: insight.type === InsightType.Backend,
         }),
         [insight]
     )

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -142,6 +142,7 @@ var deeplyMergedSettingsFields = map[string]int{
 	"search.savedQueries":     1,
 	"search.repositoryGroups": 1,
 	"insights.dashboards":     1,
+	"insights.allrepos":       1,
 	"quicklinks":              1,
 	"motd":                    1,
 	"extensions":              1,


### PR DESCRIPTION
### Context
Since this PR we have some new insight type called insight BE (or over all repositories insight). This insight will collect information from all repositories in sg instance. To introduce this new type of insight this PR adds a new form field to the insight creation/edit UI

<img width="602" alt="image" src="https://user-images.githubusercontent.com/18492575/125697319-e6911903-f070-4cb5-8324-83cd02d026d1.png">

With this turned-on mode, the creation UI creates BE insight. A couple of words about this new BE insights 
- Collect data for insight from all repositories that you have in instance (because of this we disable the repositories field in the form)
- Work with fixed time step between chart data points (2 weeks). Because of that we disable the time step and set 2 weeks-value programmatically 
- This type of insight lives in a special place in the setting file - `insights.allrepos`

```jsonc
"insights.allrepos" : { "<insight_id>: { /* insight configuration */}"}
```

### What have been done
- [x] Add all repos UI (form checkbox)
- [x] Add all repos logic to other form fields (disable repositories and time step in case if all repos is checked
- [x] Connect UI to the update logic

### How to test
1. Go to `/insights/create/search` - the search based insight creation UI page
2. Try to fill some value as you do usually when you want to create a code insight 
3. Turn on all repos mode (checked the new checkbox from screenshot above)
4. You must see that repositories and timestep field are disabled 
5. Click create button
6. Check your settings, you must see `insights.allrepos` map with your newly created insight's configurations