### PR TITLE
search: lift IsEmpty check higher up call stack

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -163,19 +163,16 @@ func TestSearchSuggestions(t *testing.T) {
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}
-			return []result.Match{
-				mkFileMatch(types.RepoName{Name: "foo-repo"}, "dir/file"),
-			}, &streaming.Stats{}, nil
+			return []result.Match{&result.RepoMatch{Name: "foo-repo", ID: 23}},
+				&streaming.Stats{},
+				nil
 		}
 		defer func() { unindexed.MockSearchFilesInRepos = nil }()
 
 		for _, v := range searchVersions {
-			testSuggestions(t, "repo:foo", v, []string{"repo:foo-repo", "file:dir/file"})
+			testSuggestions(t, "repo:foo", v, []string{"repo:foo-repo"})
 			if !calledReposListRepoNames {
 				t.Error("!calledReposListRepoNames")
-			}
-			if !calledSearchFilesInRepos.Load() {
-				t.Error("!calledSearchFilesInRepos")
 			}
 		}
 	})

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -139,6 +139,11 @@ func (a *Aggregator) DoFilePathSearch(ctx context.Context, args *search.TextPara
 		return a.DoStructuralSearch(ctx, args)
 	}
 
+	if args.PatternInfo.IsEmpty() {
+		// Empty query isn't an error, but it has no results.
+		return nil
+	}
+
 	return unindexed.SearchFilesInRepos(ctx, args, a)
 }
 

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -74,11 +74,6 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}
 	}
 
-	if args.PatternInfo.IsEmpty() {
-		// Empty query isn't an error, but it has no results.
-		return nil
-	}
-
 	g, ctx := errgroup.WithContext(ctx)
 
 	if args.Mode != search.SearcherOnly {
@@ -112,6 +107,10 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 // SearchFilesInRepoBatch is a convenience function around searchFilesInRepos
 // which collects the results from the stream.
 func SearchFilesInReposBatch(ctx context.Context, args *search.TextParameters) ([]*result.FileMatch, streaming.Stats, error) {
+	if args.PatternInfo.IsEmpty() {
+		// Empty query isn't an error, but it has no results.
+		return nil, streaming.Stats{}, nil
+	}
 	matches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
 		return SearchFilesInRepos(ctx, args, stream)
 	})


### PR DESCRIPTION
There is some logic to terminate going further in text search, if a query does not have any file patterns or search pattern. The point at which we figure this out is deeper than it needs to be because everything locally in that function [have no bearing on the result of this computation](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/unindexed/unindexed.go?L36-76). We can move it up locally in the function, but I actually want it much higher.

This PR is the start of lifting the logic, even though it's initially duplicated. I'm making this PR now because it already improves the test logic. I'm following up immediately to trace the call chain for each site, and will then merge where this into one.