### PR TITLE
API docs: LSIF: conversion: refactor documentation grouping return type

### DIFF
--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -32,7 +32,7 @@ func groupBundleData(ctx context.Context, state *State) (*semantic.GroupedBundle
 	resultChunks := serializeResultChunks(ctx, state, numResultChunks)
 	definitionRows := gatherMonikersLocations(ctx, state, state.DefinitionData, func(r Range) int { return r.DefinitionResultID })
 	referenceRows := gatherMonikersLocations(ctx, state, state.ReferenceData, func(r Range) int { return r.ReferenceResultID })
-	documentationPagesRows, documentationPathInfoRows := collectDocumentationPages(ctx, state)
+	documentation := collectDocumentation(ctx, state)
 	packages := gatherPackages(state)
 	packageReferences, err := gatherPackageReferences(state, packages)
 	if err != nil {
@@ -45,8 +45,8 @@ func groupBundleData(ctx context.Context, state *State) (*semantic.GroupedBundle
 		ResultChunks:          resultChunks,
 		Definitions:           definitionRows,
 		References:            referenceRows,
-		DocumentationPages:    documentationPagesRows,
-		DocumentationPathInfo: documentationPathInfoRows,
+		DocumentationPages:    documentation.pages,
+		DocumentationPathInfo: documentation.pathInfo,
 		Packages:              packages,
 		PackageReferences:     packageReferences,
 	}, nil


### PR DESCRIPTION
Returning a struct-of-channels will be good for extending this to
return one more channel in the near future and for solving some
other issues with this code.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>