### PR TITLE
Code Insights: Add feature flag the all repos insight mode

### DIFF
--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -43,7 +43,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     const {
         mode = 'creation',
         subjects = [],
-        settings = {},
+        settings,
         initialValue,
         className,
         dataTestId,

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -6,6 +6,7 @@ import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { FormChangeEvent, SubmissionErrors } from '../../../../../../components/form/hooks/useForm'
 import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
+import { getExperimentalFeatures } from '../../../../../../utils/get-experimental-features'
 import { CreateInsightFormFields } from '../../types'
 import { getSanitizedRepositories } from '../../utils/insight-sanitizer'
 import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLivePreview'
@@ -42,7 +43,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     const {
         mode = 'creation',
         subjects = [],
-        settings,
+        settings = {},
         initialValue,
         className,
         dataTestId,
@@ -52,6 +53,8 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     } = props
 
     const isEditMode = mode === 'edit'
+
+    const { codeInsightsAllRepos } = getExperimentalFeatures(settings)
 
     const {
         form: { values, formAPI, ref, handleSubmit },
@@ -124,6 +127,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 step={step}
                 stepValue={stepValue}
                 isFormClearActive={hasFilledValue}
+                hasAllReposUI={codeInsightsAllRepos}
                 onSeriesLiveChange={listen}
                 onCancel={onCancel}
                 onEditSeriesRequest={editRequest}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -28,6 +28,11 @@ interface CreationSearchInsightFormProps {
     className?: string
     isFormClearActive?: boolean
 
+    /**
+     * Enables the experimental insight mode (run insight on all repositories in the instance)
+     */
+    hasAllReposUI?: boolean
+
     title: useFieldAPI<CreateInsightFormFields['title']>
     repositories: useFieldAPI<CreateInsightFormFields['repositories']>
     allReposMode: useFieldAPI<CreateInsightFormFields['allRepos']>
@@ -81,6 +86,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         step,
         className,
         isFormClearActive,
+        hasAllReposUI,
         onCancel,
         onSeriesLiveChange,
         onEditSeriesRequest,
@@ -119,19 +125,23 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                     className="mb-0 d-flex flex-column"
                 />
 
-                <label className="d-flex align-items-center mb-2 mt-2 font-weight-normal">
-                    <input
-                        type="checkbox"
-                        {...allReposMode.input}
-                        value="all-repos-mode"
-                        checked={allReposMode.input.value}
-                    />
+                {hasAllReposUI && (
+                    <>
+                        <label className="d-flex align-items-center mb-2 mt-2 font-weight-normal">
+                            <input
+                                type="checkbox"
+                                {...allReposMode.input}
+                                value="all-repos-mode"
+                                checked={allReposMode.input.value}
+                            />
 
-                    <span className="pl-2">Run your insight over all your repositories</span>
-                </label>
+                            <span className="pl-2">Run your insight over all your repositories</span>
+                        </label>
+
+                        <hr className={styles.creationInsightFormSeparator} />
+                    </>
+                )}
             </FormGroup>
-
-            <hr className={styles.creationInsightFormSeparator} />
 
             <FormGroup
                 name="data series group"
@@ -139,6 +149,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 subtitle="Add any number of data series to your chart"
                 error={series.meta.touched && series.meta.error}
                 innerRef={series.input.ref}
+                className={!hasAllReposUI ? 'mt-5' : undefined}
             >
                 <FormSeries
                     series={series.input.value}

--- a/client/web/src/insights/utils/get-experimental-features.ts
+++ b/client/web/src/insights/utils/get-experimental-features.ts
@@ -9,7 +9,7 @@ import { SettingsExperimentalFeatures } from '../../schema/settings.schema'
  * @param finalSettings - final (merged) settings from settings cascade subjects.
  */
 export function getExperimentalFeatures<S extends Settings = Settings>(
-    finalSettings: SettingsCascadeOrError<S>['final']
+    finalSettings?: SettingsCascadeOrError<S>['final']
 ): SettingsExperimentalFeatures {
     const settings = !isErrorLike(finalSettings) ? finalSettings : ({} as S)
 

--- a/client/web/src/insights/utils/get-experimental-features.ts
+++ b/client/web/src/insights/utils/get-experimental-features.ts
@@ -6,12 +6,12 @@ import { SettingsExperimentalFeatures } from '../../schema/settings.schema'
 /**
  * Returns experimentalFeatures from setting cascade.
  *
- * @param settingsCascade - Possible settings cascade object or error.
+ * @param finalSettings - final (merged) settings from settings cascade subjects.
  */
 export function getExperimentalFeatures<S extends Settings = Settings>(
-    settingsCascade: SettingsCascadeOrError<S>
+    finalSettings: SettingsCascadeOrError<S>['final']
 ): SettingsExperimentalFeatures {
-    const settings = !isErrorLike(settingsCascade.final) ? settingsCascade.final : ({} as S)
+    const settings = !isErrorLike(finalSettings) ? finalSettings : ({} as S)
 
     return settings?.experimentalFeatures ?? {}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1332,7 +1332,7 @@ type SettingsExperimentalFeatures struct {
 	BatchChangesExecution *bool `json:"batchChangesExecution,omitempty"`
 	// CodeInsights description: Enables code insights on directory pages.
 	CodeInsights *bool `json:"codeInsights,omitempty"`
-	// CodeInsightsAllRepos description: Enables experimental ability to run insight on all repositories in the instance.
+	// CodeInsightsAllRepos description: Enables the experimental ability to run an insight over all repositories on the instance.
 	CodeInsightsAllRepos *bool `json:"codeInsightsAllRepos,omitempty"`
 	// CodeMonitoring description: Enables code monitoring.
 	CodeMonitoring *bool `json:"codeMonitoring,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1332,8 +1332,8 @@ type SettingsExperimentalFeatures struct {
 	BatchChangesExecution *bool `json:"batchChangesExecution,omitempty"`
 	// CodeInsights description: Enables code insights on directory pages.
 	CodeInsights *bool `json:"codeInsights,omitempty"`
-	// CodeInsightsDashboards description: Enables code insights dashboards separation for the code insight page.
-	CodeInsightsDashboards *bool `json:"codeInsightsDashboards,omitempty"`
+	// CodeInsightsAllRepos description: Enables experimental ability to run insight on all repositories in the instance.
+	CodeInsightsAllRepos *bool `json:"codeInsightsAllRepos,omitempty"`
 	// CodeMonitoring description: Enables code monitoring.
 	CodeMonitoring *bool `json:"codeMonitoring,omitempty"`
 	// CopyQueryButton description: DEPRECATED: This feature is now permanently enabled. Enables displaying the copy query button in the search bar when hovering over the global navigation bar.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -21,7 +21,7 @@
           }
         },
         "codeInsightsAllRepos": {
-          "description": "Enables experimental ability to run insight on all repositories in the instance.",
+          "description": "Enables the experimental ability to run an insight over all repositories on the instance.",
           "type": "boolean",
           "default": false,
           "!go": {

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -20,8 +20,8 @@
             "pointer": true
           }
         },
-        "codeInsightsDashboards": {
-          "description": "Enables code insights dashboards separation for the code insight page.",
+        "codeInsightsAllRepos": {
+          "description": "Enables experimental ability to run insight on all repositories in the instance.",
           "type": "boolean",
           "default": false,
           "!go": {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22488

This PR adds `codeInsightsAllRepos` feature flag to the settings schema and applies this flag for the search-based insight creation UI in order to show/hide all repositories checkbox. 