### PR TITLE
Code Insights: Fix BE insight loading card flashing 

### DIFF
--- a/client/web/src/insights/core/backend/api/get-backend-insights.ts
+++ b/client/web/src/insights/core/backend/api/get-backend-insights.ts
@@ -1,0 +1,67 @@
+import { Observable, of } from 'rxjs'
+import { catchError, map, startWith } from 'rxjs/operators'
+
+import { asError } from '@sourcegraph/shared/src/util/errors'
+
+import { fetchBackendInsights } from '../requests/fetch-backend-insights'
+import { ViewInsightProviderResult, ViewInsightProviderSourceType } from '../types'
+import { createViewContent } from '../utils/create-view-content'
+
+/**
+ * Returns list of backend insights via gql API request.
+ */
+export function getBackendInsights(insightIds?: string[]): Observable<ViewInsightProviderResult[]> {
+    // Ids field wasn't specified returns all insights
+    if (!insightIds) {
+        return getRawBackendInsights([]).pipe(
+            startWith([
+                {
+                    id: 'Backend insights',
+                    view: undefined,
+                    source: ViewInsightProviderSourceType.Backend,
+                },
+            ])
+        )
+    }
+
+    if (insightIds.length === 0) {
+        return of([])
+    }
+
+    return getRawBackendInsights(insightIds).pipe(
+        startWith(
+            insightIds.map(id => ({
+                id,
+                view: undefined,
+                source: ViewInsightProviderSourceType.Backend,
+            }))
+        )
+    )
+}
+
+function getRawBackendInsights(insightIds: string[]): Observable<ViewInsightProviderResult[]> {
+    return fetchBackendInsights(insightIds).pipe(
+        map(backendInsights =>
+            backendInsights?.map(
+                (insight): ViewInsightProviderResult => ({
+                    id: insight.id,
+                    view: {
+                        title: insight.title,
+                        subtitle: insight.description,
+                        content: [createViewContent(insight)],
+                    },
+                    source: ViewInsightProviderSourceType.Backend,
+                })
+            )
+        ),
+        catchError(error =>
+            of<ViewInsightProviderResult[]>([
+                {
+                    id: 'Backend insight',
+                    view: asError(error),
+                    source: ViewInsightProviderSourceType.Backend,
+                },
+            ])
+        )
+    )
+}

--- a/client/web/src/insights/core/backend/api/get-combined-views.ts
+++ b/client/web/src/insights/core/backend/api/get-combined-views.ts
@@ -41,7 +41,11 @@ export const getCombinedViews = (
                   startWith(null),
                   map(backendInsights =>
                       backendInsights === null
-                          ? [{ id: 'Backend insights', view: undefined, source: ViewInsightProviderSourceType.Backend }]
+                          ? insightIds.map(id => ({
+                                id,
+                                view: undefined,
+                                source: ViewInsightProviderSourceType.Backend,
+                            }))
                           : backendInsights?.map(
                                 (insight): ViewInsightProviderResult => ({
                                     id: insight.id,

--- a/client/web/src/insights/core/backend/api/get-combined-views.ts
+++ b/client/web/src/insights/core/backend/api/get-combined-views.ts
@@ -1,15 +1,15 @@
 import { Remote } from 'comlink'
-import { combineLatest, from, Observable, of } from 'rxjs'
-import { catchError, map, startWith, switchMap } from 'rxjs/operators'
+import { combineLatest, from, Observable } from 'rxjs'
+import { map, switchMap } from 'rxjs/operators'
 
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { ViewProviderResult } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
-import { fetchBackendInsights } from '../requests/fetch-backend-insights'
 import { ViewInsightProviderResult, ViewInsightProviderSourceType } from '../types'
-import { createViewContent } from '../utils/create-view-content'
+
+import { getBackendInsights } from './get-backend-insights'
 
 /**
  * Get combined (backend and extensions) code insights unified method.
@@ -36,39 +36,7 @@ export const getCombinedViews = (
                 }))
             )
         ),
-        insightIds?.length
-            ? fetchBackendInsights(insightIds).pipe(
-                  startWith(null),
-                  map(backendInsights =>
-                      backendInsights === null
-                          ? insightIds.map(id => ({
-                                id,
-                                view: undefined,
-                                source: ViewInsightProviderSourceType.Backend,
-                            }))
-                          : backendInsights?.map(
-                                (insight): ViewInsightProviderResult => ({
-                                    id: insight.id,
-                                    view: {
-                                        title: insight.title,
-                                        subtitle: insight.description,
-                                        content: [createViewContent(insight)],
-                                    },
-                                    source: ViewInsightProviderSourceType.Backend,
-                                })
-                            )
-                  ),
-                  catchError(error =>
-                      of<ViewInsightProviderResult[]>([
-                          {
-                              id: 'Backend insight',
-                              view: asError(error),
-                              source: ViewInsightProviderSourceType.Backend,
-                          },
-                      ])
-                  )
-              )
-            : of([]),
+        getBackendInsights(insightIds),
     ]).pipe(map(([extensionViews, backendInsights]) => [...backendInsights, ...extensionViews]))
 
 /**

--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -50,9 +50,11 @@ export interface ApiService {
      * homepage, directory pages.
      *
      * @param getExtensionsInsights - extensions based insights getter via extension API.
+     * @param backendInsightsIds - specific dashboard subset of BE-like insight ids.
      */
     getCombinedViews: (
-        getExtensionsInsights: () => Observable<ViewProviderResult[]>
+        getExtensionsInsights: () => Observable<ViewProviderResult[]>,
+        backendInsightsIds?: string[]
     ) => Observable<ViewInsightProviderResult[]>
 
     /**

--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -61,10 +61,12 @@ export interface ApiService {
      * @param extensionApi - extension API for getting extension insights.
      * @param insightsIds - specific insight ids for loading. Used by dashboard
      * pages that have only sub-set of all insights.
+     * @param backendInsightsIds - specific dashboard subset of BE-like insight ids.
      */
     getInsightCombinedViews: (
         extensionApi: Promise<Remote<FlatExtensionHostAPI>>,
-        insightsIds?: string[]
+        allInsightsIds?: string[],
+        backendInsightsIds?: string[]
     ) => Observable<ViewInsightProviderResult[]>
 
     /**

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -16,6 +16,8 @@ import { InsightDashboard } from '../../../../../../../core/types'
 import { useDeleteInsight } from '../../../../../../insights/insights-page/hooks/use-delete-insight'
 import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
 
+import { getBackendInsightIds } from './utils/get-backend-insight-ids'
+
 const DEFAULT_INSIGHT_IDS: string[] = []
 
 interface DashboardInsightsProps
@@ -38,11 +40,16 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     } = props
     const { getInsightCombinedViews } = useContext(InsightsApiContext)
 
-    const insightIds = dashboard.insightIds ?? DEFAULT_INSIGHT_IDS
+    const allInsightIds = dashboard.insightIds ?? DEFAULT_INSIGHT_IDS
+    const backendInsightIds = useMemo(() => getBackendInsightIds({ insightIds: allInsightIds, settingsCascade }), [
+        allInsightIds,
+        settingsCascade,
+    ])
 
     const views = useObservable(
-        useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, insightIds), [
-            insightIds,
+        useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, allInsightIds, backendInsightIds), [
+            allInsightIds,
+            backendInsightIds,
             extensionsController,
             getInsightCombinedViews,
         ])
@@ -77,7 +84,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
 
     return (
         <div>
-            {insightIds.length > 0 && views.length > 0 ? (
+            {allInsightIds.length > 0 && views.length > 0 ? (
                 <InsightsViewGrid
                     views={views}
                     hasContextMenu={true}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/utils/get-backend-insight-ids.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/utils/get-backend-insight-ids.ts
@@ -1,0 +1,30 @@
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { Settings } from '../../../../../../../../../schema/settings.schema'
+import { INSIGHTS_ALL_REPOS_SETTINGS_KEY, isInsightSettingKey } from '../../../../../../../../core/types'
+
+interface GetBackendInsightIdsInput extends SettingsCascadeProps<Settings> {
+    insightIds: string[]
+}
+
+/**
+ * Returns filtered be insights only ids list.
+ *
+ * Dashboard insight ids field contains all insights (extension based and be based). To avoid
+ * unnecessary gql BE insights request we should separate BE insights from extension like insights.
+ */
+export function getBackendInsightIds(input: GetBackendInsightIdsInput): string[] {
+    const { insightIds, settingsCascade } = input
+    const { final } = settingsCascade
+
+    if (!final || isErrorLike(final)) {
+        return insightIds
+    }
+
+    const backendBasedInsightIds = new Set(
+        Object.keys((final?.[INSIGHTS_ALL_REPOS_SETTINGS_KEY] as object) ?? {}).filter(isInsightSettingKey)
+    )
+
+    return insightIds.filter(id => backendBasedInsightIds.has(id))
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22958

### Background

At the moment the dashboard page loads only such insights that the dashboard has in its `insightIds` property. Then we use extension API and gql BE handler to load all insights from the dashboard. 

### Problem 
Before this PR changes on the main, we pass all insight ids from the dashboard object to BE insight load logic even if these insights are an extension like. As a result, we render a loading card for the BE insight as a loader for this type of loading. But because of that, we have this card flushing cause we don't have any BE insights but still make a request. 

### What have been done
- [x] Add separation insight filter and distinct BE insight id and extension insight id
- [x] Change fetch logic in a way to avoid unnecessary requests in case if we don't have any be insight ids
- [x] Add multiple BE like insight loading cards (before this PR we had only one BE insight loading card (skeleton) for all BE insights) 