### PR TITLE
security: Log AccessGranted events when repo accessed directly

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -140,7 +140,7 @@ func logPrivateRepoAccessGranted(ctx context.Context, db dbutil.DB, ids []api.Re
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
 		Resource string       `json:"resource"`
-		Repos    []api.RepoID `json:"repo_id"`
+		Repos    []api.RepoID `json:"repo_ids"`
 	}{
 		Resource: "db.repo",
 		Repos:    ids,

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -139,11 +139,11 @@ var counterAccessGranted = promauto.NewCounter(prometheus.CounterOpts{
 func logRepoAccessGranted(ctx context.Context, db dbutil.DB, repoID api.RepoID) {
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
-		Resource string `json:"resource"`
-		RepoID   int32  `json:"repo_id"`
+		Resource string  `json:"resource"`
+		Repos    []int32 `json:"repo_id"`
 	}{
 		Resource: "db.repo",
-		RepoID:   int32(repoID),
+		Repos:    []int32{int32(repoID)},
 	})
 
 	event := &SecurityEvent{

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -156,6 +156,13 @@ func logPrivateRepoAccessGranted(ctx context.Context, db dbutil.DB, ids []api.Re
 		Timestamp:       time.Now(),
 	}
 
+	// If this event was triggered by an internal actor we need to ensure that at
+	// least the UserID or AnonymousUserID field are set so that we don't trigger
+	// the security_event_logs_check_has_user constraint
+	if a.Internal {
+		event.AnonymousUserID = "internal"
+	}
+
 	SecurityEventLogs(db).LogEvent(ctx, event)
 }
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -124,6 +125,7 @@ func (s *RepoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err 
 	repo := repos[0]
 	if repo.Private {
 		counterAccessGranted.Inc()
+		logRepoAccessGranted(ctx, s.Handle().DB(), repo.ID)
 	}
 
 	return repo, repo.IsBlocked()
@@ -131,8 +133,31 @@ func (s *RepoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err 
 
 var counterAccessGranted = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_access_granted_private_repo",
-	Help: "temporary metric to measure the impact of logging access granted to private repos",
+	Help: "metric to measure the impact of logging access granted to private repos",
 })
+
+func logRepoAccessGranted(ctx context.Context, db dbutil.DB, repoID api.RepoID) {
+	a := actor.FromContext(ctx)
+	arg, _ := json.Marshal(struct {
+		Resource string `json:"resource"`
+		RepoID   int32  `json:"repo_id"`
+	}{
+		Resource: "db.repo",
+		RepoID:   int32(repoID),
+	})
+
+	event := &SecurityEvent{
+		Name:            SecurityEventNameAccessGranted,
+		URL:             "",
+		UserID:          uint32(a.UID),
+		AnonymousUserID: "",
+		Argument:        arg,
+		Source:          "BACKEND",
+		Timestamp:       time.Now(),
+	}
+
+	SecurityEventLogs(db).LogEvent(ctx, event)
+}
 
 // GetByName returns the repository with the given nameOrUri from the
 // database, or an error. If we have a match on name and uri, we prefer the


### PR DESCRIPTION
Log AccessGranted event when private repo accessed

I added some instrumentation to see how often this happens, which right now is not a lot:
https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22max(src_access_granted_private_repo)%22,%22requestId%22:%22Q-e60cde3b-6771-4b1e-b23c-196cc38600a3-0A%22%7D%5D

I've also added counter for where I plan to log events when listing repos