### PR TITLE
search: perform IsEmpty check before resolving repos in suggestions

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -319,6 +319,12 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,
 	}
+
+	if args.PatternInfo.IsEmpty() {
+		// Empty query isn't an error, but it has no results.
+		return nil, nil
+	}
+
 	repoOptions := r.toRepoOptions(args.Query, resolveRepositoriesOpts{})
 	resolved, err := r.resolveRepositories(ctx, repoOptions)
 	if err != nil {
@@ -333,10 +339,6 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 
 	args.RepoPromise = (&search.RepoPromise{}).Resolve(resolved.RepoRevs)
 
-	if args.PatternInfo.IsEmpty() {
-		// Empty query isn't an error, but it has no results.
-		return nil, nil
-	}
 	fileMatches, _, err := unindexed.SearchFilesInReposBatch(ctx, &args)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23057.

We can lift the check of whether to search files higher on the `suggestFilePaths` code path. In particular we can do the check _before resolving repositories_. The change is semantics preserving wrt to our application: previously, we would resolve repos and then just terminate further search because it would be a no op (`IsEmpty` true). 

So this PR probably comes with a performance bump for suggestions in some cases and is 💯 exactly 💯 the sort of reason to be [hygienic about our control flow / app state when we know static properties up front](https://github.com/sourcegraph/sourcegraph/pull/22997#issuecomment-883209336).