### PR TITLE
API docs: LSIF: use ResultSetData instead of separate field for documentation-by-result-set-ID

### DIFF
--- a/lib/codeintel/lsif/conversion/correlate_documentation.go
+++ b/lib/codeintel/lsif/conversion/correlate_documentation.go
@@ -41,8 +41,8 @@ func correlateDocumentationResultEdge(state *wrappedState, id int, edge Edge) er
 		return malformedDump(id, documentationResult, "documentationResult")
 	}
 
-	if _, ok := state.ResultSetData[projectOrResultSet]; ok {
-		state.DocumentationResultsByResultSet[projectOrResultSet] = documentationResult
+	if source, ok := state.ResultSetData[projectOrResultSet]; ok {
+		state.ResultSetData[projectOrResultSet] = source.SetDocumentationResultID(documentationResult)
 	} else {
 		// the `project` vertices are not stored, but this condition indicates the root documentationResult
 		// vertex was attached to the `project` vertex, and we want to store it.

--- a/lib/codeintel/lsif/conversion/correlate_test.go
+++ b/lib/codeintel/lsif/conversion/correlate_test.go
@@ -183,13 +183,12 @@ func TestCorrelate(t *testing.T) {
 		}),
 
 		// TODO(slimsag): Documentation extension tests
-		DocumentationResultsData:        map[int]protocol.Documentation{},
-		DocumentationStringsData:        map[int]protocol.MarkupContent{},
-		DocumentationResultsByResultSet: map[int]int{},
-		DocumentationResultRoot:         -1,
-		DocumentationChildren:           map[int][]int{},
-		DocumentationStringLabel:        map[int]int{},
-		DocumentationStringDetail:       map[int]int{},
+		DocumentationResultsData:  map[int]protocol.Documentation{},
+		DocumentationStringsData:  map[int]protocol.MarkupContent{},
+		DocumentationResultRoot:   -1,
+		DocumentationChildren:     map[int][]int{},
+		DocumentationStringLabel:  map[int]int{},
+		DocumentationStringDetail: map[int]int{},
 	}
 
 	if diff := cmp.Diff(expectedState, state, datastructures.Comparers...); diff != "" {
@@ -232,13 +231,12 @@ func TestCorrelateMetaDataRoot(t *testing.T) {
 		Diagnostics:            datastructures.NewDefaultIDSetMap(),
 
 		// TODO(slimsag): Documentation extension tests
-		DocumentationResultsData:        map[int]protocol.Documentation{},
-		DocumentationStringsData:        map[int]protocol.MarkupContent{},
-		DocumentationResultsByResultSet: map[int]int{},
-		DocumentationResultRoot:         -1,
-		DocumentationChildren:           map[int][]int{},
-		DocumentationStringLabel:        map[int]int{},
-		DocumentationStringDetail:       map[int]int{},
+		DocumentationResultsData:  map[int]protocol.Documentation{},
+		DocumentationStringsData:  map[int]protocol.MarkupContent{},
+		DocumentationResultRoot:   -1,
+		DocumentationChildren:     map[int][]int{},
+		DocumentationStringLabel:  map[int]int{},
+		DocumentationStringDetail: map[int]int{},
 	}
 
 	if diff := cmp.Diff(expectedState, state, datastructures.Comparers...); diff != "" {
@@ -281,13 +279,12 @@ func TestCorrelateMetaDataRootX(t *testing.T) {
 		Diagnostics:            datastructures.NewDefaultIDSetMap(),
 
 		// TODO(slimsag): Documentation extension tests
-		DocumentationResultsData:        map[int]protocol.Documentation{},
-		DocumentationStringsData:        map[int]protocol.MarkupContent{},
-		DocumentationResultsByResultSet: map[int]int{},
-		DocumentationResultRoot:         -1,
-		DocumentationChildren:           map[int][]int{},
-		DocumentationStringLabel:        map[int]int{},
-		DocumentationStringDetail:       map[int]int{},
+		DocumentationResultsData:  map[int]protocol.Documentation{},
+		DocumentationStringsData:  map[int]protocol.MarkupContent{},
+		DocumentationResultRoot:   -1,
+		DocumentationChildren:     map[int][]int{},
+		DocumentationStringLabel:  map[int]int{},
+		DocumentationStringDetail: map[int]int{},
 	}
 
 	if diff := cmp.Diff(expectedState, state, datastructures.Comparers...); diff != "" {

--- a/lib/codeintel/lsif/conversion/state.go
+++ b/lib/codeintel/lsif/conversion/state.go
@@ -30,7 +30,6 @@ type State struct {
 	// Sourcegraph extensions
 	DocumentationResultsData        map[int]protocol.Documentation // maps documentationResult vertices -> their data
 	DocumentationStringsData        map[int]protocol.MarkupContent // maps documentationString vertices -> their data
-	DocumentationResultsByResultSet map[int]int                    // maps resultSet vertex -> documentationResult vertex
 	DocumentationResultRoot         int                            // the documentationResult vertex corresponding to the project root.
 	DocumentationChildren           map[int][]int                  // maps documentationResult vertex -> ordered list of children documentationResult vertices
 	DocumentationStringLabel        map[int]int                    // maps documentationResult vertex -> label documentationString vertex
@@ -61,7 +60,6 @@ func newState() *State {
 		// Sourcegraph extensions
 		DocumentationResultsData:        map[int]protocol.Documentation{},
 		DocumentationStringsData:        map[int]protocol.MarkupContent{},
-		DocumentationResultsByResultSet: map[int]int{},
 		DocumentationResultRoot:         -1,
 		DocumentationChildren:           map[int][]int{},
 		DocumentationStringLabel:        map[int]int{},

--- a/lib/codeintel/lsif/conversion/state.go
+++ b/lib/codeintel/lsif/conversion/state.go
@@ -28,12 +28,12 @@ type State struct {
 	Diagnostics            *datastructures.DefaultIDSetMap // maps diagnostics to their documents
 
 	// Sourcegraph extensions
-	DocumentationResultsData        map[int]protocol.Documentation // maps documentationResult vertices -> their data
-	DocumentationStringsData        map[int]protocol.MarkupContent // maps documentationString vertices -> their data
-	DocumentationResultRoot         int                            // the documentationResult vertex corresponding to the project root.
-	DocumentationChildren           map[int][]int                  // maps documentationResult vertex -> ordered list of children documentationResult vertices
-	DocumentationStringLabel        map[int]int                    // maps documentationResult vertex -> label documentationString vertex
-	DocumentationStringDetail       map[int]int                    // maps documentationResult vertex -> detail documentationString vertex
+	DocumentationResultsData  map[int]protocol.Documentation // maps documentationResult vertices -> their data
+	DocumentationStringsData  map[int]protocol.MarkupContent // maps documentationString vertices -> their data
+	DocumentationResultRoot   int                            // the documentationResult vertex corresponding to the project root.
+	DocumentationChildren     map[int][]int                  // maps documentationResult vertex -> ordered list of children documentationResult vertices
+	DocumentationStringLabel  map[int]int                    // maps documentationResult vertex -> label documentationString vertex
+	DocumentationStringDetail map[int]int                    // maps documentationResult vertex -> detail documentationString vertex
 }
 
 // newState create a new State with zero-valued map fields.
@@ -58,11 +58,11 @@ func newState() *State {
 		Diagnostics:            datastructures.NewDefaultIDSetMap(),
 
 		// Sourcegraph extensions
-		DocumentationResultsData:        map[int]protocol.Documentation{},
-		DocumentationStringsData:        map[int]protocol.MarkupContent{},
-		DocumentationResultRoot:         -1,
-		DocumentationChildren:           map[int][]int{},
-		DocumentationStringLabel:        map[int]int{},
-		DocumentationStringDetail:       map[int]int{},
+		DocumentationResultsData:  map[int]protocol.Documentation{},
+		DocumentationStringsData:  map[int]protocol.MarkupContent{},
+		DocumentationResultRoot:   -1,
+		DocumentationChildren:     map[int][]int{},
+		DocumentationStringLabel:  map[int]int{},
+		DocumentationStringDetail: map[int]int{},
 	}
 }

--- a/lib/codeintel/lsif/conversion/types.go
+++ b/lib/codeintel/lsif/conversion/types.go
@@ -44,35 +44,49 @@ func (r Range) SetHoverResultID(id int) Range {
 
 type ResultSet struct {
 	reader.ResultSet
-	DefinitionResultID int
-	ReferenceResultID  int
-	HoverResultID      int
+	DefinitionResultID    int
+	ReferenceResultID     int
+	HoverResultID         int
+	DocumentationResultID int
 }
 
 func (rs ResultSet) SetDefinitionResultID(id int) ResultSet {
 	return ResultSet{
-		ResultSet:          rs.ResultSet,
-		DefinitionResultID: id,
-		ReferenceResultID:  rs.ReferenceResultID,
-		HoverResultID:      rs.HoverResultID,
+		ResultSet:             rs.ResultSet,
+		DefinitionResultID:    id,
+		ReferenceResultID:     rs.ReferenceResultID,
+		HoverResultID:         rs.HoverResultID,
+		DocumentationResultID: rs.DocumentationResultID,
 	}
 }
 
 func (rs ResultSet) SetReferenceResultID(id int) ResultSet {
 	return ResultSet{
-		ResultSet:          rs.ResultSet,
-		DefinitionResultID: rs.DefinitionResultID,
-		ReferenceResultID:  id,
-		HoverResultID:      rs.HoverResultID,
+		ResultSet:             rs.ResultSet,
+		DefinitionResultID:    rs.DefinitionResultID,
+		ReferenceResultID:     id,
+		HoverResultID:         rs.HoverResultID,
+		DocumentationResultID: rs.DocumentationResultID,
 	}
 }
 
 func (rs ResultSet) SetHoverResultID(id int) ResultSet {
 	return ResultSet{
-		ResultSet:          rs.ResultSet,
-		DefinitionResultID: rs.DefinitionResultID,
-		ReferenceResultID:  rs.ReferenceResultID,
-		HoverResultID:      id,
+		ResultSet:             rs.ResultSet,
+		DefinitionResultID:    rs.DefinitionResultID,
+		ReferenceResultID:     rs.ReferenceResultID,
+		HoverResultID:         id,
+		DocumentationResultID: rs.DocumentationResultID,
+	}
+}
+
+func (rs ResultSet) SetDocumentationResultID(id int) ResultSet {
+	return ResultSet{
+		ResultSet:             rs.ResultSet,
+		DefinitionResultID:    rs.DefinitionResultID,
+		ReferenceResultID:     rs.ReferenceResultID,
+		HoverResultID:         rs.HoverResultID,
+		DocumentationResultID: id,
 	}
 }
 


### PR DESCRIPTION
I had previously introduced a separate lookup map of information for "documentation by result set ID"
but this was before I knew about `ResultSetData`, which is definitely a better place for this info
to get stored.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
