### PR TITLE
search notebook: improve query block loading state

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -207,7 +207,7 @@ interface ErrorAggregateResults extends BaseAggregateResults {
 
 export type AggregateStreamingSearchResults = SuccessfulAggregateResults | ErrorAggregateResults
 
-const emptyAggregateResults: AggregateStreamingSearchResults = {
+export const emptyAggregateResults: AggregateStreamingSearchResults = {
     state: 'loading',
     results: [],
     filters: [],

--- a/client/web/src/search/notebook/index.ts
+++ b/client/web/src/search/notebook/index.ts
@@ -2,10 +2,15 @@ import { Observable } from 'rxjs'
 import * as uuid from 'uuid'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
-import { aggregateStreamingSearch, AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
+import {
+    aggregateStreamingSearch,
+    AggregateStreamingSearchResults,
+    emptyAggregateResults,
+} from '@sourcegraph/shared/src/search/stream'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 
 import { LATEST_VERSION } from '../results/StreamingSearchResults'
+import { startWith } from 'rxjs/operators'
 
 export type BlockType = 'md' | 'query'
 
@@ -102,7 +107,7 @@ export class Notebook {
                         caseSensitive: false,
                         versionContext: undefined,
                         trace: undefined,
-                    }),
+                    }).pipe(startWith(emptyAggregateResults)),
                 })
                 break
         }

--- a/client/web/src/search/notebook/index.ts
+++ b/client/web/src/search/notebook/index.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs'
+import { startWith } from 'rxjs/operators'
 import * as uuid from 'uuid'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
@@ -10,7 +11,6 @@ import {
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 
 import { LATEST_VERSION } from '../results/StreamingSearchResults'
-import { startWith } from 'rxjs/operators'
 
 export type BlockType = 'md' | 'query'
 


### PR DESCRIPTION
When running a query block start the output stream with an empty streaming search result. This ensures a proper loading state instead of looking stuck.

https://user-images.githubusercontent.com/6417322/126756274-cf2dc929-934c-445d-907d-62bcc6f640e0.mp4

