### PR TITLE
search: split global indexed search in public/private queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -21,11 +21,13 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -1443,6 +1445,15 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	// search results with resolved repos.
 	if args.Mode == search.ZoektGlobalSearch {
 		argsIndexed := *args
+
+		// Get all private repos that are accessible by the current actor.
+		if res, err := database.Repos(r.db).ListRepoNames(ctx, database.ReposListOptions{
+			OnlyPrivate: true,
+			LimitOffset: &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},
+		}); err == nil {
+			argsIndexed.UserPrivateRepos = res
+		}
+
 		wg := waitGroup(true)
 		wg.Add(1)
 		goroutine.Go(func() {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1450,7 +1450,9 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		if res, err := database.Repos(r.db).ListRepoNames(ctx, database.ReposListOptions{
 			OnlyPrivate: true,
 			LimitOffset: &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},
-		}); err == nil {
+		}); err != nil {
+			tr.LazyPrintf("error resolving private repos: %v", err)
+		} else {
 			argsIndexed.UserPrivateRepos = res
 		}
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -523,6 +523,9 @@ func TestSearchResultsHydration(t *testing.T) {
 	}
 
 	database.Mocks.Repos.ListRepoNames = func(_ context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
+		if op.OnlyPrivate {
+			return nil, nil
+		}
 		return []types.RepoName{{ID: repoWithIDs.ID, Name: repoWithIDs.Name}}, nil
 	}
 	database.Mocks.Repos.Count = mockCount

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -78,9 +78,12 @@ func TestSearchSuggestions(t *testing.T) {
 		mockDecodedViewerFinalSettings = &schema.Settings{}
 		defer func() { mockDecodedViewerFinalSettings = nil }()
 
+		mu := sync.Mutex{}
 		var calledReposListNamesAll, calledReposListFoo bool
-		database.Mocks.Repos.ListRepoNames = func(_ context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
 
+		database.Mocks.Repos.ListRepoNames = func(_ context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
+			mu.Lock()
+			defer mu.Unlock()
 			if reflect.DeepEqual(op.IncludePatterns, []string{"foo"}) {
 				// when treating term as repo: field
 				calledReposListFoo = true

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -162,6 +162,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer pingTicker.Stop()
 
 	first := true
+	lastID := api.RepoID(-1)
 
 	for {
 		var event streaming.SearchEvent
@@ -195,6 +196,16 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		repoMetadata := h.getEventRepoMetadata(ctx, event)
 		for _, match := range event.Results {
+			// Don't send matches which we cannot map to a repo the actor has access to. This
+			// check is expected to always pass. Missing metadata is a sign that we have
+			// searched repos that user shouldn't have access to.
+			if _, ok = repoMetadata[match.RepoName().ID]; !ok {
+				if thisID := match.RepoName().ID; thisID != lastID {
+					lastID = thisID
+					log15.Warn("unexpected missing metadata for repository with ID %d. Results for this repository will be dropped.", thisID)
+				}
+				continue
+			}
 			matchesAppend(fromMatch(match, repoMetadata))
 		}
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -162,7 +162,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer pingTicker.Stop()
 
 	first := true
-	lastID := api.RepoID(-1)
 
 	for {
 		var event streaming.SearchEvent
@@ -200,10 +199,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// check is expected to always pass. Missing metadata is a sign that we have
 			// searched repos that user shouldn't have access to.
 			if _, ok = repoMetadata[match.RepoName().ID]; !ok {
-				if thisID := match.RepoName().ID; thisID != lastID {
-					lastID = thisID
-					log15.Warn("unexpected missing metadata for repository with ID %d. Results for this repository will be dropped.", thisID)
-				}
 				continue
 			}
 			matchesAppend(fromMatch(match, repoMetadata))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -198,7 +198,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// Don't send matches which we cannot map to a repo the actor has access to. This
 			// check is expected to always pass. Missing metadata is a sign that we have
 			// searched repos that user shouldn't have access to.
-			if _, ok = repoMetadata[match.RepoName().ID]; !ok {
+			if md, ok := repoMetadata[match.RepoName().ID]; !ok || md.Name != match.RepoName().Name {
 				continue
 			}
 			matchesAppend(fromMatch(match, repoMetadata))

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -136,10 +137,12 @@ type TextParameters struct {
 	ResultTypes result.Types
 	Timeout     time.Duration
 
-	// Performance optimization: For global queries, resolving repositories and
-	// querying zoekt happens concurrently.
+	// deprecated
 	RepoPromise *RepoPromise
-	Mode        GlobalSearchMode
+
+	// perf: For global queries, we only resolve private repos.
+	UserPrivateRepos []types.RepoName
+	Mode             GlobalSearchMode
 
 	// Query is the parsed query from the user. You should be using Pattern
 	// instead, but Query is useful for checking extra fields that are set and

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -347,8 +347,6 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 		apply(zoektquery.RcNoForks, args.RepoOptions.NoForks)
 
 		g.Go(func() error {
-			// Copy context to avoid duplicate span IDs in tracing.
-			ctx := ctx
 			return doZoektSearchGlobal(ctx, zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc, query), args, typ, c)
 		})
 	}
@@ -362,7 +360,6 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 		}
 
 		g.Go(func() error {
-			ctx := ctx
 			return doZoektSearchGlobal(ctx, zoektquery.NewAnd(&zoektquery.RepoBranches{Set: privateRepoSet}, query), args, typ, c)
 		})
 	}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -311,13 +311,13 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 
 // zoektSearchGlobal searches the entire universe of indexed repositories.
 //
+// We send 2 queries to Zoekt. One query for public repos and one query for
+// private repos.
+//
 // We only have to search "HEAD", because global queries, per definition, don't
 // have a repo: filter and consequently no rev: filter. This makes the code a bit
 // simpler because we don't have to resolve revisions before sending off (global)
 // requests to Zoekt.
-//
-// We send 2 queries to Zoekt. One query for public repos and one query for
-// private repos
 func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query zoektquery.Q, typ IndexedRequestType, since func(t time.Time) time.Duration, c streaming.Sender) error {
 	if args == nil {
 		return nil
@@ -358,11 +358,11 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 		for _, r := range args.UserPrivateRepos {
 			privateRepoSet[string(r.Name)] = head
 		}
+
 		g.Go(func() error {
 			return doZoektSearchGlobal(ctx, zoektquery.NewAnd(&zoektquery.RepoBranches{Set: privateRepoSet}, query), args, typ, c)
 		})
 	}
-
 	return g.Wait()
 }
 
@@ -419,7 +419,6 @@ func doZoektSearchGlobal(ctx context.Context, q zoektquery.Q, args *search.TextP
 			return repo, []string{""}, true
 		}, typ, c)
 	}))
-
 }
 
 // zoektSearch searches repositories using zoekt.

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -310,10 +310,19 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 }
 
 // zoektSearchGlobal searches the entire universe of indexed repositories.
+//
+// We only have to search "HEAD", because global queries, per definition, don't
+// have a repo: filter and consequently no rev: filter. This makes the code a bit
+// simpler because we don't have to resolve revisions before sending off (global)
+// requests to Zoekt.
+//
+// We send 2 queries to Zoekt. One query for public repos and one query for
+// private repos
 func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query zoektquery.Q, typ IndexedRequestType, since func(t time.Time) time.Duration, c streaming.Sender) error {
 	if args == nil {
 		return nil
 	}
+
 	if args.Mode != search.ZoektGlobalSearch {
 		return fmt.Errorf("zoektSearchGlobal called with args.Mode %d instead of %d", args.Mode, search.ZoektGlobalSearch)
 	}
@@ -321,116 +330,96 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	finalQuery := zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, query)
+	var queries []zoektquery.Q
+
+	// Public
+	if !args.RepoOptions.OnlyPrivate {
+		rc := zoektquery.RcOnlyPublic
+		apply := func(f zoektquery.RawConfig, b bool) {
+			if !b {
+				return
+			}
+			rc |= f
+		}
+		apply(zoektquery.RcOnlyArchived, args.RepoOptions.OnlyArchived)
+		apply(zoektquery.RcNoArchived, args.RepoOptions.NoArchived)
+		apply(zoektquery.RcOnlyForks, args.RepoOptions.OnlyForks)
+		apply(zoektquery.RcNoForks, args.RepoOptions.NoForks)
+
+		queries = append(queries, zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc, query))
+	}
+
+	// Private
+	if !args.RepoOptions.OnlyPublic && len(args.UserPrivateRepos) > 0 {
+		privateRepoSet := make(map[string][]string, len(args.UserPrivateRepos))
+		head := []string{"HEAD"}
+		for _, r := range args.UserPrivateRepos {
+			privateRepoSet[string(r.Name)] = head
+		}
+		queries = append(queries, zoektquery.NewAnd(&zoektquery.RepoBranches{Set: privateRepoSet}, query))
+	}
+
 	k := ResultCountFactor(0, args.PatternInfo.FileMatchLimit, true)
 	searchOpts := SearchOpts(ctx, k, args.PatternInfo)
 
-	// Start event stream.
-	t0 := time.Now()
-
-	// We use reposResolved to synchronize repo resolution and event processing.
-	reposResolved := make(chan struct{})
-	var getRepoInputRev repoRevFunc
-	var repoRevMap map[api.RepoID]*search.RepositoryRevisions
+	if deadline, ok := ctx.Deadline(); ok {
+		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
+		searchOpts.MaxWallTime = time.Until(deadline)
+		if searchOpts.MaxWallTime < 0 {
+			return ctx.Err()
+		}
+		// We don't want our context's deadline to cut off zoekt so that we can get the results
+		// found before the deadline.
+		//
+		// We'll create a new context that gets cancelled if the other context is cancelled for any
+		// reason other than the deadline being exceeded. This essentially means the deadline for the new context
+		// will be `deadline + time for zoekt to cancel + network latency`.
+		var cancel context.CancelFunc
+		ctx, cancel = contextWithoutDeadline(ctx)
+		defer cancel()
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
-		defer close(reposResolved)
-		repos, err := args.RepoPromise.Get(ctx)
-		if err != nil {
-			return err
-		}
-		repoRevMap = make(map[api.RepoID]*search.RepositoryRevisions, len(repos))
-		for _, r := range repos {
-			repoRevMap[r.Repo.ID] = r
-		}
-		getRepoInputRev = func(file *zoekt.FileMatch) (repo types.RepoName, revs []string, ok bool) {
-			if repoRev, ok := repoRevMap[api.RepoID(file.RepositoryID)]; ok {
-				return repoRev.Repo, repoRev.RevSpecs(), true
-			}
-			return types.RepoName{}, nil, false
-		}
-		return nil
-	})
-
-	foundResults := atomic.Bool{}
-	g.Go(func() error {
-		ctx := ctx
-		if deadline, ok := ctx.Deadline(); ok {
-			// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
-			searchOpts.MaxWallTime = time.Until(deadline)
-			if searchOpts.MaxWallTime < 0 {
-				return ctx.Err()
-			}
-			// We don't want our context's deadline to cut off zoekt so that we can get the results
-			// found before the deadline.
-			//
-			// We'll create a new context that gets cancelled if the other context is cancelled for any
-			// reason other than the deadline being exceeded. This essentially means the deadline for the new context
-			// will be `deadline + time for zoekt to cancel + network latency`.
-			var cancel context.CancelFunc
-			ctx, cancel = contextWithoutDeadline(ctx)
-			defer cancel()
-		}
-
-		// PERF: if we are going to be selecting to repo results only anyways, we can just ask
-		// zoekt for only results of type repo.
-		if args.PatternInfo.Select.Root() == filter.Repository {
-			return zoektSearchReposOnly(ctx, args.Zoekt.Client, finalQuery, c, func() map[api.RepoID]*search.RepositoryRevisions {
-				<-reposResolved
-				// getRepoInputRev is nil only if we encountered an error during repo resolution.
-				if getRepoInputRev == nil {
-					return nil
+	for _, q := range queries {
+		q2 := q
+		g.Go(func() error {
+			// PERF: if we are going to be selecting to repo results only anyways, we can
+			// just ask zoekt for only results of type repo.
+			if args.PatternInfo.Select.Root() == filter.Repository {
+				repoList, err := args.Zoekt.Client.List(ctx, q2, nil)
+				if err != nil {
+					return err
 				}
-				return repoRevMap
-			})
-		}
 
-		// The buffered backend.ZoektStreamFunc allows us to consume events from Zoekt
-		// while we wait for repo resolution.
-		bufSender, cleanup := bufferedSender(240, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
-			foundResults.CAS(false, event.FileCount != 0 || event.MatchCount != 0)
+				matches := make([]result.Match, 0, len(repoList.Repos))
+				for _, repo := range repoList.Repos {
+					matches = append(matches, &result.RepoMatch{
+						Name: api.RepoName(repo.Repository.Name),
+						ID:   api.RepoID(repo.Repository.ID),
+					})
+				}
 
-			files := event.Files
-			limitHit := event.FilesSkipped+event.ShardsSkipped > 0
-
-			if len(files) == 0 {
 				c.Send(streaming.SearchEvent{
-					Stats: streaming.Stats{IsLimitHit: limitHit},
+					Results: matches,
+					Stats:   streaming.Stats{}, // TODO
 				})
-				return
+				return nil
 			}
 
-			<-reposResolved
-			// getRepoInputRev is nil only if we encountered an error during repo resolution.
-			if getRepoInputRev == nil {
-				return
-			}
-
-			sendMatches(files, getRepoInputRev, typ, c, limitHit)
-		}))
-		defer cleanup()
-
-		return args.Zoekt.Client.StreamSearch(ctx, finalQuery, &searchOpts, bufSender)
-	})
-
-	if err := g.Wait(); err != nil {
-		return err
+			return args.Zoekt.Client.StreamSearch(ctx, q2, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+				sendMatches(event, func(file *zoekt.FileMatch) (types.RepoName, []string, bool) {
+					repo := types.RepoName{
+						ID:   api.RepoID(file.RepositoryID),
+						Name: api.RepoName(file.Repository),
+					}
+					return repo, []string{""}, true
+				}, typ, c)
+			}))
+		})
 	}
 
-	if !foundResults.Load() && since(t0) >= searchOpts.MaxWallTime {
-		var statusMap search.RepoStatusMap
-		repos, err := args.RepoPromise.Get(ctx)
-		if err != nil {
-			return nil
-		}
-		for _, r := range repos {
-			statusMap.Update(r.Repo.ID, search.RepoStatusTimedout)
-		}
-		c.Send(streaming.SearchEvent{Stats: streaming.Stats{Status: statusMap}})
-	}
-	return nil
+	return g.Wait()
 }
 
 // zoektSearch searches repositories using zoekt.
@@ -490,21 +479,10 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, q zoektquery.
 	foundResults := atomic.Bool{}
 	err := args.Zoekt.Client.StreamSearch(ctx, finalQuery, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 		foundResults.CAS(false, event.FileCount != 0 || event.MatchCount != 0)
-
-		files := event.Files
-		limitHit := event.FilesSkipped+event.ShardsSkipped > 0
-
-		if len(files) == 0 {
-			c.Send(streaming.SearchEvent{
-				Stats: streaming.Stats{IsLimitHit: limitHit},
-			})
-			return
-		}
-
-		sendMatches(files, func(file *zoekt.FileMatch) (types.RepoName, []string, bool) {
+		sendMatches(event, func(file *zoekt.FileMatch) (types.RepoName, []string, bool) {
 			repo, inputRevs := repos.getRepoInputRev(file)
 			return repo, inputRevs, true
-		}, typ, c, limitHit)
+		}, typ, c)
 	}))
 	if err != nil {
 		return err
@@ -524,7 +502,17 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, q zoektquery.
 	return nil
 }
 
-func sendMatches(files []zoekt.FileMatch, getRepoInputRev repoRevFunc, typ IndexedRequestType, c streaming.Sender, limitHit bool) {
+func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ IndexedRequestType, c streaming.Sender) {
+	files := event.Files
+	limitHit := event.FilesSkipped+event.ShardsSkipped > 0
+
+	if len(files) == 0 {
+		c.Send(streaming.SearchEvent{
+			Stats: streaming.Stats{IsLimitHit: limitHit},
+		})
+		return
+	}
+
 	matches := make([]result.Match, 0, len(files))
 	for _, file := range files {
 		repo, inputRevs, ok := getRepoInputRev(&file)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -347,6 +347,7 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 		apply(zoektquery.RcNoForks, args.RepoOptions.NoForks)
 
 		g.Go(func() error {
+			// Copy context to avoid duplicate span IDs in tracing.
 			ctx := ctx
 			return doZoektSearchGlobal(ctx, zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc, query), args, typ, c)
 		})

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -318,7 +318,7 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 // have a repo: filter and consequently no rev: filter. This makes the code a bit
 // simpler because we don't have to resolve revisions before sending off (global)
 // requests to Zoekt.
-func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query zoektquery.Q, typ IndexedRequestType, since func(t time.Time) time.Duration, c streaming.Sender) error {
+func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query zoektquery.Q, typ IndexedRequestType, c streaming.Sender) error {
 	if args == nil {
 		return nil
 	}
@@ -430,7 +430,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, q zoektquery.
 	}
 
 	if args.Mode == search.ZoektGlobalSearch {
-		return zoektSearchGlobal(ctx, args, q, typ, since, c)
+		return zoektSearchGlobal(ctx, args, q, typ, c)
 	}
 
 	if len(repos.repoRevs) == 0 {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -347,6 +347,7 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 		apply(zoektquery.RcNoForks, args.RepoOptions.NoForks)
 
 		g.Go(func() error {
+			ctx := ctx
 			return doZoektSearchGlobal(ctx, zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc, query), args, typ, c)
 		})
 	}
@@ -360,6 +361,7 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 		}
 
 		g.Go(func() error {
+			ctx := ctx
 			return doZoektSearchGlobal(ctx, zoektquery.NewAnd(&zoektquery.RepoBranches{Set: privateRepoSet}, query), args, typ, c)
 		})
 	}


### PR DESCRIPTION
This changes how we query Zoekt for global searches. Instead of querying
the entire universe of indexed repos with 1 query and filtering the
results based on resolved repos, we send 2 queries: (1) a query
targeting all public repos (2) a query targeting all user accessible
private repos.

This has following advantages

1. We can skip repo resolution and filtering for query (1).
2. Query (2) will usually target a small subset of all repositories
which makes querying and filtering fast.

However, without repo resolution we don't validate the results coming
back from Zoekt, which could potentially lead to issues if the IDs and
repo names in Zoekt are out of sync with Sourcegraph. To guard against
this, we drop results if we fail to match them against repositories
during metadata hydration.