### PR TITLE
httpcli: add retries to NewExternalHTTPClientFactory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/PuerkitoBio/rehttp v1.1.0 // indirect
+	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/RoaringBitmap/roaring v0.5.1
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
+	github.com/PuerkitoBio/rehttp v1.1.0 // indirect
 	github.com/RoaringBitmap/roaring v0.5.1
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,12 +167,14 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.2/go.mod h1:zu7rotIY9P4Aoc6ytqLP9j
 github.com/aws/smithy-go v1.2.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.3.1 h1:xJFO4pK0y9J8fCl34uGsSJX5KNnGbdARDlA5BPhXnwE=
 github.com/aws/smithy-go v1.3.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/rehttp v1.1.0 h1:JFZ7OeK+hbJpTxhNB0NDZT47AuXqCU0Smxfjtph7/Rs=
+github.com/PuerkitoBio/rehttp v1.1.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -165,11 +167,13 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.2/go.mod h1:zu7rotIY9P4Aoc6ytqLP9j
 github.com/aws/smithy-go v1.2.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.3.1 h1:xJFO4pK0y9J8fCl34uGsSJX5KNnGbdARDlA5BPhXnwE=
 github.com/aws/smithy-go v1.3.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -1620,6 +1624,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20170517211232-f52d1811a629/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -1,16 +1,21 @@
 package httpcli
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
+	"github.com/PuerkitoBio/rehttp"
 	"github.com/cockroachdb/errors"
 	"github.com/gregjones/httpcache"
 	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
@@ -72,11 +77,15 @@ func NewExternalHTTPClientFactory() *Factory {
 		NewMiddleware(
 			ContextErrorMiddleware,
 		),
-		NewTimeoutOpt(60*time.Second),
+		NewTimeoutOpt(5*time.Minute),
 		// ExternalTransportOpt needs to be before TracedTransportOpt and
 		// NewCachedTransportOpt since it wants to extract a http.Transport,
 		// not a generic http.RoundTripper.
 		ExternalTransportOpt,
+		NewErrorResilientTransportOpt(
+			DefaultRetryPolicy,
+			rehttp.ExpJitterDelay(200*time.Millisecond, 10*time.Second),
+		),
 		TracedTransportOpt,
 		NewCachedTransportOpt(redisCache, true),
 	)
@@ -305,6 +314,84 @@ func TracedTransportOpt(cli *http.Client) error {
 
 	cli.Transport = &ot.Transport{RoundTripper: cli.Transport}
 	return nil
+}
+
+// A regular expression to match the error returned by net/http when the
+// configured number of redirects is exhausted. This error isn't typed
+// specifically so we resort to matching on the error string.
+var redirectsErrorRe = lazyregexp.New(`stopped after \d+ redirects\z`)
+
+// A regular expression to match the error returned by net/http when the
+// scheme specified in the URL is invalid. This error isn't typed
+// specifically so we resort to matching on the error string.
+var schemeErrorRe = lazyregexp.New(`unsupported protocol scheme`)
+
+func DefaultRetryPolicy(a rehttp.Attempt) (retry bool) {
+	status := 0
+
+	defer func() {
+		log15.Error(
+			"external HTTP request",
+			"attempt", a.Index,
+			"method", a.Request.Method,
+			"url", a.Request.URL,
+			"status", status,
+			"retry", retry,
+			"err", a.Error,
+		)
+	}()
+
+	if a.Response != nil {
+		status = a.Response.StatusCode
+	}
+
+	if a.Index > 20 { // Max retries
+		return false
+	}
+
+	switch a.Error {
+	case nil:
+	case context.DeadlineExceeded, context.Canceled:
+		return false
+	default:
+		if v, ok := a.Error.(*url.Error); ok {
+			// Don't retry if the error was due to too many redirects.
+			if redirectsErrorRe.MatchString(v.Error()) {
+				return false
+			}
+
+			// Don't retry if the error was due to an invalid protocol scheme.
+			if schemeErrorRe.MatchString(v.Error()) {
+				return false
+			}
+
+			// Don't retry if the error was due to TLS cert verification failure.
+			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+				return false
+			}
+		}
+		// The error is likely recoverable so retry.
+		return true
+	}
+
+	if status == 0 || status == 429 || (status >= 500 && status != 501) {
+		return true
+	}
+
+	return false
+}
+
+// NewErrorResilientTransportOpt returns an Opt that wraps an existing
+// http.Transport of an http.Client with automatic retries.
+func NewErrorResilientTransportOpt(retry rehttp.RetryFn, delay rehttp.DelayFn) Opt {
+	return func(cli *http.Client) error {
+		if cli.Transport == nil {
+			cli.Transport = http.DefaultTransport
+		}
+
+		cli.Transport = rehttp.NewTransport(cli.Transport, retry, delay)
+		return nil
+	}
 }
 
 // NewIdleConnTimeoutOpt returns a Opt that sets the IdleConnTimeout of an

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -326,6 +326,8 @@ var redirectsErrorRe = lazyregexp.New(`stopped after \d+ redirects\z`)
 // specifically so we resort to matching on the error string.
 var schemeErrorRe = lazyregexp.New(`unsupported protocol scheme`)
 
+// DefaultRetryPolicy is the retry policy used in any Doer or Client returned
+// by NewExternalHTTPClientFactory.
 func DefaultRetryPolicy(a rehttp.Attempt) (retry bool) {
 	status := 0
 

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -281,7 +281,7 @@ func TestNewTimeoutOpt(t *testing.T) {
 func TestExternalHTTPClientErrorResilience(t *testing.T) {
 	failures := int64(5)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		status := 200
+		status := 0
 		switch n := atomic.AddInt64(&failures, -1); n {
 		case 4:
 			status = 429
@@ -292,6 +292,8 @@ func TestExternalHTTPClientErrorResilience(t *testing.T) {
 		case 1:
 			status = 302
 			w.Header().Set("Location", "/")
+		case 0:
+			status = 404
 		}
 		w.WriteHeader(status)
 	}))
@@ -309,8 +311,8 @@ func TestExternalHTTPClientErrorResilience(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if res.StatusCode != 200 {
-		t.Fatalf("want status code 200, got: %d", res.StatusCode)
+	if res.StatusCode != 404 {
+		t.Fatalf("want status code 404, got: %d", res.StatusCode)
 	}
 }
 

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -14,11 +14,13 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
 
 func TestHeadersMiddleware(t *testing.T) {
@@ -273,6 +275,42 @@ func TestNewTimeoutOpt(t *testing.T) {
 
 	if have, want := cli.Timeout, timeout; have != want {
 		t.Errorf("have Timeout %s, want %s", have, want)
+	}
+}
+
+func TestExternalHTTPClientErrorResilience(t *testing.T) {
+	failures := int64(5)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		status := 200
+		switch n := atomic.AddInt64(&failures, -1); n {
+		case 4:
+			status = 429
+		case 3:
+			status = 500
+		case 2:
+			status = 900
+		case 1:
+			status = 302
+			w.Header().Set("Location", "/")
+		}
+		w.WriteHeader(status)
+	}))
+
+	rcache.SetupForTest(t)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ExternalDoer().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.StatusCode != 200 {
+		t.Fatalf("want status code 200, got: %d", res.StatusCode)
 	}
 }
 


### PR DESCRIPTION
This commit adds an error resilience transport middleware to the
`NewExternalHTTPClientFactory`. This means that in every place we
talk to the outside world via HTTP, we'll now automatically retry
requests that meet the criteria defined in `DefaultRetryPolicy`.

To support retries, we increase the default timeout to 5 minutes.

This change is driven by intermittent failures in long external
service syncing jobs that cause us to entirely fail the whole thing,
when we can instead retry sporadic errors and deploys of github-proxy
that happen frequently.