### PR TITLE
executor: pass HOME/PATH to src-cli if Firecracker is disabled

### DIFF
--- a/enterprise/cmd/executor/internal/worker/handler_test.go
+++ b/enterprise/cmd/executor/internal/worker/handler_test.go
@@ -110,7 +110,11 @@ func TestHandle(t *testing.T) {
 }
 
 func TestHandleSrcCliStepsWithoutFirecracker(t *testing.T) {
-	makeTempDir = func() (string, error) { return os.TempDir(), nil }
+	testDir := "/tmp/src-executor-without-firecracker"
+	makeTempDir = func() (string, error) { return testDir, nil }
+	if err := os.MkdirAll(filepath.Join(testDir, command.ScriptsPath), os.ModePerm); err != nil {
+		t.Fatalf("unexpected error creating workspace: %s", err)
+	}
 
 	overwriteEnv := func(k, v string) {
 		old := os.Getenv(k)

--- a/enterprise/cmd/executor/internal/worker/handler_test.go
+++ b/enterprise/cmd/executor/internal/worker/handler_test.go
@@ -108,3 +108,67 @@ func TestHandle(t *testing.T) {
 		t.Errorf("unexpected commands (-want +got):\n%s", diff)
 	}
 }
+
+func TestHandleSrcCliStepsWithoutFirecracker(t *testing.T) {
+	makeTempDir = func() (string, error) { return os.TempDir(), nil }
+
+	overwriteEnv := func(k, v string) {
+		old := os.Getenv(k)
+		os.Setenv(k, v)
+		t.Cleanup(func() { os.Setenv(k, old) })
+	}
+
+	overwriteEnv("HOME", "/home/my-user-account")
+	overwriteEnv("PATH", "/the/best/bin:/usr/local/bin")
+
+	job := executor.Job{
+		CliSteps: []executor.CliStep{
+			{
+				Commands: []string{"batch", "help"},
+				Env:      []string{"STEPDEFENV=true"},
+			},
+			{
+				Commands: []string{"batch", "apply", "-f", "spec.yaml"},
+			},
+		},
+	}
+
+	options := Options{
+		FirecrackerOptions: command.FirecrackerOptions{Enabled: false},
+	}
+
+	runner := NewMockRunner()
+
+	handler := &handler{
+		idSet:      newIDSet(),
+		options:    options,
+		operations: command.NewOperations(&observation.TestContext),
+		runnerFactory: func(dir string, logger *command.Logger, options command.Options, operations *command.Operations) command.Runner {
+			if dir == "" {
+				// See comment in test above
+				return NewMockRunner()
+			}
+
+			return runner
+		},
+	}
+
+	if err := handler.Handle(context.Background(), job); err != nil {
+		t.Fatalf("unexpected error handling record: %s", err)
+	}
+
+	var commands [][]string
+	for _, call := range runner.RunFunc.History() {
+		commands = append(commands, append(call.Arg1.Env, call.Arg1.Command...))
+	}
+
+	expectedCommands := [][]string{
+		{"STEPDEFENV=true", "HOME=/home/my-user-account", "PATH=/the/best/bin:/usr/local/bin",
+			"src", "batch", "help"},
+		{"HOME=/home/my-user-account", "PATH=/the/best/bin:/usr/local/bin",
+			"src", "batch", "apply", "-f", "spec.yaml"},
+	}
+	if diff := cmp.Diff(expectedCommands, commands); diff != "" {
+		t.Errorf("unexpected commands (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This implements the solution discussed in [this comment][comment].

What problem this solves: when the `executor` is executed on a developer
machine then Firecracker is very likely disabled (and can't even be
enabled on macOS). When that's the case the `CliSteps` of an executor
job are executed on the host machine directly.

But that won't work with `src batch [...]` commands since those need
`HOME` and `PATH` to be set, which they are not, because when executing
on the host the environment of `src` consists only of the env vars
set in the `CliStep.Env` field. (That's how Go's `exec.Command.Env`
field works: once values are set, nothing else is inherited from the
parent process).

What this change here does is to fix that special case by checking
whether Firecracker is enabled and if not setting the env vars.

[comment]: https://github.com/sourcegraph/sourcegraph/pull/22726#discussion_r667766891



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
