### PR TITLE
search: lift ad-hoc pattern validation to parsing

### DIFF
--- a/internal/search/text_pattern_info.go
+++ b/internal/search/text_pattern_info.go
@@ -10,12 +10,6 @@ func (p *TextPatternInfo) IsEmpty() bool {
 }
 
 func (p *TextPatternInfo) Validate() error {
-	if p.IsRegExp {
-		if _, err := syntax.Parse(p.Pattern, syntax.Perl); err != nil {
-			return err
-		}
-	}
-
 	if p.ExcludePattern != "" {
 		if _, err := syntax.Parse(p.ExcludePattern, syntax.Perl); err != nil {
 			return err


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22938. 

We have left over / old code that does inline validation checks on our "internal" representation on our search path. This validation should be done immediately after parsing and before conversion to the internal representation.