### PR TITLE
search: simplify repo rev callback resolution

### DIFF
--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -123,4 +123,4 @@ func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k
 
 // repoRevFunc is a function which maps repository names returned from Zoekt
 // into the Sourcegraph's resolved repository revisions for the search.
-type repoRevFunc func(file *zoekt.FileMatch) (repo types.RepoName, revs []string, ok bool)
+type repoRevFunc func(file *zoekt.FileMatch) (repo types.RepoName, revs []string)


### PR DESCRIPTION
Semantics preserving. See inline comments.

I'm looking at this code because I was wondering about a way to cleanly separate text and symbol matches (`sendMatches` tries to do too much disjoint stuff)