### PR TITLE
Code Insights: Turn off the homepage insight by default 

### DIFF
--- a/client/web/src/search/input/SearchPage.tsx
+++ b/client/web/src/search/input/SearchPage.tsx
@@ -79,7 +79,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
     const showCodeInsights =
         !isErrorLike(props.settingsCascade.final) &&
         !!props.settingsCascade.final?.experimentalFeatures?.codeInsights &&
-        props.settingsCascade.final['insights.displayLocation.homepage'] !== false
+        props.settingsCascade.final['insights.displayLocation.homepage'] === true
 
     const { getCombinedViews } = useContext(InsightsApiContext)
     const views = useObservable(


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22985

This PR turns off homepage insights by default. 