### PR TITLE
github: automatic repositoryQuery refinement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The extensions status bar on diff pages has been redesigned and now shows information for both the base and head commits. [#22123](https://github.com/sourcegraph/sourcegraph/pull/22123/files)
 - The `applyBatchChange` and `createBatchChange` mutations now accept an optional `publicationStates` argument to set the publication state of specific changesets within the batch change. [#22485](https://github.com/sourcegraph/sourcegraph/pull/22485) and [#22854](https://github.com/sourcegraph/sourcegraph/pull/22854)
 - Search queries now return up to 80 suggested filters. Previously we returned up to 24. [#22863](https://github.com/sourcegraph/sourcegraph/pull/22863)
+- GitHub code host connections can now include `repositoryQuery` entries that match more than 1000 repositories from the GitHub search API without requiring the previously document work-around of splitting the query up with `created:` qualifiers, which is now done automatically. [#2562](https://github.com/sourcegraph/sourcegraph/issues/2562)
 
 ### Fixed
 

--- a/internal/extsvc/github/testdata/golden/SearchRepos-huge-query
+++ b/internal/extsvc/github/testdata/golden/SearchRepos-huge-query
@@ -1,0 +1,81 @@
+{
+  "Repos": [
+   {
+    "ID": "MDEwOlJlcG9zaXRvcnkyODQ1NzgyMw==",
+    "DatabaseID": 28457823,
+    "NameWithOwner": "freeCodeCamp/freeCodeCamp",
+    "Description": "freeCodeCamp.org's open-source codebase and curriculum. Learn to code for free.",
+    "URL": "https://github.com/freeCodeCamp/freeCodeCamp",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 326274,
+    "ForkCount": 26133
+   },
+   {
+    "ID": "MDEwOlJlcG9zaXRvcnkxNzc3MzY1MzM=",
+    "DatabaseID": 177736533,
+    "NameWithOwner": "996icu/996.ICU",
+    "Description": "Repo for counting stars and contributing. Press F to pay respect to glorious developers.",
+    "URL": "https://github.com/996icu/996.ICU",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 257953,
+    "ForkCount": 21341
+   },
+   {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMzQ5MTg5NQ==",
+    "DatabaseID": 13491895,
+    "NameWithOwner": "EbookFoundation/free-programming-books",
+    "Description": ":books: Freely available programming books",
+    "URL": "https://github.com/EbookFoundation/free-programming-books",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 196925,
+    "ForkCount": 43345
+   },
+   {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==",
+    "DatabaseID": 11730342,
+    "NameWithOwner": "vuejs/vue",
+    "Description": "🖖 Vue.js is a progressive, incrementally-adoptable JavaScript framework for building UI on the web.",
+    "URL": "https://github.com/vuejs/vue",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 185828,
+    "ForkCount": 29655
+   },
+   {
+    "ID": "MDEwOlJlcG9zaXRvcnk2MDQ5MzEwMQ==",
+    "DatabaseID": 60493101,
+    "NameWithOwner": "jwasham/coding-interview-university",
+    "Description": "A complete computer science study plan to become a software engineer.",
+    "URL": "https://github.com/jwasham/coding-interview-university",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 184411,
+    "ForkCount": 50216
+   }
+  ],
+  "TotalCount": 2284861,
+  "EndCursor": "Y3Vyc29yOjU="
+ }

--- a/internal/extsvc/github/testdata/golden/SearchRepos-narrow-query
+++ b/internal/extsvc/github/testdata/golden/SearchRepos-narrow-query
@@ -1,0 +1,21 @@
+{
+  "Repos": [
+   {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==",
+    "DatabaseID": 12080551,
+    "NameWithOwner": "tsenart/vegeta",
+    "Description": "HTTP load testing tool and library. It's over 9000!",
+    "URL": "https://github.com/tsenart/vegeta",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "ADMIN",
+    "StargazerCount": 17722,
+    "ForkCount": 1101
+   }
+  ],
+  "TotalCount": 1,
+  "EndCursor": ""
+ }

--- a/internal/extsvc/github/testdata/vcr/SearchRepos.yaml
+++ b/internal/extsvc/github/testdata/vcr/SearchRepos.yaml
@@ -1,0 +1,144 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":1,"query":"repo:tsenart/vegeta","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"search":{"repositoryCount":1,"pageInfo":{"hasNextPage":false,"endCursor":"Y3Vyc29yOjE="},"nodes":[{"id":"MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==","databaseId":12080551,"nameWithOwner":"tsenart/vegeta","description":"HTTP
+      load testing tool and library. It''s over 9000!","url":"https://github.com/tsenart/vegeta","isPrivate":false,"isFork":false,"isArchived":false,"isLocked":false,"isDisabled":false,"viewerPermission":"ADMIN","stargazerCount":17722,"forkCount":1101}]}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 19 Jul 2021 10:51:16 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - C016:3180:580A1C4:5AA15DA:60F55924
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4999"
+      X-Ratelimit-Reset:
+      - "1626695476"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "1"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":5,"query":"stars:5..500000 sort:stars-desc","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: "{\"data\":{\"search\":{\"repositoryCount\":2284861,\"pageInfo\":{\"hasNextPage\":true,\"endCursor\":\"Y3Vyc29yOjU=\"},\"nodes\":[{\"id\":\"MDEwOlJlcG9zaXRvcnkyODQ1NzgyMw==\",\"databaseId\":28457823,\"nameWithOwner\":\"freeCodeCamp/freeCodeCamp\",\"description\":\"freeCodeCamp.org's
+      open-source codebase and curriculum. Learn to code for free.\",\"url\":\"https://github.com/freeCodeCamp/freeCodeCamp\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":326274,\"forkCount\":26133},{\"id\":\"MDEwOlJlcG9zaXRvcnkxNzc3MzY1MzM=\",\"databaseId\":177736533,\"nameWithOwner\":\"996icu/996.ICU\",\"description\":\"Repo
+      for counting stars and contributing. Press F to pay respect to glorious developers.\",\"url\":\"https://github.com/996icu/996.ICU\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":257953,\"forkCount\":21341},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMzQ5MTg5NQ==\",\"databaseId\":13491895,\"nameWithOwner\":\"EbookFoundation/free-programming-books\",\"description\":\":books:
+      Freely available programming books\",\"url\":\"https://github.com/EbookFoundation/free-programming-books\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":196925,\"forkCount\":43345},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==\",\"databaseId\":11730342,\"nameWithOwner\":\"vuejs/vue\",\"description\":\"\U0001F596
+      Vue.js is a progressive, incrementally-adoptable JavaScript framework for building
+      UI on the web.\",\"url\":\"https://github.com/vuejs/vue\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":185828,\"forkCount\":29655},{\"id\":\"MDEwOlJlcG9zaXRvcnk2MDQ5MzEwMQ==\",\"databaseId\":60493101,\"nameWithOwner\":\"jwasham/coding-interview-university\",\"description\":\"A
+      complete computer science study plan to become a software engineer.\",\"url\":\"https://github.com/jwasham/coding-interview-university\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":184411,\"forkCount\":50216}]}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 19 Jul 2021 10:51:17 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - C016:3180:580A1FC:5AA1618:60F55924
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4998"
+      X-Ratelimit-Reset:
+      - "1626695476"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "2"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -82,6 +82,59 @@ func TestGetAuthenticatedUserV4(t *testing.T) {
 	)
 }
 
+func TestV4Client_SearchRepos(t *testing.T) {
+	cli, save := newV4Client(t, "SearchRepos")
+	t.Cleanup(save)
+
+	for _, tc := range []struct {
+		name   string
+		ctx    context.Context
+		params SearchReposParams
+		err    string
+	}{
+		{
+			name: "narrow-query",
+			params: SearchReposParams{
+				Query: "repo:tsenart/vegeta",
+				First: 1,
+			},
+		},
+		{
+			name: "huge-query",
+			params: SearchReposParams{
+				Query: "stars:5..500000 sort:stars-desc",
+				First: 5,
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ctx == nil {
+				tc.ctx = context.Background()
+			}
+
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			results, err := cli.SearchRepos(tc.ctx, tc.params)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			testutil.AssertGolden(t,
+				fmt.Sprintf("testdata/golden/SearchRepos-%s", tc.name),
+				update("SearchRepos"),
+				results,
+			)
+		})
+	}
+}
+
 func TestLoadPullRequest(t *testing.T) {
 	cli, save := newV4Client(t, "LoadPullRequest")
 	defer save()

--- a/internal/repos/testdata/golden/TestRepositoryQuery_Do/doesnt-exceed-limit
+++ b/internal/repos/testdata/golden/TestRepositoryQuery_Do/doesnt-exceed-limit
@@ -1,0 +1,20 @@
+[
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==",
+    "DatabaseID": 12080551,
+    "NameWithOwner": "tsenart/vegeta",
+    "Description": "HTTP load testing tool and library. It's over 9000!",
+    "URL": "https://github.com/tsenart/vegeta",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "ADMIN",
+    "StargazerCount": 17729,
+    "ForkCount": 1101
+   },
+   "Error": ""
+  }
+ ]

--- a/internal/repos/testdata/golden/TestRepositoryQuery_Do/exceeds-limit
+++ b/internal/repos/testdata/golden/TestRepositoryQuery_Do/exceeds-limit
@@ -1,0 +1,686 @@
+[
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxODY3NTQ4MzA=",
+    "DatabaseID": 186754830,
+    "NameWithOwner": "umijs/qiankun",
+    "Description": "📦 🚀 Blazing fast, simple and complete solution for micro frontends.",
+    "URL": "https://github.com/umijs/qiankun",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10100,
+    "ForkCount": 1184
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkyOTkzNTQyMDc=",
+    "DatabaseID": 299354207,
+    "NameWithOwner": "rustdesk/rustdesk",
+    "Description": "Yet another remote desktop software",
+    "URL": "https://github.com/rustdesk/rustdesk",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10089,
+    "ForkCount": 815
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxNTI1NzIxODY=",
+    "DatabaseID": 152572186,
+    "NameWithOwner": "wasmerio/wasmer",
+    "Description": "🚀 The leading WebAssembly Runtime supporting WASI and Emscripten",
+    "URL": "https://github.com/wasmerio/wasmer",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10081,
+    "ForkCount": 384
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk3MTU1MTYyOQ==",
+    "DatabaseID": 71551629,
+    "NameWithOwner": "carloscuesta/gitmoji",
+    "Description": "An emoji guide for your commit messages. 😜 ",
+    "URL": "https://github.com/carloscuesta/gitmoji",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10079,
+    "ForkCount": 590
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk2NTA3MzY0OA==",
+    "DatabaseID": 65073648,
+    "NameWithOwner": "JessYanCoding/MVPArms",
+    "Description": "⚔️ A common architecture for Android applications developing based on MVP, integrates many open source projects, to make your developing quicker and easier (一个整合了大量主流开源项目高度可配置化的 Android MVP 快速集成框架). ",
+    "URL": "https://github.com/JessYanCoding/MVPArms",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10075,
+    "ForkCount": 2415
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk2Nzc3ODAzMQ==",
+    "DatabaseID": 67778031,
+    "NameWithOwner": "seaswalker/spring-analysis",
+    "Description": "Spring源码阅读",
+    "URL": "https://github.com/seaswalker/spring-analysis",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10072,
+    "ForkCount": 3383
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkyNzczNzM5Mw==",
+    "DatabaseID": 27737393,
+    "NameWithOwner": "qmk/qmk_firmware",
+    "Description": "Open-source keyboard firmware for Atmel AVR and Arm USB families",
+    "URL": "https://github.com/qmk/qmk_firmware",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10071,
+    "ForkCount": 20628
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk5MDMyMDQ5NA==",
+    "DatabaseID": 90320494,
+    "NameWithOwner": "ish-app/ish",
+    "Description": "Linux shell for iOS",
+    "URL": "https://github.com/ish-app/ish",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10067,
+    "ForkCount": 545
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMTY1NzY3ODM=",
+    "DatabaseID": 116576783,
+    "NameWithOwner": "bettercap/bettercap",
+    "Description": "The Swiss Army knife for 802.11, BLE, IPv4 and IPv6 networks reconnaissance and MITM attacks.",
+    "URL": "https://github.com/bettercap/bettercap",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10056,
+    "ForkCount": 1021
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk3Mjk0NTE0MQ==",
+    "DatabaseID": 72945141,
+    "NameWithOwner": "chiphuyen/stanford-tensorflow-tutorials",
+    "Description": "This repository contains code examples for the Stanford's course: TensorFlow for Deep Learning Research. ",
+    "URL": "https://github.com/chiphuyen/stanford-tensorflow-tutorials",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": true,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10047,
+    "ForkCount": 4418
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxNDkyMTE2ODg=",
+    "DatabaseID": 149211688,
+    "NameWithOwner": "hoya012/deep_learning_object_detection",
+    "Description": "A paper list of object detection using deep learning.",
+    "URL": "https://github.com/hoya012/deep_learning_object_detection",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10042,
+    "ForkCount": 2737
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk1MjA3MTQ3MQ==",
+    "DatabaseID": 52071471,
+    "NameWithOwner": "reactstrap/reactstrap",
+    "Description": "Simple React Bootstrap 4 components",
+    "URL": "https://github.com/reactstrap/reactstrap",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10041,
+    "ForkCount": 1218
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk0ODc5NjE3OQ==",
+    "DatabaseID": 48796179,
+    "NameWithOwner": "z-song/laravel-admin",
+    "Description": "Build a full-featured administrative interface in ten minutes",
+    "URL": "https://github.com/z-song/laravel-admin",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10035,
+    "ForkCount": 2523
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMjAzNjA3NjU=",
+    "DatabaseID": 120360765,
+    "NameWithOwner": "chromium/chromium",
+    "Description": "The official GitHub mirror of the Chromium source",
+    "URL": "https://github.com/chromium/chromium",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10033,
+    "ForkCount": 3956
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk4ODY3NDQwNA==",
+    "DatabaseID": 88674404,
+    "NameWithOwner": "GoogleContainerTools/distroless",
+    "Description": "🥑  Language focused docker images, minus the operating system.  ",
+    "URL": "https://github.com/GoogleContainerTools/distroless",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10031,
+    "ForkCount": 567
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkyOTQ1NjYyNA==",
+    "DatabaseID": 29456624,
+    "NameWithOwner": "matiassingers/awesome-readme",
+    "Description": "A curated list of awesome READMEs",
+    "URL": "https://github.com/matiassingers/awesome-readme",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10025,
+    "ForkCount": 2702
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk0OTAxNDc5NQ==",
+    "DatabaseID": 49014795,
+    "NameWithOwner": "phpstan/phpstan",
+    "Description": "PHP Static Analysis Tool - discover bugs in your code without running it!",
+    "URL": "https://github.com/phpstan/phpstan",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10018,
+    "ForkCount": 719
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk2MzgzMjA4OQ==",
+    "DatabaseID": 63832089,
+    "NameWithOwner": "lengstrom/fast-style-transfer",
+    "Description": "TensorFlow CNN for fast style transfer ⚡🖥🎨🖼",
+    "URL": "https://github.com/lengstrom/fast-style-transfer",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10015,
+    "ForkCount": 2542
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk4MDYyNzI3OA==",
+    "DatabaseID": 80627278,
+    "NameWithOwner": "k4m4/terminals-are-sexy",
+    "Description": "💥 A curated list of Terminal frameworks, plugins \u0026 resources for CLI lovers.",
+    "URL": "https://github.com/k4m4/terminals-are-sexy",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10013,
+    "ForkCount": 547
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkzMDczMjM2NA==",
+    "DatabaseID": 30732364,
+    "NameWithOwner": "Netflix/falcor",
+    "Description": "A JavaScript library for efficient data fetching",
+    "URL": "https://github.com/Netflix/falcor",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10001,
+    "ForkCount": 468
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkyMTUwMDY5Mg==",
+    "DatabaseID": 21500692,
+    "NameWithOwner": "0xnr/awesome-bigdata",
+    "Description": "A curated list of awesome big data frameworks, ressources and other awesomeness.",
+    "URL": "https://github.com/0xnr/awesome-bigdata",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10099,
+    "ForkCount": 2295
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxOTQ0ODcwMA==",
+    "DatabaseID": 19448700,
+    "NameWithOwner": "leanote/leanote",
+    "Description": "Not Just A Notepad! (golang + mongodb) http://leanote.org",
+    "URL": "https://github.com/leanote/leanote",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10095,
+    "ForkCount": 2278
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMjM0Nzgz",
+    "DatabaseID": 1234783,
+    "NameWithOwner": "mobile-shell/mosh",
+    "Description": "Mobile Shell",
+    "URL": "https://github.com/mobile-shell/mosh",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10094,
+    "ForkCount": 628
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkyMzY4MDY3OA==",
+    "DatabaseID": 23680678,
+    "NameWithOwner": "tymondesigns/jwt-auth",
+    "Description": "🔐 JSON Web Token Authentication for Laravel \u0026 Lumen",
+    "URL": "https://github.com/tymondesigns/jwt-auth",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10091,
+    "ForkCount": 1336
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk2NDg0MTQ=",
+    "DatabaseID": 648414,
+    "NameWithOwner": "jquery-validation/jquery-validation",
+    "Description": "jQuery Validation Plugin library sources",
+    "URL": "https://github.com/jquery-validation/jquery-validation",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10083,
+    "ForkCount": 2852
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk3ODU1MzQw",
+    "DatabaseID": 7855340,
+    "NameWithOwner": "chjj/blessed",
+    "Description": "A high-level terminal interface library for node.js.",
+    "URL": "https://github.com/chjj/blessed",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10072,
+    "ForkCount": 502
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkzNTAyMTIw",
+    "DatabaseID": 3502120,
+    "NameWithOwner": "scottjehl/picturefill",
+    "Description": "A responsive image polyfill for \u003cpicture\u003e, srcset, sizes, and more",
+    "URL": "https://github.com/scottjehl/picturefill",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10069,
+    "ForkCount": 1135
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxNjYzMDMzMg==",
+    "DatabaseID": 16630332,
+    "NameWithOwner": "pagekit/vue-resource",
+    "Description": "The HTTP client for Vue.js",
+    "URL": "https://github.com/pagekit/vue-resource",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10059,
+    "ForkCount": 1708
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk5NjAzNzE0",
+    "DatabaseID": 9603714,
+    "NameWithOwner": "alcatraz/Alcatraz",
+    "Description": "Package manager for Xcode",
+    "URL": "https://github.com/alcatraz/Alcatraz",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": true,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10052,
+    "ForkCount": 1191
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMjIyODc0Ng==",
+    "DatabaseID": 12228746,
+    "NameWithOwner": "sovereign/sovereign",
+    "Description": "A set of Ansible playbooks to build and maintain your own private cloud: email, calendar, contacts, file sync, IRC bouncer, VPN, and more.",
+    "URL": "https://github.com/sovereign/sovereign",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10040,
+    "ForkCount": 847
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxNDI1OTM5MA==",
+    "DatabaseID": 14259390,
+    "NameWithOwner": "Maatwebsite/Laravel-Excel",
+    "Description": "🚀 Supercharged Excel exports and imports in Laravel",
+    "URL": "https://github.com/Maatwebsite/Laravel-Excel",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10035,
+    "ForkCount": 1592
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxNzUzNzc0OA==",
+    "DatabaseID": 17537748,
+    "NameWithOwner": "humiaozuzu/awesome-flask",
+    "Description": "A curated list of awesome Flask resources and plugins",
+    "URL": "https://github.com/humiaozuzu/awesome-flask",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10033,
+    "ForkCount": 1454
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk3NTczNjM=",
+    "DatabaseID": 757363,
+    "NameWithOwner": "knockout/knockout",
+    "Description": "Knockout makes it easier to create rich, responsive UIs with JavaScript",
+    "URL": "https://github.com/knockout/knockout",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10032,
+    "ForkCount": 1567
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxMjE3NDA0",
+    "DatabaseID": 1217404,
+    "NameWithOwner": "jordansissel/fpm",
+    "Description": "Effing package management! Build packages for multiple platforms (deb, rpm, etc) with great ease and sanity.",
+    "URL": "https://github.com/jordansissel/fpm",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10030,
+    "ForkCount": 1003
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkyMjI1NDg1Ng==",
+    "DatabaseID": 22254856,
+    "NameWithOwner": "codecentric/spring-boot-admin",
+    "Description": "Admin UI for administration of spring boot applications",
+    "URL": "https://github.com/codecentric/spring-boot-admin",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10029,
+    "ForkCount": 2732
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkxNzc4NDcx",
+    "DatabaseID": 1778471,
+    "NameWithOwner": "postmanlabs/httpbin",
+    "Description": "HTTP Request \u0026 Response Service, written in Python + Flask.",
+    "URL": "https://github.com/postmanlabs/httpbin",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10029,
+    "ForkCount": 1476
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnk2NjgzMzUy",
+    "DatabaseID": 6683352,
+    "NameWithOwner": "muaz-khan/WebRTC-Experiment",
+    "Description": "WebRTC, WebRTC and WebRTC. Everything here is all about WebRTC!!",
+    "URL": "https://github.com/muaz-khan/WebRTC-Experiment",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10013,
+    "ForkCount": 3714
+   },
+   "Error": ""
+  },
+  {
+   "Repo": {
+    "ID": "MDEwOlJlcG9zaXRvcnkyMTYyNzE5",
+    "DatabaseID": 2162719,
+    "NameWithOwner": "xdissent/ievms",
+    "Description": "Automated installation of the Microsoft IE App Compat virtual machines",
+    "URL": "https://github.com/xdissent/ievms",
+    "IsPrivate": false,
+    "IsFork": false,
+    "IsArchived": false,
+    "IsLocked": false,
+    "IsDisabled": false,
+    "ViewerPermission": "READ",
+    "StargazerCount": 10011,
+    "ForkCount": 517
+   },
+   "Error": ""
+  }
+ ]

--- a/internal/repos/testdata/sources/GITHUB/excluded-repos-are-never-yielded.yaml
+++ b/internal/repos/testdata/sources/GITHUB/excluded-repos-are-never-yielded.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tviewerPermission\n}\n\tquery
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\tquery
       {\nrepo0: repository(owner: \"sourcegraph\", name: \"Sourcegraph\") { ... on
       Repository { ...RepositoryFields } }\nrepo1: repository(owner: \"keegancsmith\",
       name: \"sqlf\") { ... on Repository { ...RepositoryFields } }\nrepo2: repository(owner:
@@ -18,306 +18,19 @@ interactions:
     url: https://api.github.com/graphql
     method: POST
   response:
-    body: '{"message":"This endpoint requires you to be authenticated.","documentation_url":"https://developer.github.com/v3/#authentication"}'
+    body: '{"data":{"repo0":{"id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","databaseId":41288708,"nameWithOwner":"sourcegraph/sourcegraph","description":"Universal
+      code search (self-hosted)","url":"https://github.com/sourcegraph/sourcegraph","isPrivate":false,"isFork":false,"isArchived":false,"isLocked":false,"isDisabled":false,"viewerPermission":"ADMIN","stargazerCount":4888,"forkCount":579},"repo1":{"id":"MDEwOlJlcG9zaXRvcnk1ODk1ODk0Mg==","databaseId":58958942,"nameWithOwner":"keegancsmith/sqlf","description":"sqlf
+      generates parameterized SQL statements in Go, sprintf style","url":"https://github.com/keegancsmith/sqlf","isPrivate":false,"isFork":false,"isArchived":false,"isLocked":false,"isDisabled":false,"viewerPermission":"READ","stargazerCount":54,"forkCount":3},"repo2":{"id":"MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==","databaseId":12080551,"nameWithOwner":"tsenart/vegeta","description":"HTTP
+      load testing tool and library. It''s over 9000!","url":"https://github.com/tsenart/vegeta","isPrivate":false,"isFork":false,"isArchived":false,"isLocked":false,"isDisabled":false,"viewerPermission":"ADMIN","stargazerCount":17729,"forkCount":1101},"repo3":{"id":"MDEwOlJlcG9zaXRvcnkxNDE3OTgwNzU=","databaseId":141798075,"nameWithOwner":"tsenart/go-tsz","description":"Time
+      series compression algorithm from Facebook''s Gorilla paper","url":"https://github.com/tsenart/go-tsz","isPrivate":false,"isFork":true,"isArchived":false,"isLocked":false,"isDisabled":false,"viewerPermission":"ADMIN","stargazerCount":4,"forkCount":5}}}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Content-Length:
-      - "131"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 12 Mar 2020 11:35:26 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 401 Unauthorized
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Vary:
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.antiope-preview; format=json
-      X-Github-Request-Id:
-      - 559E:42752:256C878:2BF8F8E:5E6A1E7E
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 401 Unauthorized
-    code: 401
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
-      - application/vnd.github.machine-man-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.github.com/repos/tsenart/go-tsz
-    method: GET
-  response:
-    body: '{"id":141798075,"node_id":"MDEwOlJlcG9zaXRvcnkxNDE3OTgwNzU=","name":"go-tsz","full_name":"tsenart/go-tsz","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/go-tsz","description":"Time
-      series compression algorithm from Facebook''s Gorilla paper","fork":true,"url":"https://api.github.com/repos/tsenart/go-tsz","forks_url":"https://api.github.com/repos/tsenart/go-tsz/forks","keys_url":"https://api.github.com/repos/tsenart/go-tsz/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/go-tsz/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/go-tsz/teams","hooks_url":"https://api.github.com/repos/tsenart/go-tsz/hooks","issue_events_url":"https://api.github.com/repos/tsenart/go-tsz/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/go-tsz/events","assignees_url":"https://api.github.com/repos/tsenart/go-tsz/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/go-tsz/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/go-tsz/tags","blobs_url":"https://api.github.com/repos/tsenart/go-tsz/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/go-tsz/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/go-tsz/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/go-tsz/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/go-tsz/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/go-tsz/languages","stargazers_url":"https://api.github.com/repos/tsenart/go-tsz/stargazers","contributors_url":"https://api.github.com/repos/tsenart/go-tsz/contributors","subscribers_url":"https://api.github.com/repos/tsenart/go-tsz/subscribers","subscription_url":"https://api.github.com/repos/tsenart/go-tsz/subscription","commits_url":"https://api.github.com/repos/tsenart/go-tsz/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/go-tsz/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/go-tsz/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/go-tsz/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/go-tsz/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/go-tsz/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/go-tsz/merges","archive_url":"https://api.github.com/repos/tsenart/go-tsz/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/go-tsz/downloads","issues_url":"https://api.github.com/repos/tsenart/go-tsz/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/go-tsz/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/go-tsz/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/go-tsz/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/go-tsz/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/go-tsz/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/go-tsz/deployments","created_at":"2018-07-21T09:17:19Z","updated_at":"2018-08-14T23:56:35Z","pushed_at":"2018-08-14T23:56:33Z","git_url":"git://github.com/tsenart/go-tsz.git","ssh_url":"git@github.com:tsenart/go-tsz.git","clone_url":"https://github.com/tsenart/go-tsz.git","svn_url":"https://github.com/tsenart/go-tsz","homepage":"","size":326,"stargazers_count":0,"watchers_count":0,"language":"Go","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"topics":[],"forks":2,"open_issues":0,"watchers":0,"default_branch":"master","temp_clone_token":null,"parent":{"id":41533478,"node_id":"MDEwOlJlcG9zaXRvcnk0MTUzMzQ3OA==","name":"go-tsz","full_name":"dgryski/go-tsz","private":false,"owner":{"login":"dgryski","id":970862,"node_id":"MDQ6VXNlcjk3MDg2Mg==","avatar_url":"https://avatars2.githubusercontent.com/u/970862?v=4","gravatar_id":"","url":"https://api.github.com/users/dgryski","html_url":"https://github.com/dgryski","followers_url":"https://api.github.com/users/dgryski/followers","following_url":"https://api.github.com/users/dgryski/following{/other_user}","gists_url":"https://api.github.com/users/dgryski/gists{/gist_id}","starred_url":"https://api.github.com/users/dgryski/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/dgryski/subscriptions","organizations_url":"https://api.github.com/users/dgryski/orgs","repos_url":"https://api.github.com/users/dgryski/repos","events_url":"https://api.github.com/users/dgryski/events{/privacy}","received_events_url":"https://api.github.com/users/dgryski/received_events","type":"User","site_admin":false},"html_url":"https://github.com/dgryski/go-tsz","description":"Time
-      series compression algorithm from Facebook''s Gorilla paper","fork":false,"url":"https://api.github.com/repos/dgryski/go-tsz","forks_url":"https://api.github.com/repos/dgryski/go-tsz/forks","keys_url":"https://api.github.com/repos/dgryski/go-tsz/keys{/key_id}","collaborators_url":"https://api.github.com/repos/dgryski/go-tsz/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/dgryski/go-tsz/teams","hooks_url":"https://api.github.com/repos/dgryski/go-tsz/hooks","issue_events_url":"https://api.github.com/repos/dgryski/go-tsz/issues/events{/number}","events_url":"https://api.github.com/repos/dgryski/go-tsz/events","assignees_url":"https://api.github.com/repos/dgryski/go-tsz/assignees{/user}","branches_url":"https://api.github.com/repos/dgryski/go-tsz/branches{/branch}","tags_url":"https://api.github.com/repos/dgryski/go-tsz/tags","blobs_url":"https://api.github.com/repos/dgryski/go-tsz/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/dgryski/go-tsz/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/dgryski/go-tsz/git/refs{/sha}","trees_url":"https://api.github.com/repos/dgryski/go-tsz/git/trees{/sha}","statuses_url":"https://api.github.com/repos/dgryski/go-tsz/statuses/{sha}","languages_url":"https://api.github.com/repos/dgryski/go-tsz/languages","stargazers_url":"https://api.github.com/repos/dgryski/go-tsz/stargazers","contributors_url":"https://api.github.com/repos/dgryski/go-tsz/contributors","subscribers_url":"https://api.github.com/repos/dgryski/go-tsz/subscribers","subscription_url":"https://api.github.com/repos/dgryski/go-tsz/subscription","commits_url":"https://api.github.com/repos/dgryski/go-tsz/commits{/sha}","git_commits_url":"https://api.github.com/repos/dgryski/go-tsz/git/commits{/sha}","comments_url":"https://api.github.com/repos/dgryski/go-tsz/comments{/number}","issue_comment_url":"https://api.github.com/repos/dgryski/go-tsz/issues/comments{/number}","contents_url":"https://api.github.com/repos/dgryski/go-tsz/contents/{+path}","compare_url":"https://api.github.com/repos/dgryski/go-tsz/compare/{base}...{head}","merges_url":"https://api.github.com/repos/dgryski/go-tsz/merges","archive_url":"https://api.github.com/repos/dgryski/go-tsz/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/dgryski/go-tsz/downloads","issues_url":"https://api.github.com/repos/dgryski/go-tsz/issues{/number}","pulls_url":"https://api.github.com/repos/dgryski/go-tsz/pulls{/number}","milestones_url":"https://api.github.com/repos/dgryski/go-tsz/milestones{/number}","notifications_url":"https://api.github.com/repos/dgryski/go-tsz/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/dgryski/go-tsz/labels{/name}","releases_url":"https://api.github.com/repos/dgryski/go-tsz/releases{/id}","deployments_url":"https://api.github.com/repos/dgryski/go-tsz/deployments","created_at":"2015-08-28T07:28:39Z","updated_at":"2020-03-09T21:21:51Z","pushed_at":"2018-07-21T09:44:43Z","git_url":"git://github.com/dgryski/go-tsz.git","ssh_url":"git@github.com:dgryski/go-tsz.git","clone_url":"https://github.com/dgryski/go-tsz.git","svn_url":"https://github.com/dgryski/go-tsz","homepage":"","size":295,"stargazers_count":373,"watchers_count":373,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":42,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":2,"license":{"key":"bsd-2-clause","name":"BSD
-      2-Clause \"Simplified\" License","spdx_id":"BSD-2-Clause","url":"https://api.github.com/licenses/bsd-2-clause","node_id":"MDc6TGljZW5zZTQ="},"forks":42,"open_issues":2,"watchers":373,"default_branch":"master"},"source":{"id":41533478,"node_id":"MDEwOlJlcG9zaXRvcnk0MTUzMzQ3OA==","name":"go-tsz","full_name":"dgryski/go-tsz","private":false,"owner":{"login":"dgryski","id":970862,"node_id":"MDQ6VXNlcjk3MDg2Mg==","avatar_url":"https://avatars2.githubusercontent.com/u/970862?v=4","gravatar_id":"","url":"https://api.github.com/users/dgryski","html_url":"https://github.com/dgryski","followers_url":"https://api.github.com/users/dgryski/followers","following_url":"https://api.github.com/users/dgryski/following{/other_user}","gists_url":"https://api.github.com/users/dgryski/gists{/gist_id}","starred_url":"https://api.github.com/users/dgryski/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/dgryski/subscriptions","organizations_url":"https://api.github.com/users/dgryski/orgs","repos_url":"https://api.github.com/users/dgryski/repos","events_url":"https://api.github.com/users/dgryski/events{/privacy}","received_events_url":"https://api.github.com/users/dgryski/received_events","type":"User","site_admin":false},"html_url":"https://github.com/dgryski/go-tsz","description":"Time
-      series compression algorithm from Facebook''s Gorilla paper","fork":false,"url":"https://api.github.com/repos/dgryski/go-tsz","forks_url":"https://api.github.com/repos/dgryski/go-tsz/forks","keys_url":"https://api.github.com/repos/dgryski/go-tsz/keys{/key_id}","collaborators_url":"https://api.github.com/repos/dgryski/go-tsz/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/dgryski/go-tsz/teams","hooks_url":"https://api.github.com/repos/dgryski/go-tsz/hooks","issue_events_url":"https://api.github.com/repos/dgryski/go-tsz/issues/events{/number}","events_url":"https://api.github.com/repos/dgryski/go-tsz/events","assignees_url":"https://api.github.com/repos/dgryski/go-tsz/assignees{/user}","branches_url":"https://api.github.com/repos/dgryski/go-tsz/branches{/branch}","tags_url":"https://api.github.com/repos/dgryski/go-tsz/tags","blobs_url":"https://api.github.com/repos/dgryski/go-tsz/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/dgryski/go-tsz/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/dgryski/go-tsz/git/refs{/sha}","trees_url":"https://api.github.com/repos/dgryski/go-tsz/git/trees{/sha}","statuses_url":"https://api.github.com/repos/dgryski/go-tsz/statuses/{sha}","languages_url":"https://api.github.com/repos/dgryski/go-tsz/languages","stargazers_url":"https://api.github.com/repos/dgryski/go-tsz/stargazers","contributors_url":"https://api.github.com/repos/dgryski/go-tsz/contributors","subscribers_url":"https://api.github.com/repos/dgryski/go-tsz/subscribers","subscription_url":"https://api.github.com/repos/dgryski/go-tsz/subscription","commits_url":"https://api.github.com/repos/dgryski/go-tsz/commits{/sha}","git_commits_url":"https://api.github.com/repos/dgryski/go-tsz/git/commits{/sha}","comments_url":"https://api.github.com/repos/dgryski/go-tsz/comments{/number}","issue_comment_url":"https://api.github.com/repos/dgryski/go-tsz/issues/comments{/number}","contents_url":"https://api.github.com/repos/dgryski/go-tsz/contents/{+path}","compare_url":"https://api.github.com/repos/dgryski/go-tsz/compare/{base}...{head}","merges_url":"https://api.github.com/repos/dgryski/go-tsz/merges","archive_url":"https://api.github.com/repos/dgryski/go-tsz/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/dgryski/go-tsz/downloads","issues_url":"https://api.github.com/repos/dgryski/go-tsz/issues{/number}","pulls_url":"https://api.github.com/repos/dgryski/go-tsz/pulls{/number}","milestones_url":"https://api.github.com/repos/dgryski/go-tsz/milestones{/number}","notifications_url":"https://api.github.com/repos/dgryski/go-tsz/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/dgryski/go-tsz/labels{/name}","releases_url":"https://api.github.com/repos/dgryski/go-tsz/releases{/id}","deployments_url":"https://api.github.com/repos/dgryski/go-tsz/deployments","created_at":"2015-08-28T07:28:39Z","updated_at":"2020-03-09T21:21:51Z","pushed_at":"2018-07-21T09:44:43Z","git_url":"git://github.com/dgryski/go-tsz.git","ssh_url":"git@github.com:dgryski/go-tsz.git","clone_url":"https://github.com/dgryski/go-tsz.git","svn_url":"https://github.com/dgryski/go-tsz","homepage":"","size":295,"stargazers_count":373,"watchers_count":373,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":42,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":2,"license":{"key":"bsd-2-clause","name":"BSD
-      2-Clause \"Simplified\" License","spdx_id":"BSD-2-Clause","url":"https://api.github.com/licenses/bsd-2-clause","node_id":"MDc6TGljZW5zZTQ="},"topics":[],"forks":42,"open_issues":2,"watchers":373,"default_branch":"master"},"network_count":42,"subscribers_count":1}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 12 Mar 2020 11:35:27 GMT
-      Etag:
-      - W/"6d32db5f2197c2d57b35b86eb44902f8"
-      Last-Modified:
-      - Tue, 14 Aug 2018 23:56:35 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Vary:
-      - Accept
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
-        github.machine-man-preview; format=json
-      X-Github-Request-Id:
-      - 559E:42752:256C8D6:2BF8FE6:5E6A1E7E
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
-      - application/vnd.github.machine-man-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.github.com/repos/tsenart/VEGETA
-    method: GET
-  response:
-    body: '{"id":12080551,"node_id":"MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==","name":"vegeta","full_name":"tsenart/vegeta","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/vegeta","description":"HTTP
-      load testing tool and library. It''s over 9000!","fork":false,"url":"https://api.github.com/repos/tsenart/vegeta","forks_url":"https://api.github.com/repos/tsenart/vegeta/forks","keys_url":"https://api.github.com/repos/tsenart/vegeta/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/vegeta/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/vegeta/teams","hooks_url":"https://api.github.com/repos/tsenart/vegeta/hooks","issue_events_url":"https://api.github.com/repos/tsenart/vegeta/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/vegeta/events","assignees_url":"https://api.github.com/repos/tsenart/vegeta/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/vegeta/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/vegeta/tags","blobs_url":"https://api.github.com/repos/tsenart/vegeta/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/vegeta/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/vegeta/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/vegeta/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/vegeta/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/vegeta/languages","stargazers_url":"https://api.github.com/repos/tsenart/vegeta/stargazers","contributors_url":"https://api.github.com/repos/tsenart/vegeta/contributors","subscribers_url":"https://api.github.com/repos/tsenart/vegeta/subscribers","subscription_url":"https://api.github.com/repos/tsenart/vegeta/subscription","commits_url":"https://api.github.com/repos/tsenart/vegeta/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/vegeta/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/vegeta/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/vegeta/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/vegeta/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/vegeta/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/vegeta/merges","archive_url":"https://api.github.com/repos/tsenart/vegeta/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/vegeta/downloads","issues_url":"https://api.github.com/repos/tsenart/vegeta/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/vegeta/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/vegeta/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/vegeta/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/vegeta/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/vegeta/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/vegeta/deployments","created_at":"2013-08-13T11:45:21Z","updated_at":"2020-03-12T10:26:23Z","pushed_at":"2020-03-09T14:50:16Z","git_url":"git://github.com/tsenart/vegeta.git","ssh_url":"git@github.com:tsenart/vegeta.git","clone_url":"https://github.com/tsenart/vegeta.git","svn_url":"https://github.com/tsenart/vegeta","homepage":"http://godoc.org/github.com/tsenart/vegeta/lib","size":1703,"stargazers_count":14055,"watchers_count":14055,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":905,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":35,"license":{"key":"mit","name":"MIT
-      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"topics":["benchmarking","go","http","load-testing"],"forks":905,"open_issues":35,"watchers":14055,"default_branch":"master","temp_clone_token":null,"network_count":905,"subscribers_count":293}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 12 Mar 2020 11:35:27 GMT
-      Etag:
-      - W/"e35268ce80294fa31a4c7d01e4c64f23"
-      Last-Modified:
-      - Thu, 12 Mar 2020 10:26:23 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Vary:
-      - Accept
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
-        github.machine-man-preview; format=json
-      X-Github-Request-Id:
-      - 559E:42752:256C956:2BF908C:5E6A1E7F
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
-      - application/vnd.github.machine-man-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.github.com/repos/keegancsmith/sqlf
-    method: GET
-  response:
-    body: '{"id":58958942,"node_id":"MDEwOlJlcG9zaXRvcnk1ODk1ODk0Mg==","name":"sqlf","full_name":"keegancsmith/sqlf","private":false,"owner":{"login":"keegancsmith","id":187831,"node_id":"MDQ6VXNlcjE4NzgzMQ==","avatar_url":"https://avatars1.githubusercontent.com/u/187831?v=4","gravatar_id":"","url":"https://api.github.com/users/keegancsmith","html_url":"https://github.com/keegancsmith","followers_url":"https://api.github.com/users/keegancsmith/followers","following_url":"https://api.github.com/users/keegancsmith/following{/other_user}","gists_url":"https://api.github.com/users/keegancsmith/gists{/gist_id}","starred_url":"https://api.github.com/users/keegancsmith/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/keegancsmith/subscriptions","organizations_url":"https://api.github.com/users/keegancsmith/orgs","repos_url":"https://api.github.com/users/keegancsmith/repos","events_url":"https://api.github.com/users/keegancsmith/events{/privacy}","received_events_url":"https://api.github.com/users/keegancsmith/received_events","type":"User","site_admin":false},"html_url":"https://github.com/keegancsmith/sqlf","description":"sqlf
-      generates parameterized SQL statements in Go, sprintf style","fork":false,"url":"https://api.github.com/repos/keegancsmith/sqlf","forks_url":"https://api.github.com/repos/keegancsmith/sqlf/forks","keys_url":"https://api.github.com/repos/keegancsmith/sqlf/keys{/key_id}","collaborators_url":"https://api.github.com/repos/keegancsmith/sqlf/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/keegancsmith/sqlf/teams","hooks_url":"https://api.github.com/repos/keegancsmith/sqlf/hooks","issue_events_url":"https://api.github.com/repos/keegancsmith/sqlf/issues/events{/number}","events_url":"https://api.github.com/repos/keegancsmith/sqlf/events","assignees_url":"https://api.github.com/repos/keegancsmith/sqlf/assignees{/user}","branches_url":"https://api.github.com/repos/keegancsmith/sqlf/branches{/branch}","tags_url":"https://api.github.com/repos/keegancsmith/sqlf/tags","blobs_url":"https://api.github.com/repos/keegancsmith/sqlf/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/keegancsmith/sqlf/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/keegancsmith/sqlf/git/refs{/sha}","trees_url":"https://api.github.com/repos/keegancsmith/sqlf/git/trees{/sha}","statuses_url":"https://api.github.com/repos/keegancsmith/sqlf/statuses/{sha}","languages_url":"https://api.github.com/repos/keegancsmith/sqlf/languages","stargazers_url":"https://api.github.com/repos/keegancsmith/sqlf/stargazers","contributors_url":"https://api.github.com/repos/keegancsmith/sqlf/contributors","subscribers_url":"https://api.github.com/repos/keegancsmith/sqlf/subscribers","subscription_url":"https://api.github.com/repos/keegancsmith/sqlf/subscription","commits_url":"https://api.github.com/repos/keegancsmith/sqlf/commits{/sha}","git_commits_url":"https://api.github.com/repos/keegancsmith/sqlf/git/commits{/sha}","comments_url":"https://api.github.com/repos/keegancsmith/sqlf/comments{/number}","issue_comment_url":"https://api.github.com/repos/keegancsmith/sqlf/issues/comments{/number}","contents_url":"https://api.github.com/repos/keegancsmith/sqlf/contents/{+path}","compare_url":"https://api.github.com/repos/keegancsmith/sqlf/compare/{base}...{head}","merges_url":"https://api.github.com/repos/keegancsmith/sqlf/merges","archive_url":"https://api.github.com/repos/keegancsmith/sqlf/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/keegancsmith/sqlf/downloads","issues_url":"https://api.github.com/repos/keegancsmith/sqlf/issues{/number}","pulls_url":"https://api.github.com/repos/keegancsmith/sqlf/pulls{/number}","milestones_url":"https://api.github.com/repos/keegancsmith/sqlf/milestones{/number}","notifications_url":"https://api.github.com/repos/keegancsmith/sqlf/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/keegancsmith/sqlf/labels{/name}","releases_url":"https://api.github.com/repos/keegancsmith/sqlf/releases{/id}","deployments_url":"https://api.github.com/repos/keegancsmith/sqlf/deployments","created_at":"2016-05-16T19:01:04Z","updated_at":"2019-12-05T07:32:47Z","pushed_at":"2018-09-13T13:40:54Z","git_url":"git://github.com/keegancsmith/sqlf.git","ssh_url":"git@github.com:keegancsmith/sqlf.git","clone_url":"https://github.com/keegancsmith/sqlf.git","svn_url":"https://github.com/keegancsmith/sqlf","homepage":"","size":14,"stargazers_count":49,"watchers_count":49,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":3,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":{"key":"mit","name":"MIT
-      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"topics":["go","golang","sprintf-style","sql"],"forks":3,"open_issues":0,"watchers":49,"default_branch":"master","temp_clone_token":null,"network_count":3,"subscribers_count":2}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 12 Mar 2020 11:35:27 GMT
-      Etag:
-      - W/"3f72859dc224ea8e125bd52e2987ed52"
-      Last-Modified:
-      - Thu, 05 Dec 2019 07:32:47 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Vary:
-      - Accept
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
-        github.machine-man-preview; format=json
-      X-Github-Request-Id:
-      - 559E:42752:256C9BD:2BF9102:5E6A1E7F
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
-      - application/vnd.github.machine-man-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.github.com/repos/sourcegraph/Sourcegraph
-    method: GET
-  response:
-    body: '{"id":41288708,"node_id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","name":"sourcegraph","full_name":"sourcegraph/sourcegraph","private":false,"owner":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/sourcegraph/sourcegraph","description":"Universal
-      code search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2020-03-12T11:26:20Z","pushed_at":"2020-03-12T11:17:02Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":356829,"stargazers_count":3336,"watchers_count":3336,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":321,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1152,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"topics":["code-intelligence","code-search","lsif-enabled","open-source","repo-type-main","sourcegraph"],"forks":321,"open_issues":1152,"watchers":3336,"default_branch":"master","temp_clone_token":null,"organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":321,"subscribers_count":82}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 12 Mar 2020 11:35:27 GMT
-      Etag:
-      - W/"b4b96df4f51ad712c1cc6ddcecbb13bb"
-      Last-Modified:
-      - Thu, 12 Mar 2020 11:26:20 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Vary:
-      - Accept
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
-        github.machine-man-preview; format=json
-      X-Github-Request-Id:
-      - 559E:42752:256CA28:2BF9180:5E6A1E7F
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
-      - application/vnd.github.machine-man-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol
-    method: GET
-  response:
-    body: '{"total_count":1,"incomplete_results":false,"items":[{"id":153657245,"node_id":"MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU=","name":"patrol","full_name":"tsenart/patrol","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/patrol","description":"Patrol
-      is an operator friendly distributed rate limiting HTTP API with strong eventually
-      consistent CvRDT based replication.","fork":false,"url":"https://api.github.com/repos/tsenart/patrol","forks_url":"https://api.github.com/repos/tsenart/patrol/forks","keys_url":"https://api.github.com/repos/tsenart/patrol/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/patrol/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/patrol/teams","hooks_url":"https://api.github.com/repos/tsenart/patrol/hooks","issue_events_url":"https://api.github.com/repos/tsenart/patrol/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/patrol/events","assignees_url":"https://api.github.com/repos/tsenart/patrol/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/patrol/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/patrol/tags","blobs_url":"https://api.github.com/repos/tsenart/patrol/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/patrol/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/patrol/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/patrol/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/patrol/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/patrol/languages","stargazers_url":"https://api.github.com/repos/tsenart/patrol/stargazers","contributors_url":"https://api.github.com/repos/tsenart/patrol/contributors","subscribers_url":"https://api.github.com/repos/tsenart/patrol/subscribers","subscription_url":"https://api.github.com/repos/tsenart/patrol/subscription","commits_url":"https://api.github.com/repos/tsenart/patrol/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/patrol/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/patrol/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/patrol/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/patrol/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/patrol/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/patrol/merges","archive_url":"https://api.github.com/repos/tsenart/patrol/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/patrol/downloads","issues_url":"https://api.github.com/repos/tsenart/patrol/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/patrol/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/patrol/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/patrol/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/patrol/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/patrol/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/patrol/deployments","created_at":"2018-10-18T16:50:37Z","updated_at":"2019-10-29T09:53:49Z","pushed_at":"2018-11-13T14:57:15Z","git_url":"git://github.com/tsenart/patrol.git","ssh_url":"git@github.com:tsenart/patrol.git","clone_url":"https://github.com/tsenart/patrol.git","svn_url":"https://github.com/tsenart/patrol","homepage":"","size":95,"stargazers_count":26,"watchers_count":26,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":3,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":{"key":"mit","name":"MIT
-      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"topics":[],"forks":3,"open_issues":1,"watchers":26,"default_branch":"master","score":1.0}]}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
       Cache-Control:
       - no-cache
       Content-Security-Policy:
@@ -325,28 +38,96 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Mar 2020 11:35:27 GMT
+      - Tue, 20 Jul 2021 18:51:56 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
       - GitHub.com
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Vary:
       - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - deny
       X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
-        github.machine-man-preview; format=json
+      - github.v4; param=antiope-preview; format=json
       X-Github-Request-Id:
-      - 559E:42752:256CA9A:2BF9204:5E6A1E7F
+      - B8E2:9885:4A73C8:4C0935:60F71B4C
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "1"
       X-Xss-Protection:
-      - 1; mode=block
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":100,"query":"user:tsenart in:name patrol","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"search":{"repositoryCount":1,"pageInfo":{"hasNextPage":false,"endCursor":"Y3Vyc29yOjE="},"nodes":[{"id":"MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU=","databaseId":153657245,"nameWithOwner":"tsenart/patrol","description":"Patrol
+      is an operator friendly distributed rate limiting HTTP API with strong eventually
+      consistent CvRDT based replication.","url":"https://github.com/tsenart/patrol","isPrivate":false,"isFork":false,"isArchived":false,"isLocked":false,"isDisabled":false,"viewerPermission":"ADMIN","stargazerCount":33,"forkCount":3}]}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 18:51:56 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B8E2:9885:4A740B:4C0981:60F71B4C
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "2"
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/repos/testdata/vcr/TestRepositoryQuery_Do/doesnt-exceed-limit.yaml
+++ b/internal/repos/testdata/vcr/TestRepositoryQuery_Do/doesnt-exceed-limit.yaml
@@ -1,0 +1,71 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":10,"query":"repo:tsenart/vegeta stars:\u003e=14000","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"search":{"repositoryCount":1,"pageInfo":{"hasNextPage":false,"endCursor":"Y3Vyc29yOjE="},"nodes":[{"id":"MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==","databaseId":12080551,"nameWithOwner":"tsenart/vegeta","description":"HTTP
+      load testing tool and library. It''s over 9000!","url":"https://github.com/tsenart/vegeta","isPrivate":false,"isFork":false,"isArchived":false,"isLocked":false,"isDisabled":false,"viewerPermission":"ADMIN","stargazerCount":17729,"forkCount":1101}]}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 17:21:06 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B300:D4F6:12E488A:134929D:60F70602
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4978"
+      X-Ratelimit-Reset:
+      - "1626805026"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "22"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/testdata/vcr/TestRepositoryQuery_Do/exceeds-limit.yaml
+++ b/internal/repos/testdata/vcr/TestRepositoryQuery_Do/exceeds-limit.yaml
@@ -1,0 +1,474 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":10,"query":"stars:10000..10100","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: "{\"data\":{\"search\":{\"repositoryCount\":38,\"pageInfo\":{\"hasNextPage\":true,\"endCursor\":\"Y3Vyc29yOjEw\"},\"nodes\":[{\"id\":\"MDEwOlJlcG9zaXRvcnkxODY3NTQ4MzA=\",\"databaseId\":186754830,\"nameWithOwner\":\"umijs/qiankun\",\"description\":\"\U0001F4E6
+      \U0001F680 Blazing fast, simple and complete solution for micro frontends.\",\"url\":\"https://github.com/umijs/qiankun\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10100,\"forkCount\":1184},{\"id\":\"MDEwOlJlcG9zaXRvcnkyMTUwMDY5Mg==\",\"databaseId\":21500692,\"nameWithOwner\":\"0xnr/awesome-bigdata\",\"description\":\"A
+      curated list of awesome big data frameworks, ressources and other awesomeness.\",\"url\":\"https://github.com/0xnr/awesome-bigdata\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10099,\"forkCount\":2295},{\"id\":\"MDEwOlJlcG9zaXRvcnkxOTQ0ODcwMA==\",\"databaseId\":19448700,\"nameWithOwner\":\"leanote/leanote\",\"description\":\"Not
+      Just A Notepad! (golang + mongodb) http://leanote.org\",\"url\":\"https://github.com/leanote/leanote\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10095,\"forkCount\":2278},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMjM0Nzgz\",\"databaseId\":1234783,\"nameWithOwner\":\"mobile-shell/mosh\",\"description\":\"Mobile
+      Shell\",\"url\":\"https://github.com/mobile-shell/mosh\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10094,\"forkCount\":628},{\"id\":\"MDEwOlJlcG9zaXRvcnkyMzY4MDY3OA==\",\"databaseId\":23680678,\"nameWithOwner\":\"tymondesigns/jwt-auth\",\"description\":\"\U0001F510
+      JSON Web Token Authentication for Laravel & Lumen\",\"url\":\"https://github.com/tymondesigns/jwt-auth\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10091,\"forkCount\":1336},{\"id\":\"MDEwOlJlcG9zaXRvcnkyOTkzNTQyMDc=\",\"databaseId\":299354207,\"nameWithOwner\":\"rustdesk/rustdesk\",\"description\":\"Yet
+      another remote desktop software\",\"url\":\"https://github.com/rustdesk/rustdesk\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10089,\"forkCount\":815},{\"id\":\"MDEwOlJlcG9zaXRvcnk2NDg0MTQ=\",\"databaseId\":648414,\"nameWithOwner\":\"jquery-validation/jquery-validation\",\"description\":\"jQuery
+      Validation Plugin library sources\",\"url\":\"https://github.com/jquery-validation/jquery-validation\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10083,\"forkCount\":2852},{\"id\":\"MDEwOlJlcG9zaXRvcnkxNTI1NzIxODY=\",\"databaseId\":152572186,\"nameWithOwner\":\"wasmerio/wasmer\",\"description\":\"\U0001F680
+      The leading WebAssembly Runtime supporting WASI and Emscripten\",\"url\":\"https://github.com/wasmerio/wasmer\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10081,\"forkCount\":384},{\"id\":\"MDEwOlJlcG9zaXRvcnk3MTU1MTYyOQ==\",\"databaseId\":71551629,\"nameWithOwner\":\"carloscuesta/gitmoji\",\"description\":\"An
+      emoji guide for your commit messages. \U0001F61C \",\"url\":\"https://github.com/carloscuesta/gitmoji\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10079,\"forkCount\":590},{\"id\":\"MDEwOlJlcG9zaXRvcnk2NTA3MzY0OA==\",\"databaseId\":65073648,\"nameWithOwner\":\"JessYanCoding/MVPArms\",\"description\":\"⚔️
+      A common architecture for Android applications developing based on MVP, integrates
+      many open source projects, to make your developing quicker and easier (一个整合了大量主流开源项目高度可配置化的
+      Android MVP 快速集成框架). \",\"url\":\"https://github.com/JessYanCoding/MVPArms\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10075,\"forkCount\":2415}]}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 17:21:04 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B300:D4F6:12E4051:1348A69:60F705FF
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4984"
+      X-Ratelimit-Reset:
+      - "1626805026"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "16"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":10,"query":"stars:10000..10100 created:2008-01-01T00:00:00+00:00..2021-07-20T17:21:04+00:00","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: "{\"data\":{\"search\":{\"repositoryCount\":38,\"pageInfo\":{\"hasNextPage\":true,\"endCursor\":\"Y3Vyc29yOjEw\"},\"nodes\":[{\"id\":\"MDEwOlJlcG9zaXRvcnkxODY3NTQ4MzA=\",\"databaseId\":186754830,\"nameWithOwner\":\"umijs/qiankun\",\"description\":\"\U0001F4E6
+      \U0001F680 Blazing fast, simple and complete solution for micro frontends.\",\"url\":\"https://github.com/umijs/qiankun\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10100,\"forkCount\":1184},{\"id\":\"MDEwOlJlcG9zaXRvcnkyMTUwMDY5Mg==\",\"databaseId\":21500692,\"nameWithOwner\":\"0xnr/awesome-bigdata\",\"description\":\"A
+      curated list of awesome big data frameworks, ressources and other awesomeness.\",\"url\":\"https://github.com/0xnr/awesome-bigdata\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10099,\"forkCount\":2295},{\"id\":\"MDEwOlJlcG9zaXRvcnkxOTQ0ODcwMA==\",\"databaseId\":19448700,\"nameWithOwner\":\"leanote/leanote\",\"description\":\"Not
+      Just A Notepad! (golang + mongodb) http://leanote.org\",\"url\":\"https://github.com/leanote/leanote\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10095,\"forkCount\":2278},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMjM0Nzgz\",\"databaseId\":1234783,\"nameWithOwner\":\"mobile-shell/mosh\",\"description\":\"Mobile
+      Shell\",\"url\":\"https://github.com/mobile-shell/mosh\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10094,\"forkCount\":628},{\"id\":\"MDEwOlJlcG9zaXRvcnkyMzY4MDY3OA==\",\"databaseId\":23680678,\"nameWithOwner\":\"tymondesigns/jwt-auth\",\"description\":\"\U0001F510
+      JSON Web Token Authentication for Laravel & Lumen\",\"url\":\"https://github.com/tymondesigns/jwt-auth\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10091,\"forkCount\":1336},{\"id\":\"MDEwOlJlcG9zaXRvcnkyOTkzNTQyMDc=\",\"databaseId\":299354207,\"nameWithOwner\":\"rustdesk/rustdesk\",\"description\":\"Yet
+      another remote desktop software\",\"url\":\"https://github.com/rustdesk/rustdesk\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10089,\"forkCount\":815},{\"id\":\"MDEwOlJlcG9zaXRvcnk2NDg0MTQ=\",\"databaseId\":648414,\"nameWithOwner\":\"jquery-validation/jquery-validation\",\"description\":\"jQuery
+      Validation Plugin library sources\",\"url\":\"https://github.com/jquery-validation/jquery-validation\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10083,\"forkCount\":2852},{\"id\":\"MDEwOlJlcG9zaXRvcnkxNTI1NzIxODY=\",\"databaseId\":152572186,\"nameWithOwner\":\"wasmerio/wasmer\",\"description\":\"\U0001F680
+      The leading WebAssembly Runtime supporting WASI and Emscripten\",\"url\":\"https://github.com/wasmerio/wasmer\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10081,\"forkCount\":384},{\"id\":\"MDEwOlJlcG9zaXRvcnk3MTU1MTYyOQ==\",\"databaseId\":71551629,\"nameWithOwner\":\"carloscuesta/gitmoji\",\"description\":\"An
+      emoji guide for your commit messages. \U0001F61C \",\"url\":\"https://github.com/carloscuesta/gitmoji\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10079,\"forkCount\":590},{\"id\":\"MDEwOlJlcG9zaXRvcnk2NTA3MzY0OA==\",\"databaseId\":65073648,\"nameWithOwner\":\"JessYanCoding/MVPArms\",\"description\":\"⚔️
+      A common architecture for Android applications developing based on MVP, integrates
+      many open source projects, to make your developing quicker and easier (一个整合了大量主流开源项目高度可配置化的
+      Android MVP 快速集成框架). \",\"url\":\"https://github.com/JessYanCoding/MVPArms\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10075,\"forkCount\":2415}]}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 17:21:05 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B300:D4F6:12E4306:1348D23:60F705FF
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4983"
+      X-Ratelimit-Reset:
+      - "1626805026"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "17"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":10,"query":"stars:10000..10100 created:2014-10-10T20:40:32+00:00..2021-07-20T17:21:04+00:00","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: "{\"data\":{\"search\":{\"repositoryCount\":20,\"pageInfo\":{\"hasNextPage\":true,\"endCursor\":\"Y3Vyc29yOjEw\"},\"nodes\":[{\"id\":\"MDEwOlJlcG9zaXRvcnkxODY3NTQ4MzA=\",\"databaseId\":186754830,\"nameWithOwner\":\"umijs/qiankun\",\"description\":\"\U0001F4E6
+      \U0001F680 Blazing fast, simple and complete solution for micro frontends.\",\"url\":\"https://github.com/umijs/qiankun\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10100,\"forkCount\":1184},{\"id\":\"MDEwOlJlcG9zaXRvcnkyOTkzNTQyMDc=\",\"databaseId\":299354207,\"nameWithOwner\":\"rustdesk/rustdesk\",\"description\":\"Yet
+      another remote desktop software\",\"url\":\"https://github.com/rustdesk/rustdesk\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10089,\"forkCount\":815},{\"id\":\"MDEwOlJlcG9zaXRvcnkxNTI1NzIxODY=\",\"databaseId\":152572186,\"nameWithOwner\":\"wasmerio/wasmer\",\"description\":\"\U0001F680
+      The leading WebAssembly Runtime supporting WASI and Emscripten\",\"url\":\"https://github.com/wasmerio/wasmer\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10081,\"forkCount\":384},{\"id\":\"MDEwOlJlcG9zaXRvcnk3MTU1MTYyOQ==\",\"databaseId\":71551629,\"nameWithOwner\":\"carloscuesta/gitmoji\",\"description\":\"An
+      emoji guide for your commit messages. \U0001F61C \",\"url\":\"https://github.com/carloscuesta/gitmoji\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10079,\"forkCount\":590},{\"id\":\"MDEwOlJlcG9zaXRvcnk2NTA3MzY0OA==\",\"databaseId\":65073648,\"nameWithOwner\":\"JessYanCoding/MVPArms\",\"description\":\"⚔️
+      A common architecture for Android applications developing based on MVP, integrates
+      many open source projects, to make your developing quicker and easier (一个整合了大量主流开源项目高度可配置化的
+      Android MVP 快速集成框架). \",\"url\":\"https://github.com/JessYanCoding/MVPArms\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10075,\"forkCount\":2415},{\"id\":\"MDEwOlJlcG9zaXRvcnk2Nzc3ODAzMQ==\",\"databaseId\":67778031,\"nameWithOwner\":\"seaswalker/spring-analysis\",\"description\":\"Spring源码阅读\",\"url\":\"https://github.com/seaswalker/spring-analysis\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10072,\"forkCount\":3383},{\"id\":\"MDEwOlJlcG9zaXRvcnkyNzczNzM5Mw==\",\"databaseId\":27737393,\"nameWithOwner\":\"qmk/qmk_firmware\",\"description\":\"Open-source
+      keyboard firmware for Atmel AVR and Arm USB families\",\"url\":\"https://github.com/qmk/qmk_firmware\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10071,\"forkCount\":20628},{\"id\":\"MDEwOlJlcG9zaXRvcnk5MDMyMDQ5NA==\",\"databaseId\":90320494,\"nameWithOwner\":\"ish-app/ish\",\"description\":\"Linux
+      shell for iOS\",\"url\":\"https://github.com/ish-app/ish\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10067,\"forkCount\":545},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMTY1NzY3ODM=\",\"databaseId\":116576783,\"nameWithOwner\":\"bettercap/bettercap\",\"description\":\"The
+      Swiss Army knife for 802.11, BLE, IPv4 and IPv6 networks reconnaissance and
+      MITM attacks.\",\"url\":\"https://github.com/bettercap/bettercap\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10056,\"forkCount\":1021},{\"id\":\"MDEwOlJlcG9zaXRvcnk3Mjk0NTE0MQ==\",\"databaseId\":72945141,\"nameWithOwner\":\"chiphuyen/stanford-tensorflow-tutorials\",\"description\":\"This
+      repository contains code examples for the Stanford's course: TensorFlow for
+      Deep Learning Research. \",\"url\":\"https://github.com/chiphuyen/stanford-tensorflow-tutorials\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":true,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10047,\"forkCount\":4418}]}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 17:21:05 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B300:D4F6:12E4495:1348EA2:60F70600
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4982"
+      X-Ratelimit-Reset:
+      - "1626805026"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "18"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"after":"Y3Vyc29yOjEw","first":10,"query":"stars:10000..10100
+      created:2014-10-10T20:40:32+00:00..2021-07-20T17:21:04+00:00","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: "{\"data\":{\"search\":{\"repositoryCount\":20,\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":\"Y3Vyc29yOjIw\"},\"nodes\":[{\"id\":\"MDEwOlJlcG9zaXRvcnkxNDkyMTE2ODg=\",\"databaseId\":149211688,\"nameWithOwner\":\"hoya012/deep_learning_object_detection\",\"description\":\"A
+      paper list of object detection using deep learning.\",\"url\":\"https://github.com/hoya012/deep_learning_object_detection\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10042,\"forkCount\":2737},{\"id\":\"MDEwOlJlcG9zaXRvcnk1MjA3MTQ3MQ==\",\"databaseId\":52071471,\"nameWithOwner\":\"reactstrap/reactstrap\",\"description\":\"Simple
+      React Bootstrap 4 components\",\"url\":\"https://github.com/reactstrap/reactstrap\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10041,\"forkCount\":1218},{\"id\":\"MDEwOlJlcG9zaXRvcnk0ODc5NjE3OQ==\",\"databaseId\":48796179,\"nameWithOwner\":\"z-song/laravel-admin\",\"description\":\"Build
+      a full-featured administrative interface in ten minutes\",\"url\":\"https://github.com/z-song/laravel-admin\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10035,\"forkCount\":2523},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMjAzNjA3NjU=\",\"databaseId\":120360765,\"nameWithOwner\":\"chromium/chromium\",\"description\":\"The
+      official GitHub mirror of the Chromium source\",\"url\":\"https://github.com/chromium/chromium\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10033,\"forkCount\":3956},{\"id\":\"MDEwOlJlcG9zaXRvcnk4ODY3NDQwNA==\",\"databaseId\":88674404,\"nameWithOwner\":\"GoogleContainerTools/distroless\",\"description\":\"\U0001F951
+      \ Language focused docker images, minus the operating system.  \",\"url\":\"https://github.com/GoogleContainerTools/distroless\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10031,\"forkCount\":567},{\"id\":\"MDEwOlJlcG9zaXRvcnkyOTQ1NjYyNA==\",\"databaseId\":29456624,\"nameWithOwner\":\"matiassingers/awesome-readme\",\"description\":\"A
+      curated list of awesome READMEs\",\"url\":\"https://github.com/matiassingers/awesome-readme\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10025,\"forkCount\":2702},{\"id\":\"MDEwOlJlcG9zaXRvcnk0OTAxNDc5NQ==\",\"databaseId\":49014795,\"nameWithOwner\":\"phpstan/phpstan\",\"description\":\"PHP
+      Static Analysis Tool - discover bugs in your code without running it!\",\"url\":\"https://github.com/phpstan/phpstan\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10018,\"forkCount\":719},{\"id\":\"MDEwOlJlcG9zaXRvcnk2MzgzMjA4OQ==\",\"databaseId\":63832089,\"nameWithOwner\":\"lengstrom/fast-style-transfer\",\"description\":\"TensorFlow
+      CNN for fast style transfer ⚡\U0001F5A5\U0001F3A8\U0001F5BC\",\"url\":\"https://github.com/lengstrom/fast-style-transfer\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10015,\"forkCount\":2542},{\"id\":\"MDEwOlJlcG9zaXRvcnk4MDYyNzI3OA==\",\"databaseId\":80627278,\"nameWithOwner\":\"k4m4/terminals-are-sexy\",\"description\":\"\U0001F4A5
+      A curated list of Terminal frameworks, plugins & resources for CLI lovers.\",\"url\":\"https://github.com/k4m4/terminals-are-sexy\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10013,\"forkCount\":547},{\"id\":\"MDEwOlJlcG9zaXRvcnkzMDczMjM2NA==\",\"databaseId\":30732364,\"nameWithOwner\":\"Netflix/falcor\",\"description\":\"A
+      JavaScript library for efficient data fetching\",\"url\":\"https://github.com/Netflix/falcor\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10001,\"forkCount\":468}]}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 17:21:05 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B300:D4F6:12E4593:1348FA6:60F70601
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4981"
+      X-Ratelimit-Reset:
+      - "1626805026"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "19"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"first":10,"query":"stars:10000..10100 created:2008-01-01T00:00:00+00:00..2014-10-10T20:40:31+00:00","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: "{\"data\":{\"search\":{\"repositoryCount\":18,\"pageInfo\":{\"hasNextPage\":true,\"endCursor\":\"Y3Vyc29yOjEw\"},\"nodes\":[{\"id\":\"MDEwOlJlcG9zaXRvcnkyMTUwMDY5Mg==\",\"databaseId\":21500692,\"nameWithOwner\":\"0xnr/awesome-bigdata\",\"description\":\"A
+      curated list of awesome big data frameworks, ressources and other awesomeness.\",\"url\":\"https://github.com/0xnr/awesome-bigdata\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10099,\"forkCount\":2295},{\"id\":\"MDEwOlJlcG9zaXRvcnkxOTQ0ODcwMA==\",\"databaseId\":19448700,\"nameWithOwner\":\"leanote/leanote\",\"description\":\"Not
+      Just A Notepad! (golang + mongodb) http://leanote.org\",\"url\":\"https://github.com/leanote/leanote\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10095,\"forkCount\":2278},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMjM0Nzgz\",\"databaseId\":1234783,\"nameWithOwner\":\"mobile-shell/mosh\",\"description\":\"Mobile
+      Shell\",\"url\":\"https://github.com/mobile-shell/mosh\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10094,\"forkCount\":628},{\"id\":\"MDEwOlJlcG9zaXRvcnkyMzY4MDY3OA==\",\"databaseId\":23680678,\"nameWithOwner\":\"tymondesigns/jwt-auth\",\"description\":\"\U0001F510
+      JSON Web Token Authentication for Laravel & Lumen\",\"url\":\"https://github.com/tymondesigns/jwt-auth\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10091,\"forkCount\":1336},{\"id\":\"MDEwOlJlcG9zaXRvcnk2NDg0MTQ=\",\"databaseId\":648414,\"nameWithOwner\":\"jquery-validation/jquery-validation\",\"description\":\"jQuery
+      Validation Plugin library sources\",\"url\":\"https://github.com/jquery-validation/jquery-validation\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10083,\"forkCount\":2852},{\"id\":\"MDEwOlJlcG9zaXRvcnk3ODU1MzQw\",\"databaseId\":7855340,\"nameWithOwner\":\"chjj/blessed\",\"description\":\"A
+      high-level terminal interface library for node.js.\",\"url\":\"https://github.com/chjj/blessed\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10072,\"forkCount\":502},{\"id\":\"MDEwOlJlcG9zaXRvcnkzNTAyMTIw\",\"databaseId\":3502120,\"nameWithOwner\":\"scottjehl/picturefill\",\"description\":\"A
+      responsive image polyfill for <picture>, srcset, sizes, and more\",\"url\":\"https://github.com/scottjehl/picturefill\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10069,\"forkCount\":1135},{\"id\":\"MDEwOlJlcG9zaXRvcnkxNjYzMDMzMg==\",\"databaseId\":16630332,\"nameWithOwner\":\"pagekit/vue-resource\",\"description\":\"The
+      HTTP client for Vue.js\",\"url\":\"https://github.com/pagekit/vue-resource\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10059,\"forkCount\":1708},{\"id\":\"MDEwOlJlcG9zaXRvcnk5NjAzNzE0\",\"databaseId\":9603714,\"nameWithOwner\":\"alcatraz/Alcatraz\",\"description\":\"Package
+      manager for Xcode\",\"url\":\"https://github.com/alcatraz/Alcatraz\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":true,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10052,\"forkCount\":1191},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMjIyODc0Ng==\",\"databaseId\":12228746,\"nameWithOwner\":\"sovereign/sovereign\",\"description\":\"A
+      set of Ansible playbooks to build and maintain your own private cloud: email,
+      calendar, contacts, file sync, IRC bouncer, VPN, and more.\",\"url\":\"https://github.com/sovereign/sovereign\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10040,\"forkCount\":847}]}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 17:21:06 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B300:D4F6:12E4698:13490AD:60F70601
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4980"
+      X-Ratelimit-Reset:
+      - "1626805026"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "20"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tisLocked\n\tisDisabled\n\tviewerPermission\n\tstargazerCount\n\tforkCount\n}\n\t\nquery($query:
+      String!, $type: SearchType!, $after: String, $first: Int!) {\n\tsearch(query:
+      $query, type: $type, after: $after, first: $first) {\n\t\trepositoryCount\n\t\tpageInfo
+      { hasNextPage,  endCursor }\n\t\tnodes { ... on Repository { ...RepositoryFields
+      } }\n\t}\n}","variables":{"after":"Y3Vyc29yOjEw","first":10,"query":"stars:10000..10100
+      created:2008-01-01T00:00:00+00:00..2014-10-10T20:40:31+00:00","type":"REPOSITORY"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: "{\"data\":{\"search\":{\"repositoryCount\":18,\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":\"Y3Vyc29yOjE4\"},\"nodes\":[{\"id\":\"MDEwOlJlcG9zaXRvcnkxNDI1OTM5MA==\",\"databaseId\":14259390,\"nameWithOwner\":\"Maatwebsite/Laravel-Excel\",\"description\":\"\U0001F680
+      Supercharged Excel exports and imports in Laravel\",\"url\":\"https://github.com/Maatwebsite/Laravel-Excel\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10035,\"forkCount\":1592},{\"id\":\"MDEwOlJlcG9zaXRvcnkxNzUzNzc0OA==\",\"databaseId\":17537748,\"nameWithOwner\":\"humiaozuzu/awesome-flask\",\"description\":\"A
+      curated list of awesome Flask resources and plugins\",\"url\":\"https://github.com/humiaozuzu/awesome-flask\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10033,\"forkCount\":1454},{\"id\":\"MDEwOlJlcG9zaXRvcnk3NTczNjM=\",\"databaseId\":757363,\"nameWithOwner\":\"knockout/knockout\",\"description\":\"Knockout
+      makes it easier to create rich, responsive UIs with JavaScript\",\"url\":\"https://github.com/knockout/knockout\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10032,\"forkCount\":1567},{\"id\":\"MDEwOlJlcG9zaXRvcnkxMjE3NDA0\",\"databaseId\":1217404,\"nameWithOwner\":\"jordansissel/fpm\",\"description\":\"Effing
+      package management! Build packages for multiple platforms (deb, rpm, etc) with
+      great ease and sanity.\",\"url\":\"https://github.com/jordansissel/fpm\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10030,\"forkCount\":1003},{\"id\":\"MDEwOlJlcG9zaXRvcnkyMjI1NDg1Ng==\",\"databaseId\":22254856,\"nameWithOwner\":\"codecentric/spring-boot-admin\",\"description\":\"Admin
+      UI for administration of spring boot applications\",\"url\":\"https://github.com/codecentric/spring-boot-admin\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10029,\"forkCount\":2732},{\"id\":\"MDEwOlJlcG9zaXRvcnkxNzc4NDcx\",\"databaseId\":1778471,\"nameWithOwner\":\"postmanlabs/httpbin\",\"description\":\"HTTP
+      Request & Response Service, written in Python + Flask.\",\"url\":\"https://github.com/postmanlabs/httpbin\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10029,\"forkCount\":1476},{\"id\":\"MDEwOlJlcG9zaXRvcnk2NjgzMzUy\",\"databaseId\":6683352,\"nameWithOwner\":\"muaz-khan/WebRTC-Experiment\",\"description\":\"WebRTC,
+      WebRTC and WebRTC. Everything here is all about WebRTC!!\",\"url\":\"https://github.com/muaz-khan/WebRTC-Experiment\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10013,\"forkCount\":3714},{\"id\":\"MDEwOlJlcG9zaXRvcnkyMTYyNzE5\",\"databaseId\":2162719,\"nameWithOwner\":\"xdissent/ievms\",\"description\":\"Automated
+      installation of the Microsoft IE App Compat virtual machines\",\"url\":\"https://github.com/xdissent/ievms\",\"isPrivate\":false,\"isFork\":false,\"isArchived\":false,\"isLocked\":false,\"isDisabled\":false,\"viewerPermission\":\"READ\",\"stargazerCount\":10011,\"forkCount\":517}]}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 20 Jul 2021 17:21:06 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - B300:D4F6:12E47A6:13491C5:60F70602
+      X-Oauth-Scopes:
+      - ""
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4979"
+      X-Ratelimit-Reset:
+      - "1626805026"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "21"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -15,10 +15,10 @@ func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
 	data := marshal(t, want)
 
 	if update {
-		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 			t.Fatalf("failed to update golden file %q: %s", path, err)
 		}
-		if err := os.WriteFile(path, data, 0640); err != nil {
+		if err := os.WriteFile(path, data, 0o640); err != nil {
 			t.Fatalf("failed to update golden file %q: %s", path, err)
 		}
 	}


### PR DESCRIPTION
This PR extends our `GitHubSource` to automatically refine `repositoryQuery` queries that hit the 1000 results limit that the GitHub's Search API enforces.

It does so by `ANDing` a `created:` qualifier with the original query with a range from before GitHub was created until `time.Now()`. It then refines that range until the limit isn't hit and traverses that search space by moving the window that `created:` matches, until we reach the time before GitHub was created (i.e. `minCreated`).

Existing customers that use the manual version of this work-around should not need to change anything. This code path only kicks in when we hit the search API limit.

This is needed for us to continuously sync all repos with more than 1star, with a site level external service.

Fixes #2562
