### PR TITLE
search: remove ad-hoc Empty check

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -319,10 +319,6 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,
 	}
-	if err := args.PatternInfo.Validate(); err != nil {
-		return nil, err
-	}
-
 	repoOptions := r.toRepoOptions(args.Query, resolveRepositoriesOpts{})
 	resolved, err := r.resolveRepositories(ctx, repoOptions)
 	if err != nil {
@@ -356,20 +352,4 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 		})
 	}
 	return suggestions, nil
-}
-
-type badRequestError struct {
-	err error
-}
-
-func (e *badRequestError) BadRequest() bool {
-	return true
-}
-
-func (e *badRequestError) Error() string {
-	return "bad request: " + e.err.Error()
-}
-
-func (e *badRequestError) Cause() error {
-	return e.err
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -586,9 +586,6 @@ func (r *searchResolver) toTextParameters(q query.Q) (*search.TextParameters, er
 		SearcherURLs: r.searcherURLs,
 		RepoPromise:  &search.RepoPromise{},
 	}
-	if err := args.PatternInfo.Validate(); err != nil {
-		return nil, &badRequestError{err}
-	}
 	args = withResultTypes(args, forceResultTypes)
 	args = withMode(args, r.PatternType, r.VersionContext)
 	return &args, nil

--- a/internal/search/text_pattern_info.go
+++ b/internal/search/text_pattern_info.go
@@ -1,25 +1,6 @@
 // Validation logic for TextPatternInfo
 package search
 
-import (
-	"regexp/syntax"
-)
-
 func (p *TextPatternInfo) IsEmpty() bool {
 	return p.Pattern == "" && p.ExcludePattern == "" && len(p.IncludePatterns) == 0
-}
-
-func (p *TextPatternInfo) Validate() error {
-	if p.ExcludePattern != "" {
-		if _, err := syntax.Parse(p.ExcludePattern, syntax.Perl); err != nil {
-			return err
-		}
-	}
-	for _, expr := range p.IncludePatterns {
-		if _, err := syntax.Parse(expr, syntax.Perl); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/internal/search/text_pattern_info.go
+++ b/internal/search/text_pattern_info.go
@@ -1,6 +1,0 @@
-// Validation logic for TextPatternInfo
-package search
-
-func (p *TextPatternInfo) IsEmpty() bool {
-	return p.Pattern == "" && p.ExcludePattern == "" && len(p.IncludePatterns) == 0
-}

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -74,11 +74,6 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}
 	}
 
-	if args.PatternInfo.IsEmpty() {
-		// Empty query isn't an error, but it has no results.
-		return nil
-	}
-
 	g, ctx := errgroup.WithContext(ctx)
 
 	if args.Mode != search.SearcherOnly {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/22940.

There is inline logic to check whether a pattern is "empty". What this is really checking is that the absence of a pattern and file patterns returns no results, when we run a text search. Removing this naively [breaks things](https://buildkite.com/sourcegraph/sourcegraph/builds/101957#d4175d74-b34e-4b40-8bf1-1f02196b3df4/2088). 

This PR promotes this logic and removes the inline check.