### PR TITLE
search: lift IsEmpty check into doResults guards

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1437,7 +1437,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	// performance optimization: call zoekt early, resolve repos concurrently, filter
 	// search results with resolved repos.
-	if args.Mode == search.ZoektGlobalSearch {
+	if args.Mode == search.ZoektGlobalSearch && !args.PatternInfo.IsEmpty() {
 		argsIndexed := *args
 		wg := waitGroup(true)
 		wg.Add(1)
@@ -1513,7 +1513,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	}
 
 	if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
-		if args.Mode != search.NoFilePath {
+		if args.Mode != search.NoFilePath && !args.PatternInfo.IsEmpty() {
 			wg := waitGroup(true)
 			wg.Add(1)
 			goroutine.Go(func() {

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -126,11 +126,6 @@ func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextPa
 }
 
 func (a *Aggregator) DoFilePathSearch(ctx context.Context, args *search.TextParameters) (err error) {
-	if args.PatternInfo.IsEmpty() {
-		// Empty query isn't an error, but it has no results.
-		return nil
-	}
-
 	tr, ctx := trace.New(ctx, "doFilePathSearch", "")
 	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {


### PR DESCRIPTION
Lifts the `IsEmpty` check to where we decide to run file searches. Note this gets rid of the [intermediate concern](https://github.com/sourcegraph/sourcegraph/pull/22997#pullrequestreview-710297350) where the check was previously in `aggregator`.