### PR TITLE
search: empty patterns imply skipping content/file search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -552,6 +552,9 @@ func withMode(args search.TextParameters, st query.SearchType, versionContext *s
 	if isGlobalSearch() && isIndexedSearch && isFileOrPath && !isEmpty {
 		args.Mode = search.ZoektGlobalSearch
 	}
+	if isEmpty {
+		args.Mode = search.SkipContentAndPathSearch
+	}
 	return args
 }
 
@@ -1450,7 +1453,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		// of indexed default searchrepos. No need to call searcher, because
 		// len(searcherRepos) will always be 0.
 		if envvar.SourcegraphDotComMode() {
-			args.Mode = search.NoFilePath
+			args.Mode = search.SkipContentAndPathSearch
 		} else {
 			args.Mode = search.SearcherOnly
 		}
@@ -1514,7 +1517,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	}
 
 	if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
-		if args.Mode != search.NoFilePath && !args.PatternInfo.IsEmpty() {
+		if args.Mode != search.SkipContentAndPathSearch {
 			wg := waitGroup(true)
 			wg.Add(1)
 			goroutine.Go(func() {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -108,15 +108,16 @@ const (
 	// optimised code path.
 	SearcherOnly
 
-	// Disables file/path search. Used only in conjunction with ZoektGlobalSearch on
-	// Sourcegraph.com.
-	NoFilePath
+	// Disables content and file path search. Used:
+	// (1) in conjunction with ZoektGlobalSearch on Sourcegraph.com.
+	// (2) when a query does not specify any patterns for a content or file path search.
+	SkipContentAndPathSearch
 )
 
 var globalSearchModeStrings = map[GlobalSearchMode]string{
-	ZoektGlobalSearch: "ZoektGlobalSearch",
-	SearcherOnly:      "SearcherOnly",
-	NoFilePath:        "NoFilePath",
+	ZoektGlobalSearch:        "ZoektGlobalSearch",
+	SearcherOnly:             "SearcherOnly",
+	SkipContentAndPathSearch: "SkipContentAndPathSearch",
 }
 
 func (m GlobalSearchMode) String() string {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23093.

See inline comments.