### PR TITLE
codeintel: temporarily use sourcegraph-shipped coursier musl binary

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -13,8 +13,10 @@ RUN wget http://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/p4 && \
 
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304 AS coursier
 
-RUN wget -O coursier https://github.com/coursier/coursier/releases/download/v2.0.16/cs-x86_64-pc-linux && \
-    mv coursier /usr/local/bin/coursier && \
+# TODO(code-intel): replace with official streams when musl builds are upstreamed
+RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+    unzip coursier.zip && \
+    mv cs-musl /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304

--- a/cmd/repo-updater/Dockerfile
+++ b/cmd/repo-updater/Dockerfile
@@ -5,8 +5,10 @@
 
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304 AS coursier
 
-RUN wget -O coursier https://github.com/coursier/coursier/releases/download/v2.0.16/cs-x86_64-pc-linux && \
-    mv coursier /usr/local/bin/coursier && \
+# TODO(code-intel): replace with official streams when musl builds are upstreamed
+RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+    unzip coursier.zip && \
+    mv cs-musl /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -13,8 +13,10 @@ RUN wget http://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/p4 && \
 
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304 AS coursier
 
-RUN wget -O coursier https://github.com/coursier/coursier/releases/download/v2.0.16/cs-x86_64-pc-linux && \
-    mv coursier /usr/local/bin/coursier && \
+# TODO(code-intel): replace with official streams when musl builds are upstreamed
+RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+    unzip coursier.zip && \
+    mv cs-musl /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304


### PR DESCRIPTION
Follow-up from [previous PR](https://github.com/sourcegraph/sourcegraph/pull/21971) due to the binaries not being built for musl. More details outlined [here](https://github.com/sourcegraph/sourcegraph/pull/22923).

Once musl builds are upstreamed to coursier, we will transition to use those binaries instead.