### PR TITLE
Code Insights: Add explanation tooltip on the creation insight form.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Batch Changes changesets can now be [published from the Sourcegraph UI](https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#within-the-ui). [#18277](https://github.com/sourcegraph/sourcegraph/issues/18277)
 - The repository page now has a new button to view batch change changesets created in that specific repository, with a badge indicating how many changesets are currently open. [#22804](https://github.com/sourcegraph/sourcegraph/pull/22804)
 - Experimental: Search-based code insights can run over all repositories on the instance. To enable, use the feature flag `"experimentalFeatures": { "codeInsightsAllRepos": true }`. [#22759](https://github.com/sourcegraph/sourcegraph/issues/22759)
+- Experimental: Search-based code insights can run over all repositories on the instance. To enable, use the feature flag `"experimentalFeatures": { "codeInsightsAllRepos": true }` and tick the checkbox in the insight creation/edit UI. [#22759](https://github.com/sourcegraph/sourcegraph/issues/22759)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ All notable changes to Sourcegraph are documented in this file.
 - Added "Groovy" to the initial `lang:` filter suggestions in the search bar. [#22755](https://github.com/sourcegraph/sourcegraph/pull/22755)
 - The `lang:` filter suggestions now show all supported, matching languages as the user types a language name. [#22765](https://github.com/sourcegraph/sourcegraph/pull/22765)
 - Code Insights can now be grouped into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
-- Added the code insights dashboards functionality. Now you can divide insights into dashboards. [#22215](https://github.com/sourcegraph/sourcegraph/issues/22215)
 - Batch Changes changesets can now be [published from the Sourcegraph UI](https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#within-the-ui). [#18277](https://github.com/sourcegraph/sourcegraph/issues/18277)
 - The repository page now has a new button to view batch change changesets created in that specific repository, with a badge indicating how many changesets are currently open. [#22804](https://github.com/sourcegraph/sourcegraph/pull/22804)
+- Experimental: Search-based code insights can run over all repositories on the instance. To enable, use the feature flag `"experimentalFeatures": { "codeInsightsAllRepos": true }`. [#22759](https://github.com/sourcegraph/sourcegraph/issues/22759)
 
 ### Changed
 

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -9,9 +9,9 @@ import {
     isUserSubject,
     SupportedInsightSubject,
 } from '../../core/types/subjects'
+import { getGlobalSubjectTooltipText } from '../../pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text'
 import { FormGroup } from '../form/form-group/FormGroup'
 import { FormRadioInput } from '../form/form-radio-input/FormRadioInput'
-import { getGlobalSubjectTooltipText } from '../../pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text';
 
 export interface VisibilityPickerProps {
     /**
@@ -108,7 +108,7 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
                 checked={value === globalSubject.id}
                 disabled={!canGlobalSubjectBeEdited}
                 labelTooltipText={getGlobalSubjectTooltipText(globalSubject)}
-                labelTooltipPosition='bottom'
+                labelTooltipPosition="bottom"
                 className="mr-3 w-100"
                 onChange={handleChange}
             />

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent } from 'react'
 import { Link } from 'react-router-dom'
 
-import { SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
+import { SettingsSiteSubject, SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
 
 import {
     isGlobalSubject,
@@ -9,7 +9,6 @@ import {
     isUserSubject,
     SupportedInsightSubject,
 } from '../../core/types/subjects'
-import { getGlobalSubjectTooltipText } from '../../pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text'
 import { FormGroup } from '../form/form-group/FormGroup'
 import { FormRadioInput } from '../form/form-radio-input/FormRadioInput'
 
@@ -124,4 +123,21 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
 export function getUserSubject(subjects: SupportedInsightSubject[]): SettingsUserSubject {
     // We always have user subject in our settings cascade
     return subjects.find(isUserSubject)!
+}
+
+/**
+ * Returns tooltip text for global subject visibility option.
+ */
+export function getGlobalSubjectTooltipText(globalSubject: SettingsSiteSubject | undefined): string | undefined {
+    if (!globalSubject) {
+        return
+    }
+
+    const globalSubjectAdminCheckMessage = globalSubject.viewerCanAdminister
+        ? undefined
+        : 'Only site admins can create global insights'
+
+    return globalSubject.allowSiteSettingsEdits
+        ? globalSubjectAdminCheckMessage
+        : 'The global subject cannot be edited since your Sourcegraph instance is using a separate settings file'
 }

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../core/types/subjects'
 import { FormGroup } from '../form/form-group/FormGroup'
 import { FormRadioInput } from '../form/form-radio-input/FormRadioInput'
+import { getGlobalSubjectTooltipText } from '../../pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text';
 
 export interface VisibilityPickerProps {
     /**
@@ -106,6 +107,8 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
                 description="visible to everyone on your Sourcegraph instance"
                 checked={value === globalSubject.id}
                 disabled={!canGlobalSubjectBeEdited}
+                labelTooltipText={getGlobalSubjectTooltipText(globalSubject)}
+                labelTooltipPosition='bottom'
                 className="mr-3 w-100"
                 onChange={handleChange}
             />

--- a/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
+++ b/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
@@ -10,7 +10,7 @@ export function getGlobalSubjectTooltipText(globalSubject: SettingsSiteSubject |
 
     const globalSubjectAdminCheckMessage = globalSubject.viewerCanAdminister
         ? undefined
-        : "Only site admins can change global settings"
+        : 'Only site admins can create global dashboards'
 
     return globalSubject.allowSiteSettingsEdits
         ? globalSubjectAdminCheckMessage

--- a/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
+++ b/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
@@ -10,7 +10,7 @@ export function getGlobalSubjectTooltipText(globalSubject: SettingsSiteSubject |
 
     const globalSubjectAdminCheckMessage = globalSubject.viewerCanAdminister
         ? undefined
-        : "You don't have a permission to change global scope. Reach out your site admin"
+        : "You don't have permission to change the global scope. Reach out to your site admin"
 
     return globalSubject.allowSiteSettingsEdits
         ? globalSubjectAdminCheckMessage

--- a/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
+++ b/client/web/src/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
@@ -10,7 +10,7 @@ export function getGlobalSubjectTooltipText(globalSubject: SettingsSiteSubject |
 
     const globalSubjectAdminCheckMessage = globalSubject.viewerCanAdminister
         ? undefined
-        : "You don't have permission to change the global scope. Reach out to your site admin"
+        : "Only site admins can change global settings"
 
     return globalSubject.allowSiteSettingsEdits
         ? globalSubjectAdminCheckMessage

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -46,18 +46,18 @@ export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props 
                 <MenuItem
                     as="button"
                     disabled={!permissions.isConfigurable}
-                    data-tooltip={getTooltipMessage(permissions)}
+                    data-tooltip={getTooltipMessage(dashboard, permissions)}
                     data-placement="right"
                     className={classnames(styles.menuItem, 'btn btn-outline')}
                     onSelect={() => onSelect(DashboardMenuAction.AddRemoveInsights)}
                 >
-                    Add/remove insights
+                    Assign or Remove insights
                 </MenuItem>
 
                 <MenuItem
                     as="button"
                     disabled={!permissions.isConfigurable}
-                    data-tooltip={getTooltipMessage(permissions)}
+                    data-tooltip={getTooltipMessage(dashboard, permissions)}
                     data-placement="right"
                     className={classnames(styles.menuItem, 'btn btn-outline')}
                     onSelect={() => onSelect(DashboardMenuAction.Configure)}
@@ -79,7 +79,7 @@ export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props 
                 <MenuItem
                     as="button"
                     disabled={!permissions.isConfigurable}
-                    data-tooltip={getTooltipMessage(permissions)}
+                    data-tooltip={getTooltipMessage(dashboard, permissions)}
                     data-placement="right"
                     className={classnames(styles.menuItem, 'btn btn-outline', styles.menuItemDanger)}
                     onSelect={() => onSelect(DashboardMenuAction.Delete)}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -67,12 +67,12 @@ export const EmptySettingsBasedDashboard: React.FunctionComponent<EmptyInsightDa
                 className="btn btn-secondary p-0 w-100 border-0"
             >
                 <div
-                    data-tooltip={!permissions.isConfigurable ? getTooltipMessage(permissions) : undefined}
+                    data-tooltip={!permissions.isConfigurable ? getTooltipMessage(dashboard, permissions) : undefined}
                     data-placement="right"
                     className={classnames(styles.itemCard, 'card')}
                 >
                     <PlusIcon size="2rem" />
-                    <span>Add insight</span>
+                    <span>Assign insights</span>
                 </div>
             </button>
             <span className="d-flex justify-content-center mt-3">

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -85,7 +85,7 @@ export function getTooltipMessage(permissions: DashboardPermissions): string | u
         case DashboardReasonDenied.UnknownDashboard:
             return 'Dashboard not found'
         case DashboardReasonDenied.PermissionDenied:
-            return "You don't a permission to edit this dashboard"
+            return "You don't have permission to edit this dashboard"
         case DashboardReasonDenied.BuiltInCantBeEdited:
             return "Built-in dashboards can't be edited"
     }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -1,12 +1,13 @@
 import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 
 import { Settings } from '../../../../../schema/settings.schema'
-import { InsightDashboard, isRealDashboard, isVirtualDashboard } from '../../../../core/types'
+import { InsightDashboard, InsightsDashboardType, isRealDashboard, isVirtualDashboard } from '../../../../core/types'
 import { isSettingsBasedInsightsDashboard } from '../../../../core/types/dashboard/real-dashboard'
 import { isGlobalSubject } from '../../../../core/types/subjects'
 import { useInsightSubjects } from '../../../../hooks/use-insight-subjects/use-insight-subjects'
 
 enum DashboardReasonDenied {
+    AllVirtualDashboard,
     BuiltInCantBeEdited,
     PermissionDenied,
     UnknownDashboard,
@@ -35,7 +36,7 @@ export function useDashboardPermissions(
     if (isVirtualDashboard(dashboard)) {
         return {
             isConfigurable: false,
-            reason: DashboardReasonDenied.BuiltInCantBeEdited,
+            reason: DashboardReasonDenied.AllVirtualDashboard,
         }
     }
 
@@ -76,7 +77,14 @@ export function useDashboardPermissions(
     return DEFAULT_DASHBOARD_PERMISSIONS
 }
 
-export function getTooltipMessage(permissions: DashboardPermissions): string | undefined {
+export function getTooltipMessage(
+    dashboard: InsightDashboard | undefined,
+    permissions: DashboardPermissions
+): string | undefined {
+    if (!dashboard) {
+        return 'Dashboard not found'
+    }
+
     if (permissions.isConfigurable) {
         return
     }
@@ -87,6 +95,16 @@ export function getTooltipMessage(permissions: DashboardPermissions): string | u
         case DashboardReasonDenied.PermissionDenied:
             return "You don't have permission to edit this dashboard"
         case DashboardReasonDenied.BuiltInCantBeEdited:
-            return "Built-in dashboards can't be edited"
+            switch (dashboard.type) {
+                case InsightsDashboardType.All:
+                    return "This is an automatically created dashboard that lists all the insights you have access to. You can't edit this dashboard."
+                case InsightsDashboardType.Personal:
+                    return "This is an automatically created dashboard that lists all your private insights. You can't edit this dashboard."
+                case InsightsDashboardType.Organization:
+                case InsightsDashboardType.Global:
+                    return `This is an automatically created dashboard that lists all the ${dashboard.owner.name}'s insights. You can't edit this dashboard.`
+            }
+        case DashboardReasonDenied.AllVirtualDashboard:
+            return "This is an automatically created dashboard that lists all the insights you have access to. You can't edit this dashboard."
     }
 }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -102,7 +102,7 @@ export function getTooltipMessage(
                     return "This is an automatically created dashboard that lists all your private insights. You can't edit this dashboard."
                 case InsightsDashboardType.Organization:
                 case InsightsDashboardType.Global:
-                    return `This is an automatically created dashboard that lists all the ${dashboard.owner.name}'s insights. You can't edit this dashboard.`
+                    return `This is an automatically created dashboard that lists all the ${dashboard.owner.name} insights. You can't edit this dashboard.`
             }
         case DashboardReasonDenied.AllVirtualDashboard:
             return "This is an automatically created dashboard that lists all the insights you have access to. You can't edit this dashboard."


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22963

### Background
This PR adds an explanation tooltip for the disabled global visibility radio button in the creation form and fixes tooltip dashboard-related texts. 

Also, this PR adds a changelog announcement line about all repos insight