### PR TITLE
Add new type of dashboard initial state for the built in and settings based dashboards

### DIFF
--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -85,6 +85,10 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
         }
     }
 
+    const handleAddInsightRequest = (): void => {
+        setAddInsightsState(true)
+    }
+
     return (
         <div>
             <section className="d-flex flex-wrap align-items-center">
@@ -110,11 +114,12 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
 
             {currentDashboard ? (
                 <DashboardInsights
-                    insightIds={currentDashboard.insightIds}
+                    dashboard={currentDashboard}
                     extensionsController={extensionsController}
                     telemetryService={telemetryService}
                     platformContext={platformContext}
                     settingsCascade={settingsCascade}
+                    onAddInsightRequest={handleAddInsightRequest}
                 />
             ) : (
                 <HeroPage icon={MapSearchIcon} title="Hmm, the dashboard wasn't found." />

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -12,23 +12,33 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { Settings } from '../../../../../../../../schema/settings.schema'
 import { CodeInsightsIcon, InsightsViewGrid } from '../../../../../../../components'
 import { InsightsApiContext } from '../../../../../../../core/backend/api-provider'
+import { InsightDashboard } from '../../../../../../../core/types'
 import { useDeleteInsight } from '../../../../../../insights/insights-page/hooks/use-delete-insight'
 import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
+
+const DEFAULT_INSIGHT_IDS: string[] = []
 
 interface DashboardInsightsProps
     extends ExtensionsControllerProps,
         TelemetryProps,
         SettingsCascadeProps<Settings>,
         PlatformContextProps<'updateSettings'> {
-    /**
-     * Dashboard specific insight ids.
-     */
-    insightIds?: string[]
+    dashboard: InsightDashboard
+    onAddInsightRequest: () => void
 }
 
 export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> = props => {
-    const { telemetryService, extensionsController, insightIds = [], settingsCascade, platformContext } = props
+    const {
+        telemetryService,
+        extensionsController,
+        dashboard,
+        settingsCascade,
+        platformContext,
+        onAddInsightRequest,
+    } = props
     const { getInsightCombinedViews } = useContext(InsightsApiContext)
+
+    const insightIds = dashboard.insightIds ?? DEFAULT_INSIGHT_IDS
 
     const views = useObservable(
         useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, insightIds), [
@@ -75,7 +85,11 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
                     onDelete={handleDelete}
                 />
             ) : (
-                <EmptyInsightDashboard />
+                <EmptyInsightDashboard
+                    dashboard={dashboard}
+                    settingsCascade={settingsCascade}
+                    onAddInsight={onAddInsightRequest}
+                />
             )}
         </div>
     )

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.module.scss
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.module.scss
@@ -4,7 +4,7 @@
 
 .item-card {
     min-height: 20rem;
-    height: 0;
+    height: 100%;
     width: 100%;
     display: flex;
     align-items: center;

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -3,20 +3,81 @@ import PlusIcon from 'mdi-react/PlusIcon'
 import React from 'react'
 import { Link } from 'react-router-dom'
 
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+
+import { Settings } from '../../../../../../../../schema/settings.schema'
+import { InsightDashboard } from '../../../../../../../core/types'
+import { getTooltipMessage, useDashboardPermissions } from '../../../../hooks/use-dashboard-permissions'
+import { isDashboardConfigurable } from '../../utils/is-dashboard-configurable'
+
 import styles from './EmptyInsightDashboard.module.scss'
 
-export const EmptyInsightDashboard: React.FunctionComponent = () => (
-    <div>
+interface EmptyInsightDashboardProps extends SettingsCascadeProps<Settings> {
+    dashboard: InsightDashboard
+    onAddInsight: () => void
+}
+
+export const EmptyInsightDashboard: React.FunctionComponent<EmptyInsightDashboardProps> = props => {
+    const { onAddInsight, dashboard, settingsCascade } = props
+
+    return isDashboardConfigurable(dashboard) ? (
+        <EmptySettingsBasedDashboard
+            dashboard={dashboard}
+            settingsCascade={settingsCascade}
+            onAddInsight={onAddInsight}
+        />
+    ) : (
+        <EmptyBuiltInDashboard />
+    )
+}
+
+/**
+ * Built-in empty dashboard state provides link to create a new code insight via creation UI.
+ * Since all insights within built-in dashboards are calculated there's no ability to add insight to
+ * this type of dashboard.
+ */
+export const EmptyBuiltInDashboard: React.FunctionComponent = () => (
+    <section className={styles.emptySection}>
+        <Link to="/insights/create" className={classnames(styles.itemCard, 'card')}>
+            <PlusIcon size="2rem" />
+            <span>Create new insight</span>
+        </Link>
+        <span className="d-flex justify-content-center mt-3">
+            <span>
+                ...or add existing insights from <Link to="/insights/dashboards/all">All Insights</Link>
+            </span>
+        </span>
+    </section>
+)
+
+/**
+ * Settings based empty dashboard state provides button for adding existing insights to the dashboard.
+ * Since it is possible with settings based dashboard to add existing insights to it.
+ */
+export const EmptySettingsBasedDashboard: React.FunctionComponent<EmptyInsightDashboardProps> = props => {
+    const { onAddInsight, settingsCascade, dashboard } = props
+    const permissions = useDashboardPermissions(dashboard, settingsCascade)
+
+    return (
         <section className={styles.emptySection}>
-            <Link to="/insights/create" className={classnames(styles.itemCard, 'card')}>
-                <PlusIcon size="2rem" />
-                <span>Create new insight</span>
-            </Link>
+            <button
+                type="button"
+                disabled={!permissions.isConfigurable}
+                onClick={onAddInsight}
+                className="btn btn-secondary p-0 w-100 border-0"
+            >
+                <div
+                    data-tooltip={!permissions.isConfigurable ? getTooltipMessage(permissions) : undefined}
+                    data-placement="right"
+                    className={classnames(styles.itemCard, 'card')}
+                >
+                    <PlusIcon size="2rem" />
+                    <span>Add insight</span>
+                </div>
+            </button>
             <span className="d-flex justify-content-center mt-3">
-                <span>
-                    ...or add existing insights from <Link to="/insights/dashboards/all">All Insights</Link>
-                </span>
+                <Link to="/insights/create">...or create a new insight</Link>
             </span>
         </section>
-    </div>
-)
+    )
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -87,6 +87,6 @@ export function getTooltipMessage(permissions: DashboardPermissions): string | u
         case DashboardReasonDenied.PermissionDenied:
             return "You don't a permission to edit this dashboard"
         case DashboardReasonDenied.BuiltInCantBeEdited:
-            return "This dashboard is built-in. You can't edit built-in dashboards"
+            return "Built-in dashboards can't be edited"
     }
 }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -1,0 +1,92 @@
+import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+
+import { Settings } from '../../../../../schema/settings.schema'
+import { InsightDashboard, isRealDashboard, isVirtualDashboard } from '../../../../core/types'
+import { isSettingsBasedInsightsDashboard } from '../../../../core/types/dashboard/real-dashboard'
+import { isGlobalSubject } from '../../../../core/types/subjects'
+import { useInsightSubjects } from '../../../../hooks/use-insight-subjects/use-insight-subjects'
+
+enum DashboardReasonDenied {
+    BuiltInCantBeEdited,
+    PermissionDenied,
+    UnknownDashboard,
+}
+
+type DashboardPermissions =
+    | {
+          isConfigurable: false
+          reason: DashboardReasonDenied
+      }
+    | {
+          isConfigurable: true
+      }
+
+const DEFAULT_DASHBOARD_PERMISSIONS: DashboardPermissions = {
+    isConfigurable: false,
+    reason: DashboardReasonDenied.UnknownDashboard,
+}
+
+export function useDashboardPermissions(
+    dashboard: InsightDashboard | undefined,
+    settingsCascade: SettingsCascadeOrError<Settings>
+): DashboardPermissions {
+    const supportedSubject = useInsightSubjects({ settingsCascade })
+
+    if (isVirtualDashboard(dashboard)) {
+        return {
+            isConfigurable: false,
+            reason: DashboardReasonDenied.BuiltInCantBeEdited,
+        }
+    }
+
+    const dashboardOwner = supportedSubject.find(subject => subject.id === dashboard?.owner?.id)
+
+    // No dashboard can't be modified
+    if (!dashboard || !dashboardOwner) {
+        return DEFAULT_DASHBOARD_PERMISSIONS
+    }
+
+    if (isRealDashboard(dashboard)) {
+        // Settings based insights dashboards (custom dashboards created by users)
+        if (isSettingsBasedInsightsDashboard(dashboard)) {
+            // Global scope permission handling
+            if (isGlobalSubject(dashboardOwner)) {
+                const canBeEdited = dashboardOwner.viewerCanAdminister && dashboardOwner.allowSiteSettingsEdits
+
+                if (!canBeEdited) {
+                    return {
+                        isConfigurable: false,
+                        reason: DashboardReasonDenied.PermissionDenied,
+                    }
+                }
+            }
+
+            return {
+                isConfigurable: true,
+            }
+        }
+
+        // Not settings based dashboard (built-in-dashboard case)
+        return {
+            isConfigurable: false,
+            reason: DashboardReasonDenied.BuiltInCantBeEdited,
+        }
+    }
+
+    return DEFAULT_DASHBOARD_PERMISSIONS
+}
+
+export function getTooltipMessage(permissions: DashboardPermissions): string | undefined {
+    if (permissions.isConfigurable) {
+        return
+    }
+
+    switch (permissions.reason) {
+        case DashboardReasonDenied.UnknownDashboard:
+            return "We didn't find a dashboard. You can't edit unknown dashboard"
+        case DashboardReasonDenied.PermissionDenied:
+            return "You don't a permission to edit this dashboard"
+        case DashboardReasonDenied.BuiltInCantBeEdited:
+            return "This dashboard is built-in. You can't edit built-in dashboards"
+    }
+}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -83,7 +83,7 @@ export function getTooltipMessage(permissions: DashboardPermissions): string | u
 
     switch (permissions.reason) {
         case DashboardReasonDenied.UnknownDashboard:
-            return "Dashboard not found"
+            return 'Dashboard not found'
         case DashboardReasonDenied.PermissionDenied:
             return "You don't a permission to edit this dashboard"
         case DashboardReasonDenied.BuiltInCantBeEdited:

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -83,7 +83,7 @@ export function getTooltipMessage(permissions: DashboardPermissions): string | u
 
     switch (permissions.reason) {
         case DashboardReasonDenied.UnknownDashboard:
-            return "We didn't find a dashboard. You can't edit unknown dashboard"
+            return "Dashboard not found"
         case DashboardReasonDenied.PermissionDenied:
             return "You don't a permission to edit this dashboard"
         case DashboardReasonDenied.BuiltInCantBeEdited:


### PR DESCRIPTION
### Context

This PR improves our initial state of empty insights dashboard. Currently, on main we have the following empty dashboard state for all types of dashboards (virtual, built-in like personal and org dashboards, custom type of dashboards that were created by users) 

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/18492575/125938648-436d1815-398c-443f-a6e6-7f23c01efe40.png">

This button `create new insight` actually makes sense for built-in dashboards (the only one way to add insight to a built-in dashboard is to create a dashboard with some specific to this dashboard visibility settings)

But this `create new insight` button may confuse users on custom dashboards, cause just to create a code insight isn't enough to see this insight on some custom dashboards. In fact, you have to go to the dashboard page pick the custom dashboard and by dashboard context menu action `Add insights` add some insight to this custom dashboard.

So I assume it would make sense to have a different initial state for the custom dashboards. This PR add this specific initial state. 

![image](https://user-images.githubusercontent.com/18492575/125939179-fcbc0b3a-442b-4958-a351-5ab37768283a.png)

By click on add insight, you will see the Add insight to dashboard modal UI 

<img alt="Screenshot 2021-07-16 at 12 21 23" src="https://user-images.githubusercontent.com/18492575/125939224-e500b9d2-4e94-4524-8c3a-e393279a009b.png">

And in this UI you can find and add some insights to the active dashboard. 