### PR TITLE
compute: match environment from line results

### DIFF
--- a/internal/compute/match.go
+++ b/internal/compute/match.go
@@ -1,0 +1,86 @@
+package compute
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+)
+
+type Location struct {
+	Offset int `json:"offset"`
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type Range struct {
+	Start Location `json:"start"`
+	End   Location `json:"end"`
+}
+
+type Data struct {
+	Value string `json:"value"`
+	Range Range  `json:"range"`
+}
+
+type Environment map[string]Data
+
+type Match struct {
+	Value       string      `json:"value"`
+	Range       Range       `json:"range"`
+	Environment Environment `json:"environment"`
+}
+
+type Result struct {
+	Matches []Match `json:"matches"`
+	Path    string  `json:"path"`
+}
+
+func newLocation(line, column, offset int) Location {
+	return Location{
+		Offset: offset,
+		Line:   line,
+		Column: column,
+	}
+}
+
+func newRange(startLine, endLine, startColumn, endColumn int) Range {
+	return Range{
+		Start: newLocation(startLine, startColumn, -1),
+		End:   newLocation(endLine, endColumn, -1),
+	}
+}
+
+func ofRegexpMatches(matches [][]int, lineValue string, lineNumber int) Match {
+	env := make(Environment)
+	var firstValue string
+	var firstRange Range
+	for _, m := range matches {
+		for j := 0; j < len(m); j += 2 {
+			start := m[j]
+			end := m[j+1]
+			value := lineValue[start:end]
+			range_ := newRange(lineNumber, lineNumber, start, end)
+
+			if j == 0 {
+				// The first submatch is the overall match
+				// value. Don't add this to the Environment
+				firstValue = value
+				firstRange = range_
+				continue
+			}
+			v := fmt.Sprintf("$%d", j/2)
+			env[v] = Data{Value: value, Range: range_}
+		}
+	}
+	return Match{Value: firstValue, Range: firstRange, Environment: env}
+}
+
+func ofFileMatches(fm *result.FileMatch, r *regexp.Regexp) *Result {
+	var matches []Match
+	for _, l := range fm.LineMatches {
+		regexpMatches := r.FindAllStringSubmatchIndex(l.Preview, -1)
+		matches = append(matches, ofRegexpMatches(regexpMatches, l.Preview, int(l.LineNumber)))
+	}
+	return &Result{Matches: matches, Path: fm.Path}
+}

--- a/internal/compute/match_test.go
+++ b/internal/compute/match_test.go
@@ -1,0 +1,112 @@
+package compute
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+)
+
+func TestOfLineMatches(t *testing.T) {
+	data := &result.FileMatch{
+		File: result.File{Path: "bedge"},
+		LineMatches: []*result.LineMatch{
+			{
+				Preview:    "abcdefgh",
+				LineNumber: 1,
+			},
+		},
+	}
+
+	test := func(input string) string {
+		r, _ := regexp.Compile(input)
+		result := ofFileMatches(data, r)
+		v, _ := json.MarshalIndent(result, "", "  ")
+		return string(v)
+	}
+
+	autogold.Want("compute regexp submatch environment", `{
+  "matches": [
+    {
+      "value": "abcdefgh",
+      "range": {
+        "start": {
+          "offset": -1,
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "offset": -1,
+          "line": 1,
+          "column": 8
+        }
+      },
+      "environment": {
+        "$1": {
+          "value": "bc",
+          "range": {
+            "start": {
+              "offset": -1,
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "offset": -1,
+              "line": 1,
+              "column": 3
+            }
+          }
+        },
+        "$2": {
+          "value": "c",
+          "range": {
+            "start": {
+              "offset": -1,
+              "line": 1,
+              "column": 2
+            },
+            "end": {
+              "offset": -1,
+              "line": 1,
+              "column": 3
+            }
+          }
+        },
+        "$3": {
+          "value": "de",
+          "range": {
+            "start": {
+              "offset": -1,
+              "line": 1,
+              "column": 3
+            },
+            "end": {
+              "offset": -1,
+              "line": 1,
+              "column": 5
+            }
+          }
+        },
+        "$4": {
+          "value": "g",
+          "range": {
+            "start": {
+              "offset": -1,
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "offset": -1,
+              "line": 1,
+              "column": 7
+            }
+          }
+        }
+      }
+    }
+  ],
+  "path": "bedge"
+}`).Equal(t, test("a(b(c))(de)f(g)h"))
+}


### PR DESCRIPTION
This PR introduces regex submatching and exposes it in match environment. See https://github.com/sourcegraph/sourcegraph/issues/21579 for context.

It is not used anywhere yet. I will hook it up to an experimental GQL or streaming interface in a follow up PR. 

It uses convention of `$1`... names for regexp submatch variables. I will work on named regex capture groups a bit later. This is an early kick off to just get the types right and some basic regex postprocessing.

Larger context: I am minting a new `internal/compute` package for computed values that are typically more expensive to compute than pure text search results. You can generally think of `internal/compute` as "postprocessing logic that manipulates search results". In future I expect that "postprocessing" will include, e.g., hooking into LSIF data _in order to_ still manipulate results. So this package carves out a new place for code that relies on search as a precursor to other result computation, and may make sense to integrate with our worker service and not, e.g., be called from the frontend to do extra result computation.