### PR TITLE
insights: added graphQL arguments to filter an insights query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Backend Code Insights GraphQL queries now support arguments `includeRepoRegex` and `excludeRepoRegex` to filter on repository names. [#23256](https://github.com/sourcegraph/sourcegraph/pull/23256)
 - Code Insights background queries now process in a priority order backwards through time. This will allow insights to populate concurrently. [#23101](https://github.com/sourcegraph/sourcegraph/pull/23101)
 - Operator documentation has been added to the Search Reference sidebar section. [#23116]https://github.com/sourcegraph/sourcegraph/pull/23116)
 

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -34,8 +34,10 @@ type InsightStatusResolver interface {
 }
 
 type InsightsPointsArgs struct {
-	From *DateTime
-	To   *DateTime
+	From             *DateTime
+	To               *DateTime
+	IncludeRepoRegex *string
+	ExcludeRepoRegex *string
 }
 
 type InsightSeriesResolver interface {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -70,8 +70,12 @@ type InsightsSeries {
     If no 'from' time range is specified, the last 90 days of data is assumed.
 
     If no 'to' time range is specified, the current point in time is assumed.
+
+    includeRepoRegex will include in the aggregation any repository names that match the provided regex
+
+    excludeRepoRegex will exclude in the aggregation any repository names that match the provided regex
     """
-    points(from: DateTime, to: DateTime): [InsightDataPoint!]!
+    points(from: DateTime, to: DateTime, includeRepoRegex: String, excludeRepoRegex: String): [InsightDataPoint!]!
 
     """
     The status of this series of data, e.g. progress collecting it.

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -40,6 +40,12 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 	if args.To != nil {
 		opts.To = &args.To.Time
 	}
+	if args.IncludeRepoRegex != nil {
+		opts.IncludeRepoRegex = *args.IncludeRepoRegex
+	}
+	if args.ExcludeRepoRegex != nil {
+		opts.ExcludeRepoRegex = *args.ExcludeRepoRegex
+	}
 	// TODO(slimsag): future: Pass through opts.Limit
 
 	points, err := r.insightsStore.SeriesPoints(ctx, opts)

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -103,7 +103,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			autogold.Want("insights[0][0].Points store opts", `{"SeriesID":"s:087855E6A24440837303FD8A252E9893E8ABDFECA55B61AC83DA1B521906626E","RepoID":null,"Excluded":null,"Included":null,"From":"2006-01-02T15:04:05Z","To":"2006-01-03T15:04:05Z","Limit":0}`).Equal(t, string(json))
+			autogold.Want("insights[0][0].Points store opts", `{"SeriesID":"s:087855E6A24440837303FD8A252E9893E8ABDFECA55B61AC83DA1B521906626E","RepoID":null,"Excluded":null,"Included":null,"IncludeRepoRegex":"","ExcludeRepoRegex":"","From":"2006-01-02T15:04:05Z","To":"2006-01-03T15:04:05Z","Limit":0}`).Equal(t, string(json))
 			return []store.SeriesPoint{
 				{Time: args.From.Time, Value: 1},
 				{Time: args.From.Time, Value: 2},

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -92,6 +92,9 @@ type SeriesPointsOpts struct {
 	// TODO(slimsag): Add ability to filter based on repo name, original name.
 	// TODO(slimsag): Add ability to do limited filtering based on metadata.
 
+	IncludeRepoRegex string
+	ExcludeRepoRegex string
+
 	// Time ranges to query from/to, if non-nil, in UTC.
 	From, To *time.Time
 
@@ -99,7 +102,7 @@ type SeriesPointsOpts struct {
 	Limit int
 }
 
-//SeriesPoints queries data points over time for a specific insights' series.
+// SeriesPoints queries data points over time for a specific insights' series.
 func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error) {
 	points := make([]SeriesPoint, 0, opts.Limit)
 
@@ -142,7 +145,7 @@ func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]Seri
 // this query is too expensive to run in real-time and should be moved to a materialized view.
 const lastObservationCarriedPointsSql = `select sub.series_id, sub.interval_time, sum(value) as value, null as metadata from (WITH target_times AS (SELECT *
 FROM GENERATE_SERIES(CURRENT_TIMESTAMP::date - INTERVAL '26 weeks', CURRENT_TIMESTAMP::date, '2 weeks') as interval_time)
-SELECT sub.series_id, sub.repo_id, sub.value, interval_time
+SELECT sub.series_id, sub.repo_id, sub.value, interval_time, repo_name_id
 FROM (select distinct repo_id, series_id from series_points) as r
 cross join target_times tt
 join LATERAL (
@@ -152,6 +155,7 @@ join LATERAL (
     limit 1
     ) sub on sub.repo_id = r.repo_id and r.series_id = sub.series_id
 order by interval_time, repo_id) as sub
+left join repo_names rn on sub.repo_name_id = rn.id
 where %s
 group by sub.series_id, sub.interval_time
 order by interval_time desc
@@ -202,6 +206,12 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 	if len(opts.Excluded) > 0 {
 		s := fmt.Sprintf("repo_id != all(%v)", values(opts.Excluded))
 		preds = append(preds, sqlf.Sprintf(s))
+	}
+	if len(opts.IncludeRepoRegex) > 0 {
+		preds = append(preds, sqlf.Sprintf("rn.name ~ %s", opts.IncludeRepoRegex))
+	}
+	if len(opts.ExcludeRepoRegex) > 0 {
+		preds = append(preds, sqlf.Sprintf("rn.name !~ %s", opts.ExcludeRepoRegex))
 	}
 
 	if len(preds) == 0 {

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -155,7 +155,7 @@ join LATERAL (
     limit 1
     ) sub on sub.repo_id = r.repo_id and r.series_id = sub.series_id
 order by interval_time, repo_id) as sub
-left join repo_names rn on sub.repo_name_id = rn.id
+join repo_names rn on sub.repo_name_id = rn.id
 where %s
 group by sub.series_id, sub.interval_time
 order by interval_time desc


### PR DESCRIPTION
Closes #23236

Adds a very basic regex filtering to the current insights GraphQL query that operates on include / exclude. The performance isn't amazing because this doesn't reduce the cross-join happening, but it isn't significantly worse (marginally worse on my laptop).

I have some tests on another branch that for some reason are behaving weirdly. I wanted to get this out to unblock the frontend folks and will add those back in tomorrow.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
