### PR TITLE
extensibility: use sideloaded settings schema over remote

### DIFF
--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -203,7 +203,9 @@ export class SettingsArea extends React.Component<Props, State> {
             ),
         ]).pipe(
             map(([registryExtensions, sideloadedExtension]) =>
-                [...registryExtensions, sideloadedExtension].filter(isDefined)
+                // Ensure that sideloaded extension settings keys have precedence over
+                // the same keys from its registry extension counterpart
+                [sideloadedExtension, ...registryExtensions].filter(isDefined)
             ),
             map(extensions => ({
                 $id: 'mergedSettings.schema.json#',


### PR DESCRIPTION
Fix #20679.

It appears that Monaco uses the first occurrence of a key in an [`allOf`](https://json-schema.org/understanding-json-schema/reference/combining.html#id5) array.

#### Before

![Screenshot from 2021-07-25 18-09-36](https://user-images.githubusercontent.com/37420160/126914996-3c16483a-1dc5-412a-be43-9d8e30930b42.png)

#### After

![Screenshot from 2021-07-25 18-09-24](https://user-images.githubusercontent.com/37420160/126915000-fe3bf9a2-3789-4d9c-a762-641fe26ec01f.png)
