### PR TITLE
API docs: LSIF: add methods for looking up PathID <-> Result ID

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -15,14 +15,15 @@ import (
 )
 
 type operations struct {
-	queryResolver         *observation.Operation
-	definitions           *observation.Operation
-	diagnostics           *observation.Operation
-	hover                 *observation.Operation
-	ranges                *observation.Operation
-	references            *observation.Operation
-	documentationPage     *observation.Operation
-	documentationPathInfo *observation.Operation
+	queryResolver           *observation.Operation
+	definitions             *observation.Operation
+	diagnostics             *observation.Operation
+	hover                   *observation.Operation
+	ranges                  *observation.Operation
+	references              *observation.Operation
+	documentationPage       *observation.Operation
+	documentationPathInfo   *observation.Operation
+	documentationIDToPathID *observation.Operation
 
 	findClosestDumps *observation.Operation
 }
@@ -53,14 +54,15 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		queryResolver:         op("QueryResolver"),
-		definitions:           op("Definitions"),
-		diagnostics:           op("Diagnostics"),
-		hover:                 op("Hover"),
-		ranges:                op("Ranges"),
-		references:            op("References"),
-		documentationPage:     op("DocumentationPage"),
-		documentationPathInfo: op("DocumentationPathInfo"),
+		queryResolver:           op("QueryResolver"),
+		definitions:             op("Definitions"),
+		diagnostics:             op("Diagnostics"),
+		hover:                   op("Hover"),
+		ranges:                  op("Ranges"),
+		references:              op("References"),
+		documentationPage:       op("DocumentationPage"),
+		documentationPathInfo:   op("DocumentationPathInfo"),
+		documentationIDToPathID: op("DocumentationIDToPathID"),
 
 		findClosestDumps: subOp("findClosestDumps"),
 	}

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -3,6 +3,7 @@ package lsifstore
 import (
 	"context"
 	"database/sql"
+	"strconv"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
@@ -128,4 +129,98 @@ func (s *Store) scanFirstDocumentationPathInfoData(rows *sql.Rows, queryErr erro
 		return nil, err
 	}
 	return record, nil
+}
+
+func (s *Store) documentationIDToPathID(ctx context.Context, bundleID int, id semantic.ID) (_ string, err error) {
+	if id == "" {
+		return "", nil
+	}
+	ctx, _, endObservation := s.operations.documentationIDToPathID.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("bundleID", bundleID),
+		log.String("id", string(id)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	pathID, err := s.scanFirstDocumentationPathID(s.Store.Query(ctx, sqlf.Sprintf(documentationIDToPathIDQuery, bundleID, id)))
+	if err != nil {
+		return "", err
+	}
+	return pathID, nil
+}
+
+const documentationIDToPathIDQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/ranges.go:documentationIDToPathID
+SELECT
+	path_id
+FROM
+	lsif_documentation_mappings
+WHERE
+	dump_id = %s AND
+	result_id = %s
+LIMIT 1
+`
+
+// scanFirstDocumentationPathID reads the first path_id row. If no rows match the query, an empty string is returned.
+func (s *Store) scanFirstDocumentationPathID(rows *sql.Rows, queryErr error) (_ string, err error) {
+	if queryErr != nil {
+		return "", queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	if !rows.Next() {
+		return "", nil
+	}
+
+	var pathID string
+	if err := rows.Scan(&pathID); err != nil {
+		return "", err
+	}
+	return pathID, nil
+}
+
+func (s *Store) documentationPathIDToID(ctx context.Context, bundleID int, pathID string) (_ semantic.ID, err error) {
+	ctx, _, endObservation := s.operations.documentationPathIDToID.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("bundleID", bundleID),
+		log.String("pathID", string(pathID)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	resultID, err := s.scanFirstDocumentationResultID(s.Store.Query(ctx, sqlf.Sprintf(documentationPathIDToIDQuery, bundleID, pathID)))
+	if err != nil {
+		return "", err
+	}
+	if resultID == -1 {
+		return "", err
+	}
+	return semantic.ID(strconv.FormatInt(resultID, 10)), nil
+}
+
+const documentationPathIDToIDQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/ranges.go:documentationPathIDToID
+SELECT
+	result_id
+FROM
+	lsif_documentation_mappings
+WHERE
+	dump_id = %s AND
+	path_id = %s
+LIMIT 1
+`
+
+// scanFirstDocumentationResultID reads the first result_id row. If no rows match the query, an empty string is returned.
+func (s *Store) scanFirstDocumentationResultID(rows *sql.Rows, queryErr error) (_ int64, err error) {
+	if queryErr != nil {
+		return -1, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	if !rows.Next() {
+		return -1, nil
+	}
+
+	var resultID int64
+	if err := rows.Scan(&resultID); err != nil {
+		return -1, err
+	}
+	return resultID, nil
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -21,6 +21,8 @@ type operations struct {
 	references                 *observation.Operation
 	documentationPage          *observation.Operation
 	documentationPathInfo      *observation.Operation
+	documentationIDToPathID    *observation.Operation
+	documentationPathIDToID    *observation.Operation
 	writeDefinitions           *observation.Operation
 	writeDocuments             *observation.Operation
 	writeMeta                  *observation.Operation
@@ -73,6 +75,8 @@ func newOperations(observationContext *observation.Context) *operations {
 		references:                 op("References"),
 		documentationPage:          op("DocumentationPage"),
 		documentationPathInfo:      op("DocumentationPathInfo"),
+		documentationIDToPathID:    op("DocumentationIDToPathID"),
+		documentationPathIDToID:    op("DocumentationPathIDToID"),
 		writeDefinitions:           op("WriteDefinitions"),
 		writeDocuments:             op("WriteDocuments"),
 		writeMeta:                  op("WriteMeta"),


### PR DESCRIPTION
Builds on top of #22899 by exposing the information in those tables via
the lsifstore layer.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>