### PR TITLE
Move heartbeats from executor-queue to executor

### DIFF
--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
@@ -17,9 +17,6 @@ import (
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
-// HeartbeatInterval is the duration between heartbeat updates to the job records.
-const HeartbeatInterval = time.Second
-
 // StalledJobMaximumAge is the maximum allowable duration between updating the state of a
 // job as "processing" and locking the record during processing. An unlocked row that is
 // marked as processing likely indicates that the executor that dequeued the job has died.
@@ -52,7 +49,6 @@ func newWorkerStore(db dbutil.DB, observationContext *observation.Context) dbwor
 		ColumnExpressions: store.IndexColumnsWithNullRank,
 		Scan:              store.ScanFirstIndexRecord,
 		OrderByExpression: sqlf.Sprintf("u.queued_at, u.id"),
-		HeartbeatInterval: HeartbeatInterval,
 		StalledMaxAge:     StalledJobMaximumAge,
 		MaxNumResets:      MaximumNumResets,
 	}

--- a/enterprise/cmd/executor-queue/internal/server/handler_test.go
+++ b/enterprise/cmd/executor-queue/internal/server/handler_test.go
@@ -24,7 +24,7 @@ func TestDequeue(t *testing.T) {
 	}
 
 	store := workerstoremocks.NewMockStore()
-	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42, Payload: "secret"}, func() {}, true, nil)
+	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42, Payload: "secret"}, true, nil)
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		if tr, ok := record.(testRecord); !ok {
 			t.Errorf("mismatched record type.")
@@ -87,9 +87,9 @@ func TestDequeueUnknownQueue(t *testing.T) {
 
 func TestDequeueMaxTransactions(t *testing.T) {
 	store := workerstoremocks.NewMockStore()
-	store.DequeueFunc.PushReturn(testRecord{ID: 41}, func() {}, true, nil)
-	store.DequeueFunc.PushReturn(testRecord{ID: 42}, func() {}, true, nil)
-	store.DequeueFunc.PushReturn(testRecord{ID: 43}, func() {}, true, nil)
+	store.DequeueFunc.PushReturn(testRecord{ID: 41}, true, nil)
+	store.DequeueFunc.PushReturn(testRecord{ID: 42}, true, nil)
+	store.DequeueFunc.PushReturn(testRecord{ID: 43}, true, nil)
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		return apiclient.Job{}, nil
 	}
@@ -141,7 +141,7 @@ func TestDequeueMaxTransactions(t *testing.T) {
 
 func TestAddExecutionLogEntry(t *testing.T) {
 	store := workerstoremocks.NewMockStore()
-	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, func() {}, true, nil)
+	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
@@ -213,9 +213,8 @@ func TestAddExecutionLogEntryUnknownJob(t *testing.T) {
 }
 
 func TestMarkComplete(t *testing.T) {
-	var cancel int
 	store := workerstoremocks.NewMockStore()
-	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, func() { cancel++ }, true, nil)
+	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
@@ -247,10 +246,6 @@ func TestMarkComplete(t *testing.T) {
 	if call.Arg1 != 42 {
 		t.Errorf("unexpected job identifier. want=%d have=%d", 42, call.Arg1)
 	}
-
-	if cancel != 1 {
-		t.Errorf("unexpected cancel call count. want=%d have=%d", 1, cancel)
-	}
 }
 
 func TestMarkCompleteUnknownJob(t *testing.T) {
@@ -276,9 +271,8 @@ func TestMarkCompleteUnknownQueue(t *testing.T) {
 }
 
 func TestMarkErrored(t *testing.T) {
-	var cancel int
 	store := workerstoremocks.NewMockStore()
-	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, func() { cancel++ }, true, nil)
+	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
@@ -313,10 +307,6 @@ func TestMarkErrored(t *testing.T) {
 	if call.Arg2 != "OH NO" {
 		t.Errorf("unexpected job error. want=%s have=%s", "OH NO", call.Arg2)
 	}
-
-	if cancel != 1 {
-		t.Errorf("unexpected cancel call count. want=%d have=%d", 1, cancel)
-	}
 }
 
 func TestMarkErroredUnknownJob(t *testing.T) {
@@ -342,9 +332,8 @@ func TestMarkErroredUnknownQueue(t *testing.T) {
 }
 
 func TestMarkFailed(t *testing.T) {
-	var cancel int
 	store := workerstoremocks.NewMockStore()
-	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, func() { cancel++ }, true, nil)
+	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
@@ -378,10 +367,6 @@ func TestMarkFailed(t *testing.T) {
 	}
 	if call.Arg2 != "OH NO" {
 		t.Errorf("unexpected job error. want=%s have=%s", "OH NO", call.Arg2)
-	}
-
-	if cancel != 1 {
-		t.Errorf("unexpected cancel call count. want=%d have=%d", 1, cancel)
 	}
 }
 

--- a/enterprise/cmd/executor-queue/internal/server/lifecycle.go
+++ b/enterprise/cmd/executor-queue/internal/server/lifecycle.go
@@ -30,9 +30,9 @@ func (h *handler) cleanup(ctx context.Context) error {
 
 // heartbeatJobs updates the set of job identifiers assigned to the given executor and returns
 // any job that was known to us but not reported by the executor, plus the set of job identifiers
-// reported by the executor which do not have an associated transaction held by this instance of
-// the executor queue. This can occur when the executor-queue restarts and loses its transaction
-// state. We send these identifiers back to the executor as a hint to stop processing.
+// reported by the executor which do not have an associated record held by this instance of the
+// executor queue. This can occur when the executor-queue restarts and loses its in-memory state.
+// We send these identifiers back to the executor as a hint to stop processing.
 func (h *handler) heartbeatJobs(ctx context.Context, executorName string, ids []int) (dead []jobMeta, unknownIDs []int, errs error) {
 	now := h.clock.Now()
 

--- a/enterprise/cmd/executor-queue/internal/server/lifecycle.go
+++ b/enterprise/cmd/executor-queue/internal/server/lifecycle.go
@@ -11,10 +11,8 @@ import (
 // identifiers to the /heartbeat route. This method returns the set of identifiers which the
 // executor erroneously claims to hold (and are sent back as a hint to stop processing).
 func (h *handler) heartbeat(ctx context.Context, executorName string, jobIDs []int) ([]int, error) {
-	unknownIDs := h.unknownJobs(executorName, jobIDs)
-	executor, deadJobs := h.pruneJobs(executorName, jobIDs)
-	err := h.requeueJobs(ctx, deadJobs)
-	err2 := h.heartbeatJobs(ctx, executor)
+	deadJobs, unknownIDs, err := h.heartbeatJobs(ctx, executorName, jobIDs)
+	err2 := h.requeueJobs(ctx, deadJobs)
 	if err != nil && err2 != nil {
 		err = multierror.Append(err, err2)
 	}
@@ -30,43 +28,17 @@ func (h *handler) cleanup(ctx context.Context) error {
 	return h.requeueJobs(ctx, h.pruneExecutors())
 }
 
-// unknownJobs returns the set of job identifiers reported by the executor which do not
-// have an associated transaction held by this instance of the executor queue. This can
-// occur when the executor-queue restarts and loses its transaction state. We send these
-// identifiers back to the executor as a hint to stop processing.
-func (h *handler) unknownJobs(executorName string, ids []int) []int {
-	h.m.Lock()
-	defer h.m.Unlock()
-
-	executor, ok := h.executors[executorName]
-	if !ok {
-		// If executor is unknown, all ids are unknown
-		return ids
-	}
-
-	idMap := map[int]struct{}{}
-	for _, job := range executor.jobs {
-		idMap[job.record.RecordID()] = struct{}{}
-	}
-
-	unknown := make([]int, 0, len(ids))
-	for _, id := range ids {
-		if _, ok := idMap[id]; !ok {
-			unknown = append(unknown, id)
-		}
-	}
-
-	return unknown
-}
-
-// pruneJobs updates the set of job identifiers assigned to the given executor and returns
-// any job that was known to us but not reported by the executor.
-func (h *handler) pruneJobs(executorName string, ids []int) (executor *executorMeta, dead []jobMeta) {
+// heartbeatJobs updates the set of job identifiers assigned to the given executor and returns
+// any job that was known to us but not reported by the executor, plus the set of job identifiers
+// reported by the executor which do not have an associated transaction held by this instance of
+// the executor queue. This can occur when the executor-queue restarts and loses its transaction
+// state. We send these identifiers back to the executor as a hint to stop processing.
+func (h *handler) heartbeatJobs(ctx context.Context, executorName string, ids []int) (dead []jobMeta, unknownIDs []int, errs error) {
 	now := h.clock.Now()
 
-	idMap := map[int]struct{}{}
+	executorIDsMap := map[int]struct{}{}
 	for _, id := range ids {
-		idMap[id] = struct{}{}
+		executorIDsMap[id] = struct{}{}
 	}
 
 	h.m.Lock()
@@ -78,18 +50,30 @@ func (h *handler) pruneJobs(executorName string, ids []int) (executor *executorM
 		h.executors[executorName] = executor
 	}
 
+	executorQueueIDsMap := map[int]struct{}{}
 	var live []jobMeta
 	for _, job := range executor.jobs {
-		if _, ok := idMap[job.record.RecordID()]; ok || now.Sub(job.started) < h.options.UnreportedMaxAge {
+		executorQueueIDsMap[job.record.RecordID()] = struct{}{}
+		if _, ok := executorIDsMap[job.record.RecordID()]; ok || now.Sub(job.started) < h.options.UnreportedMaxAge {
 			live = append(live, job)
+			if err := h.heartbeatJob(ctx, job); err != nil {
+				errs = multierror.Append(errs, err)
+			}
 		} else {
 			dead = append(dead, job)
 		}
 	}
-
 	executor.jobs = live
 	executor.lastUpdate = now
-	return executor, dead
+
+	unknownIDs = make([]int, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := executorQueueIDsMap[id]; !ok {
+			unknownIDs = append(unknownIDs, id)
+		}
+	}
+
+	return dead, unknownIDs, errs
 }
 
 // pruneExecutors will release the transactions held by any executor that has not sent a
@@ -108,19 +92,6 @@ func (h *handler) pruneExecutors() (jobs []jobMeta) {
 	}
 
 	return jobs
-}
-
-func (h *handler) heartbeatJobs(ctx context.Context, executor *executorMeta) (errs error) {
-	h.m.Lock()
-	defer h.m.Unlock()
-
-	for _, job := range executor.jobs {
-		if err := h.heartbeatJob(ctx, job); err != nil {
-			errs = multierror.Append(errs, err)
-		}
-	}
-
-	return errs
 }
 
 func (h *handler) heartbeatJob(ctx context.Context, job jobMeta) error {

--- a/enterprise/cmd/executor-queue/internal/server/server.go
+++ b/enterprise/cmd/executor-queue/internal/server/server.go
@@ -30,4 +30,3 @@ var _ goroutine.Handler = &handlerWrapper{}
 
 func (hw *handlerWrapper) Handle(ctx context.Context) error { return hw.handler.cleanup(ctx) }
 func (hw *handlerWrapper) HandleError(err error)            { log15.Error("Failed to requeue jobs", "err", err) }
-func (hw *handlerWrapper) OnShutdown()                      { hw.handler.shutdown() }

--- a/enterprise/cmd/executor/internal/worker/mock_store_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_store_test.go
@@ -19,6 +19,9 @@ type MockStore struct {
 	// DequeueFunc is an instance of a mock function object controlling the
 	// behavior of the method Dequeue.
 	DequeueFunc *StoreDequeueFunc
+	// HeartbeatFunc is an instance of a mock function object controlling
+	// the behavior of the method Heartbeat.
+	HeartbeatFunc *StoreHeartbeatFunc
 	// MarkCompleteFunc is an instance of a mock function object controlling
 	// the behavior of the method MarkComplete.
 	MarkCompleteFunc *StoreMarkCompleteFunc
@@ -43,8 +46,13 @@ func NewMockStore() *MockStore {
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc{
-			defaultHook: func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error) {
-				return nil, nil, false, nil
+			defaultHook: func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
+				return nil, false, nil
+			},
+		},
+		HeartbeatFunc: &StoreHeartbeatFunc{
+			defaultHook: func(context.Context, int) error {
+				return nil
 			},
 		},
 		MarkCompleteFunc: &StoreMarkCompleteFunc{
@@ -79,6 +87,9 @@ func NewMockStoreFrom(i workerutil.Store) *MockStore {
 		},
 		DequeueFunc: &StoreDequeueFunc{
 			defaultHook: i.Dequeue,
+		},
+		HeartbeatFunc: &StoreHeartbeatFunc{
+			defaultHook: i.Heartbeat,
 		},
 		MarkCompleteFunc: &StoreMarkCompleteFunc{
 			defaultHook: i.MarkComplete,
@@ -207,23 +218,23 @@ func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
 // parent MockStore instance is invoked.
 type StoreDequeueFunc struct {
-	defaultHook func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error)
-	hooks       []func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error)
+	defaultHook func(context.Context, string, interface{}) (workerutil.Record, bool, error)
+	hooks       []func(context.Context, string, interface{}) (workerutil.Record, bool, error)
 	history     []StoreDequeueFuncCall
 	mutex       sync.Mutex
 }
 
 // Dequeue delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (workerutil.Record, context.CancelFunc, bool, error) {
-	r0, r1, r2, r3 := m.DequeueFunc.nextHook()(v0, v1, v2)
-	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2, r3})
-	return r0, r1, r2, r3
+func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (workerutil.Record, bool, error) {
+	r0, r1, r2 := m.DequeueFunc.nextHook()(v0, v1, v2)
+	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the Dequeue method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error)) {
+func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, interface{}) (workerutil.Record, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -231,7 +242,7 @@ func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, int
 // Dequeue method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error)) {
+func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface{}) (workerutil.Record, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -239,21 +250,21 @@ func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *StoreDequeueFunc) SetDefaultReturn(r0 workerutil.Record, r1 context.CancelFunc, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error) {
-		return r0, r1, r2, r3
+func (f *StoreDequeueFunc) SetDefaultReturn(r0 workerutil.Record, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *StoreDequeueFunc) PushReturn(r0 workerutil.Record, r1 context.CancelFunc, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error) {
-		return r0, r1, r2, r3
+func (f *StoreDequeueFunc) PushReturn(r0 workerutil.Record, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *StoreDequeueFunc) nextHook() func(context.Context, string, interface{}) (workerutil.Record, context.CancelFunc, bool, error) {
+func (f *StoreDequeueFunc) nextHook() func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -300,13 +311,10 @@ type StoreDequeueFuncCall struct {
 	Result0 workerutil.Record
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 context.CancelFunc
+	Result1 bool
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
-	Result2 bool
-	// Result3 is the value of the 4th result returned from this method
-	// invocation.
-	Result3 error
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -318,7 +326,112 @@ func (c StoreDequeueFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreHeartbeatFunc describes the behavior when the Heartbeat method of
+// the parent MockStore instance is invoked.
+type StoreHeartbeatFunc struct {
+	defaultHook func(context.Context, int) error
+	hooks       []func(context.Context, int) error
+	history     []StoreHeartbeatFuncCall
+	mutex       sync.Mutex
+}
+
+// Heartbeat delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockStore) Heartbeat(v0 context.Context, v1 int) error {
+	r0 := m.HeartbeatFunc.nextHook()(v0, v1)
+	m.HeartbeatFunc.appendCall(StoreHeartbeatFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Heartbeat method of
+// the parent MockStore instance is invoked and the hook queue is empty.
+func (f *StoreHeartbeatFunc) SetDefaultHook(hook func(context.Context, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Heartbeat method of the parent MockStore instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *StoreHeartbeatFunc) PushHook(hook func(context.Context, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreHeartbeatFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreHeartbeatFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+func (f *StoreHeartbeatFunc) nextHook() func(context.Context, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreHeartbeatFunc) appendCall(r0 StoreHeartbeatFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreHeartbeatFuncCall objects describing
+// the invocations of this function.
+func (f *StoreHeartbeatFunc) History() []StoreHeartbeatFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreHeartbeatFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreHeartbeatFuncCall is an object that describes an invocation of
+// method Heartbeat on an instance of MockStore.
+type StoreHeartbeatFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreHeartbeatFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreHeartbeatFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // StoreMarkCompleteFunc describes the behavior when the MarkComplete method

--- a/enterprise/cmd/executor/internal/worker/store.go
+++ b/enterprise/cmd/executor/internal/worker/store.go
@@ -28,14 +28,19 @@ func (s *storeShim) QueuedCount(ctx context.Context, extraArguments interface{})
 	return 0, errors.New("unimplemented")
 }
 
-func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (workerutil.Record, context.CancelFunc, bool, error) {
+func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (workerutil.Record, bool, error) {
 	var job executor.Job
 	dequeued, err := s.queueStore.Dequeue(ctx, s.queueName, &job)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, false, err
 	}
 
-	return job, func() {}, dequeued, nil
+	return job, dequeued, nil
+}
+
+func (s *storeShim) Heartbeat(ctx context.Context, id int) error {
+	// Not needed, we do bulk updates from the executor.
+	return nil
 }
 
 func (s *storeShim) AddExecutionLogEntry(ctx context.Context, id int, entry workerutil.ExecutionLogEntry) error {

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -11,6 +11,9 @@ import (
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
+// UploadHeartbeatInterval is the duration between heartbeat updates to the upload job records.
+const UploadHeartbeatInterval = time.Second
+
 func NewWorker(
 	dbStore DBStore,
 	workerStore dbworkerstore.Store,
@@ -35,9 +38,10 @@ func NewWorker(
 	}
 
 	return dbworker.NewWorker(rootContext, workerStore, handler, workerutil.WorkerOptions{
-		Name:        "precise_code_intel_upload_worker",
-		NumHandlers: numProcessorRoutines,
-		Interval:    pollInterval,
-		Metrics:     workerMetrics,
+		Name:              "precise_code_intel_upload_worker",
+		NumHandlers:       numProcessorRoutines,
+		Interval:          pollInterval,
+		HeartbeatInterval: UploadHeartbeatInterval,
+		Metrics:           workerMetrics,
 	})
 }

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
@@ -33,10 +33,11 @@ func NewDependencyIndexingScheduler(
 	}
 
 	return dbworker.NewWorker(rootContext, workerStore, handler, workerutil.WorkerOptions{
-		Name:        "precise_code_intel_dependency_indexing_scheduler_worker",
-		NumHandlers: numProcessorRoutines,
-		Interval:    pollInterval,
-		Metrics:     workerMetrics,
+		Name:              "precise_code_intel_dependency_indexing_scheduler_worker",
+		NumHandlers:       numProcessorRoutines,
+		Interval:          pollInterval,
+		Metrics:           workerMetrics,
+		HeartbeatInterval: 1 * time.Second,
 	})
 }
 

--- a/enterprise/internal/batches/background/bulk_processor_worker.go
+++ b/enterprise/internal/batches/background/bulk_processor_worker.go
@@ -35,10 +35,11 @@ func newBulkOperationWorker(
 	r := &bulkProcessorWorker{sourcer: sourcer, store: s}
 
 	options := workerutil.WorkerOptions{
-		Name:        "batches_bulk_processor",
-		NumHandlers: 5,
-		Interval:    5 * time.Second,
-		Metrics:     metrics.bulkProcessorWorkerMetrics,
+		Name:              "batches_bulk_processor",
+		NumHandlers:       5,
+		HeartbeatInterval: 15 * time.Second,
+		Interval:          5 * time.Second,
+		Metrics:           metrics.bulkProcessorWorkerMetrics,
 	}
 
 	workerStore := createBulkOperationDBWorkerStore(s)
@@ -71,9 +72,8 @@ func createBulkOperationDBWorkerStore(s *store.Store) dbworkerstore.Store {
 
 		OrderByExpression: sqlf.Sprintf("changeset_jobs.state = 'errored', changeset_jobs.updated_at DESC"),
 
-		HeartbeatInterval: 15 * time.Second,
-		StalledMaxAge:     60 * time.Second,
-		MaxNumResets:      bulkProcessorMaxNumResets,
+		StalledMaxAge: 60 * time.Second,
+		MaxNumResets:  bulkProcessorMaxNumResets,
 
 		RetryAfter:    5 * time.Second,
 		MaxNumRetries: bulkProcessorMaxNumRetries,

--- a/enterprise/internal/batches/background/executor_store.go
+++ b/enterprise/internal/batches/background/executor_store.go
@@ -24,7 +24,7 @@ import (
 // job as "processing" and locking the record during processing. An unlocked row that is
 // marked as processing likely indicates that the executor that dequeued the job has died.
 // There should be a nearly-zero delay between these states during normal operation.
-const executorStalledJobMaximumAge = time.Second * 5
+const executorStalledJobMaximumAge = time.Second * 25
 
 // executorMaximumNumResets is the maximum number of times a job can be reset. If a job's failed
 // attempts counter reaches this threshold, it will be moved into "errored" rather than
@@ -39,7 +39,6 @@ var executorWorkerStoreOptions = dbworkerstore.Options{
 	OrderByExpression: sqlf.Sprintf("batch_spec_executions.created_at, batch_spec_executions.id"),
 	StalledMaxAge:     executorStalledJobMaximumAge,
 	MaxNumResets:      executorMaximumNumResets,
-	HeartbeatInterval: 1 * time.Second,
 	// Explicitly disable retries.
 	MaxNumRetries: 0,
 }

--- a/enterprise/internal/batches/background/executor_store.go
+++ b/enterprise/internal/batches/background/executor_store.go
@@ -39,6 +39,7 @@ var executorWorkerStoreOptions = dbworkerstore.Options{
 	OrderByExpression: sqlf.Sprintf("batch_spec_executions.created_at, batch_spec_executions.id"),
 	StalledMaxAge:     executorStalledJobMaximumAge,
 	MaxNumResets:      executorMaximumNumResets,
+	HeartbeatInterval: 1 * time.Second,
 	// Explicitly disable retries.
 	MaxNumRetries: 0,
 }

--- a/enterprise/internal/batches/background/reconciler_worker.go
+++ b/enterprise/internal/batches/background/reconciler_worker.go
@@ -36,10 +36,11 @@ func newReconcilerWorker(
 	r := reconciler.New(gitClient, sourcer, s)
 
 	options := workerutil.WorkerOptions{
-		Name:        "batches_reconciler_worker",
-		NumHandlers: 5,
-		Interval:    5 * time.Second,
-		Metrics:     metrics.reconcilerWorkerMetrics,
+		Name:              "batches_reconciler_worker",
+		NumHandlers:       5,
+		Interval:          5 * time.Second,
+		HeartbeatInterval: 15 * time.Second,
+		Metrics:           metrics.reconcilerWorkerMetrics,
 	}
 
 	workerStore := createReconcilerDBWorkerStore(s)
@@ -79,9 +80,8 @@ func createReconcilerDBWorkerStore(s *store.Store) dbworkerstore.Store {
 		// If state is equal, prefer the newer ones.
 		OrderByExpression: sqlf.Sprintf("changesets.reconciler_state = 'errored', changesets.updated_at DESC"),
 
-		HeartbeatInterval: 15 * time.Second,
-		StalledMaxAge:     60 * time.Second,
-		MaxNumResets:      reconcilerMaxNumResets,
+		StalledMaxAge: 60 * time.Second,
+		MaxNumResets:  reconcilerMaxNumResets,
 
 		RetryAfter:    5 * time.Second,
 		MaxNumRetries: reconcilerMaxNumRetries,

--- a/enterprise/internal/codeintel/stores/dbstore/worker.go
+++ b/enterprise/internal/codeintel/stores/dbstore/worker.go
@@ -90,6 +90,7 @@ var dependencyIndexingJobWorkerStoreOptions = dbworkerstore.Options{
 	OrderByExpression: sqlf.Sprintf("j.queued_at, j.upload_id"),
 	StalledMaxAge:     StalledDependencyIndexingJobMaxAge,
 	MaxNumResets:      DependencyIndexingJobMaxNumResets,
+	HeartbeatInterval: 1 * time.Second,
 }
 
 func WorkerutilDependencyIndexingJobStore(s basestore.ShareableStore, observationContext *observation.Context) dbworkerstore.Store {

--- a/enterprise/internal/codeintel/stores/dbstore/worker.go
+++ b/enterprise/internal/codeintel/stores/dbstore/worker.go
@@ -10,9 +10,6 @@ import (
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
-// UploadHeartbeatInterval is the duration between heartbeat updates to the upload job records.
-const UploadHeartbeatInterval = time.Second
-
 // StalledUploadMaxAge is the maximum allowable duration between updating the state of an
 // upload as "processing" and locking the upload row during processing. An unlocked row that
 // is marked as processing likely indicates that the worker that dequeued the upload has died.
@@ -31,7 +28,6 @@ var uploadWorkerStoreOptions = dbworkerstore.Options{
 	ColumnExpressions: uploadColumnsWithNullRank,
 	Scan:              scanFirstUploadRecord,
 	OrderByExpression: sqlf.Sprintf("u.uploaded_at, u.id"),
-	HeartbeatInterval: UploadHeartbeatInterval,
 	StalledMaxAge:     StalledUploadMaxAge,
 	MaxNumResets:      UploadMaxNumResets,
 }
@@ -39,9 +35,6 @@ var uploadWorkerStoreOptions = dbworkerstore.Options{
 func WorkerutilUploadStore(s basestore.ShareableStore, observationContext *observation.Context) dbworkerstore.Store {
 	return dbworkerstore.NewWithMetrics(s.Handle(), uploadWorkerStoreOptions, observationContext)
 }
-
-// IndexHeartbeatInterval is the duration between heartbeat updates to the index job records.
-const IndexHeartbeatInterval = time.Second
 
 // StalledIndexMaxAge is the maximum allowable duration between updating the state of an
 // index as "processing" and locking the index row during processing. An unlocked row that
@@ -61,7 +54,6 @@ var indexWorkerStoreOptions = dbworkerstore.Options{
 	ColumnExpressions: indexColumnsWithNullRank,
 	Scan:              scanFirstIndexRecord,
 	OrderByExpression: sqlf.Sprintf("u.queued_at, u.id"),
-	HeartbeatInterval: IndexHeartbeatInterval,
 	StalledMaxAge:     StalledIndexMaxAge,
 	MaxNumResets:      IndexMaxNumResets,
 }
@@ -90,7 +82,6 @@ var dependencyIndexingJobWorkerStoreOptions = dbworkerstore.Options{
 	OrderByExpression: sqlf.Sprintf("j.queued_at, j.upload_id"),
 	StalledMaxAge:     StalledDependencyIndexingJobMaxAge,
 	MaxNumResets:      DependencyIndexingJobMaxNumResets,
-	HeartbeatInterval: 1 * time.Second,
 }
 
 func WorkerutilDependencyIndexingJobStore(s basestore.ShareableStore, observationContext *observation.Context) dbworkerstore.Store {

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -24,10 +24,11 @@ const (
 
 func newTriggerQueryRunner(ctx context.Context, s *cm.Store, metrics codeMonitorsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
-		Name:        "code_monitors_trigger_jobs_worker",
-		NumHandlers: 1,
-		Interval:    5 * time.Second,
-		Metrics:     metrics.workerMetrics,
+		Name:              "code_monitors_trigger_jobs_worker",
+		NumHandlers:       1,
+		Interval:          5 * time.Second,
+		HeartbeatInterval: 15 * time.Second,
+		Metrics:           metrics.workerMetrics,
 	}
 	worker := dbworker.NewWorker(ctx, createDBWorkerStoreForTriggerJobs(s), &queryRunner{s}, options)
 	return worker
@@ -78,10 +79,11 @@ func newTriggerJobsLogDeleter(ctx context.Context, store *cm.Store) goroutine.Ba
 
 func newActionRunner(ctx context.Context, s *cm.Store, metrics codeMonitorsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
-		Name:        "code_monitors_action_jobs_worker",
-		NumHandlers: 1,
-		Interval:    5 * time.Second,
-		Metrics:     metrics.workerMetrics,
+		Name:              "code_monitors_action_jobs_worker",
+		NumHandlers:       1,
+		Interval:          5 * time.Second,
+		HeartbeatInterval: 15 * time.Second,
+		Metrics:           metrics.workerMetrics,
 	}
 	worker := dbworker.NewWorker(ctx, createDBWorkerStoreForActionJobs(s), &actionRunner{s}, options)
 	return worker
@@ -108,7 +110,6 @@ func createDBWorkerStoreForTriggerJobs(s *cm.Store) dbworkerstore.Store {
 		TableName:         "cm_trigger_jobs",
 		ColumnExpressions: cm.TriggerJobsColumns,
 		Scan:              cm.ScanTriggerJobs,
-		HeartbeatInterval: 15 * time.Second,
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        10 * time.Second,
 		MaxNumRetries:     3,
@@ -122,7 +123,6 @@ func createDBWorkerStoreForActionJobs(s *cm.Store) dbworkerstore.Store {
 		TableName:         "cm_action_jobs",
 		ColumnExpressions: cm.ActionJobsColumns,
 		Scan:              cm.ScanActionJobs,
-		HeartbeatInterval: 15 * time.Second,
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        10 * time.Second,
 		MaxNumRetries:     3,

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -42,10 +42,11 @@ func NewWorker(ctx context.Context, workerBaseStore *basestore.Store, insightsSt
 	}
 
 	options := workerutil.WorkerOptions{
-		Name:        "insights_query_runner_worker",
-		NumHandlers: numHandlers,
-		Interval:    5 * time.Second,
-		Metrics:     metrics,
+		Name:              "insights_query_runner_worker",
+		NumHandlers:       numHandlers,
+		Interval:          5 * time.Second,
+		HeartbeatInterval: 15 * time.Second,
+		Metrics:           metrics,
 	}
 
 	defaultRateLimit := rate.Limit(2.0)
@@ -108,7 +109,6 @@ func createDBWorkerStore(s *basestore.Store) dbworkerstore.Store {
 		//
 		// If you change this, be sure to adjust the interval that work is enqueued in
 		// enterprise/internal/insights/background:newInsightEnqueuer.
-		HeartbeatInterval: 15 * time.Second,
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        10 * time.Second,
 		MaxNumRetries:     3,

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -68,17 +68,17 @@ func NewSyncWorker(ctx context.Context, db dbutil.DB, handler workerutil.Handler
 		Scan:              scanSingleJob,
 		OrderByExpression: sqlf.Sprintf("next_sync_at"),
 		ColumnExpressions: syncJobColumns,
-		HeartbeatInterval: 15 * time.Second,
 		StalledMaxAge:     30 * time.Second,
 		MaxNumResets:      5,
 		MaxNumRetries:     0,
 	})
 
 	worker := dbworker.NewWorker(ctx, store, handler, workerutil.WorkerOptions{
-		Name:        "repo_sync_worker",
-		NumHandlers: opts.NumHandlers,
-		Interval:    opts.WorkerInterval,
-		Metrics:     newWorkerMetrics(opts.PrometheusRegisterer),
+		Name:              "repo_sync_worker",
+		NumHandlers:       opts.NumHandlers,
+		Interval:          opts.WorkerInterval,
+		HeartbeatInterval: 15 * time.Second,
+		Metrics:           newWorkerMetrics(opts.PrometheusRegisterer),
 	})
 
 	resetter := dbworker.NewResetter(store, dbworker.ResetterOptions{

--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -148,22 +147,20 @@ func defaultTestStoreOptions(clock glock.Clock) Options {
 			sqlf.Sprintf("w.id"),
 			sqlf.Sprintf("w.state"),
 		},
-		HeartbeatInterval: time.Second,
-		StalledMaxAge:     time.Second * 5,
-		MaxNumResets:      5,
-		MaxNumRetries:     3,
-		clock:             clock,
+		StalledMaxAge: time.Second * 5,
+		MaxNumResets:  5,
+		MaxNumRetries: 3,
+		clock:         clock,
 	}
 }
 
-func assertDequeueRecordResult(t *testing.T, expectedID int, record interface{}, cancel context.CancelFunc, ok bool, err error) {
+func assertDequeueRecordResult(t *testing.T, expectedID int, record interface{}, ok bool, err error) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	if !ok {
 		t.Fatalf("expected a dequeueable record")
 	}
-	defer cancel()
 
 	if val := record.(TestRecord).ID; val != expectedID {
 		t.Errorf("unexpected id. want=%d have=%d", expectedID, val)
@@ -173,14 +170,13 @@ func assertDequeueRecordResult(t *testing.T, expectedID int, record interface{},
 	}
 }
 
-func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField int, record interface{}, cancel context.CancelFunc, ok bool, err error) {
+func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField int, record interface{}, ok bool, err error) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	if !ok {
 		t.Fatalf("expected a dequeueable record")
 	}
-	defer cancel()
 
 	if val := record.(TestRecordView).ID; val != expectedID {
 		t.Errorf("unexpected id. want=%d have=%d", expectedID, val)
@@ -193,14 +189,13 @@ func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField in
 	}
 }
 
-func assertDequeueRecordRetryResult(t *testing.T, expectedID, record interface{}, cancel context.CancelFunc, ok bool, err error) {
+func assertDequeueRecordRetryResult(t *testing.T, expectedID, record interface{}, ok bool, err error) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	if !ok {
 		t.Fatalf("expected a dequeueable record")
 	}
-	defer cancel()
 
 	if val := record.(TestRecordRetry).ID; val != expectedID {
 		t.Errorf("unexpected id. want=%d have=%d", expectedID, val)

--- a/internal/workerutil/dbworker/store/mocks/mock_store.go
+++ b/internal/workerutil/dbworker/store/mocks/mock_store.go
@@ -27,6 +27,9 @@ type MockStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *StoreHandleFunc
+	// HeartbeatFunc is an instance of a mock function object controlling
+	// the behavior of the method Heartbeat.
+	HeartbeatFunc *StoreHeartbeatFunc
 	// MarkCompleteFunc is an instance of a mock function object controlling
 	// the behavior of the method MarkComplete.
 	MarkCompleteFunc *StoreMarkCompleteFunc
@@ -57,12 +60,17 @@ func NewMockStore() *MockStore {
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc{
-			defaultHook: func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error) {
-				return nil, nil, false, nil
+			defaultHook: func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error) {
+				return nil, false, nil
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
 			defaultHook: func() *basestore.TransactableHandle {
+				return nil
+			},
+		},
+		HeartbeatFunc: &StoreHeartbeatFunc{
+			defaultHook: func(context.Context, int) error {
 				return nil
 			},
 		},
@@ -111,6 +119,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		HandleFunc: &StoreHandleFunc{
 			defaultHook: i.Handle,
+		},
+		HeartbeatFunc: &StoreHeartbeatFunc{
+			defaultHook: i.Heartbeat,
 		},
 		MarkCompleteFunc: &StoreMarkCompleteFunc{
 			defaultHook: i.MarkComplete,
@@ -245,23 +256,23 @@ func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
 // parent MockStore instance is invoked.
 type StoreDequeueFunc struct {
-	defaultHook func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error)
-	hooks       []func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error)
+	defaultHook func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error)
+	hooks       []func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error)
 	history     []StoreDequeueFuncCall
 	mutex       sync.Mutex
 }
 
 // Dequeue delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error) {
-	r0, r1, r2, r3 := m.DequeueFunc.nextHook()(v0, v1, v2)
-	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2, r3})
-	return r0, r1, r2, r3
+func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 []*sqlf.Query) (workerutil.Record, bool, error) {
+	r0, r1, r2 := m.DequeueFunc.nextHook()(v0, v1, v2)
+	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the Dequeue method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error)) {
+func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -269,7 +280,7 @@ func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, []*
 // Dequeue method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error)) {
+func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -277,21 +288,21 @@ func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, []*sqlf.Q
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *StoreDequeueFunc) SetDefaultReturn(r0 workerutil.Record, r1 context.CancelFunc, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error) {
-		return r0, r1, r2, r3
+func (f *StoreDequeueFunc) SetDefaultReturn(r0 workerutil.Record, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *StoreDequeueFunc) PushReturn(r0 workerutil.Record, r1 context.CancelFunc, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error) {
-		return r0, r1, r2, r3
+func (f *StoreDequeueFunc) PushReturn(r0 workerutil.Record, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *StoreDequeueFunc) nextHook() func(context.Context, string, []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error) {
+func (f *StoreDequeueFunc) nextHook() func(context.Context, string, []*sqlf.Query) (workerutil.Record, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -338,13 +349,10 @@ type StoreDequeueFuncCall struct {
 	Result0 workerutil.Record
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 context.CancelFunc
+	Result1 bool
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
-	Result2 bool
-	// Result3 is the value of the 4th result returned from this method
-	// invocation.
-	Result3 error
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -356,7 +364,7 @@ func (c StoreDequeueFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreHandleFunc describes the behavior when the Handle method of the
@@ -455,6 +463,111 @@ func (c StoreHandleFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreHandleFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// StoreHeartbeatFunc describes the behavior when the Heartbeat method of
+// the parent MockStore instance is invoked.
+type StoreHeartbeatFunc struct {
+	defaultHook func(context.Context, int) error
+	hooks       []func(context.Context, int) error
+	history     []StoreHeartbeatFuncCall
+	mutex       sync.Mutex
+}
+
+// Heartbeat delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockStore) Heartbeat(v0 context.Context, v1 int) error {
+	r0 := m.HeartbeatFunc.nextHook()(v0, v1)
+	m.HeartbeatFunc.appendCall(StoreHeartbeatFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Heartbeat method of
+// the parent MockStore instance is invoked and the hook queue is empty.
+func (f *StoreHeartbeatFunc) SetDefaultHook(hook func(context.Context, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Heartbeat method of the parent MockStore instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *StoreHeartbeatFunc) PushHook(hook func(context.Context, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreHeartbeatFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreHeartbeatFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+func (f *StoreHeartbeatFunc) nextHook() func(context.Context, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreHeartbeatFunc) appendCall(r0 StoreHeartbeatFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreHeartbeatFuncCall objects describing
+// the invocations of this function.
+func (f *StoreHeartbeatFunc) History() []StoreHeartbeatFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreHeartbeatFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreHeartbeatFuncCall is an object that describes an invocation of
+// method Heartbeat on an instance of MockStore.
+type StoreHeartbeatFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreHeartbeatFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreHeartbeatFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/derision-test/glock"
-	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
@@ -37,7 +36,9 @@ type Store interface {
 	// Most often, this will be when the handler moves the record into a terminal state.
 	//
 	// The supplied conditions may use the alias provided in `ViewName`, if one was supplied.
-	Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (workerutil.Record, context.CancelFunc, bool, error)
+	Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (workerutil.Record, bool, error)
+
+	Heartbeat(ctx context.Context, id int) error
 
 	// Requeue updates the state of the record with the given identifier to queued and adds a processing delay before
 	// the next dequeue of this record can be performed.
@@ -160,11 +161,6 @@ type Options struct {
 	// ColumnExpressions are the target columns provided to the query when selecting a job record. These
 	// expressions may use the alias provided in `ViewName`, if one was supplied.
 	ColumnExpressions []*sqlf.Query
-
-	// HeartbeatInterval is the interval between heartbeat updates to a job's last_heartbeat_at field. This
-	// field is periodically updated while being actively processed to signal to other workers that the
-	// record is neither pending nor abandoned.
-	HeartbeatInterval time.Duration
 
 	// StalledMaxAge is the maximum allowed duration between heartbeat updates of a job's last_heartbeat_at
 	// field. An unmodified row that is marked as processing likely indicates that the worker that dequeued
@@ -307,12 +303,12 @@ SELECT COUNT(*) FROM %s WHERE (
 // Most often, this will be when the handler moves the record into a terminal state.
 //
 // The supplied conditions may use the alias provided in `ViewName`, if one was supplied.
-func (s *store) Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (_ workerutil.Record, _ context.CancelFunc, _ bool, err error) {
+func (s *store) Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (_ workerutil.Record, _ bool, err error) {
 	ctx, traceLog, endObservation := s.operations.dequeue.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	if s.InTransaction() {
-		return nil, nil, false, ErrDequeueTransaction
+		return nil, false, ErrDequeueTransaction
 	}
 
 	now := s.now()
@@ -334,10 +330,10 @@ func (s *store) Dequeue(ctx context.Context, workerHostname string, conditions [
 		workerHostname,
 	)))
 	if err != nil {
-		return nil, nil, false, err
+		return nil, false, err
 	}
 	if !exists {
-		return nil, nil, false, nil
+		return nil, false, nil
 	}
 	traceLog(log.Int("id", id))
 
@@ -349,34 +345,13 @@ func (s *store) Dequeue(ctx context.Context, workerHostname string, conditions [
 		id,
 	)))
 	if err != nil {
-		return nil, nil, false, err
+		return nil, false, err
 	}
 	if !exists {
-		return nil, nil, false, nil
+		return nil, false, nil
 	}
 
-	// Create a background routine that periodically writes the current time to the record.
-	// This will keep a record claimed by an active worker for a small amount of time so that
-	// it will not be processed by a second worker concurrently.
-
-	heartbeatCtx, cancel := context.WithCancel(ctx)
-	go func() {
-		for {
-			select {
-			case <-heartbeatCtx.Done():
-				return
-			case <-s.options.clock.After(s.options.HeartbeatInterval):
-			}
-
-			if err = s.Exec(heartbeatCtx, s.formatQuery(updateCandidateQuery, quote(s.options.TableName), s.now(), record.RecordID())); err != nil {
-				if err != heartbeatCtx.Err() {
-					log15.Error("Failed to refresh last_heartbeat_at", "name", s.options.Name, "id", id, "error", err)
-				}
-			}
-		}
-	}()
-
-	return record, cancel, true, nil
+	return record, true, nil
 }
 
 const selectCandidateQuery = `
@@ -417,8 +392,18 @@ const selectRecordQuery = `
 SELECT %s FROM %s WHERE {id} = %s
 `
 
+func (s *store) Heartbeat(ctx context.Context, id int) error {
+	err := s.Exec(ctx, s.formatQuery(updateCandidateQuery, quote(s.options.TableName), s.now(), id))
+	if err != nil {
+		if err != ctx.Err() {
+			return err
+		}
+	}
+	return nil
+}
+
 const updateCandidateQuery = `
--- source: internal/workerutil/store.go:Dequeue
+-- source: internal/workerutil/store.go:Heartbeat
 UPDATE %s
 SET {last_heartbeat_at} = %s
 WHERE {id} = %s AND {state} = 'processing'

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -31,14 +31,10 @@ type Store interface {
 	// is such a record, it is returned. If there is no such unclaimed record, a nil record and and a nil cancel function
 	// will be returned along with a false-valued flag. This method must not be called from within a transaction.
 	//
-	// A background goroutine that continuously updates the record's last modified time will be started. The returned cancel
-	// function should be called once the record no longer needs to be locked from selection or reset by another process.
-	// Most often, this will be when the handler moves the record into a terminal state.
-	//
 	// The supplied conditions may use the alias provided in `ViewName`, if one was supplied.
 	Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (workerutil.Record, bool, error)
 
-	// Record a heartbeat, flagging that the record is still being worked on.
+	// Heartbeat marks the given record as currently being processed.
 	Heartbeat(ctx context.Context, id int) error
 
 	// Requeue updates the state of the record with the given identifier to queued and adds a processing delay before

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -38,6 +38,7 @@ type Store interface {
 	// The supplied conditions may use the alias provided in `ViewName`, if one was supplied.
 	Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (workerutil.Record, bool, error)
 
+	// Record a heartbeat, flagging that the record is still being worked on.
 	Heartbeat(ctx context.Context, id int) error
 
 	// Requeue updates the state of the record with the given identifier to queued and adds a processing delay before

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -810,7 +810,8 @@ func TestStoreHeartbeat(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	clock := glock.NewMockClock()
+	now := time.Unix(1587396557, 0).UTC()
+	clock := glock.NewMockClockAt(now)
 	store := testStore(db, defaultTestStoreOptions(clock))
 
 	if err := store.Heartbeat(context.Background(), 1); err != nil {
@@ -852,7 +853,6 @@ func TestStoreHeartbeat(t *testing.T) {
 		t.Fatalf("unexpected error updating heartbeat: %s", err)
 	}
 
-	// Expect null time to be stored.
-	now := clock.Now().UTC()
+	// Now expect time to be stored properly.
 	readAndCompareTime(&now)
 }

--- a/internal/workerutil/dbworker/store_shim.go
+++ b/internal/workerutil/dbworker/store_shim.go
@@ -37,10 +37,10 @@ func (s *storeShim) QueuedCount(ctx context.Context, extraArguments interface{})
 }
 
 // Dequeue calls into the inner store.
-func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (workerutil.Record, context.CancelFunc, bool, error) {
+func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (workerutil.Record, bool, error) {
 	conditions, err := convertArguments(extraArguments)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, false, err
 	}
 
 	return s.Store.Dequeue(ctx, workerHostname, conditions)

--- a/internal/workerutil/mock_store_test.go
+++ b/internal/workerutil/mock_store_test.go
@@ -17,6 +17,9 @@ type MockStore struct {
 	// DequeueFunc is an instance of a mock function object controlling the
 	// behavior of the method Dequeue.
 	DequeueFunc *StoreDequeueFunc
+	// HeartbeatFunc is an instance of a mock function object controlling
+	// the behavior of the method Heartbeat.
+	HeartbeatFunc *StoreHeartbeatFunc
 	// MarkCompleteFunc is an instance of a mock function object controlling
 	// the behavior of the method MarkComplete.
 	MarkCompleteFunc *StoreMarkCompleteFunc
@@ -41,8 +44,13 @@ func NewMockStore() *MockStore {
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc{
-			defaultHook: func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error) {
-				return nil, nil, false, nil
+			defaultHook: func(context.Context, string, interface{}) (Record, bool, error) {
+				return nil, false, nil
+			},
+		},
+		HeartbeatFunc: &StoreHeartbeatFunc{
+			defaultHook: func(context.Context, int) error {
+				return nil
 			},
 		},
 		MarkCompleteFunc: &StoreMarkCompleteFunc{
@@ -77,6 +85,9 @@ func NewMockStoreFrom(i Store) *MockStore {
 		},
 		DequeueFunc: &StoreDequeueFunc{
 			defaultHook: i.Dequeue,
+		},
+		HeartbeatFunc: &StoreHeartbeatFunc{
+			defaultHook: i.Heartbeat,
 		},
 		MarkCompleteFunc: &StoreMarkCompleteFunc{
 			defaultHook: i.MarkComplete,
@@ -205,23 +216,23 @@ func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
 // parent MockStore instance is invoked.
 type StoreDequeueFunc struct {
-	defaultHook func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error)
-	hooks       []func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error)
+	defaultHook func(context.Context, string, interface{}) (Record, bool, error)
+	hooks       []func(context.Context, string, interface{}) (Record, bool, error)
 	history     []StoreDequeueFuncCall
 	mutex       sync.Mutex
 }
 
 // Dequeue delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (Record, context.CancelFunc, bool, error) {
-	r0, r1, r2, r3 := m.DequeueFunc.nextHook()(v0, v1, v2)
-	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2, r3})
-	return r0, r1, r2, r3
+func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (Record, bool, error) {
+	r0, r1, r2 := m.DequeueFunc.nextHook()(v0, v1, v2)
+	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the Dequeue method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error)) {
+func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, interface{}) (Record, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -229,7 +240,7 @@ func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, int
 // Dequeue method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error)) {
+func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface{}) (Record, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -237,21 +248,21 @@ func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *StoreDequeueFunc) SetDefaultReturn(r0 Record, r1 context.CancelFunc, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error) {
-		return r0, r1, r2, r3
+func (f *StoreDequeueFunc) SetDefaultReturn(r0 Record, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, interface{}) (Record, bool, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *StoreDequeueFunc) PushReturn(r0 Record, r1 context.CancelFunc, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error) {
-		return r0, r1, r2, r3
+func (f *StoreDequeueFunc) PushReturn(r0 Record, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, string, interface{}) (Record, bool, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *StoreDequeueFunc) nextHook() func(context.Context, string, interface{}) (Record, context.CancelFunc, bool, error) {
+func (f *StoreDequeueFunc) nextHook() func(context.Context, string, interface{}) (Record, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -298,13 +309,10 @@ type StoreDequeueFuncCall struct {
 	Result0 Record
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 context.CancelFunc
+	Result1 bool
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
-	Result2 bool
-	// Result3 is the value of the 4th result returned from this method
-	// invocation.
-	Result3 error
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -316,7 +324,112 @@ func (c StoreDequeueFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreHeartbeatFunc describes the behavior when the Heartbeat method of
+// the parent MockStore instance is invoked.
+type StoreHeartbeatFunc struct {
+	defaultHook func(context.Context, int) error
+	hooks       []func(context.Context, int) error
+	history     []StoreHeartbeatFuncCall
+	mutex       sync.Mutex
+}
+
+// Heartbeat delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockStore) Heartbeat(v0 context.Context, v1 int) error {
+	r0 := m.HeartbeatFunc.nextHook()(v0, v1)
+	m.HeartbeatFunc.appendCall(StoreHeartbeatFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Heartbeat method of
+// the parent MockStore instance is invoked and the hook queue is empty.
+func (f *StoreHeartbeatFunc) SetDefaultHook(hook func(context.Context, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Heartbeat method of the parent MockStore instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *StoreHeartbeatFunc) PushHook(hook func(context.Context, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreHeartbeatFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreHeartbeatFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+func (f *StoreHeartbeatFunc) nextHook() func(context.Context, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreHeartbeatFunc) appendCall(r0 StoreHeartbeatFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreHeartbeatFuncCall objects describing
+// the invocations of this function.
+func (f *StoreHeartbeatFunc) History() []StoreHeartbeatFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreHeartbeatFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreHeartbeatFuncCall is an object that describes an invocation of
+// method Heartbeat on an instance of MockStore.
+type StoreHeartbeatFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreHeartbeatFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreHeartbeatFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // StoreMarkCompleteFunc describes the behavior when the MarkComplete method

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -22,7 +22,9 @@ type Store interface {
 	// flag indicating the existence of a processable record along with a cancel function that should be called once
 	// the record is finished being processed. This will release any resources used to lock the record from selection
 	// by another concurrent worker process.
-	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (Record, context.CancelFunc, bool, error)
+	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (Record, bool, error)
+
+	Heartbeat(ctx context.Context, id int) error
 
 	// AddExecutionLogEntry adds an executor log entry to the record.
 	AddExecutionLogEntry(ctx context.Context, id int, entry ExecutionLogEntry) error

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -24,6 +24,7 @@ type Store interface {
 	// by another concurrent worker process.
 	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (Record, bool, error)
 
+	// Record a heartbeat, flagging that the record is still being worked on.
 	Heartbeat(ctx context.Context, id int) error
 
 	// AddExecutionLogEntry adds an executor log entry to the record.

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -24,7 +24,7 @@ type Store interface {
 	// by another concurrent worker process.
 	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (Record, bool, error)
 
-	// Record a heartbeat, flagging that the record is still being worked on.
+	// Heartbeat marks the given record as currently being processed.
 	Heartbeat(ctx context.Context, id int) error
 
 	// AddExecutionLogEntry adds an executor log entry to the record.

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -19,12 +19,10 @@ type Store interface {
 
 	// Dequeue selects a record for processing. Any extra arguments supplied will be used in accordance with the
 	// concrete persistence layer (e.g. additional SQL conditions for a database layer). This method returns a boolean
-	// flag indicating the existence of a processable record along with a cancel function that should be called once
-	// the record is finished being processed. This will release any resources used to lock the record from selection
-	// by another concurrent worker process.
+	// flag indicating the existence of a processable record.
 	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (Record, bool, error)
 
-	// Heartbeat marks the given record as currently being processed.
+	// Heartbeat marks the given record as currently being processed.:2
 	Heartbeat(ctx context.Context, id int) error
 
 	// AddExecutionLogEntry adds an executor log entry to the record.


### PR DESCRIPTION
Before, the executor queue would keep the heartbeat up to date, but we actually want to know if the executor is still alive. This also gets rid of in-memory state for the cancel function, which brings us a step closer to removing the executor-queue singleton. 