### PR TITLE
sg: add ability to define `checks` per `commandset`

### DIFF
--- a/dev/sg/config_test.go
+++ b/dev/sg/config_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseConfig(t *testing.T) {
+	input := `
+env:
+  SRC_REPOS_DIR: $HOME/.sourcegraph/repos
+
+commands:
+  frontend:
+    cmd: ulimit -n 10000 && .bin/frontend
+    install: go build -o .bin/frontend github.com/sourcegraph/sourcegraph/cmd/frontend
+    checkBinary: .bin/frontend
+    env:
+      CONFIGURATION_MODE: server
+    watch:
+      - lib
+
+checks:
+  docker:
+    cmd: docker version
+    failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
+
+commandsets:
+  oss:
+    - frontend
+    - gitserver
+  enterprise:
+    checks:
+      - docker
+    commands:
+      - frontend
+      - gitserver
+`
+
+	have, err := ParseConfig([]byte(input))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	want := &Config{
+		Env: map[string]string{"SRC_REPOS_DIR": "$HOME/.sourcegraph/repos"},
+		Commands: map[string]Command{
+			"frontend": {
+				Name:        "frontend",
+				Cmd:         "ulimit -n 10000 && .bin/frontend",
+				Install:     "go build -o .bin/frontend github.com/sourcegraph/sourcegraph/cmd/frontend",
+				CheckBinary: ".bin/frontend",
+				Env:         map[string]string{"CONFIGURATION_MODE": "server"},
+				Watch:       []string{"lib"},
+			},
+		},
+		Commandsets: map[string]*Commandset{
+			"oss": {
+				Name:     "oss",
+				Commands: []string{"frontend", "gitserver"},
+			},
+			"enterprise": {
+				Name:     "enterprise",
+				Commands: []string{"frontend", "gitserver"},
+				Checks:   []string{"docker"},
+			},
+		},
+		Checks: map[string]Check{
+			"docker": {
+				Name:        "docker",
+				Cmd:         "docker version",
+				FailMessage: "Failed to run 'docker version'. Please make sure Docker is running.",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatalf("wrong config. (-want +got):\n%s", diff)
+	}
+}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -232,14 +232,14 @@ func main() {
 	}
 }
 
-// conf is the global config. If a command needs to access it, it *must* call
+// globalConf is the global config. If a command needs to access it, it *must* call
 // `parseConf` before.
-var conf *Config
+var globalConf *Config
 
 // parseConf parses the config file and the optional overwrite file.
 // Iear the conf has already been parsed it's a noop.
 func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
-	if conf != nil {
+	if globalConf != nil {
 		return true, output.FancyLine{}
 	}
 
@@ -259,7 +259,7 @@ func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
 		overwriteFile = filepath.Join(repoRoot, overwriteFile)
 	}
 
-	conf, err = ParseConfigFile(confFile)
+	globalConf, err = ParseConfigFile(confFile)
 	if err != nil {
 		return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s\n", output.StyleBold, confFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
 	}
@@ -269,7 +269,7 @@ func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
 		if err != nil {
 			return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s\n", output.StyleBold, overwriteFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
 		}
-		conf.Merge(overwriteConf)
+		globalConf.Merge(overwriteConf)
 	}
 
 	return true, output.FancyLine{}
@@ -292,15 +292,35 @@ func runSetExec(ctx context.Context, args []string) error {
 		return flag.ErrHelp
 	}
 
-	names, ok := conf.Commandsets[args[0]]
+	set, ok := globalConf.Commandsets[args[0]]
 	if !ok {
 		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: commandset %q not found :(\n", args[0]))
 		return flag.ErrHelp
 	}
 
-	cmds := make([]Command, 0, len(names))
-	for _, name := range names {
-		cmd, ok := conf.Commands[name]
+	var checks []Check
+	for _, name := range set.Checks {
+		check, ok := globalConf.Checks[name]
+		if !ok {
+			out.WriteLine(output.Linef("", output.StyleWarning, "WARNING: check %s not found in config\n", name))
+			continue
+		}
+		checks = append(checks, check)
+	}
+
+	ok, err := runChecks(ctx, checks...)
+	if err != nil {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: checks could not be run: %s\n", err))
+	}
+
+	if !ok {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: checks did not pass, aborting start of commandset %s\n", set.Name))
+		return nil
+	}
+
+	cmds := make([]Command, 0, len(set.Commands))
+	for _, name := range set.Commands {
+		cmd, ok := globalConf.Commands[name]
 		if !ok {
 			return errors.Errorf("command %q not found in commandset %q", name, args[0])
 		}
@@ -323,7 +343,7 @@ func testExec(ctx context.Context, args []string) error {
 		return flag.ErrHelp
 	}
 
-	cmd, ok := conf.Tests[args[0]]
+	cmd, ok := globalConf.Tests[args[0]]
 	if !ok {
 		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(\n", args[0]))
 		return flag.ErrHelp
@@ -364,7 +384,7 @@ func runExec(ctx context.Context, args []string) error {
 		return flag.ErrHelp
 	}
 
-	cmd, ok := conf.Commands[args[0]]
+	cmd, ok := globalConf.Commands[args[0]]
 	if !ok {
 		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: command %q not found :(\n", args[0]))
 		return flag.ErrHelp
@@ -380,7 +400,12 @@ func doctorExec(ctx context.Context, args []string) error {
 		os.Exit(1)
 	}
 
-	return runChecks(ctx, conf.Checks)
+	var checks []Check
+	for _, c := range globalConf.Checks {
+		checks = append(checks, c)
+	}
+	_, err := runChecks(ctx, checks...)
+	return err
 }
 
 func liveExec(ctx context.Context, args []string) error {
@@ -536,11 +561,11 @@ func printRunUsage(c *ffcli.Command) string {
 	// error, because we should never error when the user wants --help output.
 	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
 
-	if conf != nil {
+	if globalConf != nil {
 		fmt.Fprintf(&out, "\n")
 		fmt.Fprintf(&out, "AVAILABLE COMMANDS IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
 
-		for name := range conf.Commands {
+		for name := range globalConf.Commands {
 			fmt.Fprintf(&out, "  %s\n", name)
 		}
 	}
@@ -590,11 +615,11 @@ func printTestUsage(c *ffcli.Command) string {
 	// error, because we should never error when the user wants --help output.
 	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
 
-	if conf != nil {
+	if globalConf != nil {
 		fmt.Fprintf(&out, "\n")
 		fmt.Fprintf(&out, "AVAILABLE TESTSUITES IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
 
-		for name := range conf.Tests {
+		for name := range globalConf.Tests {
 			fmt.Fprintf(&out, "  %s\n", name)
 		}
 	}
@@ -611,11 +636,11 @@ func printRunSetUsage(c *ffcli.Command) string {
 	// Attempt to parse config so we can list available sets, but don't fail on
 	// error, because we should never error when the user wants --help output.
 	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
-	if conf != nil {
+	if globalConf != nil {
 		fmt.Fprintf(&out, "\n")
 		fmt.Fprintf(&out, "AVAILABLE COMMANDSETS IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
 
-		for name := range conf.Commandsets {
+		for name := range globalConf.Commandsets {
 			fmt.Fprintf(&out, "  %s\n", name)
 		}
 	}

--- a/dev/sg/sg.config.example.yaml
+++ b/dev/sg/sg.config.example.yaml
@@ -91,6 +91,15 @@ commands:
       NODE_ENV: development
       NODE_OPTIONS: "--max_old_space_size=4096"
 
+checks:
+  docker:
+    cmd: docker version
+    failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
+
+  redis:
+    cmd: redis-cli -p 6379 PING
+    failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
+
 commandsets:
   minimal:
     - frontend
@@ -101,6 +110,16 @@ commandsets:
     - repo-updater
     - gitserver
     - web
+
+  fancy:
+    checks:
+      - docker
+      - redis
+    commands:
+      - frontend
+      - repo-updater
+      - gitserver
+      - web
 
 tests:
   # These can be run with `sg test [name]`

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -501,11 +501,11 @@ checks:
     failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
 
   redis:
-    cmd: redis-cli -p 6379 PING
+    cmd: redis-cli -p 6379 PING || docker-compose -f dev/redis-postgres.yml exec redis redis-cli PING
     failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
 
   postgres:
-    cmd: psql -c 'SELECT 1;'
+    cmd: psql -c 'SELECT 1;' || docker-compose -f dev/redis-postgres.yml exec postgresql psql -U ${PGUSER} -c 'select 1;'
     failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
 
 commandsets:
@@ -530,23 +530,28 @@ commandsets:
     - zoekt-webserver-1
 
   enterprise: &enterprise_set
-    - enterprise-frontend
-    - enterprise-worker
-    - enterprise-repo-updater
-    - enterprise-web
-    - gitserver
-    - searcher
-    - symbols
-    - query-runner
-    - caddy
-    - docsite
-    - syntect_server
-    - github-proxy
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
-    - executor-queue
+    checks:
+      - docker
+      - redis
+      - postgres
+    commands:
+      - enterprise-frontend
+      - enterprise-worker
+      - enterprise-repo-updater
+      - enterprise-web
+      - gitserver
+      - searcher
+      - symbols
+      - query-runner
+      - caddy
+      - docsite
+      - syntect_server
+      - github-proxy
+      - zoekt-indexserver-0
+      - zoekt-indexserver-1
+      - zoekt-webserver-0
+      - zoekt-webserver-1
+      - executor-queue
 
   default: *enterprise_set
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -508,11 +508,11 @@ checks:
     failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
 
   redis:
-    cmd: (command -v redis-cli && redis-cli -p 6379 PING) || docker-compose -f dev/redis-postgres.yml exec redis redis-cli PING
+    cmd: (command -v redis-cli && redis-cli -p 6379 PING) || docker-compose -f dev/redis-postgres.yml exec -i redis redis-cli PING
     failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
 
   postgres:
-    cmd: (command -v psql && psql -c 'SELECT 1;') || docker-compose -f dev/redis-postgres.yml exec postgresql psql -U ${PGUSER} -c 'select 1;'
+    cmd: (command -v psql && psql -c 'SELECT 1;') || docker-compose -f dev/redis-postgres.yml exec -i postgresql psql -U ${PGUSER} -c 'select 1;'
     failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
 
 commandsets:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -508,11 +508,11 @@ checks:
     failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
 
   redis:
-    cmd: (command -v redis-cli && redis-cli -p 6379 PING) || docker-compose -f dev/redis-postgres.yml exec -i redis redis-cli PING
+    cmd: (command -v redis-cli && redis-cli -p 6379 PING) || docker-compose -f dev/redis-postgres.yml exec -T redis redis-cli PING
     failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
 
   postgres:
-    cmd: (command -v psql && psql -c 'SELECT 1;') || docker-compose -f dev/redis-postgres.yml exec -i postgresql psql -U ${PGUSER} -c 'select 1;'
+    cmd: (command -v psql && psql -c 'SELECT 1;') || docker-compose -f dev/redis-postgres.yml exec -T postgresql psql -U ${PGUSER} -c 'select 1;'
     failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
 
 commandsets:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -508,11 +508,11 @@ checks:
     failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
 
   redis:
-    cmd: redis-cli -p 6379 PING || docker-compose -f dev/redis-postgres.yml exec redis redis-cli PING
+    cmd: (command -v redis-cli && redis-cli -p 6379 PING) || docker-compose -f dev/redis-postgres.yml exec redis redis-cli PING
     failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
 
   postgres:
-    cmd: psql -c 'SELECT 1;' || docker-compose -f dev/redis-postgres.yml exec postgresql psql -U ${PGUSER} -c 'select 1;'
+    cmd: (command -v psql && psql -c 'SELECT 1;') || docker-compose -f dev/redis-postgres.yml exec postgresql psql -U ${PGUSER} -c 'select 1;'
     failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
 
 commandsets:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1,4 +1,11 @@
 env:
+  PGPORT: 5432
+  PGHOST: localhost
+  PGUSER: sourcegraph
+  PGPASSWORD: sourcegraph
+  PGDATABASE: sourcegraph
+  PGSSLMODE: disable
+
   SRC_REPOS_DIR: $HOME/.sourcegraph/repos
   SRC_LOG_LEVEL: info
   SRC_LOG_FORMAT: condensed

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -519,22 +519,27 @@ commandsets:
   # TODO: Should we be able to define "env" vars _per set_?
 
   oss:
-    - frontend
-    - worker
-    - repo-updater
-    - gitserver
-    - searcher
-    - symbols
-    - query-runner
-    - web
-    - caddy
-    - docsite
-    - syntect_server
-    - github-proxy
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
+    checks:
+      - docker
+      - redis
+      - postgres
+    commands:
+      - frontend
+      - worker
+      - repo-updater
+      - gitserver
+      - searcher
+      - symbols
+      - query-runner
+      - web
+      - caddy
+      - docsite
+      - syntect_server
+      - github-proxy
+      - zoekt-indexserver-0
+      - zoekt-indexserver-1
+      - zoekt-webserver-0
+      - zoekt-webserver-1
 
   enterprise: &enterprise_set
     checks:
@@ -563,26 +568,31 @@ commandsets:
   default: *enterprise_set
 
   enterprise-codeintel:
-    - enterprise-frontend
-    - enterprise-worker
-    - enterprise-repo-updater
-    - enterprise-web
-    - gitserver
-    - searcher
-    - symbols
-    - query-runner
-    - caddy
-    - docsite
-    - syntect_server
-    - github-proxy
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
-    - minio
-    - executor-queue
-    - precise-code-intel-worker
-    - codeintel-executor
+    checks:
+      - docker
+      - redis
+      - postgres
+    commands:
+      - enterprise-frontend
+      - enterprise-worker
+      - enterprise-repo-updater
+      - enterprise-web
+      - gitserver
+      - searcher
+      - symbols
+      - query-runner
+      - caddy
+      - docsite
+      - syntect_server
+      - github-proxy
+      - zoekt-indexserver-0
+      - zoekt-indexserver-1
+      - zoekt-webserver-0
+      - zoekt-webserver-1
+      - minio
+      - executor-queue
+      - precise-code-intel-worker
+      - codeintel-executor
 
   enterprise-codeinsights:
     # Add the following overwrites to your sg.config.overwrite.yaml to get
@@ -592,56 +602,71 @@ commandsets:
     #     DISABLE_CODE_INSIGHTS_HISTORICAL: false
     #     DISABLE_CODE_INSIGHTS: false
     #
-    - enterprise-frontend
-    - enterprise-worker
-    - enterprise-repo-updater
-    - enterprise-web
-    - gitserver
-    - searcher
-    - symbols
-    - query-runner
-    - caddy
-    - docsite
-    - syntect_server
-    - github-proxy
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
-    - codeinsights-db
+    checks:
+      - docker
+      - redis
+      - postgres
+    commands:
+      - enterprise-frontend
+      - enterprise-worker
+      - enterprise-repo-updater
+      - enterprise-web
+      - gitserver
+      - searcher
+      - symbols
+      - query-runner
+      - caddy
+      - docsite
+      - syntect_server
+      - github-proxy
+      - zoekt-indexserver-0
+      - zoekt-indexserver-1
+      - zoekt-webserver-0
+      - zoekt-webserver-1
+      - codeinsights-db
 
   api-only:
-    - enterprise-frontend
-    - enterprise-worker
-    - enterprise-repo-updater
-    - gitserver
-    - searcher
-    - symbols
-    - github-proxy
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
+    checks:
+      - docker
+      - redis
+      - postgres
+    commands:
+      - enterprise-frontend
+      - enterprise-worker
+      - enterprise-repo-updater
+      - gitserver
+      - searcher
+      - symbols
+      - github-proxy
+      - zoekt-indexserver-0
+      - zoekt-indexserver-1
+      - zoekt-webserver-0
+      - zoekt-webserver-1
 
   batches:
-    - enterprise-frontend
-    - enterprise-worker
-    - enterprise-repo-updater
-    - enterprise-web
-    - gitserver
-    - searcher
-    - symbols
-    - query-runner
-    - caddy
-    - docsite
-    - syntect_server
-    - github-proxy
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
-    - executor-queue
-    - batches-executor
+    checks:
+      - docker
+      - redis
+      - postgres
+    commands:
+      - enterprise-frontend
+      - enterprise-worker
+      - enterprise-repo-updater
+      - enterprise-web
+      - gitserver
+      - searcher
+      - symbols
+      - query-runner
+      - caddy
+      - docsite
+      - syntect_server
+      - github-proxy
+      - zoekt-indexserver-0
+      - zoekt-indexserver-1
+      - zoekt-webserver-0
+      - zoekt-webserver-1
+      - executor-queue
+      - batches-executor
 
 tests:
   # These can be run with `sg test [name]`


### PR DESCRIPTION
This allows us to check whether services are running before we boot up
the environment.

The changes to the config file format are backwards compatible. See the
`UnmarshalYAML` method on `Commandset`.

It also updates the checks to make sure that they work for users of the
docker-compose setup.

## Screenshots

Config:

![screenshot_2021-07-20_12 41 14@2x](https://user-images.githubusercontent.com/1185253/126310778-cfebe730-67af-423e-a473-9d563b81b8f2.png)

In action:

<img width="813" alt="screenshot_2021-07-20_12 42 19@2x" src="https://user-images.githubusercontent.com/1185253/126310937-97af9b4e-6629-4b18-b374-0c8275c38741.png">
