### PR TITLE
API docs: LSIF: add references/definitions to tree API, not just blob API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 -
 
+## 3.30.1
+
+### Fixed
+
+- An issue where the UI would occassionally display `lsifStore.Ranges: ERROR: relation \"lsif_documentation_mappings\" does not exist (SQLSTATE 42P01)` [#23115](https://github.com/sourcegraph/sourcegraph/pull/23115)
+
 ## 3.30.0
 
 ### Added

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -135,6 +135,8 @@ type GitTreeLSIFDataResolver interface {
 	Diagnostics(ctx context.Context, args *LSIFDiagnosticsArgs) (DiagnosticConnectionResolver, error)
 	DocumentationPage(ctx context.Context, args *LSIFDocumentationPageArgs) (DocumentationPageResolver, error)
 	DocumentationPathInfo(ctx context.Context, args *LSIFDocumentationPathInfoArgs) (JSONValue, error)
+	DocumentationDefinitions(ctx context.Context, args *LSIFQueryDocumentationArgs) (LocationConnectionResolver, error)
+	DocumentationReferences(ctx context.Context, args *LSIFPagedQueryDocumentationArgs) (LocationConnectionResolver, error)
 }
 
 type CodeIntelligenceCommitGraphResolver interface {
@@ -152,8 +154,6 @@ type GitBlobLSIFDataResolver interface {
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)
 	Documentation(ctx context.Context, args *LSIFQueryPositionArgs) (DocumentationResolver, error)
-	DocumentationDefinitions(ctx context.Context, args *LSIFQueryDocumentationArgs) (LocationConnectionResolver, error)
-	DocumentationReferences(ctx context.Context, args *LSIFPagedQueryDocumentationArgs) (LocationConnectionResolver, error)
 }
 
 type GitBlobLSIFDataArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -258,6 +258,36 @@ interface TreeEntryLSIFData {
     https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+type+DocumentationPathInfoResult+struct&patternType=literal&case=yes
     """
     documentationPathInfo(pathID: String!, maxDepth: Int, ignoreIndex: Boolean): JSONValue!
+
+    """
+    A list of definitions of the symbol described by the given documentation path ID, if any.
+    """
+    documentationDefinitions(pathID: String!): LocationConnection!
+
+    """
+    A list of references of the symbol under the given document position.
+    """
+    documentationReferences(
+        """
+        The documentation path ID, e.g. from the documentationPage return value.
+        """
+        pathID: String!
+
+        """
+        When specified, indicates that this request should be paginated and
+        to fetch results starting at this cursor.
+        A future request can be made for more results by passing in the
+        'LocationConnection.pageInfo.endCursor' that is returned.
+        """
+        after: String
+
+        """
+        When specified, indicates that this request should be paginated and
+        the first N results (relative to the cursor) should be returned. i.e.
+        how many results to return per page.
+        """
+        first: Int
+    ): LocationConnection!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
@@ -34,6 +34,7 @@ func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID str
 			return nil, errors.Wrap(err, "lsifStore.DocumentationDefinitions")
 		}
 		if len(locations) > 0 {
+			r.path = locations[0].Path
 			uploadsByID := map[int]dbstore.Dump{upload.ID: upload}
 			return r.adjustLocations(ctx, uploadsByID, locations)
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
@@ -17,7 +17,6 @@ func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID str
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
-			log.String("path", r.path),
 			log.Int("numUploads", len(r.uploads)),
 			log.String("uploads", uploadIDsToString(r.uploads)),
 			log.String("pathID", pathID),
@@ -30,7 +29,7 @@ func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID str
 	// repository.
 	for _, upload := range r.uploads {
 		traceLog(log.Int("uploadID", upload.ID))
-		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, r.path, pathID, DefinitionsLimit, 0)
+		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, pathID, DefinitionsLimit, 0)
 		if err != nil {
 			return nil, errors.Wrap(err, "lsifStore.DocumentationDefinitions")
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
@@ -16,7 +16,6 @@ func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID stri
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
-			log.String("path", r.path),
 			log.Int("numUploads", len(r.uploads)),
 			log.String("uploads", uploadIDsToString(r.uploads)),
 			log.String("pathID", pathID),
@@ -33,7 +32,7 @@ func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID stri
 	// request on the first location we find.
 	for _, upload := range r.uploads {
 		traceLog(log.Int("uploadID", upload.ID))
-		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, r.path, pathID, DefinitionsLimit, 0)
+		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, pathID, DefinitionsLimit, 0)
 		if err != nil {
 			return nil, "", errors.Wrap(err, "lsifStore.DocumentationDefinitions")
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
@@ -38,6 +38,7 @@ func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID stri
 		}
 		if len(locations) > 0 {
 			location := locations[0]
+			r.path = location.Path
 			return r.References(ctx, location.Range.Start.Line, location.Range.Start.Character, limit, rawCursor)
 		}
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -54,8 +54,8 @@ type LSIFStore interface {
 	PackageInformation(ctx context.Context, bundleID int, path string, packageInformationID string) (semantic.PackageInformationData, bool, error)
 	DocumentationPage(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPageData, error)
 	DocumentationPathInfo(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPathInfoData, error)
-	DocumentationDefinitions(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
-	DocumentationReferences(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
+	DocumentationDefinitions(ctx context.Context, bundleID int, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
+	DocumentationReferences(ctx context.Context, bundleID int, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
 	DocumentationAtPosition(ctx context.Context, bundleID int, path string, line, character int) ([]string, error)
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4784,7 +4784,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		DocumentationDefinitionsFunc: &LSIFStoreDocumentationDefinitionsFunc{
-			defaultHook: func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+			defaultHook: func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 				return nil, 0, nil
 			},
 		},
@@ -4799,7 +4799,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		DocumentationReferencesFunc: &LSIFStoreDocumentationReferencesFunc{
-			defaultHook: func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+			defaultHook: func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 				return nil, 0, nil
 			},
 		},
@@ -5383,24 +5383,24 @@ func (c LSIFStoreDocumentationAtPositionFuncCall) Results() []interface{} {
 // DocumentationDefinitions method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreDocumentationDefinitionsFunc struct {
-	defaultHook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
-	hooks       []func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	defaultHook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
+	hooks       []func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
 	history     []LSIFStoreDocumentationDefinitionsFuncCall
 	mutex       sync.Mutex
 }
 
 // DocumentationDefinitions delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) DocumentationDefinitions(v0 context.Context, v1 int, v2 string, v3 string, v4 int, v5 int) ([]lsifstore.Location, int, error) {
-	r0, r1, r2 := m.DocumentationDefinitionsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.DocumentationDefinitionsFunc.appendCall(LSIFStoreDocumentationDefinitionsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
+func (m *MockLSIFStore) DocumentationDefinitions(v0 context.Context, v1 int, v2 string, v3 int, v4 int) ([]lsifstore.Location, int, error) {
+	r0, r1, r2 := m.DocumentationDefinitionsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DocumentationDefinitionsFunc.appendCall(LSIFStoreDocumentationDefinitionsFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // DocumentationDefinitions method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -5409,7 +5409,7 @@ func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreDocumentationDefinitionsFunc) PushHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationDefinitionsFunc) PushHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5418,7 +5418,7 @@ func (f *LSIFStoreDocumentationDefinitionsFunc) PushHook(hook func(context.Conte
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.SetDefaultHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
@@ -5426,12 +5426,12 @@ func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultReturn(r0 []lsifstore.
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *LSIFStoreDocumentationDefinitionsFunc) PushReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.PushHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LSIFStoreDocumentationDefinitionsFunc) nextHook() func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+func (f *LSIFStoreDocumentationDefinitionsFunc) nextHook() func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5476,13 +5476,10 @@ type LSIFStoreDocumentationDefinitionsFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
+	Arg3 int
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 int
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []lsifstore.Location
@@ -5497,7 +5494,7 @@ type LSIFStoreDocumentationDefinitionsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreDocumentationDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
@@ -5736,24 +5733,24 @@ func (c LSIFStoreDocumentationPathInfoFuncCall) Results() []interface{} {
 // DocumentationReferences method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreDocumentationReferencesFunc struct {
-	defaultHook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
-	hooks       []func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	defaultHook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
+	hooks       []func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
 	history     []LSIFStoreDocumentationReferencesFuncCall
 	mutex       sync.Mutex
 }
 
 // DocumentationReferences delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) DocumentationReferences(v0 context.Context, v1 int, v2 string, v3 string, v4 int, v5 int) ([]lsifstore.Location, int, error) {
-	r0, r1, r2 := m.DocumentationReferencesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.DocumentationReferencesFunc.appendCall(LSIFStoreDocumentationReferencesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
+func (m *MockLSIFStore) DocumentationReferences(v0 context.Context, v1 int, v2 string, v3 int, v4 int) ([]lsifstore.Location, int, error) {
+	r0, r1, r2 := m.DocumentationReferencesFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DocumentationReferencesFunc.appendCall(LSIFStoreDocumentationReferencesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // DocumentationReferences method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -5762,7 +5759,7 @@ func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5771,7 +5768,7 @@ func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.SetDefaultHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
@@ -5779,12 +5776,12 @@ func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultReturn(r0 []lsifstore.L
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *LSIFStoreDocumentationReferencesFunc) PushReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.PushHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LSIFStoreDocumentationReferencesFunc) nextHook() func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+func (f *LSIFStoreDocumentationReferencesFunc) nextHook() func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5829,13 +5826,10 @@ type LSIFStoreDocumentationReferencesFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
+	Arg3 int
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 int
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []lsifstore.Location
@@ -5850,7 +5844,7 @@ type LSIFStoreDocumentationReferencesFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreDocumentationReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -244,26 +244,69 @@ func (s *Store) scanFirstDocumentationResultID(rows *sql.Rows, queryErr error) (
 	return resultID, nil
 }
 
+// documentationPathIDToFilePath queries the file path associated with a documentation path ID,
+// e.g. the file where the documented symbol is located - if the path ID is describing such a
+// symbol, or nil otherwise.
+func (s *Store) documentationPathIDToFilePath(ctx context.Context, bundleID int, pathID string) (_ *string, err error) {
+	ctx, _, endObservation := s.operations.documentationPathIDToFilePath.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("bundleID", bundleID),
+		log.String("pathID", pathID),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	return s.scanFirstDocumentationFilePath(s.Store.Query(ctx, sqlf.Sprintf(documentationPathIDToFilePathQuery, bundleID, pathID)))
+}
+
+const documentationPathIDToFilePathQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/ranges.go:documentationPathIDToFilePath
+SELECT
+	file_path
+FROM
+	lsif_documentation_mappings
+WHERE
+	dump_id = %s AND
+	path_id = %s
+LIMIT 1
+`
+
+// scanFirstDocumentationFilePath reads the first file_path row. If no rows match the query, an empty string is returned.
+func (s *Store) scanFirstDocumentationFilePath(rows *sql.Rows, queryErr error) (_ *string, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	if !rows.Next() {
+		return nil, nil
+	}
+
+	var filePath *string
+	if err := rows.Scan(&filePath); err != nil {
+		return nil, err
+	}
+	return filePath, nil
+}
+
 // DocumentationDefinitions returns the set of locations defining the symbol found at the given path ID, if any.
-func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, path, pathID string, limit, offset int) (_ []Location, _ int, err error) {
+func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, pathID string, limit, offset int) (_ []Location, _ int, err error) {
 	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
 	if err != nil || resultID == "" {
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.DefinitionResultID }
 	operation := s.operations.documentationDefinitions
-	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
+	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, pathID, resultID, limit, offset)
 }
 
 // DocumentationReferences returns the set of locations referencing the symbol found at the given path ID, if any.
-func (s *Store) DocumentationReferences(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) (_ []Location, _ int, err error) {
+func (s *Store) DocumentationReferences(ctx context.Context, bundleID int, pathID string, limit, offset int) (_ []Location, _ int, err error) {
 	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
 	if resultID == "" || err != nil {
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.ReferenceResultID }
 	operation := s.operations.documentationReferences
-	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
+	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, pathID, resultID, limit, offset)
 }
 
 func (s *Store) documentationDefinitionsReferences(
@@ -271,19 +314,27 @@ func (s *Store) documentationDefinitionsReferences(
 	extractor func(r semantic.RangeData) semantic.ID,
 	operation *observation.Operation,
 	bundleID int,
-	path string,
+	pathID string,
 	resultID semantic.ID,
 	limit,
 	offset int,
 ) (_ []Location, _ int, err error) {
 	ctx, traceLog, endObservation := operation.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
-		log.String("path", path),
 		log.String("resultID", string(resultID)),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	documentData, exists, err := s.scanFirstDocumentData(s.Store.Query(ctx, sqlf.Sprintf(locationsDocumentQuery, bundleID, path)))
+	filePath, err := s.documentationPathIDToFilePath(ctx, bundleID, pathID)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "documentationPathIDToFilePath")
+	}
+	if filePath == nil {
+		// The documentation result is not attached to a file, it cannot have references.
+		return nil, 0, nil
+	}
+
+	documentData, exists, err := s.scanFirstDocumentData(s.Store.Query(ctx, sqlf.Sprintf(locationsDocumentQuery, bundleID, filePath)))
 	if err != nil || !exists {
 		return nil, 0, err
 	}

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -191,7 +191,7 @@ SELECT
 	result_id,
 	path_id
 FROM
-	lsif_documentation_mappings
+	lsif_data_documentation_mappings
 WHERE
 	dump_id = %s AND
 	result_id = ANY (%s)
@@ -219,7 +219,7 @@ const documentationPathIDToIDQuery = `
 SELECT
 	result_id
 FROM
-	lsif_documentation_mappings
+	lsif_data_documentation_mappings
 WHERE
 	dump_id = %s AND
 	path_id = %s
@@ -262,7 +262,7 @@ const documentationPathIDToFilePathQuery = `
 SELECT
 	file_path
 FROM
-	lsif_documentation_mappings
+	lsif_data_documentation_mappings
 WHERE
 	dump_id = %s AND
 	path_id = %s

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -8,32 +8,33 @@ import (
 )
 
 type operations struct {
-	bulkMonikerResults         *observation.Operation
-	clear                      *observation.Operation
-	definitions                *observation.Operation
-	diagnostics                *observation.Operation
-	exists                     *observation.Operation
-	hover                      *observation.Operation
-	monikerResults             *observation.Operation
-	monikersByPosition         *observation.Operation
-	packageInformation         *observation.Operation
-	ranges                     *observation.Operation
-	references                 *observation.Operation
-	documentationPage          *observation.Operation
-	documentationPathInfo      *observation.Operation
-	documentationIDsToPathIDs  *observation.Operation
-	documentationPathIDToID    *observation.Operation
-	documentationDefinitions   *observation.Operation
-	documentationReferences    *observation.Operation
-	documentationAtPosition    *observation.Operation
-	writeDefinitions           *observation.Operation
-	writeDocuments             *observation.Operation
-	writeMeta                  *observation.Operation
-	writeReferences            *observation.Operation
-	writeResultChunks          *observation.Operation
-	writeDocumentationPages    *observation.Operation
-	writeDocumentationPathInfo *observation.Operation
-	writeDocumentationMappings *observation.Operation
+	bulkMonikerResults            *observation.Operation
+	clear                         *observation.Operation
+	definitions                   *observation.Operation
+	diagnostics                   *observation.Operation
+	exists                        *observation.Operation
+	hover                         *observation.Operation
+	monikerResults                *observation.Operation
+	monikersByPosition            *observation.Operation
+	packageInformation            *observation.Operation
+	ranges                        *observation.Operation
+	references                    *observation.Operation
+	documentationPage             *observation.Operation
+	documentationPathInfo         *observation.Operation
+	documentationIDsToPathIDs     *observation.Operation
+	documentationPathIDToID       *observation.Operation
+	documentationPathIDToFilePath *observation.Operation
+	documentationDefinitions      *observation.Operation
+	documentationReferences       *observation.Operation
+	documentationAtPosition       *observation.Operation
+	writeDefinitions              *observation.Operation
+	writeDocuments                *observation.Operation
+	writeMeta                     *observation.Operation
+	writeReferences               *observation.Operation
+	writeResultChunks             *observation.Operation
+	writeDocumentationPages       *observation.Operation
+	writeDocumentationPathInfo    *observation.Operation
+	writeDocumentationMappings    *observation.Operation
 
 	locations           *observation.Operation
 	locationsWithinFile *observation.Operation
@@ -65,32 +66,33 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		bulkMonikerResults:         op("BulkMonikerResults"),
-		clear:                      op("Clear"),
-		definitions:                op("Definitions"),
-		diagnostics:                op("Diagnostics"),
-		exists:                     op("Exists"),
-		hover:                      op("Hover"),
-		monikerResults:             op("MonikerResults"),
-		monikersByPosition:         op("MonikersByPosition"),
-		packageInformation:         op("PackageInformation"),
-		ranges:                     op("Ranges"),
-		references:                 op("References"),
-		documentationPage:          op("DocumentationPage"),
-		documentationPathInfo:      op("DocumentationPathInfo"),
-		documentationIDsToPathIDs:  op("DocumentationIDsToPathIDs"),
-		documentationPathIDToID:    op("DocumentationPathIDToID"),
-		documentationDefinitions:   op("DocumentationDefinitions"),
-		documentationReferences:    op("DocumentationReferences"),
-		documentationAtPosition:    op("DocumentationAtPosition"),
-		writeDefinitions:           op("WriteDefinitions"),
-		writeDocuments:             op("WriteDocuments"),
-		writeMeta:                  op("WriteMeta"),
-		writeReferences:            op("WriteReferences"),
-		writeResultChunks:          op("WriteResultChunks"),
-		writeDocumentationPages:    op("WriteDocumentationPages"),
-		writeDocumentationPathInfo: op("WriteDocumentationPathInfo"),
-		writeDocumentationMappings: op("WriteDocumentationMappings"),
+		bulkMonikerResults:            op("BulkMonikerResults"),
+		clear:                         op("Clear"),
+		definitions:                   op("Definitions"),
+		diagnostics:                   op("Diagnostics"),
+		exists:                        op("Exists"),
+		hover:                         op("Hover"),
+		monikerResults:                op("MonikerResults"),
+		monikersByPosition:            op("MonikersByPosition"),
+		packageInformation:            op("PackageInformation"),
+		ranges:                        op("Ranges"),
+		references:                    op("References"),
+		documentationPage:             op("DocumentationPage"),
+		documentationPathInfo:         op("DocumentationPathInfo"),
+		documentationIDsToPathIDs:     op("DocumentationIDsToPathIDs"),
+		documentationPathIDToID:       op("DocumentationPathIDToID"),
+		documentationPathIDToFilePath: op("DocumentationPathIDToFilePath"),
+		documentationDefinitions:      op("DocumentationDefinitions"),
+		documentationReferences:       op("DocumentationReferences"),
+		documentationAtPosition:       op("DocumentationAtPosition"),
+		writeDefinitions:              op("WriteDefinitions"),
+		writeDocuments:                op("WriteDocuments"),
+		writeMeta:                     op("WriteMeta"),
+		writeReferences:               op("WriteReferences"),
+		writeResultChunks:             op("WriteResultChunks"),
+		writeDocumentationPages:       op("WriteDocumentationPages"),
+		writeDocumentationPathInfo:    op("WriteDocumentationPathInfo"),
+		writeDocumentationMappings:    op("WriteDocumentationMappings"),
 
 		locations:           subOp("locations"),
 		locationsWithinFile: subOp("locationsWithinFile"),

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -69,6 +69,7 @@ Tracks the range of schema_versions for each upload in the lsif_data_definitions
  dump_id   | integer |           | not null | 
  path_id   | text    |           | not null | 
  result_id | integer |           | not null | 
+ file_path | text    |           |          | 
 Indexes:
     "lsif_data_documentation_mappings_pkey" PRIMARY KEY, btree (dump_id, path_id)
     "lsif_data_documentation_mappings_inverse_unique_idx" UNIQUE, btree (dump_id, result_id)
@@ -78,6 +79,8 @@ Indexes:
 Maps documentation path IDs to their corresponding integral documentationResult vertex IDs, which are unique within a dump.
 
 **dump_id**: The identifier of the associated dump in the lsif_uploads table (state=completed).
+
+**file_path**: The document file path for the documentationResult, if any. e.g. the path to the file where the symbol described by this documentationResult is located, if it is a symbol.
 
 **path_id**: The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.
 

--- a/lib/codeintel/lsif/conversion/group_documentation.go
+++ b/lib/codeintel/lsif/conversion/group_documentation.go
@@ -129,6 +129,18 @@ func collectDocumentation(ctx context.Context, state *State) documentationChanne
 		return channels
 	}
 
+	// Build a map of documentationResult IDs -> document IDs.
+	documentationResultIDToDocumentID := map[int]int{}
+	for documentID, _ := range state.DocumentData {
+		ranges := state.Contains.Get(documentID)
+		if ranges != nil {
+			ranges.Each(func(rangeID int) {
+				rn := state.RangeData[rangeID]
+				documentationResultIDToDocumentID[rn.DocumentationResultID] = documentID
+			})
+		}
+	}
+
 	pageCollector := &pageCollector{
 		numWorkers:                  32,
 		isChildPage:                 false,
@@ -137,6 +149,13 @@ func collectDocumentation(ctx context.Context, state *State) documentationChanne
 		startingDocumentationResult: state.DocumentationResultRoot,
 		dupChecker:                  &duplicateChecker{pathIDs: make(map[string]struct{}, 16*1024)},
 		walkedPages:                 &duplicateChecker{pathIDs: make(map[string]struct{}, 128)},
+		lookupFilepath: func(documentationResultID int) *string {
+			if documentID, ok := documentationResultIDToDocumentID[documentationResultID]; ok {
+				tmp := state.DocumentData[documentID]
+				return &tmp
+			}
+			return nil
+		},
 	}
 
 	tmpPages := make(chan *semantic.DocumentationPageData)
@@ -204,6 +223,7 @@ type pageCollector struct {
 	state                       *State
 	startingDocumentationResult int
 	dupChecker, walkedPages     *duplicateChecker
+	lookupFilepath              func(documentationResultID int) *string
 }
 
 func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.DocumentationPageData, mappings chan<- semantic.DocumentationMapping) (remainingPages []*pageCollector) {
@@ -244,6 +264,7 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 					mappings <- semantic.DocumentationMapping{
 						ResultID: uint64(documentationResult),
 						PathID:   this.PathID,
+						FilePath: p.lookupFilepath(documentationResult),
 					}
 					remainingPages = append(remainingPages, &pageCollector{
 						isChildPage:                 true,
@@ -252,6 +273,7 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 						startingDocumentationResult: documentationResult,
 						dupChecker:                  p.dupChecker,
 						walkedPages:                 p.walkedPages,
+						lookupFilepath:              p.lookupFilepath,
 					})
 				}
 				return
@@ -259,6 +281,7 @@ func (p *pageCollector) collect(ctx context.Context, ch chan<- *semantic.Documen
 				mappings <- semantic.DocumentationMapping{
 					ResultID: uint64(documentationResult),
 					PathID:   this.PathID,
+					FilePath: p.lookupFilepath(documentationResult),
 				}
 				parent.Children = append(parent.Children, semantic.DocumentationNodeChild{
 					Node: this,

--- a/lib/codeintel/lsif/conversion/group_documentation.go
+++ b/lib/codeintel/lsif/conversion/group_documentation.go
@@ -131,7 +131,7 @@ func collectDocumentation(ctx context.Context, state *State) documentationChanne
 
 	// Build a map of documentationResult IDs -> document IDs.
 	documentationResultIDToDocumentID := map[int]int{}
-	for documentID, _ := range state.DocumentData {
+	for documentID := range state.DocumentData {
 		ranges := state.Contains.Get(documentID)
 		if ranges != nil {
 			ranges.Each(func(rangeID int) {

--- a/lib/codeintel/semantic/types.go
+++ b/lib/codeintel/semantic/types.go
@@ -180,6 +180,10 @@ type DocumentationMapping struct {
 
 	// PathID is the path ID corresponding to the documentationResult vertex ID.
 	PathID string `json:"pathID"`
+
+	// The file path corresponding to the documentationResult vertex ID, or nil if there is no
+	// associated file.
+	FilePath *string `json:"filePath"`
 }
 
 // Package pairs a package name and the dump that provides it.

--- a/migrations/codeintel/1000000019_documentation_path_mapping.down.sql
+++ b/migrations/codeintel/1000000019_documentation_path_mapping.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE lsif_data_documentation_mappings DROP COLUMN file_path;
+
+COMMIT;

--- a/migrations/codeintel/1000000019_documentation_path_mapping.up.sql
+++ b/migrations/codeintel/1000000019_documentation_path_mapping.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+-- Add nullable file_path column, for mapping documentationResult ID -> file_path
+ALTER TABLE lsif_data_documentation_mappings ADD COLUMN file_path text;
+COMMENT ON COLUMN lsif_data_documentation_mappings.file_path IS 'The document file path for the documentationResult, if any. e.g. the path to the file where the symbol described by this documentationResult is located, if it is a symbol.';
+
+COMMIT;


### PR DESCRIPTION
Prior to this commit I had defined `documentationDefinitions` and `documentationReferences` on just `GitBlobLSIFData`, but that requires you have a specific file path you're interested in. A more common case will be having a documentation path ID - and not having a file path at all - and wanting to know the references/definition locations from that.

I've implemented this here by defining it on `TreeEntryLSIFData`, alongside the other path-relative resolvers: `documentationPage` and `documentationPathInfo`.

Helps #21932