### PR TITLE
web: improve code block border consistency

### DIFF
--- a/client/branded/src/components/CodeSnippet.tsx
+++ b/client/branded/src/components/CodeSnippet.tsx
@@ -15,7 +15,7 @@ interface CodeSnippetProps {
 export const CodeSnippet: React.FunctionComponent<CodeSnippetProps> = ({ code, language, className }) => {
     const highlightedInput = useMemo(() => ({ __html: highlightCodeSafe(code, language) }), [code, language])
     return (
-        <pre className={classNames('bg-code rounded p-3', className)}>
+        <pre className={classNames('bg-code rounded border p-3', className)}>
             <code dangerouslySetInnerHTML={highlightedInput} />
         </pre>
     )

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -272,7 +272,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
                     }}
                     ref={this.setRef}
                     id={this.props.id}
-                    className={classNames(this.props.className, this.props.border !== false && 'border')}
+                    className={classNames(this.props.className, this.props.border !== false && 'border rounded')}
                 />
                 {this.props.keyboardShortcutForFocus?.keybindings.map((keybinding, index) => (
                     <Shortcut key={index} {...keybinding} onMatch={this.focusInput} />


### PR DESCRIPTION
This PR:

- Adds a border to `CodeSnippet`, so that it matches the Monaco editor
- Adds a border radius to `MonacoEditor`, so that it matches `CodeSnippet`

<img src="https://user-images.githubusercontent.com/8942601/127112885-b358a915-192c-43da-a722-d2b2953afef1.png">

I couldn't find evidence in the wildcard designs that this was intentional, so to me it seemed to make more sense with these changes.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
