### PR TITLE
Implement auto-inference for Java package repositories.

### DIFF
--- a/lib/codeintel/autoindex/inference/java.go
+++ b/lib/codeintel/autoindex/inference/java.go
@@ -1,0 +1,65 @@
+package inference
+
+import (
+	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
+)
+
+func CanIndexJavaRepo(gitserver GitClient, paths []string) bool {
+	for _, path := range paths {
+		if isJavaPath(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func InferJavaIndexJobs(gitserver GitClient, paths []string) (indexes []config.IndexJob) {
+	for _, path := range paths {
+		if !isJavaPath(path) {
+			continue
+		}
+		indexes = append(indexes, config.IndexJob{
+			Indexer: "sourcegraph:lsif-java",
+			IndexerArgs: []string{
+				"/coursier launch --contrib --ttl 0 lsif-java -- index",
+			},
+			Outfile: "dump.lsif",
+			Root:    "",
+			Steps:   []config.DockerStep{},
+		})
+	}
+	return indexes
+}
+
+func JavaPatterns() []*regexp.Regexp {
+	var patterns []*regexp.Regexp
+	for _, filename := range supportedFilenames {
+		patterns = append(patterns, suffixPattern(rawPattern(filename)))
+	}
+	return patterns
+}
+
+func isJavaPath(path string) bool {
+	for _, filename := range supportedFilenames {
+		if filename == path {
+			return true
+		}
+	}
+	return false
+}
+
+var supportedFilenames = []string{
+	// The "lsif-java.json" file is used to index package repositories such as
+	// the JDK sources and published Java libraries.
+	"lsif-java.json",
+	// Maven and Gradle are intentionally excluded from these patterns to
+	// begin with. We want to gain experience with auto-indexing only
+	// package repos, which have a higher likelyhood of indexing
+	// successfully because they have a simpler build structure compared to
+	// Gradle/Maven repos.
+	// "pom.xml",
+	// "build.gradle",
+	// "settings.gradle",
+}

--- a/lib/codeintel/autoindex/inference/java.go
+++ b/lib/codeintel/autoindex/inference/java.go
@@ -21,7 +21,7 @@ func InferJavaIndexJobs(gitserver GitClient, paths []string) (indexes []config.I
 			continue
 		}
 		indexes = append(indexes, config.IndexJob{
-			Indexer: "sourcegraph:lsif-java",
+			Indexer: "sourcegraph/lsif-java",
 			IndexerArgs: []string{
 				"/coursier launch --contrib --ttl 0 lsif-java -- index",
 			},

--- a/lib/codeintel/autoindex/inference/java_test.go
+++ b/lib/codeintel/autoindex/inference/java_test.go
@@ -1,0 +1,95 @@
+package inference
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
+)
+
+func TestLSIFJavaJobRecognizerCanIndex(t *testing.T) {
+	recognizer := lsifJavaJobRecognizer{}
+	testCases := []struct {
+		paths    []string
+		expected bool
+	}{
+		{paths: []string{"pom.xml"}, expected: true},
+		{paths: []string{"nested/pom.xml"}, expected: false},
+		{paths: []string{"build.gradle"}, expected: true},
+		{paths: []string{"nested/build.gradle"}, expected: false},
+		{paths: []string{"settings.gradle"}, expected: true},
+		{paths: []string{"nested/settings.gradle"}, expected: false},
+		{paths: []string{"lsif-java.json"}, expected: true},
+		{paths: []string{"nested/lsif-java.json"}, expected: false},
+		{paths: []string{"build.sbt"}, expected: false},
+		{paths: []string{"package.json"}, expected: false},
+		{paths: []string{"MyApp.java"}, expected: false},
+		{paths: []string{"MyApp.groovy"}, expected: false},
+		{paths: []string{"gradle.properties"}, expected: false},
+	}
+
+	for _, testCase := range testCases {
+		name := strings.Join(testCase.paths, ", ")
+
+		t.Run(name, func(t *testing.T) {
+			if value := recognizer.CanIndex(testCase.paths, NewMockGitserverClientWrapper()); value != testCase.expected {
+				t.Errorf("unexpected result from CanIndex. want=%v have=%v", testCase.expected, value)
+			}
+		})
+	}
+}
+
+func TestLsifJavaJobRecognizerInferIndexJobsTsConfigRoot(t *testing.T) {
+	recognizer := lsifJavaJobRecognizer{}
+	paths := []string{
+		"pom.xml",
+	}
+
+	expectedIndexJobs := []config.IndexJob{
+		{
+			Indexer: "gradle:7.0.0-jdk8",
+			LocalSteps: []string{
+				"apt-get update",
+				"apt-get install --yes maven",
+				"curl -fLo coursier https://git.io/coursier-cli",
+				"chmod +x coursier",
+			},
+			IndexerArgs: []string{
+				"./coursier launch --contrib lsif-java -- --packagehub=https://packagehub-ohcltxh6aq-uc.a.run.app index",
+			},
+			Outfile: "dump.lsif",
+			Root:    "",
+			Steps:   []config.DockerStep{},
+		},
+	}
+	if diff := cmp.Diff(expectedIndexJobs, recognizer.InferIndexJobs(paths, NewMockGitserverClientWrapper())); diff != "" {
+		t.Errorf("unexpected index jobs (-want +got):\n%s", diff)
+	}
+}
+
+func TestLSIFJavaJobRecognizerPatterns(t *testing.T) {
+	recognizer := lsifJavaJobRecognizer{}
+	paths := []string{
+		"lsif-java.json",
+		"settings.gradle",
+		"build.gradle",
+		"pom.xml",
+	}
+
+	for _, path := range paths {
+		match := false
+		for _, pattern := range recognizer.Patterns() {
+			if pattern.MatchString(path) {
+				match = true
+				break
+			}
+		}
+
+		if !match {
+			t.Error(fmt.Sprintf("failed to match %s", path))
+		}
+	}
+}

--- a/lib/codeintel/autoindex/inference/recognizers.go
+++ b/lib/codeintel/autoindex/inference/recognizers.go
@@ -25,8 +25,9 @@ type IndexJobRecognizer interface {
 
 // Recognizers is a list of registered index job recognizers.
 var Recognizers = map[string]IndexJobRecognizer{
-	"go":  recognizer{GoPatterns, CanIndexGoRepo, InferGoIndexJobs},
-	"tsc": recognizer{TypeScriptPatterns, CanIndexTypeScriptRepo, InferTypeScriptIndexJobs},
+	"go":   recognizer{GoPatterns, CanIndexGoRepo, InferGoIndexJobs},
+	"tsc":  recognizer{TypeScriptPatterns, CanIndexTypeScriptRepo, InferTypeScriptIndexJobs},
+	"java": recognizer{JavaPatterns, CanIndexJavaRepo, InferJavaIndexJobs},
 }
 
 type recognizer struct {


### PR DESCRIPTION
Fixes #20835. Previously, we had to manually add auto-indexing
configuration for Java package repositories. This commit implements
auto-inference for repos that have a `lsif-java.json` file at the root
directory. These repositories are created by the new JVM Dependencies
external service type and they should have a high likelyhood of indexing
successfully.

If this change works out well in production, we can consider expanding
the pattern list to also match Gradle/Maven builds.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
