### PR TITLE
Code Insights: Remove `nav-link` class to keep search insight-button padding consistent

### DIFF
--- a/client/web/src/search/results/components/CreateCodeInsightButton.tsx
+++ b/client/web/src/search/results/components/CreateCodeInsightButton.tsx
@@ -35,7 +35,7 @@ export const CreateCodeInsightButton: React.FunctionComponent<CreateCodeInsightB
 
     return (
         <li data-tooltip="Create Insight based on this search query" data-delay={10000} className="nav-item mr-2">
-            <ButtonLink to={toURL} className="btn btn-sm btn-outline-secondary nav-link text-decoration-none">
+            <ButtonLink to={toURL} className="btn btn-sm btn-outline-secondary text-decoration-none">
                 <CodeInsightsIcon className="icon-inline mr-1" />
                 Create Insight
             </ButtonLink>


### PR DESCRIPTION
We probably missed that in the typography PR update but just removing the nav-link class helps to make insight button padding consistent again.

**Before:** 
<img width="406" alt="Screenshot 2021-07-21 at 12 28 23" src="https://user-images.githubusercontent.com/18492575/126466198-3f392aed-65af-4ec5-83f4-2c4e88cd3a9d.png">

**After**
<img width="378" alt="Screenshot 2021-07-21 at 12 28 47" src="https://user-images.githubusercontent.com/18492575/126466224-1706a97d-0a64-4c14-a940-44885121c02b.png">
