### PR TITLE
search frontend: accurate hovers for multiline query inputs

### DIFF
--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -655,3 +655,27 @@ test('returns repo:contains hovers', () => {
         }
     `)
 })
+
+test('returns multiline hovers', () => {
+    const input = `repo:contains(
+      file:foo
+      content:bar
+)`
+    const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.literal))
+
+    expect(getHoverResult(scannedQuery, new Position(4, 1), editor.createModel(input))).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that satisfy the specified \`file:\` and \`content:\` filters. \`file:\` and \`content:\` filters should be regular expressions."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 4,
+            "startColumn": 6,
+            "endColumn": 2
+          }
+        }
+    `)
+})

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -1,9 +1,12 @@
-import { SearchPatternType } from '../../graphql-operations'
 import { editor, Position } from 'monaco-editor'
+
+import { SearchPatternType } from '../../graphql-operations'
 
 import { getHoverResult } from './hover'
 import { scanSearchQuery, ScanSuccess, ScanResult } from './scanner'
 import { Token } from './token'
+
+/* eslint-disable ban/ban */
 
 /**
  * Needed for mocking methods not implemented in JSDom, for tests dependent on Monaco editor model.

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -2,7 +2,6 @@ import * as Monaco from 'monaco-editor'
 
 import {
     decorate,
-    toMonacoRange,
     DecoratedToken,
     MetaRegexp,
     MetaRegexpKind,
@@ -16,7 +15,7 @@ import {
     MetaPredicate,
 } from './decoratedToken'
 import { resolveFilter } from './filters'
-import { Token } from './token'
+import { CharacterRange, Token } from './token'
 
 const toRegexpHover = (token: MetaRegexp): string => {
     switch (token.kind) {
@@ -193,17 +192,33 @@ const toHover = (token: DecoratedToken): string => {
     return ''
 }
 
-const inside = (column: number) => ({ range }: Pick<Token | DecoratedToken, 'range'>): boolean =>
-    range.start + 1 <= column && range.end >= column
+/**
+ * Converts a zero-indexed offset {@link CharacterRange} to a {@link Monaco.IRange} line-and-column range.
+ * This ensures hover tooltips happen at correct line and column offsets, and for ranges that span multiple lines.
+ */
+const toMonacoHoverRange = ({ start, end }: CharacterRange, textModel: Monaco.editor.ITextModel): Monaco.IRange => {
+    const startPos = textModel.getPositionAt(start)
+    const endPos = textModel.getPositionAt(end)
+    return {
+        startLineNumber: startPos.lineNumber,
+        endLineNumber: endPos.lineNumber,
+        startColumn: startPos.column,
+        endColumn: endPos.column,
+    }
+}
+
+const inside = (offset: number) => ({ range }: Pick<Token | DecoratedToken, 'range'>): boolean =>
+    range.start <= offset && range.end > offset
 
 /**
  * Returns the hover result for a hovered search token in the Monaco query input.
  */
 export const getHoverResult = (
     tokens: Token[],
-    { column }: Pick<Monaco.Position, 'column'>
+    position: Monaco.Position,
+    textModel: Monaco.editor.ITextModel
 ): Monaco.languages.Hover | null => {
-    const tokensAtCursor = tokens.flatMap(decorate).filter(inside(column))
+    const tokensAtCursor = tokens.flatMap(decorate).filter(inside(textModel.getOffsetAt(position)))
     if (tokensAtCursor.length === 0) {
         return null
     }
@@ -220,7 +235,7 @@ export const getHoverResult = (
                             : resolvedFilter.definition.description
                     )
                     // Add 1 to end of range to include the ':'.
-                    range = toMonacoRange({ start: token.range.start, end: token.range.end + 1 })
+                    range = toMonacoHoverRange({ start: token.range.start, end: token.range.end + 1 }, textModel)
                 }
                 break
             }
@@ -229,13 +244,13 @@ export const getHoverResult = (
             case 'metaRepoRevisionSeparator':
             case 'metaSelector':
                 values.push(toHover(token))
-                range = toMonacoRange(token.range)
+                range = toMonacoHoverRange(token.range, textModel)
                 break
             case 'metaRegexp':
             case 'metaStructural':
             case 'metaPredicate':
                 values.push(toHover(token))
-                range = toMonacoRange(token.groupRange ? token.groupRange : token.range)
+                range = toMonacoHoverRange(token.groupRange ? token.groupRange : token.range, textModel)
                 break
         }
     })

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -197,13 +197,13 @@ const toHover = (token: DecoratedToken): string => {
  * This ensures hover tooltips happen at correct line and column offsets, and for ranges that span multiple lines.
  */
 const toMonacoHoverRange = ({ start, end }: CharacterRange, textModel: Monaco.editor.ITextModel): Monaco.IRange => {
-    const startPos = textModel.getPositionAt(start)
-    const endPos = textModel.getPositionAt(end)
+    const startPosition = textModel.getPositionAt(start)
+    const endPosition = textModel.getPositionAt(end)
     return {
-        startLineNumber: startPos.lineNumber,
-        endLineNumber: endPos.lineNumber,
-        startColumn: startPos.column,
-        endColumn: endPos.column,
+        startLineNumber: startPosition.lineNumber,
+        endLineNumber: endPosition.lineNumber,
+        startColumn: startPosition.column,
+        endColumn: endPosition.column,
     }
 }
 

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -65,7 +65,9 @@ export function getProviders(
                 of(textModel.getValue())
                     .pipe(
                         map(value => scanSearchQuery(value, options.interpretComments ?? false, options.patternType)),
-                        map(scanned => (scanned.type === 'error' ? null : getHoverResult(scanned.term, position))),
+                        map(scanned =>
+                            scanned.type === 'error' ? null : getHoverResult(scanned.term, position, textModel)
+                        ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )
                     .toPromise(),


### PR DESCRIPTION
In support of notebooks.

Go by commit:

- First commit updates the logic
- Second is just a mechanical refactor for existing test
- Third is a new test. Just a basic one that's sufficient until we discover we want more features or coverage.

Cool thing, this will actually also give hover/selection range highlighting over multiple lines for single expressions:

<img width="693" alt="Screen Shot 2021-07-21 at 6 26 11 PM" src="https://user-images.githubusercontent.com/888624/126581214-1a5568a3-2b57-4ded-8b9d-509e8c39990f.png">

Caveat: our highlighting still carries a line-based assumption so that doesn't quite work as well yet. I will dig into that in a follow up. It's not immediately as important, since individual query terms are short and fit well on one line for now. Just thought it was worth fixing up for hovers while I was looking into this.
