### PR TITLE
batches: add docs and changelog for publish from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The `lang:` filter suggestions now show all supported, matching languages as the user types a language name. [#22765](https://github.com/sourcegraph/sourcegraph/pull/22765)
 - Code Insights can now be grouped into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
 - Added the code insights dashboards functionality. Now you can divide insights into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
+- Batch Changes changesets can now be published from Sourcegraph by omitting the `published` field in the batch spec and publishing changesets from the batch change page. (TODO: insert doc link; reword after writing that) [#18277](https://github.com/sourcegraph/sourcegraph/issues/18277)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The `lang:` filter suggestions now show all supported, matching languages as the user types a language name. [#22765](https://github.com/sourcegraph/sourcegraph/pull/22765)
 - Code Insights can now be grouped into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
 - Added the code insights dashboards functionality. Now you can divide insights into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
-- Batch Changes changesets can now be published from Sourcegraph by omitting the `published` field in the batch spec and publishing changesets from the batch change page. (TODO: insert doc link; reword after writing that) [#18277](https://github.com/sourcegraph/sourcegraph/issues/18277)
+- Batch Changes changesets can now be [published from the Sourcegraph UI](https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#within-the-ui). [#18277](https://github.com/sourcegraph/sourcegraph/issues/18277)
 
 ### Changed
 

--- a/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
+++ b/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
@@ -25,6 +25,7 @@ Bulk operations allow a single action to be performed across many changesets in 
 - Re-enqueue: Only available if filtering by state `failed`. Re-enqueues the pending changes for all selected changesets that failed.
 - <span class="badge badge-experimental">Experimental</span> Merge: Only available if filtering by state `open`. Tries to merge the selected changesets on the code hosts. Due to the nature of changesets, there are many states in which a changeset is not mergeable. This won't break the entire bulk operation, but single changesets may not be merged after the run for this reason. The bulk operations tab lists those where merging failed below the bulk operation in that case. In the confirmation modal, you can select to merge using the squash merge strategy. This is supported on both GitHub and GitLab, but not on Bitbucket Server. In this case, regular merges are always used for merging the changesets.
 - Close: Only available if filtering by state `open` or `draft`. Tries to close the selected changesets on the code hosts.
+- Publish: Publishes the selected changesets, provided they don't have a [`published` field](../references/batch_spec_yaml_reference.md#changesettemplate-published) in the batch spec. You can choose between draft and normal changesets in the confirmation modal.
 
 _More types coming soon._
 

--- a/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
+++ b/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
@@ -27,8 +27,6 @@ Bulk operations allow a single action to be performed across many changesets in 
 - Close: Only available if filtering by state `open` or `draft`. Tries to close the selected changesets on the code hosts.
 - Publish: Publishes the selected changesets, provided they don't have a [`published` field](../references/batch_spec_yaml_reference.md#changesettemplate-published) in the batch spec. You can choose between draft and normal changesets in the confirmation modal.
 
-_More types coming soon._
-
 ## Monitoring bulk operations
 
 On the **Bulk operations** tab, you can view all bulk operations that have been run over the batch change. Since bulk operations can involve quite some operations to perform, you can track the progress, and see what operations have been performed in the past.

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -1,6 +1,20 @@
 # Publishing changesets to the code host
 
-After you've [created a batch change](creating_a_batch_change.md) with `published: false` in its batch spec, you can see a preview of the changesets (e.g., GitHub pull requests) that will be created on the code host once they're published:
+<style>
+
+.publishing-changesets td {
+  vertical-align: top;
+}
+
+/* ul elements are picking up the default browser style of 1rem top and bottom, so we should align the other cells the same way. */
+.publishing-changesets td > *:first-child {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+</style>
+
+After you've [created a batch change](creating_a_batch_change.md) with the `published` field set to `false` or omitted in its batch spec, you can see a preview of the changesets (e.g., GitHub pull requests) that will be created on the code host once they're published:
 
 <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_created.png" class="screenshot center">
 
@@ -19,6 +33,75 @@ For more information, see "[Code host interactions in Batch Changes](../explanat
 
 ## Publishing changesets
 
+You can publish changesets either by [setting the `published` field in the batch spec](#within-the-spec), or [through the Sourcegraph UI](#within-the-ui). Both workflows are described in full below.
+
+A brief summary of the pros and cons of each workflow is:
+
+<table class="publishing-changesets">
+  <thead>
+    <tr>
+      <th>Workflow</th>
+      <th>Pros</th>
+      <th>Cons</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <div>
+          Setting <code>published</code> in the batch spec
+        </div>
+      </td>
+      <td>
+        <ul>
+          <li>
+            If you reuse your batch spec, or share it with others, the new batch changes will have the same changesets published
+          </li>
+          <li>
+            Easy to publish changesets in large batch changes based on specific criteria, such as the organization each repository is in
+          </li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Requires the batch spec to be re-applied before changes take effect, which can be slower
+          </li>
+          <li>
+            Requires more context switching from the UI back to the spec file when previewing diffs
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div>
+          Publishing from the UI
+        </div>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Rapid feedback loop: you can check a specific diff and immediately publish it
+          </li>
+          <li>
+            Easy to publish random changesets without having to specify rules in the `published` field
+          </li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Publication state isn't reproducible across multiple batch changes
+          </li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Within the spec
+
 When you're ready, you can publish all of a batch change's changesets by changing the `published: false` in your batch spec to `true`:
 
 ```yaml
@@ -33,7 +116,7 @@ changesetTemplate:
 
 Then run the `src batch preview` command again, or `src batch apply` to immediately publish the changesets.
 
-Publishing a changesets will:
+Publishing a changeset will:
 
 - Create a commit with the changes from the patches for that repository.
 - Push a branch using the branch name you defined in the batch spec with [`changesetTemplate.branch`](../references/batch_spec_yaml_reference.md#changesettemplate-branch).
@@ -49,7 +132,7 @@ If you run into any errors, you can retry publishing after you've resolved the p
 
 You don't need to worry about multiple branches or pull requests being created when you retry, because the same branch name will be used and the commit will be overwritten.
 
-## Publishing a subset of changesets
+#### Publishing a subset of changesets
 
 Instead of publishing all changesets at the same time, you can also publish some of a batch change's changesets, by specifying which changesets you want to publish in the `published` field:
 
@@ -66,7 +149,7 @@ changesetTemplate:
 
 See [`changesetTemplate.published`](../references/batch_spec_yaml_reference.md#changesettemplate-published) in the batch spec reference for more details.
 
-## Publishing changesets as drafts
+#### Publishing changesets as drafts
 
 Some code hosts (GitHub, GitLab) allow publishing changesets as _drafts_. To publish a changeset as a draft, use the `'draft`' value in the `published` field:
 
@@ -80,14 +163,24 @@ changesetTemplate:
 
 See [`changesetTemplate.published`](../references/batch_spec_yaml_reference.md#changesettemplate-published) in the batch spec reference for more details.
 
-## Fully publishing draft changesets
+#### Fully publishing draft changesets
 
 If you have previously published changesets as drafts on code hosts by setting `published` to `draft`, you then fully publish them and take them out of draft mode by updating the `published` to `true`.
 
 See [`changesetTemplate.published`](../references/batch_spec_yaml_reference.md#changesettemplate-published) in the batch spec reference for more details.
 
+### Within the UI
+
+> NOTE: This functionality requires Sourcegraph 3.30 or later, and also requires `src` 3.29.2 or later.
+
+To publish from the Sourcegraph UI, you'll need to remove (or omit) the `published` field from your batch spec. When you first apply a batch change without an explicit `published` fields, all changesets are treated as unpublished.
+
+Once applied, you can select the changesets you want to publish from the batch change page and publish them using the [publish bulk operation](bulk_operations_on_changesets.md), as demonstrated in this video:
+
+> TODO: VIDEO
+
 ## Specifying Git commit details
 
-The commit that's created and pushed to the branch uses the details specified in the batch spec's `changesetTemplate` field.
+Regardless of how you publish your changesets, the commit that's created and pushed to the branch uses the details specified in the batch spec's `changesetTemplate` field.
 
 See [`changesetTemplate.commit`](../references/batch_spec_yaml_reference.md#changesettemplate-commit) for details on how to set the author and the commit message.

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -177,7 +177,10 @@ To publish from the Sourcegraph UI, you'll need to remove (or omit) the `publish
 
 Once applied, you can select the changesets you want to publish from the batch change page and publish them using the [publish bulk operation](bulk_operations_on_changesets.md), as demonstrated in this video:
 
-> TODO: VIDEO
+<video width="1920" height="1080" loop playsinline controls style="width: 100%; height: auto; max-width: 50rem">
+  <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/publish-ui-docs.webm" type="video/webm">
+  <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/publish-ui-docs.mp4" type="video/mp4">
+</video>
 
 ## Specifying Git commit details
 

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -132,6 +132,8 @@ Now that you have credentials set up, you can publish the changesets in the batc
 
     > NOTE: You can also create or update a batch change by running `src batch apply`. This skips the preview stage, and is especially useful when updating an existing batch change.
 
+> NOTE: You can also publish directly from Sourcegraph by omitting the `published` field from your batch spec. This is described in more detail in "[Publishing changesets to the code host](how-tos/publishing_changesets.md#publishing-changesets)".
+
 ## Congratulations!
 
 You've created your first batch change! 🎉🎉

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -540,7 +540,7 @@ changesetTemplate:
 
 ## [`changesetTemplate.published`](#changesettemplate-published)
 
-Whether to publish the changeset. This may be a boolean value (ie `true` or `false`), `'draft'`, or [an array to only publish some changesets within the batch change](#publishing-only-specific-changesets).
+Whether to publish the changeset. This may be a boolean value (ie `true` or `false`), `'draft'`, or [an array to only publish some changesets within the batch change](#publishing-only-specific-changesets). This may also be omitted, in which case the publication state will be controlled through the Sourcegraph UI, and will default to unpublished (that is, the same as specifying `false`).
 
 An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host.
 


### PR DESCRIPTION
This is the final part eight, and therefore closes #18277.

Nothing very interesting here: I haven't changed the defaults that we recommend here, since we talked about holding off until we have more functionality on the batch spec preview page.