### PR TITLE
search: Add metrics to search reference

### DIFF
--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -602,12 +602,12 @@ const SearchReference = (props: SearchReferenceProps): ReactElement => {
     const hasFilter = filter.length === 0
 
     const selectedFilters = useMemo(() => {
-        if (filter.length === 0) {
+        if (hasFilter) {
             return searchReferenceInfo
         }
         const searchTerms = parseSearchInput(filter)
         return searchReferenceInfo.filter(info => matches(searchTerms, info))
-    }, [filter])
+    }, [filter, hasFilter])
 
     const updateQuery = useCallback(
         (searchReference: SearchReferenceInfo, negate: boolean) => {
@@ -617,7 +617,7 @@ const SearchReference = (props: SearchReferenceProps): ReactElement => {
     )
     const updateQueryWithExample = useCallback(
         (example: string) => {
-            telemetryService.log(hasFilter ? 'SearchReferenceSearchedAndClicked' : 'SearchReferenceFilterClicked')
+            telemetryService.log(hasFilter ? 'SearchReferenceClickedWithSearch' : 'SearchReferenceClickedWithoutSearch')
             onNavbarQueryChange({ query: navbarSearchQueryState.query.trimEnd() + ' ' + example })
         },
         [onNavbarQueryChange, navbarSearchQueryState, hasFilter, telemetryService]

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -617,7 +617,7 @@ const SearchReference = (props: SearchReferenceProps): ReactElement => {
     )
     const updateQueryWithExample = useCallback(
         (example: string) => {
-            telemetryService.log(hasFilter ? 'SearchReferenceClickedWithSearch' : 'SearchReferenceClickedWithoutSearch')
+            telemetryService.log(hasFilter ? 'SearchReferenceSearchedAndClicked' : 'SearchReferenceFilterClicked')
             onNavbarQueryChange({ query: navbarSearchQueryState.query.trimEnd() + ' ' + example })
         },
         [onNavbarQueryChange, navbarSearchQueryState, hasFilter, telemetryService]

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -15,6 +15,7 @@ import { parseSearchQuery } from '@sourcegraph/shared/src/search/query/parser'
 import { appendFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/validate'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
@@ -585,6 +586,7 @@ export interface SearchReferenceProps
     extends Omit<PatternTypeProps, 'setPatternType'>,
         Omit<CaseSensitivityProps, 'setCaseSensitivity'>,
         VersionContextProps,
+        TelemetryProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'> {
     query: string
     filter: string
@@ -596,15 +598,17 @@ export interface SearchReferenceProps
 const SearchReference = (props: SearchReferenceProps): ReactElement => {
     const [selectedTab, setSelectedTab] = useLocalStorage(SEARCH_REFERENCE_TAB_KEY, 0)
 
+    const { onNavbarQueryChange, navbarSearchQueryState, filter, telemetryService } = props
+    const hasFilter = filter.length === 0
+
     const selectedFilters = useMemo(() => {
-        if (props.filter === '') {
+        if (filter.length === 0) {
             return searchReferenceInfo
         }
-        const searchTerms = parseSearchInput(props.filter)
+        const searchTerms = parseSearchInput(filter)
         return searchReferenceInfo.filter(info => matches(searchTerms, info))
-    }, [props.filter])
+    }, [filter])
 
-    const { onNavbarQueryChange, navbarSearchQueryState } = props
     const updateQuery = useCallback(
         (searchReference: SearchReferenceInfo, negate: boolean) => {
             onNavbarQueryChange(updateQueryWithFilter(navbarSearchQueryState, searchReference, negate, FILTERS))
@@ -613,9 +617,10 @@ const SearchReference = (props: SearchReferenceProps): ReactElement => {
     )
     const updateQueryWithExample = useCallback(
         (example: string) => {
+            telemetryService.log(hasFilter ? 'SearchReferenceSearchedAndClicked' : 'SearchReferenceFilterClicked')
             onNavbarQueryChange({ query: navbarSearchQueryState.query.trimEnd() + ' ' + example })
         },
-        [onNavbarQueryChange, navbarSearchQueryState]
+        [onNavbarQueryChange, navbarSearchQueryState, hasFilter, telemetryService]
     )
 
     const filterList = (

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -95,6 +95,13 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         },
         [setOpenSections]
     )
+    const onSearchReferenceToggle = useCallback(
+        open => {
+            persistToggleState(SectionID.SEARCH_REFERENCE, open)
+            props.telemetryService.log(open ? 'SearchReferenceOpened' : 'SearchReferenceClosed')
+        },
+        [persistToggleState, props.telemetryService]
+    )
 
     return (
         <div className={classNames(styles.searchSidebar, props.className)}>
@@ -105,7 +112,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                         header="Search reference"
                         showSearch={true}
                         open={openSections[SectionID.SEARCH_REFERENCE] ?? true}
-                        onToggle={open => persistToggleState(SectionID.SEARCH_REFERENCE, open)}
+                        onToggle={onSearchReferenceToggle}
                     >
                         {getSearchReferenceFactory(props)}
                     </SearchSidebarSection>


### PR DESCRIPTION
(Depends on #22917)

This adds the following metrics to search references:

- SearchReferenceOpened
- SearchReferenceClosed
- SearchReferenceFilterClicked
- SearchReferenceSearchedAndClicked

I didn't find much information on metrics but from looking around the code, it looks like this is the way to collect them?

See https://www.figma.com/file/as1QusTZKQlUakfC90ANwb/Search-reference-panel?node-id=199%3A645 for more info.