### PR TITLE
search: constructs alert directly for no resolved repos

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -440,7 +440,7 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 		},
 	}
 
-	alert, err := errorToAlert(sr.errorForNoResolvedRepos(context.Background(), q))
+	alert := sr.alertForNoResolvedRepos(context.Background(), q)
 	require.NoError(t, err)
 	require.Equal(t, wantAlert, alert)
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1467,11 +1467,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	tr.LazyPrintf("searching %d repos, %d missing", len(resolved.RepoRevs), len(resolved.MissingRepoRevs))
 	if len(resolved.RepoRevs) == 0 {
-		localErr := r.errorForNoResolvedRepos(ctx, args.Query)
-		if alert, err := errorToAlert(localErr); alert != nil {
-			return alert.wrapResults(), err
-		}
-		return nil, localErr
+		return r.alertForNoResolvedRepos(ctx, args.Query).wrapResults(), nil
 	}
 
 	if len(resolved.MissingRepoRevs) > 0 {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22827. The original PR there introduced a subtle bug detected by tests: the result of `determineRepos` could be two different kinds of errors, which must pass through logic that promotes errors to alert types. Because the control flow of `determineRepos` inlined, this required awkward duplication to achieve strict semantic preserving behavior:

```go
		localErr := r.errorForNoResolvedRepos(ctx, args.Query)
		if alert, err := errorToAlert(localErr); alert != nil {
			return alert.wrapResults(), err
		}
		return nil, localErr
```

But, in the above, it's clear that we _know_ that `r.errorForNoResolvedRepos` will return an error that we know will be promoted to a specific alert. This indicates that, at this particular point that we are dealing with error/alerts, we should construct the alert directly here and not have to add a level of indirection of `err -> alert`, especially since the alert is predicated directly on the condition `len(resolved.RepoRevs) == 0` and not an error value we received from functions below.

Note that in general I agree with the premise behind `errorToAlert` that @camdencheek worked on:

https://github.com/sourcegraph/sourcegraph/blob/c3ed3386a84ac073c0f5bd37b3a97a23754735d0/cmd/frontend/graphqlbackend/search_alert.go#L555-L558

But in this case the logic is close enough to the API boundary , and not dependent on an error value, that we can remove the indirection. If we _really_ want to promote `len(resolved.RepoRevs) == 0` to an error first, and propagate it up, then the logic for `errorToAlert` should also be propagated up, _before_ `doResults` even, and this isn't a code shift I want to focus on right now.