### PR TITLE
sg: Move everything Command/exec.Cmd related to run package

### DIFF
--- a/dev/sg/config_test.go
+++ b/dev/sg/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -45,7 +46,7 @@ commandsets:
 
 	want := &Config{
 		Env: map[string]string{"SRC_REPOS_DIR": "$HOME/.sourcegraph/repos"},
-		Commands: map[string]Command{
+		Commands: map[string]run.Command{
 			"frontend": {
 				Name:        "frontend",
 				Cmd:         "ulimit -n 10000 && .bin/frontend",
@@ -66,7 +67,7 @@ commandsets:
 				Checks:   []string{"docker"},
 			},
 		},
-		Checks: map[string]Check{
+		Checks: map[string]run.Check{
 			"docker": {
 				Name:        "docker",
 				Cmd:         "docker version",

--- a/dev/sg/internal/migration/migration.go
+++ b/dev/sg/internal/migration/migration.go
@@ -17,8 +17,8 @@ import (
 	"github.com/golang-migrate/migrate/v4/source/httpfs"
 	"github.com/jackc/pgx/v4/stdlib"
 
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/command"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/db"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -390,7 +390,7 @@ func getMigrationFilesFromGit(database db.Database, revision string) ([]string, 
 		return nil, err
 	}
 
-	output, err := command.RunGit("ls-tree", "--name-only", "-r", revision, baseDir)
+	output, err := run.GitCmd("ls-tree", "--name-only", "-r", revision, baseDir)
 	if err != nil {
 		return nil, err
 	}

--- a/dev/sg/internal/run/check.go
+++ b/dev/sg/internal/run/check.go
@@ -1,0 +1,7 @@
+package run
+
+type Check struct {
+	Name        string `yaml:"-"`
+	Cmd         string `yaml:"cmd"`
+	FailMessage string `yaml:"failMessage"`
+}

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -1,0 +1,129 @@
+package run
+
+import (
+	"context"
+	"io"
+	"os/exec"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+type Command struct {
+	Name         string
+	Cmd          string            `yaml:"cmd"`
+	Install      string            `yaml:"install"`
+	CheckBinary  string            `yaml:"checkBinary"`
+	Env          map[string]string `yaml:"env"`
+	Watch        []string          `yaml:"watch"`
+	IgnoreStdout bool              `yaml:"ignoreStdout"`
+	IgnoreStderr bool              `yaml:"ignoreStderr"`
+	DefaultArgs  string            `yaml:"defaultArgs"`
+
+	// ATTENTION: If you add a new field here, be sure to also handle that
+	// field in `Merge` (below).
+}
+
+func (c Command) Merge(other Command) Command {
+	merged := c
+
+	if other.Name != merged.Name && other.Name != "" {
+		merged.Name = other.Name
+	}
+	if other.Cmd != merged.Cmd && other.Cmd != "" {
+		merged.Cmd = other.Cmd
+	}
+	if other.Install != merged.Install && other.Install != "" {
+		merged.Install = other.Install
+	}
+	if other.IgnoreStdout != merged.IgnoreStdout && !merged.IgnoreStdout {
+		merged.IgnoreStdout = other.IgnoreStdout
+	}
+	if other.IgnoreStderr != merged.IgnoreStderr && !merged.IgnoreStderr {
+		merged.IgnoreStderr = other.IgnoreStderr
+	}
+	if other.DefaultArgs != merged.DefaultArgs && other.DefaultArgs != "" {
+		merged.DefaultArgs = other.DefaultArgs
+	}
+
+	for k, v := range other.Env {
+		merged.Env[k] = v
+	}
+
+	if !equal(merged.Watch, other.Watch) {
+		merged.Watch = other.Watch
+	}
+
+	return merged
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+type startedCmd struct {
+	*exec.Cmd
+
+	cancel func()
+
+	stdoutBuf *prefixSuffixSaver
+	stderrBuf *prefixSuffixSaver
+}
+
+func (sc *startedCmd) CapturedStdout() string {
+	if sc.stdoutBuf == nil {
+		return ""
+	}
+
+	return string(sc.stdoutBuf.Bytes())
+}
+
+func (sc *startedCmd) CapturedStderr() string {
+	if sc.stderrBuf == nil {
+		return ""
+	}
+
+	return string(sc.stderrBuf.Bytes())
+}
+
+func startCmd(ctx context.Context, dir string, cmd Command, globalEnv map[string]string) (*startedCmd, error) {
+	sc := &startedCmd{
+		stdoutBuf: &prefixSuffixSaver{N: 32 << 10},
+		stderrBuf: &prefixSuffixSaver{N: 32 << 10},
+	}
+
+	commandCtx, cancel := context.WithCancel(ctx)
+	sc.cancel = cancel
+
+	sc.Cmd = exec.CommandContext(commandCtx, "bash", "-c", cmd.Cmd)
+	sc.Cmd.Dir = dir
+	sc.Cmd.Env = makeEnv(globalEnv, cmd.Env)
+
+	logger := newCmdLogger(cmd.Name, stdout.Out)
+	if cmd.IgnoreStdout {
+		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "Ignoring stdout of %s", cmd.Name))
+	} else {
+		sc.Cmd.Stdout = io.MultiWriter(logger, sc.stdoutBuf)
+	}
+	if cmd.IgnoreStderr {
+		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "Ignoring stderr of %s", cmd.Name))
+	} else {
+		sc.Cmd.Stderr = io.MultiWriter(logger, sc.stderrBuf)
+	}
+
+	if err := sc.Start(); err != nil {
+		return sc, err
+	}
+
+	return sc, nil
+}

--- a/dev/sg/internal/run/helpers.go
+++ b/dev/sg/internal/run/helpers.go
@@ -1,6 +1,7 @@
-package command
+package run
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
@@ -9,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 )
 
-func RunGit(args ...string) (string, error) {
+func GitCmd(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Env = append(os.Environ(),
 		// Don't use the system wide git config.
@@ -17,14 +18,14 @@ func RunGit(args ...string) (string, error) {
 		// And also not any other, because they can mess up output, change defaults, .. which can do unexpected things.
 		"GIT_CONFIG=/dev/null")
 
-	return RunInRoot(cmd)
+	return InRoot(cmd)
 }
 
-func RunDocker(args ...string) (string, error) {
-	return RunInRoot(exec.Command("docker", args...))
+func DockerCmd(args ...string) (string, error) {
+	return InRoot(exec.Command("docker", args...))
 }
 
-func RunInRoot(cmd *exec.Cmd) (string, error) {
+func InRoot(cmd *exec.Cmd) (string, error) {
 	repoRoot, err := root.RepositoryRoot()
 	if err != nil {
 		return "", err
@@ -37,4 +38,10 @@ func RunInRoot(cmd *exec.Cmd) (string, error) {
 	}
 
 	return string(out), nil
+}
+
+func BashInRoot(ctx context.Context, cmd string, env []string) (string, error) {
+	c := exec.CommandContext(ctx, "bash", "-c", cmd)
+	c.Env = env
+	return InRoot(c)
 }

--- a/dev/sg/internal/run/logger.go
+++ b/dev/sg/internal/run/logger.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"bytes"

--- a/dev/sg/internal/run/prefix_suffix_saver.go
+++ b/dev/sg/internal/run/prefix_suffix_saver.go
@@ -1,0 +1,85 @@
+package run
+
+import (
+	"bytes"
+	"strconv"
+)
+
+// prefixSuffixSaver is an io.Writer which retains the first N bytes
+// and the last N bytes written to it. The Bytes() methods reconstructs
+// it with a pretty error message.
+//
+// Copy of https://sourcegraph.com/github.com/golang/go@3b770f2ccb1fa6fecc22ea822a19447b10b70c5c/-/blob/src/os/exec/exec.go#L661-729
+type prefixSuffixSaver struct {
+	N         int // max size of prefix or suffix
+	prefix    []byte
+	suffix    []byte // ring buffer once len(suffix) == N
+	suffixOff int    // offset to write into suffix
+	skipped   int64
+
+	// TODO(bradfitz): we could keep one large []byte and use part of it for
+	// the prefix, reserve space for the '... Omitting N bytes ...' message,
+	// then the ring buffer suffix, and just rearrange the ring buffer
+	// suffix when Bytes() is called, but it doesn't seem worth it for
+	// now just for error messages. It's only ~64KB anyway.
+}
+
+func (w *prefixSuffixSaver) Write(p []byte) (n int, err error) {
+	lenp := len(p)
+	p = w.fill(&w.prefix, p)
+
+	// Only keep the last w.N bytes of suffix data.
+	if overage := len(p) - w.N; overage > 0 {
+		p = p[overage:]
+		w.skipped += int64(overage)
+	}
+	p = w.fill(&w.suffix, p)
+
+	// w.suffix is full now if p is non-empty. Overwrite it in a circle.
+	for len(p) > 0 { // 0, 1, or 2 iterations.
+		n := copy(w.suffix[w.suffixOff:], p)
+		p = p[n:]
+		w.skipped += int64(n)
+		w.suffixOff += n
+		if w.suffixOff == w.N {
+			w.suffixOff = 0
+		}
+	}
+	return lenp, nil
+}
+
+// fill appends up to len(p) bytes of p to *dst, such that *dst does not
+// grow larger than w.N. It returns the un-appended suffix of p.
+func (w *prefixSuffixSaver) fill(dst *[]byte, p []byte) (pRemain []byte) {
+	if remain := w.N - len(*dst); remain > 0 {
+		add := minInt(len(p), remain)
+		*dst = append(*dst, p[:add]...)
+		p = p[add:]
+	}
+	return p
+}
+
+func (w *prefixSuffixSaver) Bytes() []byte {
+	if w.suffix == nil {
+		return w.prefix
+	}
+	if w.skipped == 0 {
+		return append(w.prefix, w.suffix...)
+	}
+	var buf bytes.Buffer
+	buf.Grow(len(w.prefix) + len(w.suffix) + 50)
+	buf.Write(w.prefix)
+	buf.WriteString("\n... omitting ")
+	buf.WriteString(strconv.FormatInt(w.skipped, 10))
+	buf.WriteString(" bytes ...\n")
+	buf.Write(w.suffix[w.suffixOff:])
+	buf.Write(w.suffix[:w.suffixOff])
+	return buf.Bytes()
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"golang.org/x/mod/semver"
 
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/command"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -76,14 +76,14 @@ func printDeployedVersion(e environment) error {
 	buildSha := elems[2]
 
 	pending = out.Pending(output.Line("", output.StylePending, "Running 'git fetch' to update list of commits..."))
-	_, err = command.RunGit("fetch", "-q")
+	_, err = run.GitCmd("fetch", "-q")
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Failed: %s", err))
 		return err
 	}
 	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Done updating list of commits"))
 
-	log, err := command.RunGit("log", "--oneline", "-n", "20", `--pretty=format:%h|%ar|%an|%s`, "origin/main")
+	log, err := run.GitCmd("log", "--oneline", "-n", "20", `--pretty=format:%h|%ar|%an|%s`, "origin/main")
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Failed: %s", err))
 		return err


### PR DESCRIPTION
Baby steps. But check out how sweet the API is:

```go
run.Commands(ctx, globalConf.Env, cmd)
run.GitCmd("diff")
run.DockerCmd("run", "alpine:3")
```