### PR TITLE
search: return 40 repo filters and 40 other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search queries now disallow specifying `rev:` without `repo:`. Note that to search across potentially multiple revisions, a query like `repo:.* rev:<revision>` remains valid. [#22705](https://github.com/sourcegraph/sourcegraph/pull/22705)
 - The extensions status bar on diff pages has been redesigned and now shows information for both the base and head commits. [#22123](https://github.com/sourcegraph/sourcegraph/pull/22123/files)
 - The `applyBatchChange` and `createBatchChange` mutations now accept an optional `publicationStates` argument to set the publication state of specific changesets within the batch change. [#22485](https://github.com/sourcegraph/sourcegraph/pull/22485) and [#22854](https://github.com/sourcegraph/sourcegraph/pull/22854)
+- Search queries now return up to 80 suggested filters. Previously we returned up to 24. [#22863](https://github.com/sourcegraph/sourcegraph/pull/22863)
 
 ### Fixed
 

--- a/internal/search/streaming/filters.go
+++ b/internal/search/streaming/filters.go
@@ -42,11 +42,11 @@ func (f *Filter) Less(o *Filter) bool {
 
 }
 
-// Filters is a map of filter values to the Filter.
-type Filters map[string]*Filter
+// filters is a map of filter values to the Filter.
+type filters map[string]*Filter
 
 // Add the count to the filter with value.
-func (m Filters) Add(value string, label string, count int32, limitHit bool, kind string) {
+func (m filters) Add(value string, label string, count int32, limitHit bool, kind string) {
 	sf, ok := m[value]
 	if !ok {
 		sf = &Filter{
@@ -64,12 +64,12 @@ func (m Filters) Add(value string, label string, count int32, limitHit bool, kin
 
 // MarkImportant sets the filter with value as important. Can only be called
 // after Add.
-func (m Filters) MarkImportant(value string) {
+func (m filters) MarkImportant(value string) {
 	m[value].Important = true
 }
 
 // Compute returns an ordered slice of Filter to present to the user.
-func (m Filters) Compute() []*Filter {
+func (m filters) Compute() []*Filter {
 	repos := filterHeap{max: 12}
 	other := filterHeap{max: 12}
 	for _, f := range m {

--- a/internal/search/streaming/filters.go
+++ b/internal/search/streaming/filters.go
@@ -23,15 +23,15 @@ type Filter struct {
 	// Kind of filter. Should be "repo", "file", or "lang".
 	Kind string
 
-	// Important is used to prioritize the order that filters appear in.
-	Important bool
+	// important is used to prioritize the order that filters appear in.
+	important bool
 }
 
 // Less returns true if f is more important the o.
 func (f *Filter) Less(o *Filter) bool {
-	if f.Important != o.Important {
+	if f.important != o.important {
 		// Prefer more important
-		return f.Important
+		return f.important
 	}
 	if f.Count != o.Count {
 		// Prefer higher count
@@ -65,7 +65,7 @@ func (m filters) Add(value string, label string, count int32, limitHit bool, kin
 // MarkImportant sets the filter with value as important. Can only be called
 // after Add.
 func (m filters) MarkImportant(value string) {
-	m[value].Important = true
+	m[value].important = true
 }
 
 // Compute returns an ordered slice of Filter to present to the user.

--- a/internal/search/streaming/filters.go
+++ b/internal/search/streaming/filters.go
@@ -68,10 +68,19 @@ func (m filters) MarkImportant(value string) {
 	m[value].important = true
 }
 
+// computeOpts are the options for calling filters.Compute.
+type computeOpts struct {
+	// MaxRepos is the maximum number of filters to return with kind repo.
+	MaxRepos int
+
+	// MaxOther is the maximum number of filters to return which are not repo.
+	MaxOther int
+}
+
 // Compute returns an ordered slice of Filter to present to the user.
-func (m filters) Compute() []*Filter {
-	repos := filterHeap{max: 12}
-	other := filterHeap{max: 12}
+func (m filters) Compute(opts computeOpts) []*Filter {
+	repos := filterHeap{max: opts.MaxRepos}
+	other := filterHeap{max: opts.MaxOther}
 	for _, f := range m {
 		if f.Kind == "repo" {
 			repos.Add(f)
@@ -112,7 +121,7 @@ func (h *filterHeap) Add(f *Filter) {
 	if len(h.filterSlice) < h.max {
 		// Less than max, we keep the filter.
 		heap.Push(h, f)
-	} else if f.Less(h.filterSlice[0]) {
+	} else if h.max > 0 && f.Less(h.filterSlice[0]) {
 		// f is more important than the least important filter we have
 		// kept. So Pop that filter away and add in f. We should keep the
 		// invariant that len == h.max.

--- a/internal/search/streaming/filters_test.go
+++ b/internal/search/streaming/filters_test.go
@@ -11,7 +11,7 @@ func TestFilters(t *testing.T) {
 	// Add lots of repos, files and fork. Ensure we compute a good summary
 	// which balances types.
 
-	m := make(Filters)
+	m := make(filters)
 	for count := int32(1); count <= 1000; count++ {
 		repo := fmt.Sprintf("repo-%d", count)
 		m.Add(repo, repo, count, false, "repo")

--- a/internal/search/streaming/filters_test.go
+++ b/internal/search/streaming/filters_test.go
@@ -55,7 +55,10 @@ func TestFilters(t *testing.T) {
 		"file-90 90",
 	}
 
-	filters := m.Compute()
+	filters := m.Compute(computeOpts{
+		MaxRepos: 12,
+		MaxOther: 12,
+	})
 	var got []string
 	for _, f := range filters {
 		got = append(got, fmt.Sprintf("%s %d", f.Value, f.Count))

--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -157,5 +157,8 @@ func (s *SearchFilters) Update(event SearchEvent) {
 // Compute returns an ordered slice of Filters to present to the user based on
 // events passed to Next.
 func (s *SearchFilters) Compute() []*Filter {
-	return s.filters.Compute()
+	return s.filters.Compute(computeOpts{
+		MaxRepos: 12,
+		MaxOther: 12,
+	})
 }

--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -158,7 +158,7 @@ func (s *SearchFilters) Update(event SearchEvent) {
 // events passed to Next.
 func (s *SearchFilters) Compute() []*Filter {
 	return s.filters.Compute(computeOpts{
-		MaxRepos: 12,
-		MaxOther: 12,
+		MaxRepos: 40,
+		MaxOther: 40,
 	})
 }

--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -24,7 +24,7 @@ type SearchFilters struct {
 	// Globbing is true if the user has enabled globbing support.
 	Globbing bool
 
-	filters Filters
+	filters filters
 }
 
 // commonFileFilters are common filters used. It is used by SearchFilters to
@@ -70,7 +70,7 @@ var commonFileFilters = []struct {
 func (s *SearchFilters) Update(event SearchEvent) {
 	// Initialize state on first call.
 	if s.filters == nil {
-		s.filters = make(Filters)
+		s.filters = make(filters)
 	}
 
 	addRepoFilter := func(repoName api.RepoName, repoID api.RepoID, rev string, lineMatchCount int32) {


### PR DESCRIPTION
Previously we only returned 12. This was a hueristic value chosen based on the old search UX which used horizontal space to represent these values. We now have the sidebar (vertical space), so can display many more.

Our implementation for computing these values is NlogK. We are changing K from 12 to 40, so should not have a noticeable affect on performance.

This PR can be reviewed commit by commit. The first 3 commits are refactorings preparing this change. The 4th commit is the actual change.

Fixes https://github.com/sourcegraph/sourcegraph/issues/22853
