### PR TITLE
auth: Redirect github oauth login attempt back if user cancels

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -67,7 +67,7 @@ func SessionIssuer(s SessionIssuerHelper, sessionKey string) http.Handler {
 			return
 		}
 
-		// Delete state cookie (no longer needed, while be stale if user logs out and logs back in within 120s)
+		// Delete state cookie (no longer needed, will be stale if user logs out and logs back in within 120s)
 		defer s.DeleteStateCookie(w)
 
 		if state.Op == LoginStateOpCreateCodeHostConnection {


### PR DESCRIPTION
Before, we would show a raw plaintext error. Instead, we detect the
specifc `access_denied` error returned from GitHub and redirect the user
back.

Closes: https://sourcegraph.atlassian.net/browse/COREAPP-25