### PR TITLE
dev(sg): add run redis-postgres via compose

### DIFF
--- a/dev/redis-postgres.env
+++ b/dev/redis-postgres.env
@@ -1,0 +1,3 @@
+POSTGRES_HOST=localhost
+PGPASSWORD=sourcegraph
+PGUSER=sourcegraph

--- a/dev/redis-postgres.env
+++ b/dev/redis-postgres.env
@@ -1,3 +1,0 @@
-POSTGRES_HOST=localhost
-PGPASSWORD=sourcegraph
-PGUSER=sourcegraph

--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -2,6 +2,9 @@
 # development, via docker-compose.
 # See doc/dev/getting-started/quickstart_6_start_server.md for how to
 # use it.
+# For convenience, you can use source `.redis-postgres.env` for relevant configuration.
+#
+# You can also use `sg run redis-postgres`.
 services:
   redis:
     image: redis

--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -2,7 +2,6 @@
 # development, via docker-compose.
 # See doc/dev/getting-started/quickstart_6_start_server.md for how to
 # use it.
-# For convenience, you can use source `.redis-postgres.env` for relevant configuration.
 #
 # You can also use `sg run redis-postgres`.
 services:

--- a/doc/dev/getting-started/quickstart_1_install_dependencies.md
+++ b/doc/dev/getting-started/quickstart_1_install_dependencies.md
@@ -56,7 +56,7 @@ The following are two recommendations for installing these dependencies:
 
 5. (with docker) Install Docker Compose
 
-    We provide a docker compose file at `dev/compose.yml` to make it easy to run Redis and PostgreSQL as docker containers. Fortunately `docker-compose` comes with Docker for Mac so no additional step is required.
+    We provide a docker compose file at `dev/redis-postgres.yml` to make it easy to run Redis and PostgreSQL as docker containers. Fortunately `docker-compose` comes with Docker for Mac so no additional step is required.
 
     See the official [docker compose documentation](https://docs.docker.com/compose/install/).
 
@@ -191,7 +191,7 @@ The following are two recommendations for installing these dependencies:
 
 3. (with docker) Install Docker Compose
 
-    We provide a docker compose file at `dev/compose.yml` to make it easy to run Redis and PostgreSQL as docker containers.
+    We provide a docker compose file at `dev/redis-postgres.yml` to make it easy to run Redis and PostgreSQL as docker containers.
 
     > NOTE: Although Ubuntu provides a `docker-compose` package, we recommend to install the latest version via `pip` so that it is compatible with our compose file.
 

--- a/doc/dev/getting-started/quickstart_2_initialize_database.md
+++ b/doc/dev/getting-started/quickstart_2_initialize_database.md
@@ -65,7 +65,7 @@ export PGPASSWORD=sourcegraph
 export PGDATABASE=sourcegraph
 ```
 
-You can also use the `PGDATA_DIR` environment variable to specify a local folder (instead of a volume) to store the database files. See the `dev/compose.yml` file for more details.
+You can also use the `PGDATA_DIR` environment variable to specify a local folder (instead of a volume) to store the database files. See the `dev/redis-postgres.yml` file for more details.
 
 ## More info
 

--- a/doc/dev/getting-started/quickstart_6_start_server.md
+++ b/doc/dev/getting-started/quickstart_6_start_server.md
@@ -9,21 +9,21 @@
 2. (with docker) Start the Redis and PostgreSQL containers in the background with:
 
     ```
-    docker-compose -f dev/compose.yml up -d
+    docker-compose -f dev/redis-postgres.yml up -d
     ```
 
     You can also start either Redis or PostgreSQL, if you are running the other one directly on your system:
 
     ```
-    docker-compose -f dev/compose.yml up -d redis
+    docker-compose -f dev/redis-postgres.yml up -d redis
     # or
-    docker-compose -f dev/compose.yml up -d postgresql
+    docker-compose -f dev/redis-postgres.yml up -d postgresql
     ```
 
     When you want to stop the containers, run:
 
     ```
-    docker-compose -f dev/compose.yml down
+    docker-compose -f dev/redis-postgres.yml down
     ```
 
 3. Start the server with

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -484,7 +484,15 @@ commands:
       PORT: 5435
 
   redis-postgres:
-    cmd: docker-compose -f dev/redis-postgres.yml up
+    # Add the following overwrites to your sg.config.overwrite.yaml to use the docker-compose
+    # database:
+    #
+    #   env:
+    #       POSTGRES_HOST: localhost
+    #       PGPASSWORD: sourcegraph
+    #       PGUSER: sourcegraph
+    #
+    cmd: docker-compose -f dev/redis-postgres.yml up --force-recreate
 
 checks:
   docker:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -492,6 +492,7 @@ commands:
     #       PGPASSWORD: sourcegraph
     #       PGUSER: sourcegraph
     #
+    # You could also add an overwrite to add `redis-postgres` to the relevant command set(s).
     cmd: docker-compose -f dev/redis-postgres.yml up --force-recreate
 
 checks:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -483,6 +483,9 @@ commands:
       CONTAINER: codeinsights-db
       PORT: 5435
 
+  redis-postgres:
+    cmd: docker-compose -f dev/redis-postgres.yml up
+
 checks:
   docker:
     cmd: docker version


### PR DESCRIPTION
because I use this :) only works with override config for the `PG*` variables. not sure how to just make this work out-of-the-box


```
❯ sg run redis-postgres
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
