### PR TITLE
search/backend: add config to limit reorder buffer size.

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1181,6 +1181,8 @@ type QuickLink struct {
 
 // Ranking description: Experimental search result ranking options.
 type Ranking struct {
+	// MaxReorderQueueSize description: The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 0. Set this to small integers to limit latency increases from slow backends.
+	MaxReorderQueueSize int `json:"maxReorderQueueSize,omitempty"`
 	// RepoScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.
 	RepoScores map[string]float64 `json:"repoScores,omitempty"`
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -265,6 +265,12 @@
               "additionalProperties": {
                 "type": "number"
               }
+            },
+            "maxReorderQueueSize": {
+              "description": "The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 0. Set this to small integers to limit latency increases from slow backends.",
+              "default": 0,
+              "type": "integer",
+              "group": "Search"
             }
           }
         }


### PR DESCRIPTION
At the default of 0, it performs no reordering. This lets us prevent
blocking until the slowest backend has its first result.

