### PR TITLE
search: extract out global repo resolution logic

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -531,6 +531,29 @@ func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) 
 	}
 }
 
+func withMode(args search.TextParameters, st query.SearchType, vc *string) search.TextParameters {
+	isGlobalSearch := func() bool {
+		if st == query.SearchTypeStructural {
+			return false
+		}
+		if vc != nil && *vc != "" {
+			return false
+		}
+		querySearchContextSpec, _ := args.Query.StringValue(query.FieldContext)
+		if !searchcontexts.IsGlobalSearchContextSpec(querySearchContextSpec) {
+			return false
+		}
+		return len(args.Query.Values(query.FieldRepo)) == 0 && len(args.Query.Values(query.FieldRepoGroup)) == 0 && len(args.Query.Values(query.FieldRepoHasFile)) == 0
+	}
+
+	isFileOrPath := args.ResultTypes.Has(result.TypeFile) || args.ResultTypes.Has(result.TypePath)
+	isIndexedSearch := args.PatternInfo.Index != query.No
+	if isGlobalSearch() && isIndexedSearch && isFileOrPath {
+		args.Mode = search.ZoektGlobalSearch
+	}
+	return args
+}
+
 func (r *searchResolver) toTextParameters(q query.Q) (*search.TextParameters, error) {
 	forceResultTypes := result.TypeEmpty
 	if r.PatternType == query.SearchTypeStructural {
@@ -567,6 +590,7 @@ func (r *searchResolver) toTextParameters(q query.Q) (*search.TextParameters, er
 		return nil, &badRequestError{err}
 	}
 	args = withResultTypes(args, forceResultTypes)
+	args = withMode(args, r.PatternType, r.VersionContext)
 	return &args, nil
 }
 
@@ -1354,23 +1378,6 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 	return args
 }
 
-// isGlobalSearch returns true if the query does not contain repo, repogroup, or
-// repohasfile filters. For structural queries, queries with version context,
-// and queries with non-global search context, isGlobalSearch always return false.
-func (r *searchResolver) isGlobalSearch() bool {
-	if r.PatternType == query.SearchTypeStructural {
-		return false
-	}
-	if r.VersionContext != nil && *r.VersionContext != "" {
-		return false
-	}
-	querySearchContextSpec, _ := r.Query.StringValue(query.FieldContext)
-	if !searchcontexts.IsGlobalSearchContextSpec(querySearchContextSpec) {
-		return false
-	}
-	return len(r.Query.Values(query.FieldRepo)) == 0 && len(r.Query.Values(query.FieldRepoGroup)) == 0 && len(r.Query.Values(query.FieldRepoHasFile)) == 0
-}
-
 // doResults is one of the highest level search functions that handles finding results.
 //
 // If forceOnlyResultType is specified, only results of the given type are returned,
@@ -1432,14 +1439,10 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		_, _, _ = agg.Get()
 	}()
 
-	isFileOrPath := args.ResultTypes.Has(result.TypeFile) || args.ResultTypes.Has(result.TypePath)
-	isIndexedSearch := args.PatternInfo.Index != query.No
-
 	// performance optimization: call zoekt early, resolve repos concurrently, filter
 	// search results with resolved repos.
-	if r.isGlobalSearch() && isIndexedSearch && isFileOrPath {
+	if args.Mode == search.ZoektGlobalSearch {
 		argsIndexed := *args
-		argsIndexed.Mode = search.ZoektGlobalSearch
 		wg := waitGroup(true)
 		wg.Add(1)
 		goroutine.Go(func() {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1060,9 +1060,9 @@ func TestIsGlobalSearch(t *testing.T) {
 				},
 			}
 
-			gotIsGlobal := resolver.isGlobalSearch()
-			if gotIsGlobal != tt.wantIsGlobal {
-				t.Fatalf("got %+v, want %+v", gotIsGlobal, tt.wantIsGlobal)
+			p, _ := resolver.toTextParameters(resolver.Query)
+			if (p.Mode == search.ZoektGlobalSearch) != tt.wantIsGlobal {
+				t.Fatalf("got %+v, want %+v", p.Mode, tt.wantIsGlobal)
 			}
 		})
 	}


### PR DESCRIPTION
We have some pretty complex logic that figures out whether a query is global (i.e., a search over all repositories) that is currently called in `doResults`. This PR extracts this logic to a function `withMode` that is now called in `toTextParameters`, which happens before `doResults`. 

The purpose (is again) to break the dependency on `resolver.Query`, because figuring out whether a query is "global" currently inspects the parse tree via `resolver.Query`. 

This extraction will also simplify life when I have time to break up this concern and mint better types for it.

Note: It's important that every previous call site of `doResults` is processed by `toTextParameters`, or else we will not populate the correct values here. There are [four such call sites](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+doResults&patternType=structural) and indeed each one calls `toTextParameters` prior.