### PR TITLE
add EventPathMatch to streaming API

### DIFF
--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -4,7 +4,14 @@ import React, { useEffect, useState } from 'react'
 import { Observable } from 'rxjs'
 import { AggregableBadge, Badge } from 'sourcegraph'
 
-import { FileLineMatch, FileSymbolMatch, getFileMatchUrl, getRepositoryUrl, getRevision } from '../search/stream'
+import {
+    FileLineMatch,
+    FileSymbolMatch,
+    FilePathMatch,
+    getFileMatchUrl,
+    getRepositoryUrl,
+    getRevision,
+} from '../search/stream'
 import { SettingsCascadeProps } from '../settings/settings'
 import { pluralize } from '../util/strings'
 import { useRedesignToggle } from '../util/useRedesignToggle'
@@ -37,7 +44,7 @@ interface Props extends SettingsCascadeProps {
     /**
      * The file match search result.
      */
-    result: FileLineMatch | FileSymbolMatch
+    result: FileLineMatch | FileSymbolMatch | FilePathMatch
 
     /**
      * Formatted repository name to be displayed in repository link. If not

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { IHighlightLineRange } from '../graphql/schema'
-import { FileLineMatch, FileSymbolMatch, getFileMatchUrl } from '../search/stream'
+import { FileLineMatch, FileSymbolMatch, FilePathMatch, getFileMatchUrl } from '../search/stream'
 import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
 import { SymbolIcon } from '../symbols/SymbolIcon'
 import { ThemeProps } from '../theme'
@@ -29,7 +29,7 @@ interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
     location: H.Location
     eventLogger?: EventLogger
     items: MatchItem[]
-    result: FileLineMatch | FileSymbolMatch
+    result: FileLineMatch | FileSymbolMatch | FilePathMatch
     /* Called when the first result has fully loaded. */
     onFirstResultLoad?: () => void
     /**
@@ -137,13 +137,10 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         )
     }
 
-    const noMatches =
-        grouped.length === 0 && (result.type !== 'symbol' || !result.symbols || result.symbols.length === 0)
-
     return (
         <div className="file-match-children">
-            {/* No symbols or line matches means that this is a path match */}
-            {noMatches && (
+            {/* Path */}
+            {result.type === 'path' && (
                 <div className="file-match-children__item">
                     <small>Path match</small>
                 </div>

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -17,7 +17,16 @@ export type SearchEvent =
     | { type: 'error'; data: ErrorLike }
     | { type: 'done'; data: {} }
 
-export type SearchMatch = FileLineMatch | RepositoryMatch | CommitMatch | FileSymbolMatch
+export type SearchMatch = FileLineMatch | RepositoryMatch | CommitMatch | FileSymbolMatch | FilePathMatch
+
+export interface FilePathMatch {
+    type: 'path'
+    name: string
+    repository: string
+    repoStars?: number
+    branches?: string[]
+    version?: string
+}
 
 export interface FileLineMatch {
     type: 'file'
@@ -431,7 +440,7 @@ export function getRevision(branches?: string[], version?: string): string {
     return revision
 }
 
-export function getFileMatchUrl(fileMatch: FileLineMatch | FileSymbolMatch): string {
+export function getFileMatchUrl(fileMatch: FileLineMatch | FileSymbolMatch | FilePathMatch): string {
     const revision = getRevision(fileMatch.branches, fileMatch.version)
     return `/${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${fileMatch.name}`
 }
@@ -449,6 +458,7 @@ export function getRepoMatchUrl(repoMatch: RepositoryMatch): string {
 
 export function getMatchUrl(match: SearchMatch): string {
     switch (match.type) {
+        case 'path':
         case 'file':
         case 'symbol':
             return getFileMatchUrl(match)

--- a/client/web/src/integration/streaming-search-mocks.ts
+++ b/client/web/src/integration/streaming-search-mocks.ts
@@ -79,12 +79,11 @@ export const mixedSearchStreamEvents: SearchEvent[] = [
         data: [
             { type: 'repo', repository: 'gitlab.sgdev.org/lg-test-private/lg-test' },
             {
-                type: 'file',
+                type: 'path',
                 name: 'overridable/bool_or_string_test.go',
                 repository: 'gitlab.sgdev.org/aharvey/batch-change-utils',
                 branches: [''],
                 version: '206c057cc03eea48300a4bd33f4dc4222d242114',
-                lineMatches: [],
             },
             {
                 type: 'file',

--- a/client/web/src/search/results/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/StreamingSearchResultsList.tsx
@@ -15,6 +15,7 @@ import {
     AggregateStreamingSearchResults,
     FileLineMatch,
     FileSymbolMatch,
+    FilePathMatch,
     SearchMatch,
     getMatchUrl,
 } from '@sourcegraph/shared/src/search/stream'
@@ -73,6 +74,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
         (result: SearchMatch): JSX.Element => {
             switch (result.type) {
                 case 'file':
+                case 'path':
                 case 'symbol':
                     return (
                         <FileMatch
@@ -130,7 +132,9 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     )
 }
 
-function getFileMatchIcon(result: FileLineMatch | FileSymbolMatch): React.ComponentType<{ className?: string }> {
+function getFileMatchIcon(
+    result: FileLineMatch | FileSymbolMatch | FilePathMatch
+): React.ComponentType<{ className?: string }> {
     if (result.type === 'file' && result.lineMatches && result.lineMatches.length > 0) {
         return FileDocumentIcon
     }

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -564,6 +564,15 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 					}
 					results.Results = append(results.Results, &r)
 
+				case *streamhttp.EventPathMatch:
+					var r SearchFileResult
+					r.File.Name = v.Path
+					r.Repository.Name = v.Repository
+					if len(v.Branches) > 0 {
+						r.RevSpec.Expr = v.Branches[0]
+					}
+					results.Results = append(results.Results, &r)
+
 				case *streamhttp.EventSymbolMatch:
 					var r SearchFileResult
 					r.File.Name = v.Path
@@ -618,6 +627,12 @@ func (s *SearchStreamClient) SearchAll(query string) ([]*AnyResult, error) {
 						File:        struct{ Path string }{Path: v.Path},
 						Repository:  RepositoryResult{Name: v.Repository},
 						LineMatches: lms,
+					})
+
+				case *streamhttp.EventPathMatch:
+					results = append(results, FileResult{
+						File:       struct{ Path string }{Path: v.Path},
+						Repository: RepositoryResult{Name: v.Repository},
 					})
 
 				case *streamhttp.EventSymbolMatch:

--- a/internal/search/streaming/http/client.go
+++ b/internal/search/streaming/http/client.go
@@ -163,6 +163,8 @@ func (r *eventMatchUnmarshaller) UnmarshalJSON(b []byte) error {
 	switch typeU.Type {
 	case FileMatchType:
 		r.EventMatch = &EventFileMatch{}
+	case PathMatchType:
+		r.EventMatch = &EventPathMatch{}
 	case RepoMatchType:
 		r.EventMatch = &EventRepoMatch{}
 	case SymbolMatchType:

--- a/internal/search/streaming/http/client_test.go
+++ b/internal/search/streaming/http/client_test.go
@@ -32,6 +32,10 @@ func TestDecoder(t *testing.T) {
 				Type: FileMatchType,
 				Path: "test",
 			},
+			&EventPathMatch{
+				Type: PathMatchType,
+				Path: "test",
+			},
 			&EventRepoMatch{
 				Type:       RepoMatchType,
 				Repository: "test",


### PR DESCRIPTION
This adds EventPathMatch as a type to our streaming API. This was
previously represented as an EventFileMatch with no line matches. The
intent is to better represent our result domain. Additinally, this
allows us to add metadata to path matches that isn't needed for content
matches.

This just makes the change for streaming events, but I will also
propagate this change down to our internal/search/result types.

Also trying to get these changes in to the streaming API before
we make it available to customers and it needs to be stable

Paired with https://github.com/sourcegraph/src-cli/pull/568

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
