### PR TITLE
web(site-admin): disable instrumentation for non-kubernetes deployments

### DIFF
--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -110,6 +110,7 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
             label: 'Instrumentation',
             to: '/-/debug/',
             source: 'server',
+            condition: () => window.context.deployType === 'kubernetes',
         },
         {
             label: 'Monitoring',


### PR DESCRIPTION
follow-up to #22885 - this feature is not available for kubernetes deployments

![image](https://user-images.githubusercontent.com/23356519/125972923-6e6190fb-ce69-492d-ba31-1b8845a8bf82.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
