### PR TITLE
search: make toRepoOptions not depend on r.Query

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -524,7 +524,7 @@ func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) 
 		OnlyPrivate:        visibility == query.Private,
 		OnlyPublic:         visibility == query.Public,
 		CommitAfter:        commitAfter,
-		Query:              r.Query,
+		Query:              q,
 		Ranked:             true,
 		Limit:              opts.limit,
 		CacheLookup:        CacheLookup,


### PR DESCRIPTION
Removes the dependency on resolver value `r.Query` for this function (it's passed in as arg).