### PR TITLE
Continuously update executor log entries instead of writing at end

### DIFF
--- a/enterprise/cmd/executor-queue/internal/server/handler_test.go
+++ b/enterprise/cmd/executor-queue/internal/server/handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	workerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	workerstoremocks "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store/mocks"
 )
 
@@ -69,6 +70,8 @@ func TestAddExecutionLogEntry(t *testing.T) {
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
+	fakeEntryID := 99
+	store.AddExecutionLogEntryFunc.SetDefaultReturn(fakeEntryID, nil)
 
 	handler := newHandler(QueueOptions{Store: store, RecordTransformer: recordTransformer})
 
@@ -84,8 +87,12 @@ func TestAddExecutionLogEntry(t *testing.T) {
 		Command: []string{"ls", "-a"},
 		Out:     "<log payload>",
 	}
-	if err := handler.addExecutionLogEntry(context.Background(), "deadbeef", job.ID, entry); err != nil {
+	haveEntryID, err := handler.addExecutionLogEntry(context.Background(), "deadbeef", job.ID, entry)
+	if err != nil {
 		t.Fatalf("unexpected error updating log contents: %s", err)
+	}
+	if haveEntryID != fakeEntryID {
+		t.Fatalf("unexpected entry ID returned. want=%d, have=%d", fakeEntryID, haveEntryID)
 	}
 
 	if value := len(store.AddExecutionLogEntryFunc.History()); value != 1 {
@@ -102,14 +109,69 @@ func TestAddExecutionLogEntry(t *testing.T) {
 
 func TestAddExecutionLogEntryUnknownJob(t *testing.T) {
 	store := workerstoremocks.NewMockStore()
-	store.AddExecutionLogEntryFunc.SetDefaultReturn(ErrUnknownJob)
+	store.AddExecutionLogEntryFunc.SetDefaultReturn(0, workerstore.ErrExecutionLogEntryNotUpdated)
 	handler := newHandler(QueueOptions{Store: store})
 
 	entry := workerutil.ExecutionLogEntry{
 		Command: []string{"ls", "-a"},
 		Out:     "<log payload>",
 	}
-	if err := handler.addExecutionLogEntry(context.Background(), "deadbeef", 42, entry); err != ErrUnknownJob {
+	if _, err := handler.addExecutionLogEntry(context.Background(), "deadbeef", 42, entry); err != ErrUnknownJob {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownJob, err)
+	}
+}
+
+func TestUpdateExecutionLogEntry(t *testing.T) {
+	store := workerstoremocks.NewMockStore()
+	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
+	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
+		return apiclient.Job{ID: 42}, nil
+	}
+
+	handler := newHandler(QueueOptions{Store: store, RecordTransformer: recordTransformer})
+
+	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected a job to be dequeued")
+	}
+
+	entry := workerutil.ExecutionLogEntry{
+		Command: []string{"ls", "-a"},
+		Out:     "<log payload>",
+	}
+
+	if err := handler.updateExecutionLogEntry(context.Background(), "deadbeef", job.ID, 99, entry); err != nil {
+		t.Fatalf("unexpected error updating log contents: %s", err)
+	}
+
+	if value := len(store.UpdateExecutionLogEntryFunc.History()); value != 1 {
+		t.Fatalf("unexpected number of calls to UpdateExecutionLogEntry. want=%d have=%d", 1, value)
+	}
+	call := store.UpdateExecutionLogEntryFunc.History()[0]
+	if call.Arg1 != 42 {
+		t.Errorf("unexpected job identifier. want=%d have=%d", 42, call.Arg1)
+	}
+	if call.Arg2 != 99 {
+		t.Errorf("unexpected entry ID. want=%d have=%d", 99, call.Arg1)
+	}
+	if diff := cmp.Diff(entry, call.Arg3); diff != "" {
+		t.Errorf("unexpected entry (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateExecutionLogEntryUnknownJob(t *testing.T) {
+	store := workerstoremocks.NewMockStore()
+	store.UpdateExecutionLogEntryFunc.SetDefaultReturn(workerstore.ErrExecutionLogEntryNotUpdated)
+	handler := newHandler(QueueOptions{Store: store})
+
+	entry := workerutil.ExecutionLogEntry{
+		Command: []string{"ls", "-a"},
+		Out:     "<log payload>",
+	}
+	if err := handler.updateExecutionLogEntry(context.Background(), "deadbeef", 42, 99, entry); err != ErrUnknownJob {
 		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownJob, err)
 	}
 }

--- a/enterprise/cmd/executor/internal/apiclient/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/client_test.go
@@ -107,13 +107,17 @@ func TestAddExecutionLogEntry(t *testing.T) {
 			"out": "<log payload>",
 			"durationMs": 23123
 		}`,
-		responseStatus:  http.StatusNoContent,
-		responsePayload: ``,
+		responseStatus:  http.StatusOK,
+		responsePayload: `99`,
 	}
 
 	testRoute(t, spec, func(client *Client) {
-		if err := client.AddExecutionLogEntry(context.Background(), "test_queue", 42, entry); err != nil {
+		entryID, err := client.AddExecutionLogEntry(context.Background(), "test_queue", 42, entry)
+		if err != nil {
 			t.Fatalf("unexpected error updating log contents: %s", err)
+		}
+		if entryID != 99 {
+			t.Fatalf("unexpected entryID returned. want=%d, have=%d", 99, entryID)
 		}
 	})
 }
@@ -148,7 +152,81 @@ func TestAddExecutionLogEntryBadResponse(t *testing.T) {
 	}
 
 	testRoute(t, spec, func(client *Client) {
-		if err := client.AddExecutionLogEntry(context.Background(), "test_queue", 42, entry); err == nil {
+		if _, err := client.AddExecutionLogEntry(context.Background(), "test_queue", 42, entry); err == nil {
+			t.Fatalf("expected an error")
+		}
+	})
+}
+
+func TestUpdateExecutionLogEntry(t *testing.T) {
+	entry := workerutil.ExecutionLogEntry{
+		Key:        "foo",
+		Command:    []string{"ls", "-a"},
+		StartTime:  time.Unix(1587396557, 0).UTC(),
+		ExitCode:   123,
+		Out:        "<log payload>",
+		DurationMs: 23123,
+	}
+
+	spec := routeSpec{
+		expectedMethod:   "POST",
+		expectedPath:     "/.executors/queue/test_queue/updateExecutionLogEntry",
+		expectedUsername: "test",
+		expectedPassword: "hunter2",
+		expectedPayload: `{
+			"executorName": "deadbeef",
+			"jobId": 42,
+			"entryId": 99,
+			"key": "foo",
+			"command": ["ls", "-a"],
+			"startTime": "2020-04-20T15:29:17Z",
+			"exitCode": 123,
+			"out": "<log payload>",
+			"durationMs": 23123
+		}`,
+		responseStatus:  http.StatusNoContent,
+		responsePayload: ``,
+	}
+
+	testRoute(t, spec, func(client *Client) {
+		if err := client.UpdateExecutionLogEntry(context.Background(), "test_queue", 42, 99, entry); err != nil {
+			t.Fatalf("unexpected error updating log contents: %s", err)
+		}
+	})
+}
+
+func TestUpdateExecutionLogEntryBadResponse(t *testing.T) {
+	entry := workerutil.ExecutionLogEntry{
+		Key:        "foo",
+		Command:    []string{"ls", "-a"},
+		StartTime:  time.Unix(1587396557, 0).UTC(),
+		ExitCode:   123,
+		Out:        "<log payload>",
+		DurationMs: 23123,
+	}
+
+	spec := routeSpec{
+		expectedMethod:   "POST",
+		expectedPath:     "/.executors/queue/test_queue/updateExecutionLogEntry",
+		expectedUsername: "test",
+		expectedPassword: "hunter2",
+		expectedPayload: `{
+			"executorName": "deadbeef",
+			"jobId": 42,
+			"entryId": 99,
+			"key": "foo",
+			"command": ["ls", "-a"],
+			"startTime": "2020-04-20T15:29:17Z",
+			"exitCode": 123,
+			"out": "<log payload>",
+			"durationMs": 23123
+		}`,
+		responseStatus:  http.StatusInternalServerError,
+		responsePayload: ``,
+	}
+
+	testRoute(t, spec, func(client *Client) {
+		if err := client.UpdateExecutionLogEntry(context.Background(), "test_queue", 42, 99, entry); err == nil {
 			t.Fatalf("expected an error")
 		}
 	})

--- a/enterprise/cmd/executor/internal/apiclient/observability.go
+++ b/enterprise/cmd/executor/internal/apiclient/observability.go
@@ -8,12 +8,13 @@ import (
 )
 
 type operations struct {
-	dequeue              *observation.Operation
-	addExecutionLogEntry *observation.Operation
-	markComplete         *observation.Operation
-	markErrored          *observation.Operation
-	markFailed           *observation.Operation
-	heartbeat            *observation.Operation
+	dequeue                 *observation.Operation
+	addExecutionLogEntry    *observation.Operation
+	updateExecutionLogEntry *observation.Operation
+	markComplete            *observation.Operation
+	markErrored             *observation.Operation
+	markFailed              *observation.Operation
+	heartbeat               *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -33,11 +34,12 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		dequeue:              op("Dequeue"),
-		addExecutionLogEntry: op("AddExecutionLogEntry"),
-		markComplete:         op("MarkComplete"),
-		markErrored:          op("MarkErrored"),
-		markFailed:           op("MarkFailed"),
-		heartbeat:            op("Heartbeat"),
+		dequeue:                 op("Dequeue"),
+		addExecutionLogEntry:    op("AddExecutionLogEntry"),
+		updateExecutionLogEntry: op("UpdateExecutionLogEntry"),
+		markComplete:            op("MarkComplete"),
+		markErrored:             op("MarkErrored"),
+		markFailed:              op("MarkFailed"),
+		heartbeat:               op("Heartbeat"),
 	}
 }

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -67,7 +67,7 @@ func (h *handler) Handle(ctx context.Context, record workerutil.Record) (err err
 	// interpolate into the command. No command that we run on the host leaks environment
 	// variables, and the user-specified commands (which could leak their environment) are
 	// run in a clean VM.
-	logger := command.NewLogger(h.store, job, record, union(h.options.RedactedValues, job.RedactedValues))
+	logger := command.NewLogger(h.store, job, record.RecordID(), union(h.options.RedactedValues, job.RedactedValues))
 	defer logger.Flush()
 
 	// Create a working directory for this job which will be removed once the job completes.

--- a/enterprise/cmd/executor/internal/worker/mock_store_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_store_test.go
@@ -34,6 +34,9 @@ type MockStore struct {
 	// QueuedCountFunc is an instance of a mock function object controlling
 	// the behavior of the method QueuedCount.
 	QueuedCountFunc *StoreQueuedCountFunc
+	// UpdateExecutionLogEntryFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateExecutionLogEntry.
+	UpdateExecutionLogEntryFunc *StoreUpdateExecutionLogEntryFunc
 }
 
 // NewMockStore creates a new mock of the Store interface. All methods
@@ -41,8 +44,8 @@ type MockStore struct {
 func NewMockStore() *MockStore {
 	return &MockStore{
 		AddExecutionLogEntryFunc: &StoreAddExecutionLogEntryFunc{
-			defaultHook: func(context.Context, int, workerutil.ExecutionLogEntry) error {
-				return nil
+			defaultHook: func(context.Context, int, workerutil.ExecutionLogEntry) (int, error) {
+				return 0, nil
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc{
@@ -75,6 +78,11 @@ func NewMockStore() *MockStore {
 				return 0, nil
 			},
 		},
+		UpdateExecutionLogEntryFunc: &StoreUpdateExecutionLogEntryFunc{
+			defaultHook: func(context.Context, int, int, workerutil.ExecutionLogEntry) error {
+				return nil
+			},
+		},
 	}
 }
 
@@ -103,30 +111,33 @@ func NewMockStoreFrom(i workerutil.Store) *MockStore {
 		QueuedCountFunc: &StoreQueuedCountFunc{
 			defaultHook: i.QueuedCount,
 		},
+		UpdateExecutionLogEntryFunc: &StoreUpdateExecutionLogEntryFunc{
+			defaultHook: i.UpdateExecutionLogEntry,
+		},
 	}
 }
 
 // StoreAddExecutionLogEntryFunc describes the behavior when the
 // AddExecutionLogEntry method of the parent MockStore instance is invoked.
 type StoreAddExecutionLogEntryFunc struct {
-	defaultHook func(context.Context, int, workerutil.ExecutionLogEntry) error
-	hooks       []func(context.Context, int, workerutil.ExecutionLogEntry) error
+	defaultHook func(context.Context, int, workerutil.ExecutionLogEntry) (int, error)
+	hooks       []func(context.Context, int, workerutil.ExecutionLogEntry) (int, error)
 	history     []StoreAddExecutionLogEntryFuncCall
 	mutex       sync.Mutex
 }
 
 // AddExecutionLogEntry delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockStore) AddExecutionLogEntry(v0 context.Context, v1 int, v2 workerutil.ExecutionLogEntry) error {
-	r0 := m.AddExecutionLogEntryFunc.nextHook()(v0, v1, v2)
-	m.AddExecutionLogEntryFunc.appendCall(StoreAddExecutionLogEntryFuncCall{v0, v1, v2, r0})
-	return r0
+func (m *MockStore) AddExecutionLogEntry(v0 context.Context, v1 int, v2 workerutil.ExecutionLogEntry) (int, error) {
+	r0, r1 := m.AddExecutionLogEntryFunc.nextHook()(v0, v1, v2)
+	m.AddExecutionLogEntryFunc.appendCall(StoreAddExecutionLogEntryFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the AddExecutionLogEntry
 // method of the parent MockStore instance is invoked and the hook queue is
 // empty.
-func (f *StoreAddExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context, int, workerutil.ExecutionLogEntry) error) {
+func (f *StoreAddExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context, int, workerutil.ExecutionLogEntry) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -134,7 +145,7 @@ func (f *StoreAddExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context
 // AddExecutionLogEntry method of the parent MockStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *StoreAddExecutionLogEntryFunc) PushHook(hook func(context.Context, int, workerutil.ExecutionLogEntry) error) {
+func (f *StoreAddExecutionLogEntryFunc) PushHook(hook func(context.Context, int, workerutil.ExecutionLogEntry) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -142,21 +153,21 @@ func (f *StoreAddExecutionLogEntryFunc) PushHook(hook func(context.Context, int,
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *StoreAddExecutionLogEntryFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, workerutil.ExecutionLogEntry) error {
-		return r0
+func (f *StoreAddExecutionLogEntryFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, workerutil.ExecutionLogEntry) (int, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *StoreAddExecutionLogEntryFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, workerutil.ExecutionLogEntry) error {
-		return r0
+func (f *StoreAddExecutionLogEntryFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int, workerutil.ExecutionLogEntry) (int, error) {
+		return r0, r1
 	})
 }
 
-func (f *StoreAddExecutionLogEntryFunc) nextHook() func(context.Context, int, workerutil.ExecutionLogEntry) error {
+func (f *StoreAddExecutionLogEntryFunc) nextHook() func(context.Context, int, workerutil.ExecutionLogEntry) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -200,7 +211,10 @@ type StoreAddExecutionLogEntryFuncCall struct {
 	Arg2 workerutil.ExecutionLogEntry
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -212,7 +226,7 @@ func (c StoreAddExecutionLogEntryFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
@@ -873,4 +887,117 @@ func (c StoreQueuedCountFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreQueuedCountFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreUpdateExecutionLogEntryFunc describes the behavior when the
+// UpdateExecutionLogEntry method of the parent MockStore instance is
+// invoked.
+type StoreUpdateExecutionLogEntryFunc struct {
+	defaultHook func(context.Context, int, int, workerutil.ExecutionLogEntry) error
+	hooks       []func(context.Context, int, int, workerutil.ExecutionLogEntry) error
+	history     []StoreUpdateExecutionLogEntryFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateExecutionLogEntry delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) UpdateExecutionLogEntry(v0 context.Context, v1 int, v2 int, v3 workerutil.ExecutionLogEntry) error {
+	r0 := m.UpdateExecutionLogEntryFunc.nextHook()(v0, v1, v2, v3)
+	m.UpdateExecutionLogEntryFunc.appendCall(StoreUpdateExecutionLogEntryFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// UpdateExecutionLogEntry method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreUpdateExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context, int, int, workerutil.ExecutionLogEntry) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateExecutionLogEntry method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreUpdateExecutionLogEntryFunc) PushHook(hook func(context.Context, int, int, workerutil.ExecutionLogEntry) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreUpdateExecutionLogEntryFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, int, workerutil.ExecutionLogEntry) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreUpdateExecutionLogEntryFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, int, workerutil.ExecutionLogEntry) error {
+		return r0
+	})
+}
+
+func (f *StoreUpdateExecutionLogEntryFunc) nextHook() func(context.Context, int, int, workerutil.ExecutionLogEntry) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreUpdateExecutionLogEntryFunc) appendCall(r0 StoreUpdateExecutionLogEntryFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreUpdateExecutionLogEntryFuncCall
+// objects describing the invocations of this function.
+func (f *StoreUpdateExecutionLogEntryFunc) History() []StoreUpdateExecutionLogEntryFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreUpdateExecutionLogEntryFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreUpdateExecutionLogEntryFuncCall is an object that describes an
+// invocation of method UpdateExecutionLogEntry on an instance of MockStore.
+type StoreUpdateExecutionLogEntryFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 workerutil.ExecutionLogEntry
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreUpdateExecutionLogEntryFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreUpdateExecutionLogEntryFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }

--- a/enterprise/cmd/executor/internal/worker/store.go
+++ b/enterprise/cmd/executor/internal/worker/store.go
@@ -16,7 +16,8 @@ type storeShim struct {
 
 type QueueStore interface {
 	Dequeue(ctx context.Context, queueName string, payload *executor.Job) (bool, error)
-	AddExecutionLogEntry(ctx context.Context, queueName string, jobID int, entry workerutil.ExecutionLogEntry) error
+	AddExecutionLogEntry(ctx context.Context, queueName string, jobID int, entry workerutil.ExecutionLogEntry) (int, error)
+	UpdateExecutionLogEntry(ctx context.Context, queueName string, jobID, entryID int, entry workerutil.ExecutionLogEntry) error
 	MarkComplete(ctx context.Context, queueName string, jobID int) error
 	MarkErrored(ctx context.Context, queueName string, jobID int, errorMessage string) error
 	MarkFailed(ctx context.Context, queueName string, jobID int, errorMessage string) error
@@ -43,8 +44,12 @@ func (s *storeShim) Heartbeat(ctx context.Context, ids []int) ([]int, error) {
 	return nil, nil
 }
 
-func (s *storeShim) AddExecutionLogEntry(ctx context.Context, id int, entry workerutil.ExecutionLogEntry) error {
+func (s *storeShim) AddExecutionLogEntry(ctx context.Context, id int, entry workerutil.ExecutionLogEntry) (int, error) {
 	return s.queueStore.AddExecutionLogEntry(ctx, s.queueName, id, entry)
+}
+
+func (s *storeShim) UpdateExecutionLogEntry(ctx context.Context, jobID, entryID int, entry workerutil.ExecutionLogEntry) error {
+	return s.queueStore.UpdateExecutionLogEntry(ctx, s.queueName, jobID, entryID, entry)
 }
 
 func (s *storeShim) MarkComplete(ctx context.Context, id int) (bool, error) {

--- a/enterprise/cmd/frontend/internal/executor/internal_proxy_handler.go
+++ b/enterprise/cmd/frontend/internal/executor/internal_proxy_handler.go
@@ -63,7 +63,7 @@ func newInternalProxyHandler(uploadHandler http.Handler) (func() http.Handler, e
 		base.Path("/git/{rest:.*/(?:info/refs|git-upload-pack)}").Handler(reverseProxy(frontendOrigin))
 
 		// Proxy only the known routes in the executor queue API
-		base.Path("/queue/{rest:.*/(?:dequeue|addExecutionLogEntry|markComplete|markErrored|markFailed|heartbeat)}").Handler(reverseProxy(queueOrigin))
+		base.Path("/queue/{rest:.*/(?:dequeue|addExecutionLogEntry|updateExecutionLogEntry|markComplete|markErrored|markFailed|heartbeat)}").Handler(reverseProxy(queueOrigin))
 
 		// Upload LSIF indexes without a sudo access token or github tokens
 		base.Path("/lsif/upload").Methods("POST").Handler(uploadHandler)

--- a/enterprise/internal/batches/background/executor_store_test.go
+++ b/enterprise/internal/batches/background/executor_store_test.go
@@ -55,10 +55,13 @@ stdout: {"operation":"CREATING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.535Z
 			},
 		}
 
-		for _, e := range entries {
-			err := workStore.AddExecutionLogEntry(context.Background(), int(specExec.ID), e, dbworkerstore.AddExecutionLogEntryOptions{})
+		for i, e := range entries {
+			entryID, err := workStore.AddExecutionLogEntry(context.Background(), int(specExec.ID), e, dbworkerstore.ExecutionLogEntryOptions{})
 			if err != nil {
 				t.Fatal(err)
+			}
+			if entryID != i+1 {
+				t.Fatalf("AddExecutionLogEntry returned wrong entryID. want=%d, have=%d", i+1, entryID)
 			}
 		}
 

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -76,6 +76,13 @@ type AddExecutionLogEntryRequest struct {
 	workerutil.ExecutionLogEntry
 }
 
+type UpdateExecutionLogEntryRequest struct {
+	ExecutorName string `json:"executorName"`
+	JobID        int    `json:"jobId"`
+	EntryID      int    `json:"entryId"`
+	workerutil.ExecutionLogEntry
+}
+
 type MarkCompleteRequest struct {
 	ExecutorName string `json:"executorName"`
 	JobID        int    `json:"jobId"`

--- a/internal/workerutil/dbworker/store/mocks/mock_store.go
+++ b/internal/workerutil/dbworker/store/mocks/mock_store.go
@@ -48,6 +48,9 @@ type MockStore struct {
 	// ResetStalledFunc is an instance of a mock function object controlling
 	// the behavior of the method ResetStalled.
 	ResetStalledFunc *StoreResetStalledFunc
+	// UpdateExecutionLogEntryFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateExecutionLogEntry.
+	UpdateExecutionLogEntryFunc *StoreUpdateExecutionLogEntryFunc
 }
 
 // NewMockStore creates a new mock of the Store interface. All methods
@@ -55,8 +58,8 @@ type MockStore struct {
 func NewMockStore() *MockStore {
 	return &MockStore{
 		AddExecutionLogEntryFunc: &StoreAddExecutionLogEntryFunc{
-			defaultHook: func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error {
-				return nil
+			defaultHook: func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error) {
+				return 0, nil
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc{
@@ -104,6 +107,11 @@ func NewMockStore() *MockStore {
 				return nil, nil, nil
 			},
 		},
+		UpdateExecutionLogEntryFunc: &StoreUpdateExecutionLogEntryFunc{
+			defaultHook: func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error {
+				return nil
+			},
+		},
 	}
 }
 
@@ -141,30 +149,33 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ResetStalledFunc: &StoreResetStalledFunc{
 			defaultHook: i.ResetStalled,
 		},
+		UpdateExecutionLogEntryFunc: &StoreUpdateExecutionLogEntryFunc{
+			defaultHook: i.UpdateExecutionLogEntry,
+		},
 	}
 }
 
 // StoreAddExecutionLogEntryFunc describes the behavior when the
 // AddExecutionLogEntry method of the parent MockStore instance is invoked.
 type StoreAddExecutionLogEntryFunc struct {
-	defaultHook func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error
-	hooks       []func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error
+	defaultHook func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error)
+	hooks       []func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error)
 	history     []StoreAddExecutionLogEntryFuncCall
 	mutex       sync.Mutex
 }
 
 // AddExecutionLogEntry delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockStore) AddExecutionLogEntry(v0 context.Context, v1 int, v2 workerutil.ExecutionLogEntry, v3 store.AddExecutionLogEntryOptions) error {
-	r0 := m.AddExecutionLogEntryFunc.nextHook()(v0, v1, v2, v3)
-	m.AddExecutionLogEntryFunc.appendCall(StoreAddExecutionLogEntryFuncCall{v0, v1, v2, v3, r0})
-	return r0
+func (m *MockStore) AddExecutionLogEntry(v0 context.Context, v1 int, v2 workerutil.ExecutionLogEntry, v3 store.ExecutionLogEntryOptions) (int, error) {
+	r0, r1 := m.AddExecutionLogEntryFunc.nextHook()(v0, v1, v2, v3)
+	m.AddExecutionLogEntryFunc.appendCall(StoreAddExecutionLogEntryFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the AddExecutionLogEntry
 // method of the parent MockStore instance is invoked and the hook queue is
 // empty.
-func (f *StoreAddExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error) {
+func (f *StoreAddExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -172,7 +183,7 @@ func (f *StoreAddExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context
 // AddExecutionLogEntry method of the parent MockStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *StoreAddExecutionLogEntryFunc) PushHook(hook func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error) {
+func (f *StoreAddExecutionLogEntryFunc) PushHook(hook func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -180,21 +191,21 @@ func (f *StoreAddExecutionLogEntryFunc) PushHook(hook func(context.Context, int,
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *StoreAddExecutionLogEntryFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error {
-		return r0
+func (f *StoreAddExecutionLogEntryFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *StoreAddExecutionLogEntryFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error {
-		return r0
+func (f *StoreAddExecutionLogEntryFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error) {
+		return r0, r1
 	})
 }
 
-func (f *StoreAddExecutionLogEntryFunc) nextHook() func(context.Context, int, workerutil.ExecutionLogEntry, store.AddExecutionLogEntryOptions) error {
+func (f *StoreAddExecutionLogEntryFunc) nextHook() func(context.Context, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -238,10 +249,13 @@ type StoreAddExecutionLogEntryFuncCall struct {
 	Arg2 workerutil.ExecutionLogEntry
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 store.AddExecutionLogEntryOptions
+	Arg3 store.ExecutionLogEntryOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -253,7 +267,7 @@ func (c StoreAddExecutionLogEntryFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
@@ -1241,4 +1255,120 @@ func (c StoreResetStalledFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreResetStalledFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreUpdateExecutionLogEntryFunc describes the behavior when the
+// UpdateExecutionLogEntry method of the parent MockStore instance is
+// invoked.
+type StoreUpdateExecutionLogEntryFunc struct {
+	defaultHook func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error
+	hooks       []func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error
+	history     []StoreUpdateExecutionLogEntryFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateExecutionLogEntry delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) UpdateExecutionLogEntry(v0 context.Context, v1 int, v2 int, v3 workerutil.ExecutionLogEntry, v4 store.ExecutionLogEntryOptions) error {
+	r0 := m.UpdateExecutionLogEntryFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.UpdateExecutionLogEntryFunc.appendCall(StoreUpdateExecutionLogEntryFuncCall{v0, v1, v2, v3, v4, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// UpdateExecutionLogEntry method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreUpdateExecutionLogEntryFunc) SetDefaultHook(hook func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateExecutionLogEntry method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreUpdateExecutionLogEntryFunc) PushHook(hook func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreUpdateExecutionLogEntryFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreUpdateExecutionLogEntryFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error {
+		return r0
+	})
+}
+
+func (f *StoreUpdateExecutionLogEntryFunc) nextHook() func(context.Context, int, int, workerutil.ExecutionLogEntry, store.ExecutionLogEntryOptions) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreUpdateExecutionLogEntryFunc) appendCall(r0 StoreUpdateExecutionLogEntryFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreUpdateExecutionLogEntryFuncCall
+// objects describing the invocations of this function.
+func (f *StoreUpdateExecutionLogEntryFunc) History() []StoreUpdateExecutionLogEntryFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreUpdateExecutionLogEntryFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreUpdateExecutionLogEntryFuncCall is an object that describes an
+// invocation of method UpdateExecutionLogEntry on an instance of MockStore.
+type StoreUpdateExecutionLogEntryFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 workerutil.ExecutionLogEntry
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 store.ExecutionLogEntryOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreUpdateExecutionLogEntryFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreUpdateExecutionLogEntryFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }

--- a/internal/workerutil/dbworker/store/observability.go
+++ b/internal/workerutil/dbworker/store/observability.go
@@ -8,15 +8,16 @@ import (
 )
 
 type operations struct {
-	queuedCount          *observation.Operation
-	dequeue              *observation.Operation
-	requeue              *observation.Operation
-	addExecutionLogEntry *observation.Operation
-	markComplete         *observation.Operation
-	markErrored          *observation.Operation
-	markFailed           *observation.Operation
-	resetStalled         *observation.Operation
-	heartbeat            *observation.Operation
+	queuedCount             *observation.Operation
+	dequeue                 *observation.Operation
+	requeue                 *observation.Operation
+	addExecutionLogEntry    *observation.Operation
+	updateExecutionLogEntry *observation.Operation
+	markComplete            *observation.Operation
+	markErrored             *observation.Operation
+	markFailed              *observation.Operation
+	resetStalled            *observation.Operation
+	heartbeat               *observation.Operation
 }
 
 func newOperations(storeName string, observationContext *observation.Context) *operations {
@@ -36,14 +37,15 @@ func newOperations(storeName string, observationContext *observation.Context) *o
 	}
 
 	return &operations{
-		queuedCount:          op("QueuedCount"),
-		dequeue:              op("Dequeue"),
-		requeue:              op("Requeue"),
-		addExecutionLogEntry: op("AddExecutionLogEntry"),
-		markComplete:         op("MarkComplete"),
-		markErrored:          op("MarkErrored"),
-		markFailed:           op("MarkFailed"),
-		resetStalled:         op("ResetStalled"),
-		heartbeat:            op("Heartbeat"),
+		queuedCount:             op("QueuedCount"),
+		dequeue:                 op("Dequeue"),
+		requeue:                 op("Requeue"),
+		addExecutionLogEntry:    op("AddExecutionLogEntry"),
+		updateExecutionLogEntry: op("UpdateExecutionLogEntry"),
+		markComplete:            op("MarkComplete"),
+		markErrored:             op("MarkErrored"),
+		markFailed:              op("MarkFailed"),
+		resetStalled:            op("ResetStalled"),
+		heartbeat:               op("Heartbeat"),
 	}
 }

--- a/internal/workerutil/dbworker/store_shim.go
+++ b/internal/workerutil/dbworker/store_shim.go
@@ -50,8 +50,12 @@ func (s *storeShim) Heartbeat(ctx context.Context, ids []int) (knownIDs []int, e
 	return s.Store.Heartbeat(ctx, ids, store.HeartbeatOptions{})
 }
 
-func (s *storeShim) AddExecutionLogEntry(ctx context.Context, id int, entry workerutil.ExecutionLogEntry) error {
-	return s.Store.AddExecutionLogEntry(ctx, id, entry, store.AddExecutionLogEntryOptions{})
+func (s *storeShim) AddExecutionLogEntry(ctx context.Context, id int, entry workerutil.ExecutionLogEntry) (entryID int, err error) {
+	return s.Store.AddExecutionLogEntry(ctx, id, entry, store.ExecutionLogEntryOptions{})
+}
+
+func (s *storeShim) UpdateExecutionLogEntry(ctx context.Context, recordID, entryID int, entry workerutil.ExecutionLogEntry) error {
+	return s.Store.UpdateExecutionLogEntry(ctx, recordID, entryID, entry, store.ExecutionLogEntryOptions{})
 }
 
 func (s *storeShim) MarkComplete(ctx context.Context, id int) (bool, error) {

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -26,8 +26,14 @@ type Store interface {
 	// touched are returned.
 	Heartbeat(ctx context.Context, jobIDs []int) (knownIDs []int, err error)
 
-	// AddExecutionLogEntry adds an executor log entry to the record.
-	AddExecutionLogEntry(ctx context.Context, id int, entry ExecutionLogEntry) error
+	// AddExecutionLogEntry adds an executor log entry to the record and
+	// returns the ID of the new entry (which can be used with
+	// UpdateExecutionLogEntry) and a possible error.
+	AddExecutionLogEntry(ctx context.Context, id int, entry ExecutionLogEntry) (int, error)
+
+	// UpdateExecutionLogEntry updates the executor log entry with the given ID
+	// on the given record.
+	UpdateExecutionLogEntry(ctx context.Context, recordID, entryID int, entry ExecutionLogEntry) error
 
 	// MarkComplete attempts to update the state of the record to complete. This method returns a boolean flag indicating
 	// if the record was updated.


### PR DESCRIPTION
This adds an `UpdateExecutionLogEntry` method to the `workerutil.Store` interface and implements it in `dbworker.Store` and in the executor `apiclient`.

The single user of this method so far is `command.Logger`. It continuously updates the output produced by a command in the database by calling `UpdateExecutionLogEntry` in a syncer goroutine that receceives the command output as it comes in and then flushes it to disk by calling `UpdateExecutionLogEntry`.