### PR TITLE
Add namespace selector for create batch spec execution page

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.module.scss
@@ -1,0 +1,3 @@
+.namespace-selector {
+    max-width: 200px;
+}

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames'
 import React, { useCallback, useState } from 'react'
+import { Redirect } from 'react-router'
 
 import { CodeSnippet } from '@sourcegraph/branded/src/components/CodeSnippet'
-import { Link } from '@sourcegraph/shared/src/components/Link'
 import {
     SettingsCascadeProps,
     SettingsOrgSubject,
@@ -185,7 +185,7 @@ const CreateBatchSpecExecutionForm: React.FunctionComponent<CreateBatchSpecExecu
     )
 
     if (!userNamespace) {
-        throw new Error('Bye')
+        throw new Error('No user namespace found')
     }
 
     const [content, setContent] = useState<string>(initialContent)
@@ -206,6 +206,10 @@ const CreateBatchSpecExecutionForm: React.FunctionComponent<CreateBatchSpecExecu
             setIsLoading(error)
         }
     }, [content, selectedNamespace])
+
+    if (batchSpecExecution) {
+        return <Redirect to={`${batchSpecExecution.namespace.url}/batch-changes/executions/${batchSpecExecution.id}`} />
+    }
 
     return (
         <>
@@ -247,16 +251,6 @@ const CreateBatchSpecExecutionForm: React.FunctionComponent<CreateBatchSpecExecu
                 >
                     Run batch spec
                 </button>
-                {batchSpecExecution && (
-                    <div className="mt-3 mb-0 alert alert-success">
-                        Running batch spec.{' '}
-                        <Link
-                            to={`${batchSpecExecution.namespace.url}/batch-changes/executions/${batchSpecExecution.id}`}
-                        >
-                            Check it out here.
-                        </Link>
-                    </div>
-                )}
                 {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
             </Container>
         </>

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -5,13 +5,17 @@ import {
     BatchSpecExecutionCreateFields,
     CreateBatchSpecExecutionResult,
     CreateBatchSpecExecutionVariables,
+    Scalars,
 } from '../../../graphql-operations'
 
-export async function createBatchSpecExecution(spec: string): Promise<BatchSpecExecutionCreateFields> {
+export async function createBatchSpecExecution(
+    spec: string,
+    namespace: Scalars['ID']
+): Promise<BatchSpecExecutionCreateFields> {
     const result = await requestGraphQL<CreateBatchSpecExecutionResult, CreateBatchSpecExecutionVariables>(
         gql`
-            mutation CreateBatchSpecExecution($spec: String!) {
-                createBatchSpecExecution(spec: $spec) {
+            mutation CreateBatchSpecExecution($spec: String!, $namespace: ID) {
+                createBatchSpecExecution(spec: $spec, namespace: $namespace) {
                     ...BatchSpecExecutionCreateFields
                 }
             }
@@ -23,7 +27,7 @@ export async function createBatchSpecExecution(spec: string): Promise<BatchSpecE
                 }
             }
         `,
-        { spec }
+        { spec, namespace }
     ).toPromise()
     return dataOrThrowErrors(result).createBatchSpecExecution
 }

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -237,7 +237,8 @@ type MergeChangesetsArgs struct {
 }
 
 type CreateBatchSpecExecutionArgs struct {
-	Spec string
+	Spec      string
+	Namespace *graphql.ID
 }
 
 type CloseChangesetsArgs struct {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2170,7 +2170,7 @@ extend type Mutation {
     for work, they will pick this up eventually.
 
 
-    If namespace is not specified, the current users personal namespace is used.
+    If namespace is not specified, the current user's personal namespace is used.
     """
     createBatchSpecExecution(spec: String!, namespace: ID): BatchSpecExecution!
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2168,8 +2168,11 @@ extend type Mutation {
     Creates a new batch spec execution from a given batch spec yaml file input.
     The execution will be queued for processing by an executor. If some are available
     for work, they will pick this up eventually.
+
+
+    If namespace is not specified, the current users personal namespace is used.
     """
-    createBatchSpecExecution(spec: String!): BatchSpecExecution!
+    createBatchSpecExecution(spec: String!, namespace: ID): BatchSpecExecution!
 }
 
 extend type Query {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1436,9 +1436,24 @@ func (r *Resolver) CreateBatchSpecExecution(ctx context.Context, args *graphqlba
 	actor := actor.FromContext(ctx)
 
 	exec := &btypes.BatchSpecExecution{
-		BatchSpec:       args.Spec,
-		UserID:          actor.UID,
-		NamespaceUserID: actor.UID,
+		BatchSpec: args.Spec,
+		UserID:    actor.UID,
+	}
+
+	// TODO: Add a test to verify namespace is correctly set and permissions are enforced properly.
+	if args.Namespace != nil {
+		err = graphqlbackend.UnmarshalNamespaceID(*args.Namespace, &exec.NamespaceUserID, &exec.NamespaceOrgID)
+		if err != nil {
+			return nil, err
+		}
+		svc := service.New(r.store)
+		// 🚨 SECURITY: Check that the requesting user has access to the namespace.
+		err = svc.CheckNamespaceAccess(ctx, exec.NamespaceUserID, exec.NamespaceOrgID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		exec.NamespaceUserID = actor.UID
 	}
 
 	if err := r.store.CreateBatchSpecExecution(ctx, exec); err != nil {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1440,7 +1440,6 @@ func (r *Resolver) CreateBatchSpecExecution(ctx context.Context, args *graphqlba
 		UserID:    actor.UID,
 	}
 
-	// TODO: Add a test to verify namespace is correctly set and permissions are enforced properly.
 	if args.Namespace != nil {
 		err = graphqlbackend.UnmarshalNamespaceID(*args.Namespace, &exec.NamespaceUserID, &exec.NamespaceOrgID)
 		if err != nil {


### PR DESCRIPTION
Selecting a namespace for execution can now be done through the API and UI.

![image](https://user-images.githubusercontent.com/19534377/125982749-46e0aa82-2a05-44d4-a150-90edc73b398d.png)

Co-authored-by: Kelli Rockwell <kelli@sourcegraph.com>