### PR TITLE
codeintel: Enable dependency indexing for all Go repositories

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
@@ -99,27 +99,14 @@ func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, record 
 	return multierror.Append(nil, errs...)
 }
 
-var dependencyIndexingRepositoryIDs = []int{
-	35703861, // github.com/sourcegraph/jsonx on cloud
-	36146693, // github.com/sourcegraph/src-clion cloud
-	36809250, // github.com/sourcegraph/sourcegraph on cloud
-	38967070, // github.com/sourcegraph/lsif-go on cloud
-}
-
 // shouldIndexDependencies returns true if the given upload should undergo dependency
-// indexing. Currently, we're only enabling dependency indexing for a small, hard-coded
-// list of repository identifiers in the Cloud env.
+// indexing. Currently, we're only enabling dependency indexing for a repositories that
+// were indexed via lsif-go.
 func (h *dependencyIndexingSchedulerHandler) shouldIndexDependencies(ctx context.Context, store DBStore, uploadID int) (bool, error) {
 	upload, _, err := store.GetUploadByID(ctx, uploadID)
 	if err != nil {
 		return false, errors.Wrap(err, "dbstore.GetUploadByID")
 	}
 
-	for _, repositoryID := range dependencyIndexingRepositoryIDs {
-		if upload.RepositoryID == repositoryID {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return upload.Indexer == "lsif-go", nil
 }

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler_test.go
@@ -13,12 +13,10 @@ import (
 )
 
 func TestDependencyIndexingSchedulerHandler(t *testing.T) {
-	dependencyIndexingRepositoryIDs = []int{50}
-
 	mockDBStore := NewMockDBStore()
 	mockScanner := NewMockPackageReferenceScanner()
 	mockDBStore.WithFunc.SetDefaultReturn(mockDBStore)
-	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(dbstore.Upload{ID: 42, RepositoryID: 50}, true, nil)
+	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(dbstore.Upload{ID: 42, RepositoryID: 50, Indexer: "lsif-go"}, true, nil)
 	mockDBStore.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 
 	mockScanner.NextFunc.PushReturn(lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 42, Scheme: "test", Name: "name1", Version: "v2.2.0"}}, true, nil)
@@ -82,12 +80,10 @@ func TestDependencyIndexingSchedulerHandler(t *testing.T) {
 }
 
 func TestDependencyIndexingSchedulerHandlerShouldSkipRepository(t *testing.T) {
-	dependencyIndexingRepositoryIDs = []int{50}
-
 	mockDBStore := NewMockDBStore()
 	mockScanner := NewMockPackageReferenceScanner()
 	mockDBStore.WithFunc.SetDefaultReturn(mockDBStore)
-	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(dbstore.Upload{ID: 42, RepositoryID: 51}, true, nil)
+	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(dbstore.Upload{ID: 42, RepositoryID: 51, Indexer: "lsif-tsc"}, true, nil)
 	mockDBStore.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 
 	indexEnqueuer := NewMockIndexEnqueuer()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/21607.