### PR TITLE
CI: bump libxml2 and redis

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update && apk add --no-cache \
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     'bash=5.0.17-r0' \
-    'redis=5.0.11-r0' \
+    'redis=5.0.13-r0' \
     # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
     'git>=2.18' \
     git-p4 \

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql
 
-RUN apk add --upgrade --no-cache libxml2=2.9.10-r7 libgcrypt=1.8.8-r0
+RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r0
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \


### PR DESCRIPTION
This fixes the broken CI on main.

libxml2 2.9.10-r7 -> 2.9.12-r0
redis 5.0.11-r0 -> 5.0.13-r0

