### PR TITLE
search frontend: fix regex query highlighting for Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Sourcegraph are documented in this file.
 - An issue where using `select:repo` in conjunction with `and` patterns did not yield expected repo results. [#22743](https://github.com/sourcegraph/sourcegraph/pull/22743)
 - The `isLocked` and `isDisabled` fields of GitHub repositories are now fetched correctly from the GraphQL API of GitHub Enterprise instances. Users that rely on the `repos` config in GitHub code host connections should update so that locked and disabled repositories defined in that list are actually skipped. [#22788](https://github.com/sourcegraph/sourcegraph/pull/22788)
 - Homepage no longer fails to load if there are invalid entries in user's search history. [#22857](https://github.com/sourcegraph/sourcegraph/pull/22857)
+- An issue where regexp query highlighting in the search bar would render incorrectly on Firefox. [#23043](https://github.com/sourcegraph/sourcegraph/pull/23043)
 
 ### Removed
 

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -429,12 +429,7 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] | undefined => {
     }
     // The AST is not necessarily traversed in increasing range. We need
     // to sort by increasing range because the ordering is significant to Monaco.
-    tokens.sort((left, right) => {
-        if (left.range.start < right.range.start) {
-            return -1
-        }
-        return 0
-    })
+    tokens.sort((left, right) => left.range.start - right.range.start)
     return coalescePatterns(tokens)
 }
 


### PR DESCRIPTION
Fixes #22937 