### PR TITLE
API docs: LSIF: fix nil pointer deref in DocumentationPathInfo requests

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
@@ -65,7 +65,9 @@ func (r *QueryResolver) DocumentationPathInfo(ctx context.Context, args *gql.LSI
 				if err != nil {
 					return nil, err
 				}
-				children = append(children, *child)
+				if child != nil {
+					children = append(children, *child)
+				}
 			}
 		}
 		return &DocumentationPathInfoResult{


### PR DESCRIPTION
This fixes an issue where DocumentationPathInfo requests could result in a nil pointer deref in some situations, because `get` can return `nil` if there is no path info for a path ID. I think this is rare and would likely only occur in some situations where the backend is not functioning properly, but good to handle.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>