### PR TITLE
search frontend: don't raise quotes diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The experimental paginated search feature (the `stable:` keyword) has been removed, to be replaced with streaming search. [#22428](https://github.com/sourcegraph/sourcegraph/pull/22428)
 - The experimental extensions view page has been removed. [#22565](https://github.com/sourcegraph/sourcegraph/pull/22565)
+- A search query diagnostic that previously warned the user when quotes are interpreted literally has been removed. The literal meaning has been Sourcegraph's default search behavior for some time now. [#22892](https://github.com/sourcegraph/sourcegraph/pull/22892)
 
 ### API docs (experimental)
 

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -43,19 +43,4 @@ describe('getDiagnostics()', () => {
             getDiagnostics(toSuccess(scanSearchQuery('repo:a (file:b and c)')), SearchPatternType.regexp)
         ).toStrictEqual([])
     })
-
-    test('search query containing quoted token, literal pattern type', () => {
-        expect(
-            getDiagnostics(toSuccess(scanSearchQuery('"Configuration::doStuff(...)"')), SearchPatternType.literal)
-        ).toStrictEqual([
-            {
-                endColumn: 30,
-                endLineNumber: 1,
-                message: 'Your search is interpreted literally and contains quotes. Did you mean to search for quotes?',
-                severity: 4,
-                startColumn: 1,
-                startLineNumber: 1,
-            },
-        ])
-    })
 })

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -23,15 +23,6 @@ export function getDiagnostics(tokens: Token[], patternType: SearchPatternType):
                 message: validationResult.reason,
                 ...toMonacoRange(field.range),
             })
-        } else if (token.type === 'literal' && token.quoted) {
-            if (patternType === SearchPatternType.literal) {
-                diagnostics.push({
-                    severity: Monaco.MarkerSeverity.Warning,
-                    message:
-                        'Your search is interpreted literally and contains quotes. Did you mean to search for quotes?',
-                    ...toMonacoRange(token.range),
-                })
-            }
         }
     }
     return diagnostics


### PR DESCRIPTION
I think we should remove this because:

(1) There's been a number of people complaining about this diagnostic. Potentially misleading effect: users think they _can't_ search for patterns with quotes. Some of this could be alleviated by not making this a warning, but "Info" or such. But it's better to remove entirely IMO.

(2) I believe the foremost intent of this diagnostic was stemming from a transition of regex to literal search. literal search has been the default for quite some time > 1 year, so this is low value.

(3) I believe that partially, the original intent of this diagnostic was to have something to say/demo with diagnostics as scaffolding code to do better diagnostics.
