### PR TITLE
insights: changing searcher limit to 20k

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -41,7 +41,7 @@ const (
 	// This may be increased in the future pending stability evaluation, or may
 	// be removed entirely once streaming is in place and we don't need to buffer
 	// the whole result set in memory.
-	maxLimit = 5000
+	maxLimit = 20000
 
 	// numWorkers is how many concurrent readerGreps run in the case of
 	// regexSearch, and the number of parallel workers in the case of


### PR DESCRIPTION
Bumping up the limit a bit since 5k seems to be very easily reached.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
