### PR TITLE
rename File to Content in stream events

### DIFF
--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -11,7 +11,7 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
 import { FileMatch } from '@sourcegraph/shared/src/components/FileMatch'
 import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
-import { FileLineMatch } from '@sourcegraph/shared/src/search/stream'
+import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
@@ -180,7 +180,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
         <FileMatch
             location={this.props.location}
             expanded={true}
-            result={referencesToFileLineMatch(uri, locationsByURI.get(uri)!)}
+            result={referencesToContentMatch(uri, locationsByURI.get(uri)!)}
             icon={this.props.icon}
             onSelect={this.onSelect}
             showAllMatches={true}
@@ -191,10 +191,10 @@ export class FileLocations extends React.PureComponent<Props, State> {
     )
 }
 
-function referencesToFileLineMatch(uri: string, references: Badged<Location>[]): FileLineMatch {
+function referencesToContentMatch(uri: string, references: Badged<Location>[]): ContentMatch {
     const parsedUri = parseRepoURI(uri)
     return {
-        type: 'file',
+        type: 'content',
         name: parsedUri.filePath || '',
         version: (parsedUri.commitID || parsedUri.revision)!,
         repository: parsedUri.repoName,

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -3,14 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { Observable } from 'rxjs'
 import { AggregableBadge, Badge } from 'sourcegraph'
 
-import {
-    FileLineMatch,
-    FileSymbolMatch,
-    FilePathMatch,
-    getFileMatchUrl,
-    getRepositoryUrl,
-    getRevision,
-} from '../search/stream'
+import { ContentMatch, SymbolMatch, PathMatch, getFileMatchUrl, getRepositoryUrl, getRevision } from '../search/stream'
 import { SettingsCascadeProps } from '../settings/settings'
 import { pluralize } from '../util/strings'
 
@@ -42,7 +35,7 @@ interface Props extends SettingsCascadeProps {
     /**
      * The file match search result.
      */
-    result: FileLineMatch | FileSymbolMatch | FilePathMatch
+    result: ContentMatch | SymbolMatch | PathMatch
 
     /**
      * Formatted repository name to be displayed in repository link. If not
@@ -88,7 +81,7 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
 
     const result = props.result
     const items: MatchItem[] =
-        result.type === 'file'
+        result.type === 'content'
             ? result.lineMatches.map(match => ({
                   highlightRanges: match.offsetAndLengths.map(([start, highlightLength]) => ({
                       start,

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { IHighlightLineRange } from '../graphql/schema'
-import { FileLineMatch, FileSymbolMatch, FilePathMatch, getFileMatchUrl } from '../search/stream'
+import { ContentMatch, SymbolMatch, PathMatch, getFileMatchUrl } from '../search/stream'
 import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
 import { SymbolIcon } from '../symbols/SymbolIcon'
 import { ThemeProps } from '../theme'
@@ -29,7 +29,7 @@ interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
     location: H.Location
     eventLogger?: EventLogger
     items: MatchItem[]
-    result: FileLineMatch | FileSymbolMatch | FilePathMatch
+    result: ContentMatch | SymbolMatch | PathMatch
     /* Called when the first result has fully loaded. */
     onFirstResultLoad?: () => void
     /**

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -17,9 +17,9 @@ export type SearchEvent =
     | { type: 'error'; data: ErrorLike }
     | { type: 'done'; data: {} }
 
-export type SearchMatch = FileLineMatch | RepositoryMatch | CommitMatch | FileSymbolMatch | FilePathMatch
+export type SearchMatch = ContentMatch | RepositoryMatch | CommitMatch | SymbolMatch | PathMatch
 
-export interface FilePathMatch {
+export interface PathMatch {
     type: 'path'
     name: string
     repository: string
@@ -28,8 +28,8 @@ export interface FilePathMatch {
     version?: string
 }
 
-export interface FileLineMatch {
-    type: 'file'
+export interface ContentMatch {
+    type: 'content'
     name: string
     repository: string
     repoStars?: number
@@ -45,17 +45,17 @@ interface LineMatch {
     aggregableBadges?: AggregableBadge[]
 }
 
-export interface FileSymbolMatch {
+export interface SymbolMatch {
     type: 'symbol'
     name: string
     repository: string
     repoStars?: number
     branches?: string[]
     version?: string
-    symbols: SymbolMatch[]
+    symbols: Symbol[]
 }
 
-interface SymbolMatch {
+interface Symbol {
     url: string
     name: string
     containerName: string
@@ -440,7 +440,7 @@ export function getRevision(branches?: string[], version?: string): string {
     return revision
 }
 
-export function getFileMatchUrl(fileMatch: FileLineMatch | FileSymbolMatch | FilePathMatch): string {
+export function getFileMatchUrl(fileMatch: ContentMatch | SymbolMatch | PathMatch): string {
     const revision = getRevision(fileMatch.branches, fileMatch.version)
     return `/${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${fileMatch.name}`
 }
@@ -459,7 +459,7 @@ export function getRepoMatchUrl(repoMatch: RepositoryMatch): string {
 export function getMatchUrl(match: SearchMatch): string {
     switch (match.type) {
         case 'path':
-        case 'file':
+        case 'content':
         case 'symbol':
             return getFileMatchUrl(match)
         case 'commit':

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -52,10 +52,10 @@ export interface SymbolMatch {
     repoStars?: number
     branches?: string[]
     version?: string
-    symbols: Symbol[]
+    symbols: MatchedSymbol[]
 }
 
-interface Symbol {
+interface MatchedSymbol {
     url: string
     name: string
     containerName: string

--- a/client/shared/src/util/searchTestHelpers.ts
+++ b/client/shared/src/util/searchTestHelpers.ts
@@ -5,10 +5,10 @@ import sinon from 'sinon'
 import { FlatExtensionHostAPI } from '../api/contract'
 import { pretendProxySubscribable, pretendRemote } from '../api/util'
 import { Controller } from '../extensions/controller'
-import { AggregateStreamingSearchResults, FileLineMatch, RepositoryMatch } from '../search/stream'
+import { AggregateStreamingSearchResults, ContentMatch, RepositoryMatch } from '../search/stream'
 
-export const RESULT: FileLineMatch = {
-    type: 'file',
+export const RESULT: ContentMatch = {
+    type: 'content',
     name: '.travis.yml',
     repository: 'github.com/golang/oauth2',
     lineMatches: [
@@ -25,8 +25,8 @@ export const REPO_MATCH_RESULT: RepositoryMatch = {
     repository: 'github.com/golang/oauth2',
 }
 
-export const MULTIPLE_MATCH_RESULT: FileLineMatch = {
-    type: 'file',
+export const MULTIPLE_MATCH_RESULT: ContentMatch = {
+    type: 'content',
     name: 'clientcredentials/clientcredentials_test.go',
     repository: 'github.com/golang/oauth2',
     lineMatches: [
@@ -119,7 +119,7 @@ export const MULTIPLE_SEARCH_RESULT: AggregateStreamingSearchResults = {
         RESULT,
         MULTIPLE_MATCH_RESULT,
         {
-            type: 'file',
+            type: 'content',
             name: 'example_test.go',
             version: 'some-branch',
             repository: 'github.com/golang/oauth2',

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -340,20 +340,20 @@ describe('Search', () => {
                     data: [
                         { type: 'repo', repository: 'github.com/sourcegraph/sourcegraph' },
                         {
-                            type: 'file',
+                            type: 'content',
                             lineMatches: [],
                             name: 'stream.ts',
                             repository: 'github.com/sourcegraph/sourcegraph',
                         },
                         {
-                            type: 'file',
+                            type: 'content',
                             lineMatches: [],
                             name: 'stream.ts',
                             repository: 'github.com/sourcegraph/sourcegraph',
                             version: 'abcd',
                         },
                         {
-                            type: 'file',
+                            type: 'content',
                             lineMatches: [],
                             name: 'stream.ts',
                             repository: 'github.com/sourcegraph/sourcegraph',

--- a/client/web/src/integration/streaming-search-mocks.ts
+++ b/client/web/src/integration/streaming-search-mocks.ts
@@ -86,7 +86,7 @@ export const mixedSearchStreamEvents: SearchEvent[] = [
                 version: '206c057cc03eea48300a4bd33f4dc4222d242114',
             },
             {
-                type: 'file',
+                type: 'content',
                 name: 'src/main.test.ts',
                 repository: 'gitlab.sgdev.org/sourcegraph/lsif-cpp',
                 branches: [''],

--- a/client/web/src/search/results/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/StreamingSearchResultsList.tsx
@@ -13,9 +13,9 @@ import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink
 import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
 import {
     AggregateStreamingSearchResults,
-    FileLineMatch,
-    FileSymbolMatch,
-    FilePathMatch,
+    ContentMatch,
+    SymbolMatch,
+    PathMatch,
     SearchMatch,
     getMatchUrl,
 } from '@sourcegraph/shared/src/search/stream'
@@ -62,7 +62,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     }, [location.search])
 
     const itemKey = useCallback((item: SearchMatch): string => {
-        if (item.type === 'file' || item.type === 'symbol') {
+        if (item.type === 'content' || item.type === 'symbol') {
             return `file:${getMatchUrl(item)}`
         }
         return getMatchUrl(item)
@@ -73,7 +73,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     const renderResult = useCallback(
         (result: SearchMatch): JSX.Element => {
             switch (result.type) {
-                case 'file':
+                case 'content':
                 case 'path':
                 case 'symbol':
                     return (
@@ -132,14 +132,13 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     )
 }
 
-function getFileMatchIcon(
-    result: FileLineMatch | FileSymbolMatch | FilePathMatch
-): React.ComponentType<{ className?: string }> {
-    if (result.type === 'file' && result.lineMatches && result.lineMatches.length > 0) {
-        return FileDocumentIcon
+function getFileMatchIcon(result: ContentMatch | SymbolMatch | PathMatch): React.ComponentType<{ className?: string }> {
+    switch (result.type) {
+        case 'content':
+            return FileDocumentIcon
+        case 'symbol':
+            return AlphaSBoxIcon
+        case 'path':
+            return FileIcon
     }
-    if (result.type === 'symbol' && result.symbols && result.symbols.length > 0) {
-        return AlphaSBoxIcon
-    }
-    return FileIcon
 }

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -449,7 +449,7 @@ func fromPathMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Repo) *
 	}
 }
 
-func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Repo) *streamhttp.EventFileMatch {
+func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Repo) *streamhttp.EventContentMatch {
 	lineMatches := make([]streamhttp.EventLineMatch, 0, len(fm.LineMatches))
 	for _, lm := range fm.LineMatches {
 		lineMatches = append(lineMatches, streamhttp.EventLineMatch{
@@ -469,8 +469,8 @@ func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Repo
 		stars = r.Stars
 	}
 
-	return &streamhttp.EventFileMatch{
-		Type:        streamhttp.FileMatchType,
+	return &streamhttp.EventContentMatch{
+		Type:        streamhttp.ContentMatchType,
 		Path:        fm.Path,
 		Repository:  string(fm.Repo.Name),
 		RepoStars:   stars,

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -555,7 +555,7 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 				case *streamhttp.EventRepoMatch:
 					results.Results = append(results.Results, &SearchFileResult{})
 
-				case *streamhttp.EventFileMatch:
+				case *streamhttp.EventContentMatch:
 					var r SearchFileResult
 					r.File.Name = v.Path
 					r.Repository.Name = v.Repository
@@ -616,7 +616,7 @@ func (s *SearchStreamClient) SearchAll(query string) ([]*AnyResult, error) {
 						Name: v.Repository,
 					})
 
-				case *streamhttp.EventFileMatch:
+				case *streamhttp.EventContentMatch:
 					lms := make([]struct {
 						OffsetAndLengths [][2]int32 `json:"offsetAndLengths"`
 					}, len(v.LineMatches))

--- a/internal/search/streaming/http/client.go
+++ b/internal/search/streaming/http/client.go
@@ -161,8 +161,8 @@ func (r *eventMatchUnmarshaller) UnmarshalJSON(b []byte) error {
 	}
 
 	switch typeU.Type {
-	case FileMatchType:
-		r.EventMatch = &EventFileMatch{}
+	case ContentMatchType:
+		r.EventMatch = &EventContentMatch{}
 	case PathMatchType:
 		r.EventMatch = &EventPathMatch{}
 	case RepoMatchType:

--- a/internal/search/streaming/http/client_test.go
+++ b/internal/search/streaming/http/client_test.go
@@ -28,8 +28,8 @@ func TestDecoder(t *testing.T) {
 	}, {
 		Name: "matches",
 		Value: []EventMatch{
-			&EventFileMatch{
-				Type: FileMatchType,
+			&EventContentMatch{
+				Type: ContentMatchType,
 				Path: "test",
 			},
 			&EventPathMatch{

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -13,8 +13,8 @@ type EventMatch interface {
 	eventMatch()
 }
 
-// EventFileMatch is a subset of zoekt.FileMatch for our Event API.
-type EventFileMatch struct {
+// EventContentMatch is a subset of zoekt.FileMatch for our Event API.
+type EventContentMatch struct {
 	// Type is always FileMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
@@ -27,7 +27,7 @@ type EventFileMatch struct {
 	LineMatches []EventLineMatch `json:"lineMatches"`
 }
 
-func (e *EventFileMatch) eventMatch() {}
+func (e *EventContentMatch) eventMatch() {}
 
 // EventPathMatch is a subset of zoekt.FileMatch for our Event API.
 // It is used for result.FileMatch results with no line matches and
@@ -144,7 +144,7 @@ type EventError struct {
 type MatchType int
 
 const (
-	FileMatchType MatchType = iota
+	ContentMatchType MatchType = iota
 	RepoMatchType
 	SymbolMatchType
 	CommitMatchType
@@ -153,8 +153,8 @@ const (
 
 func (t MatchType) MarshalJSON() ([]byte, error) {
 	switch t {
-	case FileMatchType:
-		return []byte(`"file"`), nil
+	case ContentMatchType:
+		return []byte(`"content"`), nil
 	case RepoMatchType:
 		return []byte(`"repo"`), nil
 	case SymbolMatchType:
@@ -166,12 +166,11 @@ func (t MatchType) MarshalJSON() ([]byte, error) {
 	default:
 		return nil, errors.Errorf("unknown MatchType: %d", t)
 	}
-
 }
 
 func (t *MatchType) UnmarshalJSON(b []byte) error {
-	if bytes.Equal(b, []byte(`"file"`)) {
-		*t = FileMatchType
+	if bytes.Equal(b, []byte(`"content"`)) {
+		*t = ContentMatchType
 	} else if bytes.Equal(b, []byte(`"repo"`)) {
 		*t = RepoMatchType
 	} else if bytes.Equal(b, []byte(`"symbol"`)) {


### PR DESCRIPTION
This commit renames our stream events to use the term "content" in the
places that it would use "file". This does not yet modify our result
types with the same convention, but that will come as a followup change.
The intent is to make the different events better match up with our
result types, so now we have Content, Symbol, and Path events that used
to be represented by the catch-all File event.

Paired with https://github.com/sourcegraph/src-cli/pull/569

Stacked on #22996 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
