### PR TITLE
Remove nodejs from `.tool-versions`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,4 +5,3 @@ shfmt 3.2.0
 shellcheck 0.7.1
 kubectl 1.17.3
 github-cli 1.8.0
-nodejs 14.15.4


### PR DESCRIPTION
It sounds like this was added [here](https://github.com/sourcegraph/sourcegraph/commit/7099bdcbf1a5c7da697f7c43bf064d0e8e0b7a67#diff-751af1a340658c7b8176fe32d7db9fadbe15d1d075daba1919a91df04155bc70) due to an observation that asdf was not respecting the version present in `.nvmrc`. However, this isn't ideal since it means there is no longer a single source of truth on the node version. We use the renovate bot to [automatically update](https://docs.renovatebot.com/node/) our node version (which it can only do for the `.nvmrc` file and `package.json`'s `engines` entry), but asdf will favor the version in `.tool-versions` and just ignore the version in `.nvmrc` if both are present.

I'm able to observe asdf respecting `.nvmrc` and the `legacy_version_file` flag locally on the two latest major versions:

```
➜  sourcegraph git:(kr/remove-node-asdf) ✗ asdf --version
v0.8.0-c6145d0
➜  sourcegraph git:(kr/remove-node-asdf) ✗ asdf current nodejs
nodejs          14.15.4         /Users/krockwell/sourcegraph/sourcegraph/.nvmrc
➜  sourcegraph git:(kr/remove-node-asdf) ✗ asdf update
[...]
➜  sourcegraph git:(kr/remove-node-asdf) ✗ asdf --version
v0.8.1-a1ef92a
➜  sourcegraph git:(kr/remove-node-asdf) ✗ asdf current nodejs
nodejs          14.15.4         /Users/krockwell/sourcegraph/sourcegraph/.nvmrc
```

Would love corroboration from any others who are actively using asdf for node.

So long as asdf [continues to support these files](http://asdf-vm.com/guide/getting-started.html#using-existing-tool-version-files) and renovate bot [does not](https://github.com/renovatebot/renovate/issues/4051), it seems best if we can avoid defining a node version in `.tool-versions`.
