### PR TITLE
security: Instrument access granted for private repos

### DIFF
--- a/internal/database/dbconn/dbconn.go
+++ b/internal/database/dbconn/dbconn.go
@@ -368,7 +368,7 @@ func (h *hook) After(ctx context.Context, query string, args ...interface{}) (co
 	return ctx, nil
 }
 
-// OnError implements sqlhooks.OnErroer
+// OnError implements sqlhooks.OnError
 func (h *hook) OnError(ctx context.Context, err error, query string, args ...interface{}) error {
 	if tr := trace.TraceFromContext(ctx); tr != nil {
 		tr.SetError(err)

--- a/internal/database/dbconn/dbconn.go
+++ b/internal/database/dbconn/dbconn.go
@@ -368,7 +368,7 @@ func (h *hook) After(ctx context.Context, query string, args ...interface{}) (co
 	return ctx, nil
 }
 
-// After implements sqlhooks.OnErroer
+// OnError implements sqlhooks.OnErroer
 func (h *hook) OnError(ctx context.Context, err error, query string, args ...interface{}) error {
 	if tr := trace.TraceFromContext(ctx); tr != nil {
 		tr.SetError(err)

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -123,9 +123,7 @@ func (s *RepoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err 
 
 	repo := repos[0]
 	if repo.Private {
-		// TODO: Before we enable this, we want to instrument to see the volume of events
 		counterAccessGranted.Inc()
-		//logRepoAccessGranted(ctx, s.Handle().DB(), repo.ID)
 	}
 
 	return repo, repo.IsBlocked()
@@ -135,29 +133,6 @@ var counterAccessGranted = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_access_granted_private_repo",
 	Help: "temporary metric to measure the impact of logging access granted to private repos",
 })
-
-//func logRepoAccessGranted(ctx context.Context, db dbutil.DB, repoID api.RepoID) {
-//	a := actor.FromContext(ctx)
-//	arg, _ := json.Marshal(struct {
-//		Resource string `json:"resource"`
-//		RepoID   int32  `json:"repo_id"`
-//	}{
-//		Resource: "db.repo",
-//		RepoID:   int32(repoID),
-//	})
-//
-//	event := &SecurityEvent{
-//		Name:            SecurityEventNameAccessGranted,
-//		URL:             "",
-//		UserID:          uint32(a.UID),
-//		AnonymousUserID: "",
-//		Argument:        arg,
-//		Source:          "BACKEND",
-//		Timestamp:       time.Now(),
-//	}
-//
-//	SecurityEventLogs(db).LogEvent(ctx, event)
-//}
 
 // GetByName returns the repository with the given nameOrUri from the
 // database, or an error. If we have a match on name and uri, we prefer the

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -137,28 +136,28 @@ var counterAccessGranted = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "temporary metric to measure the impact of logging access granted to private repos",
 })
 
-func logRepoAccessGranted(ctx context.Context, db dbutil.DB, repoID api.RepoID) {
-	a := actor.FromContext(ctx)
-	arg, _ := json.Marshal(struct {
-		Resource string `json:"resource"`
-		RepoID   int32  `json:"repo_id"`
-	}{
-		Resource: "db.repo",
-		RepoID:   int32(repoID),
-	})
-
-	event := &SecurityEvent{
-		Name:            SecurityEventNameAccessGranted,
-		URL:             "",
-		UserID:          uint32(a.UID),
-		AnonymousUserID: "",
-		Argument:        arg,
-		Source:          "BACKEND",
-		Timestamp:       time.Now(),
-	}
-
-	SecurityEventLogs(db).LogEvent(ctx, event)
-}
+//func logRepoAccessGranted(ctx context.Context, db dbutil.DB, repoID api.RepoID) {
+//	a := actor.FromContext(ctx)
+//	arg, _ := json.Marshal(struct {
+//		Resource string `json:"resource"`
+//		RepoID   int32  `json:"repo_id"`
+//	}{
+//		Resource: "db.repo",
+//		RepoID:   int32(repoID),
+//	})
+//
+//	event := &SecurityEvent{
+//		Name:            SecurityEventNameAccessGranted,
+//		URL:             "",
+//		UserID:          uint32(a.UID),
+//		AnonymousUserID: "",
+//		Argument:        arg,
+//		Source:          "BACKEND",
+//		Timestamp:       time.Now(),
+//	}
+//
+//	SecurityEventLogs(db).LogEvent(ctx, event)
+//}
 
 // GetByName returns the repository with the given nameOrUri from the
 // database, or an error. If we have a match on name and uri, we prefer the

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -132,7 +132,7 @@ func (s *RepoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err 
 }
 
 var counterAccessGranted = promauto.NewCounter(prometheus.CounterOpts{
-	Name: "src_access_granted",
+	Name: "src_access_granted_private_repo",
 	Help: "temporary metric to measure the impact of logging access granted to private repos",
 })
 

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -38,6 +38,8 @@ const (
 
 	SecurityEventNameRoleChangeDenied  SecurityEventName = "RoleChangeDenied"
 	SecurityEventNameRoleChangeGranted SecurityEventName = "RoleChangeGranted"
+
+	SecurityEventNameAccessGranted SecurityEventName = "AccessGranted"
 )
 
 // SecurityEvent contains information needed for logging a security-relevant event.


### PR DESCRIPTION
Before writing to our security_event_logs table we should instrument to
get a feel for the volume of writes. Previous changes to log large
amounts of data had issues on deployment.
