### PR TITLE
Code Insights: Fix the "loading Sourcegraph extensions" loading message for the dashboard page

### DIFF
--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -49,7 +49,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
         return (
             <div className="d-flex justify-content-center align-items-center pt-5">
                 <LoadingSpinner />
-                <span className="mx-2">Loading Sourcegraph extensions</span>
+                <span className="mx-2">Loading code insights</span>
                 <PuzzleIcon className="icon-inline" />
             </div>
         )


### PR DESCRIPTION
I see you've got some great logic to check things, but every time I load the insights page I hit the "loading extensions." I think that's both confusing to a user and very much against our goal of abstracting away that these are powered by extensions (we want you to think of insights as a separate thing than extensions; we don't want you thinking insights is a subset feature of extensions, not the least because extensions may be available to all users on any plan and insights may not be someday). 

I realize I'm just changing it to the message in the other condition. If you agree that it's confusing to show users this, perhaps we should collapse the conditions? 

Loom: https://www.loom.com/share/cbbc9d922b3b46dea4e6242faaee7a37 