### PR TITLE
dbtest: fallback to PGDATASOURCE if specified

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -59,6 +59,9 @@ func NewDB(t testing.TB, dsn string) *sql.DB {
 	var err error
 	var config *url.URL
 	if dsn == "" {
+		dsn = os.Getenv("PGDATASOURCE")
+	}
+	if dsn == "" {
 		config, err = url.Parse("postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC")
 		if err != nil {
 			t.Fatalf("failed to parse dsn %q: %s", dsn, err)


### PR DESCRIPTION
We use PGDATASOURCE as a single environment variable for the DSN in several places. Our dbtests did not respect it though, instead they would try and mux in PG* variables into a hardcoded string.

Motivation: I prefer having a single envvar. Additionally it allows me to do things like use a unix socket instead of TCP for a local postgres. This is a path I am exploring for simplifying postgres in our dev environments.
