### PR TITLE
Docs for code insights dashboards in 3.30

### DIFF
--- a/doc/code_insights/explanations/index.md
+++ b/doc/code_insights/explanations/index.md
@@ -7,4 +7,5 @@ The following articles explain different parts of [Sourcegraph Code Insights](..
 <!-- - [User viewing permissions of Code Insights](explanations/user_viewing_permissions_of_code_insights.md) -->
 - [Administration and Security of Code Insights](administration_and_security_of_code_insights.md)
 - [Current limitations of Code Insights](current_limitations_of_code_insights.md)
+- [Viewing code insights](viewing_code_insights.md)
 <!-- - [How Code Insights work](explanations/how_code_insights_work.md) -->

--- a/doc/code_insights/explanations/viewing_code_insights.md
+++ b/doc/code_insights/explanations/viewing_code_insights.md
@@ -30,11 +30,11 @@ The following dashboards exist on every instance:
 
 If the instance has organizations, there will also be an "[Organization name] insights" dashboard for each organization, visible to members of the organization, that contains all insights set to that organization's visibility level. 
 
-To add insights to your own custom dashboard, see [Creating a custom dashboard of code insights](../how-tos/creating_a_custom_dashboard_of_code_insights.md)
+To add insights to your own custom dashboard, see [Creating a custom dashboard of code insights](../how-tos/creating_a_custom_dashboard_of_code_insights.md).
 
 ### Dashboard visibility respects insights' visibility 
 
-A Dashboard's set visibility level respects the visibility levels you [set when you created the insight](../quickstart.md#7-set-the-visibility-of-your-insight). You can't add an insight with "Private" visibility to an organization dashboard, but you can add an insight with organization visibility to your private dashboard (assuming you're in the organization). 
+A Dashboard's visibility level respects the visibility levels you [set when you created the insight](../quickstart.md#7-set-the-visibility-of-your-insight). You can't add an insight with "Private" visibility to an organization dashboard, but you can add an insight with organization visibility to your private dashboard (assuming you're in the organization). 
 
 ### Insights still enforce individual permissions regardless of dashboard visibility
 
@@ -42,7 +42,7 @@ The dashboard visibility levels have no impact on the data in the insight itself
 
 This means that two organization users with different repo read permission sets might see different values for the same insights on the same dashboards, if it contains results from a repository only one user can view. 
 
-(This also means that if you change a private-visible dashboard with both organization-visible and private-visible insights so that the dashboard is now visible to an organization, then the organization can only see the organization-visible insights on that dashboard. This is non-optimal, and we are actively improving this UX. If you have thoughts, please do [leave them on the issue](https://github.com/sourcegraph/sourcegraph/issues/23003).) 
+(This also means that if you change a private-visible dashboard with both organization-visible and private-visible insights so that the dashboard is now visible to an organization, then the organization can only see the organization-visible insights on that dashboard. This is non-optimal and a bit awkward to convey, and we are actively improving this UX. If you have strong thoughts, please do [leave them on the issue](https://github.com/sourcegraph/sourcegraph/issues/23003).) 
 
 ### Insights can be on multiple dashboards
 

--- a/doc/code_insights/explanations/viewing_code_insights.md
+++ b/doc/code_insights/explanations/viewing_code_insights.md
@@ -1,0 +1,64 @@
+# Viewing Code Insights
+
+Code Insights can display in 3 areas of Sourcegraph:
+
+- On the insight dashboard pages, which begin with `/insights/dashboards`; enabled by default
+- On repository and directly pages for insights that run over that repository; enabled by default
+- On the search home page, at `/search`; disabled by default
+
+## Insights dashboards
+
+The main way to view code insights is on a dashboard page. Dashboards have a unique name and visibility level. 
+
+There are three possible visibility levels: 
+
+- Private: visible only to you 
+- Shared with an organization: visible to everyone in the organization 
+- Global: visible to everyone on the Sourcegraph instance 
+
+> Global visibility is currently only available if your instance is not [using a separate global settings file](../../../admin/config/advanced_config_file.md#global-settings). Global visibility regardless of settings file setup will arrive by October 2021. 
+
+> The **quick workaround** is to [make an organization and easily add all users to it](../../../admin/organizations.md). 
+
+### Built-in dashboards
+
+The following dashboards exist on every instance: 
+
+- "All insights": this dashboard contains all the insights defined on the instance that are visible to this specific user 
+- "[Username] insights": this dashboard contains all the insights that are created by a user and set to "private" visibility
+- "Global insights": this dashboard contains all the insights that are set to global visibility
+
+If the instance has organizations, there will also be an "[Organization name] insights" dashboard for each organization, visible to members of the organization, that contains all insights set to that organization's visibility level. 
+
+To add insights to your own custom dashboard, see [Creating a custom dashboard of code insights](../how-tos/creating_a_custom_dashboard_of_code_insights.md)
+
+### Dashboard visibility respects insights' visibility 
+
+A Dashboard's set visibility level respects the visibility levels you [set when you created the insight](../quickstart.md#7-set-the-visibility-of-your-insight). You can't add an insight with "Private" visibility to an organization dashboard, but you can add an insight with organization visibility to your private dashboard (assuming you're in the organization). 
+
+### Insights still enforce individual permissions regardless of dashboard visibility
+
+The dashboard visibility levels have no impact on the data in the insight itself that is displayed to an individual user: insights [enforce the viewer's permissions](administration_and_security_of_code_insights.md#code-insights-enforce-user-permissions).
+
+This means that two organization users with different repo read permission sets might see different values for the same insights on the same dashboards, if it contains results from a repository only one user can view. 
+
+(This also means that if you change a private-visible dashboard with both organization-visible and private-visible insights so that the dashboard is now visible to an organization, then the organization can only see the organization-visible insights on that dashboard. This is non-optimal, and we are actively improving this UX. If you have thoughts, please do [leave them on the issue](https://github.com/sourcegraph/sourcegraph/issues/23003).) 
+
+### Insights can be on multiple dashboards
+
+You can attach insights to multiple dashboards. 
+
+## Repository and directory pages
+
+On repository pages, any code insight that runs over that repository will display. On directory pages, code insights defined for that repository will display **and** run only over files that are children of the directory. 
+
+This is enabled by default and can be disabled with a flag in your global, organization, or user settings:
+
+```"insights.displayLocation.directory": false```
+
+## Search home page
+
+Code insights can display below the search bar on the search home page. This is disabled by default because we have not yet built the capability to select which insights display on the search home page (so they all do). This can be enabled with a flag in your global, organization, or user settings: 
+
+```"insights.displayLocation.directory": true```
+

--- a/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
+++ b/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
@@ -1,0 +1,37 @@
+# Creating a custom dashboard of code insights
+
+This how-to assumes that you already have created some code insights to add to a dashboard. If you have yet to create any code insights, start with the [quickstart](../quickstart.md) guide. 
+
+## 1. Navigate to the Code Insights page 
+
+Start on the code insights page by clicking the Code Insights navbar item or going to `/insights/dashboards/all`. 
+
+## 2. Create and name a new dashboard
+
+Click "Create new dashboard" in the top right corner and name your dashboard. Dashboard names must be unique. 
+
+## 3. Select a visibility level 
+
+Set a visibility level for your dashboard. Dashboards [respect insights' permissions](../explanations/viewing_code_insights.md#dashboard-visibility-respects-insights-visibility), so don't create an organization-shared dashboard if you have private insights you want to attach to it. 
+
+- Private: visible only to you 
+- Shared with an organization: visible to everyone in the organization 
+- Global: visible to everyone on the Sourcegraph instance 
+
+> Global visibility is currently only available if your instance is not [using a separate global settings file](../../admin/config/advanced_config_file.md#global-settings). Global visibility regardless of settings file setup will arrive by October 2021. 
+
+> The **quick workaround** is to [make an organization and easily add all users to it](../../admin/organizations.md). 
+
+Then click "Create dashboard." 
+
+## 4. Add insights to your new, empty dashboard 
+
+Click the "Add insight" box on the empty dashboard view to pull up the add insights modal. You can also always pull this modal up with the contextual three-dots click to the right of the dashboard dropdown, via the "add insights" option. 
+
+Select which insights you want to add. Insights won't be added until you click save. 
+
+## 5. Share your dashboard
+
+You can share your dashboard via the url, or by copying this same url in the "copy link" menu item next to the dashboards picker. 
+
+

--- a/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
+++ b/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
@@ -26,9 +26,9 @@ Then click "Create dashboard."
 
 ## 4. Add insights to your new, empty dashboard 
 
-Click the "Add insight" box on the empty dashboard view to pull up the add insights modal. You can also always pull this modal up with the contextual three-dots click to the right of the dashboard dropdown, via the "add insights" option. 
+Click the "Add insight" box on the empty dashboard view to pull up the add insights modal. You can also always pull this modal up with the contextual three-dots click to the right of the dashboard dropdown picker, via the "Add or remove insights" option. 
 
-Select which insights you want to add. Insights won't be added until you click save. 
+Select which insights you want to add. Insights won't be added until you click save. Un-checking an insight will remove that insight after you click save. 
 
 ## 5. Share your dashboard
 

--- a/doc/code_insights/how-tos/index.md
+++ b/doc/code_insights/how-tos/index.md
@@ -1,0 +1,5 @@
+# How-tos
+
+The following is a list of how-tos that show how to use [Code Insights](../index.md):
+
+- [Creating a dashboard of code insights](creating_a_custom_dashboard_of_code_insights.md)

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -11,3 +11,6 @@ Work-in-progress table of contents:
 - [Explanations](explanations/index.md)
     - [Administration and security of Code Insights](explanations/administration_and_security_of_code_insights.md)
     - [Current limitations of Code Insights](explanations/current_limitations_of_code_insights.md)
+    - [Viewing code insights](explanations/viewing_code_insights.md)
+- [How-tos](how-tos/index.md)
+    - [Creating a dashboard of code insights](how-tos/creating_a_custom_dashboard_of_code_insights.md)

--- a/doc/code_insights/language_insight_quickstart.md
+++ b/doc/code_insights/language_insight_quickstart.md
@@ -44,7 +44,7 @@ Example: if the Threshold is set to 3%, and 2% of your code is in python and 2% 
 
 This controls who else can see your insight. 
 
-Anything set to "Personal" won't be visible by anyone else.  Otherwise, everyone in the selected organization can see your insight (if they have also enabled [the feature flag](quickstart.md#1-enable-the-experimental-feature-flag)).
+Anything set to "Private" won't be visible by anyone else.  Otherwise, everyone in the selected organization can see your insight (if they have also enabled [the feature flag](quickstart.md#1-enable-the-experimental-feature-flag)).
 
 ### 7. Click "create code insight" to view and save your insight
 

--- a/doc/code_insights/quickstart.md
+++ b/doc/code_insights/quickstart.md
@@ -59,7 +59,7 @@ Enter a descriptive **Title** for the chart, like `Count of TODOs in [repository
 
 This controls who else can see your insight. 
 
-Anything set to "Personal" won't be visible by anyone else. Otherwise, everyone in the selected organization can see your insight (if they have also enabled [the feature flag](#1-enable-the-experimental-feature-flag)).
+Anything set to "Private" won't be visible by anyone else. Otherwise, everyone in the selected organization can see your insight (if they have also enabled [the feature flag](#1-enable-the-experimental-feature-flag)).
 
 ### 8. Set the distance between data points to 1 month
 


### PR DESCRIPTION
Things explicitly left out: 
- How dashboards are currently implemented in your settings. Why: because they won't be the next 2-3 releases, so there's no reasons to confuse the user with the underlying implementation if it's going to change soon anyway. Will make sure CE and CSE are separately aware of it for debugging/settings digging issues. 