### PR TITLE
search: Add operators to search reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Code Insights background queries now process in a priority order backwards through time. This will allow insights to populate concurrently. [#23101](https://github.com/sourcegraph/sourcegraph/pull/23101)
+- Operator documentation has been added to the Search Reference sidebar section. [#23116]https://github.com/sourcegraph/sourcegraph/pull/23116)
 
 ### Changed
 

--- a/client/web/src/search/results/sidebar/SearchReference.module.scss
+++ b/client/web/src/search/results/sidebar/SearchReference.module.scss
@@ -64,6 +64,10 @@
     > :last-child {
         margin-bottom: 0;
     }
+
+    p > code {
+        white-space: break-spaces;
+    }
 }
 
 .placeholder {

--- a/client/web/src/search/results/sidebar/SearchReference.test.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.test.tsx
@@ -5,7 +5,7 @@ import { FILTERS, FilterType } from '@sourcegraph/shared/src/search/query/filter
 
 import { QueryChangeSource, QueryState } from '../../helpers'
 
-import { parsePlaceholder, updateQueryWithFilter } from './SearchReference'
+import { FilterInfo, parsePlaceholder, updateQueryWithFilter } from './SearchReference'
 
 /**
  * Automatically sets cursor position and selections from example query.
@@ -39,7 +39,7 @@ function queryStateFromExample(query: string, showSuggestions = false): QuerySta
     }
 }
 
-function createSearchReference(type: FilterType, placeholder: string) {
+function createFilterInfo(type: FilterType, placeholder: string): FilterInfo {
     return {
         type,
         placeholder: parsePlaceholder(placeholder),
@@ -50,14 +50,14 @@ function createSearchReference(type: FilterType, placeholder: string) {
 describe('repeatable filters', () => {
     it('appends placeholder filter and selects placeholder', () => {
         assert.deepStrictEqual(
-            updateQueryWithFilter({ query: 'foo' }, createSearchReference(FilterType.after, '{test}'), false, FILTERS),
+            updateQueryWithFilter({ query: 'foo' }, createFilterInfo(FilterType.after, '{test}'), false, FILTERS),
             queryStateFromExample('foo {after:[test]}')
         )
     })
 
     it('appends suggestions filter', () => {
         assert.deepStrictEqual(
-            updateQueryWithFilter({ query: 'foo' }, createSearchReference(FilterType.lang, '{lang}'), false, FILTERS),
+            updateQueryWithFilter({ query: 'foo' }, createFilterInfo(FilterType.lang, '{lang}'), false, FILTERS),
             queryStateFromExample('foo {lang:[]}', true)
         )
     })
@@ -66,12 +66,7 @@ describe('repeatable filters', () => {
 describe('unique filters', () => {
     it('appends placeholder filter and selects placeholder', () => {
         assert.deepStrictEqual(
-            updateQueryWithFilter(
-                { query: 'foo' },
-                createSearchReference(FilterType.repogroup, '{test}'),
-                false,
-                FILTERS
-            ),
+            updateQueryWithFilter({ query: 'foo' }, createFilterInfo(FilterType.repogroup, '{test}'), false, FILTERS),
             queryStateFromExample('foo {repogroup:[test]}')
         )
     })
@@ -80,7 +75,7 @@ describe('unique filters', () => {
         assert.deepStrictEqual(
             updateQueryWithFilter(
                 { query: 'repogroup:value foo' },
-                createSearchReference(FilterType.repogroup, '{test}'),
+                createFilterInfo(FilterType.repogroup, '{test}'),
                 false,
                 FILTERS
             ),
@@ -90,7 +85,7 @@ describe('unique filters', () => {
 
     it('appends suggestions filter', () => {
         assert.deepStrictEqual(
-            updateQueryWithFilter({ query: 'foo' }, createSearchReference(FilterType.case, '{test}'), false, FILTERS),
+            updateQueryWithFilter({ query: 'foo' }, createFilterInfo(FilterType.case, '{test}'), false, FILTERS),
             queryStateFromExample('foo {case:[]}', true)
         )
     })
@@ -99,7 +94,7 @@ describe('unique filters', () => {
         assert.deepStrictEqual(
             updateQueryWithFilter(
                 { query: 'case:yes foo' },
-                createSearchReference(FilterType.case, '{test}'),
+                createFilterInfo(FilterType.case, '{test}'),
                 false,
                 FILTERS
             ),

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -258,7 +258,7 @@ const operatorInfo: OperatorInfo[] = [
     {
         operator: 'AND',
         alias: 'and',
-        placeholder: parsePlaceholder('{a} AND {b}'),
+        placeholder: parsePlaceholder('{expr} AND {expr}'),
         description:
             'Returns results for files containing matches on the left and right side of the `and` (set intersection).',
         examples: ['conf.Get( and log15.Error(', 'conf.Get( AND log15.Error( AND after'],
@@ -266,7 +266,7 @@ const operatorInfo: OperatorInfo[] = [
     {
         operator: 'OR',
         alias: 'or',
-        placeholder: parsePlaceholder('{a} OR {b}'),
+        placeholder: parsePlaceholder('({expr} OR {expr})'),
         description:
             'Returns file content matching either on the left or right side, or both (set union). The number of results reports the number of matches of both strings.',
         examples: ['conf.Get( or log15.Error(', 'conf.Get( OR log15.Error( OR after'],
@@ -274,9 +274,9 @@ const operatorInfo: OperatorInfo[] = [
     {
         operator: 'NOT',
         alias: 'not',
-        placeholder: parsePlaceholder('NOT {a}'),
+        placeholder: parsePlaceholder('NOT {expr}'),
         description:
-            '`NOT` can be used in place of `-` to negate keywords, such as `file`, `content`, `lang`, `repohasfile`, and `repo`. For search patterns, `NOT` excludes documents that contain the term after `NOT`. For readability, you can also include the `AND` operator before a `NOT` (i.e. `panic NOT ever` is equivalent to `panic AND NOT ever`).',
+            '`NOT` can be prepended to negate filters like `file`, `lang`, `repo`. Prepending `NOT` to search patterns excludes documents that contain the pattern. For readability, you may use `NOT` in conjunction with `AND` if you like: `panic AND NOT ever`.',
         examples: ['lang:go not file:main.go panic', 'panic NOT ever'],
     },
 ]
@@ -452,6 +452,7 @@ interface SearchReferenceExampleProps {
 const SearchReferenceExample: React.FunctionComponent<SearchReferenceExampleProps> = ({ example, onClick }) => {
     // All current examples are literal queries
     const scanResult = scanSearchQuery(example, false, SearchPatternType.literal)
+    console.log(scanResult)
     // We only use valid queries as examples, so this will always be true
     if (scanResult.type === 'success') {
         return (
@@ -466,14 +467,7 @@ const SearchReferenceExample: React.FunctionComponent<SearchReferenceExampleProp
                                 </React.Fragment>
                             )
                         case 'keyword':
-                            // We are using example.slice instead of term.value
-                            // to get the actual character sequence in the
-                            // example. term.value doesn't preserve case
-                            return (
-                                <span className="search-filter-keyword">
-                                    {example.slice(term.range.start, term.range.end)}
-                                </span>
-                            )
+                            return <span className="search-filter-keyword">{term.value}</span>
                         default:
                             return example.slice(term.range.start, term.range.end)
                     }

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -268,7 +268,7 @@ const operatorInfo: OperatorInfo[] = [
         alias: 'or',
         placeholder: parsePlaceholder('{a} OR {b}'),
         description:
-            'Returns file content matching either on the left or right side, or both (set union). The number of results reports the number of matches of both strings. Note the regex or operator `|` may not work as expected with certain operators for example `file:(internal/repos)|(internal/gitserver)`, to recieve the expected results use [subexpressions](https://docs.sourcegraph.com/code_search/tutorials/search_subexpressions), `(file:internal/repos or file:internal/gitserver)`',
+            'Returns file content matching either on the left or right side, or both (set union). The number of results reports the number of matches of both strings.',
         examples: ['conf.Get( or log15.Error(', 'conf.Get( OR log15.Error( OR after'],
     },
     {


### PR DESCRIPTION
I refactored the types so that `SearchReferenceEntry` can work with both kinds of entries. I decided to use two separate types since the information is slightly different. I'm not sure it's worth the effort to consolidate them into a single one, but I'm open to suggestions.

<img width="214" alt="2021-07-23_14-27" src="https://user-images.githubusercontent.com/179026/126796824-c836c4a8-fb54-4dd3-b8e5-f15f7a503e45.png">

![2021-07-21_15-15](https://user-images.githubusercontent.com/179026/126602887-2ea293a7-0fec-4d41-aa45-8640031863cc.png)
