### PR TITLE
Add JDK sources to "JVM Dependencies" external service type.

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -438,9 +438,8 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 			return nil, err
 		}
 	case extsvc.JVMPackages:
-		artifactPath := strings.TrimPrefix(remoteName, "maven/")
 		if s.JVMPackagesSource != nil {
-			repo, err = s.JVMPackagesSource.GetRepo(ctx, artifactPath)
+			repo, err = s.JVMPackagesSource.GetRepo(ctx, remoteName)
 			if err != nil {
 				if errcode.IsNotFound(err) {
 					return &protocol.RepoLookupResult{

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -485,7 +485,8 @@ func UniqueCodeHostIdentifier(kind, config string) (string, error) {
 	case *schema.PerforceConnection:
 		// Perforce uses the P4PORT to specify the instance, so we use that
 		return c.P4Port, nil
-
+	case *schema.JVMPackagesConnection:
+		return KindJVMPackages, nil
 	default:
 		return "", errors.Errorf("unknown external service kind: %s", kind)
 	}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -403,8 +403,8 @@ commands:
       - enterprise/internal
       - enterprise/cmd/executor-queue
 
-  executor-template: &executor_template
-    # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
+  executor-template:
+    &executor_template # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
     cmd: |
       env TMPDIR="$HOME/.sourcegraph/executor-temp" .bin/executor
     install: |
@@ -424,8 +424,8 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/indexer-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: codeintel
-      EXECUTOR_HEALTH_SERVER_PORT: "3192"
-      SRC_PROF_HTTP: ":6092"
+      EXECUTOR_HEALTH_SERVER_PORT: '3192'
+      SRC_PROF_HTTP: ':6092'
 
   batches-executor:
     <<: *executor_template
@@ -433,8 +433,8 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: batches
-      EXECUTOR_HEALTH_SERVER_PORT: "3193"
-      SRC_PROF_HTTP: ":6093"
+      EXECUTOR_HEALTH_SERVER_PORT: '3193'
+      SRC_PROF_HTTP: ':6093'
 
   minio:
     cmd: |

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -403,8 +403,8 @@ commands:
       - enterprise/internal
       - enterprise/cmd/executor-queue
 
-  executor-template:
-    &executor_template # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
+  executor-template: &executor_template
+    # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
     cmd: |
       env TMPDIR="$HOME/.sourcegraph/executor-temp" .bin/executor
     install: |
@@ -424,8 +424,8 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/indexer-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: codeintel
-      EXECUTOR_HEALTH_SERVER_PORT: '3192'
-      SRC_PROF_HTTP: ':6092'
+      EXECUTOR_HEALTH_SERVER_PORT: "3192"
+      SRC_PROF_HTTP: ":6092"
 
   batches-executor:
     <<: *executor_template
@@ -433,8 +433,8 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: batches
-      EXECUTOR_HEALTH_SERVER_PORT: '3193'
-      SRC_PROF_HTTP: ':6093'
+      EXECUTOR_HEALTH_SERVER_PORT: "3193"
+      SRC_PROF_HTTP: ":6093"
 
   minio:
     cmd: |


### PR DESCRIPTION
Fixes #21883. Previously, the "JVM Dependencies" external service type
waas only able to host the sources of published Maven libraries. This
commit extends this functionality to also support hosting the sources of
the Java standard library (aka. JDK).

