### PR TITLE
web: change `Breader` font weight

### DIFF
--- a/client/wildcard/src/components/PageHeader/PageHeader.module.scss
+++ b/client/wildcard/src/components/PageHeader/PageHeader.module.scss
@@ -24,14 +24,9 @@ $path-icon-size: (22em / 26);
 }
 
 .divider {
-    --divider-color: var(--text-muted);
     margin-right: 0.5rem;
-
-    :global(.theme-redesign) & {
-        --divider-color: var(--icon-color);
-    }
-
-    color: var(--divider-color);
+    color: var(--icon-color);
+    font-weight: 400;
 }
 
 .path {


### PR DESCRIPTION
## Changes

- Divider `font-weight` is set to `400`.
- Removed `.theme-redesign` usage from `PageHeader` styles.

## Screenshots

### Before 

<img width="508" alt="CleanShot 2021-06-08 at 14 30 48@2x" src="https://user-images.githubusercontent.com/6304497/121185523-7039fd00-c866-11eb-8702-51f00f2d0afd.png">

### After 

<img width="287" alt="CleanShot 2021-06-08 at 14 33 33@2x" src="https://user-images.githubusercontent.com/6304497/121185599-834ccd00-c866-11eb-886f-2046f37ad986.png">

Closes https://github.com/sourcegraph/sourcegraph/issues/21866.
Part of https://github.com/sourcegraph/sourcegraph/issues/20847.