### PR TITLE
adding note about disabled code insights on dot-com

### DIFF
--- a/doc/dev/background-information/insights/backend.md
+++ b/doc/dev/background-information/insights/backend.md
@@ -34,6 +34,9 @@ The following architecture diagram shows how the backend fits into the two Sourc
 
 [![](diagrams/architecture.svg)](https://raw.githubusercontent.com/sourcegraph/sourcegraph/main/doc/dev/background-information/insights/diagrams/architecture.svg)
 
+## Deployment Status
+Code Insights backend is currently disabled on `sourcegraph.com` until solutions can be built to address the large indexed repo count.
+
 ## Feature Flags
 Code Insights is currently an experimental feature, and ships with an "escape hatch" feature flag that will completely disable the dependency on TimescaleDB (named `codeinsights-db`). This feature flag is implemented as an environment variable that if set true `DISABLE_CODE_INSIGHTS=true` will disable the dependency and will not start the Code Insights background workers or GraphQL resolvers. This variable must be set on both the `worker` and `frontend` services to remove the dependency. If the flag is not set on both services, the `codeinsights-db` dependency will be required.
 


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
