### PR TITLE
batches: add publication state support to CreateBatchChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Backend Code Insights now aggregate over 26 weeks instead of 6 months. [#22527](https://github.com/sourcegraph/sourcegraph/pull/22527)
 - Search queries now disallow specifying `rev:` without `repo:`. Note that to search across potentially multiple revisions, a query like `repo:.* rev:<revision>` remains valid. [#22705](https://github.com/sourcegraph/sourcegraph/pull/22705)
 - The extensions status bar on diff pages has been redesigned and now shows information for both the base and head commits. [#22123](https://github.com/sourcegraph/sourcegraph/pull/22123/files)
+- The `applyBatchChange` and `createBatchChange` mutations now accept an optional `publicationStates` argument to set the publication state of specific changesets within the batch change. [#22485](https://github.com/sourcegraph/sourcegraph/pull/22485) and [#22854](https://github.com/sourcegraph/sourcegraph/pull/22854)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -100,7 +100,8 @@ type CampaignsCredentialResolver interface {
 }
 
 type CreateBatchChangeArgs struct {
-	BatchSpec graphql.ID
+	BatchSpec         graphql.ID
+	PublicationStates *[]ChangesetSpecPublicationStateInput
 }
 
 type ApplyBatchChangeArgs struct {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1958,6 +1958,16 @@ extend type Mutation {
         The batch spec that describes the desired state of the batch change.
         """
         batchSpec: ID!
+
+        """
+        If set, these changeset specs will have their UI publication states set
+        to the given values.
+
+        An error will be returned if the same changeset spec ID is included
+        more than once in the array, or if a changeset spec ID is included with
+        a publication state set in its spec.
+        """
+        publicationStates: [ChangesetSpecPublicationStateInput!]
     ): BatchChange!
 
     """
@@ -2014,8 +2024,8 @@ extend type Mutation {
 
         """
         If set, these changeset specs will have their UI publication states set
-        to the given values. When updating an existing batch change, this will
-        overwrite existing publication states on the changesets.
+        to the given values. This will overwrite any existing UI publication
+        states on the changesets.
 
         An error will be returned if the same changeset spec ID is included
         more than once in the array, or if a changeset spec ID is included with


### PR DESCRIPTION
This is part… uh, whatever number I'm up to of #18277. (Five?)

This should have been in #22485, but I somehow forgot the existence of CreateBatchSpec. No matter: since the underlying service work was already done, this was a minor change.

I took the opportunity along the way to refactor some of the common code between the two resolvers into a single function: this should prevent a future Batch Changes developer (ie me) from doing the same thing again.

The publication state tests that lived uneasily in the unit test for ApplyBatchChange have now been moved into their own top level function, which similarly means we can share 90% of the test between ApplyBatchChange and CreateBatchChange.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
