### PR TITLE
Use custom postion calculator for the dashboard page contex-menu popover

### DIFF
--- a/client/web/src/insights/components/context-menu/utils.ts
+++ b/client/web/src/insights/components/context-menu/utils.ts
@@ -1,0 +1,33 @@
+import { getCollisions, Position } from '@reach/popover';
+
+const DEFAULT_VERTICAL_OFFSET = 4
+
+/**
+ * Custom popover position calculator. Returns position objects (top,left,right,bottom) styles
+ * with values such that the target and the popover element have the same right borders.
+ *
+ * ------------ | Target | --------
+ * ----|*****************| --------
+ * ----|*****************| --------
+ * ----|*** Popover *****| --------
+ * ----|*****************| --------
+ * ----|*****************| --------
+ *
+ * @param targetRectangle - bounding client rect of the target element
+ * @param popoverRectangle - bounding client rect of the pop-over element. All calculation props
+ * that are returned from this function will be applied to this element.
+ */
+export const positionRight: Position = (targetRectangle, popoverRectangle) => {
+    if (!targetRectangle || !popoverRectangle) {
+        return {};
+    }
+
+    const { directionUp } = getCollisions(targetRectangle, popoverRectangle);
+
+    return {
+        left: `${targetRectangle.right - popoverRectangle.width + window.pageXOffset}px`,
+        top: directionUp
+            ? `${targetRectangle.top - popoverRectangle.height + window.pageYOffset - DEFAULT_VERTICAL_OFFSET}px`
+            : `${targetRectangle.top + targetRectangle.height + window.pageYOffset + DEFAULT_VERTICAL_OFFSET}px`,
+    };
+};

--- a/client/web/src/insights/components/context-menu/utils.ts
+++ b/client/web/src/insights/components/context-menu/utils.ts
@@ -6,12 +6,12 @@ const DEFAULT_VERTICAL_OFFSET = 4
  * Custom popover position calculator. Returns position objects (top,left,right,bottom) styles
  * with values such that the target and the popover element have the same right borders.
  *
- * ------------ | Target | --------
- * ----|*****************| --------
- * ----|*****************| --------
- * ----|*** Popover *****| --------
- * ----|*****************| --------
- * ----|*****************| --------
+ *     ------------ | Target | --------
+ *     ----|*****************| --------
+ *     ----|*****************| --------
+ *     ----|*** Popover *****| --------
+ *     ----|*****************| --------
+ *     ----|*****************| --------
  *
  * @param targetRectangle - bounding client rect of the target element
  * @param popoverRectangle - bounding client rect of the pop-over element. All calculation props

--- a/client/web/src/insights/components/context-menu/utils.ts
+++ b/client/web/src/insights/components/context-menu/utils.ts
@@ -1,4 +1,4 @@
-import { getCollisions, Position } from '@reach/popover';
+import { getCollisions, Position } from '@reach/popover'
 
 const DEFAULT_VERTICAL_OFFSET = 4
 
@@ -19,15 +19,15 @@ const DEFAULT_VERTICAL_OFFSET = 4
  */
 export const positionRight: Position = (targetRectangle, popoverRectangle) => {
     if (!targetRectangle || !popoverRectangle) {
-        return {};
+        return {}
     }
 
-    const { directionUp } = getCollisions(targetRectangle, popoverRectangle);
+    const { directionUp } = getCollisions(targetRectangle, popoverRectangle)
 
     return {
         left: `${targetRectangle.right - popoverRectangle.width + window.pageXOffset}px`,
         top: directionUp
             ? `${targetRectangle.top - popoverRectangle.height + window.pageYOffset - DEFAULT_VERTICAL_OFFSET}px`
             : `${targetRectangle.top + targetRectangle.height + window.pageYOffset + DEFAULT_VERTICAL_OFFSET}px`,
-    };
-};
+    }
+}

--- a/client/web/src/insights/components/context-menu/utils.ts
+++ b/client/web/src/insights/components/context-menu/utils.ts
@@ -6,12 +6,14 @@ const DEFAULT_VERTICAL_OFFSET = 4
  * Custom popover position calculator. Returns position objects (top,left,right,bottom) styles
  * with values such that the target and the popover element have the same right borders.
  *
- *     ------------ | Target | --------
- *     ----|*****************| --------
- *     ----|*****************| --------
- *     ----|*** Popover *****| --------
- *     ----|*****************| --------
- *     ----|*****************| --------
+ * <pre>
+ * ------------ | Target | --------
+ * ----|*****************| --------
+ * ----|*****************| --------
+ * ----|*** Popover *****| --------
+ * ----|*****************| --------
+ * ----|*****************| --------
+ * </pre>
  *
  * @param targetRectangle - bounding client rect of the target element
  * @param popoverRectangle - bounding client rect of the pop-over element. All calculation props
@@ -25,9 +27,9 @@ export const positionRight: Position = (targetRectangle, popoverRectangle) => {
     const { directionUp } = getCollisions(targetRectangle, popoverRectangle)
 
     return {
-        left: `${targetRectangle.right - popoverRectangle.width + window.pageXOffset}px`,
+        left: `${targetRectangle.right - popoverRectangle.width + window.scrollX}px`,
         top: directionUp
-            ? `${targetRectangle.top - popoverRectangle.height + window.pageYOffset - DEFAULT_VERTICAL_OFFSET}px`
-            : `${targetRectangle.top + targetRectangle.height + window.pageYOffset + DEFAULT_VERTICAL_OFFSET}px`,
+            ? `${targetRectangle.top - popoverRectangle.height + window.scrollY - DEFAULT_VERTICAL_OFFSET}px`
+            : `${targetRectangle.top + targetRectangle.height + window.scrollY + DEFAULT_VERTICAL_OFFSET}px`,
     }
 }

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
@@ -1,8 +1,10 @@
-import { Menu, MenuButton, MenuList, MenuItem, MenuLink } from '@reach/menu-button'
+import { Menu, MenuButton, MenuItem, MenuItems, MenuLink, MenuPopover } from '@reach/menu-button'
 import classnames from 'classnames'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'
 import React, { MouseEvent } from 'react'
 import { useHistory } from 'react-router'
+
+import { positionRight } from '../../../../../context-menu/utils'
 
 import styles from './InsightCardMenu.module.scss'
 
@@ -29,23 +31,28 @@ export const InsightCardMenu: React.FunctionComponent<InsightCardMenuProps> = pr
             <MenuButton data-testid="InsightContextMenuButton" className={classnames(className, 'btn btn-outline p-1')}>
                 <DotsVerticalIcon size={16} />
             </MenuButton>
-            <MenuList data-testid={`context-menu.${insightID}`} className={classnames(styles.panel, 'dropdown-menu')}>
-                <MenuLink
-                    data-testid="InsightContextMenuEditLink"
-                    className={classnames('btn btn-outline', styles.item)}
-                    onClick={handleEditClick}
+            <MenuPopover portal={true} position={positionRight}>
+                <MenuItems
+                    data-testid={`context-menu.${insightID}`}
+                    className={classnames(styles.panel, 'dropdown-menu')}
                 >
-                    Edit
-                </MenuLink>
+                    <MenuLink
+                        data-testid="InsightContextMenuEditLink"
+                        className={classnames('btn btn-outline', styles.item)}
+                        onClick={handleEditClick}
+                    >
+                        Edit
+                    </MenuLink>
 
-                <MenuItem
-                    data-testid="insight-context-menu-delete-button"
-                    onSelect={() => onDelete(insightID)}
-                    className={classnames('btn btn-outline-', styles.item)}
-                >
-                    Delete
-                </MenuItem>
-            </MenuList>
+                    <MenuItem
+                        data-testid="insight-context-menu-delete-button"
+                        onSelect={() => onDelete(insightID)}
+                        className={classnames('btn btn-outline-', styles.item)}
+                    >
+                        Delete
+                    </MenuItem>
+                </MenuItems>
+            </MenuPopover>
         </Menu>
     )
 }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
@@ -12,6 +12,11 @@
 
     // Explicit override @reach ui border styles
     border: 1px solid var(--dropdown-border-color);
+
+    // The .dropdown-menu class adds absolute position to the element
+    // that makes parent of this element wrong width/height settled
+    // Therefore this breaks popover position of reach-ui popover
+    position: static;
 }
 
 .menu-item[data-reach-menu-item] {

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu, MenuButton, MenuItem, MenuList } from '@reach/menu-button'
+import { Menu, MenuButton, MenuItem, MenuItems, MenuPopover } from '@reach/menu-button'
 import classnames from 'classnames'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'
 import React from 'react'
@@ -6,6 +6,7 @@ import React from 'react'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 
 import { Settings } from '../../../../../../schema/settings.schema'
+import { positionRight } from '../../../../../components/context-menu/utils'
 import { InsightDashboard } from '../../../../../core/types'
 import { getTooltipMessage, useDashboardPermissions } from '../../hooks/use-dashboard-permissions'
 
@@ -42,51 +43,53 @@ export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props 
                 <DotsVerticalIcon size={16} />
             </MenuButton>
 
-            <MenuList className={classnames(styles.menuList, 'dropdown-menu')}>
-                <MenuItem
-                    as="button"
-                    disabled={!permissions.isConfigurable}
-                    data-tooltip={getTooltipMessage(dashboard, permissions)}
-                    data-placement="right"
-                    className={classnames(styles.menuItem, 'btn btn-outline')}
-                    onSelect={() => onSelect(DashboardMenuAction.AddRemoveInsights)}
-                >
-                    Add or remove insights
-                </MenuItem>
+            <MenuPopover portal={true} position={positionRight}>
+                <MenuItems className={classnames(styles.menuList, 'dropdown-menu')}>
+                    <MenuItem
+                        as="button"
+                        disabled={!permissions.isConfigurable}
+                        data-tooltip={getTooltipMessage(dashboard, permissions)}
+                        data-placement="right"
+                        className={classnames(styles.menuItem, 'btn btn-outline')}
+                        onSelect={() => onSelect(DashboardMenuAction.AddRemoveInsights)}
+                    >
+                        Add or remove insights
+                    </MenuItem>
 
-                <MenuItem
-                    as="button"
-                    disabled={!permissions.isConfigurable}
-                    data-tooltip={getTooltipMessage(dashboard, permissions)}
-                    data-placement="right"
-                    className={classnames(styles.menuItem, 'btn btn-outline')}
-                    onSelect={() => onSelect(DashboardMenuAction.Configure)}
-                >
-                    Configure dashboard
-                </MenuItem>
+                    <MenuItem
+                        as="button"
+                        disabled={!permissions.isConfigurable}
+                        data-tooltip={getTooltipMessage(dashboard, permissions)}
+                        data-placement="right"
+                        className={classnames(styles.menuItem, 'btn btn-outline')}
+                        onSelect={() => onSelect(DashboardMenuAction.Configure)}
+                    >
+                        Configure dashboard
+                    </MenuItem>
 
-                <MenuItem
-                    as="button"
-                    disabled={!hasDashboard}
-                    className={classnames(styles.menuItem, 'btn btn-outline')}
-                    onSelect={() => onSelect(DashboardMenuAction.CopyLink)}
-                >
-                    Copy link
-                </MenuItem>
+                    <MenuItem
+                        as="button"
+                        disabled={!hasDashboard}
+                        className={classnames(styles.menuItem, 'btn btn-outline')}
+                        onSelect={() => onSelect(DashboardMenuAction.CopyLink)}
+                    >
+                        Copy link
+                    </MenuItem>
 
-                <hr />
+                    <hr />
 
-                <MenuItem
-                    as="button"
-                    disabled={!permissions.isConfigurable}
-                    data-tooltip={getTooltipMessage(dashboard, permissions)}
-                    data-placement="right"
-                    className={classnames(styles.menuItem, 'btn btn-outline', styles.menuItemDanger)}
-                    onSelect={() => onSelect(DashboardMenuAction.Delete)}
-                >
-                    Delete
-                </MenuItem>
-            </MenuList>
+                    <MenuItem
+                        as="button"
+                        disabled={!permissions.isConfigurable}
+                        data-tooltip={getTooltipMessage(dashboard, permissions)}
+                        data-placement="right"
+                        className={classnames(styles.menuItem, 'btn btn-outline', styles.menuItemDanger)}
+                        onSelect={() => onSelect(DashboardMenuAction.Delete)}
+                    >
+                        Delete
+                    </MenuItem>
+                </MenuItems>
+            </MenuPopover>
         </Menu>
     )
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22793

### Background

This PR adds a custom position calculator for the context menu popover element. As you can see on screenshots below before all context menus were right-aligned. With changes from this PR, all context-menus (dashboard context and insight card context menu) have share target right border position.

You can find Figma designs about these context menus [here](https://www.figma.com/file/g5lSlPBnHt00wCogjRFnt5/RFC-398%3A-Easily-Viewing-and-Sharing-Code-Insights-WIP?node-id=849%3A4211)

<table>
 <tr>
   <th>Before</th>
   <td>
<img width="697" alt="Screenshot 2021-07-21 at 17 00 40" src="https://user-images.githubusercontent.com/18492575/126501841-0f4cca85-7671-49a8-b2b0-69d20fc56a37.png">
</td>
<td>
<img width="543" alt="Screenshot 2021-07-21 at 17 00 51" src="https://user-images.githubusercontent.com/18492575/126501926-77540da5-cdaf-4dda-9e3f-72b3c03ddb27.png">

</td>
 </tr>
 <tr>
   <th>After</th>
   <td>
    
<img width="468" alt="Screenshot 2021-07-21 at 17 01 04" src="https://user-images.githubusercontent.com/18492575/126502065-2baf1a89-e8af-4b44-9f0b-115a4214ab77.png">

   </td>
   <td>
   
<img width="391" alt="Screenshot 2021-07-21 at 17 01 23" src="https://user-images.githubusercontent.com/18492575/126502071-7ac136f1-c7ad-4922-8317-a1bd3ce120a5.png">

   </td>
 </tr>
</table>