### PR TITLE
search: lift up empty pattern check for symbols

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1507,7 +1507,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	}
 
-	if args.ResultTypes.Has(result.TypeSymbol) {
+	if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" {
 		wg := waitGroup(args.ResultTypes.Without(result.TypeSymbol) == 0)
 		wg.Add(1)
 		goroutine.Go(func() {

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -395,6 +395,9 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return nil, nil
 		}
 		p := search.ToTextPatternInfo(q, search.Batch, query.Identity)
+		if p.Pattern == "" {
+			return nil, nil
+		}
 
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -59,10 +59,6 @@ func Search(ctx context.Context, args *search.TextParameters, limit int, stream 
 		tr.Finish()
 	}()
 
-	if args.PatternInfo.Pattern == "" {
-		return nil
-	}
-
 	ctx, stream, cancel := streaming.WithLimit(ctx, stream, limit)
 	defer cancel()
 


### PR DESCRIPTION
Found more of these comparisons for empty patterns downstream in symbols code. I want it closer to the top level `doResults` function for same reasons as before.