### PR TITLE
search: add RepoOptions to TextParameters

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -261,7 +261,7 @@ type resolveRepositoriesOpts struct {
 
 // resolveRepositories calls ResolveRepositories, caching the result for the common case
 // where opts.effectiveRepoFieldValues == nil.
-func (r *searchResolver) resolveRepositories(ctx context.Context, options search.Options) (resolved searchrepos.Resolved, err error) {
+func (r *searchResolver) resolveRepositories(ctx context.Context, options search.RepoOptions) (resolved searchrepos.Resolved, err error) {
 	if mockResolveRepositories != nil {
 		return mockResolveRepositories()
 	}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -261,7 +261,7 @@ type resolveRepositoriesOpts struct {
 
 // resolveRepositories calls ResolveRepositories, caching the result for the common case
 // where opts.effectiveRepoFieldValues == nil.
-func (r *searchResolver) resolveRepositories(ctx context.Context, options searchrepos.Options) (resolved searchrepos.Resolved, err error) {
+func (r *searchResolver) resolveRepositories(ctx context.Context, options search.Options) (resolved searchrepos.Resolved, err error) {
 	if mockResolveRepositories != nil {
 		return mockResolveRepositories()
 	}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -107,7 +107,7 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 // returns 0 repos or fails, it returns false. It is a helper function for
 // raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
-func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Options) bool {
+func (r *searchResolver) reposExist(ctx context.Context, options search.Options) bool {
 	options.UserSettings = r.UserSettings
 	repositoryResolver := &searchrepos.Resolver{
 		DB:                  r.db,
@@ -198,7 +198,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context, q query.Q)
 
 	proposedQueries := []*searchQueryDescription{}
 	if forksNotSet {
-		tryIncludeForks := searchrepos.Options{
+		tryIncludeForks := search.Options{
 			RepoFilters:      repoFilters,
 			MinusRepoFilters: minusRepoFilters,
 			NoForks:          false,
@@ -213,7 +213,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context, q query.Q)
 	}
 
 	if archivedNotSet {
-		tryIncludeArchived := searchrepos.Options{
+		tryIncludeArchived := search.Options{
 			RepoFilters:      repoFilters,
 			MinusRepoFilters: minusRepoFilters,
 			OnlyForks:        onlyForks,

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -107,7 +107,7 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 // returns 0 repos or fails, it returns false. It is a helper function for
 // raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
-func (r *searchResolver) reposExist(ctx context.Context, options search.Options) bool {
+func (r *searchResolver) reposExist(ctx context.Context, options search.RepoOptions) bool {
 	options.UserSettings = r.UserSettings
 	repositoryResolver := &searchrepos.Resolver{
 		DB:                  r.db,
@@ -198,7 +198,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context, q query.Q)
 
 	proposedQueries := []*searchQueryDescription{}
 	if forksNotSet {
-		tryIncludeForks := search.Options{
+		tryIncludeForks := search.RepoOptions{
 			RepoFilters:      repoFilters,
 			MinusRepoFilters: minusRepoFilters,
 			NoForks:          false,
@@ -213,7 +213,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context, q query.Q)
 	}
 
 	if archivedNotSet {
-		tryIncludeArchived := search.Options{
+		tryIncludeArchived := search.RepoOptions{
 			RepoFilters:      repoFilters,
 			MinusRepoFilters: minusRepoFilters,
 			OnlyForks:        onlyForks,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1436,6 +1436,8 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		_, _, _ = agg.Get()
 	}()
 
+	args.RepoOptions = r.toRepoOptions(args.Query, resolveRepositoriesOpts{})
+
 	// performance optimization: call zoekt early, resolve repos concurrently, filter
 	// search results with resolved repos.
 	if args.Mode == search.ZoektGlobalSearch {
@@ -1456,8 +1458,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		}
 	}
 
-	repoOptions := r.toRepoOptions(args.Query, resolveRepositoriesOpts{})
-	resolved, err := r.resolveRepositories(ctx, repoOptions)
+	resolved, err := r.resolveRepositories(ctx, args.RepoOptions)
 	if err != nil {
 		if alert, err := errorToAlert(err); alert != nil {
 			return alert.wrapResults(), err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -455,7 +455,7 @@ func LogSearchLatency(ctx context.Context, db dbutil.DB, si *run.SearchInputs, d
 	}
 }
 
-func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) searchrepos.Options {
+func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) search.Options {
 	repoFilters, minusRepoFilters := q.Repositories()
 	if opts.effectiveRepoFieldValues != nil {
 		repoFilters = opts.effectiveRepoFieldValues
@@ -510,7 +510,7 @@ func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) 
 		CacheLookup = true
 	}
 
-	return searchrepos.Options{
+	return search.Options{
 		RepoFilters:        repoFilters,
 		MinusRepoFilters:   minusRepoFilters,
 		RepoGroupFilters:   repoGroupFilters,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -455,7 +455,7 @@ func LogSearchLatency(ctx context.Context, db dbutil.DB, si *run.SearchInputs, d
 	}
 }
 
-func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) search.Options {
+func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) search.RepoOptions {
 	repoFilters, minusRepoFilters := q.Repositories()
 	if opts.effectiveRepoFieldValues != nil {
 		repoFilters = opts.effectiveRepoFieldValues
@@ -510,7 +510,7 @@ func (r *searchResolver) toRepoOptions(q query.Q, opts resolveRepositoriesOpts) 
 		CacheLookup = true
 	}
 
-	return search.Options{
+	return search.RepoOptions{
 		RepoFilters:        repoFilters,
 		MinusRepoFilters:   minusRepoFilters,
 		RepoGroupFilters:   repoGroupFilters,

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -51,7 +51,7 @@ type Resolver struct {
 	SearchableReposFunc searchableReposFunc
 }
 
-func (r *Resolver) Resolve(ctx context.Context, op search.Options) (Resolved, error) {
+func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved, error) {
 	var err error
 	tr, ctx := trace.New(ctx, "resolveRepositories", op.String())
 	defer func() {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	regexpsyntax "regexp/syntax"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -52,7 +51,7 @@ type Resolver struct {
 	SearchableReposFunc searchableReposFunc
 }
 
-func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
+func (r *Resolver) Resolve(ctx context.Context, op search.Options) (Resolved, error) {
 	var err error
 	tr, ctx := trace.New(ctx, "resolveRepositories", op.String())
 	defer func() {
@@ -314,73 +313,6 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 		ExcludedRepos:   excluded,
 		OverLimit:       overLimit,
 	}, err
-}
-
-type Options struct {
-	RepoFilters        []string
-	MinusRepoFilters   []string
-	RepoGroupFilters   []string
-	SearchContextSpec  string
-	VersionContextName string
-	UserSettings       *schema.Settings
-	NoForks            bool
-	OnlyForks          bool
-	NoArchived         bool
-	OnlyArchived       bool
-	CommitAfter        string
-	OnlyPrivate        bool
-	OnlyPublic         bool
-	Ranked             bool // Return results ordered by rank
-	Limit              int
-	CacheLookup        bool
-	Query              query.Q
-}
-
-func (op *Options) String() string {
-	var b strings.Builder
-	if len(op.RepoFilters) == 0 {
-		b.WriteString("r=[]")
-	}
-	for i, r := range op.RepoFilters {
-		if i != 0 {
-			b.WriteByte(' ')
-		}
-		b.WriteString(strconv.Quote(r))
-	}
-
-	if len(op.MinusRepoFilters) > 0 {
-		_, _ = fmt.Fprintf(&b, " -r=%v", op.MinusRepoFilters)
-	}
-	if len(op.RepoGroupFilters) > 0 {
-		_, _ = fmt.Fprintf(&b, " groups=%v", op.RepoGroupFilters)
-	}
-	if op.VersionContextName != "" {
-		_, _ = fmt.Fprintf(&b, " versionContext=%q", op.VersionContextName)
-	}
-	if op.CommitAfter != "" {
-		_, _ = fmt.Fprintf(&b, " CommitAfter=%q", op.CommitAfter)
-	}
-
-	if op.NoForks {
-		b.WriteString(" NoForks")
-	}
-	if op.OnlyForks {
-		b.WriteString(" OnlyForks")
-	}
-	if op.NoArchived {
-		b.WriteString(" NoArchived")
-	}
-	if op.OnlyArchived {
-		b.WriteString(" OnlyArchived")
-	}
-	if op.OnlyPrivate {
-		b.WriteString(" OnlyPrivate")
-	}
-	if op.OnlyPublic {
-		b.WriteString(" OnlyPublic")
-	}
-
-	return b.String()
 }
 
 // ExactlyOneRepo returns whether exactly one repo: literal field is specified and

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -164,7 +164,7 @@ func TestRevisionValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.repoFilters[0], func(t *testing.T) {
-			op := search.Options{RepoFilters: tt.repoFilters}
+			op := search.RepoOptions{RepoFilters: tt.repoFilters}
 			repositoryResolver := &Resolver{}
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
 
@@ -431,7 +431,7 @@ func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			op := search.Options{
+			op := search.RepoOptions{
 				SearchContextSpec: tt.searchContextSpec,
 				Query:             queryInfo,
 			}
@@ -507,7 +507,7 @@ func TestResolveRepositoriesWithUserSearchContext(t *testing.T) {
 		database.Mocks.Namespaces.GetByName = nil
 	}()
 
-	op := search.Options{
+	op := search.RepoOptions{
 		Query:             queryInfo,
 		SearchContextSpec: "@" + wantName,
 	}
@@ -588,7 +588,7 @@ func TestResolveRepositoriesWithSearchContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	op := search.Options{
+	op := search.RepoOptions{
 		Query:             queryInfo,
 		SearchContextSpec: "searchcontext",
 	}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -164,7 +164,7 @@ func TestRevisionValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.repoFilters[0], func(t *testing.T) {
-			op := Options{RepoFilters: tt.repoFilters}
+			op := search.Options{RepoFilters: tt.repoFilters}
 			repositoryResolver := &Resolver{}
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
 
@@ -431,7 +431,7 @@ func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			op := Options{
+			op := search.Options{
 				SearchContextSpec: tt.searchContextSpec,
 				Query:             queryInfo,
 			}
@@ -507,7 +507,7 @@ func TestResolveRepositoriesWithUserSearchContext(t *testing.T) {
 		database.Mocks.Namespaces.GetByName = nil
 	}()
 
-	op := Options{
+	op := search.Options{
 		Query:             queryInfo,
 		SearchContextSpec: "@" + wantName,
 	}
@@ -588,7 +588,7 @@ func TestResolveRepositoriesWithSearchContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	op := Options{
+	op := search.Options{
 		Query:             queryInfo,
 		SearchContextSpec: "searchcontext",
 	}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -131,7 +131,7 @@ func (m GlobalSearchMode) String() string {
 // search. It defines behavior for text search on repository names, file names, and file content.
 type TextParameters struct {
 	PatternInfo *TextPatternInfo
-	RepoOptions Options
+	RepoOptions RepoOptions
 	ResultTypes result.Types
 	Timeout     time.Duration
 
@@ -250,7 +250,7 @@ func (p *TextPatternInfo) String() string {
 	return fmt.Sprintf("TextPatternInfo{%s}", strings.Join(args, ","))
 }
 
-type Options struct {
+type RepoOptions struct {
 	RepoFilters        []string
 	MinusRepoFilters   []string
 	RepoGroupFilters   []string
@@ -270,7 +270,7 @@ type Options struct {
 	Query              query.Q
 }
 
-func (op *Options) String() string {
+func (op *RepoOptions) String() string {
 	var b strings.Builder
 	if len(op.RepoFilters) == 0 {
 		b.WriteString("r=[]")

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -10,6 +10,7 @@ import (
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -129,6 +130,7 @@ func (m GlobalSearchMode) String() string {
 // search. It defines behavior for text search on repository names, file names, and file content.
 type TextParameters struct {
 	PatternInfo *TextPatternInfo
+	RepoOptions searchrepos.Options
 	ResultTypes result.Types
 	Timeout     time.Duration
 


### PR DESCRIPTION
This makes sure we have RepoOptions available in
indexed_search.zoektSearchGlobal via TextParameters.

The goal is to avoid repository resolution on the
critical path for global searches. So far resolved
repositories where used as filter. For example: if fork:no
was specified, Zoekt still returned results from forks, 
but since the resolved respositores didn't contain forks,
results from forks were filtered out. 

We have already enabled Zoekt to consume the flags "public", 
"fork", "archived" and we will soon be able to query Zoekt with 
these flags. This means, once zoektSearchGlobal has access to
these flags we can skip repository resolution for public repositories.

To avoid circular imports I had to move Options from
the repos package to the search package. I think
types.go is a good fit.

The first commit is the actual change.
Commit two and three are mechanical refactors.