### PR TITLE
tune down result limits in searcher

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -41,7 +41,7 @@ const (
 	// This may be increased in the future pending stability evaluation, or may
 	// be removed entirely once streaming is in place and we don't need to buffer
 	// the whole result set in memory.
-	maxLimit = 100_000
+	maxLimit = 5000
 
 	// numWorkers is how many concurrent readerGreps run in the case of
 	// regexSearch, and the number of parallel workers in the case of


### PR DESCRIPTION
The new, higher, more consistent limit is causing searcher to OOM with large search result sets. This tunes that limit down to 5000 matches per repo. This is a bandaid fix. The real fix will involve streaming for searcher. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
