### PR TITLE
Fix link to `sg` CLI README.md

### DIFF
--- a/client/web/README.md
+++ b/client/web/README.md
@@ -2,7 +2,7 @@
 
 ## Local development
 
-Use `sg` CLI tool to configure and start local development server. For more information checkout `sg` [README]('../../dev/sg/README.md').
+Use `sg` CLI tool to configure and start local development server. For more information checkout `sg` [README](../../dev/sg/README.md).
 
 ### Configuration
 


### PR DESCRIPTION
Fix link to `sg` CLI README.md from client/web/README.md.

Link wasn't working. It seemed to work when I removed the `'`'s from the link, as tested using the "Preview" option in the GitHub in-app editor.
