### PR TITLE
search notebook: always show run search action if no other blocks are selected

### DIFF
--- a/client/web/src/search/notebook/SearchNotebook.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.tsx
@@ -196,6 +196,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({ o
                                 {...block}
                                 {...blockCallbackProps}
                                 isSelected={selectedBlockId === block.id}
+                                isOtherBlockSelected={selectedBlockId !== null && selectedBlockId !== block.id}
                             />
                         )}
                         {block.type === 'query' && (
@@ -204,6 +205,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({ o
                                 {...block}
                                 {...blockCallbackProps}
                                 isSelected={selectedBlockId === block.id}
+                                isOtherBlockSelected={selectedBlockId !== null && selectedBlockId !== block.id}
                             />
                         )}
                     </>

--- a/client/web/src/search/notebook/SearchNotebookBlockMenu.tsx
+++ b/client/web/src/search/notebook/SearchNotebookBlockMenu.tsx
@@ -24,7 +24,7 @@ export const SearchNotebookBlockMenu: React.FunctionComponent<SearchNotebookBloc
 }) => (
     <div className={styles.blockMenu} role="menu">
         {mainAction && (
-            <div className={styles.mainActionButtonWrapper}>
+            <div className={classNames(actions.length > 0 && styles.mainActionButtonWrapper)}>
                 <button
                     className="btn btn-sm btn-primary d-flex align-items-center w-100"
                     type="button"

--- a/client/web/src/search/notebook/SearchNotebookPage.tsx
+++ b/client/web/src/search/notebook/SearchNotebookPage.tsx
@@ -46,7 +46,7 @@ export const SearchNotebookPage: React.FunctionComponent<SearchNotebookPageProps
         const serializedBlocks = location.hash.slice(1)
         if (serializedBlocks.length === 0) {
             return [
-                { type: 'md', input: '# Welcome to Sourcegraph Search Notebooks!\nDo something awesome.' },
+                { type: 'md', input: '## Welcome to Sourcegraph Search Notebooks!\nDo something awesome.' },
                 { type: 'query', input: '// Enter a search query' },
             ]
         }

--- a/client/web/src/search/notebook/SearchNotebookQueryBlock.story.tsx
+++ b/client/web/src/search/notebook/SearchNotebookQueryBlock.story.tsx
@@ -47,6 +47,7 @@ add('default', () => (
                 input="query"
                 output={of(streamingSearchResult)}
                 isSelected={false}
+                isOtherBlockSelected={false}
                 isMacPlatform={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
@@ -66,6 +67,7 @@ add('selected', () => (
                 input="query"
                 output={of(streamingSearchResult)}
                 isSelected={true}
+                isOtherBlockSelected={false}
                 isMacPlatform={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}

--- a/client/web/src/search/notebook/index.ts
+++ b/client/web/src/search/notebook/index.ts
@@ -32,6 +32,7 @@ export type BlockDirection = 'up' | 'down'
 
 export interface BlockProps {
     isSelected: boolean
+    isOtherBlockSelected: boolean
     onRunBlock(id: string): void
     onDeleteBlock(id: string): void
     onBlockInputChange(id: string, value: string): void


### PR DESCRIPTION
This PR improves the discoverability of query blocks within a notebook. Run search button/action is now always visible, *if* no other blocks are selected. Once a block is selected only the menu from the selected block is visible.