### PR TITLE
Add warning about 3.30 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ## 3.30.0
 
-__⚠️ Prefer upgrading to the 3.30.1 release instead of 3.30.0 release to avoid issues with repo-updater errors__
+**⚠️ Prefer upgrading to the 3.30.1 release instead of 3.30.0 release to avoid issues with repo-updater errors**
+
 ### Added
 
 - Added support for `select:file.directory` in search queries, which returns unique directory paths for results that satisfy the query. [#22449](https://github.com/sourcegraph/sourcegraph/pull/22449)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- An issue where the UI would occassionally display `lsifStore.Ranges: ERROR: relation \"lsif_documentation_mappings\" does not exist (SQLSTATE 42P01)` [#23115](https://github.com/sourcegraph/sourcegraph/pull/23115)
+- An issue where the UI would occasionally display `lsifStore.Ranges: ERROR: relation \"lsif_documentation_mappings\" does not exist (SQLSTATE 42P01)` [#23115](https://github.com/sourcegraph/sourcegraph/pull/23115)
 - Fixed a vulnerability in our Postgres Alpine image related to libgcrypt [#23174](https://github.com/sourcegraph/sourcegraph/pull/23174)
 - When syncing in streaming mode, repo-updater will now ensure a repo's transaction is committed before notifying gitserver to update that repo. [#23169](https://github.com/sourcegraph/sourcegraph/pull/23169)
 - When encountering spurious errors during streaming syncing (like temporary 500s from codehosts), repo-updater will no longer delete all associated repos that weren't seen. Deletion will happen only if there were no errors or if the error was one of "Unauthorized", "Forbidden" or "Account Suspended". [#23171](https://github.com/sourcegraph/sourcegraph/pull/23171)
@@ -42,6 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ## 3.30.0
 
+__⚠️ Prefer upgrading to the 3.30.1 release instead of 3.30 release to avoid issues with repo-updater errors__
 ### Added
 
 - Added support for `select:file.directory` in search queries, which returns unique directory paths for results that satisfy the query. [#22449](https://github.com/sourcegraph/sourcegraph/pull/22449)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ## 3.30.0
 
-__⚠️ Prefer upgrading to the 3.30.1 release instead of 3.30 release to avoid issues with repo-updater errors__
+__⚠️ Prefer upgrading to the 3.30.1 release instead of 3.30.0 release to avoid issues with repo-updater errors__
 ### Added
 
 - Added support for `select:file.directory` in search queries, which returns unique directory paths for results that satisfy the query. [#22449](https://github.com/sourcegraph/sourcegraph/pull/22449)


### PR DESCRIPTION
Suggest that customers wait till the 3.30.1  patch release

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
