### PR TITLE
Code Insights: Fix insight dashboard memoization and add extension insight batching

### DIFF
--- a/client/shared/src/api/extension/api/getInsightsViews.ts
+++ b/client/shared/src/api/extension/api/getInsightsViews.ts
@@ -1,5 +1,6 @@
+import { isEqual } from 'lodash'
 import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators'
 
 import { ContributableViewContainer } from '../../protocol'
 import { RegisteredViewProvider, ViewContexts, ViewProviderResult } from '../extensionHostApi'
@@ -40,7 +41,10 @@ export function getInsightsViews(
                 // all insights that we have.
                 return true
             })
-        )
+        ),
+        distinctUntilChanged(isEqual),
+        // batch all extension providers to avoid unnecessary network requests
+        debounceTime(0)
     )
 
     return proxySubscribable(callViewProvidersInParallel(context, dashboardInsights))

--- a/client/shared/src/api/extension/api/getInsightsViews.ts
+++ b/client/shared/src/api/extension/api/getInsightsViews.ts
@@ -1,6 +1,5 @@
-import { isEqual } from 'lodash'
 import { Observable } from 'rxjs'
-import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators'
+import { debounceTime, map } from 'rxjs/operators'
 
 import { ContributableViewContainer } from '../../protocol'
 import { RegisteredViewProvider, ViewContexts, ViewProviderResult } from '../extensionHostApi'
@@ -42,7 +41,6 @@ export function getInsightsViews(
                 return true
             })
         ),
-        distinctUntilChanged(isEqual),
         // batch all extension providers to avoid unnecessary network requests
         debounceTime(0)
     )

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -45,14 +45,13 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     const finalSettings = useDistinctValue(settingsCascade.final)
     const backendInsightIds = useBackendInsightIds({ insightIds: allInsightIds, finalSettings })
 
-    console.log({ allInsightIds, backendInsightIds })
-
     const views = useObservable(
-        useMemo(() => {
-            console.log('START RE_FETCHING')
-            // debugger;
-            return getInsightCombinedViews(extensionsController?.extHostAPI, allInsightIds, backendInsightIds)
-        }, [allInsightIds, backendInsightIds, extensionsController, getInsightCombinedViews])
+        useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, allInsightIds, backendInsightIds), [
+            allInsightIds,
+            backendInsightIds,
+            extensionsController,
+            getInsightCombinedViews,
+        ])
     )
 
     const { handleDelete } = useDeleteInsight({ settingsCascade, platformContext })

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -13,10 +13,11 @@ import { Settings } from '../../../../../../../../schema/settings.schema'
 import { CodeInsightsIcon, InsightsViewGrid } from '../../../../../../../components'
 import { InsightsApiContext } from '../../../../../../../core/backend/api-provider'
 import { InsightDashboard } from '../../../../../../../core/types'
+import { useDistinctValue } from '../../../../../../../hooks/use-distinct-value'
 import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
 
+import { useBackendInsightIds } from './hooks/use-backend-insight-ids'
 import { useDeleteInsight } from './hooks/use-delete-insight'
-import { getBackendInsightIds } from './utils/get-backend-insight-ids'
 
 const DEFAULT_INSIGHT_IDS: string[] = []
 
@@ -40,19 +41,18 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     } = props
     const { getInsightCombinedViews } = useContext(InsightsApiContext)
 
-    const allInsightIds = dashboard.insightIds ?? DEFAULT_INSIGHT_IDS
-    const backendInsightIds = useMemo(() => getBackendInsightIds({ insightIds: allInsightIds, settingsCascade }), [
-        allInsightIds,
-        settingsCascade,
-    ])
+    const allInsightIds = useDistinctValue(dashboard.insightIds) ?? DEFAULT_INSIGHT_IDS
+    const finalSettings = useDistinctValue(settingsCascade.final)
+    const backendInsightIds = useBackendInsightIds({ insightIds: allInsightIds, finalSettings })
+
+    console.log({ allInsightIds, backendInsightIds })
 
     const views = useObservable(
-        useMemo(() => getInsightCombinedViews(extensionsController?.extHostAPI, allInsightIds, backendInsightIds), [
-            allInsightIds,
-            backendInsightIds,
-            extensionsController,
-            getInsightCombinedViews,
-        ])
+        useMemo(() => {
+            console.log('START RE_FETCHING')
+            // debugger;
+            return getInsightCombinedViews(extensionsController?.extHostAPI, allInsightIds, backendInsightIds)
+        }, [allInsightIds, backendInsightIds, extensionsController, getInsightCombinedViews])
     )
 
     const { handleDelete } = useDeleteInsight({ settingsCascade, platformContext })


### PR DESCRIPTION
This PR fixes memoization of all settings inputs for the dashboard insights fetcher (extension based and backend based) and adds batching to the extension insight providers to avoid unnecessary network requests.

Currently, on main, we have double fetching for all search-based insights cause of bad memorization and listening updates from extension API without any cache level.

