### PR TITLE
monitoring: Refactor provisioning dashboards

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2744,30 +2744,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## query-runner: container_memory_usage
-
-<p class="subtitle">container memory usage by instance</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> query-runner: 99%+ container memory usage by instance
-
-**Possible solutions**
-
-- **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `memory:` of query-runner container in `docker-compose.yml`.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_query-runner_container_memory_usage"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
 ## query-runner: container_cpu_usage
 
 <p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
@@ -2785,6 +2761,30 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```json
 "observability.silenceAlerts": [
   "warning_query-runner_container_cpu_usage"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+## query-runner: container_memory_usage
+
+<p class="subtitle">container memory usage by instance</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> query-runner: 99%+ container memory usage by instance
+
+**Possible solutions**
+
+- **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
+- **Docker Compose:** Consider increasing `memory:` of query-runner container in `docker-compose.yml`.
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_query-runner_container_memory_usage"
 ]
 ```
 
@@ -6494,7 +6494,7 @@ with your code hosts connections or networking issues affecting communication wi
 **Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-indexer container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -6518,7 +6518,7 @@ with your code hosts connections or networking issues affecting communication wi
 **Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `memory:` of precise-code-intel-indexer container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -842,30 +842,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_blocked_seconds_per_conn_request
-
-<p class="subtitle">mean blocked seconds per conn request</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> frontend: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> frontend: 0.1s+ mean blocked seconds per conn request for 10m0s
-
-**Possible solutions**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_frontend_mean_blocked_seconds_per_conn_request",
-  "critical_frontend_mean_blocked_seconds_per_conn_request"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
 ## frontend: internal_indexed_search_error_responses
 
 <p class="subtitle">internal indexed search error responses every 5m</p>
@@ -1022,6 +998,30 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
+
+<br />
+
+## frontend: mean_blocked_seconds_per_conn_request
+
+<p class="subtitle">mean blocked seconds per conn request</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> frontend: 0.05s+ mean blocked seconds per conn request for 5m0s
+- <span class="badge badge-critical">critical</span> frontend: 0.1s+ mean blocked seconds per conn request for 10m0s
+
+**Possible solutions**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_mean_blocked_seconds_per_conn_request",
+  "critical_frontend_mean_blocked_seconds_per_conn_request"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -2450,30 +2450,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## precise-code-intel-worker: mean_blocked_seconds_per_conn_request
-
-<p class="subtitle">mean blocked seconds per conn request</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> precise-code-intel-worker: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> precise-code-intel-worker: 0.1s+ mean blocked seconds per conn request for 10m0s
-
-**Possible solutions**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_precise-code-intel-worker_mean_blocked_seconds_per_conn_request",
-  "critical_precise-code-intel-worker_mean_blocked_seconds_per_conn_request"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
 ## precise-code-intel-worker: frontend_internal_api_error_responses
 
 <p class="subtitle">frontend-internal API error responses every 5m by route</p>
@@ -2500,6 +2476,30 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+## precise-code-intel-worker: mean_blocked_seconds_per_conn_request
+
+<p class="subtitle">mean blocked seconds per conn request</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> precise-code-intel-worker: 0.05s+ mean blocked seconds per conn request for 5m0s
+- <span class="badge badge-critical">critical</span> precise-code-intel-worker: 0.1s+ mean blocked seconds per conn request for 10m0s
+
+**Possible solutions**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_precise-code-intel-worker_mean_blocked_seconds_per_conn_request",
+  "critical_precise-code-intel-worker_mean_blocked_seconds_per_conn_request"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -3282,30 +3282,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## worker: mean_blocked_seconds_per_conn_request
-
-<p class="subtitle">mean blocked seconds per conn request</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> worker: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> worker: 0.1s+ mean blocked seconds per conn request for 10m0s
-
-**Possible solutions**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_worker_mean_blocked_seconds_per_conn_request",
-  "critical_worker_mean_blocked_seconds_per_conn_request"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
 ## worker: frontend_internal_api_error_responses
 
 <p class="subtitle">frontend-internal API error responses every 5m by route</p>
@@ -3332,6 +3308,30 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+## worker: mean_blocked_seconds_per_conn_request
+
+<p class="subtitle">mean blocked seconds per conn request</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> worker: 0.05s+ mean blocked seconds per conn request for 5m0s
+- <span class="badge badge-critical">critical</span> worker: 0.1s+ mean blocked seconds per conn request for 10m0s
+
+**Possible solutions**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_worker_mean_blocked_seconds_per_conn_request",
+  "critical_worker_mean_blocked_seconds_per_conn_request"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -3544,35 +3544,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
-
-<br />
-
-## repo-updater: frontend_internal_api_error_responses
-
-<p class="subtitle">frontend-internal API error responses every 5m by route</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> repo-updater: 2%+ frontend-internal API error responses every 5m by route for 5m0s
-
-**Possible solutions**
-
-- **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
-- **Kubernetes:**
-	- Confirm that `kubectl get pods` shows the `frontend` pods are healthy.
-	- Check `kubectl logs repo-updater` for logs indicate request failures to `frontend` or `frontend-internal`.
-- **Docker Compose:**
-	- Confirm that `docker ps` shows the `frontend-internal` container is healthy.
-	- Check `docker logs repo-updater` for logs indicating request failures to `frontend` or `frontend-internal`.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_frontend_internal_api_error_responses"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -4252,6 +4223,35 @@ with your code hosts connections or networking issues affecting communication wi
 ```json
 "observability.silenceAlerts": [
   "critical_repo-updater_gitlab_rest_rate_limit_remaining"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+## repo-updater: frontend_internal_api_error_responses
+
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> repo-updater: 2%+ frontend-internal API error responses every 5m by route for 5m0s
+
+**Possible solutions**
+
+- **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
+- **Kubernetes:**
+	- Confirm that `kubectl get pods` shows the `frontend` pods are healthy.
+	- Check `kubectl logs repo-updater` for logs indicate request failures to `frontend` or `frontend-internal`.
+- **Docker Compose:**
+	- Confirm that `docker ps` shows the `frontend-internal` container is healthy.
+	- Check `docker logs repo-updater` for logs indicating request failures to `frontend` or `frontend-internal`.
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_repo-updater_frontend_internal_api_error_responses"
 ]
 ```
 
@@ -6086,30 +6086,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
-## executor-queue: mean_blocked_seconds_per_conn_request
-
-<p class="subtitle">mean blocked seconds per conn request</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> executor-queue: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> executor-queue: 0.1s+ mean blocked seconds per conn request for 10m0s
-
-**Possible solutions**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_executor-queue_mean_blocked_seconds_per_conn_request",
-  "critical_executor-queue_mean_blocked_seconds_per_conn_request"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
 ## executor-queue: frontend_internal_api_error_responses
 
 <p class="subtitle">frontend-internal API error responses every 5m by route</p>
@@ -6136,6 +6112,30 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+## executor-queue: mean_blocked_seconds_per_conn_request
+
+<p class="subtitle">mean blocked seconds per conn request</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> executor-queue: 0.05s+ mean blocked seconds per conn request for 5m0s
+- <span class="badge badge-critical">critical</span> executor-queue: 0.1s+ mean blocked seconds per conn request for 10m0s
+
+**Possible solutions**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_executor-queue_mean_blocked_seconds_per_conn_request",
+  "critical_executor-queue_mean_blocked_seconds_per_conn_request"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -6541,8 +6541,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
-- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the precise-code-intel-worker service.
-- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the precise-code-intel-indexer service.
+- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-indexer container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -6565,8 +6565,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
-- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the precise-code-intel-worker service.
-- **Docker Compose:** Consider increasing `memory:` of the precise-code-intel-worker container in `docker-compose.yml`.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the precise-code-intel-indexer service.
+- **Docker Compose:** Consider increasing `memory:` of the precise-code-intel-indexer container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -6590,7 +6590,7 @@ with your code hosts connections or networking issues affecting communication wi
 **Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-indexer container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -6614,7 +6614,7 @@ with your code hosts connections or networking issues affecting communication wi
 **Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `memory:` of precise-code-intel-indexer container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -540,6 +540,24 @@ This panel indicates critical test alert metric.
 
 ### Frontend: Container monitoring (not available on server)
 
+#### frontend: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod (frontend|sourcegraph-frontend)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p (frontend|sourcegraph-frontend)`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' (frontend|sourcegraph-frontend)` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs (frontend|sourcegraph-frontend)` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 #### frontend: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -560,19 +578,12 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### frontend: container_missing
+#### frontend: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod (frontend|sourcegraph-frontend)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p (frontend|sourcegraph-frontend)`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' (frontend|sourcegraph-frontend)` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs (frontend|sourcegraph-frontend)` (note this will include logs from the previous and currently running container).
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -1012,6 +1023,24 @@ This panel indicates closed by SetConnMaxIdleTime.
 
 ### Git Server: Container monitoring (not available on server)
 
+#### gitserver: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod gitserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p gitserver`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' gitserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the gitserver container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs gitserver` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 #### gitserver: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -1027,24 +1056,6 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 This panel indicates container memory usage by instance.
 
 > NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage).
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### gitserver: container_missing
-
-This panel indicates container missing.
-
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod gitserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p gitserver`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' gitserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the gitserver container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs gitserver` (note this will include logs from the previous and currently running container).
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -1157,6 +1168,24 @@ This panel indicates number of requests waiting on the global mutex.
 
 ### GitHub Proxy: Container monitoring (not available on server)
 
+#### github-proxy: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod github-proxy` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p github-proxy`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' github-proxy` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the github-proxy container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs github-proxy` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 #### github-proxy: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -1177,19 +1206,12 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### github-proxy: container_missing
+#### github-proxy: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod github-proxy` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p github-proxy`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' github-proxy` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the github-proxy container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs github-proxy` (note this will include logs from the previous and currently running container).
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -1689,6 +1711,24 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 ### Precise Code Intel Worker: Container monitoring (not available on server)
 
+#### precise-code-intel-worker: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 #### precise-code-intel-worker: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -1709,21 +1749,14 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### precise-code-intel-worker: container_missing
+#### precise-code-intel-worker: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -1821,26 +1854,6 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 ### Query Runner: Container monitoring (not available on server)
 
-#### query-runner: container_memory_usage
-
-This panel indicates container memory usage by instance.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage).
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
-#### query-runner: container_cpu_usage
-
-This panel indicates container cpu usage total (1m average) across all cores by instance.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage).
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
 #### query-runner: container_missing
 
 This panel indicates container missing.
@@ -1856,6 +1869,37 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs query-runner` (note this will include logs from the previous and currently running container).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### query-runner: container_cpu_usage
+
+This panel indicates container cpu usage total (1m average) across all cores by instance.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### query-runner: container_memory_usage
+
+This panel indicates container memory usage by instance.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### query-runner: fs_io_operations
+
+This panel indicates filesystem reads and writes rate by instance over 1h.
+
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -2221,6 +2265,24 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 ### Worker: Container monitoring (not available on server)
 
+#### worker: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p worker`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the worker container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs worker` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 #### worker: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -2241,21 +2303,14 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### worker: container_missing
+#### worker: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p worker`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the worker container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs worker` (note this will include logs from the previous and currently running container).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -2779,6 +2834,24 @@ This panel indicates closed by SetConnMaxIdleTime.
 
 ### Repo Updater: Container monitoring (not available on server)
 
+#### repo-updater: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod repo-updater` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p repo-updater`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' repo-updater` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the repo-updater container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs repo-updater` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 #### repo-updater: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -2799,19 +2872,12 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### repo-updater: container_missing
+#### repo-updater: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod repo-updater` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p repo-updater`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' repo-updater` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the repo-updater container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs repo-updater` (note this will include logs from the previous and currently running container).
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -2931,6 +2997,24 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 ### Searcher: Container monitoring (not available on server)
 
+#### searcher: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod searcher` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p searcher`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' searcher` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the searcher container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs searcher` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
 #### searcher: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -2951,21 +3035,14 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### searcher: container_missing
+#### searcher: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod searcher` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p searcher`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' searcher` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the searcher container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs searcher` (note this will include logs from the previous and currently running container).
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -3083,6 +3160,24 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 ### Symbols: Container monitoring (not available on server)
 
+#### symbols: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod symbols` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p symbols`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' symbols` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the symbols container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs symbols` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 #### symbols: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -3103,21 +3198,14 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### symbols: container_missing
+#### symbols: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod symbols` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p symbols`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' symbols` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the symbols container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs symbols` (note this will include logs from the previous and currently running container).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -3237,6 +3325,24 @@ This panel indicates syntax highlighter worker deaths every 5m.
 
 ### Syntect Server: Container monitoring (not available on server)
 
+#### syntect-server: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod syntect-server` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p syntect-server`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' syntect-server` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the syntect-server container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs syntect-server` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 #### syntect-server: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -3257,19 +3363,12 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### syntect-server: container_missing
+#### syntect-server: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod syntect-server` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p syntect-server`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' syntect-server` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the syntect-server container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs syntect-server` (note this will include logs from the previous and currently running container).
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -3395,6 +3494,24 @@ This panel indicates average resolve revision duration over 5m.
 
 ### Zoekt Index Server: Container monitoring (not available on server)
 
+#### zoekt-indexserver: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-indexserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-indexserver`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-indexserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-indexserver container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-indexserver` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
 #### zoekt-indexserver: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -3410,24 +3527,6 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 This panel indicates container memory usage by instance.
 
 > NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage).
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
-#### zoekt-indexserver: container_missing
-
-This panel indicates container missing.
-
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-indexserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-indexserver`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-indexserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-indexserver container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-indexserver` (note this will include logs from the previous and currently running container).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -3514,6 +3613,24 @@ This panel indicates indexed search request errors every 5m by code.
 
 ### Zoekt Web Server: Container monitoring (not available on server)
 
+#### zoekt-webserver: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-webserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-webserver`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-webserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-webserver container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-webserver` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
 #### zoekt-webserver: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -3529,24 +3646,6 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 This panel indicates container memory usage by instance.
 
 > NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage).
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
-#### zoekt-webserver: container_missing
-
-This panel indicates container missing.
-
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-webserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-webserver`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-webserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-webserver container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-webserver` (note this will include logs from the previous and currently running container).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -3718,6 +3817,24 @@ This panel indicates prometheus scrapes rejected due to duplicate timestamps ove
 
 ### Prometheus: Container monitoring (not available on server)
 
+#### prometheus: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod prometheus` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p prometheus`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' prometheus` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the prometheus container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs prometheus` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
+
+<br />
+
 #### prometheus: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -3738,21 +3855,14 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### prometheus: container_missing
+#### prometheus: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod prometheus` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p prometheus`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' prometheus` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the prometheus container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs prometheus` (note this will include logs from the previous and currently running container).
-
-<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -3966,6 +4076,24 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 ### Executor Queue: Container monitoring (not available on server)
 
+#### executor-queue: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod executor-queue` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p executor-queue`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' executor-queue` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the executor-queue container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs executor-queue` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 #### executor-queue: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -3986,21 +4114,14 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### executor-queue: container_missing
+#### executor-queue: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod executor-queue` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p executor-queue`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' executor-queue` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the executor-queue container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs executor-queue` (note this will include logs from the previous and currently running container).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -4194,6 +4315,24 @@ This panel indicates teardown command errors every 5m.
 
 ### Precise Code Intel Indexer: Container monitoring (not available on server)
 
+#### precise-code-intel-indexer: container_missing
+
+This panel indicates container missing.
+
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-indexer` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-indexer`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-indexer` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-indexer container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-indexer` (note this will include logs from the previous and currently running container).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 #### precise-code-intel-indexer: container_cpu_usage
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
@@ -4214,21 +4353,14 @@ This panel indicates container memory usage by instance.
 
 <br />
 
-#### precise-code-intel-indexer: container_missing
+#### precise-code-intel-indexer: fs_io_operations
 
-This panel indicates container missing.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
-This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
+This value indicates the number of filesystem read and write operations by containers of this service.
+When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -1138,7 +1138,7 @@ This panel indicates maximum go garbage collection duration.
 
 <br />
 
-### Git Server: Kubernetes monitoring (ignore if using Docker Compose or server)
+### Git Server: Kubernetes monitoring (only available on Kubernetes)
 
 #### gitserver: pods_available_percentage
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -398,74 +398,6 @@ This panel indicates out-of-band down migration errors every 5m.
 
 <br />
 
-### Frontend: Database connections
-
-#### frontend: max_open_conns
-
-This panel indicates maximum open.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: open_conns
-
-This panel indicates established.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: in_use
-
-This panel indicates used.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: idle
-
-This panel indicates idle.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: mean_blocked_seconds_per_conn_request
-
-This panel indicates mean blocked seconds per conn request.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-mean-blocked-seconds-per-conn-request).
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: closed_max_idle
-
-This panel indicates closed by SetMaxIdleConns.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: closed_max_lifetime
-
-This panel indicates closed by SetConnMaxLifetime.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-#### frontend: closed_max_idle_time
-
-This panel indicates closed by SetConnMaxIdleTime.
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
 ### Frontend: Internal service requests
 
 #### frontend: internal_indexed_search_error_responses
@@ -535,6 +467,74 @@ This panel indicates critical test alert metric.
 > NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
+
+<br />
+
+### Frontend: Database connections
+
+#### frontend: max_open_conns
+
+This panel indicates maximum open.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### frontend: open_conns
+
+This panel indicates established.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### frontend: in_use
+
+This panel indicates used.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### frontend: idle
+
+This panel indicates idle.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### frontend: mean_blocked_seconds_per_conn_request
+
+This panel indicates mean blocked seconds per conn request.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-mean-blocked-seconds-per-conn-request).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### frontend: closed_max_idle
+
+This panel indicates closed by SetMaxIdleConns.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### frontend: closed_max_lifetime
+
+This panel indicates closed by SetConnMaxLifetime.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
+#### frontend: closed_max_idle_time
+
+This panel indicates closed by SetConnMaxIdleTime.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
 <br />
 
@@ -1629,6 +1629,18 @@ This panel indicates gitserver client errors every 5m.
 
 <br />
 
+### Precise Code Intel Worker: Internal service requests
+
+#### precise-code-intel-worker: frontend_internal_api_error_responses
+
+This panel indicates frontend-internal API error responses every 5m by route.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 ### Precise Code Intel Worker: Database connections
 
 #### precise-code-intel-worker: max_open_conns
@@ -1694,18 +1706,6 @@ This panel indicates closed by SetConnMaxLifetime.
 This panel indicates closed by SetConnMaxIdleTime.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-### Precise Code Intel Worker: Internal service requests
-
-#### precise-code-intel-worker: frontend_internal_api_error_responses
-
-This panel indicates frontend-internal API error responses every 5m by route.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1841,6 +1841,8 @@ This panel indicates percentage pods available.
 ## Query Runner
 
 <p class="subtitle">Periodically runs saved searches and instructs the frontend to send out notifications.</p>
+
+### Query Runner: Internal service requests
 
 #### query-runner: frontend_internal_api_error_responses
 
@@ -2183,6 +2185,18 @@ This panel indicates index enqueuer errors every 5m.
 
 <br />
 
+### Worker: Internal service requests
+
+#### worker: frontend_internal_api_error_responses
+
+This panel indicates frontend-internal API error responses every 5m by route.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#worker-frontend-internal-api-error-responses).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 ### Worker: Database connections
 
 #### worker: max_open_conns
@@ -2248,18 +2262,6 @@ This panel indicates closed by SetConnMaxLifetime.
 This panel indicates closed by SetConnMaxIdleTime.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-### Worker: Internal service requests
-
-#### worker: frontend_internal_api_error_responses
-
-This panel indicates frontend-internal API error responses every 5m by route.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#worker-frontend-internal-api-error-responses).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2395,16 +2397,6 @@ This panel indicates percentage pods available.
 ## Repo Updater
 
 <p class="subtitle">Manages interaction with code hosts, instructs Gitserver to update repositories.</p>
-
-#### repo-updater: frontend_internal_api_error_responses
-
-This panel indicates frontend-internal API error responses every 5m by route.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses).
-
-<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
 
 ### Repo Updater: Repositories
 
@@ -2764,6 +2756,18 @@ Indicates how long we`re waiting on the rate limit once it has been exceeded
 
 <br />
 
+### Repo Updater: Internal service requests
+
+#### repo-updater: frontend_internal_api_error_responses
+
+This panel indicates frontend-internal API error responses every 5m by route.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 ### Repo Updater: Database connections
 
 #### repo-updater: max_open_conns
@@ -2985,6 +2989,8 @@ This panel indicates requests per second over 10m.
 
 <br />
 
+### Searcher: Internal service requests
+
 #### searcher: frontend_internal_api_error_responses
 
 This panel indicates frontend-internal API error responses every 5m by route.
@@ -3147,6 +3153,8 @@ This panel indicates current fetch queue size.
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
+
+### Symbols: Internal service requests
 
 #### symbols: frontend_internal_api_error_responses
 
@@ -3994,6 +4002,18 @@ This panel indicates worker store errors every 5m.
 
 <br />
 
+### Executor Queue: Internal service requests
+
+#### executor-queue: frontend_internal_api_error_responses
+
+This panel indicates frontend-internal API error responses every 5m by route.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 ### Executor Queue: Database connections
 
 #### executor-queue: max_open_conns
@@ -4059,18 +4079,6 @@ This panel indicates closed by SetConnMaxLifetime.
 This panel indicates closed by SetConnMaxIdleTime.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-### Executor Queue: Internal service requests
-
-#### executor-queue: frontend_internal_api_error_responses
-
-This panel indicates frontend-internal API error responses every 5m by route.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses).
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -106,16 +106,7 @@ func ExecutorQueue() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.GoGcDuration("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -104,19 +104,7 @@ func ExecutorQueue() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ContainerMemoryUsage("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ContainerMissing("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -95,11 +95,7 @@ func ExecutorQueue() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleDatabaseConnectionsMonitoring,
-				Hidden: true,
-				Rows:   shared.DatabaseConnectionsMonitoring("executor-queue"),
-			},
+			shared.NewDatabaseConnectionsMonitoringGroup("executor-queue"),
 			{
 				Title:  "Internal service requests",
 				Hidden: true,

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -105,20 +105,7 @@ func ExecutorQueue() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -6,6 +6,11 @@ import (
 )
 
 func ExecutorQueue() *monitoring.Container {
+	const (
+		containerName = "executor-queue"
+		primaryOwner  = monitoring.ObservableOwnerCodeIntel
+	)
+
 	return &monitoring.Container{
 		Name:        "executor-queue",
 		Title:       "Executor Queue",
@@ -104,10 +109,11 @@ func ExecutorQueue() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewProvisioningIndicatorsGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewGolangMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewKubernetesMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
+
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -6,10 +6,7 @@ import (
 )
 
 func ExecutorQueue() *monitoring.Container {
-	const (
-		containerName = "executor-queue"
-		primaryOwner  = monitoring.ObservableOwnerCodeIntel
-	)
+	const containerName = "executor-queue"
 
 	return &monitoring.Container{
 		Name:        "executor-queue",
@@ -96,12 +93,12 @@ func ExecutorQueue() *monitoring.Container {
 				},
 			},
 
-			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -95,17 +95,9 @@ func ExecutorQueue() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewDatabaseConnectionsMonitoringGroup("executor-queue"),
-			{
-				Title:  "Internal service requests",
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.FrontendInternalAPIErrorResponses("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
 
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -107,15 +107,7 @@ func ExecutorQueue() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewGolangMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("executor-queue", monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -576,19 +576,7 @@ func Frontend() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ContainerMemoryUsage(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ContainerMissing(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -494,11 +494,7 @@ func Frontend() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleDatabaseConnectionsMonitoring,
-				Hidden: true,
-				Rows:   shared.DatabaseConnectionsMonitoring("frontend"),
-			},
+			shared.NewDatabaseConnectionsMonitoringGroup("frontend"),
 			{
 				Title:  "Internal service requests",
 				Hidden: true,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -578,16 +578,7 @@ func Frontend() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.GoGcDuration(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -494,7 +494,7 @@ func Frontend() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewDatabaseConnectionsMonitoringGroup("frontend"),
+
 			{
 				Title:  "Internal service requests",
 				Hidden: true,
@@ -576,10 +576,13 @@ func Frontend() *monitoring.Container {
 					},
 				},
 			},
+
+			shared.NewDatabaseConnectionsMonitoringGroup("frontend"),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+
 			{
 				Title:  "Sentinel queries (only on sourcegraph.com)",
 				Hidden: true,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -8,8 +8,12 @@ import (
 )
 
 func Frontend() *monitoring.Container {
-	// frontend is sometimes called sourcegraph-frontend in various contexts
-	const containerName = "(frontend|sourcegraph-frontend)"
+	const (
+		// frontend is sometimes called sourcegraph-frontend in various contexts
+		containerName = "(frontend|sourcegraph-frontend)"
+
+		primaryOwner = monitoring.ObservableOwnerCoreApplication
+	)
 
 	return &monitoring.Container{
 		Name:        "frontend",
@@ -576,10 +580,10 @@ func Frontend() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 			{
 				Title:  "Sentinel queries (only on sourcegraph.com)",
 				Hidden: true,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -577,20 +577,7 @@ func Frontend() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -579,15 +579,7 @@ func Frontend() *monitoring.Container {
 			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable(containerName, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  "Sentinel queries (only on sourcegraph.com)",
 				Hidden: true,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -8,12 +8,8 @@ import (
 )
 
 func Frontend() *monitoring.Container {
-	const (
-		// frontend is sometimes called sourcegraph-frontend in various contexts
-		containerName = "(frontend|sourcegraph-frontend)"
-
-		primaryOwner = monitoring.ObservableOwnerCoreApplication
-	)
+	// frontend is sometimes called sourcegraph-frontend in various contexts
+	const containerName = "(frontend|sourcegraph-frontend)"
 
 	return &monitoring.Container{
 		Name:        "frontend",
@@ -578,10 +574,10 @@ func Frontend() *monitoring.Container {
 			},
 
 			shared.NewDatabaseConnectionsMonitoringGroup("frontend"),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 
 			{
 				Title:  "Sentinel queries (only on sourcegraph.com)",

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -309,16 +309,7 @@ func GitServer() *monitoring.Container {
 				LongTermMemoryUsage:  gitserverHighMemoryNoAlertTransformer,
 				ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
 			}),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.GoGcDuration("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  "Kubernetes monitoring (ignore if using Docker Compose or server)",
 				Hidden: true,

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -10,6 +10,11 @@ import (
 )
 
 func GitServer() *monitoring.Container {
+	const (
+		containerName = "gitserver"
+		primaryOwner  = monitoring.ObservableOwnerCoreApplication
+	)
+
 	return &monitoring.Container{
 		Name:        "gitserver",
 		Title:       "Git Server",
@@ -304,15 +309,15 @@ func GitServer() *monitoring.Container {
 				Hidden: true,
 				Rows:   shared.DatabaseConnectionsMonitoring("gitserver"),
 			},
-			shared.NewContainerMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewProvisioningIndicatorsGroup("gitserver", monitoring.ObservableOwnerCoreApplication, provisioningIndicatorsOptions),
-			shared.NewGolangMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewKubernetesMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, gitserverProvisioningIndicatorsOptions),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }
 
-var provisioningIndicatorsOptions = &shared.ContainerProvisioningIndicatorsGroupOptions{
+var gitserverProvisioningIndicatorsOptions = &shared.ContainerProvisioningIndicatorsGroupOptions{
 	LongTermMemoryUsage:  gitserverHighMemoryNoAlertTransformer,
 	ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
 }

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -304,7 +304,8 @@ func GitServer() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewDatabaseConnectionsMonitoringGroup("gitserver"),
+
+			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, gitserverProvisioningIndicatorsOptions),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -10,10 +10,7 @@ import (
 )
 
 func GitServer() *monitoring.Container {
-	const (
-		containerName = "gitserver"
-		primaryOwner  = monitoring.ObservableOwnerCoreApplication
-	)
+	const containerName = "gitserver"
 
 	gitserverHighMemoryNoAlertTransformer := func(observable shared.Observable) shared.Observable {
 		return observable.WithNoAlerts(`Git Server is expected to use up all the memory it is provided.`)
@@ -315,10 +312,10 @@ func GitServer() *monitoring.Container {
 			},
 
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, provisioningIndicatorsOptions),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, provisioningIndicatorsOptions),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
 }

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -305,22 +305,16 @@ func GitServer() *monitoring.Container {
 				Rows:   shared.DatabaseConnectionsMonitoring("gitserver"),
 			},
 			shared.NewContainerMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewProvisioningIndicatorsGroup("gitserver", monitoring.ObservableOwnerCoreApplication, &shared.ContainerProvisioningIndicatorsGroupOptions{
-				LongTermMemoryUsage:  gitserverHighMemoryNoAlertTransformer,
-				ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
-			}),
+			shared.NewProvisioningIndicatorsGroup("gitserver", monitoring.ObservableOwnerCoreApplication, provisioningIndicatorsOptions),
 			shared.NewGolangMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  "Kubernetes monitoring (ignore if using Docker Compose or server)",
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
+}
+
+var provisioningIndicatorsOptions = &shared.ContainerProvisioningIndicatorsGroupOptions{
+	LongTermMemoryUsage:  gitserverHighMemoryNoAlertTransformer,
+	ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
 }
 
 func gitserverHighMemoryNoAlertTransformer(observable shared.Observable) shared.Observable {

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -304,11 +304,7 @@ func GitServer() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleDatabaseConnectionsMonitoring,
-				Hidden: true,
-				Rows:   shared.DatabaseConnectionsMonitoring("gitserver"),
-			},
+			shared.NewDatabaseConnectionsMonitoringGroup("gitserver"),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, gitserverProvisioningIndicatorsOptions),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -15,6 +15,15 @@ func GitServer() *monitoring.Container {
 		primaryOwner  = monitoring.ObservableOwnerCoreApplication
 	)
 
+	gitserverHighMemoryNoAlertTransformer := func(observable shared.Observable) shared.Observable {
+		return observable.WithNoAlerts(`Git Server is expected to use up all the memory it is provided.`)
+	}
+
+	var provisioningIndicatorsOptions = &shared.ContainerProvisioningIndicatorsGroupOptions{
+		LongTermMemoryUsage:  gitserverHighMemoryNoAlertTransformer,
+		ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
+	}
+
 	return &monitoring.Container{
 		Name:        "gitserver",
 		Title:       "Git Server",
@@ -307,18 +316,9 @@ func GitServer() *monitoring.Container {
 
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, gitserverProvisioningIndicatorsOptions),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, provisioningIndicatorsOptions),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
-}
-
-var gitserverProvisioningIndicatorsOptions = &shared.ContainerProvisioningIndicatorsGroupOptions{
-	LongTermMemoryUsage:  gitserverHighMemoryNoAlertTransformer,
-	ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
-}
-
-func gitserverHighMemoryNoAlertTransformer(observable shared.Observable) shared.Observable {
-	return observable.WithNoAlerts(`Git Server is expected to use up all the memory it is provided.`)
 }

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -304,20 +304,7 @@ func GitServer() *monitoring.Container {
 				Hidden: true,
 				Rows:   shared.DatabaseConnectionsMonitoring("gitserver"),
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ContainerMemoryUsage("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ContainerMissing("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ContainerIOUsage("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -305,24 +305,10 @@ func GitServer() *monitoring.Container {
 				Rows:   shared.DatabaseConnectionsMonitoring("gitserver"),
 			},
 			shared.NewContainerMonitoringGroup("gitserver", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("gitserver", monitoring.ObservableOwnerCoreApplication).
-							WithNoAlerts(`Git Server is expected to use up all the memory it is provided.`).
-							Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("gitserver", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("gitserver", monitoring.ObservableOwnerCoreApplication).
-							WithNoAlerts(`Git Server is expected to use up all the memory it is provided.`).
-							Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("gitserver", monitoring.ObservableOwnerCoreApplication, &shared.ContainerProvisioningIndicatorsGroupOptions{
+				LongTermMemoryUsage:  gitserverHighMemoryNoAlertTransformer,
+				ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
+			}),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,
@@ -344,4 +330,8 @@ func GitServer() *monitoring.Container {
 			},
 		},
 	}
+}
+
+func gitserverHighMemoryNoAlertTransformer(observable shared.Observable) shared.Observable {
+	return observable.WithNoAlerts(`Git Server is expected to use up all the memory it is provided.`)
 }

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -32,20 +32,7 @@ func GitHubProxy() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -36,6 +36,7 @@ func GitHubProxy() *monitoring.Container {
 					},
 				},
 			},
+
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -8,6 +8,11 @@ import (
 )
 
 func GitHubProxy() *monitoring.Container {
+	const (
+		containerName = "github-proxy"
+		primaryOwner  = monitoring.ObservableOwnerCoreApplication
+	)
+
 	return &monitoring.Container{
 		Name:        "github-proxy",
 		Title:       "GitHub Proxy",
@@ -31,10 +36,10 @@ func GitHubProxy() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewProvisioningIndicatorsGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewGolangMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewKubernetesMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -31,19 +31,7 @@ func GitHubProxy() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ContainerMemoryUsage("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ContainerMissing("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -34,15 +34,7 @@ func GitHubProxy() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewProvisioningIndicatorsGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewGolangMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
 }

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -8,10 +8,7 @@ import (
 )
 
 func GitHubProxy() *monitoring.Container {
-	const (
-		containerName = "github-proxy"
-		primaryOwner  = monitoring.ObservableOwnerCoreApplication
-	)
+	const containerName = "github-proxy"
 
 	return &monitoring.Container{
 		Name:        "github-proxy",
@@ -37,10 +34,10 @@ func GitHubProxy() *monitoring.Container {
 				},
 			},
 
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
 }

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -33,16 +33,7 @@ func GitHubProxy() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewProvisioningIndicatorsGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.GoGcDuration("github-proxy", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("github-proxy", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -165,6 +165,7 @@ func Postgres() *monitoring.Container {
 					},
 				},
 			},
+
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -160,21 +160,7 @@ func Postgres() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				// See docstring for databaseContainerNames
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm(databaseContainerNames, monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm(databaseContainerNames, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm(databaseContainerNames, monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm(databaseContainerNames, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup(databaseContainerNames, monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -14,11 +14,9 @@ func Postgres() *monitoring.Container {
 		// all database cAdvisor metrics in a single panel using this container
 		// name regex to ensure we have observability on all platforms.
 		containerName = "(pgsql|codeintel-db)"
-
-		primaryOwner = monitoring.ObservableOwnerCoreApplication
 	)
 
-	sumAggregator := "sum"
+	var sumAggregator = "sum"
 
 	return &monitoring.Container{
 		Name:                     "postgres",
@@ -166,8 +164,8 @@ func Postgres() *monitoring.Container {
 				},
 			},
 
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
 }

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -161,15 +161,7 @@ func Postgres() *monitoring.Container {
 				},
 			},
 			shared.NewProvisioningIndicatorsGroup(databaseContainerNames, monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable(databaseContainerNames, monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup(databaseContainerNames, monitoring.ObservableOwnerCoreApplication, nil),
 		},
 
 		// This is third-party service

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -6,6 +6,11 @@ import (
 )
 
 func PreciseCodeIntelIndexer() *monitoring.Container {
+	const (
+		containerName = "precise-code-intel-indexer"
+		primaryOwner  = monitoring.ObservableOwnerCodeIntel
+	)
+
 	return &monitoring.Container{
 		Name:        "precise-code-intel-indexer",
 		Title:       "Precise Code Intel Indexer",
@@ -135,10 +140,10 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewProvisioningIndicatorsGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewGolangMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewKubernetesMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -136,20 +136,7 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -6,10 +6,7 @@ import (
 )
 
 func PreciseCodeIntelIndexer() *monitoring.Container {
-	const (
-		containerName = "precise-code-intel-indexer"
-		primaryOwner  = monitoring.ObservableOwnerCodeIntel
-	)
+	const containerName = "precise-code-intel-indexer"
 
 	return &monitoring.Container{
 		Name:        "precise-code-intel-indexer",
@@ -141,10 +138,10 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 				},
 			},
 
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -140,6 +140,7 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 					},
 				},
 			},
+
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -137,16 +137,7 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.GoGcDuration("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -135,19 +135,7 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ContainerMemoryUsage("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ContainerMissing("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -138,15 +138,7 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewGolangMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("precise-code-intel-indexer", monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -203,15 +203,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewGolangMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -202,16 +202,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.GoGcDuration("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -6,6 +6,11 @@ import (
 )
 
 func PreciseCodeIntelWorker() *monitoring.Container {
+	const (
+		containerName = "precise-code-intel-worker"
+		primaryOwner  = monitoring.ObservableOwnerCodeIntel
+	)
+
 	return &monitoring.Container{
 		Name:        "precise-code-intel-worker",
 		Title:       "Precise Code Intel Worker",
@@ -200,10 +205,10 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewProvisioningIndicatorsGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewGolangMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewKubernetesMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -200,19 +200,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ContainerMemoryUsage("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ContainerMissing("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -191,11 +191,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleDatabaseConnectionsMonitoring,
-				Hidden: true,
-				Rows:   shared.DatabaseConnectionsMonitoring("precise-code-intel-worker"),
-			},
+			shared.NewDatabaseConnectionsMonitoringGroup("precise-code-intel-worker"),
 			{
 				Title:  "Internal service requests",
 				Hidden: true,

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -201,20 +201,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -6,10 +6,7 @@ import (
 )
 
 func PreciseCodeIntelWorker() *monitoring.Container {
-	const (
-		containerName = "precise-code-intel-worker"
-		primaryOwner  = monitoring.ObservableOwnerCodeIntel
-	)
+	const containerName = "precise-code-intel-worker"
 
 	return &monitoring.Container{
 		Name:        "precise-code-intel-worker",
@@ -192,12 +189,12 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 				},
 			},
 
-			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -191,16 +191,9 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewDatabaseConnectionsMonitoringGroup("precise-code-intel-worker"),
-			{
-				Title:  "Internal service requests",
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.FrontendInternalAPIErrorResponses("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -149,20 +149,7 @@ func Prometheus() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -10,7 +10,6 @@ import (
 func Prometheus() *monitoring.Container {
 	const (
 		containerName = "prometheus"
-		primaryOwner  = monitoring.ObservableOwnerDistribution
 
 		// ruleGroupInterpretation provides interpretation documentation for observables that are per prometheus rule_group.
 		ruleGroupInterpretation = `Rules that Sourcegraph ships with are grouped under '/sg_config_prometheus'. [Custom rules are grouped under '/sg_prometheus_addons'](https://docs.sourcegraph.com/admin/observability/metrics#prometheus-configuration).`
@@ -155,9 +154,9 @@ func Prometheus() *monitoring.Container {
 				},
 			},
 
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerDistribution, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerDistribution, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerDistribution, nil),
 		},
 	}
 }

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -154,6 +154,7 @@ func Prometheus() *monitoring.Container {
 					},
 				},
 			},
+
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -8,13 +8,19 @@ import (
 )
 
 func Prometheus() *monitoring.Container {
-	// ruleGroupInterpretation provides interpretation documentation for observables that are per prometheus rule_group.
-	const ruleGroupInterpretation = `Rules that Sourcegraph ships with are grouped under '/sg_config_prometheus'. [Custom rules are grouped under '/sg_prometheus_addons'](https://docs.sourcegraph.com/admin/observability/metrics#prometheus-configuration).`
+	const (
+		containerName = "prometheus"
+		primaryOwner  = monitoring.ObservableOwnerDistribution
+
+		// ruleGroupInterpretation provides interpretation documentation for observables that are per prometheus rule_group.
+		ruleGroupInterpretation = `Rules that Sourcegraph ships with are grouped under '/sg_config_prometheus'. [Custom rules are grouped under '/sg_prometheus_addons'](https://docs.sourcegraph.com/admin/observability/metrics#prometheus-configuration).`
+	)
 
 	return &monitoring.Container{
-		Name:        "prometheus",
-		Title:       "Prometheus",
-		Description: "Sourcegraph's all-in-one Prometheus and Alertmanager service.",
+		Name:                     "prometheus",
+		Title:                    "Prometheus",
+		Description:              "Sourcegraph's all-in-one Prometheus and Alertmanager service.",
+		NoSourcegraphDebugServer: true, // This is third-party service
 		Groups: []monitoring.Group{
 			{
 				Title: "Metrics",
@@ -148,12 +154,9 @@ func Prometheus() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
-			shared.NewProvisioningIndicatorsGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
-			shared.NewKubernetesMonitoringGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
-
-		// This is third-party service
-		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -148,19 +148,7 @@ func Prometheus() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-						shared.ContainerMemoryUsage("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-					},
-					{
-						shared.ContainerMissing("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -150,15 +150,7 @@ func Prometheus() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
 			shared.NewProvisioningIndicatorsGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("prometheus", monitoring.ObservableOwnerDistribution, nil),
 		},
 
 		// This is third-party service

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -16,14 +16,7 @@ func QueryRunner() *monitoring.Container {
 		Title:       "Query Runner",
 		Description: "Periodically runs saved searches and instructs the frontend to send out notifications.",
 		Groups: []monitoring.Group{
-			{
-				Title: "General",
-				Rows: []monitoring.Row{
-					{
-						shared.FrontendInternalAPIErrorResponses("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -6,6 +6,11 @@ import (
 )
 
 func QueryRunner() *monitoring.Container {
+	const (
+		containerName = "query-runner"
+		primaryOwner  = monitoring.ObservableOwnerSearch
+	)
+
 	return &monitoring.Container{
 		Name:        "query-runner",
 		Title:       "Query Runner",
@@ -19,10 +24,10 @@ func QueryRunner() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
-			shared.NewProvisioningIndicatorsGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
-			shared.NewGolangMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
-			shared.NewKubernetesMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -20,20 +20,7 @@ func QueryRunner() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -21,16 +21,7 @@ func QueryRunner() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
 			shared.NewProvisioningIndicatorsGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-						shared.GoGcDuration("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -22,15 +22,7 @@ func QueryRunner() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
 			shared.NewProvisioningIndicatorsGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
 			shared.NewGolangMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
 		},
 	}
 }

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -6,21 +6,18 @@ import (
 )
 
 func QueryRunner() *monitoring.Container {
-	const (
-		containerName = "query-runner"
-		primaryOwner  = monitoring.ObservableOwnerSearch
-	)
+	const containerName = "query-runner"
 
 	return &monitoring.Container{
 		Name:        "query-runner",
 		Title:       "Query Runner",
 		Description: "Periodically runs saved searches and instructs the frontend to send out notifications.",
 		Groups: []monitoring.Group{
-			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
 		},
 	}
 }

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -19,19 +19,7 @@ func QueryRunner() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerMemoryUsage("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ContainerCPUUsage("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						shared.ContainerMissing("query-runner", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("query-runner", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -17,6 +17,12 @@ func RepoUpdater() *monitoring.Container {
 		syncDurationThreshold = 9 * time.Hour
 	)
 
+	var containerMonitoringOptions = &shared.ContainerMonitoringGroupOptions{
+		MemoryUsage: func(observable shared.Observable) shared.Observable {
+			return observable.WithWarning(nil).WithCritical(monitoring.Alert().GreaterOrEqual(90, nil).For(10 * time.Minute))
+		},
+	}
+
 	return &monitoring.Container{
 		Name:        "repo-updater",
 		Title:       "Repo Updater",
@@ -426,16 +432,10 @@ func RepoUpdater() *monitoring.Container {
 
 			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, repoUpdaterContainerMonitoringOptions),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, containerMonitoringOptions),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
-}
-
-var repoUpdaterContainerMonitoringOptions = &shared.ContainerMonitoringGroupOptions{
-	MemoryUsage: func(observable shared.Observable) shared.Observable {
-		return observable.WithWarning(nil).WithCritical(monitoring.Alert().GreaterOrEqual(90, nil).For(10 * time.Minute))
-	},
 }

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -23,14 +23,6 @@ func RepoUpdater() *monitoring.Container {
 		Description: "Manages interaction with code hosts, instructs Gitserver to update repositories.",
 		Groups: []monitoring.Group{
 			{
-				Title: "General",
-				Rows: []monitoring.Row{
-					{
-						shared.FrontendInternalAPIErrorResponses("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
-			{
 				Title: "Repositories",
 				Rows: []monitoring.Row{
 					{
@@ -431,7 +423,9 @@ func RepoUpdater() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewDatabaseConnectionsMonitoringGroup("repo-updater"),
+
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, repoUpdaterContainerMonitoringOptions),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -438,16 +438,7 @@ func RepoUpdater() *monitoring.Container {
 				},
 			}),
 			shared.NewProvisioningIndicatorsGroup("repo-updater", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.GoGcDuration("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("repo-updater", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -439,15 +439,7 @@ func RepoUpdater() *monitoring.Container {
 			}),
 			shared.NewProvisioningIndicatorsGroup("repo-updater", monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewGolangMonitoringGroup("repo-updater", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("repo-updater", monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
 }

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -11,7 +11,6 @@ import (
 func RepoUpdater() *monitoring.Container {
 	const (
 		containerName = "repo-updater"
-		primaryOwner  = monitoring.ObservableOwnerCoreApplication
 
 		// This is set a bit longer than maxSyncInterval in internal/repos/syncer.go
 		syncDurationThreshold = 9 * time.Hour
@@ -430,12 +429,12 @@ func RepoUpdater() *monitoring.Container {
 				},
 			},
 
-			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, containerMonitoringOptions),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, containerMonitoringOptions),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
 }

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -431,22 +431,13 @@ func RepoUpdater() *monitoring.Container {
 				Hidden: true,
 				Rows:   shared.DatabaseConnectionsMonitoring("repo-updater"),
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ContainerMemoryUsage("repo-updater", monitoring.ObservableOwnerCoreApplication).
-							WithWarning(nil).
-							WithCritical(monitoring.Alert().GreaterOrEqual(90, nil).For(10 * time.Minute)).
-							Observable(),
-					},
-					{
-						shared.ContainerMissing("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
+
+			shared.NewContainerMonitoringGroup("repo-updater", monitoring.ObservableOwnerCoreApplication, &shared.ContainerMonitoringGroupOptions{
+				MemoryUsage: func(observable shared.Observable) shared.Observable {
+					return observable.WithWarning(nil).WithCritical(monitoring.Alert().GreaterOrEqual(90, nil).For(10 * time.Minute))
 				},
-			},
+			}),
+
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -437,21 +437,7 @@ func RepoUpdater() *monitoring.Container {
 					return observable.WithWarning(nil).WithCritical(monitoring.Alert().GreaterOrEqual(90, nil).For(10 * time.Minute))
 				},
 			}),
-
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("repo-updater", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("repo-updater", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -431,12 +431,7 @@ func RepoUpdater() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleDatabaseConnectionsMonitoring,
-				Hidden: true,
-				Rows:   shared.DatabaseConnectionsMonitoring("repo-updater"),
-			},
-
+			shared.NewDatabaseConnectionsMonitoringGroup("repo-updater"),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, repoUpdaterContainerMonitoringOptions),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -8,10 +8,7 @@ import (
 )
 
 func Searcher() *monitoring.Container {
-	const (
-		containerName = "searcher"
-		primaryOwner  = monitoring.ObservableOwnerSearch
-	)
+	const containerName = "searcher"
 
 	return &monitoring.Container{
 		Name:        "searcher",
@@ -44,11 +41,11 @@ func Searcher() *monitoring.Container {
 				},
 			},
 
-			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
 		},
 	}
 }

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -39,19 +39,7 @@ func Searcher() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("searcher", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ContainerMemoryUsage("searcher", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						shared.ContainerMissing("searcher", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -8,6 +8,11 @@ import (
 )
 
 func Searcher() *monitoring.Container {
+	const (
+		containerName = "searcher"
+		primaryOwner  = monitoring.ObservableOwnerSearch
+	)
+
 	return &monitoring.Container{
 		Name:        "searcher",
 		Title:       "Searcher",
@@ -39,10 +44,10 @@ func Searcher() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
-			shared.NewProvisioningIndicatorsGroup("searcher", monitoring.ObservableOwnerSearch, nil),
-			shared.NewGolangMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
-			shared.NewKubernetesMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -42,15 +42,7 @@ func Searcher() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
 			shared.NewProvisioningIndicatorsGroup("searcher", monitoring.ObservableOwnerSearch, nil),
 			shared.NewGolangMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("searcher", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
 		},
 	}
 }

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -40,10 +40,11 @@ func Searcher() *monitoring.Container {
 							Owner:             monitoring.ObservableOwnerSearch,
 							PossibleSolutions: "none",
 						},
-						shared.FrontendInternalAPIErrorResponses("searcher", monitoring.ObservableOwnerSearch).Observable(),
 					},
 				},
 			},
+
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -41,16 +41,7 @@ func Searcher() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
 			shared.NewProvisioningIndicatorsGroup("searcher", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("searcher", monitoring.ObservableOwnerSearch).Observable(),
-						shared.GoGcDuration("searcher", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -40,20 +40,7 @@ func Searcher() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("searcher", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("searcher", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("searcher", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("searcher", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("searcher", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("searcher", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/shared/container.go
+++ b/monitoring/definitions/shared/container.go
@@ -129,7 +129,3 @@ func NewContainerMonitoringGroup(containerName string, owner monitoring.Observab
 		},
 	}
 }
-
-func NoopObservableTransformer(observable Observable) Observable {
-	return observable
-}

--- a/monitoring/definitions/shared/container.go
+++ b/monitoring/definitions/shared/container.go
@@ -115,10 +115,10 @@ func NewContainerMonitoringGroup(containerName string, owner monitoring.Observab
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.ContainerMissing.SafeApply(ContainerMissing(containerName, owner)).Observable(),
-				options.CPUUsage.SafeApply(ContainerCPUUsage(containerName, owner)).Observable(),
-				options.MemoryUsage.SafeApply(ContainerMemoryUsage(containerName, owner)).Observable(),
-				options.IOUsage.SafeApply(ContainerIOUsage(containerName, owner)).Observable(),
+				options.ContainerMissing.safeApply(ContainerMissing(containerName, owner)).Observable(),
+				options.CPUUsage.safeApply(ContainerCPUUsage(containerName, owner)).Observable(),
+				options.MemoryUsage.safeApply(ContainerMemoryUsage(containerName, owner)).Observable(),
+				options.IOUsage.safeApply(ContainerIOUsage(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/container.go
+++ b/monitoring/definitions/shared/container.go
@@ -102,18 +102,18 @@ type ContainerMonitoringGroupOptions struct {
 // NewContainerMonitoringGroup creates a group containing panels displaying
 // container monitoring metrics - cpu, memory, io resource usage as well as
 // a container missing alert - for the given container.
-func NewContainerMonitoringGroup(containerName string, owner monitoring.ObservableOwner, alerts *ContainerMonitoringGroupOptions) monitoring.Group {
-	if alerts == nil {
-		alerts = &ContainerMonitoringGroupOptions{}
+func NewContainerMonitoringGroup(containerName string, owner monitoring.ObservableOwner, options *ContainerMonitoringGroupOptions) monitoring.Group {
+	if options == nil {
+		options = &ContainerMonitoringGroupOptions{}
 	}
-	if alerts.CPUUsage == nil {
-		alerts.CPUUsage = NoopObservableTransformer
+	if options.CPUUsage == nil {
+		options.CPUUsage = NoopObservableTransformer
 	}
-	if alerts.MemoryUsage == nil {
-		alerts.MemoryUsage = NoopObservableTransformer
+	if options.MemoryUsage == nil {
+		options.MemoryUsage = NoopObservableTransformer
 	}
-	if alerts.IOUsage == nil {
-		alerts.IOUsage = NoopObservableTransformer
+	if options.IOUsage == nil {
+		options.IOUsage = NoopObservableTransformer
 	}
 
 	return monitoring.Group{
@@ -122,9 +122,9 @@ func NewContainerMonitoringGroup(containerName string, owner monitoring.Observab
 		Rows: []monitoring.Row{
 			{
 				ContainerMissing(containerName, owner).Observable(),
-				alerts.CPUUsage(ContainerCPUUsage(containerName, owner)).Observable(),
-				alerts.MemoryUsage(ContainerMemoryUsage(containerName, owner)).Observable(),
-				alerts.IOUsage(ContainerIOUsage(containerName, owner)).Observable(),
+				options.CPUUsage(ContainerCPUUsage(containerName, owner)).Observable(),
+				options.MemoryUsage(ContainerMemoryUsage(containerName, owner)).Observable(),
+				options.IOUsage(ContainerIOUsage(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/dbconns.go
+++ b/monitoring/definitions/shared/dbconns.go
@@ -100,3 +100,13 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 		},
 	}
 }
+
+// NewDatabaseConnectionsMonitoringGroup creates a group containing panels displaying
+// database monitoring metrics for the given container.
+func NewDatabaseConnectionsMonitoringGroup(containerName string) monitoring.Group {
+	return monitoring.Group{
+		Title:  TitleDatabaseConnectionsMonitoring,
+		Hidden: true,
+		Rows:   DatabaseConnectionsMonitoring(containerName),
+	}
+}

--- a/monitoring/definitions/shared/frontend.go
+++ b/monitoring/definitions/shared/frontend.go
@@ -27,3 +27,29 @@ var FrontendInternalAPIErrorResponses sharedObservable = func(containerName stri
 		`, "{{CONTAINER_NAME}}", containerName),
 	}
 }
+
+type FrontendInternalAPIERrorResponseMonitoringOptions struct {
+	// ErrorResponses transforms the default observable used to construct the error responses panel.
+	ErrorResponses func(observable Observable) Observable
+}
+
+// NewProvisioningIndicatorsGroup creates a group containing panels displaying
+// internal API error response metrics for the given container.
+func NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName string, owner monitoring.ObservableOwner, options *FrontendInternalAPIERrorResponseMonitoringOptions) monitoring.Group {
+	if options == nil {
+		options = &FrontendInternalAPIERrorResponseMonitoringOptions{}
+	}
+	if options.ErrorResponses == nil {
+		options.ErrorResponses = NoopObservableTransformer
+	}
+
+	return monitoring.Group{
+		Title:  "Internal service requests",
+		Hidden: true,
+		Rows: []monitoring.Row{
+			{
+				options.ErrorResponses(FrontendInternalAPIErrorResponses(containerName, owner)).Observable(),
+			},
+		},
+	}
+}

--- a/monitoring/definitions/shared/frontend.go
+++ b/monitoring/definitions/shared/frontend.go
@@ -30,7 +30,7 @@ var FrontendInternalAPIErrorResponses sharedObservable = func(containerName stri
 
 type FrontendInternalAPIERrorResponseMonitoringOptions struct {
 	// ErrorResponses transforms the default observable used to construct the error responses panel.
-	ErrorResponses func(observable Observable) Observable
+	ErrorResponses ObservableOption
 }
 
 // NewProvisioningIndicatorsGroup creates a group containing panels displaying
@@ -39,16 +39,13 @@ func NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName string, ow
 	if options == nil {
 		options = &FrontendInternalAPIERrorResponseMonitoringOptions{}
 	}
-	if options.ErrorResponses == nil {
-		options.ErrorResponses = NoopObservableTransformer
-	}
 
 	return monitoring.Group{
 		Title:  "Internal service requests",
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.ErrorResponses(FrontendInternalAPIErrorResponses(containerName, owner)).Observable(),
+				options.ErrorResponses.SafeApply(FrontendInternalAPIErrorResponses(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/frontend.go
+++ b/monitoring/definitions/shared/frontend.go
@@ -45,7 +45,7 @@ func NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName string, ow
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.ErrorResponses.SafeApply(FrontendInternalAPIErrorResponses(containerName, owner)).Observable(),
+				options.ErrorResponses.safeApply(FrontendInternalAPIErrorResponses(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/go.go
+++ b/monitoring/definitions/shared/go.go
@@ -60,8 +60,8 @@ func NewGolangMonitoringGroup(containerName string, owner monitoring.ObservableO
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.Goroutines.SafeApply(GoGoroutines(containerName, owner)).Observable(),
-				options.GCDuration.SafeApply(GoGcDuration(containerName, owner)).Observable(),
+				options.Goroutines.safeApply(GoGoroutines(containerName, owner)).Observable(),
+				options.GCDuration.safeApply(GoGcDuration(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/go.go
+++ b/monitoring/definitions/shared/go.go
@@ -42,10 +42,10 @@ var (
 
 type GolangMonitoringOptions struct {
 	// Goroutines transforms the default observable used to construct the Go goroutines count panel.
-	Goroutines func(observable Observable) Observable
+	Goroutines ObservableOption
 
 	// GCDuration transforms the default observable used to construct the Go GC duration panel.
-	GCDuration func(observable Observable) Observable
+	GCDuration ObservableOption
 }
 
 // NewGolangMonitoringGroup creates a group containing panels displaying Go monitoring
@@ -54,20 +54,14 @@ func NewGolangMonitoringGroup(containerName string, owner monitoring.ObservableO
 	if options == nil {
 		options = &GolangMonitoringOptions{}
 	}
-	if options.Goroutines == nil {
-		options.Goroutines = NoopObservableTransformer
-	}
-	if options.GCDuration == nil {
-		options.GCDuration = NoopObservableTransformer
-	}
 
 	return monitoring.Group{
 		Title:  TitleGolangMonitoring,
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.Goroutines(GoGoroutines(containerName, owner)).Observable(),
-				options.GCDuration(GoGcDuration(containerName, owner)).Observable(),
+				options.Goroutines.SafeApply(GoGoroutines(containerName, owner)).Observable(),
+				options.GCDuration.SafeApply(GoGcDuration(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/go.go
+++ b/monitoring/definitions/shared/go.go
@@ -41,7 +41,7 @@ var (
 )
 
 type GolangMonitoringOptions struct {
-	// Goroutines transforms the default observable used to construct the Go goroutines duration panel.
+	// Goroutines transforms the default observable used to construct the Go goroutines count panel.
 	Goroutines func(observable Observable) Observable
 
 	// GCDuration transforms the default observable used to construct the Go GC duration panel.

--- a/monitoring/definitions/shared/go.go
+++ b/monitoring/definitions/shared/go.go
@@ -50,15 +50,15 @@ type GolangMonitoringOptions struct {
 
 // NewGolangMonitoringGroup creates a group containing panels displaying Go monitoring
 // metrics for the given container.
-func NewGolangMonitoringGroup(containerName string, owner monitoring.ObservableOwner, alerts *GolangMonitoringOptions) monitoring.Group {
-	if alerts == nil {
-		alerts = &GolangMonitoringOptions{}
+func NewGolangMonitoringGroup(containerName string, owner monitoring.ObservableOwner, options *GolangMonitoringOptions) monitoring.Group {
+	if options == nil {
+		options = &GolangMonitoringOptions{}
 	}
-	if alerts.Goroutines == nil {
-		alerts.Goroutines = NoopObservableTransformer
+	if options.Goroutines == nil {
+		options.Goroutines = NoopObservableTransformer
 	}
-	if alerts.GCDuration == nil {
-		alerts.GCDuration = NoopObservableTransformer
+	if options.GCDuration == nil {
+		options.GCDuration = NoopObservableTransformer
 	}
 
 	return monitoring.Group{
@@ -66,8 +66,8 @@ func NewGolangMonitoringGroup(containerName string, owner monitoring.ObservableO
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				alerts.Goroutines(GoGoroutines(containerName, owner)).Observable(),
-				alerts.GCDuration(GoGcDuration(containerName, owner)).Observable(),
+				options.Goroutines(GoGoroutines(containerName, owner)).Observable(),
+				options.GCDuration(GoGcDuration(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/kubernetes.go
+++ b/monitoring/definitions/shared/kubernetes.go
@@ -27,3 +27,30 @@ var (
 		}
 	}
 )
+
+type KubernetesMonitoringOptions struct {
+	// PodsAvailable transforms the default observable used to construct the pods available panel.
+	PodsAvailable func(observable Observable) Observable
+}
+
+// NewProvisioningIndicatorsGroup creates a group containing panels displaying
+// provisioning indication metrics - long and short term usage for both CPU and
+// memory usage - for the given container.
+func NewKubernetesMonitoringGroup(containerName string, owner monitoring.ObservableOwner, options *KubernetesMonitoringOptions) monitoring.Group {
+	if options == nil {
+		options = &KubernetesMonitoringOptions{}
+	}
+	if options.PodsAvailable == nil {
+		options.PodsAvailable = NoopObservableTransformer
+	}
+
+	return monitoring.Group{
+		Title:  TitleKubernetesMonitoring,
+		Hidden: true,
+		Rows: []monitoring.Row{
+			{
+				options.PodsAvailable(KubernetesPodsAvailable(containerName, owner)).Observable(),
+			},
+		},
+	}
+}

--- a/monitoring/definitions/shared/kubernetes.go
+++ b/monitoring/definitions/shared/kubernetes.go
@@ -30,7 +30,7 @@ var (
 
 type KubernetesMonitoringOptions struct {
 	// PodsAvailable transforms the default observable used to construct the pods available panel.
-	PodsAvailable func(observable Observable) Observable
+	PodsAvailable ObservableOption
 }
 
 // NewProvisioningIndicatorsGroup creates a group containing panels displaying
@@ -40,16 +40,13 @@ func NewKubernetesMonitoringGroup(containerName string, owner monitoring.Observa
 	if options == nil {
 		options = &KubernetesMonitoringOptions{}
 	}
-	if options.PodsAvailable == nil {
-		options.PodsAvailable = NoopObservableTransformer
-	}
 
 	return monitoring.Group{
 		Title:  TitleKubernetesMonitoring,
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.PodsAvailable(KubernetesPodsAvailable(containerName, owner)).Observable(),
+				options.PodsAvailable.SafeApply(KubernetesPodsAvailable(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/kubernetes.go
+++ b/monitoring/definitions/shared/kubernetes.go
@@ -46,7 +46,7 @@ func NewKubernetesMonitoringGroup(containerName string, owner monitoring.Observa
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.PodsAvailable.SafeApply(KubernetesPodsAvailable(containerName, owner)).Observable(),
+				options.PodsAvailable.safeApply(KubernetesPodsAvailable(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/provisioning.go
+++ b/monitoring/definitions/shared/provisioning.go
@@ -80,16 +80,16 @@ var (
 
 type ContainerProvisioningIndicatorsGroupOptions struct {
 	// LongTermCPUUsage transforms the default observable used to construct the long-term CPU usage panel.
-	LongTermCPUUsage func(observable Observable) Observable
+	LongTermCPUUsage ObservableOption
 
 	// LongTermMemoryUsage transforms the default observable used to construct the long-term memory usage panel.
-	LongTermMemoryUsage func(observable Observable) Observable
+	LongTermMemoryUsage ObservableOption
 
 	// ShortTermCPUUsage transforms the default observable used to construct the short-term CPU usage panel.
-	ShortTermCPUUsage func(observable Observable) Observable
+	ShortTermCPUUsage ObservableOption
 
 	// ShortTermMemoryUsage transforms the default observable used to construct the short-term memory usage panel.
-	ShortTermMemoryUsage func(observable Observable) Observable
+	ShortTermMemoryUsage ObservableOption
 }
 
 // NewProvisioningIndicatorsGroup creates a group containing panels displaying
@@ -99,30 +99,18 @@ func NewProvisioningIndicatorsGroup(containerName string, owner monitoring.Obser
 	if options == nil {
 		options = &ContainerProvisioningIndicatorsGroupOptions{}
 	}
-	if options.LongTermCPUUsage == nil {
-		options.LongTermCPUUsage = NoopObservableTransformer
-	}
-	if options.LongTermMemoryUsage == nil {
-		options.LongTermMemoryUsage = NoopObservableTransformer
-	}
-	if options.ShortTermCPUUsage == nil {
-		options.ShortTermCPUUsage = NoopObservableTransformer
-	}
-	if options.ShortTermMemoryUsage == nil {
-		options.ShortTermMemoryUsage = NoopObservableTransformer
-	}
 
 	return monitoring.Group{
 		Title:  TitleProvisioningIndicators,
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.LongTermCPUUsage(ProvisioningCPUUsageLongTerm(containerName, owner)).Observable(),
-				options.LongTermMemoryUsage(ProvisioningMemoryUsageLongTerm(containerName, owner)).Observable(),
+				options.LongTermCPUUsage.SafeApply(ProvisioningCPUUsageLongTerm(containerName, owner)).Observable(),
+				options.LongTermMemoryUsage.SafeApply(ProvisioningMemoryUsageLongTerm(containerName, owner)).Observable(),
 			},
 			{
-				options.ShortTermCPUUsage(ProvisioningCPUUsageShortTerm(containerName, owner)).Observable(),
-				options.ShortTermMemoryUsage(ProvisioningMemoryUsageShortTerm(containerName, owner)).Observable(),
+				options.ShortTermCPUUsage.SafeApply(ProvisioningCPUUsageShortTerm(containerName, owner)).Observable(),
+				options.ShortTermMemoryUsage.SafeApply(ProvisioningMemoryUsageShortTerm(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/provisioning.go
+++ b/monitoring/definitions/shared/provisioning.go
@@ -95,21 +95,21 @@ type ContainerProvisioningIndicatorsGroupOptions struct {
 // NewProvisioningIndicatorsGroup creates a group containing panels displaying
 // provisioning indication metrics - long and short term usage for both CPU and
 // memory usage - for the given container.
-func NewProvisioningIndicatorsGroup(containerName string, owner monitoring.ObservableOwner, alerts *ContainerProvisioningIndicatorsGroupOptions) monitoring.Group {
-	if alerts == nil {
-		alerts = &ContainerProvisioningIndicatorsGroupOptions{}
+func NewProvisioningIndicatorsGroup(containerName string, owner monitoring.ObservableOwner, options *ContainerProvisioningIndicatorsGroupOptions) monitoring.Group {
+	if options == nil {
+		options = &ContainerProvisioningIndicatorsGroupOptions{}
 	}
-	if alerts.LongTermCPUUsage == nil {
-		alerts.LongTermCPUUsage = NoopObservableTransformer
+	if options.LongTermCPUUsage == nil {
+		options.LongTermCPUUsage = NoopObservableTransformer
 	}
-	if alerts.LongTermMemoryUsage == nil {
-		alerts.LongTermMemoryUsage = NoopObservableTransformer
+	if options.LongTermMemoryUsage == nil {
+		options.LongTermMemoryUsage = NoopObservableTransformer
 	}
-	if alerts.ShortTermCPUUsage == nil {
-		alerts.ShortTermCPUUsage = NoopObservableTransformer
+	if options.ShortTermCPUUsage == nil {
+		options.ShortTermCPUUsage = NoopObservableTransformer
 	}
-	if alerts.ShortTermMemoryUsage == nil {
-		alerts.ShortTermMemoryUsage = NoopObservableTransformer
+	if options.ShortTermMemoryUsage == nil {
+		options.ShortTermMemoryUsage = NoopObservableTransformer
 	}
 
 	return monitoring.Group{
@@ -117,12 +117,12 @@ func NewProvisioningIndicatorsGroup(containerName string, owner monitoring.Obser
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				alerts.LongTermCPUUsage(ProvisioningCPUUsageLongTerm(containerName, owner)).Observable(),
-				alerts.LongTermMemoryUsage(ProvisioningMemoryUsageLongTerm(containerName, owner)).Observable(),
+				options.LongTermCPUUsage(ProvisioningCPUUsageLongTerm(containerName, owner)).Observable(),
+				options.LongTermMemoryUsage(ProvisioningMemoryUsageLongTerm(containerName, owner)).Observable(),
 			},
 			{
-				alerts.ShortTermCPUUsage(ProvisioningCPUUsageShortTerm(containerName, owner)).Observable(),
-				alerts.ShortTermMemoryUsage(ProvisioningMemoryUsageShortTerm(containerName, owner)).Observable(),
+				options.ShortTermCPUUsage(ProvisioningCPUUsageShortTerm(containerName, owner)).Observable(),
+				options.ShortTermMemoryUsage(ProvisioningMemoryUsageShortTerm(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/provisioning.go
+++ b/monitoring/definitions/shared/provisioning.go
@@ -105,12 +105,12 @@ func NewProvisioningIndicatorsGroup(containerName string, owner monitoring.Obser
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{
-				options.LongTermCPUUsage.SafeApply(ProvisioningCPUUsageLongTerm(containerName, owner)).Observable(),
-				options.LongTermMemoryUsage.SafeApply(ProvisioningMemoryUsageLongTerm(containerName, owner)).Observable(),
+				options.LongTermCPUUsage.safeApply(ProvisioningCPUUsageLongTerm(containerName, owner)).Observable(),
+				options.LongTermMemoryUsage.safeApply(ProvisioningMemoryUsageLongTerm(containerName, owner)).Observable(),
 			},
 			{
-				options.ShortTermCPUUsage.SafeApply(ProvisioningCPUUsageShortTerm(containerName, owner)).Observable(),
-				options.ShortTermMemoryUsage.SafeApply(ProvisioningMemoryUsageShortTerm(containerName, owner)).Observable(),
+				options.ShortTermCPUUsage.safeApply(ProvisioningCPUUsageShortTerm(containerName, owner)).Observable(),
+				options.ShortTermMemoryUsage.safeApply(ProvisioningMemoryUsageShortTerm(containerName, owner)).Observable(),
 			},
 		},
 	}

--- a/monitoring/definitions/shared/shared.go
+++ b/monitoring/definitions/shared/shared.go
@@ -32,6 +32,10 @@ import (
 // customizing shared observables.
 type Observable monitoring.Observable
 
+func NoopObservableTransformer(observable Observable) Observable {
+	return observable
+}
+
 // Observable is a convenience adapter that casts this SharedObservable as an normal Observable.
 func (o Observable) Observable() monitoring.Observable { return monitoring.Observable(o) }
 

--- a/monitoring/definitions/shared/shared.go
+++ b/monitoring/definitions/shared/shared.go
@@ -32,10 +32,6 @@ import (
 // customizing shared observables.
 type Observable monitoring.Observable
 
-func NoopObservableTransformer(observable Observable) Observable {
-	return observable
-}
-
 // Observable is a convenience adapter that casts this SharedObservable as an normal Observable.
 func (o Observable) Observable() monitoring.Observable { return monitoring.Observable(o) }
 
@@ -65,6 +61,18 @@ func (o Observable) WithNoAlerts(interpretation string) Observable {
 	o.PossibleSolutions = ""
 	o.Interpretation = interpretation
 	return o
+}
+
+// ObservableOption is a function that transforms an observable.
+type ObservableOption func(observable Observable) Observable
+
+// SafeApply applies f(observable), returning the parameter when f is nil.
+func (f ObservableOption) SafeApply(observable Observable) Observable {
+	if f == nil {
+		return observable
+	}
+
+	return f(observable)
 }
 
 // sharedObservable defines the type all shared observable variables should have in this package.

--- a/monitoring/definitions/shared/shared.go
+++ b/monitoring/definitions/shared/shared.go
@@ -66,8 +66,7 @@ func (o Observable) WithNoAlerts(interpretation string) Observable {
 // ObservableOption is a function that transforms an observable.
 type ObservableOption func(observable Observable) Observable
 
-// SafeApply applies f(observable), returning the parameter when f is nil.
-func (f ObservableOption) SafeApply(observable Observable) Observable {
+func (f ObservableOption) safeApply(observable Observable) Observable {
 	if f == nil {
 		return observable
 	}

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -39,11 +39,10 @@ func Symbols() *monitoring.Container {
 							PossibleSolutions: "none",
 						},
 					},
-					{
-						shared.FrontendInternalAPIErrorResponses("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
 				},
 			},
+
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -39,19 +39,7 @@ func Symbols() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ContainerMemoryUsage("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ContainerMissing("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -6,10 +6,7 @@ import (
 )
 
 func Symbols() *monitoring.Container {
-	const (
-		containerName = "symbols"
-		primaryOwner  = monitoring.ObservableOwnerCodeIntel
-	)
+	const containerName = "symbols"
 
 	return &monitoring.Container{
 		Name:        "symbols",
@@ -42,11 +39,11 @@ func Symbols() *monitoring.Container {
 				},
 			},
 
-			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -6,6 +6,11 @@ import (
 )
 
 func Symbols() *monitoring.Container {
+	const (
+		containerName = "symbols"
+		primaryOwner  = monitoring.ObservableOwnerCodeIntel
+	)
+
 	return &monitoring.Container{
 		Name:        "symbols",
 		Title:       "Symbols",
@@ -39,10 +44,10 @@ func Symbols() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewProvisioningIndicatorsGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewGolangMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewKubernetesMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -41,16 +41,7 @@ func Symbols() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.GoGcDuration("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -42,15 +42,7 @@ func Symbols() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewGolangMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -40,20 +40,7 @@ func Symbols() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("symbols", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -57,20 +57,7 @@ func SyntectServer() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -56,19 +56,7 @@ func SyntectServer() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-						shared.ContainerMemoryUsage("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-					{
-						shared.ContainerMissing("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -62,6 +62,7 @@ func SyntectServer() *monitoring.Container {
 					},
 				},
 			},
+
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -6,10 +6,7 @@ import (
 )
 
 func SyntectServer() *monitoring.Container {
-	const (
-		containerName = "syntect-server"
-		primaryOwner  = monitoring.ObservableOwnerCoreApplication
-	)
+	const containerName = "syntect-server"
 
 	return &monitoring.Container{
 		Name:                     "syntect-server",
@@ -63,9 +60,9 @@ func SyntectServer() *monitoring.Container {
 				},
 			},
 
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 		},
 	}
 }

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -58,15 +58,7 @@ func SyntectServer() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewProvisioningIndicatorsGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("syntect-server", monitoring.ObservableOwnerCoreApplication).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
 		},
 		NoSourcegraphDebugServer: true,
 	}

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -6,10 +6,16 @@ import (
 )
 
 func SyntectServer() *monitoring.Container {
+	const (
+		containerName = "syntect-server"
+		primaryOwner  = monitoring.ObservableOwnerCoreApplication
+	)
+
 	return &monitoring.Container{
-		Name:        "syntect-server",
-		Title:       "Syntect Server",
-		Description: "Handles syntax highlighting for code files.",
+		Name:                     "syntect-server",
+		Title:                    "Syntect Server",
+		Description:              "Handles syntax highlighting for code files.",
+		NoSourcegraphDebugServer: true, // This is third-party service
 		Groups: []monitoring.Group{
 			{
 				Title: "General",
@@ -56,10 +62,9 @@ func SyntectServer() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewProvisioningIndicatorsGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
-			shared.NewKubernetesMonitoringGroup("syntect-server", monitoring.ObservableOwnerCoreApplication, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
-		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -207,11 +207,7 @@ func Worker() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleDatabaseConnectionsMonitoring,
-				Hidden: true,
-				Rows:   shared.DatabaseConnectionsMonitoring("worker"),
-			},
+			shared.NewDatabaseConnectionsMonitoringGroup("worker"),
 			{
 				Title:  "Internal service requests",
 				Hidden: true,

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -9,6 +9,11 @@ import (
 )
 
 func Worker() *monitoring.Container {
+	const (
+		containerName = "worker"
+		primaryOwner  = monitoring.ObservableOwnerCodeIntel
+	)
+
 	return &monitoring.Container{
 		Name:        "worker",
 		Title:       "Worker",
@@ -216,10 +221,10 @@ func Worker() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewProvisioningIndicatorsGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewGolangMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
-			shared.NewKubernetesMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
 		},
 	}
 }

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -219,15 +219,7 @@ func Worker() *monitoring.Container {
 			shared.NewContainerMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewGolangMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.KubernetesPodsAvailable("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewKubernetesMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -9,10 +9,7 @@ import (
 )
 
 func Worker() *monitoring.Container {
-	const (
-		containerName = "worker"
-		primaryOwner  = monitoring.ObservableOwnerCodeIntel
-	)
+	const containerName = "worker"
 
 	return &monitoring.Container{
 		Name:        "worker",
@@ -208,12 +205,12 @@ func Worker() *monitoring.Container {
 				},
 			},
 
-			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewGolangMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
+			shared.NewKubernetesMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),
 		},
 	}
 }

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -217,20 +217,7 @@ func Worker() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleGolangMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -218,16 +218,7 @@ func Worker() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
 			shared.NewProvisioningIndicatorsGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
-			{
-				Title:  shared.TitleGolangMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.GoGoroutines("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.GoGcDuration("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewGolangMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -207,16 +207,9 @@ func Worker() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewDatabaseConnectionsMonitoringGroup("worker"),
-			{
-				Title:  "Internal service requests",
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.FrontendInternalAPIErrorResponses("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+
+			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
 			shared.NewGolangMonitoringGroup(containerName, primaryOwner, nil),

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -216,19 +216,7 @@ func Worker() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ContainerMemoryUsage("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ContainerMissing("worker", monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("worker", monitoring.ObservableOwnerCodeIntel, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -96,20 +96,7 @@ func ZoektIndexServer() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ContainerMemoryUsage("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						shared.ContainerMissing("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ContainerIOUsage("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewContainerMonitoringGroup("zoekt-indexserver", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -98,18 +98,10 @@ func ZoektIndexServer() *monitoring.Container {
 			},
 			shared.NewContainerMonitoringGroup("zoekt-indexserver", monitoring.ObservableOwnerSearch, nil),
 			shared.NewProvisioningIndicatorsGroup("zoekt-indexserver", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleKubernetesMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						// zoekt_index_server, zoekt_web_server are deployed together
-						// as part of the indexed-search service, so only show pod
-						// availability here.
-						shared.KubernetesPodsAvailable("indexed-search", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+
+			// zoekt_index_server, zoekt_web_server are deployed together as part of
+			// the indexed-search service, so only show pod availability here.
+			shared.NewKubernetesMonitoringGroup("indexed-search", monitoring.ObservableOwnerSearch, nil),
 		},
 
 		NoSourcegraphDebugServer: true,

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -97,20 +97,7 @@ func ZoektIndexServer() *monitoring.Container {
 				},
 			},
 			shared.NewContainerMonitoringGroup("zoekt-indexserver", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("zoekt-indexserver", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleKubernetesMonitoring,
 				Hidden: true,

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -8,10 +8,18 @@ import (
 )
 
 func ZoektIndexServer() *monitoring.Container {
+	const (
+		containerName        = "zoekt-indexserver"
+		bundledContainerName = "indexed-search"
+		primaryOwner         = monitoring.ObservableOwnerSearch
+	)
+
 	return &monitoring.Container{
-		Name:        "zoekt-indexserver",
-		Title:       "Zoekt Index Server",
-		Description: "Indexes repositories and populates the search index.",
+		Name: "zoekt-indexserver",
+
+		Title:                    "Zoekt Index Server",
+		Description:              "Indexes repositories and populates the search index.",
+		NoSourcegraphDebugServer: true,
 		Groups: []monitoring.Group{
 			{
 				Title: "General",
@@ -96,14 +104,14 @@ func ZoektIndexServer() *monitoring.Container {
 					},
 				},
 			},
-			shared.NewContainerMonitoringGroup("zoekt-indexserver", monitoring.ObservableOwnerSearch, nil),
-			shared.NewProvisioningIndicatorsGroup("zoekt-indexserver", monitoring.ObservableOwnerSearch, nil),
 
-			// zoekt_index_server, zoekt_web_server are deployed together as part of
-			// the indexed-search service, so only show pod availability here.
-			shared.NewKubernetesMonitoringGroup("indexed-search", monitoring.ObservableOwnerSearch, nil),
+			// Note:
+			// zoekt_indexserver and zoekt_webserver are deployed together as part of the indexed-search service
+			// We show pod availability here for both the webserver and indexserver as they are bundled together.
+
+			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewKubernetesMonitoringGroup(bundledContainerName, primaryOwner, nil),
 		},
-
-		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -11,7 +11,6 @@ func ZoektIndexServer() *monitoring.Container {
 	const (
 		containerName        = "zoekt-indexserver"
 		bundledContainerName = "indexed-search"
-		primaryOwner         = monitoring.ObservableOwnerSearch
 	)
 
 	return &monitoring.Container{
@@ -109,9 +108,9 @@ func ZoektIndexServer() *monitoring.Container {
 			// zoekt_indexserver and zoekt_webserver are deployed together as part of the indexed-search service
 			// We show pod availability here for both the webserver and indexserver as they are bundled together.
 
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
-			shared.NewKubernetesMonitoringGroup(bundledContainerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewKubernetesMonitoringGroup(bundledContainerName, monitoring.ObservableOwnerSearch, nil),
 		},
 	}
 }

--- a/monitoring/definitions/zoekt_web_server.go
+++ b/monitoring/definitions/zoekt_web_server.go
@@ -8,10 +8,7 @@ import (
 )
 
 func ZoektWebServer() *monitoring.Container {
-	const (
-		containerName = "zoekt-webserver"
-		primaryOwner  = monitoring.ObservableOwnerSearch
-	)
+	const containerName = "zoekt-webserver"
 
 	return &monitoring.Container{
 		Name:                     "zoekt-webserver",
@@ -29,7 +26,7 @@ func ZoektWebServer() *monitoring.Container {
 							Query:             `sum by (code)(increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100`,
 							Warning:           monitoring.Alert().GreaterOrEqual(5, nil).For(5 * time.Minute),
 							Panel:             monitoring.Panel().LegendFormat("{{code}}").Unit(monitoring.Percentage),
-							Owner:             primaryOwner,
+							Owner:             monitoring.ObservableOwnerSearch,
 							PossibleSolutions: "none",
 						},
 					},
@@ -44,8 +41,8 @@ func ZoektWebServer() *monitoring.Container {
 			// Note 2:
 			// Kubernetes monitoring for zoekt-webserver is provided by zoekt-indexserver as they are bundled together.
 
-			shared.NewContainerMonitoringGroup(containerName, primaryOwner, nil),
-			shared.NewProvisioningIndicatorsGroup(containerName, primaryOwner, nil),
+			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerSearch, nil),
+			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerSearch, nil),
 		},
 	}
 }

--- a/monitoring/definitions/zoekt_web_server.go
+++ b/monitoring/definitions/zoekt_web_server.go
@@ -29,24 +29,11 @@ func ZoektWebServer() *monitoring.Container {
 					},
 				},
 			},
-			{
-				Title:  shared.TitleContainerMonitoring,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ContainerCPUUsage("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ContainerMemoryUsage("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						// indexed-search does not have 0-downtime deploy, so deploys can
-						// cause extended container restarts. still seta warning alert for
-						// extended periods of container restarts, since this might still
-						// indicate a problem.
-						shared.ContainerMissing("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ContainerIOUsage("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			// indexed-search does not have 0-downtime deploy, so deploys can
+			// cause extended container restarts. still seta warning alert for
+			// extended periods of container restarts, since this might still
+			// indicate a problem.
+			shared.NewContainerMonitoringGroup("zoekt-webserver", monitoring.ObservableOwnerSearch, nil),
 			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,

--- a/monitoring/definitions/zoekt_web_server.go
+++ b/monitoring/definitions/zoekt_web_server.go
@@ -29,25 +29,13 @@ func ZoektWebServer() *monitoring.Container {
 					},
 				},
 			},
+
 			// indexed-search does not have 0-downtime deploy, so deploys can
 			// cause extended container restarts. still seta warning alert for
 			// extended periods of container restarts, since this might still
 			// indicate a problem.
 			shared.NewContainerMonitoringGroup("zoekt-webserver", monitoring.ObservableOwnerSearch, nil),
-			{
-				Title:  shared.TitleProvisioningIndicators,
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						shared.ProvisioningCPUUsageLongTerm("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
-					},
-				},
-			},
+			shared.NewProvisioningIndicatorsGroup("zoekt-webserver", monitoring.ObservableOwnerSearch, nil),
 			// kubernetes monitoring for zoekt-web-server is provided by zoekt-index-server,
 			// since both services are deployed together
 		},


### PR DESCRIPTION
This PR refactors the creation of common provisioning panels to _dry_ up some of our service definitions. This is the first part in some refactoring prior to adding additional metrics.

Review by commit may help but probably isn't necessary (changes should be mostly rote).