### PR TITLE
search: remove text_pattern_info.go

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -320,7 +320,8 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 		SearcherURLs:    r.searcherURLs,
 	}
 
-	if args.PatternInfo.IsEmpty() {
+	isEmpty := args.PatternInfo.Pattern == "" && args.PatternInfo.ExcludePattern == "" && len(args.PatternInfo.IncludePatterns) == 0
+	if isEmpty {
 		// Empty query isn't an error, but it has no results.
 		return nil, nil
 	}

--- a/internal/search/text_pattern_info.go
+++ b/internal/search/text_pattern_info.go
@@ -1,6 +1,0 @@
-// Validation logic for TextPatternInfo
-package search
-
-func (p *TextPatternInfo) IsEmpty() bool {
-	return p.Pattern == "" && p.ExcludePattern == "" && len(p.IncludePatterns) == 0
-}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23094.

After all the previous stuff, there is now only one use of `PatternInfo.IsEmpty()` from `text_pattern_info.go`, in the suggestions code. I'm inlining it there so we can remove the file/method.

The query construction for suggestions code will go through `toTextParameters` processing at some point (which would make the inlining here unnecessary). But my goal isn't to clean up suggestions code directly right now.