### PR TITLE
EventLogger: Return sourcegraph.com hostname only for internal referrers

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -116,16 +116,17 @@ export class EventLogger implements TelemetryService {
     public getReferrer(): string {
         const referrer = document.referrer
         try {
-            // 🚨 SECURITY: Return if the referrer is a valid non-Sourcegraph.com URL
-            // to avoid leaking private code URLs.
+            // 🚨 SECURITY: If the referrer is a valid Sourcegraph.com URL,
+            // only send the hostname instead of the whole URL to avoid
+            // leaking private repository names and files into our data.
             const url = new URL(referrer)
-            if (url.hostname !== 'sourcegraph.com') {
-                return referrer
+            if (url.hostname === 'sourcegraph.com') {
+                return 'sourcegraph.com'
             }
+            return referrer
         } catch {
             return ''
         }
-        return ''
     }
 
     /**


### PR DESCRIPTION
Addresses part of https://github.com/sourcegraph/sourcegraph/pull/22747#issuecomment-879764196

@malomarrec wants to distinguish referrers between direct traffic (which have an empty referrer) and navigation from within sourcegraph.com.

For Sourcegraph.com URLs, show the referrer as just sourcegraph.com, and remove all pathnames/query params to avoid leaking private repo/file names and search queries.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
