### PR TITLE
Guard against a nil pointer panic

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -456,7 +456,7 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 		}
 	}
 
-	if repo.Private {
+	if repo == nil || repo.Private {
 		return &protocol.RepoLookupResult{
 			ErrorNotFound: true,
 		}, nil

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -453,10 +453,13 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 			log15.Error(
 				"JVMPackagesSource is nil: doing nothing. To fix this problem, make sure that cloud_default is true for the JVM Dependencies external service type.",
 				"remoteName", remoteName)
+			return &protocol.RepoLookupResult{
+				ErrorNotFound: true,
+			}, nil
 		}
 	}
 
-	if repo == nil || repo.Private {
+	if repo.Private {
 		return &protocol.RepoLookupResult{
 			ErrorNotFound: true,
 		}, nil


### PR DESCRIPTION
Previously, reop-updater could panic when `repo` was nil, which can
happen while adding a new external service type. This change prevents
the panic by returning a 404 "repo not found" instead.
