### PR TITLE
 API docs: LSIF: emit and store a mapping of documentationResult <-> pathID

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -15,14 +15,15 @@ import (
 )
 
 type operations struct {
-	queryResolver         *observation.Operation
-	definitions           *observation.Operation
-	diagnostics           *observation.Operation
-	hover                 *observation.Operation
-	ranges                *observation.Operation
-	references            *observation.Operation
-	documentationPage     *observation.Operation
-	documentationPathInfo *observation.Operation
+	queryResolver           *observation.Operation
+	definitions             *observation.Operation
+	diagnostics             *observation.Operation
+	hover                   *observation.Operation
+	ranges                  *observation.Operation
+	references              *observation.Operation
+	documentationPage       *observation.Operation
+	documentationPathInfo   *observation.Operation
+	documentationIDToPathID *observation.Operation
 
 	findClosestDumps *observation.Operation
 }
@@ -53,14 +54,15 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		queryResolver:         op("QueryResolver"),
-		definitions:           op("Definitions"),
-		diagnostics:           op("Diagnostics"),
-		hover:                 op("Hover"),
-		ranges:                op("Ranges"),
-		references:            op("References"),
-		documentationPage:     op("DocumentationPage"),
-		documentationPathInfo: op("DocumentationPathInfo"),
+		queryResolver:           op("QueryResolver"),
+		definitions:             op("Definitions"),
+		diagnostics:             op("Diagnostics"),
+		hover:                   op("Hover"),
+		ranges:                  op("Ranges"),
+		references:              op("References"),
+		documentationPage:       op("DocumentationPage"),
+		documentationPathInfo:   op("DocumentationPathInfo"),
+		documentationIDToPathID: op("DocumentationIDToPathID"),
 
 		findClosestDumps: subOp("findClosestDumps"),
 	}

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -267,6 +267,9 @@ func writeData(ctx context.Context, lsifStore LSIFStore, id int, groupedBundleDa
 	if err := tx.WriteDocumentationPathInfo(ctx, id, groupedBundleData.DocumentationPathInfo); err != nil {
 		return errors.Wrap(err, "store.WriteDocumentationPathInfo")
 	}
+	if err := tx.WriteDocumentationMappings(ctx, id, groupedBundleData.DocumentationMappings); err != nil {
+		return errors.Wrap(err, "store.WriteDocumentationMappings")
+	}
 
 	return nil
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/iface.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/iface.go
@@ -56,6 +56,7 @@ type LSIFStore interface {
 	WriteReferences(ctx context.Context, bundleID int, monikerLocations chan semantic.MonikerLocations) error
 	WriteDocumentationPages(ctx context.Context, bundleID int, documentation chan *semantic.DocumentationPageData) error
 	WriteDocumentationPathInfo(ctx context.Context, bundleID int, documentation chan *semantic.DocumentationPathInfoData) error
+	WriteDocumentationMappings(ctx context.Context, bundleID int, mappings chan semantic.DocumentationMapping) error
 }
 
 type LSIFStoreShim struct {

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
@@ -1750,6 +1750,10 @@ type MockLSIFStore struct {
 	// WriteDefinitionsFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteDefinitions.
 	WriteDefinitionsFunc *LSIFStoreWriteDefinitionsFunc
+	// WriteDocumentationMappingsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// WriteDocumentationMappings.
+	WriteDocumentationMappingsFunc *LSIFStoreWriteDocumentationMappingsFunc
 	// WriteDocumentationPagesFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteDocumentationPages.
 	WriteDocumentationPagesFunc *LSIFStoreWriteDocumentationPagesFunc
@@ -1787,6 +1791,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 		},
 		WriteDefinitionsFunc: &LSIFStoreWriteDefinitionsFunc{
 			defaultHook: func(context.Context, int, chan semantic.MonikerLocations) error {
+				return nil
+			},
+		},
+		WriteDocumentationMappingsFunc: &LSIFStoreWriteDocumentationMappingsFunc{
+			defaultHook: func(context.Context, int, chan semantic.DocumentationMapping) error {
 				return nil
 			},
 		},
@@ -1835,6 +1844,9 @@ func NewMockLSIFStoreFrom(i LSIFStore) *MockLSIFStore {
 		},
 		WriteDefinitionsFunc: &LSIFStoreWriteDefinitionsFunc{
 			defaultHook: i.WriteDefinitions,
+		},
+		WriteDocumentationMappingsFunc: &LSIFStoreWriteDocumentationMappingsFunc{
+			defaultHook: i.WriteDocumentationMappings,
 		},
 		WriteDocumentationPagesFunc: &LSIFStoreWriteDocumentationPagesFunc{
 			defaultHook: i.WriteDocumentationPages,
@@ -2170,6 +2182,118 @@ func (c LSIFStoreWriteDefinitionsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LSIFStoreWriteDefinitionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// LSIFStoreWriteDocumentationMappingsFunc describes the behavior when the
+// WriteDocumentationMappings method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreWriteDocumentationMappingsFunc struct {
+	defaultHook func(context.Context, int, chan semantic.DocumentationMapping) error
+	hooks       []func(context.Context, int, chan semantic.DocumentationMapping) error
+	history     []LSIFStoreWriteDocumentationMappingsFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteDocumentationMappings delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) WriteDocumentationMappings(v0 context.Context, v1 int, v2 chan semantic.DocumentationMapping) error {
+	r0 := m.WriteDocumentationMappingsFunc.nextHook()(v0, v1, v2)
+	m.WriteDocumentationMappingsFunc.appendCall(LSIFStoreWriteDocumentationMappingsFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// WriteDocumentationMappings method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreWriteDocumentationMappingsFunc) SetDefaultHook(hook func(context.Context, int, chan semantic.DocumentationMapping) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteDocumentationMappings method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreWriteDocumentationMappingsFunc) PushHook(hook func(context.Context, int, chan semantic.DocumentationMapping) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *LSIFStoreWriteDocumentationMappingsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, chan semantic.DocumentationMapping) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *LSIFStoreWriteDocumentationMappingsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, chan semantic.DocumentationMapping) error {
+		return r0
+	})
+}
+
+func (f *LSIFStoreWriteDocumentationMappingsFunc) nextHook() func(context.Context, int, chan semantic.DocumentationMapping) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreWriteDocumentationMappingsFunc) appendCall(r0 LSIFStoreWriteDocumentationMappingsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreWriteDocumentationMappingsFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreWriteDocumentationMappingsFunc) History() []LSIFStoreWriteDocumentationMappingsFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreWriteDocumentationMappingsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreWriteDocumentationMappingsFuncCall is an object that describes
+// an invocation of method WriteDocumentationMappings on an instance of
+// MockLSIFStore.
+type LSIFStoreWriteDocumentationMappingsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 chan semantic.DocumentationMapping
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreWriteDocumentationMappingsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreWriteDocumentationMappingsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -28,6 +28,7 @@ type operations struct {
 	writeResultChunks          *observation.Operation
 	writeDocumentationPages    *observation.Operation
 	writeDocumentationPathInfo *observation.Operation
+	writeDocumentationMappings *observation.Operation
 
 	locations           *observation.Operation
 	locationsWithinFile *observation.Operation
@@ -79,6 +80,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		writeResultChunks:          op("WriteResultChunks"),
 		writeDocumentationPages:    op("WriteDocumentationPages"),
 		writeDocumentationPathInfo: op("WriteDocumentationPathInfo"),
+		writeDocumentationMappings: op("WriteDocumentationMappings"),
 
 		locations:           subOp("locations"),
 		locationsWithinFile: subOp("locationsWithinFile"),

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -21,6 +21,8 @@ type operations struct {
 	references                 *observation.Operation
 	documentationPage          *observation.Operation
 	documentationPathInfo      *observation.Operation
+	documentationIDToPathID    *observation.Operation
+	documentationPathIDToID    *observation.Operation
 	writeDefinitions           *observation.Operation
 	writeDocuments             *observation.Operation
 	writeMeta                  *observation.Operation
@@ -73,6 +75,8 @@ func newOperations(observationContext *observation.Context) *operations {
 		references:                 op("References"),
 		documentationPage:          op("DocumentationPage"),
 		documentationPathInfo:      op("DocumentationPathInfo"),
+		documentationIDToPathID:    op("DocumentationIDToPathID"),
+		documentationPathIDToID:    op("DocumentationPathIDToID"),
 		writeDefinitions:           op("WriteDefinitions"),
 		writeDocuments:             op("WriteDocuments"),
 		writeMeta:                  op("WriteMeta"),

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -62,6 +62,27 @@ Tracks the range of schema_versions for each upload in the lsif_data_definitions
 
 **min_schema_version**: A lower-bound on the `lsif_data_definitions.schema_version` where `lsif_data_definitions.dump_id = dump_id`.
 
+# Table "public.lsif_data_documentation_mappings"
+```
+  Column   |  Type   | Collation | Nullable | Default 
+-----------+---------+-----------+----------+---------
+ dump_id   | integer |           | not null | 
+ path_id   | text    |           | not null | 
+ result_id | integer |           | not null | 
+Indexes:
+    "lsif_data_documentation_mappings_pkey" PRIMARY KEY, btree (dump_id, path_id)
+    "lsif_data_documentation_mappings_inverse_unique_idx" UNIQUE, btree (dump_id, result_id)
+
+```
+
+Maps documentation path IDs to their corresponding integral documentationResult vertex IDs, which are unique within a dump.
+
+**dump_id**: The identifier of the associated dump in the lsif_uploads table (state=completed).
+
+**path_id**: The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.
+
+**result_id**: The documentationResult vertex ID.
+
 # Table "public.lsif_data_documentation_pages"
 ```
  Column  |  Type   | Collation | Nullable | Default 

--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -47,6 +47,7 @@ func groupBundleData(ctx context.Context, state *State) (*semantic.GroupedBundle
 		References:            referenceRows,
 		DocumentationPages:    documentation.pages,
 		DocumentationPathInfo: documentation.pathInfo,
+		DocumentationMappings: documentation.mappings,
 		Packages:              packages,
 		PackageReferences:     packageReferences,
 	}, nil

--- a/lib/codeintel/semantic/types.go
+++ b/lib/codeintel/semantic/types.go
@@ -171,6 +171,16 @@ type DocumentationPathInfoData struct {
 	Children []string `json:"children,omitempty"`
 }
 
+// DocumentationMapping maps a documentationResult vertex ID to its path IDs, which are unique in
+// the context of a bundle.
+type DocumentationMapping struct {
+	// ResultID is the documentationResult vertex ID.
+	ResultID uint64 `json:"resultID"`
+
+	// PathID is the path ID corresponding to the documentationResult vertex ID.
+	PathID string `json:"pathID"`
+}
+
 // Package pairs a package name and the dump that provides it.
 type Package struct {
 	Scheme  string
@@ -199,6 +209,7 @@ type GroupedBundleDataChans struct {
 	PackageReferences     []PackageReference
 	DocumentationPages    chan *DocumentationPageData
 	DocumentationPathInfo chan *DocumentationPathInfoData
+	DocumentationMappings chan DocumentationMapping
 }
 
 type GroupedBundleDataMaps struct {

--- a/migrations/codeintel/1000000018_lsif_documentation_mappings.down.sql
+++ b/migrations/codeintel/1000000018_lsif_documentation_mappings.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS lsif_data_documentation_mappings;

--- a/migrations/codeintel/1000000018_lsif_documentation_mappings.up.sql
+++ b/migrations/codeintel/1000000018_lsif_documentation_mappings.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS lsif_data_documentation_mappings (
+    dump_id integer NOT NULL,
+    path_id TEXT NOT NULL,
+    result_id integer NOT NULL
+);
+
+ALTER TABLE lsif_data_documentation_mappings ADD PRIMARY KEY (dump_id, path_id);
+
+CREATE UNIQUE INDEX lsif_data_documentation_mappings_inverse_unique_idx ON lsif_data_documentation_mappings(dump_id, result_id);
+
+COMMENT ON TABLE lsif_data_documentation_mappings IS 'Maps documentation path IDs to their corresponding integral documentationResult vertex IDs, which are unique within a dump.';
+COMMENT ON COLUMN lsif_data_documentation_mappings.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';
+COMMENT ON COLUMN lsif_data_documentation_mappings.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';
+COMMENT ON COLUMN lsif_data_documentation_mappings.result_id IS 'The documentationResult vertex ID.';
+
+COMMIT;


### PR DESCRIPTION
This causes us to emit and store a mapping of documentationResult <-> pathID, which allows us to denormalize path IDs (which are often quite long strings) into integers for better storage.

This will be used to implement documentation <-> codeintel interactions.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>