### PR TITLE
codeintel: Order all bulk modifications to code intelligence tables

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/xrepo.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo.go
@@ -123,7 +123,8 @@ func (s *Store) ReferenceIDsAndFilters(ctx context.Context, repositoryID int, co
 
 const referenceIDsAndFiltersCTEDefinitions = `
 -- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:ReferenceIDsAndFilters
-WITH visible_uploads AS (
+WITH
+visible_uploads AS (
 	(%s)
 	UNION
 	(SELECT uvt.upload_id FROM lsif_uploads_visible_at_tip uvt WHERE uvt.repository_id != %s AND uvt.is_default_branch)

--- a/enterprise/internal/codeintel/stores/lsifstore/clear.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/clear.go
@@ -2,6 +2,7 @@ package lsifstore
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -32,6 +33,11 @@ func (s *Store) Clear(ctx context.Context, bundleIDs ...int) (err error) {
 	if len(bundleIDs) == 0 {
 		return nil
 	}
+
+	// Ensure ids are sorted so that we take row locks during the
+	// DELETE query in a determinstic order. This should prevent
+	// deadlocks with other queries that mass update the same table.
+	sort.Ints(bundleIDs)
 
 	var ids []*sqlf.Query
 	for _, bundleID := range bundleIDs {


### PR DESCRIPTION
Reduce possibilities of deadlocking on bulk updates/deletes on the same table by first selecting the rows to update with `FOR UPDATE` semantics.