### PR TITLE
New post-signup flow + Stepper and Terminal components

### DIFF
--- a/client/shared/src/graphql/graphql.ts
+++ b/client/shared/src/graphql/graphql.ts
@@ -2,6 +2,7 @@ import {
     gql as apolloGql,
     useQuery as useApolloQuery,
     useMutation as useApolloMutation,
+    useLazyQuery as useApolloLazyQuery,
     DocumentNode,
     ApolloClient,
     InMemoryCache,
@@ -12,6 +13,7 @@ import {
     QueryResult,
     MutationHookOptions,
     MutationTuple,
+    QueryTuple,
 } from '@apollo/client'
 import { useMemo } from 'react'
 import { Observable } from 'rxjs'
@@ -138,6 +140,14 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
 ): QueryResult<TData, TVariables> {
     const documentNode = useDocumentNode(query)
     return useApolloQuery(documentNode, options)
+}
+
+export function useLazyQuery<TData = any, TVariables = OperationVariables>(
+    query: RequestDocument,
+    options: QueryHookOptions<TData, TVariables>
+): QueryTuple<TData, TVariables> {
+    const documentNode = useDocumentNode(query)
+    return useApolloLazyQuery(documentNode, options)
 }
 
 /**

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -232,7 +232,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
         props.location.pathname === '/sign-in' ||
         props.location.pathname === '/sign-up' ||
         props.location.pathname === '/password-reset' ||
-        props.location.pathname === '/post-sign-up'
+        props.location.pathname === '/welcome'
 
     // TODO Change this behavior when we have global focus management system
     // Need to know this for disable autofocus on nav search input

--- a/client/web/src/auth/LogoAscii.tsx
+++ b/client/web/src/auth/LogoAscii.tsx
@@ -1,0 +1,240 @@
+/* eslint-disable react/forbid-dom-props */
+import React from 'react'
+
+export const LogoAscii: React.FunctionComponent<{ fontSize?: number }> = ({ fontSize = 8 }) => {
+    // colors are hardcoded as it's a 1-to-1 conversion from src-cli ASCII logo
+    const color_af5f5f = { color: '#af5f5f' }
+    const color_d75f00 = { color: '#d75f00' }
+    const color_ff5f00 = { color: '#ff5f00' }
+    const color_875faf = { color: '#875faf' }
+    const color_af00d7 = { color: '#af00d7' }
+    const color_af00ff = { color: '#af00ff' }
+    const color_af5fd7 = { color: '#af5fd7' }
+    const color_5f87af = { color: '#5f87af' }
+    const color_5fafd7 = { color: '#5fafd7' }
+    const color_00afd7 = { color: '#00afd7' }
+    const color_00afff = { color: '#00afff' }
+    const color_af0087 = { color: '#af0087' }
+    const color_0087af = { color: '#0087af' }
+    const color_005f5f = { color: '#005f5f' }
+    const color_404040 = { color: '#404040' }
+    const color_875f00 = { color: '#875f00' }
+    const color_af5f00 = { color: '#af5f00' }
+    const color_af005f = { color: '#af005f' }
+    const color_0087d7 = { color: '#0087d7' }
+    const color_005fd7 = { color: '#005fd7' }
+    const color_5f00d7 = { color: '#5f00d7' }
+    const color_5f5faf = { color: '#5f5faf' }
+    const color_5fafaf = { color: '#5fafaf' }
+    const color_8700ff = { color: '#8700ff' }
+    const color_8700d7 = { color: '#8700d7' }
+    const color_4a4a4a = { color: '#4a4a4a' }
+    const color_005f87 = { color: '#005f87' }
+    const color_875f5f = { color: '#875f5f' }
+    const color_af5faf = { color: '#af5faf' }
+    const color_af875f = { color: '#af875f' }
+
+    return (
+        <>
+            <pre style={{ fontSize }}>
+                {'                '}
+                <span style={color_af5f5f}>╓</span>
+                <span style={color_d75f00}>╦╬╬╬╦</span>
+                <span style={color_af5f5f}>╖</span>
+                {'\n'}
+                {'               '}
+                <span style={color_d75f00}>╬</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬</span>
+                {'\n'}
+                {'              '}
+                <span style={color_af5f5f}>╞</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬</span>
+                <span style={color_d75f00}>╬</span>
+                {'           '}
+                <span style={color_875faf}>╓</span>
+                <span style={color_af00d7}>╦╦╦╦</span>
+                <span style={color_875faf}>┐</span>
+                {'\n'}
+                {'               '}
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬╬</span>
+                <span style={color_af5f5f}>╕</span>
+                {'        '}
+                <span style={color_af00d7}>╔</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪</span>
+                <span style={color_af5fd7}>╕</span>
+                {'\n'}
+                {'               '}
+                <span style={color_af5f5f}>╘</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬╬</span>
+                {'      '}
+                <span style={color_af00d7}>╔</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪</span>
+                {'\n'}
+                {'                '}
+                <span style={color_d75f00}>╬</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬</span>
+                <span style={color_d75f00}>╗</span>
+                {'   '}
+                <span style={color_af5fd7}>╔</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af5fd7}>┘</span>
+                {'\n'}
+                {'   '}
+                <span style={color_5f87af}>╓</span>
+                <span style={color_5fafd7}>╦</span>
+                <span style={color_00afd7}>╦╖</span>
+                <span style={color_5f87af}>┐</span>
+                {'         '}
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬╬</span> <span style={color_af5fd7}>╔</span>
+                <span style={color_af00ff}>╝╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af00d7}>╜</span>
+                {'\n'} <span style={color_00afd7}>╬</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╬</span>
+                <span style={color_00afd7}>╗╦</span>
+                <span style={color_5f87af}>╖</span>
+                {'   '}
+                <span style={color_d75f00}>╠</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬</span>
+                <span style={color_af0087}>╝</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af00d7}>╜</span>
+                {'\n'}
+                <span style={color_00afd7}>╠</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_0087af}>╝</span>
+                <span style={color_005f5f}>╝</span>
+                <span style={color_404040}>╬</span>
+                <span style={color_875f00}>╬</span>
+                <span style={color_af5f00}>╬</span>
+                <span style={color_d75f00}>╬</span>
+                <span style={color_af005f}>╝</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af00d7}>╜</span>
+                {'\n'}
+                <span style={color_5f87af}>└</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_0087d7}>╪</span>
+                <span style={color_005fd7}>╪╪</span>
+                <span style={color_5f00d7}>╪╪</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪</span>
+                <span style={color_af00d7}>╩</span>
+                {'\n'}
+                {'  '}
+                <span style={color_00afd7}>╙╩</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_0087d7}>╪</span>
+                <span style={color_005fd7}>╪╪</span>
+                <span style={color_5f5faf}>╖</span>
+                {'\n'}
+                {'       '}
+                <span style={color_5f87af}>└</span>
+                <span style={color_00afd7}>╙╩</span>
+                <span style={color_00afff}>╬╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╬</span>
+                <span style={color_00afd7}>╦</span>
+                <span style={color_5fafd7}>╗</span>
+                <span style={color_5f87af}>┐</span>
+                {'\n'}
+                {'              '}
+                <span style={color_5fafaf}>╙</span>
+                <span style={color_00afd7}>╜</span>
+                <span style={color_0087d7}>╪</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_00afd7}>╗╦</span>
+                <span style={color_5fafaf}>╖</span>
+                {'\n'}
+                {'              '}
+                <span style={color_875faf}>┌</span>
+                <span style={color_af00ff}>╬╪╪</span>
+                <span style={color_8700ff}>╪</span>
+                <span style={color_5f00d7}>╪╪</span>
+                <span style={color_005fd7}>╪</span>
+                <span style={color_0087d7}>╪</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╬</span>
+                {'\n'}
+                {'            '}
+                <span style={color_875faf}>┌</span>
+                <span style={color_af00d7}>╗</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_8700d7}>╪</span>
+                <span style={color_4a4a4a}>╬</span>
+                <span style={color_404040}>╬</span>
+                <span style={color_005f87}>╬</span>
+                <span style={color_0087af}>╪</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                {'\n'}
+                {'          '}
+                <span style={color_875faf}>┌</span>
+                <span style={color_af00d7}>╗</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af0087}>╬</span>
+                <span style={color_d75f00}>╬</span>
+                <span style={color_ff5f00}>╬╬╬╬╬</span>
+                <span style={color_d75f00}>╬</span>
+                <span style={color_875f5f}>╬ </span>
+                <span style={color_5fafaf}>╙</span>
+                <span style={color_00afd7}>╜╩</span>
+                <span style={color_00afff}>╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_00afd7}>╜</span>
+                {'\n'}
+                {'        '}
+                <span style={color_875faf}>┌</span>
+                <span style={color_af00d7}>╦</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪╝</span>
+                <span style={color_af5faf}>╙</span>
+                <span style={color_d75f00}>╬</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬</span>
+                {'       '}
+                <span style={color_5f87af}>└</span>
+                <span style={color_00afd7}>╙╩</span>
+                <span style={color_00afff}>╬╪╪╝</span>
+                <span style={color_00afd7}>╜</span>
+                {'\n'}
+                {'       '}
+                <span style={color_af00d7}>╦</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af5fd7}>┘</span>
+                {'  '}
+                <span style={color_d75f00}>╠</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬</span>
+                <span style={color_d75f00}>╬</span>
+                {'\n'}
+                {'      '}
+                <span style={color_af00ff}>╬╪╪╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af5fd7}>┘</span>
+                {'     '}
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬╬</span>
+                <span style={color_af5f5f}>┐</span>
+                {'\n'}
+                {'      '}
+                <span style={color_af00d7}>╙</span>
+                <span style={color_af00ff}>╪╪╪╪╪╪╪╪╪</span>
+                <span style={color_af00d7}>╜</span>
+                {'       '}
+                <span style={color_af5f5f}>╘</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬╬</span>
+                {'\n'}
+                {'       '}
+                <span style={color_875faf}>└</span>
+                <span style={color_af00d7}>╩</span>
+                <span style={color_af00ff}>╪╪╪╪╝</span>
+                <span style={color_af5fd7}>╙</span>
+                {'          '}
+                <span style={color_d75f00}>╬</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬</span>
+                <span style={color_d75f00}>╕</span>
+                {'\n'}
+                {'                         '}
+                <span style={color_af875f}>└</span>
+                <span style={color_ff5f00}>╬╬╬╬╬╬╬╬╬</span>
+                <span style={color_af5f5f}>╛</span>
+                {'\n'}
+                {'                           '}
+                <span style={color_d75f00}>╩</span>
+                <span style={color_ff5f00}>╬╬╬╬╬</span>
+                <span style={color_d75f00}>╬</span>
+                <span style={color_af5f5f}>┘</span>
+                {'\n'}
+            </pre>
+        </>
+    )
+}

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -21,7 +21,7 @@ import { StartSearching } from './welcome/StartSearching'
 
 interface PostSignUpPage {
     authenticatedUser: AuthenticatedUser
-    context: Pick<SourcegraphContext, 'authProviders' | 'experimentalFeatures' | 'sourcegraphDotComMode'>
+    context: Pick<SourcegraphContext, 'authProviders'>
     telemetryService: TelemetryService
 }
 

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -8,8 +8,8 @@ import { BrandLogo } from '@sourcegraph/web/src/components/branding/BrandLogo'
 import { HeroPage } from '@sourcegraph/web/src/components/HeroPage'
 import { Steps, Step, StepList, StepPanels, StepPanel, StepActions } from '@sourcegraph/wildcard/src/components/Steps'
 
+import { AuthenticatedUser } from '../auth'
 import { PageTitle } from '../components/PageTitle'
-import { UserAreaUserFields } from '../graphql-operations'
 import { SourcegraphContext } from '../jscontext'
 import { SelectAffiliatedRepos } from '../user/settings/repositories/SelectAffiliatedRepos'
 
@@ -20,7 +20,7 @@ import { Footer } from './welcome/Footer'
 import { StartSearching } from './welcome/StartSearching'
 
 interface PostSignUpPage {
-    authenticatedUser: UserAreaUserFields
+    authenticatedUser: AuthenticatedUser
     context: Pick<SourcegraphContext, 'authProviders' | 'experimentalFeatures' | 'sourcegraphDotComMode'>
     telemetryService: TelemetryService
 }
@@ -102,7 +102,6 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
 
             <div className="signin-signup-page post-signup-page">
                 <PageTitle title="Welcome" />
-
                 <HeroPage
                     lessPadding={true}
                     className="text-left"

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -1,45 +1,168 @@
-import * as H from 'history'
-import React, { FunctionComponent } from 'react'
-import { Redirect } from 'react-router-dom'
+import React, { FunctionComponent, useState, useEffect, useCallback, useRef } from 'react'
+import { useLocation, useHistory } from 'react-router'
 
-import { AuthenticatedUser } from '../auth'
-import { HeroPage } from '../components/HeroPage'
+import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
+import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
+import { BrandLogo } from '@sourcegraph/web/src/components/branding/BrandLogo'
+import { HeroPage } from '@sourcegraph/web/src/components/HeroPage'
+import { Steps, Step, StepList, StepPanels, StepPanel, StepActions } from '@sourcegraph/wildcard/src/components/Steps'
+
 import { PageTitle } from '../components/PageTitle'
+import { UserAreaUserFields } from '../graphql-operations'
 import { SourcegraphContext } from '../jscontext'
+import { SelectAffiliatedRepos } from '../user/settings/repositories/SelectAffiliatedRepos'
 
 import { getReturnTo } from './SignInSignUpCommon'
+import { useExternalServices } from './useExternalServices'
+import { CodeHostsConnection } from './welcome/CodeHostsConnection'
+import { Footer } from './welcome/Footer'
+import { StartSearching } from './welcome/StartSearching'
 
-interface Props {
-    authenticatedUser?: AuthenticatedUser | null
-    context: Pick<SourcegraphContext, 'allowSignup' | 'sourcegraphDotComMode' | 'experimentalFeatures'>
-    location: H.Location
+interface PostSignUpPage {
+    authenticatedUser: UserAreaUserFields
+    context: Pick<SourcegraphContext, 'authProviders' | 'experimentalFeatures' | 'sourcegraphDotComMode'>
+    telemetryService: TelemetryService
 }
 
-export const PostSignUpPage: FunctionComponent<Props> = ({
-    authenticatedUser,
-    location,
-    context: { sourcegraphDotComMode, experimentalFeatures },
-}) =>
-    // post sign-up flow is available only for .com and only in two cases, user:
-    // 1. is authenticated and has AllowUserViewPostSignup tag
-    // 2. is authenticated and enablePostSignupFlow experimental feature is ON
-    sourcegraphDotComMode &&
-    ((authenticatedUser && experimentalFeatures.enablePostSignupFlow) ||
-        authenticatedUser?.tags.includes('AllowUserViewPostSignup')) ? (
-        <div className="signin-signup-page post-signup-page">
-            <PageTitle title="Post sign up page" />
+interface Step {
+    content: React.ReactElement
+    isComplete: () => boolean
+    prefetch?: () => void
+    onNextButtonClick?: () => Promise<void>
+}
 
-            <HeroPage
-                lessPadding={true}
-                className="text-left"
-                body={
-                    <div className="post-signup-page__container">
-                        <h2>Get started with Sourcegraph</h2>
-                        <p>Three quick steps to add your repositories and get searching with Sourcegraph</p>
-                    </div>
-                }
-            />
-        </div>
-    ) : (
-        <Redirect to={getReturnTo(location)} />
+// type PerformanceNavigationTimingType = 'navigate' | 'reload' | 'back_forward' | 'prerender'
+
+export type RepoSelectionMode = 'all' | 'selected' | undefined
+
+const USER_FINISHED_WELCOME_FLOW = 'finished-welcome-flow'
+
+export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
+    authenticatedUser: user,
+    context,
+    telemetryService,
+}) => {
+    const [didUserFinishWelcomeFlow, setUserFinishedWelcomeFlow] = useLocalStorage(USER_FINISHED_WELCOME_FLOW, false)
+    const isOAuthCall = useRef(false)
+    const location = useLocation()
+    const history = useHistory()
+
+    const goToSearch = (): void => history.push(getReturnTo(location))
+
+    // if the welcome flow was already finished - navigate to search
+    if (didUserFinishWelcomeFlow) {
+        goToSearch()
+    }
+
+    const finishWelcomeFlow = (): void => {
+        setUserFinishedWelcomeFlow(true)
+        goToSearch()
+    }
+
+    const [repoSelectionMode, setRepoSelectionMode] = useState<RepoSelectionMode>()
+    const { externalServices, loadingServices, errorServices, refetchExternalServices } = useExternalServices(user.id)
+
+    const beforeUnload = useCallback((): void => {
+        // user is not leaving the flow, it's an OAuth page refresh
+        if (isOAuthCall.current) {
+            return
+        }
+
+        // TODO: discuss
+        // allow user to manually refresh the page
+        // if (window.performance?.getEntriesByType) {
+        //     const entries = window.performance?.getEntriesByType('navigation')
+        //     // let TS know that we may expect PerformanceNavigationTiming.type
+        //     const lastEntry = entries.pop() as PerformanceEntry & { type?: PerformanceNavigationTimingType }
+        //     if (lastEntry?.type === 'reload') {
+        //         return
+        //     }
+        // }
+
+        setUserFinishedWelcomeFlow(true)
+    }, [setUserFinishedWelcomeFlow])
+
+    useEffect(() => {
+        window.addEventListener('beforeunload', beforeUnload)
+
+        return () => window.removeEventListener('beforeunload', beforeUnload)
+    }, [beforeUnload])
+
+    return (
+        <>
+            <LinkOrSpan to={getReturnTo(location)} className="post-signup-page__logo-link">
+                <BrandLogo
+                    className="position-absolute ml-3 mt-3 post-signup-page__logo"
+                    isLightTheme={true}
+                    variant="symbol"
+                    onClick={finishWelcomeFlow}
+                />
+            </LinkOrSpan>
+
+            <div className="signin-signup-page post-signup-page">
+                <PageTitle title="Welcome" />
+
+                <HeroPage
+                    lessPadding={true}
+                    className="text-left"
+                    body={
+                        <div className="post-signup-page__container">
+                            <h2>Get started with Sourcegraph</h2>
+                            <p className="text-muted pb-3">
+                                Three quick steps to add your repositories and get searching with Sourcegraph
+                            </p>
+                            <div className="mt-4 pb-3">
+                                <Steps initialStep={1}>
+                                    <StepList numeric={true}>
+                                        <Step borderColor="purple">Connect with code hosts</Step>
+                                        <Step borderColor="blue">Add repositories</Step>
+                                        <Step borderColor="orange">Start searching</Step>
+                                    </StepList>
+                                    <StepPanels>
+                                        <StepPanel>
+                                            {externalServices && (
+                                                <CodeHostsConnection
+                                                    user={user}
+                                                    onNavigation={(called: boolean) => {
+                                                        isOAuthCall.current = called
+                                                    }}
+                                                    loading={loadingServices}
+                                                    error={errorServices}
+                                                    externalServices={externalServices}
+                                                    context={context}
+                                                    refetch={refetchExternalServices}
+                                                />
+                                            )}
+                                        </StepPanel>
+                                        <StepPanel>
+                                            <>
+                                                <h3>Add repositories</h3>
+                                                <p className="text-muted">
+                                                    Choose repositories you own or collaborate on from your code hosts
+                                                    to search with Sourcegraph. We’ll sync and index these repositories
+                                                    so you can search your code all in one place.
+                                                </p>
+                                                <SelectAffiliatedRepos
+                                                    authenticatedUser={user}
+                                                    onRepoSelectionModeChange={setRepoSelectionMode}
+                                                    telemetryService={telemetryService}
+                                                />
+                                            </>
+                                        </StepPanel>
+                                        <StepPanel>
+                                            <StartSearching user={user} repoSelectionMode={repoSelectionMode} />
+                                        </StepPanel>
+                                    </StepPanels>
+                                    <StepActions>
+                                        <Footer onFinish={finishWelcomeFlow} />
+                                    </StepActions>
+                                </Steps>
+                            </div>
+                        </div>
+                    }
+                />
+            </div>
+        </>
     )
+}

--- a/client/web/src/auth/SignInSignUpPageCommon.scss
+++ b/client/web/src/auth/SignInSignUpPageCommon.scss
@@ -38,6 +38,21 @@
 
 .post-signup-page {
     margin-top: 7rem;
+    margin-bottom: 5rem;
+    &__logo {
+        height: 1.75rem;
+        width: 1.75rem;
+    }
+    &__logo-link {
+        outline: 0;
+        margin: 0.25rem 0.5rem;
+        display: flex;
+        width: fit-content;
+        text-decoration: none;
+    }
+    &__link-disabled {
+        color: var(--hl-gray-5);
+    }
     &__container {
         width: 37.25rem;
     }

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -32,6 +32,7 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
     telemetryService,
 }) => {
     const location = useLocation()
+    // const history = useHistory()
     const query = new URLSearchParams(location.search)
 
     useEffect(() => {
@@ -65,10 +66,12 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
             // if sign up is successful and enablePostSignupFlow feature is ON -
             // redirect user to the /post-sign-up page
             if (context.experimentalFeatures.enablePostSignupFlow) {
-                window.location.replace(new URL('/post-sign-up', window.location.href).pathname)
+                window.location.replace(new URL('/welcome', window.location.href).pathname)
             } else {
                 window.location.replace(getReturnTo(location))
             }
+
+            // TODO: check this section ^^^
 
             return Promise.resolve()
         })

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -71,8 +71,6 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
                 window.location.replace(getReturnTo(location))
             }
 
-            // TODO: check this section ^^^
-
             return Promise.resolve()
         })
 

--- a/client/web/src/auth/useAffiliatedRepos.ts
+++ b/client/web/src/auth/useAffiliatedRepos.ts
@@ -1,0 +1,60 @@
+import { ApolloError, ApolloQueryResult } from '@apollo/client'
+
+import { gql, useQuery } from '@sourcegraph/shared/src/graphql/graphql'
+
+import { Maybe, AffiliatedRepositoriesResult, AffiliatedRepositoriesVariables, Exact } from '../graphql-operations'
+
+interface UseAffiliatedReposResult {
+    affiliatedRepos: AffiliatedRepositoriesResult['affiliatedRepositories']['nodes'] | undefined
+    loadingAffiliatedRepos: boolean
+    errorAffiliatedRepos: ApolloError | undefined
+    refetchAffiliatedRepos:
+        | ((
+              variables?:
+                  | Partial<
+                        Exact<{
+                            user: string
+                            codeHost: Maybe<string>
+                            query: Maybe<string>
+                        }>
+                    >
+                  | undefined
+          ) => Promise<ApolloQueryResult<AffiliatedRepositoriesResult>>)
+        | undefined
+}
+
+const AFFILIATED_REPOS = gql`
+    query UserAffiliatedRepositories($user: ID!, $codeHost: ID, $query: String) {
+        affiliatedRepositories(user: $user, codeHost: $codeHost, query: $query) {
+            nodes {
+                name
+                codeHost {
+                    kind
+                    id
+                    displayName
+                }
+                private
+            }
+        }
+    }
+`
+
+export const useAffiliatedRepos = (userId: string): UseAffiliatedReposResult => {
+    const { data, loading, error, refetch } = useQuery<AffiliatedRepositoriesResult, AffiliatedRepositoriesVariables>(
+        AFFILIATED_REPOS,
+        {
+            variables: {
+                user: userId,
+                codeHost: null,
+                query: null,
+            },
+        }
+    )
+
+    return {
+        affiliatedRepos: data?.affiliatedRepositories.nodes,
+        loadingAffiliatedRepos: loading,
+        errorAffiliatedRepos: error,
+        refetchAffiliatedRepos: refetch,
+    }
+}

--- a/client/web/src/auth/useExternalServices.ts
+++ b/client/web/src/auth/useExternalServices.ts
@@ -1,0 +1,49 @@
+import { ApolloError, ApolloQueryResult } from '@apollo/client'
+
+import { useQuery } from '@sourcegraph/shared/src/graphql/graphql'
+import { EXTERNAL_SERVICES } from '@sourcegraph/web/src/components/externalServices/backend'
+
+import {
+    Exact,
+    ExternalServicesResult,
+    ExternalServicesVariables,
+    ListExternalServiceFields,
+    Maybe,
+} from '../graphql-operations'
+
+interface UseExternalServicesResult {
+    externalServices: ListExternalServiceFields[] | undefined
+    loadingServices: boolean
+    errorServices: ApolloError | undefined
+    refetchExternalServices: (
+        variables?:
+            | Partial<
+                  Exact<{
+                      first: Maybe<number>
+                      after: Maybe<string>
+                      namespace: Maybe<string>
+                  }>
+              >
+            | undefined
+    ) => Promise<ApolloQueryResult<ExternalServicesResult>>
+}
+
+export const useExternalServices = (userId: string): UseExternalServicesResult => {
+    const { data, loading, error, refetch } = useQuery<ExternalServicesResult, ExternalServicesVariables>(
+        EXTERNAL_SERVICES,
+        {
+            variables: {
+                namespace: userId,
+                first: null,
+                after: null,
+            },
+        }
+    )
+
+    return {
+        externalServices: data?.externalServices.nodes,
+        loadingServices: loading,
+        errorServices: error,
+        refetchExternalServices: refetch,
+    }
+}

--- a/client/web/src/auth/useExternalServices.ts
+++ b/client/web/src/auth/useExternalServices.ts
@@ -28,7 +28,7 @@ interface UseExternalServicesResult {
     ) => Promise<ApolloQueryResult<ExternalServicesResult>>
 }
 
-export const useExternalServices = (userId: string): UseExternalServicesResult => {
+export const useExternalServices = (userId: string | null): UseExternalServicesResult => {
     const { data, loading, error, refetch } = useQuery<ExternalServicesResult, ExternalServicesVariables>(
         EXTERNAL_SERVICES,
         {

--- a/client/web/src/auth/useRepoCloningStatus.ts
+++ b/client/web/src/auth/useRepoCloningStatus.ts
@@ -144,7 +144,13 @@ export const useRepoCloningStatus = ({
         return lines
     }, [] as RepoLine[])
 
-    repoLines.sort((lineA, lineB) => lineB.progress - lineA.progress)
+    // sort alphabetically
+    repoLines.sort((lineA, lineB) => {
+        const nameA = lineA.title.toUpperCase()
+        const nameB = lineB.title.toUpperCase()
+
+        return nameA < nameB ? -1 : nameA > nameB ? 1 : 0
+    })
 
     const isDoneCloning = didReceiveAllRepoStatuses && areAllRepoCloned
 

--- a/client/web/src/auth/useRepoCloningStatus.ts
+++ b/client/web/src/auth/useRepoCloningStatus.ts
@@ -1,0 +1,222 @@
+import { ApolloError, ReactiveVar } from '@apollo/client'
+import { upperFirst, xor } from 'lodash'
+
+import { useQuery, gql } from '@sourcegraph/shared/src/graphql/graphql'
+
+import { Maybe, UserRepositoriesVariables } from '../graphql-operations'
+
+import { MinSelectedRepo } from './useSelectedRepos'
+
+interface UseRepoCloningStatusArguments {
+    userId: string
+    pollInterval: number
+    selectedReposVar: ReactiveVar<MinSelectedRepo[] | undefined>
+}
+
+interface RepoLine {
+    id: string
+    title: string
+    details: string
+    progress: number
+}
+
+export interface RepoCloningStatus {
+    repos: RepoLine[] | undefined
+    loading: boolean
+    isDoneCloning: boolean
+    error: ApolloError | undefined
+}
+
+interface RepoFields {
+    id: string
+    name: string
+    mirrorInfo: { cloned: boolean; cloneProgress: string; cloneInProgress: boolean; updatedAt: Maybe<string> }
+}
+
+interface CloneProgressResult {
+    node: Maybe<{
+        repositories: {
+            nodes: RepoFields[]
+        }
+    }>
+}
+
+// temp object to store previous cloning progress percentage
+let previousPercentage: { [key: string]: number } = {}
+
+const USER_AFFILIATED_REPOS_MIRROR_INFO = gql`
+    query UserRepositoriesMirrorInfo(
+        $id: ID!
+        $first: Int
+        $query: String
+        $cloned: Boolean
+        $notCloned: Boolean
+        $indexed: Boolean
+        $notIndexed: Boolean
+        $externalServiceID: ID
+    ) {
+        node(id: $id) {
+            ... on User {
+                repositories(
+                    first: $first
+                    query: $query
+                    cloned: $cloned
+                    notCloned: $notCloned
+                    indexed: $indexed
+                    notIndexed: $notIndexed
+                    externalServiceID: $externalServiceID
+                ) {
+                    nodes {
+                        id
+                        name
+                        mirrorInfo {
+                            cloned
+                            cloneInProgress
+                            cloneProgress
+                            updatedAt
+                        }
+                    }
+                    totalCount
+                }
+            }
+        }
+    }
+`
+
+const getRepoNames = (repos: { name: string }[] | undefined): string[] | [] =>
+    repos ? repos.map(({ name }) => name) : []
+
+export const useRepoCloningStatus = ({
+    userId,
+    pollInterval = 5000,
+    selectedReposVar,
+}: UseRepoCloningStatusArguments): RepoCloningStatus => {
+    let areAllRepoCloned = true
+
+    const { called, data, loading, error, stopPolling } = useQuery<CloneProgressResult, UserRepositoriesVariables>(
+        USER_AFFILIATED_REPOS_MIRROR_INFO,
+        {
+            variables: {
+                id: userId,
+                cloned: true,
+                notCloned: true,
+                indexed: true,
+                notIndexed: true,
+                first: 2000,
+                query: null,
+                externalServiceID: null,
+            },
+            pollInterval,
+            fetchPolicy: 'no-cache',
+        }
+    )
+
+    const selectedRepos = selectedReposVar()
+
+    const repos = data?.node?.repositories.nodes
+
+    if (!Array.isArray(repos)) {
+        return {
+            repos: undefined,
+            isDoneCloning: false,
+            loading,
+            error,
+        }
+    }
+
+    // check if we received cloning status for all selected repos
+    const didReceiveAllRepoStatuses = xor(getRepoNames(selectedRepos), getRepoNames(repos)).length === 0
+
+    const repoLines: RepoLine[] = repos.reduce((lines, { id, name, mirrorInfo }) => {
+        const { details, progress, cloned } = parseMirrorInfo(id, mirrorInfo)
+
+        if (!cloned) {
+            areAllRepoCloned = false
+        }
+
+        lines.push({
+            id,
+            details,
+            progress,
+            title: ignoreExternalService(name),
+        })
+
+        return lines
+    }, [] as RepoLine[])
+
+    repoLines.sort((lineA, lineB) => lineB.progress - lineA.progress)
+
+    const isDoneCloning = didReceiveAllRepoStatuses && areAllRepoCloned
+
+    // stop polling and cleanup memory when all repos are done cloning
+    if (called && isDoneCloning) {
+        stopPolling()
+        previousPercentage = {}
+    }
+
+    return { repos: repoLines, isDoneCloning, loading, error }
+}
+
+const parseMirrorInfo = (
+    id: string,
+    mirrorInfo: RepoFields['mirrorInfo']
+): { progress: number; details: string; cloned: boolean } => {
+    const { cloneProgress, cloned, cloneInProgress } = mirrorInfo
+
+    // cloned
+    if (cloned) {
+        return {
+            cloned,
+            details: 'Successfully cloned',
+            progress: 100,
+        }
+    }
+
+    // not cloned and cloning is not in progress
+    if (!cloneInProgress) {
+        return {
+            cloned,
+            details: 'Not cloned yet',
+            progress: 0,
+        }
+    }
+
+    // remove extra spaces and upper fist character
+    const normalizedDetails = normalizeDetails(cloneProgress)
+
+    /**
+     * for the details like:
+     * 1. * [new branch] master -> master
+     * 2. * [new ref] refs/pull/9/merge -> refs/pull/9/merge
+     * use previously parsed progress value or 0
+     */
+    let percentage = 0
+    if (normalizedDetails.startsWith('*')) {
+        percentage = previousPercentage[id] || 0
+    } else {
+        percentage = findProgressPercentage(cloneProgress)
+        previousPercentage[id] = percentage
+    }
+
+    return {
+        cloned,
+        details: normalizedDetails,
+        progress: percentage,
+    }
+}
+
+const findProgressPercentage = (progress: string = ''): number => {
+    // fist 1-3 digits before the % sign
+    const PERCENTAGE = /\d{1,3}(?=%)/
+    const match = progress.match(PERCENTAGE)
+
+    if (match) {
+        // convert first string into numbers
+        return +match[0]
+    }
+
+    return 0
+}
+
+const normalizeDetails = (string: string): string => upperFirst(string.replace(/\s\s+/g, ' '))
+const ignoreExternalService = (fullRepoName: string): string => fullRepoName.slice(fullRepoName.indexOf('/') + 1)

--- a/client/web/src/auth/useSelectedRepos.tsx
+++ b/client/web/src/auth/useSelectedRepos.tsx
@@ -1,0 +1,148 @@
+import { ApolloError, ApolloQueryResult, gql, MutationFunctionOptions, FetchResult, makeVar } from '@apollo/client'
+
+import { useQuery, useMutation } from '@sourcegraph/shared/src/graphql/graphql'
+
+import {
+    Maybe,
+    Exact,
+    UserRepositoriesResult,
+    UserRepositoriesVariables,
+    SetExternalServiceReposResult,
+    SetExternalServiceReposVariables,
+} from '../graphql-operations'
+
+export interface MinSelectedRepo {
+    name: string
+    externalRepository: {
+        serviceType: string
+        id: string
+    }
+}
+
+type SelectedRepos = MinSelectedRepo[] | undefined
+const SelectedReposInitialValue: SelectedRepos = undefined
+
+export const selectedReposVar = makeVar<SelectedRepos>(SelectedReposInitialValue)
+
+interface UseSelectedReposResult {
+    selectedRepos: NonNullable<UserRepositoriesResult['node']>['repositories']['nodes'] | undefined
+    loadingSelectedRepos: boolean
+    errorSelectedRepos: ApolloError | undefined
+    refetchSelectedRepos:
+        | ((
+              variables?:
+                  | Partial<
+                        Exact<{
+                            user: string
+                            codeHost: Maybe<string>
+                            query: Maybe<string>
+                        }>
+                    >
+                  | undefined
+          ) => Promise<ApolloQueryResult<UserRepositoriesResult>>)
+        | undefined
+}
+
+const SAVE_SELECTED_REPOS = gql`
+    mutation SetExternalServiceRepos($id: ID!, $allRepos: Boolean!, $repos: [String!]) {
+        setExternalServiceRepos(id: $id, allRepos: $allRepos, repos: $repos) {
+            alwaysNil
+        }
+    }
+`
+
+type UseSaveSelectedReposResult = (
+    options?:
+        | MutationFunctionOptions<
+              SetExternalServiceReposResult,
+              Exact<{
+                  id: string
+                  allRepos: boolean
+                  repos: Maybe<string[]>
+              }>
+          >
+        | undefined
+) => Promise<FetchResult<SetExternalServiceReposResult>>
+
+export const useSaveSelectedRepos = (): UseSaveSelectedReposResult => {
+    const [saveSelectedRepos] = useMutation<SetExternalServiceReposResult, SetExternalServiceReposVariables>(
+        SAVE_SELECTED_REPOS
+    )
+
+    return saveSelectedRepos
+}
+
+export const SELECTED_REPOS = gql`
+    query UserSelectedRepositories(
+        $id: ID!
+        $first: Int
+        $query: String
+        $cloned: Boolean
+        $notCloned: Boolean
+        $indexed: Boolean
+        $notIndexed: Boolean
+        $externalServiceID: ID
+    ) {
+        node(id: $id) {
+            ... on User {
+                repositories(
+                    first: $first
+                    query: $query
+                    cloned: $cloned
+                    notCloned: $notCloned
+                    indexed: $indexed
+                    notIndexed: $notIndexed
+                    externalServiceID: $externalServiceID
+                ) {
+                    nodes {
+                        id
+                        name
+                        createdAt
+                        viewerCanAdminister
+                        url
+                        isPrivate
+                        mirrorInfo {
+                            cloned
+                            cloneInProgress
+                            cloneProgress
+                            updatedAt
+                        }
+                        externalRepository {
+                            serviceType
+                            serviceID
+                        }
+                    }
+                    totalCount(precise: true)
+                    pageInfo {
+                        hasNextPage
+                    }
+                }
+            }
+        }
+    }
+`
+
+export const useSelectedRepos = (userId: string, first?: number): UseSelectedReposResult => {
+    const { data, loading, error, refetch } = useQuery<UserRepositoriesResult, UserRepositoriesVariables>(
+        SELECTED_REPOS,
+        {
+            variables: {
+                id: userId,
+                cloned: true,
+                notCloned: true,
+                indexed: true,
+                notIndexed: true,
+                first: first || 2000,
+                query: null,
+                externalServiceID: null,
+            },
+        }
+    )
+
+    return {
+        selectedRepos: data?.node?.repositories.nodes,
+        loadingSelectedRepos: loading,
+        errorSelectedRepos: error,
+        refetchSelectedRepos: refetch,
+    }
+}

--- a/client/web/src/auth/useSelectedRepos.tsx
+++ b/client/web/src/auth/useSelectedRepos.tsx
@@ -15,7 +15,7 @@ export interface MinSelectedRepo {
     name: string
     externalRepository: {
         serviceType: string
-        id: string
+        id?: string
     }
 }
 

--- a/client/web/src/auth/welcome/CodeHostsConnection.tsx
+++ b/client/web/src/auth/welcome/CodeHostsConnection.tsx
@@ -1,0 +1,61 @@
+import { ApolloError } from '@apollo/client'
+import React, { useEffect } from 'react'
+
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { useSteps } from '@sourcegraph/wildcard/src/components/Steps'
+
+import { UserCodeHosts } from '../../user/settings/codeHosts/UserCodeHosts'
+
+interface CodeHostsConnection extends Omit<UserCodeHosts, 'onDidRemove' | 'onDidError'> {
+    refetch: UserCodeHosts['onDidRemove']
+    loading: boolean
+    error: ApolloError | undefined
+    onNavigation?: (called: boolean) => void
+}
+
+export const CodeHostsConnection: React.FunctionComponent<CodeHostsConnection> = ({
+    user,
+    context,
+    refetch,
+    externalServices,
+    loading,
+    onNavigation,
+}) => {
+    const { setComplete, currentIndex } = useSteps()
+
+    useEffect(() => {
+        if (Array.isArray(externalServices) && externalServices.length > 0) {
+            setComplete(currentIndex, true)
+        } else {
+            setComplete(currentIndex, false)
+        }
+    }, [currentIndex, externalServices, setComplete])
+
+    if (loading) {
+        return (
+            <div className="d-flex justify-content-center">
+                <LoadingSpinner className="icon-inline" />
+            </div>
+        )
+    }
+
+    return (
+        <>
+            <div className="mb-4">
+                <h3>Connect with code hosts</h3>
+                <p className="text-muted">
+                    Connect with providers where your source code is hosted. Then, choose the repositories you’d like to
+                    search with Sourcegraph.
+                </p>
+            </div>
+            <UserCodeHosts
+                user={user}
+                externalServices={externalServices}
+                context={context}
+                onNavigation={onNavigation}
+                onDidError={error => console.warn('<UserCodeHosts .../>', error)}
+                onDidRemove={refetch}
+            />
+        </>
+    )
+}

--- a/client/web/src/auth/welcome/Footer.tsx
+++ b/client/web/src/auth/welcome/Footer.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import { LoaderButton } from '@sourcegraph/web/src/components/LoaderButton'
+import { useSteps } from '@sourcegraph/wildcard/src/components/Steps/context'
+
+interface Props {
+    onFinish: () => void
+}
+
+export const Footer: React.FunctionComponent<Props> = ({ onFinish }) => {
+    const { setStep, currentIndex, currentStep } = useSteps()
+
+    return (
+        <div className="mt-4">
+            <LoaderButton
+                type="button"
+                alwaysShowLabel={true}
+                label={currentStep.isLastStep ? 'Start searching' : 'Continue'}
+                className="btn btn-primary float-right ml-2"
+                disabled={!currentStep.isComplete}
+                onClick={currentStep.isLastStep ? onFinish : () => setStep(currentIndex + 1)}
+            />
+
+            {!currentStep.isLastStep && (
+                <button
+                    type="button"
+                    className="btn btn-link font-weight-normal text-secondary float-right"
+                    onClick={onFinish}
+                >
+                    Not right now
+                </button>
+            )}
+        </div>
+    )
+}

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -10,7 +10,7 @@ import {
     TerminalProgress,
 } from '@sourcegraph/wildcard/src/components/Terminal'
 
-import { UserAreaUserFields } from '../../graphql-operations'
+import { AuthenticatedUser } from '../../auth'
 import { LogoAscii } from '../LogoAscii'
 import { RepoSelectionMode } from '../PostSignUpPage'
 import { useExternalServices } from '../useExternalServices'
@@ -18,7 +18,7 @@ import { useRepoCloningStatus } from '../useRepoCloningStatus'
 import { selectedReposVar, useSaveSelectedRepos } from '../useSelectedRepos'
 
 interface StartSearching {
-    user: UserAreaUserFields
+    user: AuthenticatedUser
     repoSelectionMode: RepoSelectionMode
 }
 

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { useSteps } from '@sourcegraph/wildcard/src/components/Steps'
+import {
+    Terminal,
+    TerminalTitle,
+    TerminalLine,
+    TerminalDetails,
+    TerminalProgress,
+} from '@sourcegraph/wildcard/src/components/Terminal'
+
+import { UserAreaUserFields } from '../../graphql-operations'
+import { LogoAscii } from '../LogoAscii'
+import { RepoSelectionMode } from '../PostSignUpPage'
+import { useExternalServices } from '../useExternalServices'
+import { useRepoCloningStatus } from '../useRepoCloningStatus'
+import { selectedReposVar, useSaveSelectedRepos } from '../useSelectedRepos'
+
+interface StartSearching {
+    user: UserAreaUserFields
+    repoSelectionMode: RepoSelectionMode
+}
+
+export const useShowAlert = (isDoneCloning: boolean): { showAlert: boolean } => {
+    const [showAlert, setShowAlert] = useState(false)
+
+    useEffect(() => {
+        const timer = setTimeout(() => setShowAlert(true), 10000)
+
+        if (isDoneCloning) {
+            clearTimeout(timer)
+            setShowAlert(false)
+        }
+
+        return () => {
+            clearTimeout(timer)
+            setShowAlert(false)
+        }
+    }, [isDoneCloning])
+
+    return { showAlert }
+}
+
+export const StartSearching: React.FunctionComponent<StartSearching> = ({ user, repoSelectionMode }) => {
+    const { externalServices } = useExternalServices(user.id)
+    const saveSelectedRepos = useSaveSelectedRepos()
+
+    const { repos: cloningStatusLines, loading: cloningStatusLoading, isDoneCloning } = useRepoCloningStatus({
+        userId: user.id,
+        pollInterval: 2000,
+        selectedReposVar,
+    })
+
+    useEffect(() => {
+        const selectedRepos = selectedReposVar()
+
+        if (externalServices && selectedRepos) {
+            const codeHostRepoPromises = []
+
+            for (const host of externalServices) {
+                const repos: string[] = []
+                for (const repo of selectedRepos) {
+                    if (repo.externalRepository.id !== host.id) {
+                        continue
+                    }
+
+                    const nameWithoutService = repo.name.slice(repo.name.indexOf('/') + 1)
+                    repos.push(nameWithoutService)
+                }
+
+                codeHostRepoPromises.push(
+                    saveSelectedRepos({
+                        variables: {
+                            id: host.id,
+                            allRepos: repoSelectionMode === 'all',
+                            repos: (repoSelectionMode === 'selected' && repos) || null,
+                        },
+                    })
+                )
+            }
+        }
+    }, [externalServices, saveSelectedRepos, repoSelectionMode])
+
+    const { showAlert } = useShowAlert(isDoneCloning)
+    const { currentIndex, setComplete } = useSteps()
+
+    useEffect(() => {
+        if (showAlert || isDoneCloning) {
+            setComplete(currentIndex, true)
+        }
+    }, [currentIndex, setComplete, showAlert, isDoneCloning])
+
+    return (
+        <>
+            <h3>Start searching...</h3>
+            <p className="text-muted">
+                We’re cloning your repos to Sourcegraph. In just a few moments, you can make your first search!
+            </p>
+            <div className="border overflow-hidden rounded">
+                <header>
+                    <h3 className="m-0 pl-4 py-3">Activity log</h3>
+                </header>
+                <Terminal>
+                    {!isDoneCloning && (
+                        <TerminalLine>
+                            <code>Cloning Repositories...</code>
+                        </TerminalLine>
+                    )}
+                    {cloningStatusLoading && (
+                        <TerminalLine>
+                            <TerminalTitle>Loading...</TerminalTitle>
+                        </TerminalLine>
+                    )}
+                    {!cloningStatusLoading &&
+                        !isDoneCloning &&
+                        cloningStatusLines?.map(({ id, title, details, progress }) => (
+                            <React.Fragment key={id}>
+                                <TerminalLine>
+                                    <TerminalTitle>{title}</TerminalTitle>
+                                </TerminalLine>
+                                <TerminalLine>
+                                    <TerminalDetails>{details}</TerminalDetails>
+                                </TerminalLine>
+                                <TerminalLine>
+                                    <TerminalProgress character="#" progress={progress} />
+                                </TerminalLine>
+                            </React.Fragment>
+                        ))}
+                    {isDoneCloning && (
+                        <>
+                            <TerminalLine>
+                                <TerminalTitle>Done!</TerminalTitle>
+                            </TerminalLine>
+                            <TerminalLine>
+                                <LogoAscii />
+                            </TerminalLine>
+                        </>
+                    )}
+                </Terminal>
+            </div>
+            {showAlert && (
+                <div className="alert alert-warning mt-4">
+                    Cloning your repositories is taking a long time. You can wait for cloning to finish, or{' '}
+                    <Link to="/search">continue to Sourcegraph now</Link> while cloning continues in the background.
+                    Note that you can only search repos that have finished cloning. Check status at any time in Settings
+                    → Your repositories.
+                </div>
+            )}
+        </>
+    )
+}

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -207,6 +207,23 @@ export const listExternalServiceFragment = gql`
     }
 `
 
+export const EXTERNAL_SERVICES = gql`
+    query ExternalServices($first: Int, $after: String, $namespace: ID) {
+        externalServices(first: $first, after: $after, namespace: $namespace) {
+            nodes {
+                ...ListExternalServiceFields
+            }
+            totalCount
+            pageInfo {
+                endCursor
+                hasNextPage
+            }
+        }
+    }
+
+    ${listExternalServiceFragment}
+`
+
 export function queryExternalServices(
     variables: ExternalServicesVariables
 ): Observable<ExternalServicesResult['externalServices']> {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -3,7 +3,6 @@ import { Redirect, RouteComponentProps } from 'react-router'
 
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
-import { AuthenticatedUser } from './auth'
 import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import { LayoutProps } from './Layout'
 import { ExtensionAlertProps } from './repo/RepoContainer'

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -3,6 +3,7 @@ import { Redirect, RouteComponentProps } from 'react-router'
 
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
+import { AuthenticatedUser } from './auth'
 import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import { LayoutProps } from './Layout'
 import { ExtensionAlertProps } from './repo/RepoContainer'
@@ -128,8 +129,16 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     },
     {
         path: '/welcome',
-        render: props => <PostSignUpPage {...props} context={window.context} />,
+        render: props => (
+            <PostSignUpPage
+                // because of condition authenticatedUser can't be null
+                authenticatedUser={props.authenticatedUser as AuthenticatedUser}
+                telemetryService={props.telemetryService}
+                context={window.context}
+            />
+        ),
         exact: true,
+        condition: props => !!props.authenticatedUser,
     },
     {
         path: '/settings',

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -127,7 +127,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         exact: true,
     },
     {
-        path: '/post-sign-up',
+        path: '/welcome',
         render: props => <PostSignUpPage {...props} context={window.context} />,
         exact: true,
     },

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -129,16 +129,31 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     },
     {
         path: '/welcome',
-        render: props => (
-            <PostSignUpPage
-                // because of condition authenticatedUser can't be null
-                authenticatedUser={props.authenticatedUser as AuthenticatedUser}
-                telemetryService={props.telemetryService}
-                context={window.context}
-            />
-        ),
+        render: props =>
+            /**
+             * Welcome flow is allowed when:
+             * 1. user is authenticated
+             * 2. it's a DotComMode instance
+             * AND
+             * instance has enabled enablePostSignupFlow experimental feature
+             * OR
+             * user authenticated has a AllowUserViewPostSignup tag
+             */
+
+            !!props.authenticatedUser &&
+            window.context.sourcegraphDotComMode &&
+            ((props.authenticatedUser && window.context.experimentalFeatures.enablePostSignupFlow) ||
+                props.authenticatedUser?.tags.includes('AllowUserViewPostSignup')) ? (
+                <PostSignUpPage
+                    authenticatedUser={props.authenticatedUser}
+                    telemetryService={props.telemetryService}
+                    context={window.context}
+                />
+            ) : (
+                <Redirect to="/search" />
+            ),
+
         exact: true,
-        condition: props => !!props.authenticatedUser,
     },
     {
         path: '/settings',

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -22,7 +22,7 @@ interface CodeHostItemProps {
     // optional service object fields when the code host connection is active
     service?: ListExternalServiceFields
 
-    onDidAdd: (service: ListExternalServiceFields) => void
+    onDidAdd?: (service: ListExternalServiceFields) => void
     onDidRemove: () => void
     onDidError: (error: ErrorLike) => void
 }

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -251,12 +251,10 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
 
             {/* display external service errors and success banners */}
             {getErrorAndSuccessBanners(statusOrError)}
-
             {/* display other errors, e.g. network errors */}
             {isErrorLike(statusOrError) && (
                 <ErrorAlert error={statusOrError} prefix="Code host action error" icon={false} />
             )}
-
             {codeHostExternalServices && isServicesByKind(statusOrError) ? (
                 <Container>
                     <ul className="list-group">

--- a/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
+++ b/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback } from 'react'
+
+import { ErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { Container } from '@sourcegraph/wildcard'
+
+import { codeHostExternalServices } from '../../../components/externalServices/externalServices'
+import { ExternalServiceKind, ListExternalServiceFields, UserAreaUserFields } from '../../../graphql-operations'
+import { SourcegraphContext } from '../../../jscontext'
+import { useCodeHostScopeContext } from '../../../site/CodeHostScopeAlerts/CodeHostScopeProvider'
+import { eventLogger } from '../../../tracking/eventLogger'
+import { githubRepoScopeRequired, gitlabAPIScopeRequired } from '../cloud-ga'
+
+import { CodeHostItem } from './CodeHostItem'
+
+export interface UserCodeHosts {
+    user: UserAreaUserFields
+    externalServices: ListExternalServiceFields[]
+    onDidError: (error: ErrorLike) => void
+    onDidRemove: () => void
+    onNavigation?: (called: boolean) => void
+    context: Pick<SourcegraphContext, 'authProviders'>
+}
+
+type ServicesByKind = Partial<Record<ExternalServiceKind, ListExternalServiceFields>>
+type AuthProvider = SourcegraphContext['authProviders'][0]
+type AuthProvidersByKind = Partial<Record<ExternalServiceKind, AuthProvider>>
+
+const cloudSupportedServices = {
+    github: codeHostExternalServices.github,
+    gitlabcom: codeHostExternalServices.gitlabcom,
+}
+
+export const UserCodeHosts: React.FunctionComponent<UserCodeHosts> = ({
+    user,
+    externalServices,
+    context,
+    onDidError,
+    onDidRemove,
+    onNavigation,
+}) => {
+    const { scopes, setScope } = useCodeHostScopeContext()
+
+    const services: ServicesByKind = externalServices.reduce<ServicesByKind>((accumulator, service) => {
+        // backend constraint - non-admin users have only one external service per ExternalServiceKind
+        accumulator[service.kind] = service
+        return accumulator
+    }, {})
+
+    // auth providers by service type
+    const authProvidersByKind = context.authProviders.reduce((accumulator: AuthProvidersByKind, provider) => {
+        if (provider.authenticationURL) {
+            accumulator[provider.serviceType.toLocaleUpperCase() as ExternalServiceKind] = provider
+        }
+        return accumulator
+    }, {})
+
+    const isTokenUpdateRequired: Partial<Record<ExternalServiceKind, boolean | undefined>> = {
+        [ExternalServiceKind.GITHUB]: githubRepoScopeRequired(user.tags, scopes.github),
+        [ExternalServiceKind.GITLAB]: gitlabAPIScopeRequired(user.tags, scopes.gitlab),
+    }
+
+    const navigateToAuthProvider = useCallback(
+        (kind: ExternalServiceKind): void => {
+            const authProvider = authProvidersByKind[kind]
+
+            if (authProvider) {
+                onNavigation?.(true)
+                eventLogger.log('UserAttemptConnectCodeHost', { kind })
+                window.location.assign(
+                    `${authProvider.authenticationURL as string}&redirect=${
+                        window.location.href
+                    }&op=createCodeHostConnection`
+                )
+            }
+        },
+        [authProvidersByKind, onNavigation]
+    )
+
+    const removeService = (kind: ExternalServiceKind) => (): void => {
+        if (
+            (kind === ExternalServiceKind.GITLAB || kind === ExternalServiceKind.GITHUB) &&
+            isTokenUpdateRequired[kind]
+        ) {
+            setScope(kind, null)
+        }
+
+        onDidRemove()
+    }
+
+    return (
+        <Container>
+            <ul className="list-group">
+                {Object.entries(cloudSupportedServices).map(([id, { kind, defaultDisplayName, icon }]) =>
+                    authProvidersByKind[kind] ? (
+                        <li key={id} className="list-group-item user-code-hosts-page__code-host-item">
+                            <CodeHostItem
+                                service={services[kind]}
+                                kind={kind}
+                                name={defaultDisplayName}
+                                isTokenUpdateRequired={isTokenUpdateRequired[kind]}
+                                navigateToAuthProvider={navigateToAuthProvider}
+                                icon={icon}
+                                onDidRemove={removeService(kind)}
+                                onDidError={onDidError}
+                            />
+                        </li>
+                    ) : null
+                )}
+            </ul>
+        </Container>
+    )
+}

--- a/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
+++ b/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
@@ -3,8 +3,9 @@ import React, { useCallback } from 'react'
 import { ErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { Container } from '@sourcegraph/wildcard'
 
+import { AuthenticatedUser } from '../../../auth'
 import { codeHostExternalServices } from '../../../components/externalServices/externalServices'
-import { ExternalServiceKind, ListExternalServiceFields, UserAreaUserFields } from '../../../graphql-operations'
+import { ExternalServiceKind, ListExternalServiceFields } from '../../../graphql-operations'
 import { SourcegraphContext } from '../../../jscontext'
 import { useCodeHostScopeContext } from '../../../site/CodeHostScopeAlerts/CodeHostScopeProvider'
 import { eventLogger } from '../../../tracking/eventLogger'
@@ -13,7 +14,7 @@ import { githubRepoScopeRequired, gitlabAPIScopeRequired } from '../cloud-ga'
 import { CodeHostItem } from './CodeHostItem'
 
 export interface UserCodeHosts {
-    user: UserAreaUserFields
+    user: AuthenticatedUser
     externalServices: ListExternalServiceFields[]
     onDidError: (error: ErrorLike) => void
     onDidRemove: () => void

--- a/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
+++ b/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
@@ -158,17 +158,22 @@ export const SelectAffiliatedRepos: FunctionComponent<Props> = ({
             const userSelectedRepos = cachedSelectedRepos || selectedRepos || []
 
             const affiliatedReposWithMirrorInfo = affiliatedRepos.map(affiliatedRepo => {
-                const foundInSelected = userSelectedRepos.find(
-                    ({ name, externalRepository: { serviceType: selectedRepoServiceType } }) => {
-                        // selected repo names formatted: code-host/owner/repository
-                        const selectedRepoName = name.slice(name.indexOf('/') + 1)
+                let foundInSelected: SiteAdminRepositoryFields | MinSelectedRepo | null = null
+                for (const selectedRepo of userSelectedRepos) {
+                    const {
+                        name,
+                        externalRepository: { serviceType: selectedRepoServiceType },
+                    } = selectedRepo
+                    const selectedRepoName = name.slice(name.indexOf('/') + 1)
 
-                        return (
-                            selectedRepoName === affiliatedRepo.name &&
-                            selectedRepoServiceType === affiliatedRepo.codeHost?.kind.toLocaleLowerCase()
-                        )
+                    if (
+                        selectedRepoName === affiliatedRepo.name &&
+                        selectedRepoServiceType === affiliatedRepo.codeHost?.kind.toLocaleLowerCase()
+                    ) {
+                        foundInSelected = selectedRepo
+                        break
                     }
-                )
+                }
 
                 if (foundInSelected) {
                     // save off only selected repos
@@ -273,7 +278,6 @@ export const SelectAffiliatedRepos: FunctionComponent<Props> = ({
         }
 
         // save off last selected repos
-
         const selection = [...selectionState.repos.values()].reduce((accumulator, repo) => {
             const serviceType = repo.codeHost?.kind.toLowerCase()
             const serviceName = serviceType ? `${serviceType}.com` : 'unknown'

--- a/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
+++ b/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
@@ -1,0 +1,531 @@
+import { FetchResult } from '@apollo/client'
+import classNames from 'classnames'
+import { isEqual } from 'lodash'
+import React, { useCallback, useEffect, useState, FunctionComponent, Dispatch, SetStateAction } from 'react'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+import { Container, PageSelector } from '@sourcegraph/wildcard'
+import { useSteps } from '@sourcegraph/wildcard/src/components/Steps'
+
+import { RepoSelectionMode } from '../../../auth/PostSignUpPage'
+import { useAffiliatedRepos } from '../../../auth/useAffiliatedRepos'
+import { useExternalServices } from '../../../auth/useExternalServices'
+import { useSelectedRepos, selectedReposVar, MinSelectedRepo } from '../../../auth/useSelectedRepos'
+import { AwayPrompt } from '../../../components/AwayPrompt'
+import {
+    ExternalServiceKind,
+    Maybe,
+    SiteAdminRepositoryFields,
+    SetExternalServiceReposResult,
+} from '../../../graphql-operations'
+import { externalServiceUserModeFromTags } from '../cloud-ga'
+
+import { CheckboxRepositoryNode } from './RepositoryNode'
+export interface AffiliatedReposReference {
+    submit: () => Promise<FetchResult<SetExternalServiceReposResult>[] | void>
+}
+
+interface authenticatedUser {
+    id: string
+    siteAdmin: boolean
+    tags: string[]
+}
+
+interface Props extends TelemetryProps {
+    authenticatedUser: authenticatedUser
+    onRepoSelectionModeChange: Dispatch<SetStateAction<RepoSelectionMode>>
+}
+
+export interface Repo {
+    name: string
+    codeHost: Maybe<{ kind: ExternalServiceKind; id: string; displayName: string }>
+    private: boolean
+    mirrorInfo?: SiteAdminRepositoryFields['mirrorInfo']
+}
+
+interface GitHubConfig {
+    repos?: string[]
+    repositoryQuery?: string[]
+    token: 'REDACTED'
+    url: string
+}
+
+interface GitLabConfig {
+    projectQuery?: string[]
+    projects?: { name: string }[]
+    token: 'REDACTED'
+    url: string
+}
+
+const PER_PAGE = 20
+
+// project queries that are used when user syncs all repos from a code host
+const GITLAB_SYNC_ALL_PROJECT_QUERY = 'projects?membership=true&archived=no'
+const GITHUB_SYNC_ALL_PROJECT_QUERY = 'affiliated'
+
+// initial state constants
+const emptyRepos: Repo[] = []
+const initialRepoState = {
+    repos: emptyRepos,
+    loading: false,
+    loaded: false,
+}
+
+const initialSelectionState = {
+    repos: new Map<string, Repo>(),
+    loaded: false,
+    radio: '',
+}
+
+/**
+ * A page to manage the repositories a user syncs from their connected code hosts.
+ */
+export const SelectAffiliatedRepos: FunctionComponent<Props> = ({
+    authenticatedUser,
+    onRepoSelectionModeChange,
+    telemetryService,
+}) => {
+    useEffect(() => {
+        telemetryService.logViewEvent('UserSettingsRepositories')
+    }, [telemetryService])
+
+    const { setComplete, currentIndex } = useSteps()
+    const { externalServices } = useExternalServices(authenticatedUser.id)
+    const { affiliatedRepos } = useAffiliatedRepos(authenticatedUser.id)
+    const { selectedRepos } = useSelectedRepos(authenticatedUser.id)
+
+    // if we should tweak UI messaging and copy
+    const ALLOW_PRIVATE_CODE = externalServiceUserModeFromTags(authenticatedUser.tags) === 'all'
+
+    // if 'sync all' radio button is enabled and users can sync all repos from code hosts
+    const ALLOW_SYNC_ALL = authenticatedUser.tags.includes('AllowUserExternalServiceSyncAll')
+
+    // set up state hooks
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    const [currentPage, setPage] = useState(1)
+    const [repoState, setRepoState] = useState(initialRepoState)
+    const [onloadSelectedRepos, setOnloadSelectedRepos] = useState<string[]>([])
+    const [selectionState, setSelectionState] = useState(initialSelectionState)
+    const [didSelectionChange, setDidSelectionChange] = useState(false)
+    const [query, setQuery] = useState('')
+    const [codeHostFilter, setCodeHostFilter] = useState('')
+    const [filteredRepos, setFilteredRepos] = useState<Repo[]>([])
+
+    const getRepoServiceAndName = (repo: Repo): string => `${repo.codeHost?.kind || 'unknown'}/${repo.name}`
+
+    useEffect(() => {
+        if (externalServices && affiliatedRepos) {
+            const codeHostsHaveSyncAllQuery = []
+
+            for (const host of externalServices) {
+                if (host.lastSyncError || host.warning) {
+                    continue
+                }
+
+                const cfg = JSON.parse(host.config) as GitHubConfig | GitLabConfig
+                switch (host.kind) {
+                    case ExternalServiceKind.GITLAB: {
+                        const gitLabCfg = cfg as GitLabConfig
+
+                        if (Array.isArray(gitLabCfg.projectQuery)) {
+                            codeHostsHaveSyncAllQuery.push(
+                                gitLabCfg.projectQuery.includes(GITLAB_SYNC_ALL_PROJECT_QUERY)
+                            )
+                        }
+
+                        break
+                    }
+
+                    case ExternalServiceKind.GITHUB: {
+                        const gitHubCfg = cfg as GitHubConfig
+
+                        if (Array.isArray(gitHubCfg.repositoryQuery)) {
+                            codeHostsHaveSyncAllQuery.push(
+                                gitHubCfg.repositoryQuery.includes(GITHUB_SYNC_ALL_PROJECT_QUERY)
+                            )
+                        }
+
+                        break
+                    }
+                }
+            }
+
+            const selectedAffiliatedRepos = new Map<string, Repo>()
+
+            const cachedSelectedRepos = selectedReposVar()
+            const userSelectedRepos = cachedSelectedRepos || selectedRepos || []
+
+            const affiliatedReposWithMirrorInfo = affiliatedRepos.map(affiliatedRepo => {
+                const foundInSelected = userSelectedRepos.find(
+                    ({ name, externalRepository: { serviceType: selectedRepoServiceType } }) => {
+                        // selected repo names formatted: code-host/owner/repository
+                        const selectedRepoName = name.slice(name.indexOf('/') + 1)
+
+                        return (
+                            selectedRepoName === affiliatedRepo.name &&
+                            selectedRepoServiceType === affiliatedRepo.codeHost?.kind.toLocaleLowerCase()
+                        )
+                    }
+                )
+
+                if (foundInSelected) {
+                    // save off only selected repos
+                    selectedAffiliatedRepos.set(getRepoServiceAndName(affiliatedRepo), affiliatedRepo)
+                }
+
+                return affiliatedRepo
+            })
+
+            // sort affiliated repos with already selected repos at the top
+            affiliatedReposWithMirrorInfo.sort((repoA, repoB): number => {
+                const isRepoASelected = selectedAffiliatedRepos.has(getRepoServiceAndName(repoA))
+                const isRepoBSelected = selectedAffiliatedRepos.has(getRepoServiceAndName(repoB))
+
+                if (!isRepoASelected && isRepoBSelected) {
+                    return 1
+                }
+
+                if (isRepoASelected && !isRepoBSelected) {
+                    return -1
+                }
+
+                return 0
+            })
+
+            // safe off initial selection state
+            setOnloadSelectedRepos(previousValue => [...previousValue, ...selectedAffiliatedRepos.keys()])
+
+            /**
+             * 1. if every code host has a project query to sync all repos or the
+             * number of affiliated repos equals to the number of selected repos -
+             * set radio to 'all'
+             * 2. if only some repos were selected - set radio to 'selected'
+             * 3. if no repos selected - empty state
+             */
+
+            const radioSelectOption =
+                ALLOW_SYNC_ALL &&
+                ((externalServices.length === codeHostsHaveSyncAllQuery.length &&
+                    codeHostsHaveSyncAllQuery.every(Boolean)) ||
+                    affiliatedReposWithMirrorInfo.length === selectedAffiliatedRepos.size)
+                    ? 'all'
+                    : selectedAffiliatedRepos.size > 0
+                    ? 'selected'
+                    : ''
+
+            onRepoSelectionModeChange(radioSelectOption as RepoSelectionMode)
+
+            // set sorted repos and mark as loaded
+            setRepoState(previousRepoState => ({
+                ...previousRepoState,
+                repos: affiliatedReposWithMirrorInfo,
+                loaded: true,
+            }))
+
+            setSelectionState({
+                repos: selectedAffiliatedRepos,
+                radio: radioSelectOption,
+                loaded: true,
+            })
+        }
+    }, [externalServices, affiliatedRepos, selectedRepos, ALLOW_SYNC_ALL, onRepoSelectionModeChange])
+
+    // select repos by code host and query
+    useEffect(() => {
+        // filter our set of repos based on query & code host selection
+        const filtered: Repo[] = []
+
+        for (const repo of repoState.repos) {
+            // filtering by code hosts
+            if (codeHostFilter !== '' && repo.codeHost?.id !== codeHostFilter) {
+                continue
+            }
+
+            const queryLoweCase = query.toLowerCase()
+            const nameLowerCase = repo.name.toLowerCase()
+            if (!nameLowerCase.includes(queryLoweCase)) {
+                continue
+            }
+
+            filtered.push(repo)
+        }
+
+        // set new filtered pages and reset the pagination
+        setFilteredRepos(filtered)
+        setPage(1)
+    }, [repoState.repos, codeHostFilter, query])
+
+    // track selection changes
+    useEffect(() => {
+        const affiliatedRepos = selectionState.repos.keys()
+
+        const currentlySelectedRepos = [...affiliatedRepos]
+
+        const didChange = !isEqual(currentlySelectedRepos.sort(), onloadSelectedRepos.sort())
+
+        // set current step as complete if user had already selected repos or made changes
+        if (didChange || onloadSelectedRepos.length !== 0) {
+            setComplete(currentIndex, true)
+        } else {
+            setComplete(currentIndex, false)
+        }
+
+        // save off last selected repos
+
+        const selection = [...selectionState.repos.values()].reduce((accumulator, repo) => {
+            const serviceType = repo.codeHost?.kind.toLowerCase()
+            const serviceName = serviceType ? `${serviceType}.com` : 'unknown'
+
+            accumulator.push({
+                name: `${serviceName}/${repo.name}`,
+                externalRepository: { serviceType: serviceType || 'unknown', id: repo.codeHost?.id },
+            })
+            return accumulator
+        }, [] as MinSelectedRepo[])
+
+        // safe off repo selection to apollo
+        selectedReposVar(selection)
+
+        setDidSelectionChange(didChange)
+    }, [currentIndex, onloadSelectedRepos, selectionState.repos, setComplete])
+
+    const handleRadioSelect = (changeEvent: React.ChangeEvent<HTMLInputElement>): void => {
+        setSelectionState({
+            repos: selectionState.repos,
+            radio: changeEvent.currentTarget.value,
+            loaded: selectionState.loaded,
+        })
+
+        onRepoSelectionModeChange(changeEvent.currentTarget.value as RepoSelectionMode)
+    }
+
+    const hasCodeHosts = Array.isArray(externalServices) && externalServices.length > 0
+
+    const modeSelect: JSX.Element = (
+        <>
+            <label className="d-flex flex-row align-items-baseline">
+                <input
+                    type="radio"
+                    value="all"
+                    disabled={!ALLOW_SYNC_ALL}
+                    checked={selectionState.radio === 'all'}
+                    onChange={handleRadioSelect}
+                />
+                <div className="d-flex flex-column ml-2">
+                    <p
+                        className={classNames('mb-0', {
+                            'user-settings-repos__text': ALLOW_SYNC_ALL,
+                            'user-settings-repos__text-disabled': !ALLOW_SYNC_ALL,
+                        })}
+                    >
+                        Sync all repositories {!ALLOW_SYNC_ALL && '(coming soon)'}
+                    </p>
+                    <p
+                        className={classNames({
+                            'user-settings-repos__text': ALLOW_SYNC_ALL,
+                            'user-settings-repos__text-disabled': !ALLOW_SYNC_ALL,
+                        })}
+                    >
+                        Will sync all current and future public and private repositories
+                    </p>
+                </div>
+            </label>
+            <label className="d-flex flex-row align-items-baseline mb-0">
+                <input
+                    type="radio"
+                    value="selected"
+                    checked={selectionState.radio === 'selected'}
+                    onChange={handleRadioSelect}
+                />
+                <div className="d-flex flex-column ml-2">
+                    <p
+                        className={classNames({
+                            'user-settings-repos__text-disabled': false,
+                            'mb-0': true,
+                        })}
+                    >
+                        Sync selected {!ALLOW_PRIVATE_CODE && 'public'} repositories
+                    </p>
+                </div>
+            </label>
+        </>
+    )
+
+    const filterControls: JSX.Element = (
+        <div className="w-100 d-inline-flex justify-content-between flex-row mt-3">
+            <div className="d-inline-flex flex-row mr-3 align-items-baseline">
+                <p className="text-xl-center text-nowrap mr-2">Code Host:</p>
+                <select
+                    className="form-control"
+                    name="code-host"
+                    aria-label="select code host type"
+                    onChange={event => setCodeHostFilter(event.target.value)}
+                >
+                    <option key="any" value="" label="Any" />
+                    {externalServices?.map(value => (
+                        <option key={value.id} value={value.id} label={value.displayName} />
+                    ))}
+                </select>
+            </div>
+            <input
+                className="form-control user-settings-repos__filter-input"
+                type="search"
+                placeholder="Search..."
+                name="query"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                onChange={event => {
+                    setQuery(event.target.value)
+                }}
+            />
+        </div>
+    )
+
+    const onRepoClicked = useCallback(
+        (repo: Repo) => (): void => {
+            const clickedRepo = getRepoServiceAndName(repo)
+            const newMap = new Map(selectionState.repos)
+            if (newMap.has(clickedRepo)) {
+                newMap.delete(clickedRepo)
+            } else {
+                newMap.set(clickedRepo, repo)
+            }
+            setSelectionState({
+                repos: newMap,
+                radio: selectionState.radio,
+                loaded: selectionState.loaded,
+            })
+        },
+        [selectionState, setSelectionState]
+    )
+
+    const selectAll = (): void => {
+        const newMap = new Map<string, Repo>()
+        // if not all repos are selected, we should select all, otherwise empty the selection
+
+        if (selectionState.repos.size !== filteredRepos.length) {
+            for (const repo of filteredRepos) {
+                newMap.set(getRepoServiceAndName(repo), repo)
+            }
+        }
+        setSelectionState({
+            repos: newMap,
+            loaded: selectionState.loaded,
+            radio: selectionState.radio,
+        })
+    }
+
+    const rows: JSX.Element = (
+        <tbody>
+            <tr className="align-items-baseline d-flex" key="header">
+                <td className="user-settings-repos__repositorynode p-2 w-100 d-flex align-items-center border-top-0 border-bottom">
+                    <input
+                        id="select-all-repos"
+                        className="mr-3"
+                        type="checkbox"
+                        checked={selectionState.repos.size !== 0 && selectionState.repos.size === filteredRepos.length}
+                        onChange={selectAll}
+                    />
+                    <label
+                        htmlFor="select-all-repos"
+                        className={classNames({
+                            'text-muted': selectionState.repos.size === 0,
+                            'text-body': selectionState.repos.size !== 0,
+                            'mb-0': true,
+                        })}
+                    >
+                        {(selectionState.repos.size > 0 && (
+                            <small>{`${selectionState.repos.size} ${
+                                selectionState.repos.size === 1 ? 'repository' : 'repositories'
+                            } selected`}</small>
+                        )) || <small>Select all</small>}
+                    </label>
+                </td>
+            </tr>
+            {filteredRepos.map((repo, index) => {
+                if (index < (currentPage - 1) * PER_PAGE || index >= currentPage * PER_PAGE) {
+                    return
+                }
+
+                const serviceAndRepoName = getRepoServiceAndName(repo)
+
+                return (
+                    <CheckboxRepositoryNode
+                        name={repo.name}
+                        key={serviceAndRepoName}
+                        onClick={onRepoClicked(repo)}
+                        checked={selectionState.repos.has(serviceAndRepoName)}
+                        serviceType={repo.codeHost?.kind || 'unknown'}
+                        isPrivate={repo.private}
+                    />
+                )
+            })}
+        </tbody>
+    )
+
+    const modeSelectShimmer: JSX.Element = (
+        <div className="container">
+            <div className="mt-2 row">
+                <div className="user-settings-repos__shimmer-circle mr-2" />
+                <div className="user-settings-repos__shimmer mb-1 p-2 border-top-0 col-sm-2" />
+            </div>
+            <div className="mt-1 ml-2 row">
+                <div className="user-settings-repos__shimmer mb-3 p-2 ml-1 border-top-0 col-sm-6" />
+            </div>
+            <div className="mt-2 row">
+                <div className="user-settings-repos__shimmer-circle mr-2" />
+                <div className="user-settings-repos__shimmer p-2 mb-1 border-top-0 col-sm-3" />
+            </div>
+        </div>
+    )
+
+    return (
+        <div className="user-settings-repos mb-0">
+            <Container>
+                <ul className="list-group">
+                    <li className="list-group-item user-settings-repos__container" key="from-code-hosts">
+                        <div className={classNames(!isRedesignEnabled && 'p-4')}>
+                            {!affiliatedRepos && modeSelectShimmer}
+
+                            {/* display type of repo sync radio buttons */}
+                            {hasCodeHosts && selectionState.loaded && modeSelect}
+
+                            {
+                                // if we're in 'selected' mode, show a list of all the repos on the code hosts to select from
+                                hasCodeHosts && selectionState.radio === 'selected' && (
+                                    <div className="ml-4">
+                                        {filterControls}
+                                        <table role="grid" className="table">
+                                            {
+                                                // if the repos are loaded display the rows of repos
+                                                repoState.loaded && rows
+                                            }
+                                        </table>
+                                        {filteredRepos.length > 0 && (
+                                            <PageSelector
+                                                currentPage={currentPage}
+                                                onPageChange={setPage}
+                                                totalPages={Math.ceil(filteredRepos.length / PER_PAGE)}
+                                                className="pt-4"
+                                            />
+                                        )}
+                                    </div>
+                                )
+                            }
+                        </div>
+                    </li>
+                </ul>
+            </Container>
+            <AwayPrompt
+                header="Discard unsaved changes?"
+                message="Currently synced repositories will be unchanged"
+                button_ok_text="Discard"
+                when={didSelectionChange}
+            />
+        </div>
+    )
+}

--- a/client/wildcard/src/components/Steps/Steps.module.scss
+++ b/client/wildcard/src/components/Steps/Steps.module.scss
@@ -1,0 +1,56 @@
+.list,
+.list-numeric {
+    display: flex;
+    gap: 1rem;
+    padding: 0;
+    margin: 0;
+    justify-content: space-between;
+    list-style-position: inside;
+}
+
+.list {
+    list-style: none;
+}
+
+.list-item {
+    flex: 1;
+    border: 0;
+    border-top-width: 2px;
+    padding-top: 0.5rem;
+    border-style: solid;
+    color: var(--text-muted);
+}
+
+.active {
+    color: var(--body-color);
+}
+
+.border-reset {
+    border: 0;
+}
+
+.color-purple {
+    border-top-color: var(--logo-purple);
+}
+
+.color-blue {
+    border-top-color: var(--logo-blue);
+}
+
+.color-orange {
+    border-top-color: var(--logo-orange);
+}
+
+.disabled {
+    color: var(--color-text-3);
+    border-top-color: var(--color-bg);
+}
+
+.button {
+    background: none;
+    padding: 0;
+    border: none;
+    &:disabled {
+        cursor: not-allowed;
+    }
+}

--- a/client/wildcard/src/components/Steps/Steps.story.tsx
+++ b/client/wildcard/src/components/Steps/Steps.story.tsx
@@ -1,0 +1,63 @@
+import { Meta, Story } from '@storybook/react'
+import React from 'react'
+
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
+
+import { Container } from '..'
+
+import { Steps, Step, StepList, StepPanels, StepPanel, StepActions, useSteps } from '.'
+
+const Actions = () => {
+    const { setStep, currentIndex, currentStep } = useSteps()
+    return (
+        <>
+            <button
+                disabled={currentStep.isFirstStep}
+                className="btn btn-primary"
+                onClick={() => setStep(currentIndex - 1)}
+            >
+                Previous
+            </button>
+            <button
+                disabled={currentStep.isLastStep}
+                className="btn btn-primary"
+                onClick={() => setStep(currentIndex + 1)}
+            >
+                Next
+            </button>
+        </>
+    )
+}
+
+export const Stepper: Story = () => (
+    <BrandedStory styles={webStyles}>
+        {() => (
+            <Container>
+                <Steps initialStep={2}>
+                    <StepList numeric={true}>
+                        <Step borderColor="blue">Panel 1 title</Step>
+                        <Step borderColor="orange">Panel 2 Title</Step>
+                        <Step borderColor="purple">Panel 3 Title</Step>
+                    </StepList>
+                    <StepPanels>
+                        <StepPanel>Panel 1</StepPanel>
+                        <StepPanel>Panel 2</StepPanel>
+                        <StepPanel>Panel 3</StepPanel>
+                    </StepPanels>
+                    <StepActions>
+                        <Actions />
+                    </StepActions>
+                </Steps>
+            </Container>
+        )}
+    </BrandedStory>
+)
+
+Stepper.storyName = 'Steps component top navigation'
+
+// eslint-disable-next-line import/no-default-export
+export default {
+    title: 'wildcard/Steps',
+    component: Stepper,
+} as Meta

--- a/client/wildcard/src/components/Steps/Steps.test.tsx
+++ b/client/wildcard/src/components/Steps/Steps.test.tsx
@@ -1,0 +1,130 @@
+import { render, RenderResult, cleanup } from '@testing-library/react'
+import React from 'react'
+import sinon from 'sinon'
+
+import { Steps, Step, StepsProps, StepList, StepPanel, StepPanels } from '.'
+
+describe('Steps', () => {
+    let queries: RenderResult
+
+    const renderWithProps = (props: StepsProps): RenderResult =>
+        render(<Steps initialStep={props.initialStep}>{props.children}</Steps>)
+    const onChangeMock = sinon.spy()
+
+    beforeEach(() => {
+        onChangeMock.resetHistory()
+    })
+
+    afterEach(cleanup)
+
+    describe('Invalid configuration', () => {
+        it('will error when initial step is less than 1', () => {
+            expect(() =>
+                renderWithProps({
+                    initialStep: -1,
+                    children: [
+                        <StepList key={1} numeric={true}>
+                            <Step borderColor="blue">Panel 1 title</Step>
+                        </StepList>,
+                        <StepPanels key={2}>
+                            <StepPanel>Panel 1</StepPanel>
+                        </StepPanels>,
+                    ],
+                })
+            ).toThrowErrorMatchingSnapshot()
+        })
+
+        it('will error when initial step is more than Steps length', () => {
+            expect(() =>
+                renderWithProps({
+                    initialStep: 10,
+                    children: [
+                        <StepList key={1} numeric={true}>
+                            <Step borderColor="blue">Panel 1 title</Step>
+                        </StepList>,
+                        <StepPanels key={2}>
+                            <StepPanel>Panel 1</StepPanel>
+                        </StepPanels>,
+                    ],
+                })
+            ).toThrowErrorMatchingSnapshot()
+        })
+
+        it('will error when initial step is more than <Step> components length', () => {
+            expect(() =>
+                renderWithProps({
+                    initialStep: 2,
+                    children: [
+                        <StepList key={1} numeric={true}>
+                            <Step borderColor="blue">Panel 1 title</Step>
+                        </StepList>,
+                        <StepPanels key={2}>
+                            <StepPanel>Panel 1</StepPanel>
+                        </StepPanels>,
+                    ],
+                })
+            ).toThrowErrorMatchingSnapshot()
+        })
+
+        it('will error when StepPanels does not includes children', () => {
+            expect(() =>
+                renderWithProps({
+                    initialStep: 1,
+                    children: [
+                        <StepList key={1} numeric={true}>
+                            <Step borderColor="blue">Panel 1 title</Step>
+                        </StepList>,
+                        <StepPanels key={2} />,
+                    ],
+                })
+            ).toThrowErrorMatchingSnapshot()
+        })
+    })
+
+    describe('Steps navigation', () => {
+        const initialStep = 1
+        beforeEach(() => {
+            queries = renderWithProps({
+                initialStep,
+                children: [
+                    <>
+                        <StepList key={1} numeric={true}>
+                            <Step key={1} borderColor="blue">
+                                Panel 1 title
+                            </Step>
+                            <Step key={2} borderColor="orange">
+                                Panel 2 title
+                            </Step>
+                            <Step key={3} borderColor="orange">
+                                Panel 3 title
+                            </Step>
+                        </StepList>
+                        <StepPanels key={2}>
+                            <StepPanel key={2}>Panel 1</StepPanel>
+                            <StepPanel key={1}>Panel 2</StepPanel>
+                            <StepPanel key={3}>Panel 3</StepPanel>
+                        </StepPanels>
+                    </>,
+                ],
+            })
+        })
+
+        it('Will render all the <Step> elements', () => {
+            expect(queries.getByText('Panel 1 title', { selector: 'button' })).toBeInTheDocument()
+            expect(queries.getByText('Panel 2 title', { selector: 'button' })).toBeInTheDocument()
+            expect(queries.getByText('Panel 3 title', { selector: 'button' })).toBeInTheDocument()
+        })
+
+        it('<Step> is enabled when is visited or current', () => {
+            expect(queries.getByText('Panel 1 title', { selector: 'button' })).toBeEnabled()
+            expect(queries.getByText('Panel 2 title', { selector: 'button' })).toBeDisabled()
+            expect(queries.getByText('Panel 3 title', { selector: 'button' })).toBeDisabled()
+        })
+
+        it('Will render the <StepPanel> element associated to their respective <Step> element', () => {
+            expect(queries.getByText('Panel 1')).toBeInTheDocument()
+            expect(queries.queryByText('Panel 2')).toBe(null)
+            expect(queries.queryByText('Panel 3')).toBe(null)
+        })
+    })
+})

--- a/client/wildcard/src/components/Steps/Steps.tsx
+++ b/client/wildcard/src/components/Steps/Steps.tsx
@@ -1,0 +1,140 @@
+import classNames from 'classnames'
+import { upperFirst } from 'lodash'
+import React, { useEffect, useMemo, useReducer, useRef, MutableRefObject } from 'react'
+
+import { StepsContext, useStepsContext, StepListContext, useStepListContext, Steps as StepsInterface } from './context'
+import { initialState, reducer } from './reducer'
+import stepsStyles from './Steps.module.scss'
+
+type Color = 'orange' | 'blue' | 'purple'
+
+export interface StepProps {
+    borderColor: Color
+    children: React.ReactNode
+}
+
+interface StepListProps {
+    numeric: boolean
+    children: React.ReactElement<StepProps> | React.ReactElement<StepProps, string | React.JSXElementConstructor<any>>[]
+}
+
+export interface StepsProps {
+    children: React.ReactElement<StepProps> | React.ReactElement<StepProps>[]
+    initialStep: number
+}
+
+export const Steps: React.FunctionComponent<StepsProps> = ({ initialStep = 1, children }) => {
+    const [state, dispatch] = useReducer(reducer, initialState(initialStep))
+
+    if (!children) {
+        throw new Error('Steps must include at least one child')
+    }
+
+    if (initialStep < 1 || initialStep > React.Children.count(children)) {
+        throw new Error('Current step is out of limits')
+    }
+
+    const contextValue = useMemo(() => ({ state, dispatch }), [state, dispatch])
+
+    return <StepsContext.Provider value={contextValue}>{children}</StepsContext.Provider>
+}
+
+export const Step: React.FunctionComponent<StepProps> = ({ children, borderColor }) => {
+    const { state } = useStepsContext()
+    const { setCurrent, stepIndex } = useStepListContext()
+
+    const { current, steps } = state
+    const disabled = !steps[stepIndex]?.isVisited && current !== steps[stepIndex]?.index
+    const active = current === steps[stepIndex]?.index || steps[stepIndex]?.isVisited
+
+    return (
+        <li
+            className={classNames(
+                disabled && stepsStyles.disabled,
+                stepsStyles.listItem,
+                stepsStyles.active,
+                borderColor && stepsStyles[`color${upperFirst(borderColor)}` as keyof typeof stepsStyles]
+            )}
+            aria-current={active}
+        >
+            <button
+                type="button"
+                tabIndex={active ? 0 : -1}
+                disabled={disabled}
+                className={stepsStyles.button}
+                onClick={() => !disabled && setCurrent()}
+            >
+                {children}
+            </button>
+        </li>
+    )
+}
+
+export const StepList: React.FunctionComponent<StepListProps> = ({ children, numeric }) => {
+    const { state, dispatch } = useStepsContext()
+
+    const { initialStep } = state
+
+    const childrenArray = React.Children.toArray(children)
+
+    const stepsCollection: MutableRefObject<() => StepsInterface> = useRef(() =>
+        childrenArray.reduce((accumulator: StepsInterface, _current, index) => {
+            const value = {
+                index: index + 1,
+                isFirstStep: index === 0,
+                isLastStep: index === childrenArray.length - 1,
+                isVisited: initialStep === index + 1,
+                isComplete: false,
+            }
+
+            accumulator[index + 1] = value
+            return accumulator
+        }, {})
+    )
+
+    useEffect(() => {
+        dispatch({ type: 'SET_STEPS', payload: { steps: stepsCollection.current() } })
+    }, [dispatch, stepsCollection])
+
+    const element = React.Children.map(children, (child: React.ReactElement<StepProps>, index) => {
+        const setCurrent = (): void => {
+            dispatch({ type: 'SET_CURRENT_STEP', payload: { index: index + 1 } })
+        }
+
+        return <StepListContext.Provider value={{ setCurrent, stepIndex: index + 1 }}>{child}</StepListContext.Provider>
+    })
+
+    return (
+        <nav>
+            {numeric ? (
+                <ol className={stepsStyles.listNumeric}>{element}</ol>
+            ) : (
+                <ul className={stepsStyles.list}>{element}</ul>
+            )}
+        </nav>
+    )
+}
+
+export const StepPanels: React.FunctionComponent = ({ children }) => {
+    const { state } = useStepsContext()
+    const { current } = state
+
+    const childrenArray = React.Children.toArray(children)
+    const indexArray = current - 1
+
+    if (!children) {
+        throw new Error('StepPanels must include at least one child')
+    }
+
+    if (indexArray < 0 || current > childrenArray.length) {
+        throw new Error(
+            'The step-index is out of the boundaries. Check if the number of steps and your initialStep or setStep assignation are in concordance.'
+        )
+    }
+
+    return <div className="mt-4 pb-3">{childrenArray[indexArray]}</div>
+}
+
+export const StepPanel: React.FunctionComponent = ({ children }) => <>{children}</>
+
+export const StepActions: React.FunctionComponent = ({ children }) => <>{children}</>

--- a/client/wildcard/src/components/Steps/__snapshots__/Steps.test.tsx.snap
+++ b/client/wildcard/src/components/Steps/__snapshots__/Steps.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Steps Invalid configuration will error when StepPanels does not includes children 1`] = `"StepPanels must include at least one child"`;
+
+exports[`Steps Invalid configuration will error when initial step is less than 1 1`] = `"Current step is out of limits"`;
+
+exports[`Steps Invalid configuration will error when initial step is more than <Step> components length 1`] = `"The step-index is out of the boundaries. Check if the number of steps and your initialStep or setStep assignation are in concordance."`;
+
+exports[`Steps Invalid configuration will error when initial step is more than Steps length 1`] = `"Current step is out of limits"`;

--- a/client/wildcard/src/components/Steps/context.ts
+++ b/client/wildcard/src/components/Steps/context.ts
@@ -1,0 +1,86 @@
+import React, { useMemo } from 'react'
+
+export interface Step {
+    index: number
+    isFirstStep: boolean
+    isLastStep: boolean
+    isVisited: boolean
+    isComplete: boolean
+}
+
+export interface Steps {
+    [key: number]: Step
+}
+
+export interface State {
+    current: number
+    initialStep: number
+    steps: Steps
+}
+
+export type Action =
+    | { type: 'SET_CURRENT_STEP'; payload: { index: number } }
+    | { type: 'SET_COMPLETE_STEP'; payload: { index: number; complete: boolean } }
+    | { type: 'SET_STEPS'; payload: { steps: Steps } }
+
+export interface StepsContext {
+    state: State
+    dispatch: React.Dispatch<Action>
+}
+
+export interface StepListContext {
+    setCurrent: () => void
+    stepIndex: number
+}
+
+interface UseSteps {
+    setStep: (index: number) => void
+    setComplete: (index: number, complete: boolean) => void
+    currentIndex: number
+    currentStep: Step
+    steps: State['steps']
+}
+
+export const StepsContext = React.createContext<StepsContext | null>(null)
+StepsContext.displayName = 'StepsContext'
+
+export const StepListContext = React.createContext<StepListContext | null>(null)
+StepsContext.displayName = 'StepListContext'
+
+export const useStepListContext = (): StepListContext => {
+    const context = React.useContext(StepListContext)
+    if (!context) {
+        throw new Error('You are trying to use this component outside the <StepList /> component')
+    }
+    return context
+}
+
+export const useStepsContext = (): StepsContext => {
+    const context = React.useContext(StepsContext)
+    if (!context) {
+        throw new Error('Steps compound components cannot be rendered outside the <Steps> component')
+    }
+    return context
+}
+
+export const useSteps = (): UseSteps => {
+    const context = useStepsContext()
+    const { state, dispatch } = context
+
+    const getters = {
+        currentIndex: state.current,
+        currentStep: state.steps[state.current],
+        steps: state.steps,
+    }
+
+    const setters = useMemo(
+        () => ({
+            setStep: (index: number): void => dispatch({ type: 'SET_CURRENT_STEP', payload: { index } }),
+            setComplete: (index: number, complete = true): void =>
+                dispatch({ type: 'SET_COMPLETE_STEP', payload: { index, complete } }),
+        }),
+        [dispatch]
+    )
+
+    return { ...getters, ...setters }
+}

--- a/client/wildcard/src/components/Steps/index.tsx
+++ b/client/wildcard/src/components/Steps/index.tsx
@@ -1,0 +1,2 @@
+export * from './Steps'
+export { useSteps } from './context'

--- a/client/wildcard/src/components/Steps/reducer.ts
+++ b/client/wildcard/src/components/Steps/reducer.ts
@@ -1,0 +1,50 @@
+import { State, Action } from './context'
+
+export const initialState = (initialStep: number): State => ({
+    current: initialStep,
+    initialStep,
+    steps: {
+        [initialStep]: {
+            index: initialStep,
+            isFirstStep: true,
+            isLastStep: false,
+            isVisited: true,
+            isComplete: false,
+        },
+    },
+})
+
+export const reducer = (state: State, action: Action): State => {
+    switch (action.type) {
+        case 'SET_CURRENT_STEP':
+            return {
+                ...state,
+                current: action.payload.index,
+                steps: {
+                    ...state.steps,
+                    [state.steps[action.payload.index].index]: {
+                        ...state.steps[action.payload.index],
+                        isVisited: true,
+                    },
+                },
+            }
+        case 'SET_COMPLETE_STEP':
+            return {
+                ...state,
+                steps: {
+                    ...state.steps,
+                    [state.steps[action.payload.index].index]: {
+                        ...state.steps[action.payload.index],
+                        isComplete: action.payload.complete,
+                    },
+                },
+            }
+        case 'SET_STEPS':
+            return {
+                ...state,
+                steps: { ...action.payload.steps },
+            }
+        default:
+            throw new Error('wrong action type')
+    }
+}

--- a/client/wildcard/src/components/Terminal/Terminal.module.scss
+++ b/client/wildcard/src/components/Terminal/Terminal.module.scss
@@ -1,0 +1,46 @@
+.download-progress-wrapper,
+.download-progress-item {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex: 1;
+}
+
+.terminal-wrapper {
+    padding: 1.5rem;
+    background-color: #214863;
+    color: var(--light-text);
+    height: 14.25rem;
+    overflow-y: auto;
+}
+
+.terminal-line {
+    display: flex;
+    width: 100%;
+}
+
+.terminal-title {
+    flex: 1;
+    font-weight: bold;
+    color: var(--oc-green-4);
+}
+
+.download-progress-wrapper {
+    flex-direction: column;
+}
+
+.download-progress {
+    display: flex;
+    flex: 1;
+    max-width: 100%;
+    &::before {
+        content: '[';
+    }
+    &::after {
+        content: ']';
+        display: flex;
+        flex: 1;
+        justify-content: flex-end;
+    }
+}

--- a/client/wildcard/src/components/Terminal/Terminal.module.scss
+++ b/client/wildcard/src/components/Terminal/Terminal.module.scss
@@ -11,7 +11,7 @@
     padding: 1.5rem;
     background-color: #214863;
     color: var(--light-text);
-    height: 14.25rem;
+    height: 25rem;
     overflow-y: auto;
 }
 

--- a/client/wildcard/src/components/Terminal/Terminal.tsx
+++ b/client/wildcard/src/components/Terminal/Terminal.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import terminalStyles from './Terminal.module.scss'
+
+// 73 '=' characters are the 100% of the progress bar
+const CHARACTERS_LENGTH = 73
+
+export const Terminal: React.FunctionComponent = ({ children }) => (
+    <section className={terminalStyles.terminalWrapper}>
+        <ul className={terminalStyles.downloadProgressWrapper}>{children}</ul>
+    </section>
+)
+
+export const TerminalTitle: React.FunctionComponent = ({ children }) => (
+    <header className={terminalStyles.terminalTitle}>
+        <code>{children}</code>
+    </header>
+)
+
+export const TerminalLine: React.FunctionComponent = ({ children }) => (
+    <li className={terminalStyles.terminalLine}>{children}</li>
+)
+
+export const TerminalDetails: React.FunctionComponent = ({ children }) => (
+    <div>
+        <code>{children}</code>
+    </div>
+)
+
+export const TerminalProgress: React.FunctionComponent<{ progress: number; character: string }> = ({
+    progress = 0,
+    character = '#',
+}) => {
+    const numberOfChars = Math.ceil((progress / 100) * CHARACTERS_LENGTH)
+
+    return <code className={terminalStyles.downloadProgress}>{character.repeat(numberOfChars)}</code>
+}

--- a/client/wildcard/src/components/Terminal/index.tsx
+++ b/client/wildcard/src/components/Terminal/index.tsx
@@ -1,0 +1,1 @@
+export * from './Terminal'

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -24,6 +24,7 @@ const (
 	SignIn             = "sign-in"
 	SignOut            = "sign-out"
 	SignUp             = "sign-up"
+	Welcome            = "welcome"
 	SiteInit           = "site-init"
 	VerifyEmail        = "verify-email"
 	ResetPasswordInit  = "reset-password.init"
@@ -69,6 +70,7 @@ func newRouter() *mux.Router {
 	base.Path("/-/logout").Methods("GET").Name(Logout)
 
 	base.Path("/-/sign-up").Methods("POST").Name(SignUp)
+	base.Path("/-/welcome").Methods("GET").Name(Welcome)
 	base.Path("/-/site-init").Methods("POST").Name(SiteInit)
 	base.Path("/-/verify-email").Methods("GET").Name(VerifyEmail)
 	base.Path("/-/sign-in").Methods("POST").Name(SignIn)

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -46,6 +46,7 @@ const (
 	routeRepoStats        = "repo-stats"
 	routeInsights         = "insights"
 	routeBatchChanges     = "batch-changes"
+	routeWelcome          = "welcome"
 	routeCodeMonitoring   = "code-monitoring"
 	routeContexts         = "contexts"
 	routeThreads          = "threads"
@@ -139,6 +140,7 @@ func newRouter() *mux.Router {
 	r.Path("/search/notebook").Methods("GET").Name(routeSearchNotebook)
 	r.Path("/sign-in").Methods("GET").Name(uirouter.RouteSignIn)
 	r.Path("/sign-up").Methods("GET").Name(uirouter.RouteSignUp)
+	r.Path("/welcome").Methods("GET").Name(routeWelcome)
 	r.PathPrefix("/insights").Methods("GET").Name(routeInsights)
 	r.PathPrefix("/batch-changes").Methods("GET").Name(routeBatchChanges)
 	r.PathPrefix("/code-monitoring").Methods("GET").Name(routeCodeMonitoring)
@@ -238,6 +240,7 @@ func initRouter(db dbutil.DB, router *mux.Router) {
 	router.Get(routeContexts).Handler(handler(serveBrandedPageString("Search Contexts", nil)))
 	router.Get(uirouter.RouteSignIn).Handler(handler(serveSignIn))
 	router.Get(uirouter.RouteSignUp).Handler(handler(serveBrandedPageString("Sign up", nil)))
+	router.Get(routeWelcome).Handler(handler(serveBrandedPageString("Welcome", nil)))
 	router.Get(routeOrganizations).Handler(handler(serveBrandedPageString("Organization", nil)))
 	router.Get(routeSettings).Handler(handler(serveBrandedPageString("Settings", nil)))
 	router.Get(routeSiteAdmin).Handler(handler(serveBrandedPageString("Admin", nil)))


### PR DESCRIPTION
### Description

This PR adds the post-sign-up (welcome) flow + a `Stepper` and `Terminal` components (@5h1rU )

Relevant links:
* [New post-signup flow epic](https://sourcegraph.atlassian.net/browse/COREAPP-3)
* [UX enhancements to new post-signup flow epic](https://sourcegraph.atlassian.net/browse/COREAPP-18)
* [Design in Figma](https://www.figma.com/file/zXvqCASHDzmvKbrAl1EVsd/Public-and-Private-Repos-for-Users-on-Cloud?node-id=2633%3A60566)

### Demo

https://user-images.githubusercontent.com/1319181/126425814-01ec3cf8-4bb9-4512-b994-7440709ef50f.mov

### Notes 🚧

<details>
  <summary>How to test in Dev (hard)</summary>  
<br/>
It could be hard to test the welcome flow in Dev because of:

- local repo caches
- feature flags
- local storage cache keys that prevent the user from going through the flow multiple times

**Steps**:

1. _to enable the post sign up flow_:

      **a**) (**preferred way**) enable `enablePostSignupFlow` experimental feature for the instance
      Experimental features can be found here: `Settings -> Site Admin -> Site configuration -> experimentalFeatures`

      **b**) add a user  `AllowUserViewPostSignup` tag to your user
      Local DB access needed

2. _to see private repositories_:
      Set `externalService.userMode` to `all` in Site configuration (see above)

3. _If you want repositories to be cloned again_:
     remove `rm -rf  ~/.sourcegraph/repos/` directory (local cache)
    
4. _to trigger the flow_:
    sign out and register a new user
</details>

I tried adding some extra context in single comments to some files.

### Todos

- [ ]  Because of backend API limitation, we decided to change how the `Terminal` displays progress data.
Now I need to confirm with @quinnkeast what UI/UX changes need to happen to make progress more easily readable.

