### PR TITLE
HubSpot: Send database ID on Cloud signups

### DIFF
--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -43,7 +43,7 @@ type ContactProperties struct {
 	LatestPing      int64  `json:"latest_ping"`
 	AnonymousUserID string `json:"anonymous_user_id"`
 	FirstSourceURL  string `json:"first_source_url"`
-	DatabaseID      int32  `json:"database_user_id"`
+	DatabaseID      int32  `json:"database_id"`
 }
 
 // ContactResponse represents HubSpot user properties returned

--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -43,6 +43,7 @@ type ContactProperties struct {
 	LatestPing      int64  `json:"latest_ping"`
 	AnonymousUserID string `json:"anonymous_user_id"`
 	FirstSourceURL  string `json:"first_source_url"`
+	DatabaseID      int32  `json:"database_user_id"`
 }
 
 // ContactResponse represents HubSpot user properties returned
@@ -61,6 +62,7 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("latest_ping", h.LatestPing)
 	apiProps.set("anonymous_user_id", h.AnonymousUserID)
 	apiProps.set("first_source_url", h.FirstSourceURL)
+	apiProps.set("database_id", h.DatabaseID)
 	return apiProps
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -191,7 +191,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 
 	// Track user data
 	if r.UserAgent() != "Sourcegraph e2etest-bot" {
-		go hubspotutil.SyncUser(creds.Email, hubspotutil.SignupEventID, &hubspot.ContactProperties{AnonymousUserID: creds.AnonymousUserID, FirstSourceURL: creds.FirstSourceURL})
+		go hubspotutil.SyncUser(creds.Email, hubspotutil.SignupEventID, &hubspot.ContactProperties{AnonymousUserID: creds.AnonymousUserID, FirstSourceURL: creds.FirstSourceURL, DatabaseID: usr.ID})
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/analytics/issues/217.

Sends a user's database ID to HubSpot to be added to their contact property when they sign up for an account on Sourcegraph Cloud. Requested by marketing and sales ops to have a unique identifier for users.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
