### PR TITLE
Fix panic in error log

### DIFF
--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -337,7 +337,7 @@ func (c *V4Client) fetchGitHubVersion(ctx context.Context) *semver.Version {
 		return allMatchingSemver
 	}
 	if _, err = doRequest(ctx, c.apiURL, c.auth, c.rateLimitMonitor, c.httpClient, req, &resp); err != nil {
-		log15.Warn("Failed to fetch GitHub enterprise version", "doRequest", "apiURL", c.apiURL, "err", err)
+		log15.Warn("Failed to fetch GitHub enterprise version: doRequest", "apiURL", c.apiURL, "err", err)
 		return allMatchingSemver
 	}
 	version, err := semver.NewVersion(resp.InstalledVersion)


### PR DESCRIPTION
This would panic because the input is not balanced strings and `interface{}`s.
