### PR TITLE
codeintel: Consider dependency graph for LSIF data retention

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/xrepo.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo.go
@@ -123,7 +123,8 @@ func (s *Store) ReferenceIDsAndFilters(ctx context.Context, repositoryID int, co
 
 const referenceIDsAndFiltersCTEDefinitions = `
 -- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:ReferenceIDsAndFilters
-WITH visible_uploads AS (
+WITH
+visible_uploads AS (
 	(%s)
 	UNION
 	(SELECT uvt.upload_id FROM lsif_uploads_visible_at_tip uvt WHERE uvt.repository_id != %s AND uvt.is_default_branch)

--- a/enterprise/internal/codeintel/stores/lsifstore/clear.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/clear.go
@@ -2,6 +2,7 @@ package lsifstore
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -32,6 +33,11 @@ func (s *Store) Clear(ctx context.Context, bundleIDs ...int) (err error) {
 	if len(bundleIDs) == 0 {
 		return nil
 	}
+
+	// Ensure ids are sorted so that we take row locks during the
+	// DELETE query in a determinstic order. This should prevent
+	// deadlocks with other queries that mass update the same table.
+	sort.Ints(bundleIDs)
 
 	var ids []*sqlf.Query
 	for _, bundleID := range bundleIDs {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -982,7 +982,7 @@ Associates commits with the closest ancestor commit with usable upload data. Tog
  dump_id | integer |           | not null | 
 Indexes:
     "lsif_packages_pkey" PRIMARY KEY, btree (id)
-    "lsif_packages_scheme_name_version" btree (scheme, name, version)
+    "lsif_packages_scheme_name_version_dump_id" btree (scheme, name, version, dump_id)
 Foreign-key constraints:
     "lsif_packages_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
 
@@ -1010,7 +1010,7 @@ Associates an upload with the set of packages they provide within a given packag
  dump_id | integer |           | not null | 
 Indexes:
     "lsif_references_pkey" PRIMARY KEY, btree (id)
-    "lsif_references_package" btree (scheme, name, version)
+    "lsif_references_scheme_name_version_dump_id" btree (scheme, name, version, dump_id)
 Foreign-key constraints:
     "lsif_references_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
 

--- a/migrations/frontend/1528395852_lsif_add_covering_index.down.sql
+++ b/migrations/frontend/1528395852_lsif_add_covering_index.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE INDEX lsif_packages_scheme_name_version ON lsif_packages(scheme, name, version);
+DROP INDEX lsif_packages_scheme_name_version_dump_id;
+
+CREATE INDEX lsif_references_package ON lsif_references(scheme, name, version);
+DROP INDEX lsif_references_scheme_name_version_dump_id;
+
+COMMIT;

--- a/migrations/frontend/1528395852_lsif_add_covering_index.up.sql
+++ b/migrations/frontend/1528395852_lsif_add_covering_index.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE INDEX lsif_packages_scheme_name_version_dump_id ON lsif_packages(scheme, name, version, dump_id);
+DROP INDEX lsif_packages_scheme_name_version;
+
+CREATE INDEX lsif_references_scheme_name_version_dump_id ON lsif_references(scheme, name, version, dump_id);
+DROP INDEX lsif_references_package;
+
+COMMIT;


### PR DESCRIPTION
This updates the query that periodically soft-deletes stale LSIF data to better support dependency indexing. Previously, we would mark all records older than 720h (configurable) that were not used to resolve code intelligence data from a non-stale tag or the tip of a non-stale branch. This ignores dependencies, meaning that go to definition could stop working for a repository we care about.

Now, the query deletes all irrelevant LSIF data by:

- initializing a working set by adding all uploads younger than 720h as well as all uploads used to resolve code intelligence for a non-stale branch or tag
- expanding the working set by adding dependencies of the working set to itself
- deleting all uploads outside of the working set

This ensures that while an upload is protected, all of its transitive dependencies are as well. Fixes #19120.

This query may be susceptible in the future to performance issues as we grow the dependency graph. I've tried to make adjustments early on to help with scaling concerns, but was so far unsuccessful:

- We thought of storing the set of branch and tags from which each upload is visible. This turns out to be a huge mapping, as some uploads in our production database today are visible from 8k distinct interesting commits. We don't want to materialize what is basically a cross-join of our dependency graph and our upload records in our database.
- We thought of selecting a small set of old _candidates_, then tracing each one _up_ the dependency graph. This should be more efficient when the number of uploads to delete is rather small (as it would amount to only a small number of traversals of the dependency graph). I'm not sure how to do this in SQL without issuing n+1 queries from the application (there's not an obvious way to share traversal work, and I'm not sure how to invoke a recursive CTE on each row of a candidate set).

We should check on this query periodically as we grow. It current runs in 1m10s on a clone of the production database and is nowhere near a hot path.