### PR TITLE
batches: restore global nav item on sourcegraph.com

### DIFF
--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -28,7 +28,10 @@ export const enterpriseRoutes: readonly LayoutRouteProps<{}>[] = [
     {
         path: '/batch-changes',
         render: lazyComponent(() => import('./batches/global/GlobalBatchChangesArea'), 'GlobalBatchChangesArea'),
-        condition: ({ batchChangesEnabled }) => batchChangesEnabled,
+        // We also render this route on sourcegraph.com as a precaution in case anyone
+        // follows an in-app link to /batch-changes from sourcegraph.com; the component
+        // will just redirect the visitor to the marketing page
+        condition: ({ batchChangesEnabled, isSourcegraphDotCom }) => batchChangesEnabled || isSourcegraphDotCom,
     },
     {
         path: '/stats',

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -253,7 +253,12 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                                 <NavLink to="/code-monitoring">Monitoring</NavLink>
                             </NavItem>
                         )}
-                        {props.batchChangesEnabled && <BatchChangesNavItem isSourcegraphDotCom={isSourcegraphDotCom} />}
+                        {/* This is the only circumstance where we show something
+                         batch-changes-related even if the instance does not have batch
+                         changes enabled, for marketing purposes on sourcegraph.com */}
+                        {(props.batchChangesEnabled || isSourcegraphDotCom) && (
+                            <BatchChangesNavItem isSourcegraphDotCom={isSourcegraphDotCom} />
+                        )}
                         {codeInsights && (
                             <NavItem icon={BarChartIcon}>
                                 <NavLink to="/insights/dashboards/all">Insights</NavLink>


### PR DESCRIPTION
Whoops #23052 accidentally removed the global Batch Changes navigation item on sourcegraph.com. 🤦‍♀️

Since this is pretty much the only exception to the rules of disabling/hiding/blocking anything batch-changes-related on the frontend if batch changes aren't enabled on the instance, I feel like it's fine to just make + state the exception from the frontend code as opposed to building another variable into that `JSContext`.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
