### PR TITLE
repos: Don't cancel context on unauth / forbidden / accountsuspended

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -1011,8 +1011,6 @@ func (s *Syncer) StreamingSyncExternalService(ctx context.Context, tx *Store, ex
 			if errcode.IsUnauthorized(errs) || errcode.IsForbidden(errs) || errcode.IsAccountSuspended(errs) {
 				// Delete all external service repos of this external service
 				seen = map[api.RepoID]struct{}{}
-				// Eagerly stop sourcing, instead of waiting for all the follow up deletions to finish.
-				cancel()
 				break
 			}
 			continue

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -198,9 +198,11 @@ func testSyncerSync(s *repos.Store, streaming bool) func(*testing.T) {
 				testCase{
 					// If the source is unauthorized we should treat this as if zero repos were
 					// returned as it indicates that the source no longer has access to its repos
-					name:    string(tc.repo.Name) + "/unauthorized",
-					sourcer: repos.NewFakeSourcer(&repos.ErrUnauthorized{}),
-					store:   s,
+					name: string(tc.repo.Name) + "/unauthorized",
+					sourcer: repos.NewFakeSourcer(nil,
+						repos.NewFakeSource(tc.svc.Clone(), &repos.ErrUnauthorized{}),
+					),
+					store: s,
 					stored: types.Repos{tc.repo.With(
 						types.Opt.RepoSources(tc.svc.URN()),
 					)},
@@ -214,9 +216,11 @@ func testSyncerSync(s *repos.Store, streaming bool) func(*testing.T) {
 				testCase{
 					// If the source is forbidden we should treat this as if zero repos were returned
 					// as it indicates that the source no longer has access to its repos
-					name:    string(tc.repo.Name) + "/forbidden",
-					sourcer: repos.NewFakeSourcer(&repos.ErrForbidden{}),
-					store:   s,
+					name: string(tc.repo.Name) + "/forbidden",
+					sourcer: repos.NewFakeSourcer(nil,
+						repos.NewFakeSource(tc.svc.Clone(), &repos.ErrForbidden{}),
+					),
+					store: s,
 					stored: types.Repos{tc.repo.With(
 						types.Opt.RepoSources(tc.svc.URN()),
 					)},
@@ -230,9 +234,11 @@ func testSyncerSync(s *repos.Store, streaming bool) func(*testing.T) {
 				testCase{
 					// If the source account has been suspended we should treat this as if zero repos were returned as it indicates
 					// that the source no longer has access to its repos
-					name:    string(tc.repo.Name) + "/accountsuspended",
-					sourcer: repos.NewFakeSourcer(&repos.ErrAccountSuspended{}),
-					store:   s,
+					name: string(tc.repo.Name) + "/accountsuspended",
+					sourcer: repos.NewFakeSourcer(nil,
+						repos.NewFakeSource(tc.svc.Clone(), &repos.ErrAccountSuspended{}),
+					),
+					store: s,
 					stored: types.Repos{tc.repo.With(
 						types.Opt.RepoSources(tc.svc.URN()),
 					)},
@@ -528,10 +534,6 @@ func testSyncerSync(s *repos.Store, streaming bool) func(*testing.T) {
 
 					if have, want := fmt.Sprint(err), tc.err; !strings.Contains(have, want) {
 						t.Errorf("error %q doesn't contain %q", have, want)
-					}
-
-					if err != nil {
-						return
 					}
 				}
 


### PR DESCRIPTION
Cancelling that context eagerly means all follow up operations that use it will fail with context: canceled

This also fixes the tests to actually catch this bug. Saw this in https://sourcegraph.com/-/debug/proxies/repo-updater-10.164.5.144/debug/requests?fam=Store.DeleteExternalServiceReposNotIn&b=8&exp=1