### PR TITLE
Second attempt to PR "Add new "JVM Packages" external services type. (#21703)"

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -5,6 +5,7 @@ import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import GithubIcon from 'mdi-react/GithubIcon'
 import GitIcon from 'mdi-react/GitIcon'
 import GitLabIcon from 'mdi-react/GitlabIcon'
+import LanguageJavaIcon from 'mdi-react/LanguageJavaIcon'
 import React from 'react'
 
 import { PhabricatorIcon } from '@sourcegraph/shared/src/components/icons'
@@ -15,6 +16,7 @@ import bitbucketServerSchemaJSON from '../../../../../schema/bitbucket_server.sc
 import githubSchemaJSON from '../../../../../schema/github.schema.json'
 import gitlabSchemaJSON from '../../../../../schema/gitlab.schema.json'
 import gitoliteSchemaJSON from '../../../../../schema/gitolite.schema.json'
+import jvmPackagesSchemaJSON from '../../../../../schema/jvm-packages.schema.json'
 import otherExternalServiceSchemaJSON from '../../../../../schema/other_external_service.schema.json'
 import perforceSchemaJSON from '../../../../../schema/perforce.schema.json'
 import phabricatorSchemaJSON from '../../../../../schema/phabricator.schema.json'
@@ -1175,6 +1177,37 @@ const PERFORCE: AddExternalServiceOptions = {
         },
     ],
 }
+const JVM_PACKAGES: AddExternalServiceOptions = {
+    kind: ExternalServiceKind.JVMPACKAGES,
+    title: 'JVM Dependencies',
+    icon: LanguageJavaIcon,
+    jsonSchema: jvmPackagesSchemaJSON,
+    defaultDisplayName: 'JVM Dependencies',
+    defaultConfig: `{
+  "maven": {
+    "repositories": [],
+    "dependencies": []
+  }
+}`,
+    instructions: (
+        <div>
+            <ol>
+                <li>
+                    In the configuration below, set <Field>maven.repositories</Field> to the list of Maven repositories.
+                    For example,
+                    <code>"https://maven.google.com"</code>.
+                </li>
+                <li>
+                    In the configuration below, set <Field>maven.dependencies</Field> to the list of artifacts that you
+                    want to manually add. For example,
+                    <code>"junit:junit:4.13.2"</code> or
+                    <code>"org.hamcrest:hamcrest-core:1.3:default"</code>.
+                </li>
+            </ol>
+        </div>
+    ),
+    editorActions: [],
+}
 
 export const codeHostExternalServices: Record<string, AddExternalServiceOptions> = {
     github: GITHUB_DOTCOM,
@@ -1188,6 +1221,7 @@ export const codeHostExternalServices: Record<string, AddExternalServiceOptions>
     gitolite: GITOLITE,
     git: GENERIC_GIT,
     ...(window.context?.experimentalFeatures?.perforce === 'enabled' ? { perforce: PERFORCE } : {}),
+    ...(window.context?.experimentalFeatures?.jvmPackages === 'enabled' ? { jvmPackages: JVM_PACKAGES } : {}),
 }
 
 export const nonCodeHostExternalServices: Record<string, AddExternalServiceOptions> = {
@@ -1209,4 +1243,5 @@ export const defaultExternalServices: Record<ExternalServiceKind, AddExternalSer
     [ExternalServiceKind.OTHER]: GENERIC_GIT,
     [ExternalServiceKind.AWSCODECOMMIT]: AWS_CODE_COMMIT,
     [ExternalServiceKind.PERFORCE]: PERFORCE,
+    [ExternalServiceKind.JVMPACKAGES]: JVM_PACKAGES,
 }

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -60,6 +60,7 @@ const helpTexts: Record<ExternalServiceKind, JSX.Element> = {
     // These are just for type completeness and serve as placeholders for a bright future.
     [ExternalServiceKind.BITBUCKETCLOUD]: <span>Unsupported</span>,
     [ExternalServiceKind.GITOLITE]: <span>Unsupported</span>,
+    [ExternalServiceKind.JVMPACKAGES]: <span>Unsupported</span>,
     [ExternalServiceKind.PERFORCE]: <span>Unsupported</span>,
     [ExternalServiceKind.PHABRICATOR]: <span>Unsupported</span>,
     [ExternalServiceKind.AWSCODECOMMIT]: <span>Unsupported</span>,

--- a/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
@@ -14,6 +14,7 @@ const configInstructionLinks: Record<ExternalServiceKind, string> = {
     [ExternalServiceKind.AWSCODECOMMIT]: 'unsupported',
     [ExternalServiceKind.BITBUCKETCLOUD]: 'unsupported',
     [ExternalServiceKind.GITOLITE]: 'unsupported',
+    [ExternalServiceKind.JVMPACKAGES]: 'unsupported',
     [ExternalServiceKind.OTHER]: 'unsupported',
     [ExternalServiceKind.PERFORCE]: 'unsupported',
     [ExternalServiceKind.PHABRICATOR]: 'unsupported',

--- a/client/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/client/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -14,6 +14,7 @@ import bitbucketServerSchemaJSON from '../../../../schema/bitbucket_server.schem
 import githubSchemaJSON from '../../../../schema/github.schema.json'
 import gitlabSchemaJSON from '../../../../schema/gitlab.schema.json'
 import gitoliteSchemaJSON from '../../../../schema/gitolite.schema.json'
+import jvmPackagesSchemaJSON from '../../../../schema/jvm-packages.schema.json'
 import otherExternalServiceSchemaJSON from '../../../../schema/other_external_service.schema.json'
 import perforceSchemaJSON from '../../../../schema/perforce.schema.json'
 import phabricatorSchemaJSON from '../../../../schema/phabricator.schema.json'
@@ -40,6 +41,7 @@ const externalServices: Record<ExternalServiceKind, JSONSchema> = {
     GITHUB: githubSchemaJSON,
     GITLAB: gitlabSchemaJSON,
     GITOLITE: gitoliteSchemaJSON,
+    JVMPACKAGES: jvmPackagesSchemaJSON,
     OTHER: otherExternalServiceSchemaJSON,
     PERFORCE: perforceSchemaJSON,
     PHABRICATOR: phabricatorSchemaJSON,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2055,6 +2055,7 @@ enum ExternalServiceKind {
     GITHUB
     GITLAB
     GITOLITE
+    JVMPACKAGES
     PERFORCE
     PHABRICATOR
     OTHER

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -135,6 +135,26 @@ func main() {
 				return &server.PerforceDepotSyncer{
 					MaxChanges: int(c.MaxChanges),
 				}, nil
+			case extsvc.TypeJVMPackages:
+				var c schema.JVMPackagesConnection
+				for _, info := range r.Sources {
+					es, err := externalServiceStore.GetByID(ctx, info.ExternalServiceID())
+					if err != nil {
+						return nil, errors.Wrap(err, "get external service")
+					}
+
+					normalized, err := jsonc.Parse(es.Config)
+					if err != nil {
+						return nil, errors.Wrap(err, "normalize JSON")
+					}
+
+					if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+						return nil, errors.Wrap(err, "unmarshal JSON")
+					}
+					break
+				}
+
+				return &server.JVMPackagesSyncer{Config: &c}, nil
 			}
 			return &server.GitRepoSyncer{}, nil
 		},

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+const (
+	// DO NOT CHANGE. This timestamp needs to be stable so that JVM package
+	// repos consistently produce the same git revhash.  Changing this
+	// timestamp will cause links to JVM package repos to return 404s
+	// because Sourcegraph URLs can optionally include the git commit sha.
+	stableGitCommitDate = "Thu Apr 8 14:24:52 2021 +0200"
+)
+
+type JVMPackagesSyncer struct {
+	Config *schema.JVMPackagesConnection
+}
+
+var _ VCSSyncer = &JVMPackagesSyncer{}
+
+func (s *JVMPackagesSyncer) Type() string {
+	return "jvm_packages"
+}
+
+// IsCloneable checks to see if the VCS remote URL is cloneable. Any non-nil
+// error indicates there is a problem.
+func (s *JVMPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) error {
+	dependencies, err := s.packageDependencies(remoteURL.Path)
+	if err != nil {
+		return err
+	}
+
+	for _, dependency := range dependencies {
+		sources, err := coursier.FetchSources(ctx, s.Config, dependency)
+		if err != nil {
+			return err
+		}
+		if len(sources) == 0 {
+			return errors.Errorf("no sources.jar for dependency %s", dependency)
+		}
+	}
+	return nil
+}
+
+// CloneCommand returns the command to be executed for cloning from remote.
+// There is no external tool that performs all the step for creating a JVM
+// package repository so the actual cloning happens inside this method and the
+// returned command is a no-op. This means that the web UI can't display a
+// helpful progress bar while cloning JVM package repositories, but that's an
+// acceptable tradeoff we're willing to make.
+func (s *JVMPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, bareGitDirectory string) (*exec.Cmd, error) {
+	err := os.MkdirAll(bareGitDirectory, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "--bare", "init")
+	if _, err := runCommandInDirectory(ctx, cmd, bareGitDirectory); err != nil {
+		return nil, err
+	}
+
+	// The Fetch method is responsible for cleaning up temporary directories.
+	if err := s.Fetch(ctx, remoteURL, GitDir(bareGitDirectory)); err != nil {
+		return nil, err
+	}
+
+	// no-op command to satisfy VCSSyncer interface, see docstring for more details.
+	return exec.CommandContext(ctx, "git", "--version"), nil
+}
+
+// Fetch does nothing for Maven packages because they are immutable and cannot be updated after publishing.
+func (s *JVMPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir) error {
+	dependencies, err := s.packageDependencies(remoteURL.Path)
+	if err != nil {
+		return err
+	}
+
+	tags := make(map[string]bool)
+
+	out, err := runCommandInDirectory(ctx, exec.CommandContext(ctx, "git", "tag"), string(dir))
+	if err != nil {
+		return err
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		tags[line] = true
+	}
+
+	for i, dependency := range dependencies {
+		if tags[dependency.GitTagFromVersion()] {
+			continue
+		}
+		// the gitPushDependencyTag method is reponsible for cleaning up temporary directories.
+		if err := s.gitPushDependencyTag(ctx, string(dir), dependency, i == 0); err != nil {
+			return errors.Wrapf(err, "error pushing dependency %q", dependency)
+		}
+	}
+
+	dependencyTags := make(map[string]struct{})
+	for _, dependency := range dependencies {
+		dependencyTags[dependency.GitTagFromVersion()] = struct{}{}
+	}
+
+	for tag := range tags {
+		if _, isDependencyTag := dependencyTags[tag]; !isDependencyTag {
+			cmd := exec.CommandContext(ctx, "git", "tag", "-d", tag)
+			if _, err := runCommandInDirectory(ctx, cmd, string(dir)); err != nil {
+				log15.Error("Failed to delete git tag", "error", err, "tag", tag)
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+// RemoteShowCommand returns the command to be executed for showing remote.
+func (s *JVMPackagesSyncer) RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error) {
+	return exec.CommandContext(ctx, "git", "remote", "show", "./"), nil
+}
+
+// packageDependencies returns the list of JVM dependencies that belong to the given URL path.
+// The returned package dependencies are sorted by semantic versioning.
+// A URL maps to a single JVM package, which may contain multiple versions (one git tag per version).
+func (s *JVMPackagesSyncer) packageDependencies(repoUrlPath string) (dependencies []reposource.MavenDependency, err error) {
+	module, err := reposource.ParseMavenModule(repoUrlPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, dependency := range s.Config.Maven.Dependencies {
+		if module.MatchesDependencyString(dependency) {
+			dependency, err := reposource.ParseMavenDependency(dependency)
+			if err != nil {
+				return nil, err
+			}
+			dependencies = append(dependencies, dependency)
+		}
+	}
+	if len(dependencies) == 0 {
+		return nil, errors.Errorf("no tracked dependencies for URL path %s", repoUrlPath)
+	}
+	reposource.SortDependencies(dependencies)
+	return dependencies, nil
+}
+
+// gitPushDependencyTag pushes a git tag to the given bareGitDirectory path. The
+// tag points to a commit that adds all sources of given dependency. When
+// isMainBranch is true, the main branch of the bare git directory will also be
+// updated to point to the same commit as the git tag.
+func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDirectory string, dependency reposource.MavenDependency, isLatestVersion bool) error {
+	tmpDirectory, err := ioutil.TempDir("", "maven")
+	if err != nil {
+		return err
+	}
+	// Always clean up created temporary directories.
+	defer os.RemoveAll(tmpDirectory)
+
+	paths, err := coursier.FetchSources(ctx, s.Config, dependency)
+	if err != nil {
+		return err
+	}
+
+	if len(paths) == 0 {
+		return errors.Errorf("no sources.jar for dependency %s", dependency)
+	}
+
+	path := paths[0]
+
+	cmd := exec.CommandContext(ctx, "git", "init")
+	if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory); err != nil {
+		return err
+	}
+
+	err = s.commitJar(ctx, dependency, tmpDirectory, path)
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "remote", "add", "origin", bareGitDirectory)
+	if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory); err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "push", "--force", "origin", "--tags")
+	if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory); err != nil {
+		return err
+	}
+
+	if isLatestVersion {
+		defaultBranch, err := runCommandInDirectory(ctx, exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD"), tmpDirectory)
+		if err != nil {
+			return err
+		}
+		cmd = exec.CommandContext(ctx, "git", "push", "--force", "origin", strings.TrimSpace(defaultBranch)+":latest", dependency.GitTagFromVersion())
+		if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// commitJar creates a git commit in the given working directory that adds all the file contents of the given jar file.
+// A `*.jar` file works the same way as a `*.zip` file, it can even be uncompressed with the `unzip` command-line tool.
+func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource.MavenDependency, workingDirectory, jarPath string) error {
+	cmd := exec.CommandContext(ctx, "unzip", jarPath)
+	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory); err != nil {
+		return err
+	}
+
+	file, err := os.Create(filepath.Join(workingDirectory, "lsif-java.json"))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	jsonContents, err := json.Marshal(&lsifJavaJSON{
+		Kind:         "maven",
+		JVM:          "8",
+		Dependencies: []string{dependency.CoursierSyntax()},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(jsonContents)
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "add", ".")
+	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory); err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "commit", "-m", dependency.CoursierSyntax(), "--date", stableGitCommitDate)
+	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory); err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "tag", "-m", dependency.CoursierSyntax(), dependency.GitTagFromVersion())
+	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runCommandInDirectory(ctx context.Context, cmd *exec.Cmd, workingDirectory string) (string, error) {
+	cmd.Dir = workingDirectory
+	output, err := runWith(ctx, cmd, false, nil)
+	if err != nil {
+		return "", errors.Wrapf(err, "command %s failed with output %s", cmd.Args, string(output))
+	}
+	return string(output), nil
+}
+
+type lsifJavaJSON struct {
+	Kind         string   `json:"kind"`
+	JVM          string   `json:"jvm"`
+	Dependencies []string `json:"dependencies"`
+}

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+const (
+	exampleJar                = "sources.jar"
+	exampleJar2               = "sources2.jar"
+	exampleFilePath           = "Example.java"
+	exampleFileContents       = "package example;\npublic class Example {}\n"
+	exampleFileContents2      = "package example;\npublic class Example { public static final int x = 42; }\n"
+	examplePackageVersion     = "1.0.0"
+	examplePackageVersion2    = "2.0.0"
+	examplePackageDependency  = "org.example:example:1.0.0"
+	examplePackageDependency2 = "org.example:example:2.0.0"
+)
+
+func createPlaceholderSourcesJar(t *testing.T, dir, contents, jarName string) {
+	t.Helper()
+	sourcesPath, err := os.Create(path.Join(dir, jarName))
+	assert.Nil(t, err)
+	zipWriter := zip.NewWriter(sourcesPath)
+	exampleWriter, err := zipWriter.Create(exampleFilePath)
+	assert.Nil(t, err)
+	_, err = exampleWriter.Write([]byte(contents))
+	assert.Nil(t, err)
+	assert.Nil(t, zipWriter.Close())
+	assert.Nil(t, sourcesPath.Close())
+}
+
+func assertCommandOutput(t *testing.T, cmd *exec.Cmd, workingDir, expectedOut string) {
+	t.Helper()
+	cmd.Dir = workingDir
+	showOut, err := cmd.Output()
+	assert.Nil(t, errors.Wrapf(err, "cmd=%q", cmd))
+	if string(showOut) != expectedOut {
+		t.Fatalf("got %q, want %q", showOut, expectedOut)
+	}
+}
+
+func coursierScript(t *testing.T, dir string) string {
+	coursierPath, err := os.OpenFile(path.Join(dir, "coursier"), os.O_CREATE|os.O_RDWR, 07777)
+	assert.Nil(t, err)
+	defer coursierPath.Close()
+	script := fmt.Sprintf(`#!/usr/bin/env bash
+ARG="$3"
+if [[ "$ARG" =~ "%s" ]]; then
+  echo "%s"
+elif [[ "$ARG" =~ "%s" ]]; then
+  echo "%s"
+else
+  echo "Invalid argument $1"
+  exit 1
+fi
+`,
+		examplePackageVersion, path.Join(dir, exampleJar),
+		examplePackageVersion2, path.Join(dir, exampleJar2))
+	_, err = coursierPath.WriteString(script)
+	assert.Nil(t, err)
+	return coursierPath.Name()
+}
+
+func (s JVMPackagesSyncer) runCloneCommand(t *testing.T, bareGitDirectory string, dependencies []string) {
+	url := vcs.URL{
+		URL: url.URL{Path: "maven/org.example/example"},
+	}
+	s.Config.Maven.Dependencies = dependencies
+	cmd, err := s.CloneCommand(context.Background(), &url, bareGitDirectory)
+	assert.Nil(t, err)
+	assert.Nil(t, cmd.Run())
+}
+
+func TestJVMCloneCommand(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	createPlaceholderSourcesJar(t, dir, exampleFileContents, exampleJar)
+	createPlaceholderSourcesJar(t, dir, exampleFileContents2, exampleJar2)
+
+	coursier.CoursierBinary = coursierScript(t, dir)
+
+	s := JVMPackagesSyncer{Config: &schema.JVMPackagesConnection{
+		Maven: &schema.Maven{Dependencies: []string{}},
+	}}
+	bareGitDirectory := path.Join(dir, "git")
+
+	s.runCloneCommand(t, bareGitDirectory, []string{examplePackageDependency})
+	assertCommandOutput(t,
+		exec.Command("git", "tag", "--list"),
+		bareGitDirectory,
+		"v1.0.0\n",
+	)
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion, exampleFilePath)),
+		bareGitDirectory,
+		exampleFileContents,
+	)
+
+	s.runCloneCommand(t, bareGitDirectory, []string{examplePackageDependency, examplePackageDependency2})
+	assertCommandOutput(t,
+		exec.Command("git", "tag", "--list"),
+		bareGitDirectory,
+		"v1.0.0\nv2.0.0\n", // verify that the v2.0.0 tag got added
+	)
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion, exampleFilePath)),
+		bareGitDirectory,
+		exampleFileContents,
+	)
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion2, exampleFilePath)),
+		bareGitDirectory,
+		exampleFileContents2,
+	)
+
+	s.runCloneCommand(t, bareGitDirectory, []string{examplePackageDependency})
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion, exampleFilePath)),
+		bareGitDirectory,
+		exampleFileContents,
+	)
+	assertCommandOutput(t,
+		exec.Command("git", "tag", "--list"),
+		bareGitDirectory,
+		"v1.0.0\n", // verify that the v2.0.0 tag has been removed.
+	)
+}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -37,6 +38,9 @@ type Server struct {
 	}
 	GitLabDotComSource interface {
 		GetRepo(ctx context.Context, projectWithNamespace string) (*types.Repo, error)
+	}
+	JVMPackagesSource interface {
+		GetRepo(ctx context.Context, artifactName string) (*types.Repo, error)
 	}
 	Scheduler interface {
 		UpdateOnce(id api.RepoID, name api.RepoName)
@@ -429,6 +433,17 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 			if isUnauthorized(err) {
 				return &protocol.RepoLookupResult{
 					ErrorUnauthorized: true,
+				}, nil
+			}
+			return nil, err
+		}
+	case extsvc.JVMPackages:
+		artifactPath := strings.TrimPrefix(remoteName, "maven/")
+		repo, err = s.JVMPackagesSource.GetRepo(ctx, artifactPath)
+		if err != nil {
+			if errcode.IsNotFound(err) {
+				return &protocol.RepoLookupResult{
+					ErrorNotFound: true,
 				}, nil
 			}
 			return nil, err

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -439,14 +439,20 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 		}
 	case extsvc.JVMPackages:
 		artifactPath := strings.TrimPrefix(remoteName, "maven/")
-		repo, err = s.JVMPackagesSource.GetRepo(ctx, artifactPath)
-		if err != nil {
-			if errcode.IsNotFound(err) {
-				return &protocol.RepoLookupResult{
-					ErrorNotFound: true,
-				}, nil
+		if s.JVMPackagesSource != nil {
+			repo, err = s.JVMPackagesSource.GetRepo(ctx, artifactPath)
+			if err != nil {
+				if errcode.IsNotFound(err) {
+					return &protocol.RepoLookupResult{
+						ErrorNotFound: true,
+					}, nil
+				}
+				return nil, err
 			}
-			return nil, err
+		} else {
+			log15.Error(
+				"JVMPackagesSource is nil: doing nothing. To fix this problem, make sure that cloud_default is true for the JVM Dependencies external service type.",
+				"remoteName", remoteName)
 		}
 	}
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -196,7 +196,11 @@ func Main(enterpriseInit EnterpriseInit) {
 			// cloud_default flag has been set.
 			NoNamespace:      true,
 			OnlyCloudDefault: true,
-			Kinds:            []string{extsvc.KindGitHub, extsvc.KindGitLab},
+			Kinds: []string{
+				extsvc.KindGitHub,
+				extsvc.KindGitLab,
+				extsvc.KindJVMPackages,
+			},
 		})
 		if err != nil {
 			log.Fatalf("failed to list external services: %v", err)
@@ -217,6 +221,8 @@ func Main(enterpriseInit EnterpriseInit) {
 				if strings.HasPrefix(c.Url, "https://gitlab.com") && c.Token != "" {
 					server.GitLabDotComSource, err = repos.NewGitLabSource(e, cf)
 				}
+			case *schema.JVMPackagesConnection:
+				server.JVMPackagesSource, err = repos.NewJVMPackagesSource(e)
 			}
 
 			if err != nil {

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -1,0 +1,99 @@
+package reposource
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+type MavenModule struct {
+	GroupID    string
+	ArtifactID string
+}
+
+func (m *MavenModule) MatchesDependencyString(dependency string) bool {
+	return strings.HasPrefix(dependency, fmt.Sprintf("%s:%s:", m.GroupID, m.ArtifactID))
+}
+
+func (m *MavenModule) SortText() string {
+	return fmt.Sprintf("%s:%s", m.GroupID, m.ArtifactID)
+}
+
+func (m *MavenModule) RepoName() api.RepoName {
+	return api.RepoName(fmt.Sprintf("maven/%s/%s", m.GroupID, m.ArtifactID))
+}
+
+func (m *MavenModule) CloneURL() string {
+	cloneURL := url.URL{Path: string(m.RepoName())}
+	return cloneURL.String()
+}
+
+type MavenDependency struct {
+	MavenModule
+	Version         string
+	SemanticVersion *semver.Version
+}
+
+// SortDependencies sorts the dependencies by the semantic version in descending
+// order. The latest version of a dependency becomes the first element of the
+// slice
+func SortDependencies(dependencies []MavenDependency) {
+	sort.Slice(dependencies, func(i, j int) bool {
+		if dependencies[i].MavenModule == dependencies[j].MavenModule {
+			return dependencies[i].SemanticVersion.GreaterThan(dependencies[j].SemanticVersion)
+		}
+		return dependencies[i].MavenModule.SortText() > dependencies[j].MavenModule.SortText()
+	})
+}
+
+func (d *MavenDependency) CoursierSyntax() string {
+	return fmt.Sprintf("%s:%s:%s", d.MavenModule.GroupID, d.MavenModule.ArtifactID, d.Version)
+}
+
+func (d *MavenDependency) GitTagFromVersion() string {
+	return "v" + d.Version
+}
+
+func ParseMavenDependency(dependency string) (MavenDependency, error) {
+	parts := strings.Split(dependency, ":")
+	if len(parts) < 3 {
+		return MavenDependency{}, fmt.Errorf("dependency %q must contain at least two colon ':' characters", dependency)
+
+	}
+	version := parts[2]
+
+	// Ignore error from semantic version parsing because we only use the
+	// semantic version for sorting dependencies, which falls back to
+	// lexicographical ordering if the semantic version is missing. We can't
+	// guarantee that every published Java package has a valid semantic
+	// version according to the implementation of the Go-lang semver
+	// package.
+	semanticVersion, _ := semver.NewVersion(version)
+
+	return MavenDependency{
+		MavenModule: MavenModule{
+			GroupID:    parts[0],
+			ArtifactID: parts[1],
+		},
+		Version:         version,
+		SemanticVersion: semanticVersion,
+	}, nil
+}
+
+// ParseMavenModule returns a parsed JVM module from the provided URL path, without a leading `/`
+func ParseMavenModule(urlPath string) (MavenModule, error) {
+	parts := strings.SplitN(strings.TrimPrefix(urlPath, "maven/"), "/", 2)
+	if len(parts) != 2 {
+		return MavenModule{}, fmt.Errorf("failed to parse a maven module from the path %s", urlPath)
+	}
+
+	return MavenModule{
+		GroupID:    parts[0],
+		ArtifactID: parts[1],
+	}, nil
+}

--- a/internal/conf/reposource/jvm_packages_test.go
+++ b/internal/conf/reposource/jvm_packages_test.go
@@ -1,0 +1,47 @@
+package reposource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func TestDecomposeMavenPath(t *testing.T) {
+	obtained, _ := ParseMavenModule("maven/org.hamcrest/hamcrest-core")
+	assert.Equal(t, obtained.GroupID, "org.hamcrest")
+	assert.Equal(t, obtained.ArtifactID, "hamcrest-core")
+	assert.Equal(t, api.RepoName("maven/org.hamcrest/hamcrest-core"), obtained.RepoName())
+}
+
+func ParseMavenDependencyOrPanic(t *testing.T, value string) MavenDependency {
+	dependency, err := ParseMavenDependency(value)
+	if err != nil {
+		t.Fatalf("error=%s", err)
+	}
+	return dependency
+}
+
+func TestSortDependencies(t *testing.T) {
+	dependencies := []MavenDependency{
+		ParseMavenDependencyOrPanic(t, "a:c:1.2.0"),
+		ParseMavenDependencyOrPanic(t, "a:a:1.2.0"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.2.0"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.11.0"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-M11"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-M1"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.1.0"),
+	}
+	expected := []MavenDependency{
+		ParseMavenDependencyOrPanic(t, "a:c:1.2.0"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.11.0"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.2.0"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-M11"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-M1"),
+		ParseMavenDependencyOrPanic(t, "a:b:1.1.0"),
+		ParseMavenDependencyOrPanic(t, "a:a:1.2.0"),
+	}
+	SortDependencies(dependencies)
+	assert.Equal(t, expected, dependencies)
+}

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -124,6 +124,7 @@ var ExternalServiceKinds = map[string]ExternalServiceKind{
 	extsvc.KindGitHub:          {CodeHost: true, JSONSchema: schema.GitHubSchemaJSON},
 	extsvc.KindGitLab:          {CodeHost: true, JSONSchema: schema.GitLabSchemaJSON},
 	extsvc.KindGitolite:        {CodeHost: true, JSONSchema: schema.GitoliteSchemaJSON},
+	extsvc.KindJVMPackages:     {CodeHost: true, JSONSchema: schema.JVMPackagesSchemaJSON},
 	extsvc.KindPerforce:        {CodeHost: true, JSONSchema: schema.PerforceSchemaJSON},
 	extsvc.KindPhabricator:     {CodeHost: true, JSONSchema: schema.PhabricatorSchemaJSON},
 	extsvc.KindOther:           {CodeHost: true, JSONSchema: schema.OtherExternalServiceSchemaJSON},
@@ -614,7 +615,7 @@ func (e *ExternalServiceStore) maybeDecryptConfig(ctx context.Context, config st
 		// config is not encrypted, return plaintext
 		return config, nil
 	}
-	var key = keyring.Default().ExternalServiceKey
+	key := keyring.Default().ExternalServiceKey
 	if e.key != nil {
 		key = e.key
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -342,6 +344,7 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 
 	typ, ok := extsvc.ParseServiceType(r.ExternalRepo.ServiceType)
 	if !ok {
+		log15.Warn("scanRepo - failed to parse service type", "r.ExternalRepo.ServiceType", r.ExternalRepo.ServiceType)
 		return nil
 	}
 	switch typ {
@@ -363,7 +366,10 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		r.Metadata = new(phabricator.Repo)
 	case extsvc.TypeOther:
 		r.Metadata = new(extsvc.OtherRepoMetadata)
+	case extsvc.TypeJVMPackages:
+		r.Metadata = new(jvmpackages.Metadata)
 	default:
+		log15.Warn("scanRepo - unknown service type", "typ", typ)
 		return nil
 	}
 

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -21,9 +21,13 @@ var (
 	GitLabDotComURL = mustParseURL("https://gitlab.com")
 	GitLabDotCom    = NewCodeHost(GitLabDotComURL, TypeGitLab)
 
+	MavenURL    = &url.URL{Host: "maven"}
+	JVMPackages = NewCodeHost(MavenURL, TypeJVMPackages)
+
 	PublicCodeHosts = []*CodeHost{
 		GitHubDotCom,
 		GitLabDotCom,
+		JVMPackages,
 	}
 )
 

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -1,0 +1,66 @@
+package coursier
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+var CoursierBinary = "coursier"
+
+func ListArtifactIDs(ctx context.Context, config *schema.JVMPackagesConnection, groupID string) ([]string, error) {
+	return runCoursierCommand(ctx, config, "complete", groupID+":")
+}
+
+func ListVersions(ctx context.Context, config *schema.JVMPackagesConnection, groupID, artifactID string) ([]string, error) {
+	return runCoursierCommand(ctx, config, "complete", groupID+":"+artifactID+":")
+}
+
+func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) ([]string, error) {
+	return runCoursierCommand(
+		ctx,
+		config,
+		"fetch", "--intransitive",
+		dependency.CoursierSyntax(),
+		"--classifier", "sources",
+	)
+}
+
+func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (bool, error) {
+	versions, err := runCoursierCommand(
+		ctx,
+		config,
+		"complete",
+		dependency.CoursierSyntax(),
+	)
+	return len(versions) > 0, err
+}
+
+func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnection, args ...string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, CoursierBinary, args...)
+	if config.Maven.Credentials != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("COURSIER_CREDENTIALS=%v", config.Maven.Credentials))
+	}
+	if len(config.Maven.Repositories) > 0 {
+		cmd.Env = append(
+			cmd.Env,
+			fmt.Sprintf("COURSIER_REPOSITORIES=%v", strings.Join(config.Maven.Repositories, "|")),
+		)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return nil, errors.Wrapf(err, "coursier command %q failed with stderr %q and stdout %q", cmd, stderr, &stdout)
+	}
+
+	return strings.Split(strings.TrimSpace(stdout.String()), "\n"), nil
+}

--- a/internal/extsvc/jvmpackages/repos.go
+++ b/internal/extsvc/jvmpackages/repos.go
@@ -1,0 +1,7 @@
+package jvmpackages
+
+import "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+
+type Metadata struct {
+	Module reposource.MavenModule
+}

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -82,6 +82,7 @@ const (
 	KindGitolite        = "GITOLITE"
 	KindPerforce        = "PERFORCE"
 	KindPhabricator     = "PHABRICATOR"
+	KindJVMPackages     = "JVMPACKAGES"
 	KindOther           = "OTHER"
 )
 
@@ -118,8 +119,13 @@ const (
 	// TypePhabricator is the (api.ExternalRepoSpec).ServiceType value for Phabricator projects.
 	TypePhabricator = "phabricator"
 
+	// TypeJVMPackages is the (api.ExternalRepoSpec).ServiceType value for Maven packages (Java/JVM ecosystem libraries).
+	TypeJVMPackages = "jvmPackages"
+
 	// TypeOther is the (api.ExternalRepoSpec).ServiceType value for other projects.
 	TypeOther = "other"
+
+	defaultRateLimit = rate.Limit(2)
 )
 
 // KindToType returns a Type constants given a Kind
@@ -142,6 +148,8 @@ func KindToType(kind string) string {
 		return TypePhabricator
 	case KindPerforce:
 		return TypePerforce
+	case KindJVMPackages:
+		return TypeJVMPackages
 	case KindOther:
 		return TypeOther
 	default:
@@ -169,6 +177,8 @@ func TypeToKind(t string) string {
 		return KindPerforce
 	case TypePhabricator:
 		return KindPhabricator
+	case TypeJVMPackages:
+		return KindJVMPackages
 	case TypeOther:
 		return KindOther
 	default:
@@ -180,6 +190,7 @@ var (
 	// Precompute these for use in ParseServiceType below since the constants are mixed case
 	bbsLower = strings.ToLower(TypeBitbucketServer)
 	bbcLower = strings.ToLower(TypeBitbucketCloud)
+	jvmLower = strings.ToLower(TypeJVMPackages)
 )
 
 // ParseServiceType will return a ServiceType constant after doing a case insensitive match on s.
@@ -202,6 +213,8 @@ func ParseServiceType(s string) (string, bool) {
 		return TypePerforce, true
 	case TypePhabricator:
 		return TypePhabricator, true
+	case jvmLower:
+		return TypeJVMPackages, true
 	case TypeOther:
 		return TypeOther, true
 	default:
@@ -229,6 +242,8 @@ func ParseServiceKind(s string) (string, bool) {
 		return KindPerforce, true
 	case KindPhabricator:
 		return KindPhabricator, true
+	case KindJVMPackages:
+		return KindJVMPackages, true
 	case KindOther:
 		return KindOther, true
 	default:
@@ -268,6 +283,8 @@ func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 		cfg = &schema.PerforceConnection{}
 	case KindPhabricator:
 		cfg = &schema.PhabricatorConnection{}
+	case KindJVMPackages:
+		cfg = &schema.JVMPackagesConnection{}
 	case KindOther:
 		cfg = &schema.OtherExternalServiceConnection{}
 	default:
@@ -353,21 +370,26 @@ func GetLimitFromConfig(kind string, config interface{}) (rlc RateLimitConfig, e
 		}
 		rlc.BaseURL = c.Url
 	case *schema.BitbucketCloudConnection:
-		// 2/s is the default limit we enforce
-		rlc.Limit = rate.Limit(2)
+		rlc.Limit = defaultRateLimit
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 			rlc.IsDefault = false
 		}
 		rlc.BaseURL = c.Url
 	case *schema.PerforceConnection:
-		// 2/s is the default limit we enforce
 		rlc.Limit = rate.Limit(5000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 			rlc.IsDefault = false
 		}
 		rlc.BaseURL = c.P4Port
+	case *schema.JVMPackagesConnection:
+		rlc.Limit = defaultRateLimit
+		if c != nil && c.Maven.RateLimit != nil {
+			rlc.Limit = limitOrInf(c.Maven.RateLimit.Enabled, c.Maven.RateLimit.RequestsPerHour)
+			rlc.IsDefault = false
+		}
+		rlc.BaseURL = "maven"
 	default:
 		return rlc, ErrRateLimitUnsupported{codehostKind: kind}
 	}

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -65,6 +66,10 @@ func CloneURL(kind, config string, repo *types.Repo) (string, error) {
 	case *schema.OtherExternalServiceConnection:
 		if r, ok := repo.Metadata.(*extsvc.OtherRepoMetadata); ok {
 			return otherCloneURL(repo, r), nil
+		}
+	case *schema.JVMPackagesConnection:
+		if r, ok := repo.Metadata.(*jvmpackages.Metadata); ok {
+			return r.Module.CloneURL(), nil
 		}
 	default:
 		return "", errors.Errorf("unknown external service kind %q for repo %d", kind, repo.ID)

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -1,0 +1,157 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// A JVMPackagesSource creates git repositories from `*-sources.jar` files of
+// published Maven dependencies from the JVM ecosystem.
+type JVMPackagesSource struct {
+	svc    *types.ExternalService
+	config *schema.JVMPackagesConnection
+}
+
+// NewJVMPackagesSource returns a new MavenSource from the given external
+// service.
+func NewJVMPackagesSource(svc *types.ExternalService) (*JVMPackagesSource, error) {
+	var c schema.JVMPackagesConnection
+	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
+		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
+	}
+	return newJVMPackagesSource(svc, &c)
+}
+
+func newJVMPackagesSource(svc *types.ExternalService, c *schema.JVMPackagesConnection) (*JVMPackagesSource, error) {
+	return &JVMPackagesSource{
+		svc:    svc,
+		config: c,
+	}, nil
+}
+
+// ListRepos returns all Maven artifacts accessible to all connections
+// configured in Sourcegraph via the external services configuration.
+func (s *JVMPackagesSource) ListRepos(ctx context.Context, results chan SourceResult) {
+	s.listDependentRepos(ctx, results)
+}
+
+func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan SourceResult) {
+	modules, err := MavenModules(*s.config)
+	if err != nil {
+		results <- SourceResult{Err: err}
+		return
+	}
+	for _, module := range modules {
+		repo := s.makeRepo(module)
+		results <- SourceResult{
+			Source: s,
+			Repo:   repo,
+		}
+	}
+}
+
+func (s *JVMPackagesSource) GetRepo(ctx context.Context, artifactPath string) (*types.Repo, error) {
+	module, err := reposource.ParseMavenModule(artifactPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dependencies, err := MavenDependencies(*s.config)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dep := range dependencies {
+		if dep.MavenModule == module {
+			exists, err := coursier.Exists(ctx, s.config, dep)
+			if err != nil {
+				return nil, err
+			}
+			if !exists {
+				return nil, &mavenArtifactNotFound{
+					dependency: dep,
+				}
+			}
+		}
+	}
+
+	return s.makeRepo(module), nil
+}
+
+type mavenArtifactNotFound struct {
+	dependency reposource.MavenDependency
+}
+
+func (mavenArtifactNotFound) NotFound() bool {
+	return true
+}
+
+func (e *mavenArtifactNotFound) Error() string {
+	return fmt.Sprintf("not found: maven dependency '%v'", e.dependency)
+}
+
+func (s *JVMPackagesSource) makeRepo(module reposource.MavenModule) *types.Repo {
+	urn := s.svc.URN()
+	cloneURL := module.CloneURL()
+	return &types.Repo{
+		Name: module.RepoName(),
+		URI:  string(module.RepoName()),
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          string(module.RepoName()),
+			ServiceID:   extsvc.TypeJVMPackages,
+			ServiceType: extsvc.TypeJVMPackages,
+		},
+		Private: false,
+		Sources: map[string]*types.SourceInfo{
+			urn: {
+				ID:       urn,
+				CloneURL: cloneURL,
+			},
+		},
+		Metadata: &jvmpackages.Metadata{
+			Module: module,
+		},
+	}
+}
+
+// ExternalServices returns a singleton slice containing the external service.
+func (s *JVMPackagesSource) ExternalServices() types.ExternalServices {
+	return types.ExternalServices{s.svc}
+}
+
+func MavenDependencies(connection schema.JVMPackagesConnection) (dependencies []reposource.MavenDependency, err error) {
+	for _, dep := range connection.Maven.Dependencies {
+		dependency, err := reposource.ParseMavenDependency(dep)
+		if err != nil {
+			return nil, err
+		}
+		dependencies = append(dependencies, dependency)
+	}
+	return dependencies, nil
+}
+
+func MavenModules(connection schema.JVMPackagesConnection) ([]reposource.MavenModule, error) {
+	isAdded := make(map[reposource.MavenModule]bool)
+	modules := []reposource.MavenModule{}
+	dependencies, err := MavenDependencies(connection)
+	if err != nil {
+		return nil, err
+	}
+	for _, dep := range dependencies {
+		module := dep.MavenModule
+		if _, added := isAdded[module]; !added {
+			modules = append(modules, module)
+		}
+		isAdded[module] = true
+	}
+	return modules, nil
+}

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -72,6 +72,8 @@ func NewSource(svc *types.ExternalService, cf *httpcli.Factory) (Source, error) 
 		return NewAWSCodeCommitSource(svc, cf)
 	case extsvc.KindPerforce:
 		return NewPerforceSource(svc)
+	case extsvc.KindJVMPackages:
+		return NewJVMPackagesSource(svc)
 	case extsvc.KindOther:
 		return NewOtherSource(svc, cf)
 	default:

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -68,6 +68,8 @@ func (e *ExternalService) RedactConfigSecrets() error {
 		newCfg, err = redactField(e.Config)
 	case *schema.OtherExternalServiceConnection:
 		newCfg, err = redactField(e.Config, "url")
+	case *schema.JVMPackagesConnection:
+		newCfg, err = e.Config, nil
 	default:
 		// return an error here, it's safer to fail than to incorrectly return unsafe data.
 		err = errors.Errorf("RedactExternalServiceConfig: kind %q not implemented", e.Kind)
@@ -143,6 +145,8 @@ func (e *ExternalService) UnredactConfig(old *ExternalService) error {
 		unredacted, err = unredactField(old.Config, e.Config, &cfg)
 	case *schema.OtherExternalServiceConnection:
 		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"url", &cfg.Url})
+	case *schema.JVMPackagesConnection:
+		unredacted, err = e.Config, nil
 	default:
 		// return an error here, it's safer to fail than to incorrectly return unsafe data.
 		err = errors.Errorf("UnRedactExternalServiceConfig: kind %q not implemented", e.Kind)

--- a/schema/jvm-packages.schema.json
+++ b/schema/jvm-packages.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "jvm-packages.schema.json#",
+  "title": "JVMPackagesConnection",
+  "description": "Configuration for a connection to a JVM packages repository.",
+  "allowComments": true,
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "maven": {
+      "description": "Configuration for resolving from Maven repositories.",
+      "title": "Maven",
+      "type": "object",
+      "properties": {
+        "repositories": {
+          "description": "The url at which the maven repository can be found.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["central"],
+          "examples": [
+            ["https://maven.google.com", "https://artifactory.mycompany.com", "central"],
+            ["https://nexus.mycompany.com", "jcenter", "clojars", "jitpack"]
+          ]
+        },
+        "credentials": {
+          "description": "Contents of a coursier.credentials file needed for accessing the Maven repositories.",
+          "type": "string"
+        },
+        "rateLimit": {
+          "description": "Rate limit applied when making background API requests to the Maven repository.",
+          "title": "MavenRateLimit",
+          "type": "object",
+          "required": ["enabled", "requestsPerHour"],
+          "properties": {
+            "enabled": {
+              "description": "true if rate limiting is enabled.",
+              "type": "boolean",
+              "default": true
+            },
+            "requestsPerHour": {
+              "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+              "type": "number",
+              "default": 5000,
+              "minimum": 0
+            }
+          },
+          "default": {
+            "enabled": true,
+            "requestsPerHour": 5000
+          }
+        },
+        "dependencies": {
+          "description": "An array of artifact \"groupID:artifactID:version\" strings specifying which Maven artifacts to mirror on Sourcegraph.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^:]+:[^:]+:[^:]+(:[^:]+)?$"
+          },
+          "examples": [["groupID:artifactID"], ["org.apache.commons:commons-csv", "com.google.guava:guava"]]
+        }
+      }
+    }
+  }
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -533,6 +533,8 @@ type ExperimentalFeatures struct {
 	EnablePostSignupFlow bool `json:"enablePostSignupFlow,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
+	// JvmPackages description: Allow adding JVM packages code host connections
+	JvmPackages string `json:"jvmPackages,omitempty"`
 	// Perforce description: Allow adding Perforce code host connections
 	Perforce string `json:"perforce,omitempty"`
 	// Ranking description: Experimental search result ranking options.
@@ -873,10 +875,36 @@ type InsightSeries struct {
 	Webhook string `json:"webhook,omitempty"`
 }
 
+// JVMPackagesConnection description: Configuration for a connection to a JVM packages repository.
+type JVMPackagesConnection struct {
+	// Maven description: Configuration for resolving from Maven repositories.
+	Maven *Maven `json:"maven,omitempty"`
+}
+
 // Log description: Configuration for logging and alerting, including to external services.
 type Log struct {
 	// Sentry description: Configuration for Sentry
 	Sentry *Sentry `json:"sentry,omitempty"`
+}
+
+// Maven description: Configuration for resolving from Maven repositories.
+type Maven struct {
+	// Credentials description: Contents of a coursier.credentials file needed for accessing the Maven repositories.
+	Credentials string `json:"credentials,omitempty"`
+	// Dependencies description: An array of artifact "groupID:artifactID:version" strings specifying which Maven artifacts to mirror on Sourcegraph.
+	Dependencies []string `json:"dependencies,omitempty"`
+	// RateLimit description: Rate limit applied when making background API requests to the Maven repository.
+	RateLimit *MavenRateLimit `json:"rateLimit,omitempty"`
+	// Repositories description: The url at which the maven repository can be found.
+	Repositories []string `json:"repositories,omitempty"`
+}
+
+// MavenRateLimit description: Rate limit applied when making background API requests to the Maven repository.
+type MavenRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
 // MountedEncryptionKey description: This encryption key is mounted from a given file path or an environment variable.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -102,6 +102,12 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "jvmPackages": {
+          "description": "Allow adding JVM packages code host connections",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "enabled"
+        },
         "tls.external": {
           "description": "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.",
           "type": "object",

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -34,6 +34,10 @@ var GitLabSchemaJSON string
 //go:embed gitolite.schema.json
 var GitoliteSchemaJSON string
 
+// JVMPackagesSchemaJSON is the content of the file "jvm-packages.schema.json".
+//go:embed jvm-packages.schema.json
+var JVMPackagesSchemaJSON string
+
 // OtherExternalServiceSchemaJSON is the content of the file "other_external_service.schema.json".
 //go:embed other_external_service.schema.json
 var OtherExternalServiceSchemaJSON string


### PR DESCRIPTION
This PR reverts the revert from https://github.com/sourcegraph/sourcegraph/pull/22887 (commit 22389f3683089d0cde3566b6c9570498c904b700)

Steps that were taken to resolve the previous error:

- log helpful error message instead of panic on nil pointer dereference
- build new musl-compatible binary of `coursier` https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip
- add new `coursier` binary to repo-updater docker container image

This commit should be safe to merge but it's probably best to wait next week Monday to
causing production issues over the weekend.
