### PR TITLE
search: ZoektGlobalSearch mode implied by non-empty path/content query

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -548,7 +548,8 @@ func withMode(args search.TextParameters, st query.SearchType, versionContext *s
 
 	isFileOrPath := args.ResultTypes.Has(result.TypeFile) || args.ResultTypes.Has(result.TypePath)
 	isIndexedSearch := args.PatternInfo.Index != query.No
-	if isGlobalSearch() && isIndexedSearch && isFileOrPath {
+	isEmpty := args.PatternInfo.Pattern == "" && args.PatternInfo.ExcludePattern == "" && len(args.PatternInfo.IncludePatterns) == 0
+	if isGlobalSearch() && isIndexedSearch && isFileOrPath && !isEmpty {
 		args.Mode = search.ZoektGlobalSearch
 	}
 	return args
@@ -1437,7 +1438,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	// performance optimization: call zoekt early, resolve repos concurrently, filter
 	// search results with resolved repos.
-	if args.Mode == search.ZoektGlobalSearch && !args.PatternInfo.IsEmpty() {
+	if args.Mode == search.ZoektGlobalSearch {
 		argsIndexed := *args
 		wg := waitGroup(true)
 		wg.Add(1)


### PR DESCRIPTION
Lifts more logic to the place where we construct queries. Needed to simplify control flow logic up the stack.