### PR TITLE
extensibility: add alert for return of Firefox addon 

### DIFF
--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -999,6 +999,13 @@ describe('Blob viewer', () => {
                     response.type('application/javascript; charset=utf-8').send(extensionBundleString)
                 })
 
+            // TEMPORARY: Mock `Date.now` to prevent temporary Firefox from rendering.
+            await driver.page.evaluateOnNewDocument(() => {
+                // Number of ms between Unix epoch and July 1, 2020 (outside of Firefox campaign range)
+                const mockMs = new Date('July 1, 2020 00:00:00 UTC').getTime()
+                Date.now = () => mockMs
+            })
+
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/test.ts`)
 
             // Click on "log" in "console.log()" in line 2

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -129,6 +129,7 @@ interface RepoContainerProps
 
 export const HOVER_COUNT_KEY = 'hover-count'
 const HAS_DISMISSED_ALERT_KEY = 'has-dismissed-extension-alert'
+const HAS_DISMISSED_FIREFOX_ALERT_KEY = 'has-dismissed-firefox-addon-alert'
 
 export const HOVER_THRESHOLD = 5
 
@@ -357,10 +358,18 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         setHasDismissedPopover(true)
     }, [])
 
+    const [hasDismissedFirefoxAlert, setHasDismissedFirefoxAlert] = useLocalStorage(
+        HAS_DISMISSED_FIREFOX_ALERT_KEY,
+        false
+    )
+    const showFirefoxAddonAlert = !hasDismissedFirefoxAlert
+
     const onAlertDismissed = useCallback(() => {
         onExtensionAlertDismissed()
         setHasDismissedExtensionAlert(true)
-    }, [onExtensionAlertDismissed, setHasDismissedExtensionAlert])
+        // TEMPORARY
+        setHasDismissedFirefoxAlert(true)
+    }, [onExtensionAlertDismissed, setHasDismissedExtensionAlert, setHasDismissedFirefoxAlert])
 
     if (!repoOrError) {
         // Render nothing while loading
@@ -405,12 +414,13 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                         }
                     />
                 )}
-            {showExtensionAlert && (
+            {(showExtensionAlert || showFirefoxAddonAlert) && (
                 <InstallBrowserExtensionAlert
                     isChrome={IS_CHROME}
                     onAlertDismissed={onAlertDismissed}
                     externalURLs={repoOrError.externalURLs}
                     codeHostIntegrationMessaging={codeHostIntegrationMessaging}
+                    showFirefoxAddonAlert={showFirefoxAddonAlert}
                 />
             )}
             <RepoHeader

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -51,7 +51,7 @@ import { RouteDescriptor } from '../util/contributions'
 import { parseBrowserRepoURL } from '../util/url'
 
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
-import { InstallBrowserExtensionAlert } from './actions/InstallBrowserExtensionAlert'
+import { InstallBrowserExtensionAlert, isFirefoxCampaignActive } from './actions/InstallBrowserExtensionAlert'
 import { fetchFileExternalLinks, fetchRepository, resolveRevision } from './backend'
 import { RepoHeader, RepoHeaderActionButton, RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
@@ -362,7 +362,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         HAS_DISMISSED_FIREFOX_ALERT_KEY,
         false
     )
-    const showFirefoxAddonAlert = !hasDismissedFirefoxAlert
+    const showFirefoxAddonAlert = !hasDismissedFirefoxAlert && isFirefoxCampaignActive(Date.now())
 
     const onAlertDismissed = useCallback(() => {
         onExtensionAlertDismissed()

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.scss
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.scss
@@ -1,57 +1,11 @@
 .install-browser-extension-alert {
-    &__text {
-        max-width: 42rem;
-        // stylelint-disable-next-line declaration-property-unit-whitelist
-        margin-left: calc(0.75rem - 2px);
-
-        .theme-redesign & {
-            margin-left: 0;
-        }
-    }
-
     &__icon {
         height: 1.5rem;
         width: 1.5rem;
     }
 
-    &__icon-flash {
-        position: absolute;
-        animation: 3.2s pulsate ease-in-out infinite;
-        top: 0;
-        left: 0;
-        opacity: 0;
-        height: 1.5rem;
-        width: 1.5rem;
-        border-radius: 50%;
-        background: rgba(56, 117, 127, 0.2);
-        filter: blur(1px);
-    }
-
     &__close-icon {
         height: 1.5rem;
         width: 1.5rem;
-    }
-}
-
-@keyframes pulsate {
-    0% {
-        transform: scale(1, 1);
-        opacity: 0;
-    }
-    25% {
-        transform: scale(1.2, 1.2);
-        opacity: 1;
-    }
-    50% {
-        transform: scale(1.2, 1.2);
-        opacity: 1;
-    }
-    75% {
-        transform: scale(1, 1);
-        opacity: 0;
-    }
-    100% {
-        transform: scale(1, 1);
-        opacity: 0;
     }
 }

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -11,7 +11,7 @@ interface Props {
     externalURLs: ExternalLinkFields[]
     isChrome: boolean
     codeHostIntegrationMessaging: 'browser-extension' | 'native-integration'
-    showFirefoxAddonAlert: boolean
+    showFirefoxAddonAlert?: boolean
 }
 
 // TODO(tj): Add Firefox once the Firefox extension is back

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -131,8 +131,15 @@ interface FirefoxAlertProps {
     displayName: string
 }
 
+const FIREFOX_ALERT_START_DATE = new Date('July 16, 2021')
+export const FIREFOX_ALERT_FINAL_DATE = new Date('October 18, 2021')
+
+export function isFirefoxCampaignActive(currentMs: number): boolean {
+    return currentMs < FIREFOX_ALERT_FINAL_DATE.getTime() && currentMs > FIREFOX_ALERT_START_DATE.getTime()
+}
+
 export const FirefoxAddonAlert: React.FunctionComponent<FirefoxAlertProps> = ({ onAlertDismissed, displayName }) => (
-    <div className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert">
+    <div className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert percy-hide">
         <div>
             <p className="font-weight-medium my-0 mr-3">
                 Sourcegraph is back at{' '}

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -150,7 +150,7 @@ export const FirefoxAddonAlert: React.FunctionComponent<FirefoxAlertProps> = ({ 
             <p className="mt-1 mb-0">
                 If you already have the local version,{' '}
                 <a
-                    href="https://docs.sourcegraph.com/integration/browser_extension"
+                    href="https://docs.sourcegraph.com/integration/migrating_firefox_extension"
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={onInstallLinkClick}

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -2,6 +2,7 @@ import CloseIcon from 'mdi-react/CloseIcon'
 import React from 'react'
 
 import { ExternalLinkFields, ExternalServiceKind } from '../../graphql-operations'
+import { eventLogger } from '../../tracking/eventLogger'
 
 import { serviceKindDisplayNameAndIcon } from './GoToCodeHostAction'
 
@@ -10,6 +11,7 @@ interface Props {
     externalURLs: ExternalLinkFields[]
     isChrome: boolean
     codeHostIntegrationMessaging: 'browser-extension' | 'native-integration'
+    showFirefoxAddonAlert: boolean
 }
 
 // TODO(tj): Add Firefox once the Firefox extension is back
@@ -28,6 +30,7 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
     externalURLs,
     isChrome,
     codeHostIntegrationMessaging,
+    showFirefoxAddonAlert,
 }) => {
     const externalLink = externalURLs.find(link => link.serviceKind && supportedServiceTypes.has(link.serviceKind))
     if (!externalLink) {
@@ -36,6 +39,10 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
 
     const { serviceKind } = externalLink
     const { displayName } = serviceKindDisplayNameAndIcon(serviceKind)
+
+    if (showFirefoxAddonAlert) {
+        return <FirefoxAddonAlert onAlertDismissed={onAlertDismissed} displayName={displayName} />
+    }
 
     return (
         <div className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert">
@@ -117,4 +124,53 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
             </button>
         </div>
     )
+}
+
+interface FirefoxAlertProps {
+    onAlertDismissed: () => void
+    displayName: string
+}
+
+export const FirefoxAddonAlert: React.FunctionComponent<FirefoxAlertProps> = ({ onAlertDismissed, displayName }) => (
+    <div className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert">
+        <div>
+            <p className="font-weight-medium my-0 mr-3">
+                Sourcegraph is back at{' '}
+                <a
+                    href="https://addons.mozilla.org/en-US/firefox/addon/sourcegraph-for-firefox"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="alert-link"
+                    onClick={onInstallLinkClick}
+                >
+                    Firefox Add-ons
+                </a>{' '}
+                🎉️
+            </p>
+            <p className="mt-1 mb-0">
+                If you already have the local version,{' '}
+                <a
+                    href="https://docs.sourcegraph.com/integration/browser_extension"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={onInstallLinkClick}
+                >
+                    make sure to upgrade
+                </a>
+                . The extension adds code intelligence to code views on {displayName} or any other connected code host.
+            </p>
+        </div>
+        <button
+            type="button"
+            onClick={onAlertDismissed}
+            aria-label="Close alert"
+            className="btn btn-icon test-close-alert"
+        >
+            <CloseIcon className="icon-inline" />
+        </button>
+    </div>
+)
+
+const onInstallLinkClick = (): void => {
+    eventLogger.log('FirefoxAlertInstallClicked')
 }


### PR DESCRIPTION
Closes #14233. 

Identical to #22126, which we merged with Percy errors.