### PR TITLE
Code Insights: Add uniqBy check for the be insight gql handler

### DIFF
--- a/client/web/src/insights/core/backend/requests/fetch-backend-insights.ts
+++ b/client/web/src/insights/core/backend/requests/fetch-backend-insights.ts
@@ -1,3 +1,4 @@
+import { uniqBy } from 'lodash'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -40,7 +41,8 @@ export function fetchBackendInsights(insightsIds: string[]): Observable<InsightF
         { ids: insightsIds }
     ).pipe(
         map(dataOrThrowErrors),
-        map(data => data.insights?.nodes ?? [])
+        map(data => data.insights?.nodes ?? []),
+        map(data => uniqBy(data, 'id'))
     )
 }
 


### PR DESCRIPTION
At the moment gql be may return insight with duplicates. To avoid this PR adds `uniqBy` check and groups all insight by id field.

![image](https://user-images.githubusercontent.com/18492575/126320501-bb690311-2c69-47e0-b3d6-950366914663.png)
