### PR TITLE
Tweak global settings error message

### DIFF
--- a/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
+++ b/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
@@ -14,5 +14,5 @@ export function getGlobalSubjectTooltipText(globalSubject: SettingsSiteSubject |
 
     return globalSubject.allowSiteSettingsEdits
         ? globalSubjectAdminCheckMessage
-        : 'The global subject can not be edited since it was configured by settings file'
+        : 'The global subject cannot be edited since your Sourcegraph instance is using a separate settings file'
 }


### PR DESCRIPTION
Wanted to give the user a little more guidance since I don't know if "global subject" is enough to give them a sense of what's going on – a "settings file" could technically be the native one as well. 

(Also a few small stupid english-is-a-dumb-language tweaks, like "a settings file" – only noting this in case you disagree with this overall change, in which case we still should modify the message so "can not" -> "cannot" and "by settings file -> "by a settings file")