### PR TITLE
Code insights: Implement delete insights with new dashboard functionality 

### DIFF
--- a/client/web/src/insights/core/settings-action/edits/apply-edit-operations.ts
+++ b/client/web/src/insights/core/settings-action/edits/apply-edit-operations.ts
@@ -1,0 +1,44 @@
+import { addInsightToDashboard, removeInsightFromDashboard } from '../dashboards'
+import { addInsightToSettings, removeInsightFromSettings } from '../insights'
+
+import { SettingsOperation, SettingsOperationType } from './edits'
+
+/**
+ * Apply edit operation over jsonc settings string and return serialized final string
+ * with all applied edit operations.
+ *
+ * @param settings - original jsonc setting content
+ * @param operations - list of edit operations
+ */
+export function applyEditOperations(settings: string, operations: SettingsOperation[]): string {
+    let settingsContent: string = settings
+
+    for (const operation of operations) {
+        switch (operation.type) {
+            case SettingsOperationType.addInsight:
+                settingsContent = addInsightToSettings(settingsContent, operation.insight)
+                continue
+            case SettingsOperationType.removeInsight:
+                settingsContent = removeInsightFromSettings({
+                    originalSettings: settingsContent,
+                    insightID: operation.insightID,
+                })
+                continue
+            case SettingsOperationType.addInsightToDashboard:
+                settingsContent = addInsightToDashboard(
+                    settingsContent,
+                    operation.dashboardSettingKey,
+                    operation.insightId
+                )
+                continue
+            case SettingsOperationType.removeInsightFromDashboard:
+                settingsContent = removeInsightFromDashboard(
+                    settingsContent,
+                    operation.dashboardSettingKey,
+                    operation.insightId
+                )
+        }
+    }
+
+    return settingsContent
+}

--- a/client/web/src/insights/core/settings-action/edits/edits.ts
+++ b/client/web/src/insights/core/settings-action/edits/edits.ts
@@ -1,0 +1,36 @@
+import { Insight } from '../../types'
+
+export enum SettingsOperationType {
+    addInsight,
+    removeInsight,
+    removeInsightFromDashboard,
+    addInsightToDashboard,
+}
+
+export interface RemoveInsight {
+    type: SettingsOperationType.removeInsight
+    subjectId: string
+    insightID: string
+}
+
+export interface AddInsight {
+    type: SettingsOperationType.addInsight
+    subjectId: string
+    insight: Insight
+}
+
+export interface RemoveInsightFromDashboard {
+    type: SettingsOperationType.removeInsightFromDashboard
+    subjectId: string
+    insightId: string
+    dashboardSettingKey: string
+}
+
+export interface AddInsightToDashboard {
+    type: SettingsOperationType.addInsightToDashboard
+    subjectId: string
+    insightId: string
+    dashboardSettingKey: string
+}
+
+export type SettingsOperation = AddInsight | RemoveInsight | AddInsightToDashboard | RemoveInsightFromDashboard

--- a/client/web/src/insights/core/settings-action/edits/index.ts
+++ b/client/web/src/insights/core/settings-action/edits/index.ts
@@ -1,0 +1,2 @@
+export * from './edits'
+export { applyEditOperations } from './apply-edit-operations'

--- a/client/web/src/insights/hooks/use-persist-edit-operations.ts
+++ b/client/web/src/insights/hooks/use-persist-edit-operations.ts
@@ -1,0 +1,49 @@
+import { groupBy } from 'lodash'
+import { useCallback, useContext } from 'react'
+
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+
+import { InsightsApiContext } from '../core/backend/api-provider'
+import { applyEditOperations, SettingsOperation } from '../core/settings-action/edits'
+
+interface UsePersistEditOperationsProps extends PlatformContextProps<'updateSettings'> {}
+
+interface UsePersistEditOperationsOutput {
+    persist: (operations: SettingsOperation[]) => Promise<void>
+}
+
+/**
+ * This react hook simplifies persist (update logic) over the settings cascade subject's setting file.
+ */
+export function usePersistEditOperations(props: UsePersistEditOperationsProps): UsePersistEditOperationsOutput {
+    const { platformContext } = props
+    const { getSubjectSettings, updateSubjectSettings } = useContext(InsightsApiContext)
+
+    const persist = useCallback(
+        async (operations: SettingsOperation[]) => {
+            const subjectsToUpdate = groupBy(operations, operation => operation.subjectId)
+
+            const subjectUpdateRequests = Object.keys(subjectsToUpdate).map(subjectId => {
+                async function updateSettings(): Promise<void> {
+                    const editOperations = subjectsToUpdate[subjectId]
+
+                    // Get jsonc subject settings file.
+                    const settings = await getSubjectSettings(subjectId).toPromise()
+
+                    // Modify this jsonc file according to this subject's operations
+                    const nextSubjectSettings = applyEditOperations(settings.contents, editOperations)
+
+                    // Call the async update mutation for the new subject's settings file
+                    await updateSubjectSettings(platformContext, subjectId, nextSubjectSettings).toPromise()
+                }
+
+                return updateSettings()
+            })
+
+            await Promise.all(subjectUpdateRequests)
+        },
+        [platformContext, getSubjectSettings, updateSubjectSettings]
+    )
+
+    return { persist }
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -113,6 +113,8 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
                     insightIds={currentDashboard.insightIds}
                     extensionsController={extensionsController}
                     telemetryService={telemetryService}
+                    platformContext={platformContext}
+                    settingsCascade={settingsCascade}
                 />
             ) : (
                 <HeroPage icon={MapSearchIcon} title="Hmm, the dashboard wasn't found." />

--- a/client/web/src/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
+++ b/client/web/src/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
@@ -39,7 +39,7 @@ export const EditLangStatsInsight: React.FunctionComponent<EditLangStatsInsightP
     }
 
     const handleCancel = (): void => {
-        history.push('/insights')
+        history.push(`/insights/dashboards/${insight.visibility}`)
     }
 
     return (

--- a/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
+++ b/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
@@ -43,7 +43,7 @@ export const EditSearchBasedInsight: React.FunctionComponent<EditSearchBasedInsi
     }
 
     const handleCancel = (): void => {
-        history.push('/insights')
+        history.push(`/insights/dashboards/${insight.visibility}`)
     }
 
     return (

--- a/client/web/src/insights/pages/insights/insights-page/hooks/delete-helpers.ts
+++ b/client/web/src/insights/pages/insights/insights-page/hooks/delete-helpers.ts
@@ -1,0 +1,69 @@
+import { get } from 'lodash'
+
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { Settings } from '../../../../../schema/settings.schema'
+import {
+    RemoveInsight,
+    RemoveInsightFromDashboard,
+    SettingsOperation,
+    SettingsOperationType,
+} from '../../../../core/settings-action/edits'
+import { INSIGHTS_ALL_REPOS_SETTINGS_KEY, INSIGHTS_DASHBOARDS_SETTINGS_KEY } from '../../../../core/types'
+
+interface Props extends SettingsCascadeProps<Settings> {
+    insightId: string
+}
+
+/**
+ * Returns list of edit operations. Remove insight from all setting cascade subjects
+ * and from all dashboard that include this insightId in their insight ids.
+ */
+export function getDeleteInsightEditOperations(props: Props): SettingsOperation[] {
+    const { settingsCascade, insightId } = props
+
+    if (!settingsCascade.subjects) {
+        return []
+    }
+
+    const removeInsightOperation = settingsCascade.subjects
+        .filter(configuredSubject => {
+            const { settings } = configuredSubject
+
+            if (!settings || isErrorLike(settings)) {
+                return false
+            }
+
+            const hasExtensionInsight = settings[insightId]
+            const hasBackendInsight = get(settings, [INSIGHTS_ALL_REPOS_SETTINGS_KEY, insightId])
+
+            return hasExtensionInsight || hasBackendInsight
+        })
+        .map<RemoveInsight>(configuredSubject => ({
+            type: SettingsOperationType.removeInsight,
+            subjectId: configuredSubject.subject.id,
+            insightID: insightId,
+        }))
+
+    const removeInsightFromAllDashboards = settingsCascade.subjects.flatMap(configuredSubject => {
+        const { settings, subject } = configuredSubject
+
+        if (!settings || isErrorLike(settings)) {
+            return []
+        }
+
+        const dashboards = settings[INSIGHTS_DASHBOARDS_SETTINGS_KEY] ?? {}
+
+        return Object.keys(dashboards)
+            .filter(key => dashboards[key].insightIds?.includes(insightId))
+            .map<RemoveInsightFromDashboard>(key => ({
+                type: SettingsOperationType.removeInsightFromDashboard,
+                subjectId: subject.id,
+                dashboardSettingKey: key,
+                insightId,
+            }))
+    })
+
+    return [...removeInsightOperation, ...removeInsightFromAllDashboards]
+}

--- a/client/web/src/insights/pages/insights/insights-page/hooks/use-delete-insight.ts
+++ b/client/web/src/insights/pages/insights/insights-page/hooks/use-delete-insight.ts
@@ -1,12 +1,12 @@
-import { useCallback, useContext } from 'react'
+import { useCallback } from 'react'
 
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
-import { InsightsApiContext } from '../../../../core/backend/api-provider'
-import { removeInsightFromSettings } from '../../../../core/settings-action/insights'
 import { InsightTypePrefix } from '../../../../core/types'
+import { usePersistEditOperations } from '../../../../hooks/use-persist-edit-operations'
+
+import { getDeleteInsightEditOperations } from './delete-helpers'
 
 export interface UseDeleteInsightProps extends SettingsCascadeProps, PlatformContextProps<'updateSettings'> {}
 
@@ -14,15 +14,16 @@ export interface UseDeleteInsightAPI {
     handleDelete: (insightID: string) => Promise<void>
 }
 
+/**
+ * Returns delete handler that deletes insight from all subject settings and from all dashboards
+ * that include this insight.
+ */
 export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsightAPI {
     const { settingsCascade, platformContext } = props
-
-    const { getSubjectSettings, updateSubjectSettings } = useContext(InsightsApiContext)
+    const { persist } = usePersistEditOperations({ platformContext })
 
     const handleDelete = useCallback(
         async (insightID: string) => {
-            const subjects = settingsCascade.subjects
-
             // For backward compatibility with old code stats insight api we have to delete
             // this insight in a special way. See link below for more information.
             // https://github.com/sourcegraph/sourcegraph-code-stats-insights/blob/master/src/code-stats-insights.ts#L33
@@ -33,36 +34,19 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
                   'codeStatsInsights.query'
                 : insightID
 
-            const subjectID = subjects?.find(
-                ({ settings }) => settings && !isErrorLike(settings) && !!settings[keyForSearchInSettings]
-            )?.subject?.id
-
-            if (!subjectID) {
-                console.error("Couldn't find the subject when trying to delete insight. Parameters", {
-                    insightID,
-                    subjects,
-                })
-                return
-            }
-
             try {
-                // Fetch the settings of particular subject which the insight belongs to
-                const settings = await getSubjectSettings(subjectID).toPromise()
-
-                const editedSettings = removeInsightFromSettings({
-                    originalSettings: settings.contents,
-                    insightID,
-                    isOldCodeStatsInsight,
+                const deleteInsightOperations = getDeleteInsightEditOperations({
+                    insightId: keyForSearchInSettings,
+                    settingsCascade,
                 })
 
-                // Update local settings of application with new settings without insight
-                await updateSubjectSettings(platformContext, subjectID, editedSettings).toPromise()
+                await persist(deleteInsightOperations)
             } catch (error) {
                 // TODO [VK] Improve error UI for deleting
                 console.error(error)
             }
         },
-        [platformContext, settingsCascade, getSubjectSettings, updateSubjectSettings]
+        [persist, settingsCascade]
     )
 
     return { handleDelete }


### PR DESCRIPTION
### Context

We always have this core insight functionality but with the dashboards system, we missed that at some point. This PR brings this functionality back. Currently, we have `delete` item in the insight context menu component. By click on that, you will delete this insight from all settings subjects and exclude this insight from all code insights dashboards. 

<img width="534" alt="image" src="https://user-images.githubusercontent.com/18492575/125853135-d80dbf19-332e-445a-9237-524d2d1768fe.png">

### Knowing issues
- Currently, if you delete some insight this operation triggers re-fetching all insights in the dashboard. This problem will be fixed in this ticket. https://github.com/sourcegraph/sourcegraph/issues/21097
- Delete operation doesn't have a confirmation UI (Related issues https://github.com/sourcegraph/sourcegraph/issues/21515) 


### What have been done 
- [x] Extract edit operations concept from the edit insight page 
- [x] Re-write use-delete-insight handler taking into account new code insight dashboard system
- [x] Connect handler and UI 