### PR TITLE
batches: fix the UI draft → UI published transition

### DIFF
--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -195,9 +195,17 @@ func DeterminePlan(previousSpec, currentSpec *btypes.ChangesetSpec, ch *btypes.C
 			pl.SetOp(btypes.ReconcilerOperationReopen)
 		}
 
-		// Only do undraft, when the codehost supports draft changesets.
-		if delta.Undraft && btypes.ExternalServiceSupports(ch.ExternalServiceType, btypes.CodehostCapabilityDraftChangesets) {
-			pl.AddOp(btypes.ReconcilerOperationUndraft)
+		// Figure out if we need to do an undraft, assuming the code host
+		// supports draft changesets. This may be due to a new spec being
+		// applied, which would mean delta.Undraft is set, or because the UI
+		// publication state has been changed, for which we need to compare the
+		// current changeset state against the desired state.
+		if btypes.ExternalServiceSupports(ch.ExternalServiceType, btypes.CodehostCapabilityDraftChangesets) {
+			if delta.Undraft {
+				pl.AddOp(btypes.ReconcilerOperationUndraft)
+			} else if calc := calculatePublicationState(currentSpec.Spec.Published, ch.UiPublicationState); calc.IsPublished() && ch.ExternalState == btypes.ChangesetExternalStateDraft {
+				pl.AddOp(btypes.ReconcilerOperationUndraft)
+			}
 		}
 
 		if delta.AttributesChanged() {

--- a/enterprise/internal/batches/reconciler/plan_test.go
+++ b/enterprise/internal/batches/reconciler/plan_test.go
@@ -177,6 +177,27 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 			wantOperations: Operations{},
 		},
 		{
+			name:        "ui published draft to ui published published",
+			currentSpec: &ct.TestSpecOpts{Published: nil},
+			changeset: ct.TestChangesetOpts{
+				PublicationState:   btypes.ChangesetPublicationStatePublished,
+				ExternalState:      btypes.ChangesetExternalStateDraft,
+				UiPublicationState: &btypes.ChangesetUiPublicationStatePublished,
+			},
+			wantOperations: Operations{btypes.ReconcilerOperationUndraft},
+		},
+		{
+			name:        "ui published published to ui published draft",
+			currentSpec: &ct.TestSpecOpts{Published: nil},
+			changeset: ct.TestChangesetOpts{
+				PublicationState:   btypes.ChangesetPublicationStatePublished,
+				ExternalState:      btypes.ChangesetExternalStateOpen,
+				UiPublicationState: &btypes.ChangesetUiPublicationStateDraft,
+			},
+			// We expect a no-op here.
+			wantOperations: Operations{},
+		},
+		{
 			name:         "title changed on published changeset",
 			previousSpec: &ct.TestSpecOpts{Published: true, Title: "Before"},
 			currentSpec:  &ct.TestSpecOpts{Published: true, Title: "After"},


### PR DESCRIPTION
This is part 3.5 of #18277. (Yep, now we're time travelling.)

This was a missing transition in #21092 that was — I think — initially spotted by @mrnugget yesterday and again by me today.

I believe this was the only missing valid state transition, based on a re-review of the relevant code.