### PR TITLE
repos: Don't panic if we find unknown external service kind

### DIFF
--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -77,7 +77,7 @@ func NewSource(svc *types.ExternalService, cf *httpcli.Factory) (Source, error) 
 	case extsvc.KindOther:
 		return NewOtherSource(svc, cf)
 	default:
-		panic(fmt.Sprintf("source not implemented for external service kind %q", svc.Kind))
+		return nil, fmt.Errorf("cannot create source for kind %q", svc.Kind)
 	}
 }
 


### PR DESCRIPTION
The function already returns an error so it should be fine to return an
error instead of panicking

Fixes: https://github.com/sourcegraph/sourcegraph/issues/22894
