### PR TITLE
API docs: LSIF: use a queue for documentation grouping channels

### DIFF
--- a/lib/codeintel/lsif/conversion/group_documentation.go
+++ b/lib/codeintel/lsif/conversion/group_documentation.go
@@ -13,16 +13,80 @@ import (
 type documentationChannels struct {
 	pages    chan *semantic.DocumentationPageData
 	pathInfo chan *semantic.DocumentationPathInfoData
+
+	enqueuePages    chan *semantic.DocumentationPageData
+	enqueuePathInfo chan *semantic.DocumentationPathInfoData
+}
+
+func (c *documentationChannels) close() {
+	close(c.enqueuePages)
+	close(c.enqueuePathInfo)
+}
+
+func newDocumentationChannels() documentationChannels {
+	channels := documentationChannels{
+		pages:           make(chan *semantic.DocumentationPageData, 128),
+		pathInfo:        make(chan *semantic.DocumentationPathInfoData, 128),
+		enqueuePages:    make(chan *semantic.DocumentationPageData, 128),
+		enqueuePathInfo: make(chan *semantic.DocumentationPathInfoData, 128),
+	}
+	go func() {
+		dst := channels.pages
+		src := channels.enqueuePages
+		var buf []*semantic.DocumentationPageData
+		for {
+			if len(buf) == 0 {
+				v, ok := <-src
+				if !ok {
+					close(dst)
+					return
+				}
+				buf = append(buf, v)
+			}
+			select {
+			case dst <- buf[0]:
+				buf = buf[1:]
+			case v, ok := <-src:
+				if !ok {
+					close(dst)
+					return
+				}
+				buf = append(buf, v)
+			}
+		}
+	}()
+	go func() {
+		dst := channels.pathInfo
+		src := channels.enqueuePathInfo
+		var buf []*semantic.DocumentationPathInfoData
+		for {
+			if len(buf) == 0 {
+				v, ok := <-src
+				if !ok {
+					close(dst)
+					return
+				}
+				buf = append(buf, v)
+			}
+			select {
+			case dst <- buf[0]:
+				buf = buf[1:]
+			case v, ok := <-src:
+				if !ok {
+					close(dst)
+					return
+				}
+				buf = append(buf, v)
+			}
+		}
+	}()
+	return channels
 }
 
 func collectDocumentation(ctx context.Context, state *State) documentationChannels {
-	channels := documentationChannels{
-		pages:    make(chan *semantic.DocumentationPageData, 1024),
-		pathInfo: make(chan *semantic.DocumentationPathInfoData, 1024),
-	}
+	channels := newDocumentationChannels()
 	if state.DocumentationResultRoot == -1 {
-		close(channels.pages)
-		close(channels.pathInfo)
+		channels.close()
 		return channels
 	}
 
@@ -38,7 +102,6 @@ func collectDocumentation(ctx context.Context, state *State) documentationChanne
 
 	tmpPages := make(chan *semantic.DocumentationPageData)
 	go pageCollector.collect(ctx, tmpPages)
-
 	go func() {
 		// Emit path info for each page as a post-processing step once we've collected pages.
 		for page := range tmpPages {
@@ -56,15 +119,14 @@ func collectDocumentation(ctx context.Context, state *State) documentationChanne
 			}
 			isIndex := page.Tree.Label.Value == "" && page.Tree.Detail.Value == ""
 
-			channels.pages <- page
-			channels.pathInfo <- &semantic.DocumentationPathInfoData{
+			channels.enqueuePages <- page
+			channels.enqueuePathInfo <- &semantic.DocumentationPathInfoData{
 				PathID:   page.Tree.PathID,
 				IsIndex:  isIndex,
 				Children: collectChildrenPages(page.Tree),
 			}
 		}
-		close(channels.pages)
-		close(channels.pathInfo)
+		channels.close()
 	}()
 	return channels
 }


### PR DESCRIPTION
This switches `collectDocumentation` from emitting two channels of information,
which are co-dependent (i.e., if one channel becomes full more results may not
be sent until that channel is emptied) to a queued implementation where both
channels operate independently. If more values are put into the queues than are
being consumed, they get buffered in-memory until they are consumed. Otherwise,
no additional dynamic buffering is done.

This is an important pre-requisite to adding documentation <-> codeintel
mapping information.

It also occurs to me that this could have potentially been the cause of the fabled "I sometimes see LSIF uploads cause a deadlock" - I think that still shouldn't happen, but this (channel deadlock) could've been the cause potentially. I haven't explored that extensively.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>