### PR TITLE
flake: disable Puppeteer Search Feature Tour test

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -523,15 +523,16 @@ describe('Search', () => {
             expect(await isCreateCodeMonitorFeatureTourVisible()).toBeFalsy()
         })
 
-        test('Show create code monitor button feature tour with valid search type', async () => {
-            testContext.overrideSearchStreamEvents(mockDefaultStreamEvents)
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test+type:diff', {
-                waitUntil: 'networkidle0',
-            })
-            await resetCreateCodeMonitorFeatureTour()
-            await driver.page.waitForSelector('#monaco-query-input', { visible: true })
-            expect(await isCreateCodeMonitorFeatureTourVisible()).toBeTruthy()
-        })
+        // TODO: Disabled because it's flaky. https://github.com/sourcegraph/sourcegraph/issues/23046
+        // test('Show create code monitor button feature tour with valid search type', async () => {
+        //     testContext.overrideSearchStreamEvents(mockDefaultStreamEvents)
+        //     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test+type:diff', {
+        //         waitUntil: 'networkidle0',
+        //     })
+        //     await resetCreateCodeMonitorFeatureTour()
+        //     await driver.page.waitForSelector('#monaco-query-input', { visible: true })
+        //     expect(await isCreateCodeMonitorFeatureTourVisible()).toBeTruthy()
+        // })
 
         test('Do not show create code monitor button feature tour if search contexts feature tour is not dismissed', async () => {
             testContext.overrideSearchStreamEvents(mockDefaultStreamEvents)


### PR DESCRIPTION
Observed this test failing a couple times on `main` over the past few hours. As always, let me know if you'd like to proceed differently. 🙂

See #23046.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
