### PR TITLE
doc: use Swiftype search

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -262,6 +262,15 @@ body > #sidebar #search-form .search-icon {
     left: 26px;
     top: 18px;
 }
+/* disable swiftype search icon */
+body > #sidebar #search-form .st-default-search-input, .st-ui-search-input {
+    background: none;
+}
+/* tweak generated swifttype autocomplete bar */
+.st-default-autocomplete {
+    position: fixed;
+    min-width: 25%;
+}
 /* Nav */
 body > #sidebar nav.links {
     margin-top: calc(0.75*var(--spacing));
@@ -689,6 +698,14 @@ body > #page > main > #content {
 .search-result .excerpt {
   display: inline-block;
   margin: 0;
+}
+/* tweak swifttype search results */
+.search-result a.st-ui-result:hover .st-ui-type-detail,
+.search-result a.st-ui-result:hover .st-ui-type-detail .st-ui-type-detail-bold {
+    color: var(--text-color);
+}
+body.theme-dark .search-result a.st-ui-result:hover .st-ui-type-detail em {
+    color: var(--body-bg);
 }
 
 /* CONTENT */

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -42,7 +42,7 @@
                     </a></h1>
                     <form id="search-form" method="get" action="/search">
                         <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="M21.172 24l-7.387-7.387c-1.388.874-3.024 1.387-4.785 1.387-4.971 0-9-4.029-9-9s4.029-9 9-9 9 4.029 9 9c0 1.761-.514 3.398-1.387 4.785l7.387 7.387-2.828 2.828zm-12.172-8c3.859 0 7-3.14 7-7s-3.141-7-7-7-7 3.14-7 7 3.141 7 7 7z"/></svg>
-					    <input type="text" id="search" name="q" value="{{block "query" .}}{{end}}" placeholder="" spellcheck="false" aria-label="Query" />
+					    <input type="text" id="search" name="q" value="{{block "query" .}}{{end}}" placeholder="" spellcheck="false" aria-label="Query" class="st-default-search-input" />
                         <input type="hidden" name="v" value="{{block "version" .}}{{end}}">
 					    <button id="search-button" type="submit" aria-label="Search" class="sr-only">Search</button>
 				    </form>
@@ -91,6 +91,20 @@
                 </footer>
             </div>
 		</body>
+
+        <!--
+            https://app.swiftype.com/engines/sourcegraph-docs
+
+            Remove the script block to disable Swifttype search and use the built-in docsite search!
+        -->
+        <script type="text/javascript">
+            (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+            (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+            e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+            })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+
+            _st('install','u68TjdsBrrjUZHvJqtyt','2.0.0');
+        </script>
 	</html>
 {{end}}
 

--- a/doc/_resources/templates/search.html
+++ b/doc/_resources/templates/search.html
@@ -1,5 +1,5 @@
 {{define "title"}}
-	{{.Query}} - Search
+	Search{{if .Query}} - {{.Query}}{{end}}
 {{end}}
 
 {{define "head"}}
@@ -9,8 +9,10 @@
 {{define "query"}}{{.Query}}{{end}}
 
 {{define "content"}}
-	<section id="content" class="search-result">
-		<h1>{{.Result.Total}} result{{if ne .Result.Total 1}}s{{end}} found for <strong>{{.Query}}</strong></h1>
+	<section id="content" class="search-result st-search-container">
+        {{if .Query}}
+		    <h1>{{.Result.Total}} result{{if ne .Result.Total 1}}s{{end}} found for <strong>{{.Query}}</strong></h1>
+        {{end}}
 		{{if .Result.DocumentResults}}
 		<ol class="document-results">
 			{{range $dr := .Result.DocumentResults}}


### PR DESCRIPTION
Integrate [Swiftype](https://swiftype.com/) for https://docs.sourcegraph.com at https://app.swiftype.com/engines/sourcegraph-docs, similar to what is available in the handbook (https://github.com/sourcegraph/about/pull/3153)

This gives us some pretty exciting features on the backend:

![image](https://user-images.githubusercontent.com/23356519/127024563-546719dc-6e23-4121-876c-854ced975024.png)
![image](https://user-images.githubusercontent.com/23356519/127024859-d4cb7ff1-5b60-4561-9a8b-8c3b9a3bef6b.png)
![image](https://user-images.githubusercontent.com/23356519/127024896-f78923ba-8c6d-4e82-bfdc-4ab29980e9db.png)

We can also make regular reports, like is currently done for the handbook: https://sourcegraph.slack.com/archives/C021KFCA5MF/p1627303929083700

On the frontend, it _mostly_ integrates quite nicely into the existing UI. NGL it don't look great in but I fiddled for about an hour and I think this is good enough, CSS is too hard. I kept the `/search` page which I like better than the popup (quite laggy on the handbook):

![image](https://user-images.githubusercontent.com/23356519/127024060-26e78902-7ea9-4456-aca5-1884e0f6946d.png)

![image](https://user-images.githubusercontent.com/23356519/127024109-71273e9c-0c95-4370-b851-562a89c52f0b.png)

![image](https://user-images.githubusercontent.com/23356519/127024318-a0c85f48-3d23-4d0d-9d72-d94842267b1e.png)

![image](https://user-images.githubusercontent.com/23356519/127024278-355776c9-1cbf-46d7-9640-0d96c0834fd1.png)


