### PR TITLE
Use type=password for credentials input and turn off autocomplete

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -169,7 +169,8 @@ export const AddCredentialModal: React.FunctionComponent<AddCredentialModalProps
                                 <input
                                     id="token"
                                     name="token"
-                                    type="text"
+                                    type="password"
+                                    autoComplete="off"
                                     className="form-control test-add-credential-modal-input"
                                     required={true}
                                     spellCheck="false"


### PR DESCRIPTION
This addresses a user feedback that type=text could lead to security
leaks since it shows pasted tokens again.
