### PR TITLE
Insights: migrate setting insights to database with a background job

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
 
 	"github.com/inconshreveable/log15"
@@ -82,6 +84,8 @@ func StartBackgroundJobs(ctx context.Context, mainAppDB *sql.DB) {
 	if !disableHistorical {
 		routines = append(routines, newInsightHistoricalEnqueuer(ctx, workerBaseStore, settingStore, insightsStore, observationContext))
 	}
+
+	routines = append(routines, discovery.NewMigrateSettingInsightsJob(ctx, mainAppDB, timescale))
 
 	go goroutine.MonitorBackgroundRoutines(ctx, routines...)
 }

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -2,6 +2,19 @@ package discovery
 
 import (
 	"context"
+	"time"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 
 	"github.com/sourcegraph/sourcegraph/internal/insights"
 
@@ -30,8 +43,8 @@ func Discover(ctx context.Context, settingStore SettingStore, loader insights.Lo
 	return applyFilters(discovered, args), nil
 }
 
-// DiscoverIntegrated will load any insights that are integrated (meaning backend capable) from the extensions settings
-func DiscoverIntegrated(ctx context.Context, loader insights.Loader) ([]insights.SearchInsight, error) {
+// discoverIntegrated will load any insights that are integrated (meaning backend capable) from the extensions settings
+func discoverIntegrated(ctx context.Context, loader insights.Loader) ([]insights.SearchInsight, error) {
 	return loader.LoadAll(ctx)
 }
 
@@ -47,7 +60,7 @@ func discoverAll(ctx context.Context, settingStore SettingStore, loader insights
 		return nil, err
 	}
 	results := convertFromBackendInsight(globalSettings.Insights)
-	integrated, err := DiscoverIntegrated(ctx, loader)
+	integrated, err := discoverIntegrated(ctx, loader)
 	if err != nil {
 		return nil, err
 	}
@@ -113,4 +126,116 @@ func filterByIds(ids []string, insight []insights.SearchInsight) []insights.Sear
 		}
 	}
 	return filtered
+}
+
+type settingMigrator struct {
+	base     dbutil.DB
+	insights dbutil.DB
+}
+
+// NewMigrateSettingInsightsJob will migrate insights from settings into the database. This is a job that will be
+// deprecated as soon as this functionality is available over an API.
+func NewMigrateSettingInsightsJob(ctx context.Context, base dbutil.DB, insights dbutil.DB) goroutine.BackgroundRoutine {
+	interval := time.Hour
+	m := settingMigrator{
+		base:     base,
+		insights: insights,
+	}
+
+	return goroutine.NewPeriodicGoroutine(ctx, interval,
+		goroutine.NewHandlerWithErrorMessage("insight_setting_migrator", func(ctx context.Context) error {
+			return m.migrate(ctx)
+		}))
+}
+
+func (m *settingMigrator) migrate(ctx context.Context) error {
+	insightStore := store.NewInsightStore(m.insights)
+	loader := insights.NewLoader(m.base)
+
+	discovered, err := discoverIntegrated(ctx, loader)
+	if err != nil {
+		return err
+	}
+
+	var count, skipped, errors int
+	for _, d := range discovered {
+		if d.ID == "" {
+			// we need a unique ID, and if for some reason this insight doesn't have one, it can't be migrated.
+			skipped++
+			continue
+		}
+		results, err := insightStore.Get(ctx, store.InsightQueryArgs{
+			UniqueID: d.ID,
+		})
+		if err != nil {
+			return err
+		}
+		if len(results) != 0 {
+			// this insight has already been ingested, so let's skip it. Technically this insight could have been edited
+			// but for now we are going to ignore any edits to display settings.
+			skipped++
+			continue
+		}
+
+		err = migrateSeries(ctx, insightStore, d)
+		if err != nil {
+			// we can't do anything about errors, so we will just skip it and log it
+			errors++
+			log15.Error("error while migrating insight", "error", err)
+		}
+		count++
+	}
+	log15.Info("insights settings migration complete", "count", count, "skipped", skipped, "errors", errors)
+	return nil
+}
+
+// migrateSeries will attempt to take an insight defined in Sourcegraph settings and migrate it to the database.
+func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from insights.SearchInsight) (err error) {
+	tx, err := insightStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Store.Done(err) }()
+
+	log15.Info("attempting to migrate insight", "unique_id", from.ID)
+	series := make([]types.InsightSeries, len(from.Series))
+	metadata := make([]types.InsightViewSeriesMetadata, len(from.Series))
+
+	for i, timeSeries := range from.Series {
+		temp := types.InsightSeries{
+			SeriesID:              Encode(timeSeries),
+			Query:                 timeSeries.Query,
+			RecordingIntervalDays: 1,
+		}
+		result, err := tx.CreateSeries(ctx, temp)
+		if err != nil {
+			return errors.Wrapf(err, "unable to migrate insight unique_id: %s series_id: %s", from.ID, temp.SeriesID)
+		}
+		series[i] = result
+
+		metadata[i] = types.InsightViewSeriesMetadata{
+			Label:  timeSeries.Name,
+			Stroke: timeSeries.Stroke,
+		}
+	}
+
+	view := types.InsightView{
+		Title:       from.Title,
+		Description: from.Description,
+		UniqueID:    from.ID,
+	}
+
+	view, err = tx.CreateView(ctx, view)
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+
+	for i, insightSeries := range series {
+
+		err := tx.AttachSeriesToView(ctx, insightSeries, view, metadata[i])
+		if err != nil {
+			return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+		}
+	}
+	return nil
 }

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -143,9 +143,7 @@ func NewMigrateSettingInsightsJob(ctx context.Context, base dbutil.DB, insights 
 	}
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insight_setting_migrator", func(ctx context.Context) error {
-			return m.migrate(ctx)
-		}))
+		goroutine.NewHandlerWithErrorMessage("insight_setting_migrator", m.migrate))
 }
 
 func (m *settingMigrator) migrate(ctx context.Context) error {

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -231,7 +231,6 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 	}
 
 	for i, insightSeries := range series {
-
 		err := tx.AttachSeriesToView(ctx, insightSeries, view, metadata[i])
 		if err != nil {
 			return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -22,9 +22,7 @@ type InsightStore struct {
 
 // NewInsightStore returns a new InsightStore backed by the given Timescale db.
 func NewInsightStore(db dbutil.DB) *InsightStore {
-	return &InsightStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), Now: func() time.Time {
-		return time.Now()
-	}}
+	return &InsightStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), Now: time.Now}
 }
 
 // Handle returns the underlying transactable database handle.

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -51,10 +51,10 @@ type InsightQueryArgs struct {
 
 // Get returns all matching viewable insight series.
 func (s *InsightStore) Get(ctx context.Context, args InsightQueryArgs) ([]types.InsightViewSeries, error) {
-	preds := make([]*sqlf.Query, 0)
+	preds := make([]*sqlf.Query, 0, 2)
 
 	if len(args.UniqueIDs) > 0 {
-		elems := make([]*sqlf.Query, 0)
+		elems := make([]*sqlf.Query, 0, len(args.UniqueIDs))
 		for _, id := range args.UniqueIDs {
 			elems = append(elems, sqlf.Sprintf("%s", id))
 		}
@@ -105,12 +105,7 @@ func (s *InsightStore) AttachSeriesToView(ctx context.Context,
 	if series.ID == 0 || view.ID == 0 {
 		return errors.New("input series or view not found")
 	}
-	err := s.Exec(ctx, sqlf.Sprintf(attachSeriesToViewSql, series.ID, view.ID, metadata.Label, metadata.Stroke))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.Exec(ctx, sqlf.Sprintf(attachSeriesToViewSql, series.ID, view.ID, metadata.Label, metadata.Stroke))
 }
 
 // CreateView will create a new insight view with no associated data series. This view must have a unique identifier.

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -31,8 +31,8 @@ func (s *InsightStore) Handle() *basestore.TransactableHandle { return s.Store.H
 
 // With creates a new InsightStore with the given basestore.Shareable store as the underlying basestore.Store.
 // Needed to implement the basestore.Store interface
-func (s *InsightStore) With(other basestore.ShareableStore) *Store {
-	return &Store{Store: s.Store.With(other)}
+func (s *InsightStore) With(other *InsightStore) *InsightStore {
+	return &InsightStore{Store: s.Store.With(other.Store), Now: other.Now}
 }
 
 func (s *InsightStore) Transact(ctx context.Context) (*InsightStore, error) {

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -151,9 +151,6 @@ func (s *InsightStore) CreateSeries(ctx context.Context, series types.InsightSer
 		series.NextRecordingAfter,
 		series.RecordingIntervalDays,
 	))
-	if row.Err() != nil {
-		return types.InsightSeries{}, row.Err()
-	}
 	var id int
 	err := row.Scan(&id)
 	if err != nil {

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -1,0 +1,84 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+type InsightStore struct {
+	*basestore.Store
+}
+
+// NewInsightStore returns a new InsightStore backed by the given Timescale db.
+func NewInsightStore(db dbutil.DB) *InsightStore {
+	return &InsightStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+}
+
+// Handle returns the underlying transactable database handle.
+// Needed to implement the ShareableStore interface.
+func (s *InsightStore) Handle() *basestore.TransactableHandle { return s.Store.Handle() }
+
+// With creates a new InsightStore with the given basestore.Shareable store as the underlying basestore.Store.
+// Needed to implement the basestore.Store interface
+func (s *InsightStore) With(other basestore.ShareableStore) *Store {
+	return &Store{Store: s.Store.With(other)}
+}
+
+type InsightQueryArgs struct {
+	UniqueIDs []string
+}
+
+func (s *InsightStore) Get(ctx context.Context, args InsightQueryArgs) ([]types.InsightViewSeries, error) {
+	q := sqlf.Sprintf(getInsightByViewSql)
+	if len(args.UniqueIDs) > 0 {
+		q = sqlf.Join([]*sqlf.Query{q, sqlf.Sprintf("AND iv.unique_id = ANY(%s)", args.UniqueIDs)}, " ")
+	}
+	log15.Info("querying for insights", "query", q.Query(sqlf.PostgresBindVar), "args", q.Args())
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return []types.InsightViewSeries{}, err
+	}
+
+	results := make([]types.InsightViewSeries, 0)
+	for rows.Next() {
+		var temp types.InsightViewSeries
+		if err := rows.Scan(
+			&temp.UniqueID,
+			&temp.Title,
+			&temp.Description,
+			&temp.Label,
+			&temp.Stroke,
+			&temp.SeriesID,
+			&temp.Query,
+			&temp.CreatedAt,
+			&temp.OldestHistoricalAt,
+			&temp.LastRecordedAt,
+			&temp.NextRecordingAfter,
+			&temp.RecordingIntervalDays); err != nil {
+			return []types.InsightViewSeries{}, err
+		}
+		results = append(results, temp)
+	}
+	return results, nil
+}
+
+const getInsightByViewSql = `
+-- source: enterprise/internal/insights/store/insight_store.go:Get
+SELECT iv.unique_id, iv.title, iv.description, ivs.label, ivs.stroke,
+i.series_id, i.query, i.created_at, i.oldest_historical_at, i.last_recorded_at,
+i.next_recording_after, i.recording_interval_days
+FROM insight_view iv
+         JOIN insight_view_series ivs ON iv.id = ivs.insight_view_id
+         JOIN insight_series i ON ivs.insight_series_id = i.id
+WHERE i.deleted_at IS NULL
+ORDER BY iv.unique_id
+`

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -282,8 +282,8 @@ func TestAttachSeriesView(t *testing.T) {
 		series := types.InsightSeries{
 			SeriesID:              "unique-1",
 			Query:                 "query-1",
-			OldestHistoricalAt:    now.Add(-time.Hour * 24 * 365).Round(0),
-			LastRecordedAt:        now.Add(-time.Hour * 24 * 365).Round(0),
+			OldestHistoricalAt:    now.Add(-time.Hour * 24 * 365).Truncate(time.Microsecond).Round(0),
+			LastRecordedAt:        now.Add(-time.Hour * 24 * 365).Truncate(time.Microsecond).Round(0),
 			NextRecordingAfter:    now,
 			RecordingIntervalDays: 4,
 		}
@@ -319,7 +319,7 @@ func TestAttachSeriesView(t *testing.T) {
 			Title:                 view.Title,
 			Description:           view.Description,
 			Query:                 series.Query,
-			CreatedAt:             series.CreatedAt.Round(0),
+			CreatedAt:             series.CreatedAt.Truncate(time.Microsecond).Round(0),
 			OldestHistoricalAt:    series.OldestHistoricalAt,
 			LastRecordedAt:        series.LastRecordedAt,
 			NextRecordingAfter:    series.NextRecordingAfter,

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -284,7 +284,7 @@ func TestAttachSeriesView(t *testing.T) {
 			Query:                 "query-1",
 			OldestHistoricalAt:    now.Add(-time.Hour * 24 * 365).Truncate(time.Microsecond).Round(0),
 			LastRecordedAt:        now.Add(-time.Hour * 24 * 365).Truncate(time.Microsecond).Round(0),
-			NextRecordingAfter:    now,
+			NextRecordingAfter:    now.Truncate(time.Microsecond),
 			RecordingIntervalDays: 4,
 		}
 		series, err := store.CreateSeries(ctx, series)

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -270,7 +270,7 @@ func TestCreateView(t *testing.T) {
 func TestAttachSeriesView(t *testing.T) {
 	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
 	defer cleanup()
-	now := time.Now()
+	now := time.Now().Round(0)
 	ctx := context.Background()
 
 	store := NewInsightStore(timescale)
@@ -282,8 +282,8 @@ func TestAttachSeriesView(t *testing.T) {
 		series := types.InsightSeries{
 			SeriesID:              "unique-1",
 			Query:                 "query-1",
-			OldestHistoricalAt:    now.Add(-time.Hour * 24 * 365),
-			LastRecordedAt:        now.Add(-time.Hour * 24 * 365),
+			OldestHistoricalAt:    now.Add(-time.Hour * 24 * 365).Round(0),
+			LastRecordedAt:        now.Add(-time.Hour * 24 * 365).Round(0),
 			NextRecordingAfter:    now,
 			RecordingIntervalDays: 4,
 		}
@@ -319,7 +319,7 @@ func TestAttachSeriesView(t *testing.T) {
 			Title:                 view.Title,
 			Description:           view.Description,
 			Query:                 series.Query,
-			CreatedAt:             series.CreatedAt,
+			CreatedAt:             series.CreatedAt.Round(0),
 			OldestHistoricalAt:    series.OldestHistoricalAt,
 			LastRecordedAt:        series.LastRecordedAt,
 			NextRecordingAfter:    series.NextRecordingAfter,
@@ -327,11 +327,8 @@ func TestAttachSeriesView(t *testing.T) {
 			Label:                 "my label",
 			Stroke:                "my stroke",
 		}}
-		opt := cmp.Comparer(func(x, y time.Time) bool {
-			return x.Equal(y)
-		})
 
-		if diff := cmp.Diff(want, got, opt); diff != "" {
+		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("unexpected result after attaching series to view (want/got): %s", diff)
 		}
 	})

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+
+	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
+)
+
+func TestGet(t *testing.T) {
+	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+	defer cleanup()
+
+	_, err := timescale.Exec(`INSERT INTO insight_view (title, description, unique_id)
+									VALUES ('test title', 'test description', 'unique-1'),
+									       ('test title 2', 'description2', 'unique-2');`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = timescale.Exec(`INSERT INTO insight_series (series_id, query, recording_interval_days)
+									VALUES ('series-id-1', 'query-1', 5), ('series-id-2', 'query-2', 6);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = timescale.Exec(`INSERT INTO insight_view_series (insight_view_id, insight_series_id, label, stroke)
+									VALUES (1, 1, 'label1', 'color1'), (1, 2, 'label2', 'color2'), (2, 2, 'second-label-2', 'second-color-2');`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	t.Run("test get all", func(t *testing.T) {
+		store := NewInsightStore(timescale)
+
+		got, err := store.Get(ctx, InsightQueryArgs{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var want []types.InsightViewSeries
+
+		autogold.Want("want-all-results", want).Equal(t, got)
+	})
+}

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -154,7 +154,7 @@ func TestCreateSeries(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("test get and retrieve", func(t *testing.T) {
+	t.Run("test create series", func(t *testing.T) {
 
 		series := types.InsightSeries{
 			SeriesID:              "unique-1",
@@ -182,7 +182,45 @@ func TestCreateSeries(t *testing.T) {
 		}
 
 		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("unexpected result from create / read insight series (want/got): %s", diff)
+			t.Errorf("unexpected result from create insight series (want/got): %s", diff)
+		}
+	})
+}
+
+func TestCreateView(t *testing.T) {
+	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+	defer cleanup()
+	now := time.Now()
+
+	store := NewInsightStore(timescale)
+	store.Now = func() time.Time {
+		return now
+	}
+
+	ctx := context.Background()
+
+	t.Run("test create view", func(t *testing.T) {
+
+		view := types.InsightView{
+			Title:       "my view",
+			Description: "my view description",
+			UniqueID:    "1234567",
+		}
+
+		got, err := store.CreateView(ctx, view)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := types.InsightView{
+			ID:          1,
+			Title:       "my view",
+			Description: "my view description",
+			UniqueID:    "1234567",
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpected result from create insight view (want/got): %s", diff)
 		}
 	})
 }

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -97,10 +97,53 @@ func TestGet(t *testing.T) {
 		}
 	})
 
-	t.Run("test get by unique id", func(t *testing.T) {
+	t.Run("test get by unique ids", func(t *testing.T) {
 		store := NewInsightStore(timescale)
 
 		got, err := store.Get(ctx, InsightQueryArgs{UniqueIDs: []string{"unique-1"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(got)
+		want := []types.InsightViewSeries{
+			{
+				UniqueID:              "unique-1",
+				SeriesID:              "series-id-1",
+				Title:                 "test title",
+				Description:           "test description",
+				Query:                 "query-1",
+				CreatedAt:             now,
+				OldestHistoricalAt:    now,
+				LastRecordedAt:        now,
+				NextRecordingAfter:    now,
+				RecordingIntervalDays: 5,
+				Label:                 "label1",
+				Stroke:                "color1",
+			},
+			{
+				UniqueID:              "unique-1",
+				SeriesID:              "series-id-2",
+				Title:                 "test title",
+				Description:           "test description",
+				Query:                 "query-2",
+				CreatedAt:             now,
+				OldestHistoricalAt:    now,
+				LastRecordedAt:        now,
+				NextRecordingAfter:    now,
+				RecordingIntervalDays: 6,
+				Label:                 "label2",
+				Stroke:                "color2",
+			},
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpected insight view series want/got: %s", diff)
+		}
+	})
+	t.Run("test get by unique ids", func(t *testing.T) {
+		store := NewInsightStore(timescale)
+
+		got, err := store.Get(ctx, InsightQueryArgs{UniqueID: "unique-1"})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -327,8 +327,11 @@ func TestAttachSeriesView(t *testing.T) {
 			Label:                 "my label",
 			Stroke:                "my stroke",
 		}}
+		opt := cmp.Comparer(func(x, y time.Time) bool {
+			return x.Equal(y)
+		})
 
-		if diff := cmp.Diff(want, got); diff != "" {
+		if diff := cmp.Diff(want, got, opt); diff != "" {
 			t.Errorf("unexpected result after attaching series to view (want/got): %s", diff)
 		}
 	})

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -18,3 +18,14 @@ type InsightViewSeries struct {
 	Label                 string
 	Stroke                string
 }
+
+type InsightSeries struct {
+	ID                    int
+	SeriesID              string
+	Query                 string
+	CreatedAt             time.Time
+	OldestHistoricalAt    time.Time
+	LastRecordedAt        time.Time
+	NextRecordingAfter    time.Time
+	RecordingIntervalDays int
+}

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// InsightViewSeries is an abstraction of a complete Code Insight. This type materializes a view with any associated series.
 type InsightViewSeries struct {
 	UniqueID              string
 	SeriesID              string
@@ -19,6 +20,13 @@ type InsightViewSeries struct {
 	Stroke                string
 }
 
+// InsightViewSeriesMetadata contains metadata about a viewable insight series such as render properties.
+type InsightViewSeriesMetadata struct {
+	Label  string
+	Stroke string
+}
+
+// InsightView is a single insight view that may or may not have any associated series.
 type InsightView struct {
 	ID          int
 	Title       string
@@ -26,6 +34,8 @@ type InsightView struct {
 	UniqueID    string
 }
 
+// InsightSeries is a single data series for a Code Insight. This contains some metadata about the data series, as well
+// as its unique series ID.
 type InsightSeries struct {
 	ID                    int
 	SeriesID              string

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -19,6 +19,13 @@ type InsightViewSeries struct {
 	Stroke                string
 }
 
+type InsightView struct {
+	ID          int
+	Title       string
+	Description string
+	UniqueID    string
+}
+
 type InsightSeries struct {
 	ID                    int
 	SeriesID              string

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	"time"
+)
+
+type InsightViewSeries struct {
+	UniqueID              string
+	SeriesID              string
+	Title                 string
+	Description           string
+	Query                 string
+	CreatedAt             time.Time
+	OldestHistoricalAt    time.Time
+	LastRecordedAt        time.Time
+	NextRecordingAfter    time.Time
+	RecordingIntervalDays int
+	Label                 string
+	Stroke                string
+}

--- a/migrations/codeinsights/1000000008_insights_views_series.down.sql
+++ b/migrations/codeinsights/1000000008_insights_views_series.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TABLE IF EXISTS insight_view_series;
+DROP TABLE IF EXISTS insight_view;
+DROP TABLE IF EXISTS insight_series;
+
+COMMIT;

--- a/migrations/codeinsights/1000000008_insights_views_series.up.sql
+++ b/migrations/codeinsights/1000000008_insights_views_series.up.sql
@@ -22,15 +22,15 @@ CREATE TABLE insight_view
     id          SERIAL NOT NULL PRIMARY KEY,
     title       TEXT,
     description TEXT,
-    unique_id   TEXT
+    unique_id   TEXT NOT NULL
 );
 
 CREATE UNIQUE INDEX insight_view_unique_id_unique_idx ON insight_view (unique_id);
 
 CREATE TABLE insight_view_series
 (
-    insight_view_id   INT,
-    insight_series_id INT,
+    insight_view_id   INT NOT NULL,
+    insight_series_id INT NOT NULL,
     label             TEXT,
     stroke            TEXT,
     PRIMARY KEY (insight_view_id, insight_series_id)

--- a/migrations/codeinsights/1000000008_insights_views_series.up.sql
+++ b/migrations/codeinsights/1000000008_insights_views_series.up.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+CREATE TABLE insight_series
+(
+    id                      SERIAL    NOT NULL PRIMARY KEY,
+    series_id               TEXT      NOT NULL,
+    query                   TEXT      NOT NULL,
+    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    oldest_historical_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP - INTERVAL '1 year',
+    last_recorded_at        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP - INTERVAL '10 year',
+    next_recording_after    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    recording_interval_days INT       NOT NULL DEFAULT 1,
+    deleted_at              TIMESTAMP
+);
+
+CREATE UNIQUE INDEX insight_series_series_id_unique_idx ON insight_series (series_id);
+CREATE INDEX insight_series_deleted_at_idx ON insight_series (deleted_at);
+CREATE INDEX insight_series_next_recording_after_idx ON insight_series (next_recording_after);
+
+CREATE TABLE insight_view
+(
+    id          SERIAL NOT NULL PRIMARY KEY,
+    title       TEXT,
+    description TEXT,
+    unique_id   TEXT
+);
+
+CREATE UNIQUE INDEX insight_view_unique_id_unique_idx ON insight_view (unique_id);
+
+CREATE TABLE insight_view_series
+(
+    insight_view_id   INT,
+    insight_series_id INT,
+    label             TEXT,
+    stroke            TEXT,
+    PRIMARY KEY (insight_view_id, insight_series_id)
+);
+
+ALTER TABLE insight_view_series
+    ADD FOREIGN KEY (insight_view_id) REFERENCES insight_view (id);
+
+ALTER TABLE insight_view_series
+    ADD FOREIGN KEY (insight_series_id) REFERENCES insight_series (id);
+
+COMMIT;

--- a/migrations/codeinsights/1000000008_insights_views_series.up.sql
+++ b/migrations/codeinsights/1000000008_insights_views_series.up.sql
@@ -13,6 +13,18 @@ CREATE TABLE insight_series
     deleted_at              TIMESTAMP
 );
 
+comment on table insight_series is 'Data series that comprise code insights.';
+
+comment on column insight_series.id is 'Primary key ID of this series';
+comment on column insight_series.series_id is 'Unique Series ID represents a globally unique identifier for this series.';
+comment on column insight_series.query is 'Query string that generates this series';
+comment on column insight_series.created_at is 'Timestamp when this series was created';
+comment on column insight_series.oldest_historical_at is 'Timestamp representing the oldest point of which this series is backfilled.';
+comment on column insight_series.last_recorded_at is 'Timestamp when this series was last recorded (non-historical).';
+comment on column insight_series.next_recording_after is 'Timestamp when this series should next record (non-historical).';
+comment on column insight_series.recording_interval_days is 'Number of days that should pass between recordings (non-historical)';
+comment on column insight_series.deleted_at is 'Timestamp of a soft-delete of this row.';
+
 CREATE UNIQUE INDEX insight_series_series_id_unique_idx ON insight_series (series_id);
 CREATE INDEX insight_series_deleted_at_idx ON insight_series (deleted_at);
 CREATE INDEX insight_series_next_recording_after_idx ON insight_series (next_recording_after);
@@ -25,6 +37,13 @@ CREATE TABLE insight_view
     unique_id   TEXT NOT NULL
 );
 
+comment on table insight_view is 'Views for insight data series. An insight view is an abstraction on top of an insight data series that allows for lightweight modifications to filters or metadata without regenerating the underlying series.';
+
+comment on column insight_view.id is 'Primary key ID for this view';
+comment on column insight_view.title is 'Title of the view. This may render in a chart depending on the view type.';
+comment on column insight_view.description is 'Description of the view. This may render in a chart depending on the view type.';
+comment on column insight_view.unique_id is 'Globally unique identifier for this view that is externally referencable.';
+
 CREATE UNIQUE INDEX insight_view_unique_id_unique_idx ON insight_view (unique_id);
 
 CREATE TABLE insight_view_series
@@ -35,6 +54,12 @@ CREATE TABLE insight_view_series
     stroke            TEXT,
     PRIMARY KEY (insight_view_id, insight_series_id)
 );
+
+comment on table insight_view_series is 'Join table to correlate data series with insight views';
+comment on column insight_view_series.insight_view_id is 'Foreign key to insight view.';
+comment on column insight_view_series.insight_series_id is 'Foreign key to insight data series.';
+comment on column insight_view_series.label is 'Label text for this data series. This may render in a chart depending on the view type.';
+comment on column insight_view_series.stroke is 'Stroke color metadata for this data series. This may render in a chart depending on the view type.';
 
 ALTER TABLE insight_view_series
     ADD FOREIGN KEY (insight_view_id) REFERENCES insight_view (id);


### PR DESCRIPTION
Closes #22810

This is the first in a series of pull requests that are moving code insights to a database. This adds some initial tables, some of the `Store`, as well as a background job that will periodically attempt to migrate settings that are discovered to the tables.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
