### PR TITLE
Refine error handling for JVM dependencies that fail to resolve.

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -52,7 +52,7 @@ func (s *JVMPackagesSyncer) Type() string {
 // IsCloneable checks to see if the VCS remote URL is cloneable. Any non-nil
 // error indicates there is a problem.
 func (s *JVMPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) error {
-	dependencies, err := s.packageDependencies(remoteURL.Path)
+	dependencies, err := s.packageDependencies(ctx, remoteURL.Path)
 	if err != nil {
 		return err
 	}
@@ -95,9 +95,10 @@ func (s *JVMPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL
 	return exec.CommandContext(ctx, "git", "--version"), nil
 }
 
-// Fetch does nothing for Maven packages because they are immutable and cannot be updated after publishing.
+// Fetch add git tags for newly added dependency versions and removes git tags
+// for deleted deleted versions.
 func (s *JVMPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir) error {
-	dependencies, err := s.packageDependencies(remoteURL.Path)
+	dependencies, err := s.packageDependencies(ctx, remoteURL.Path)
 	if err != nil {
 		return err
 	}
@@ -152,23 +153,32 @@ func (s *JVMPackagesSyncer) RemoteShowCommand(ctx context.Context, remoteURL *vc
 // packageDependencies returns the list of JVM dependencies that belong to the given URL path.
 // The returned package dependencies are sorted by semantic versioning.
 // A URL maps to a single JVM package, which may contain multiple versions (one git tag per version).
-func (s *JVMPackagesSyncer) packageDependencies(repoUrlPath string) (dependencies []reposource.MavenDependency, err error) {
+func (s *JVMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath string) (dependencies []reposource.MavenDependency, err error) {
 	module, err := reposource.ParseMavenModule(repoUrlPath)
 	if err != nil {
 		return nil, err
 	}
+
 	for _, dependency := range s.MavenDependencies() {
 		if module.MatchesDependencyString(dependency) {
 			dependency, err := reposource.ParseMavenDependency(dependency)
 			if err != nil {
 				return nil, err
 			}
-			dependencies = append(dependencies, dependency)
+
+			if coursier.Exists(ctx, s.Config, dependency) {
+				dependencies = append(dependencies, dependency)
+			}
+			// Silently ignore non-existent dependencies because
+			// they are already logged out in the `GetRepo` method
+			// in internal/repos/jvm_packages.go.
 		}
 	}
+
 	if len(dependencies) == 0 {
-		return nil, errors.Errorf("no tracked dependencies for URL path %s", repoUrlPath)
+		return nil, errors.Errorf("no JVM dependencies for URL path %s", repoUrlPath)
 	}
+
 	reposource.SortDependencies(dependencies)
 	return dependencies, nil
 }

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -95,7 +95,7 @@ func (s *JVMPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL
 	return exec.CommandContext(ctx, "git", "--version"), nil
 }
 
-// Fetch add git tags for newly added dependency versions and removes git tags
+// Fetch adds git tags for newly added dependency versions and removes git tags
 // for deleted deleted versions.
 func (s *JVMPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir) error {
 	dependencies, err := s.packageDependencies(ctx, remoteURL.Path)

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -79,8 +79,8 @@ func coursierScript(t *testing.T, dir string) string {
 	assert.Nil(t, err)
 	defer coursierPath.Close()
 	script := fmt.Sprintf(`#!/usr/bin/env bash
-ARG="$3"
-CLASSIFIER="$5"
+ARG="$4"
+CLASSIFIER="$6"
 if [[ "$ARG" =~ "%s" ]]; then
   if [[ "$CLASSIFIER" =~ "sources" ]]; then
     echo "%s"

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -79,8 +79,8 @@ func coursierScript(t *testing.T, dir string) string {
 	assert.Nil(t, err)
 	defer coursierPath.Close()
 	script := fmt.Sprintf(`#!/usr/bin/env bash
-ARG="$4"
-CLASSIFIER="$6"
+ARG="$5"
+CLASSIFIER="$7"
 if [[ "$ARG" =~ "%s" ]]; then
   if [[ "$CLASSIFIER" =~ "sources" ]]; then
     echo "%s"

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -79,9 +79,9 @@ func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependenc
 		config,
 		"resolve",
 		"--quiet", "--quiet",
-		dependency.CoursierSyntax(),
+		"--intransitive", dependency.CoursierSyntax(),
 	)
-	return err != nil
+	return err == nil
 }
 
 func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnection, args ...string) ([]string, error) {

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -48,8 +48,9 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 		// vcs_syncer_jvm_packages_test.go if you change the arguments
 		// here. The test case assumes that the "--classifier sources"
 		// arguments appears at a specific index.
-		"fetch", "--quiet", "--intransitive",
-		dependency.CoursierSyntax(),
+		"fetch",
+		"--quiet", "--quiet",
+		"--intransitive", dependency.CoursierSyntax(),
 		"--classifier", "sources",
 	)
 }
@@ -62,8 +63,9 @@ func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, de
 		// vcs_syncer_jvm_packages_test.go if you change the arguments
 		// here. The test case assumes that the "--classifier sources"
 		// arguments appears at a specific index.
-		"fetch", "--quiet", "--intransitive",
-		dependency.CoursierSyntax(),
+		"fetch",
+		"--quiet", "--quiet",
+		"--intransitive", dependency.CoursierSyntax(),
 	)
 }
 
@@ -76,7 +78,7 @@ func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependenc
 		ctx,
 		config,
 		"resolve",
-		"--quiet",
+		"--quiet", "--quiet",
 		dependency.CoursierSyntax(),
 	)
 	return err != nil

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -17,14 +17,6 @@ import (
 
 var CoursierBinary = "coursier"
 
-func ListArtifactIDs(ctx context.Context, config *schema.JVMPackagesConnection, groupID string) ([]string, error) {
-	return runCoursierCommand(ctx, config, "complete", groupID+":")
-}
-
-func ListVersions(ctx context.Context, config *schema.JVMPackagesConnection, groupID, artifactID string) ([]string, error) {
-	return runCoursierCommand(ctx, config, "complete", groupID+":"+artifactID+":")
-}
-
 func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) ([]string, error) {
 	if dependency.IsJdk() {
 		output, err := runCoursierCommand(
@@ -52,7 +44,11 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 	return runCoursierCommand(
 		ctx,
 		config,
-		"fetch", "--intransitive",
+		// NOTE: make sure to update the method `coursierScript` in
+		// vcs_syncer_jvm_packages_test.go if you change the arguments
+		// here. The test case assumes that the "--classifier sources"
+		// arguments appears at a specific index.
+		"fetch", "--quiet", "--intransitive",
 		dependency.CoursierSyntax(),
 		"--classifier", "sources",
 	)
@@ -62,29 +58,28 @@ func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, de
 	return runCoursierCommand(
 		ctx,
 		config,
-		"fetch", "--intransitive",
+		// NOTE: make sure to update the method `coursierScript` in
+		// vcs_syncer_jvm_packages_test.go if you change the arguments
+		// here. The test case assumes that the "--classifier sources"
+		// arguments appears at a specific index.
+		"fetch", "--quiet", "--intransitive",
 		dependency.CoursierSyntax(),
 	)
 }
 
-func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (bool, error) {
+func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) bool {
 	if dependency.IsJdk() {
-		lines, err := runCoursierCommand(
-			ctx,
-			config,
-			"java-home",
-			"--jvm",
-			dependency.Version,
-		)
-		return len(lines) > 0, err
+		sources, err := FetchSources(ctx, config, dependency)
+		return err == nil && len(sources) == 1
 	}
-	versions, err := runCoursierCommand(
+	_, err := runCoursierCommand(
 		ctx,
 		config,
-		"complete",
+		"resolve",
+		"--quiet",
 		dependency.CoursierSyntax(),
 	)
-	return len(versions) > 0, err
+	return err != nil
 }
 
 func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnection, args ...string) ([]string, error) {

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -105,10 +105,6 @@ type jvmDependencyNotFound struct {
 	dependencies []reposource.MavenDependency
 }
 
-func (jvmDependencyNotFound) NotFound() bool {
-	return true
-}
-
 func (e *jvmDependencyNotFound) Error() string {
 	return fmt.Sprintf("not found: jvm dependency '%v'", e.dependencies)
 }

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -70,33 +72,45 @@ func (s *JVMPackagesSource) GetRepo(ctx context.Context, artifactPath string) (*
 		return nil, err
 	}
 
+	nonExistentDependencies := make([]reposource.MavenDependency, 0)
+	hasAtLeastOneValidDependency := false
 	for _, dep := range dependencies {
 		if dep.MavenModule == module {
-			exists, err := coursier.Exists(ctx, s.config, dep)
-			if err != nil {
-				return nil, err
-			}
-			if !exists {
-				return nil, &mavenArtifactNotFound{
-					dependency: dep,
-				}
+			if coursier.Exists(ctx, s.config, dep) {
+				hasAtLeastOneValidDependency = true
+			} else {
+				nonExistentDependencies = append(nonExistentDependencies, dep)
 			}
 		}
+	}
+
+	if !hasAtLeastOneValidDependency {
+		return nil, &jvmDependencyNotFound{
+			dependencies: nonExistentDependencies,
+		}
+	}
+
+	for _, nonExistentDependency := range nonExistentDependencies {
+		// Don't reject all versions if a single version fails to
+		// resolve. Instead, we just log a warning about the unresolved
+		// dependency. A dependency can fail to resolve if it gets
+		// removed from the package host for some reason.
+		log15.Warn("Skipping non-existing JVM package", "nonExistentDependency", nonExistentDependency.CoursierSyntax())
 	}
 
 	return s.makeRepo(module), nil
 }
 
-type mavenArtifactNotFound struct {
-	dependency reposource.MavenDependency
+type jvmDependencyNotFound struct {
+	dependencies []reposource.MavenDependency
 }
 
-func (mavenArtifactNotFound) NotFound() bool {
+func (jvmDependencyNotFound) NotFound() bool {
 	return true
 }
 
-func (e *mavenArtifactNotFound) Error() string {
-	return fmt.Sprintf("not found: maven dependency '%v'", e.dependency)
+func (e *jvmDependencyNotFound) Error() string {
+	return fmt.Sprintf("not found: jvm dependency '%v'", e.dependencies)
 }
 
 func (s *JVMPackagesSource) makeRepo(module reposource.MavenModule) *types.Repo {


### PR DESCRIPTION
- Use `coursier resolve` instead of `coursier complete` to determine the
  existence of a dependency. The complete method is only intended to
  power tab completions, it can still have false positives/negatives
  when determining whether a dependency exists.
- Don't fail fast if a single version fails to resolve. Now, the repo
  gets created as long as at least one version resolves successfully.
  Versions that fail to resolve get logged as warnings instead (unless
  all versions fail to resolve, which is a hard error).
- Use the `--quit` flag when resolving dependencies to reduce logs noise.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
