### PR TITLE
web: load runtime bundle in locally executed integration tests

### DIFF
--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -44,6 +44,12 @@ const getAppBundle = (): string => {
     return manifest['app.js']
 }
 
+const getRuntimeAppBundle = (): string => {
+    // eslint-disable-next-line no-sync
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8')) as Record<string, string>
+    return manifest['runtime.js']
+}
+
 /**
  * Creates the intergation test context for integration tests testing the web app.
  * This should be called in a `beforeEach()` hook and assigned to a variable `testContext` in the test scope.
@@ -58,6 +64,11 @@ export const createWebIntegrationTestContext = async ({
         string & keyof (WebGraphQlOperations & SharedGraphQlOperations)
     >({ driver, currentTest, directory })
     sharedTestContext.overrideGraphQL(commonWebGraphQlResults)
+
+    // On CI, we don't use `react-fast-refresh`, so we don't need the runtime bundle.
+    // This branching will be redundant after switching to production bundles for integration tests:
+    // https://github.com/sourcegraph/sourcegraph/issues/22831
+    const runtimeChunkScriptTag = process.env.CI === 'true' ? '' : `<script src=${getRuntimeAppBundle()}></script>`
 
     // Serve all requests for index.html (everything that does not match the handlers above) the same index.html
     let jsContext = createJsContext({ sourcegraphBaseUrl: sharedTestContext.driver.sourcegraphBaseUrl })
@@ -75,6 +86,7 @@ export const createWebIntegrationTestContext = async ({
                         <script>
                             window.context = ${JSON.stringify(jsContext)}
                         </script>
+                        ${runtimeChunkScriptTag}
                         <script src=${getAppBundle()}></script>
                     </body>
                 </html>

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -14,6 +14,7 @@ import {
 import { WebGraphQlOperations } from '../graphql-operations'
 import { SourcegraphContext } from '../jscontext'
 
+import { isHotReloadEnabled } from './environment'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { createJsContext } from './jscontext'
 
@@ -68,7 +69,7 @@ export const createWebIntegrationTestContext = async ({
     // On CI, we don't use `react-fast-refresh`, so we don't need the runtime bundle.
     // This branching will be redundant after switching to production bundles for integration tests:
     // https://github.com/sourcegraph/sourcegraph/issues/22831
-    const runtimeChunkScriptTag = process.env.CI === 'true' ? '' : `<script src=${getRuntimeAppBundle()}></script>`
+    const runtimeChunkScriptTag = isHotReloadEnabled ? `<script src=${getRuntimeAppBundle()}></script>` : ''
 
     // Serve all requests for index.html (everything that does not match the handlers above) the same index.html
     let jsContext = createJsContext({ sourcegraphBaseUrl: sharedTestContext.driver.sourcegraphBaseUrl })

--- a/client/web/src/integration/environment.ts
+++ b/client/web/src/integration/environment.ts
@@ -1,0 +1,2 @@
+// A shared variable to keep webpack.config and integration tests context configuration in sync.
+export const isHotReloadEnabled = process.env.NODE_ENV !== 'production' && process.env.CI !== 'true'

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -14,6 +14,7 @@ const { WebpackManifestPlugin } = require('webpack-manifest-plugin')
 
 const { getCSSLoaders } = require('./dev/webpack/get-css-loaders')
 const { getHTMLWebpackPlugins } = require('./dev/webpack/get-html-webpack-plugins')
+const { isHotReloadEnabled } = require('./src/integration/environment')
 
 const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
 logger.info('Using mode', mode)
@@ -22,7 +23,6 @@ const isDevelopment = mode === 'development'
 const isProduction = mode === 'production'
 const isCI = process.env.CI === 'true'
 const isCacheEnabled = isDevelopment && !isCI
-const isHotReloadEnabled = isDevelopment && !isCI
 
 const devtool = isProduction ? 'source-map' : 'eval-cheap-module-source-map'
 


### PR DESCRIPTION
## Changes 

- Added script tag with runtime bundle to the `index.html` used by local integration tests.

[Slack thread](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1626692016272100) for more context.