### PR TITLE
vcs/git: include environ in test helper

### DIFF
--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -119,7 +119,7 @@ func InitGitRepository(t testing.TB, cmds ...string) string {
 func GitCommand(dir, name string, args ...string) *exec.Cmd {
 	c := exec.Command(name, args...)
 	c.Dir = dir
-	c.Env = append(c.Env, "GIT_CONFIG="+path.Join(dir, ".git", "config"))
+	c.Env = append(os.Environ(), "GIT_CONFIG="+path.Join(dir, ".git", "config"))
 	return c
 }
 


### PR DESCRIPTION
We only set GIT_CONFIG, which means we didn't have important envvars like PATH. Without this change the test does not work for me on NixOS.
