### PR TITLE
codeintel: Rate limit auto-indexing requests to repo-updater/gitserver

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/config.go
+++ b/enterprise/cmd/frontend/internal/codeintel/config.go
@@ -3,6 +3,7 @@ package codeintel
 import (
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/enqueuer"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
@@ -11,6 +12,7 @@ type Config struct {
 	env.BaseConfig
 
 	UploadStoreConfig                         *uploadstore.Config
+	AutoIndexEnqueuerConfig                   *enqueuer.Config
 	HunkCacheSize                             int
 	DiagnosticsCountMigrationBatchSize        int
 	DiagnosticsCountMigrationBatchInterval    time.Duration
@@ -30,6 +32,10 @@ func init() {
 	uploadStoreConfig := &uploadstore.Config{}
 	uploadStoreConfig.Load()
 	config.UploadStoreConfig = uploadStoreConfig
+
+	enqueuerConfig := &enqueuer.Config{}
+	enqueuerConfig.Load()
+	config.AutoIndexEnqueuerConfig = enqueuerConfig
 
 	config.HunkCacheSize = config.GetInt("PRECISE_CODE_INTEL_HUNK_CACHE_SIZE", "1000", "The capacity of the git diff hunk cache.")
 	config.DiagnosticsCountMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_DIAGNOSTICS_COUNT_MIGRATION_BATCH_SIZE", "1000", "The maximum number of document records to migrate at a time.")

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -67,7 +67,7 @@ func initServices(ctx context.Context, db dbutil.DB) error {
 		gitserverClient := gitserver.New(dbStore, observationContext)
 
 		// Initialize the index enqueuer
-		indexEnqueuer := enqueuer.NewIndexEnqueuer(&enqueuer.DBStoreShim{dbStore}, gitserverClient, repoupdater.DefaultClient, observationContext)
+		indexEnqueuer := enqueuer.NewIndexEnqueuer(&enqueuer.DBStoreShim{dbStore}, gitserverClient, repoupdater.DefaultClient, config.AutoIndexEnqueuerConfig, observationContext)
 
 		services.dbStore = dbStore
 		services.locker = locker

--- a/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -38,7 +37,6 @@ func TestIndexSchedulerUpdate(t *testing.T) {
 		settingStore:  mockSettingStore,
 		repoStore:     mockRepoStore,
 		indexEnqueuer: indexEnqueuer,
-		limiter:       rate.NewLimiter(25, 1),
 		operations:    newOperations(&observation.TestContext),
 	}
 
@@ -86,7 +84,6 @@ func TestDisabledAutoindexConfiguration(t *testing.T) {
 		settingStore:  mockSettingStore,
 		repoStore:     mockRepoStore,
 		indexEnqueuer: indexEnqueuer,
-		limiter:       rate.NewLimiter(25, 1),
 		operations:    newOperations(&observation.TestContext),
 	}
 

--- a/enterprise/cmd/worker/internal/codeintel/indexing_config.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing_config.go
@@ -3,12 +3,14 @@ package codeintel
 import (
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/enqueuer"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
 type indexingConfig struct {
 	env.BaseConfig
 
+	AutoIndexEnqueuerConfig                *enqueuer.Config
 	AutoIndexingTaskInterval               time.Duration
 	DependencyIndexerSchedulerPollInterval time.Duration
 	DependencyIndexerSchedulerConcurrency  int
@@ -17,6 +19,10 @@ type indexingConfig struct {
 var indexingConfigInst = &indexingConfig{}
 
 func (c *indexingConfig) Load() {
+	enqueuerConfig := &enqueuer.Config{}
+	enqueuerConfig.Load()
+	indexingConfigInst.AutoIndexEnqueuerConfig = enqueuerConfig
+
 	c.AutoIndexingTaskInterval = c.GetInterval("PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL", "10m", "The frequency with which to run periodic codeintel auto-indexing tasks.")
 	c.DependencyIndexerSchedulerPollInterval = c.GetInterval("PRECISE_CODE_INTEL_DEPENDENCY_INDEXER_SCHEDULER_POLL_INTERVAL", "1s", "Interval between queries to the dependency indexing job queue.")
 	c.DependencyIndexerSchedulerConcurrency = c.GetInt("PRECISE_CODE_INTEL_DEPENDENCY_INDEXER_SCHEDULER_CONCURRENCY", "1", "The maximum number of dependency graphs that can be processed concurrently.")

--- a/enterprise/cmd/worker/internal/codeintel/indexing_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing_job.go
@@ -58,7 +58,7 @@ func (j *indexingJob) Routines(ctx context.Context) ([]goroutine.BackgroundRouti
 
 	dbStoreShim := &indexing.DBStoreShim{Store: dbStore}
 	enqueuerDBStoreShim := &enqueuer.DBStoreShim{Store: dbStore}
-	indexEnqueuer := enqueuer.NewIndexEnqueuer(enqueuerDBStoreShim, gitserverClient, repoupdater.DefaultClient, observationContext)
+	indexEnqueuer := enqueuer.NewIndexEnqueuer(enqueuerDBStoreShim, gitserverClient, repoupdater.DefaultClient, indexingConfigInst.AutoIndexEnqueuerConfig, observationContext)
 	metrics := workerutil.NewMetrics(observationContext, "codeintel_dependency_index_processor", nil)
 
 	settingStore := database.Settings(db)

--- a/enterprise/internal/codeintel/autoindex/enqueuer/config.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/config.go
@@ -1,0 +1,27 @@
+package enqueuer
+
+import (
+	"golang.org/x/time/rate"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+type Config struct {
+	env.BaseConfig
+
+	MaximumRepositoriesInspectedPerSecond    rate.Limit
+	MaximumIndexJobsPerInferredConfiguration int
+}
+
+func (c *Config) Load() {
+	c.MaximumRepositoriesInspectedPerSecond = toRate(c.GetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_INSPECTED_PER_SECOND", "0", "The maximum number of repositories inspected for auto-indexing per second. Set to zero to disable limit."))
+	c.MaximumIndexJobsPerInferredConfiguration = c.GetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_INDEX_JOBS_PER_INFERRED_CONFIGURATION", "25", "Repositories with a number of inferred auto-index jobs exceeding this threshold will be auto-indexed.")
+}
+
+func toRate(value int) rate.Limit {
+	if value == 0 {
+		return rate.Inf
+	}
+
+	return rate.Limit(value)
+}

--- a/enterprise/internal/codeintel/autoindex/enqueuer/config.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/config.go
@@ -10,11 +10,13 @@ type Config struct {
 	env.BaseConfig
 
 	MaximumRepositoriesInspectedPerSecond    rate.Limit
+	MaximumRepositoriesUpdatedPerSecond      rate.Limit
 	MaximumIndexJobsPerInferredConfiguration int
 }
 
 func (c *Config) Load() {
 	c.MaximumRepositoriesInspectedPerSecond = toRate(c.GetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_INSPECTED_PER_SECOND", "0", "The maximum number of repositories inspected for auto-indexing per second. Set to zero to disable limit."))
+	c.MaximumRepositoriesUpdatedPerSecond = toRate(c.GetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_UPDATED_PER_SECOND", "0", "The maximum number of repositories cloned or fetched for auto-indexing per second. Set to zero to disable limit."))
 	c.MaximumIndexJobsPerInferredConfiguration = c.GetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_INDEX_JOBS_PER_INFERRED_CONFIGURATION", "25", "Repositories with a number of inferred auto-index jobs exceeding this threshold will be auto-indexed.")
 }
 

--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
+	"golang.org/x/time/rate"
 
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -17,22 +18,28 @@ import (
 )
 
 type IndexEnqueuer struct {
-	dbStore          DBStore
-	gitserverClient  GitserverClient
-	repoUpdater      RepoUpdaterClient
-	maxJobsPerCommit int
-	operations       *operations
+	dbStore         DBStore
+	gitserverClient GitserverClient
+	repoUpdater     RepoUpdaterClient
+	config          *Config
+	limiter         *rate.Limiter
+	operations      *operations
 }
 
-const defaultMaxJobsPerCommit = 25
-
-func NewIndexEnqueuer(dbStore DBStore, gitClient GitserverClient, repoUpdater RepoUpdaterClient, observationContext *observation.Context) *IndexEnqueuer {
+func NewIndexEnqueuer(
+	dbStore DBStore,
+	gitClient GitserverClient,
+	repoUpdater RepoUpdaterClient,
+	config *Config,
+	observationContext *observation.Context,
+) *IndexEnqueuer {
 	return &IndexEnqueuer{
-		dbStore:          dbStore,
-		gitserverClient:  gitClient,
-		repoUpdater:      repoUpdater,
-		maxJobsPerCommit: defaultMaxJobsPerCommit,
-		operations:       newOperations(observationContext),
+		dbStore:         dbStore,
+		gitserverClient: gitClient,
+		repoUpdater:     repoUpdater,
+		config:          config,
+		limiter:         rate.NewLimiter(config.MaximumRepositoriesInspectedPerSecond, 1),
+		operations:      newOperations(observationContext),
 	}
 }
 
@@ -198,6 +205,10 @@ func (s *IndexEnqueuer) queueIndexes(ctx context.Context, repositoryID int, comm
 
 // inferIndexJobsFromRepositoryStructure collects the result of  InferIndexJobs over all registered recognizers.
 func (s *IndexEnqueuer) inferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string) ([]config.IndexJob, error) {
+	if err := s.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
 	paths, err := s.gitserverClient.ListFiles(ctx, repositoryID, commit, inference.Patterns)
 	if err != nil {
 		return nil, errors.Wrap(err, "gitserver.ListFiles")
@@ -210,7 +221,7 @@ func (s *IndexEnqueuer) inferIndexJobsFromRepositoryStructure(ctx context.Contex
 		indexes = append(indexes, recognizer.InferIndexJobs(gitclient, paths)...)
 	}
 
-	if len(indexes) > s.maxJobsPerCommit {
+	if len(indexes) > s.config.MaximumIndexJobsPerInferredConfiguration {
 		log15.Info("Too many inferred roots. Scheduling no index jobs for repository.", "repository_id", repositoryID)
 		return nil, nil
 	}


### PR DESCRIPTION
Limit the (significant) requests we make to gitserver and repo-updater for auto-indexing tasks. We can control the rate of requests from a service with the following envvars:

- `PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_INSPECTED_PER_SECOND`
- `PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_UPDATED_PER_SECOND`
- `PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_INDEX_JOBS_PER_INFERRED_CONFIGURATION`

Fixes https://github.com/sourcegraph/sourcegraph/issues/12380.