### PR TITLE
authz: Sync user permissions based on external service tokens

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/schema"
-
 	"github.com/RoaringBitmap/roaring"
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
@@ -29,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // PermsSyncer is a permissions syncing manager that is in charge of keeping

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -347,9 +347,11 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			default:
 				log15.Warn("External service kind %q not supported", "kind", v.Kind)
 			}
+
 			if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
 				return errors.Wrap(err, "wait for rate limiter")
 			}
+
 			extIDs, err = provider.FetchUserPermsByToken(ctx, token)
 			if err != nil {
 				log15.Warn("Fetching user permissions by token", "error", err)

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -52,6 +52,10 @@ func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Accou
 	panic("should never be called")
 }
 
+func (m gitlabAuthzProviderParams) FetchUserPermsByToken(context.Context, string) (*authz.ExternalUserPermissions, error) {
+	panic("should never be called")
+}
+
 func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
 	panic("should never be called")
 }

--- a/internal/authz/bitbucketserver/provider.go
+++ b/internal/authz/bitbucketserver/provider.go
@@ -155,6 +155,12 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 	}, err
 }
 
+// FetchUserPermsByToken is currently only required for syncing permissions for
+// GitHub and GitLab on sourcegraph.com
+func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
+	return nil, errors.New("not implemented")
+}
+
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given repo on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/internal/authz/github/github.go
+++ b/internal/authz/github/github.go
@@ -59,6 +59,36 @@ func (p *Provider) Validate() (problems []string) {
 	return nil
 }
 
+// FetchUserPermsByToken fetches all the privare repo ids that the token can
+// access.
+func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
+	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
+	client := p.client.WithToken(token)
+
+	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
+	// when appending the first 100 results to the slice.
+	repoIDs := make([]extsvc.RepoID, 0, 100)
+	hasNextPage := true
+	var err error
+	for page := 1; hasNextPage; page++ {
+		var repos []*github.Repository
+		repos, hasNextPage, _, err = client.ListAffiliatedRepositories(ctx, github.VisibilityPrivate, page)
+		if err != nil {
+			return &authz.ExternalUserPermissions{
+				Exacts: repoIDs,
+			}, err
+		}
+
+		for _, r := range repos {
+			repoIDs = append(repoIDs, extsvc.RepoID(r.ID))
+		}
+	}
+
+	return &authz.ExternalUserPermissions{
+		Exacts: repoIDs,
+	}, nil
+}
+
 // FetchUserPerms returns a list of repository IDs (on code host) that the given account
 // has read access on the code host. The repository ID has the same value as it would be
 // used as api.ExternalRepoSpec.ID. The returned list only includes private repository IDs.
@@ -82,30 +112,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		return nil, errors.New("no token found in the external account data")
 	}
 
-	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
-	client := p.client.WithToken(tok.AccessToken)
-
-	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
-	// when appending the first 100 results to the slice.
-	repoIDs := make([]extsvc.RepoID, 0, 100)
-	hasNextPage := true
-	for page := 1; hasNextPage; page++ {
-		var repos []*github.Repository
-		repos, hasNextPage, _, err = client.ListAffiliatedRepositories(ctx, github.VisibilityPrivate, page)
-		if err != nil {
-			return &authz.ExternalUserPermissions{
-				Exacts: repoIDs,
-			}, err
-		}
-
-		for _, r := range repos {
-			repoIDs = append(repoIDs, extsvc.RepoID(r.ID))
-		}
-	}
-
-	return &authz.ExternalUserPermissions{
-		Exacts: repoIDs,
-	}, nil
+	return p.FetchUserPermsByToken(ctx, tok.AccessToken)
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/internal/authz/github/github.go
+++ b/internal/authz/github/github.go
@@ -59,7 +59,7 @@ func (p *Provider) Validate() (problems []string) {
 	return nil
 }
 
-// FetchUserPermsByToken fetches all the privare repo ids that the token can
+// FetchUserPermsByToken fetches all the private repo ids that the token can
 // access.
 func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
 	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.

--- a/internal/authz/gitlab/oauth.go
+++ b/internal/authz/gitlab/oauth.go
@@ -102,6 +102,13 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 	return listProjects(ctx, client)
 }
 
+// FetchUserPermsByToken is the same as FetchUserPerms but it only requires a
+// token.
+func (p *OAuthProvider) FetchUserPermsByToken(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
+	client := p.clientProvider.GetOAuthClient(token)
+	return listProjects(ctx, client)
+}
+
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given project on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/internal/authz/gitlab/sudo.go
+++ b/internal/authz/gitlab/sudo.go
@@ -212,7 +212,8 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 	return listProjects(ctx, client)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms but only requires a token.
+// FetchUserPermsByToken is the same as FetchUserPerms but it only requires a
+// token.
 func (p *SudoProvider) FetchUserPermsByToken(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
 	client := p.clientProvider.GetOAuthClient(token)
 	return listProjects(ctx, client)

--- a/internal/authz/gitlab/sudo.go
+++ b/internal/authz/gitlab/sudo.go
@@ -212,6 +212,12 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 	return listProjects(ctx, client)
 }
 
+// FetchUserPermsByToken is the same as FetchUserPerms but only requires a token.
+func (p *SudoProvider) FetchUserPermsByToken(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
+	client := p.clientProvider.GetOAuthClient(token)
+	return listProjects(ctx, client)
+}
+
 // listProjects is a helper function to request for all private projects that are accessible
 // (access level: 20 => Reporter access) by the authenticated or impersonated user in the client.
 // It may return partial but valid results in case of error, and it is up to callers to decide

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -59,6 +59,10 @@ type Provider interface {
 	// to decide whether to discard.
 	FetchUserPerms(ctx context.Context, account *extsvc.Account) (*ExternalUserPermissions, error)
 
+	// FetchUserPermsByToken is similar to FetchUserPerms but only requires a token
+	// in order to communicate with the code host.
+	FetchUserPermsByToken(ctx context.Context, token string) (*ExternalUserPermissions, error)
+
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 	// the given repository/project on the code host. The user ID should be the same value
 	// as it would be used as extsvc.Account.AccountID. The returned list should

--- a/internal/authz/perforce/perforce.go
+++ b/internal/authz/perforce/perforce.go
@@ -263,6 +263,12 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 	}, errors.Wrap(scanner.Err(), "scanner.Err")
 }
 
+// FetchUserPermsByToken is currently only required for syncing permissions for
+// GitHub and GitLab on sourcegraph.com
+func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
+	return nil, errors.New("not implemented")
+}
+
 // getAllUserEmails returns a set of username <-> email pairs of all users in the Perforce server.
 func (p *Provider) getAllUserEmails(ctx context.Context) (map[string]string, error) {
 	if p.cachedAllUserEmails != nil {

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -39,6 +39,10 @@ func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) (*authz.
 	return nil, nil
 }
 
+func (p *fakeProvider) FetchUserPermsByToken(context.Context, string) (*authz.ExternalUserPermissions, error) {
+	return nil, nil
+}
+
 func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This change modifies our permissions syncer so that in addition to
syncing user permissions using external accounts (sign in connections)
it will now also sync using OAuth tokens in user added code hosts (code
host connections).

This allows us to properly sync user permissions for repos that have
only been added by a user added external service and allows us to remove
a workaround that we added to the repo syncer:
https://github.com/sourcegraph/sourcegraph/pull/20727

The repo syncer workaround will be removed in subsequent PR.
