### PR TITLE
search: promote zoekt query conversion

### DIFF
--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -62,8 +62,13 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 	// because zoekt will anyway have to search all its shards.
 	var indexed *zoektutil.IndexedSearchRequest
 	if args.Mode == search.ZoektGlobalSearch {
+		q, err := search.QueryToZoektQuery(args.PatternInfo, false)
+		if err != nil {
+			return err
+		}
 		indexed = &zoektutil.IndexedSearchRequest{
 			Args:     args,
+			Query:    q,
 			Typ:      zoektutil.TextRequest,
 			RepoRevs: &zoektutil.IndexedRepoRevs{},
 		}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23153

This promotes the logic that converts our internal query representation to a Zoekt query up the call chain (it gets done earlier). Why is this useful? Optional reading below.

This PR in particular constructs a Zoekt query earlier, in `NewIndexedSearchRequest`, and one other place where we construct an indexed request value. To propagate the zoekt query down, it's necessary to mint a field in our `IndexedSearchRequest` type because there is a level of indirection via the `IndexedSearchRequest` that must be used to execute downstream search (i.e., `IndexedSearchRequest.Search()`)

I address this inline, but you may ask: "Why can't the `Zoekt` value be part of Args?". The answer is, it _will_ be part of `Args`. But right now, making it part of `Args` will just contribute to the fact that `Args` is a dumping ground. Clearly, a `Zoekt` query is only particular to `Zoekt` code and not other things, so I prefer to keep it separate, until `Args` can express variants of queries (still working towards that by bubbling things up).

---

Optional reading:

Ultimately, we want up front query construction, especially for Zoekt, for cases where a user's search input with expressions can be expressed as a single Zoekt query. Like these:

- `a and b`
- `a and b and not c`
- `a or b`

Currently, these expression are _not_ converted to Zoekt queries directly, but each term `a`, `b`, `c` are effectively searched independently and then merged by our generic evaluation routine for `and`, `or` operations. This can be cripplingly poor/slow. We'll get a lot of amazing speed up for the common cases if we convert the above to Zoekt queries and send that down stream to process.

The problem: All of our Zoekt conversion code basically converts our input (and this is true historically) right before sending a request off to Zoekt, very deep in the call chain. By the time we get to that part of the code, it's too late to convert a complex expression like the above, we've already chopped up individual terms. So: we must do the conversion from the above to Zoekt queries before executing searches of individual terms and solves this snag: https://github.com/sourcegraph/sourcegraph/issues/9824

I _could_ approach this by trying to do these conversions to an alternate representation, and send that down stream in our code. That would make our logic even worse, and it would be difficult for me to tell that I'm doing things correctly. So I'm bubbling up all the parts that I can before attempting the optimization that sends things downstream.

---

