### PR TITLE
gitserver: use os.Remove in testRepoCorrupter

### DIFF
--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -761,7 +761,9 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		s := makeTestServer(ctx, reposDir, remote, nil)
 
 		testRepoCorrupter = func(_ context.Context, tmpDir GitDir) {
-			cmd("sh", "-c", fmt.Sprintf("rm %s/HEAD", tmpDir))
+			if err := os.Remove(tmpDir.Path("HEAD")); err != nil {
+				t.Fatal(err)
+			}
 		}
 		t.Cleanup(func() { testRepoCorrupter = nil })
 		if _, err := s.cloneRepo(ctx, "example.com/foo/bar", nil); err != nil {


### PR DESCRIPTION
This way we handle an error if the file is already gone. Noticed it because we are not setting PATH in cmd test wrapper, so depending on your environment it might not find "rm". An example is nix where rm (coreutils) is in a separate bin to sh (bash). We could just specify PATH, but I thought it's better to just use os.Remove anyways.
