### PR TITLE
usagestats: use a temporary redis for tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -159,6 +159,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/stripe/stripe-go v70.15.0+incompatible
+	github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203
 	github.com/temoto/robotstxt v1.1.1
 	github.com/throttled/throttled/v2 v2.7.1
 	github.com/tidwall/gjson v1.6.8


### PR DESCRIPTION
Hardcoding that redis is running locally is not needed. We can just
start up redis ourselves. This might break users who only run redis via
docker and do not have it installed. However, I think the benefit of
this approach is worth them brew installing redis.

We should consider using a unix socket for redis even for our dev
environment. Starting up redis ourselves would simplify the requirements
on a users dev environment further.
