### PR TITLE
Remove search-reference feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The repository page now has a new button to view batch change changesets created in that specific repository, with a badge indicating how many changesets are currently open. [#22804](https://github.com/sourcegraph/sourcegraph/pull/22804)
 - Experimental: Search-based code insights can run over all repositories on the instance. To enable, use the feature flag `"experimentalFeatures": { "codeInsightsAllRepos": true }`. [#22759](https://github.com/sourcegraph/sourcegraph/issues/22759)
 - Experimental: Search-based code insights can run over all repositories on the instance. To enable, use the feature flag `"experimentalFeatures": { "codeInsightsAllRepos": true }` and tick the checkbox in the insight creation/edit UI. [#22759](https://github.com/sourcegraph/sourcegraph/issues/22759)
+- Search References is a new search sidebar section to simplify learning about the available search filters directly where they are used. [#21539](https://github.com/sourcegraph/sourcegraph/issues/21539)
 
 ### Changed
 

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -6,7 +6,7 @@ import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { requestGraphQL } from '../backend/graphql'
 import { FetchFeatureFlagsResult } from '../graphql-operations'
 
-export type FeatureFlagName = 'w0-signup-optimisation' | 'w1-signup-optimisation' | 'search-reference'
+export type FeatureFlagName = 'w0-signup-optimisation' | 'w1-signup-optimisation'
 
 export type FlagSet = Map<FeatureFlagName, boolean>
 

--- a/client/web/src/search/input/SearchBox.module.scss
+++ b/client/web/src/search/input/SearchBox.module.scss
@@ -8,8 +8,6 @@
     min-width: 12rem;
 
     :global(.theme-redesign) & {
-        box-shadow: var(--search-input-shadow);
-
         @media (--xs-breakpoint-down) {
             background-color: var(--color-bg-1);
             border: 1px solid var(--input-border-color);
@@ -17,6 +15,10 @@
             display: inline;
             padding: 0.5rem;
         }
+    }
+
+    :global(.theme-redesign) &__shadow {
+        box-shadow: var(--search-input-shadow);
     }
 
     &__background-container {

--- a/client/web/src/search/input/SearchBox.module.scss
+++ b/client/web/src/search/input/SearchBox.module.scss
@@ -17,7 +17,7 @@
         }
     }
 
-    :global(.theme-redesign) &__shadow {
+    &__shadow {
         box-shadow: var(--search-input-shadow);
     }
 

--- a/client/web/src/search/input/SearchBox.story.tsx
+++ b/client/web/src/search/input/SearchBox.story.tsx
@@ -52,7 +52,6 @@ const defaultProps: SearchBoxProps = {
     authenticatedUser: null,
     hasUserAddedExternalServices: false,
     getUserSearchContextNamespaces: mockGetUserSearchContextNamespaces,
-    featureFlags: new Map(),
 }
 
 add(

--- a/client/web/src/search/input/SearchBox.tsx
+++ b/client/web/src/search/input/SearchBox.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
@@ -47,13 +48,16 @@ export interface SearchBoxProps
 
     /** Don't show the version contexts dropdown. */
     hideVersionContexts?: boolean
+
+    /** Don't show search help button */
+    hideHelpButton?: boolean
 }
 
 export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
     const { queryState } = props
 
     return (
-        <div className={styles.searchBox}>
+        <div className={classNames(styles.searchBox, props.hideHelpButton ? styles.searchBoxShadow : null)}>
             {!props.hideVersionContexts && (
                 <VersionContextDropdown
                     history={props.history}
@@ -84,7 +88,7 @@ export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
                     <Toggles {...props} navbarSearchQuery={queryState.query} className={styles.searchBoxToggles} />
                 </div>
             </div>
-            <SearchButton noHelp={true} className={styles.searchBoxButton} />
+            <SearchButton hideHelpButton={props.hideHelpButton} className={styles.searchBoxButton} />
         </div>
     )
 }

--- a/client/web/src/search/input/SearchBox.tsx
+++ b/client/web/src/search/input/SearchBox.tsx
@@ -7,7 +7,6 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { SearchContextInputProps } from '..'
 import { AuthenticatedUser } from '../../auth'
-import { FeatureFlagProps } from '../../featureFlags/featureFlags'
 import { VersionContextDropdown } from '../../nav/VersionContextDropdown'
 import { VersionContext } from '../../schema/site.schema'
 import { QueryState, submitSearch } from '../helpers'
@@ -20,7 +19,6 @@ import { Toggles, TogglesProps } from './toggles/Toggles'
 
 export interface SearchBoxProps
     extends Omit<TogglesProps, 'navbarSearchQuery'>,
-        FeatureFlagProps,
         ThemeProps,
         SearchContextInputProps,
         TelemetryProps,
@@ -52,7 +50,7 @@ export interface SearchBoxProps
 }
 
 export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
-    const { queryState, featureFlags } = props
+    const { queryState } = props
 
     return (
         <div className={styles.searchBox}>
@@ -86,7 +84,7 @@ export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
                     <Toggles {...props} navbarSearchQuery={queryState.query} className={styles.searchBoxToggles} />
                 </div>
             </div>
-            <SearchButton noHelp={featureFlags.get('search-reference')} className={styles.searchBoxButton} />
+            <SearchButton noHelp={true} className={styles.searchBoxButton} />
         </div>
     )
 }

--- a/client/web/src/search/input/SearchButton.tsx
+++ b/client/web/src/search/input/SearchButton.tsx
@@ -5,7 +5,7 @@ import { SearchHelpDropdownButton } from './SearchHelpDropdownButton'
 
 interface Props {
     /** Hide the "help" icon and dropdown. */
-    noHelp?: boolean
+    hideHelpButton?: boolean
     className?: string
 }
 
@@ -13,11 +13,11 @@ interface Props {
  * A search button with a dropdown with related links. It must be wrapped in a form whose onSubmit
  * handler performs the search.
  */
-export const SearchButton: React.FunctionComponent<Props> = ({ noHelp, className }) => (
+export const SearchButton: React.FunctionComponent<Props> = ({ hideHelpButton, className }) => (
     <div className={className}>
         <button className="btn btn-primary search-button__btn test-search-button" type="submit" aria-label="Search">
             <SearchIcon className="icon-inline" aria-hidden="true" />
         </button>
-        {!noHelp && <SearchHelpDropdownButton />}
+        {!hideHelpButton && <SearchHelpDropdownButton />}
     </div>
 )

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -8,7 +8,13 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { PatternTypeProps, CaseSensitivityProps, OnboardingTourProps, SearchContextInputProps } from '..'
+import {
+    PatternTypeProps,
+    CaseSensitivityProps,
+    OnboardingTourProps,
+    SearchContextInputProps,
+    parseSearchURLQuery,
+} from '..'
 import { AuthenticatedUser } from '../../auth'
 import { FeatureFlagProps } from '../../featureFlags/featureFlags'
 import { VersionContext } from '../../schema/site.schema'
@@ -44,6 +50,9 @@ interface Props
  */
 export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) => {
     const autoFocus = props.isSearchAutoFocusRequired ?? true
+    // This uses the same logic as in Layout.tsx until we have a better solution
+    // or remove the search help button
+    const isSearchPage = props.location.pathname === '/search' && Boolean(parseSearchURLQuery(props.location.search))
 
     const onSubmit = useCallback(
         (event?: React.FormEvent): void => {
@@ -66,6 +75,7 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
                 autoFocus={autoFocus}
                 showSearchContextFeatureTour={true}
                 isSearchOnboardingTourVisible={false}
+                hideHelpButton={isSearchPage}
             />
         </Form>
     )

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -611,7 +611,7 @@ const SearchReference = (props: SearchReferenceProps): ReactElement => {
     const hasFilter = filter.length === 0
 
     const selectedFilters = useMemo(() => {
-        if (hasFilter) {
+        if (!hasFilter) {
             return searchReferenceInfo
         }
         const searchTerms = parseSearchInput(filter)

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -19,7 +19,6 @@ import { getQuickLinks } from './QuickLink'
 import { getSearchReferenceFactory } from './SearchReference'
 import styles from './SearchSidebar.module.scss'
 import { SearchSidebarSection } from './SearchSidebarSection'
-import { getSearchTypeLinks } from './SearchTypeLink'
 
 const SEARCH_SIDEBAR_VISIBILITY_KEY = 'SearchProduct.SearchSidebar.Visibility'
 
@@ -106,27 +105,15 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     return (
         <div className={classNames(styles.searchSidebar, props.className)}>
             <StickyBox className={styles.searchSidebarStickyBox}>
-                {props.featureFlags.get('search-reference') && (
-                    <SearchSidebarSection
-                        className={styles.searchSidebarItem}
-                        header="Search reference"
-                        showSearch={true}
-                        open={openSections[SectionID.SEARCH_REFERENCE] ?? true}
-                        onToggle={onSearchReferenceToggle}
-                    >
-                        {getSearchReferenceFactory(props)}
-                    </SearchSidebarSection>
-                )}
-                {!props.featureFlags.get('search-reference') && (
-                    <SearchSidebarSection
-                        className={styles.searchSidebarItem}
-                        header="Search types"
-                        open={openSections[SectionID.SEARCH_TYPES] ?? true}
-                        onToggle={open => persistToggleState(SectionID.SEARCH_TYPES, open)}
-                    >
-                        {getSearchTypeLinks(props)}
-                    </SearchSidebarSection>
-                )}
+                <SearchSidebarSection
+                    className={styles.searchSidebarItem}
+                    header="Search reference"
+                    showSearch={true}
+                    open={openSections[SectionID.SEARCH_REFERENCE] ?? true}
+                    onToggle={onSearchReferenceToggle}
+                >
+                    {getSearchReferenceFactory(props)}
+                </SearchSidebarSection>
                 <SearchSidebarSection
                     className={styles.searchSidebarItem}
                     header="Dynamic filters"


### PR DESCRIPTION
This commit removes all relevant references to the feature flag to roll it out to all users.

Some more cleanup might be required to remove references to `FeatureFlagProps` that have been introduced just for this flag.