### PR TITLE
Don't limit maximum number of dequeued jobs

### DIFF
--- a/enterprise/cmd/executor-queue/config.go
+++ b/enterprise/cmd/executor-queue/config.go
@@ -11,7 +11,6 @@ type Config struct {
 	env.BaseConfig
 
 	Port                       int
-	MaximumNumTransactions     int
 	JobRequeueDelay            time.Duration
 	JobCleanupInterval         time.Duration
 	MaximumNumMissedHeartbeats int
@@ -19,7 +18,6 @@ type Config struct {
 
 func (c *Config) Load() {
 	c.Port = c.GetInt("EXECUTOR_QUEUE_API_PORT", "3191", "The port to listen on.")
-	c.MaximumNumTransactions = c.GetInt("EXECUTOR_QUEUE_MAXIMUM_NUM_TRANSACTIONS", "10", "Number of jobs that can be processing at one time.")
 	c.JobRequeueDelay = c.GetInterval("EXECUTOR_QUEUE_JOB_REQUEUE_DELAY", "1m", "The requeue delay of jobs assigned to an unreachable executor.")
 	c.JobCleanupInterval = c.GetInterval("EXECUTOR_QUEUE_JOB_CLEANUP_INTERVAL", "10s", "Interval between cleanup runs.")
 	c.MaximumNumMissedHeartbeats = c.GetInt("EXECUTOR_QUEUE_MAXIMUM_NUM_MISSED_HEARTBEATS", "5", "The number of heartbeats an executor must miss to be considered unreachable.")
@@ -27,12 +25,11 @@ func (c *Config) Load() {
 
 func (c *Config) ServerOptions(queueOptions map[string]apiserver.QueueOptions) apiserver.Options {
 	return apiserver.Options{
-		Port:                   c.Port,
-		QueueOptions:           queueOptions,
-		MaximumNumTransactions: c.MaximumNumTransactions,
-		RequeueDelay:           c.JobRequeueDelay,
-		UnreportedMaxAge:       c.JobCleanupInterval * time.Duration(c.MaximumNumMissedHeartbeats),
-		DeathThreshold:         c.JobCleanupInterval * time.Duration(c.MaximumNumMissedHeartbeats),
-		CleanupInterval:        c.JobCleanupInterval,
+		Port:             c.Port,
+		QueueOptions:     queueOptions,
+		RequeueDelay:     c.JobRequeueDelay,
+		UnreportedMaxAge: c.JobCleanupInterval * time.Duration(c.MaximumNumMissedHeartbeats),
+		DeathThreshold:   c.JobCleanupInterval * time.Duration(c.MaximumNumMissedHeartbeats),
+		CleanupInterval:  c.JobCleanupInterval,
 	}
 }

--- a/enterprise/cmd/executor-queue/internal/server/handler.go
+++ b/enterprise/cmd/executor-queue/internal/server/handler.go
@@ -17,12 +17,11 @@ import (
 )
 
 type handler struct {
-	options          Options
-	clock            glock.Clock
-	executors        map[string]*executorMeta
-	dequeueSemaphore chan struct{} // tracks available dequeue slots
-	m                sync.Mutex    // protects executors
-	queueMetrics     *QueueMetrics
+	options      Options
+	clock        glock.Clock
+	executors    map[string]*executorMeta
+	m            sync.Mutex // protects executors
+	queueMetrics *QueueMetrics
 }
 
 type Options struct {
@@ -31,11 +30,6 @@ type Options struct {
 
 	// QueueOptions is a map from queue name to options specific to that queue.
 	QueueOptions map[string]QueueOptions
-
-	// MaximumNumTransactions is the maximum number of active records that can be given out
-	// to executors from this machine. The dequeue method will stop returning records while
-	// the number of outstanding transactions is at or above this threshold.
-	MaximumNumTransactions int
 
 	// RequeueDelay controls how far into the future to make a job record visible to the job
 	// queue once the currently processing executor has become unresponsive.
@@ -80,17 +74,11 @@ func newHandler(options Options, clock glock.Clock) *handler {
 }
 
 func newHandlerWithMetrics(options Options, clock glock.Clock, observationContext *observation.Context) *handler {
-	dequeueSemaphore := make(chan struct{}, options.MaximumNumTransactions)
-	for i := 0; i < options.MaximumNumTransactions; i++ {
-		dequeueSemaphore <- struct{}{}
-	}
-
 	return &handler{
-		options:          options,
-		clock:            clock,
-		dequeueSemaphore: dequeueSemaphore,
-		executors:        map[string]*executorMeta{},
-		queueMetrics:     newQueueMetrics(observationContext),
+		options:      options,
+		clock:        clock,
+		executors:    map[string]*executorMeta{},
+		queueMetrics: newQueueMetrics(observationContext),
 	}
 }
 
@@ -107,20 +95,6 @@ func (m *handler) dequeue(ctx context.Context, queueName, executorName, executor
 	if !ok {
 		return apiclient.Job{}, false, ErrUnknownQueue
 	}
-
-	select {
-	case <-m.dequeueSemaphore:
-	default:
-		return apiclient.Job{}, false, nil
-	}
-	defer func() {
-		if !dequeued {
-			// Ensure that if we do not dequeue a record successfully we do not
-			// leak from the semaphore. This will happen if the dequeue call fails
-			// or if there are no records to process
-			m.dequeueSemaphore <- struct{}{}
-		}
-	}()
 
 	record, dequeued, err := queueOptions.Store.Dequeue(context.Background(), executorHostname, nil)
 	if err != nil {
@@ -177,7 +151,6 @@ func (m *handler) markComplete(ctx context.Context, queueName, executorName stri
 		return err
 	}
 
-	defer func() { m.dequeueSemaphore <- struct{}{} }()
 	_, err = queueOptions.Store.MarkComplete(ctx, job.record.RecordID())
 	return err
 }
@@ -195,7 +168,6 @@ func (m *handler) markErrored(ctx context.Context, queueName, executorName strin
 		return err
 	}
 
-	defer func() { m.dequeueSemaphore <- struct{}{} }()
 	_, err = queueOptions.Store.MarkErrored(ctx, job.record.RecordID(), errorMessage)
 	return err
 }
@@ -213,7 +185,6 @@ func (m *handler) markFailed(ctx context.Context, queueName, executorName string
 		return err
 	}
 
-	defer func() { m.dequeueSemaphore <- struct{}{} }()
 	_, err = queueOptions.Store.MarkFailed(ctx, job.record.RecordID(), errorMessage)
 	return err
 }

--- a/enterprise/cmd/executor-queue/internal/server/lifecycle.go
+++ b/enterprise/cmd/executor-queue/internal/server/lifecycle.go
@@ -121,6 +121,5 @@ func (h *handler) requeueJob(ctx context.Context, job jobMeta) error {
 		return ErrUnknownQueue
 	}
 
-	defer func() { h.dequeueSemaphore <- struct{}{} }()
 	return queueOptions.Store.Requeue(ctx, job.record.RecordID(), h.clock.Now().Add(h.options.RequeueDelay))
 }

--- a/enterprise/cmd/executor-queue/internal/server/lifecycle_test.go
+++ b/enterprise/cmd/executor-queue/internal/server/lifecycle_test.go
@@ -30,8 +30,7 @@ func TestHeartbeat(t *testing.T) {
 			"q1": {Store: store1, RecordTransformer: recordTransformer},
 			"q2": {Store: store2, RecordTransformer: recordTransformer},
 		},
-		MaximumNumTransactions: 10,
-		UnreportedMaxAge:       time.Second,
+		UnreportedMaxAge: time.Second,
 	}
 	clock := glock.NewMockClock()
 	handler := newHandler(options, clock)
@@ -111,8 +110,7 @@ func TestCleanup(t *testing.T) {
 			"q1": {Store: store1, RecordTransformer: recordTransformer},
 			"q2": {Store: store2, RecordTransformer: recordTransformer},
 		},
-		MaximumNumTransactions: 10,
-		DeathThreshold:         time.Minute * 5,
+		DeathThreshold: time.Minute * 5,
 	}
 	clock := glock.NewMockClock()
 	handler := newHandler(options, clock)


### PR DESCRIPTION
This was only a problem because previously each dequeued job was consuming one database connection, which we don't have anymore. This allows way more jobs to run in parallel. In a follow-up refactor, the memory requirements for jobs will also go down even further.
