### PR TITLE
Change "add" to "add/remove" so you know how to remove insights

### DIFF
--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -51,7 +51,7 @@ export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props 
                     className={classnames(styles.menuItem, 'btn btn-outline')}
                     onSelect={() => onSelect(DashboardMenuAction.AddRemoveInsights)}
                 >
-                    Add insights
+                    Add/remove insights
                 </MenuItem>
 
                 <MenuItem


### PR DESCRIPTION
@AlicjaSuska @vovakulikov can you review this? 

@AlicjaSuska I think since this is the only way to remove insights we want users to know that in the label, not have to mentally connect the dots of "I saw a checkbox on the add screen...oh, a checkbox goes both ways" to figure out how to remove. Attached is a modified-in-the-browser-elements shot of what I assume it will render as. 

@vovakulikov dumb question, the slash won't break our JSX right? 99% sure it won't but just confirming. 

![image](https://user-images.githubusercontent.com/11967660/126249900-e745c4b3-0649-4ef2-baa2-4c8ad878eb44.png)
