### PR TITLE
API docs: LSIF: add GraphQL backend for "Go to code" / "Usage examples"

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -152,8 +152,8 @@ type GitBlobLSIFDataResolver interface {
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)
 	Documentation(ctx context.Context, args *LSIFQueryPositionArgs) (DocumentationResolver, error)
-	DocumentationDefinitions(ctx context.Context, args *LSIFDocumentationQueryArgs) (LocationConnectionResolver, error)
-	DocumentationReferences(ctx context.Context, args *LSIFDocumentationPagedQueryArgs) (LocationConnectionResolver, error)
+	DocumentationDefinitions(ctx context.Context, args *LSIFQueryDocumentationArgs) (LocationConnectionResolver, error)
+	DocumentationReferences(ctx context.Context, args *LSIFPagedQueryDocumentationArgs) (LocationConnectionResolver, error)
 }
 
 type GitBlobLSIFDataArgs struct {
@@ -180,11 +180,11 @@ type LSIFPagedQueryPositionArgs struct {
 	After *string
 }
 
-type LSIFDocumentationQueryArgs struct {
+type LSIFQueryDocumentationArgs struct {
 	PathID string
 }
 
-type LSIFDocumentationPagedQueryArgs struct {
+type LSIFPagedQueryDocumentationArgs struct {
 	PathID string
 	graphqlutil.ConnectionArgs
 	After *string

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -152,6 +152,8 @@ type GitBlobLSIFDataResolver interface {
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)
 	Documentation(ctx context.Context, args *LSIFQueryPositionArgs) (DocumentationResolver, error)
+	DocumentationDefinitions(ctx context.Context, args *LSIFDocumentationQueryArgs) (LocationConnectionResolver, error)
+	DocumentationReferences(ctx context.Context, args *LSIFDocumentationPagedQueryArgs) (LocationConnectionResolver, error)
 }
 
 type GitBlobLSIFDataArgs struct {
@@ -174,6 +176,16 @@ type LSIFQueryPositionArgs struct {
 
 type LSIFPagedQueryPositionArgs struct {
 	LSIFQueryPositionArgs
+	graphqlutil.ConnectionArgs
+	After *string
+}
+
+type LSIFDocumentationQueryArgs struct {
+	PathID string
+}
+
+type LSIFDocumentationPagedQueryArgs struct {
+	PathID string
 	graphqlutil.ConnectionArgs
 	After *string
 }

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -403,6 +403,36 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
     https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+type+DocumentationPathInfoResult+struct&patternType=literal&case=yes
     """
     documentationPathInfo(pathID: String!, maxDepth: Int, ignoreIndex: Boolean): JSONValue!
+
+    """
+    A list of definitions of the symbol described by the given documentation path ID, if any.
+    """
+    documentationDefinitions(pathID: String!): LocationConnection!
+
+    """
+    A list of references of the symbol under the given document position.
+    """
+    documentationReferences(
+        """
+        The documentation path ID, e.g. from the documentationPage return value.
+        """
+        pathID: String!
+
+        """
+        When specified, indicates that this request should be paginated and
+        to fetch results starting at this cursor.
+        A future request can be made for more results by passing in the
+        'LocationConnection.pageInfo.endCursor' that is returned.
+        """
+        after: String
+
+        """
+        When specified, indicates that this request should be paginated and
+        the first N results (relative to the cursor) should be returned. i.e.
+        how many results to return per page.
+        """
+        first: Int
+    ): LocationConnection!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
@@ -1,0 +1,43 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// DocumentationDefinitions returns the list of source locations that define the symbol found at
+// the given documentation path ID, if any.
+func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID string) (_ []AdjustedLocation, err error) {
+	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationDefinitions", r.operations.definitions, slowDefinitionsRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.Int("numUploads", len(r.uploads)),
+			log.String("uploads", uploadIDsToString(r.uploads)),
+			log.String("pathID", pathID),
+		},
+	})
+	defer endObservation()
+
+	// Because a documentation path ID is repo-local, i.e. the associated definition is always
+	// going to be found in the "local" bundle, i.e. it's not possible for it to be in another
+	// repository.
+	for _, upload := range r.uploads {
+		traceLog(log.Int("uploadID", upload.ID))
+		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, r.path, pathID, DefinitionsLimit, 0)
+		if err != nil {
+			return nil, errors.Wrap(err, "lsifStore.DocumentationDefinitions")
+		}
+		if len(locations) > 0 {
+			uploadsByID := map[int]dbstore.Dump{upload.ID: upload}
+			return r.adjustLocations(ctx, uploadsByID, locations)
+		}
+	}
+	return nil, nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
@@ -1,0 +1,46 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// DocumentationReferences returns the list of source locations that reference the symbol found at
+// the given documentation path ID, if any.
+func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID string, limit int, rawCursor string) (_ []AdjustedLocation, _ string, err error) {
+	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationReferences", r.operations.references, slowReferencesRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.Int("numUploads", len(r.uploads)),
+			log.String("uploads", uploadIDsToString(r.uploads)),
+			log.String("pathID", pathID),
+		},
+	})
+	defer endObservation()
+
+	// A documentation path ID is repo-local, i.e. the associated definition is always going to be
+	// found in the "local" bundles. It's not possible for it to be in another repository. However,
+	// references to that definition could be in other repositories and we want to include those.
+	// That requires some fairly complex logic (see query_references.go) for moniker searches, etc.
+	//
+	// What we do here is first resolve the local definitions, then execute a standard references
+	// request on the first location we find.
+	for _, upload := range r.uploads {
+		traceLog(log.Int("uploadID", upload.ID))
+		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, r.path, pathID, DefinitionsLimit, 0)
+		if err != nil {
+			return nil, "", errors.Wrap(err, "lsifStore.DocumentationDefinitions")
+		}
+		if len(locations) > 0 {
+			location := locations[0]
+			return r.References(ctx, location.Range.Start.Line, location.Range.Start.Character, limit, rawCursor)
+		}
+	}
+	return nil, "", nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
@@ -12,7 +12,7 @@ import (
 // DocumentationReferences returns the list of source locations that reference the symbol found at
 // the given documentation path ID, if any.
 func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID string, limit int, rawCursor string) (_ []AdjustedLocation, _ string, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationReferences", r.operations.references, slowReferencesRequestThreshold, observation.Args{
+	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationReferences", r.operations.documentationReferences, slowReferencesRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
@@ -106,7 +106,7 @@ type DocumentationPathInfoResult struct {
 	Children []DocumentationPathInfoResult `json:"children"`
 }
 
-func (r *QueryResolver) DocumentationDefinitions(ctx context.Context, args *gql.LSIFDocumentationQueryArgs) (gql.LocationConnectionResolver, error) {
+func (r *QueryResolver) DocumentationDefinitions(ctx context.Context, args *gql.LSIFQueryDocumentationArgs) (gql.LocationConnectionResolver, error) {
 	locations, err := r.resolver.DocumentationDefinitions(ctx, args.PathID)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func (r *QueryResolver) DocumentationDefinitions(ctx context.Context, args *gql.
 	return NewLocationConnectionResolver(locations, nil, r.locationResolver), nil
 }
 
-func (r *QueryResolver) DocumentationReferences(ctx context.Context, args *gql.LSIFDocumentationPagedQueryArgs) (gql.LocationConnectionResolver, error) {
+func (r *QueryResolver) DocumentationReferences(ctx context.Context, args *gql.LSIFPagedQueryDocumentationArgs) (gql.LocationConnectionResolver, error) {
 	limit := derefInt32(args.First, DefaultReferencesPageSize)
 	if limit <= 0 {
 		return nil, ErrIllegalLimit

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
@@ -105,3 +105,30 @@ type DocumentationPathInfoResult struct {
 	// Children is a list of the children page paths immediately below this one.
 	Children []DocumentationPathInfoResult `json:"children"`
 }
+
+func (r *QueryResolver) DocumentationDefinitions(ctx context.Context, args *gql.LSIFDocumentationQueryArgs) (gql.LocationConnectionResolver, error) {
+	locations, err := r.resolver.DocumentationDefinitions(ctx, args.PathID)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewLocationConnectionResolver(locations, nil, r.locationResolver), nil
+}
+
+func (r *QueryResolver) DocumentationReferences(ctx context.Context, args *gql.LSIFDocumentationPagedQueryArgs) (gql.LocationConnectionResolver, error) {
+	limit := derefInt32(args.First, DefaultReferencesPageSize)
+	if limit <= 0 {
+		return nil, ErrIllegalLimit
+	}
+	cursor, err := decodeCursor(args.After)
+	if err != nil {
+		return nil, err
+	}
+
+	locations, cursor, err := r.resolver.DocumentationReferences(ctx, args.PathID, limit, cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewLocationConnectionResolver(locations, strPtr(cursor), r.locationResolver), nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -54,6 +54,8 @@ type LSIFStore interface {
 	PackageInformation(ctx context.Context, bundleID int, path string, packageInformationID string) (semantic.PackageInformationData, bool, error)
 	DocumentationPage(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPageData, error)
 	DocumentationPathInfo(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPathInfoData, error)
+	DocumentationDefinitions(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
+	DocumentationReferences(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
 }
 
 type IndexEnqueuer interface {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4724,12 +4724,18 @@ type MockLSIFStore struct {
 	// DiagnosticsFunc is an instance of a mock function object controlling
 	// the behavior of the method Diagnostics.
 	DiagnosticsFunc *LSIFStoreDiagnosticsFunc
+	// DocumentationDefinitionsFunc is an instance of a mock function object
+	// controlling the behavior of the method DocumentationDefinitions.
+	DocumentationDefinitionsFunc *LSIFStoreDocumentationDefinitionsFunc
 	// DocumentationPageFunc is an instance of a mock function object
 	// controlling the behavior of the method DocumentationPage.
 	DocumentationPageFunc *LSIFStoreDocumentationPageFunc
 	// DocumentationPathInfoFunc is an instance of a mock function object
 	// controlling the behavior of the method DocumentationPathInfo.
 	DocumentationPathInfoFunc *LSIFStoreDocumentationPathInfoFunc
+	// DocumentationReferencesFunc is an instance of a mock function object
+	// controlling the behavior of the method DocumentationReferences.
+	DocumentationReferencesFunc *LSIFStoreDocumentationReferencesFunc
 	// ExistsFunc is an instance of a mock function object controlling the
 	// behavior of the method Exists.
 	ExistsFunc *LSIFStoreExistsFunc
@@ -4769,6 +4775,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 				return nil, 0, nil
 			},
 		},
+		DocumentationDefinitionsFunc: &LSIFStoreDocumentationDefinitionsFunc{
+			defaultHook: func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+				return nil, 0, nil
+			},
+		},
 		DocumentationPageFunc: &LSIFStoreDocumentationPageFunc{
 			defaultHook: func(context.Context, int, string) (*semantic.DocumentationPageData, error) {
 				return nil, nil
@@ -4777,6 +4788,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 		DocumentationPathInfoFunc: &LSIFStoreDocumentationPathInfoFunc{
 			defaultHook: func(context.Context, int, string) (*semantic.DocumentationPathInfoData, error) {
 				return nil, nil
+			},
+		},
+		DocumentationReferencesFunc: &LSIFStoreDocumentationReferencesFunc{
+			defaultHook: func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+				return nil, 0, nil
 			},
 		},
 		ExistsFunc: &LSIFStoreExistsFunc{
@@ -4825,11 +4841,17 @@ func NewMockLSIFStoreFrom(i LSIFStore) *MockLSIFStore {
 		DiagnosticsFunc: &LSIFStoreDiagnosticsFunc{
 			defaultHook: i.Diagnostics,
 		},
+		DocumentationDefinitionsFunc: &LSIFStoreDocumentationDefinitionsFunc{
+			defaultHook: i.DocumentationDefinitions,
+		},
 		DocumentationPageFunc: &LSIFStoreDocumentationPageFunc{
 			defaultHook: i.DocumentationPage,
 		},
 		DocumentationPathInfoFunc: &LSIFStoreDocumentationPathInfoFunc{
 			defaultHook: i.DocumentationPathInfo,
+		},
+		DocumentationReferencesFunc: &LSIFStoreDocumentationReferencesFunc{
+			defaultHook: i.DocumentationReferences,
 		},
 		ExistsFunc: &LSIFStoreExistsFunc{
 			defaultHook: i.Exists,
@@ -5225,6 +5247,133 @@ func (c LSIFStoreDiagnosticsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// LSIFStoreDocumentationDefinitionsFunc describes the behavior when the
+// DocumentationDefinitions method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreDocumentationDefinitionsFunc struct {
+	defaultHook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	hooks       []func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	history     []LSIFStoreDocumentationDefinitionsFuncCall
+	mutex       sync.Mutex
+}
+
+// DocumentationDefinitions delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) DocumentationDefinitions(v0 context.Context, v1 int, v2 string, v3 string, v4 int, v5 int) ([]lsifstore.Location, int, error) {
+	r0, r1, r2 := m.DocumentationDefinitionsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.DocumentationDefinitionsFunc.appendCall(LSIFStoreDocumentationDefinitionsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// DocumentationDefinitions method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DocumentationDefinitions method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreDocumentationDefinitionsFunc) PushHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultReturn(r0 []lsifstore.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *LSIFStoreDocumentationDefinitionsFunc) PushReturn(r0 []lsifstore.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *LSIFStoreDocumentationDefinitionsFunc) nextHook() func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreDocumentationDefinitionsFunc) appendCall(r0 LSIFStoreDocumentationDefinitionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreDocumentationDefinitionsFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreDocumentationDefinitionsFunc) History() []LSIFStoreDocumentationDefinitionsFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreDocumentationDefinitionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreDocumentationDefinitionsFuncCall is an object that describes an
+// invocation of method DocumentationDefinitions on an instance of
+// MockLSIFStore.
+type LSIFStoreDocumentationDefinitionsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 int
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []lsifstore.Location
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreDocumentationDefinitionsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreDocumentationDefinitionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
 // LSIFStoreDocumentationPageFunc describes the behavior when the
 // DocumentationPage method of the parent MockLSIFStore instance is invoked.
 type LSIFStoreDocumentationPageFunc struct {
@@ -5449,6 +5598,133 @@ func (c LSIFStoreDocumentationPathInfoFuncCall) Args() []interface{} {
 // invocation.
 func (c LSIFStoreDocumentationPathInfoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// LSIFStoreDocumentationReferencesFunc describes the behavior when the
+// DocumentationReferences method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreDocumentationReferencesFunc struct {
+	defaultHook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	hooks       []func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	history     []LSIFStoreDocumentationReferencesFuncCall
+	mutex       sync.Mutex
+}
+
+// DocumentationReferences delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) DocumentationReferences(v0 context.Context, v1 int, v2 string, v3 string, v4 int, v5 int) ([]lsifstore.Location, int, error) {
+	r0, r1, r2 := m.DocumentationReferencesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.DocumentationReferencesFunc.appendCall(LSIFStoreDocumentationReferencesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// DocumentationReferences method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DocumentationReferences method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultReturn(r0 []lsifstore.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *LSIFStoreDocumentationReferencesFunc) PushReturn(r0 []lsifstore.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *LSIFStoreDocumentationReferencesFunc) nextHook() func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreDocumentationReferencesFunc) appendCall(r0 LSIFStoreDocumentationReferencesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreDocumentationReferencesFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreDocumentationReferencesFunc) History() []LSIFStoreDocumentationReferencesFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreDocumentationReferencesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreDocumentationReferencesFuncCall is an object that describes an
+// invocation of method DocumentationReferences on an instance of
+// MockLSIFStore.
+type LSIFStoreDocumentationReferencesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 int
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []lsifstore.Location
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreDocumentationReferencesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreDocumentationReferencesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreExistsFunc describes the behavior when the Exists method of the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
@@ -25,12 +25,18 @@ type MockQueryResolver struct {
 	// DocumentationFunc is an instance of a mock function object
 	// controlling the behavior of the method Documentation.
 	DocumentationFunc *QueryResolverDocumentationFunc
+	// DocumentationDefinitionsFunc is an instance of a mock function object
+	// controlling the behavior of the method DocumentationDefinitions.
+	DocumentationDefinitionsFunc *QueryResolverDocumentationDefinitionsFunc
 	// DocumentationPageFunc is an instance of a mock function object
 	// controlling the behavior of the method DocumentationPage.
 	DocumentationPageFunc *QueryResolverDocumentationPageFunc
 	// DocumentationPathInfoFunc is an instance of a mock function object
 	// controlling the behavior of the method DocumentationPathInfo.
 	DocumentationPathInfoFunc *QueryResolverDocumentationPathInfoFunc
+	// DocumentationReferencesFunc is an instance of a mock function object
+	// controlling the behavior of the method DocumentationReferences.
+	DocumentationReferencesFunc *QueryResolverDocumentationReferencesFunc
 	// HoverFunc is an instance of a mock function object controlling the
 	// behavior of the method Hover.
 	HoverFunc *QueryResolverHoverFunc
@@ -61,6 +67,11 @@ func NewMockQueryResolver() *MockQueryResolver {
 				return nil, nil
 			},
 		},
+		DocumentationDefinitionsFunc: &QueryResolverDocumentationDefinitionsFunc{
+			defaultHook: func(context.Context, string) ([]resolvers.AdjustedLocation, error) {
+				return nil, nil
+			},
+		},
 		DocumentationPageFunc: &QueryResolverDocumentationPageFunc{
 			defaultHook: func(context.Context, string) (*semantic.DocumentationPageData, error) {
 				return nil, nil
@@ -69,6 +80,11 @@ func NewMockQueryResolver() *MockQueryResolver {
 		DocumentationPathInfoFunc: &QueryResolverDocumentationPathInfoFunc{
 			defaultHook: func(context.Context, string) (*semantic.DocumentationPathInfoData, error) {
 				return nil, nil
+			},
+		},
+		DocumentationReferencesFunc: &QueryResolverDocumentationReferencesFunc{
+			defaultHook: func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error) {
+				return nil, "", nil
 			},
 		},
 		HoverFunc: &QueryResolverHoverFunc{
@@ -103,11 +119,17 @@ func NewMockQueryResolverFrom(i resolvers.QueryResolver) *MockQueryResolver {
 		DocumentationFunc: &QueryResolverDocumentationFunc{
 			defaultHook: i.Documentation,
 		},
+		DocumentationDefinitionsFunc: &QueryResolverDocumentationDefinitionsFunc{
+			defaultHook: i.DocumentationDefinitions,
+		},
 		DocumentationPageFunc: &QueryResolverDocumentationPageFunc{
 			defaultHook: i.DocumentationPage,
 		},
 		DocumentationPathInfoFunc: &QueryResolverDocumentationPathInfoFunc{
 			defaultHook: i.DocumentationPathInfo,
+		},
+		DocumentationReferencesFunc: &QueryResolverDocumentationReferencesFunc{
+			defaultHook: i.DocumentationReferences,
 		},
 		HoverFunc: &QueryResolverHoverFunc{
 			defaultHook: i.Hover,
@@ -457,6 +479,119 @@ func (c QueryResolverDocumentationFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// QueryResolverDocumentationDefinitionsFunc describes the behavior when the
+// DocumentationDefinitions method of the parent MockQueryResolver instance
+// is invoked.
+type QueryResolverDocumentationDefinitionsFunc struct {
+	defaultHook func(context.Context, string) ([]resolvers.AdjustedLocation, error)
+	hooks       []func(context.Context, string) ([]resolvers.AdjustedLocation, error)
+	history     []QueryResolverDocumentationDefinitionsFuncCall
+	mutex       sync.Mutex
+}
+
+// DocumentationDefinitions delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockQueryResolver) DocumentationDefinitions(v0 context.Context, v1 string) ([]resolvers.AdjustedLocation, error) {
+	r0, r1 := m.DocumentationDefinitionsFunc.nextHook()(v0, v1)
+	m.DocumentationDefinitionsFunc.appendCall(QueryResolverDocumentationDefinitionsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// DocumentationDefinitions method of the parent MockQueryResolver instance
+// is invoked and the hook queue is empty.
+func (f *QueryResolverDocumentationDefinitionsFunc) SetDefaultHook(hook func(context.Context, string) ([]resolvers.AdjustedLocation, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DocumentationDefinitions method of the parent MockQueryResolver instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *QueryResolverDocumentationDefinitionsFunc) PushHook(hook func(context.Context, string) ([]resolvers.AdjustedLocation, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *QueryResolverDocumentationDefinitionsFunc) SetDefaultReturn(r0 []resolvers.AdjustedLocation, r1 error) {
+	f.SetDefaultHook(func(context.Context, string) ([]resolvers.AdjustedLocation, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *QueryResolverDocumentationDefinitionsFunc) PushReturn(r0 []resolvers.AdjustedLocation, r1 error) {
+	f.PushHook(func(context.Context, string) ([]resolvers.AdjustedLocation, error) {
+		return r0, r1
+	})
+}
+
+func (f *QueryResolverDocumentationDefinitionsFunc) nextHook() func(context.Context, string) ([]resolvers.AdjustedLocation, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *QueryResolverDocumentationDefinitionsFunc) appendCall(r0 QueryResolverDocumentationDefinitionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// QueryResolverDocumentationDefinitionsFuncCall objects describing the
+// invocations of this function.
+func (f *QueryResolverDocumentationDefinitionsFunc) History() []QueryResolverDocumentationDefinitionsFuncCall {
+	f.mutex.Lock()
+	history := make([]QueryResolverDocumentationDefinitionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// QueryResolverDocumentationDefinitionsFuncCall is an object that describes
+// an invocation of method DocumentationDefinitions on an instance of
+// MockQueryResolver.
+type QueryResolverDocumentationDefinitionsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []resolvers.AdjustedLocation
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c QueryResolverDocumentationDefinitionsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c QueryResolverDocumentationDefinitionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // QueryResolverDocumentationPageFunc describes the behavior when the
 // DocumentationPage method of the parent MockQueryResolver instance is
 // invoked.
@@ -678,6 +813,128 @@ func (c QueryResolverDocumentationPathInfoFuncCall) Args() []interface{} {
 // invocation.
 func (c QueryResolverDocumentationPathInfoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// QueryResolverDocumentationReferencesFunc describes the behavior when the
+// DocumentationReferences method of the parent MockQueryResolver instance
+// is invoked.
+type QueryResolverDocumentationReferencesFunc struct {
+	defaultHook func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error)
+	hooks       []func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error)
+	history     []QueryResolverDocumentationReferencesFuncCall
+	mutex       sync.Mutex
+}
+
+// DocumentationReferences delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockQueryResolver) DocumentationReferences(v0 context.Context, v1 string, v2 int, v3 string) ([]resolvers.AdjustedLocation, string, error) {
+	r0, r1, r2 := m.DocumentationReferencesFunc.nextHook()(v0, v1, v2, v3)
+	m.DocumentationReferencesFunc.appendCall(QueryResolverDocumentationReferencesFuncCall{v0, v1, v2, v3, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// DocumentationReferences method of the parent MockQueryResolver instance
+// is invoked and the hook queue is empty.
+func (f *QueryResolverDocumentationReferencesFunc) SetDefaultHook(hook func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DocumentationReferences method of the parent MockQueryResolver instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *QueryResolverDocumentationReferencesFunc) PushHook(hook func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *QueryResolverDocumentationReferencesFunc) SetDefaultReturn(r0 []resolvers.AdjustedLocation, r1 string, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *QueryResolverDocumentationReferencesFunc) PushReturn(r0 []resolvers.AdjustedLocation, r1 string, r2 error) {
+	f.PushHook(func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *QueryResolverDocumentationReferencesFunc) nextHook() func(context.Context, string, int, string) ([]resolvers.AdjustedLocation, string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *QueryResolverDocumentationReferencesFunc) appendCall(r0 QueryResolverDocumentationReferencesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// QueryResolverDocumentationReferencesFuncCall objects describing the
+// invocations of this function.
+func (f *QueryResolverDocumentationReferencesFunc) History() []QueryResolverDocumentationReferencesFuncCall {
+	f.mutex.Lock()
+	history := make([]QueryResolverDocumentationReferencesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// QueryResolverDocumentationReferencesFuncCall is an object that describes
+// an invocation of method DocumentationReferences on an instance of
+// MockQueryResolver.
+type QueryResolverDocumentationReferencesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []resolvers.AdjustedLocation
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 string
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c QueryResolverDocumentationReferencesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c QueryResolverDocumentationReferencesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // QueryResolverHoverFunc describes the behavior when the Hover method of

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -24,6 +24,7 @@ type operations struct {
 	documentationPage       *observation.Operation
 	documentationPathInfo   *observation.Operation
 	documentationIDToPathID *observation.Operation
+	documentationReferences *observation.Operation
 	documentation           *observation.Operation
 
 	findClosestDumps *observation.Operation
@@ -64,6 +65,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		documentationPage:       op("DocumentationPage"),
 		documentationPathInfo:   op("DocumentationPathInfo"),
 		documentationIDToPathID: op("DocumentationIDToPathID"),
+		documentationReferences: op("DocumentationReferences"),
 		documentation:           op("Documentation"),
 
 		findClosestDumps: subOp("findClosestDumps"),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -57,6 +57,8 @@ type QueryResolver interface {
 	DocumentationPage(ctx context.Context, pathID string) (*semantic.DocumentationPageData, error)
 	DocumentationPathInfo(ctx context.Context, pathID string) (*semantic.DocumentationPathInfoData, error)
 	Documentation(ctx context.Context, line int, character int) ([]*Documentation, error)
+	DocumentationDefinitions(ctx context.Context, pathID string) ([]AdjustedLocation, error)
+	DocumentationReferences(ctx context.Context, pathID string, limit int, rawCursor string) ([]AdjustedLocation, string, error)
 }
 
 type Documentation struct {

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -179,7 +179,6 @@ func (s *Store) scanFirstDocumentationPathID(rows *sql.Rows, queryErr error) (_ 
 	return pathID, nil
 }
 
-//nolint:unused
 func (s *Store) documentationPathIDToID(ctx context.Context, bundleID int, pathID string) (_ semantic.ID, err error) {
 	ctx, _, endObservation := s.operations.documentationPathIDToID.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
@@ -210,7 +209,6 @@ LIMIT 1
 `
 
 // scanFirstDocumentationResultID reads the first result_id row. If no rows match the query, an empty string is returned.
-//nolint:unused
 func (s *Store) scanFirstDocumentationResultID(rows *sql.Rows, queryErr error) (_ int64, err error) {
 	if queryErr != nil {
 		return -1, queryErr

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -231,7 +231,7 @@ func (s *Store) scanFirstDocumentationResultID(rows *sql.Rows, queryErr error) (
 // DocumentationDefinitions returns the set of locations defining the symbol found at the given path ID, if any.
 func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, path, pathID string, limit, offset int) (_ []Location, _ int, err error) {
 	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
-	if resultID == "" || err != nil {
+	if  err != nil || resultID == "" {
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.DefinitionResultID }

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -231,7 +231,7 @@ func (s *Store) scanFirstDocumentationResultID(rows *sql.Rows, queryErr error) (
 // DocumentationDefinitions returns the set of locations defining the symbol found at the given path ID, if any.
 func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, path, pathID string, limit, offset int) (_ []Location, _ int, err error) {
 	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
-	if  err != nil || resultID == "" {
+	if err != nil || resultID == "" {
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.DefinitionResultID }

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -235,7 +235,7 @@ func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, path
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.DefinitionResultID }
-	operation := s.operations.definitions
+	operation := s.operations.documentationDefinitions
 	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
 }
 
@@ -246,7 +246,7 @@ func (s *Store) DocumentationReferences(ctx context.Context, bundleID int, path 
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.ReferenceResultID }
-	operation := s.operations.references
+	operation := s.operations.documentationReferences
 	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
 }
 

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"strconv"
 
+	"github.com/cockroachdb/errors"
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
@@ -225,4 +226,76 @@ func (s *Store) scanFirstDocumentationResultID(rows *sql.Rows, queryErr error) (
 		return -1, err
 	}
 	return resultID, nil
+}
+
+// DocumentationDefinitions returns the set of locations defining the symbol found at the given path ID, if any.
+func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, path, pathID string, limit, offset int) (_ []Location, _ int, err error) {
+	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
+	if resultID == "" || err != nil {
+		return nil, 0, err
+	}
+	extractor := func(r semantic.RangeData) semantic.ID { return r.DefinitionResultID }
+	operation := s.operations.definitions
+	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
+}
+
+// DocumentationReferences returns the set of locations referencing the symbol found at the given path ID, if any.
+func (s *Store) DocumentationReferences(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) (_ []Location, _ int, err error) {
+	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
+	if resultID == "" || err != nil {
+		return nil, 0, err
+	}
+	extractor := func(r semantic.RangeData) semantic.ID { return r.ReferenceResultID }
+	operation := s.operations.references
+	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
+}
+
+func (s *Store) documentationDefinitionsReferences(
+	ctx context.Context,
+	extractor func(r semantic.RangeData) semantic.ID,
+	operation *observation.Operation,
+	bundleID int,
+	path string,
+	resultID semantic.ID,
+	limit,
+	offset int,
+) (_ []Location, _ int, err error) {
+	ctx, traceLog, endObservation := operation.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("bundleID", bundleID),
+		log.String("path", path),
+		log.String("resultID", string(resultID)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	documentData, exists, err := s.scanFirstDocumentData(s.Store.Query(ctx, sqlf.Sprintf(locationsDocumentQuery, bundleID, path)))
+	if err != nil || !exists {
+		return nil, 0, err
+	}
+
+	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+	var found *semantic.RangeData
+	for _, rn := range documentData.Document.Ranges {
+		if rn.DocumentationResultID == resultID {
+			found = &rn
+			break
+		}
+	}
+	traceLog(log.Bool("found", found == nil))
+	if found == nil {
+		return nil, 0, errors.New("not found")
+	}
+
+	orderedResultIDs := extractResultIDs([]semantic.RangeData{*found}, extractor)
+	locationsMap, totalCount, err := s.locations(ctx, bundleID, orderedResultIDs, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	traceLog(log.Int("totalCount", totalCount))
+
+	locations := make([]Location, 0, limit)
+	for _, resultID := range orderedResultIDs {
+		locations = append(locations, locationsMap[resultID]...)
+	}
+
+	return locations, totalCount, nil
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -23,6 +23,8 @@ type operations struct {
 	documentationPathInfo      *observation.Operation
 	documentationIDToPathID    *observation.Operation
 	documentationPathIDToID    *observation.Operation
+	documentationDefinitions   *observation.Operation
+	documentationReferences    *observation.Operation
 	writeDefinitions           *observation.Operation
 	writeDocuments             *observation.Operation
 	writeMeta                  *observation.Operation
@@ -77,6 +79,8 @@ func newOperations(observationContext *observation.Context) *operations {
 		documentationPathInfo:      op("DocumentationPathInfo"),
 		documentationIDToPathID:    op("DocumentationIDToPathID"),
 		documentationPathIDToID:    op("DocumentationPathIDToID"),
+		documentationDefinitions:   op("DocumentationDefinitions"),
+		documentationReferences:    op("DocumentationReferences"),
 		writeDefinitions:           op("WriteDefinitions"),
 		writeDocuments:             op("WriteDocuments"),
 		writeMeta:                  op("WriteMeta"),


### PR DESCRIPTION
Stacked on #22902

This PR adds the GraphQL backend needed to perform definition/references requests
on the symbol described in documentation, i.e. at a given `pathID` like `/auth#AuthInfo`
instead of a regular definition/references request which operates on a file line/column.

This effectively gives us everything we need to add a "Go to code" option to API docs,
as well as usage examples (including cross-repo.)

I've chosen to use LSIF references as usage examples, because it gives us all the existing
infrastructure and we can defer any complex ranking/upvoting/downvoting/etc of usage
examples. Plus, if we do eventually add those, it would benefit both codeintel references
and API docs usage examples at the same time. I also plan to share the UI components for
displaying these.

Here's an example of [a documentationDefinitions request](http://localhost:3080/api/console#%7B%22query%22%3A%22query%20DocumentationDefinition(%24repository%3A%20String!%2C%20%24commit%3A%20String!%2C%20%24path%3A%20String!%2C%20%24pathID%3A%20String!)%20%7B%5Cn%20%20repository(name%3A%20%24repository)%20%7B%5Cn%20%20%20%20commit(rev%3A%20%24commit)%20%7B%5Cn%20%20%20%20%20%20blob(path%3A%20%24path)%20%7B%5Cn%20%20%20%20%20%20%20%20lsif%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20documentationDefinitions(pathID%3A%20%24pathID)%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20resource%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20path%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20range%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20start%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20character%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20end%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20character%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20url%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20pageInfo%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20endCursor%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%2C%22variables%22%3A%22%7B%5Cn%20%20%5C%22repository%5C%22%3A%20%5C%22github.com%2Fsourcegraph-testing%2Fetcd%5C%22%2C%5Cn%20%20%5C%22commit%5C%22%3A%20%5C%22461eb90e5e85791f08332657dfdfa1a60677edf5%5C%22%2C%5Cn%20%20%5C%22path%5C%22%3A%20%5C%22auth%2Fstore.go%5C%22%2C%5Cn%20%20%5C%22pathID%5C%22%3A%20%5C%22%2Fauth%23AuthInfo%5C%22%5Cn%7D%22%2C%22operationName%22%3A%22DocumentationDefinition%22%7D):

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/3173176/125878321-a1be934f-5181-4123-966a-beb9c6fd789b.png">

And here's an example of [a documentationReferences request](http://localhost:3080/api/console#%7B%22query%22%3A%22query%20DocumentationReferences(%24repository%3A%20String!%2C%20%24commit%3A%20String!%2C%20%24path%3A%20String!%2C%20%24pathID%3A%20String!)%20%7B%5Cn%20%20repository(name%3A%20%24repository)%20%7B%5Cn%20%20%20%20commit(rev%3A%20%24commit)%20%7B%5Cn%20%20%20%20%20%20blob(path%3A%20%24path)%20%7B%5Cn%20%20%20%20%20%20%20%20lsif%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20documentationReferences(pathID%3A%20%24pathID)%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20resource%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20path%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20range%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20start%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20character%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20end%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20character%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20url%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20pageInfo%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20endCursor%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%2C%22variables%22%3A%22%7B%5Cn%20%20%5C%22repository%5C%22%3A%20%5C%22github.com%2Fsourcegraph-testing%2Fetcd%5C%22%2C%5Cn%20%20%5C%22commit%5C%22%3A%20%5C%22461eb90e5e85791f08332657dfdfa1a60677edf5%5C%22%2C%5Cn%20%20%5C%22path%5C%22%3A%20%5C%22auth%2Fstore.go%5C%22%2C%5Cn%20%20%5C%22pathID%5C%22%3A%20%5C%22%2Fauth%23AuthInfo%5C%22%5Cn%7D%22%2C%22operationName%22%3A%22DocumentationReferences%22%7D):

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/3173176/125878377-f4d5ed20-926c-4ea6-9561-cc3929b32254.png">

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>