### PR TITLE
fix vuln in libgcrypt

### DIFF
--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql
 
-RUN apk add --upgrade --no-cache libxml2=2.9.10-r7
+RUN apk add --upgrade --no-cache libxml2=2.9.10-r7 libgcrypt=1.8.8-r0
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \


### PR DESCRIPTION
remediates a vulnerability in libgcrypt

> 
<html>
<body>
<!--StartFragment--><p style="box-sizing: border-box; margin-bottom: 16px; margin-top: 0px !important; color: rgb(201, 209, 217); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">v3.30 images scanned. Were down to a few last vulnerabilities:</p><ul style="box-sizing: border-box; margin-bottom: 16px; margin-top: 0px; padding-left: 2em; color: rgb(201, 209, 217); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 0px;">sourcegraph/codeintel-db@sha256:4942c0fb6acc6227e0cdb9ee6ee1a917bc121638d61e2961a637546b0e828426/codeintel-db</li></ul>

Severity | Score | ID | Module
-- | -- | -- | --
high | 7.5 | CVE-2021-33560 | alpine:3.13:libgcrypt/libgcrypt@1.8.7-r0

<!--EndFragment-->
</body>
</html>