### PR TITLE
fix: CodeIntelligence Overlay wrong position with OctoTree Plugin

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -285,6 +285,18 @@ export const checkIsGitHub = (): boolean => checkIsGitHubDotCom() || checkIsGitH
 
 const OPEN_ON_SOURCEGRAPH_ID = 'open-on-sourcegraph'
 
+const adjustOverlayPosition: CodeHost['adjustOverlayPosition'] = ({ top, left }) => {
+    const octotree = document.querySelector('.octotree-sidebar')
+    // When browser install octotree plugin, it shows a sidebar on left.
+    if (octotree) {
+        left += octotree.getBoundingClientRect().right
+    }
+    return {
+        top,
+        left,
+    }
+}
+
 export const createOpenOnSourcegraphIfNotExists: MountGetter = (container: HTMLElement): HTMLElement | null => {
     const pageheadActions = querySelectorOrSelf(container, '.pagehead-actions')
     // If ran on page that isn't under a repository namespace.
@@ -324,6 +336,7 @@ export const githubCodeHost: CodeHost = {
     codeViewResolvers: [genericCodeViewResolver, fileLineContainerResolver, searchResultCodeViewResolver],
     contentViewResolvers: [markdownBodyViewResolver],
     nativeTooltipResolvers: [nativeTooltipResolver],
+    adjustOverlayPosition,
     getContext: () => {
         const repoHeaderHasPrivateMarker =
             !!document.querySelector('.repohead .private') ||


### PR DESCRIPTION
Before fix:
![image](https://user-images.githubusercontent.com/10740043/126524407-f290ac27-bf54-4de0-8a15-c23ff4a9540b.png)

After fix:
![image](https://user-images.githubusercontent.com/10740043/126524473-64768b3b-4f49-4aa5-9d52-9bd54a5930b1.png)
