### PR TITLE
web: change code monitoring form label margins

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -152,7 +152,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                         <input
                             id="code-monitor-form-name"
                             type="text"
-                            className="form-control my-2 test-name-input"
+                            className="form-control mb-2 test-name-input"
                             required={true}
                             onChange={event => {
                                 onNameChange(event.target.value)
@@ -178,7 +178,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                         <label htmlFor="code-monitor-form-owner">Owner</label>
                         <select
                             id="code-monitor-form-owner"
-                            className="form-control my-2 code-monitor-form__owner-dropdown w-auto"
+                            className="form-control mb-2 code-monitor-form__owner-dropdown w-auto"
                             disabled={true}
                         >
                             <option value={authenticatedUser.displayName || authenticatedUser.username}>

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -139,7 +139,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                         <input
                             id="code-monitoring-form-actions-recipients"
                             type="text"
-                            className="form-control my-2"
+                            className="form-control mb-2"
                             value={`${authenticatedUser.email || ''} (you)`}
                             disabled={true}
                             autoFocus={true}

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
       </label>
       <input
         autoFocus={true}
-        className="form-control my-2"
+        className="form-control mb-2"
         disabled={true}
         id="code-monitoring-form-actions-recipients"
         required={true}


### PR DESCRIPTION
## Changes

- Removed extra margin from labels in code-monitoring form.

## Screenshots

### Before 

<img width="724" alt="Screenshot 2021-07-19 at 10 14 04" src="https://user-images.githubusercontent.com/3846380/126118254-15e07597-d339-46d1-8381-1ed0eeb9ffeb.png">

### After 

<img width="727" alt="Screenshot 2021-07-19 at 10 13 44" src="https://user-images.githubusercontent.com/3846380/126118275-92632e45-eb72-47ec-b2b0-6245d8ad035e.png">


Closes https://github.com/sourcegraph/sourcegraph/issues/21867.
Part of https://github.com/sourcegraph/sourcegraph/issues/20847.