### PR TITLE
search: pass file limit to zoekt search options

### DIFF
--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -142,7 +142,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, repoBranches
 
 	// Choose sensible values for k when we generalize this.
 	k := zoektutil.ResultCountFactor(len(repoBranches), args.FileMatchLimit, false)
-	searchOpts := zoektutil.SearchOpts(ctx, k, args)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.FileMatchLimit)
 	searchOpts.Whole = true
 
 	// TODO(@camdencheek) TODO(@rvantonder) handle "timeout:..." values in this context.

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -368,7 +368,7 @@ func zoektSearchGlobal(ctx context.Context, args *search.TextParameters, query z
 
 func doZoektSearchGlobal(ctx context.Context, q zoektquery.Q, args *search.TextParameters, typ IndexedRequestType, c streaming.Sender) error {
 	k := ResultCountFactor(0, args.PatternInfo.FileMatchLimit, true)
-	searchOpts := SearchOpts(ctx, k, args.PatternInfo)
+	searchOpts := SearchOpts(ctx, k, args.PatternInfo.FileMatchLimit)
 
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
@@ -441,7 +441,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, q zoektquery.
 	finalQuery := zoektquery.NewAnd(&zoektquery.RepoBranches{Set: repos.repoBranches}, q)
 
 	k := ResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, false)
-	searchOpts := SearchOpts(ctx, k, args.PatternInfo)
+	searchOpts := SearchOpts(ctx, k, args.PatternInfo.FileMatchLimit)
 
 	// Start event stream.
 	t0 := time.Now()

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -68,7 +68,7 @@ func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[stri
 	return true, spanContext
 }
 
-func SearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt.SearchOptions {
+func SearchOpts(ctx context.Context, k int, fileMatchLimit int32) zoekt.SearchOptions {
 	shouldTrace, spanContext := getSpanContext(ctx)
 	searchOpts := zoekt.SearchOptions{
 		Trace:                  shouldTrace,
@@ -80,11 +80,11 @@ func SearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt
 		TotalMaxImportantMatch: 25 * k,
 		// Ask for 2000 more results so we have results to populate
 		// RepoStatusLimitHit.
-		MaxDocDisplayCount: int(query.FileMatchLimit) + 2000,
+		MaxDocDisplayCount: int(fileMatchLimit) + 2000,
 	}
 
-	if userProbablyWantsToWaitLonger := query.FileMatchLimit > search.DefaultMaxSearchResults; userProbablyWantsToWaitLonger {
-		searchOpts.MaxWallTime *= time.Duration(3 * float64(query.FileMatchLimit) / float64(search.DefaultMaxSearchResults))
+	if userProbablyWantsToWaitLonger := fileMatchLimit > search.DefaultMaxSearchResults; userProbablyWantsToWaitLonger {
+		searchOpts.MaxWallTime *= time.Duration(3 * float64(fileMatchLimit) / float64(search.DefaultMaxSearchResults))
 	}
 
 	return searchOpts


### PR DESCRIPTION
`SearchOpts` only depends on one value inside args: `FileMatchLimit`. Pass that value directly instead. This simplifies upcoming changes to narrow the dependency on values of `args` in the Zoekt code path.