### PR TITLE
search: use callback for missing repo revs; don't propagate stream

### DIFF
--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -62,7 +62,7 @@ func Search(ctx context.Context, args *search.TextParameters, limit int, stream 
 	ctx, stream, cancel := streaming.WithLimit(ctx, stream, limit)
 	defer cancel()
 
-	indexed, err := zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.SymbolRequest, stream)
+	indexed, err := zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.SymbolRequest, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -73,7 +73,7 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 			RepoRevs: &zoektutil.IndexedRepoRevs{},
 		}
 	} else {
-		indexed, err = zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.TextRequest, stream)
+		indexed, err = zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.TextRequest, zoektutil.MissingRepoRevStatus(stream))
 		if err != nil {
 			return err
 		}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -269,7 +269,7 @@ func TestIndexedSearch(t *testing.T) {
 				},
 			}
 
-			indexed, err := NewIndexedSearchRequest(context.Background(), args, TextRequest, streaming.StreamFunc(func(streaming.SearchEvent) {}))
+			indexed, err := NewIndexedSearchRequest(context.Background(), args, TextRequest, MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Semantics preserving. We have a function `NewIndexedSearchRequest` that partitions indexed/unindexed repos for searcher paths. I'm in the process of simplifying the surrounding call chain for our varieties of search (zoekt, unindexed, structural) that ends up calling this function. Part of this means lowering stateful dependencies that we propagate. I noticed that one thing we propagate is stream, and found that after some indirection it is only used to propagate status messages for missing repos. 

This PR changes propagating the `stream` to instead propagate a generic callback function that is called down stream for missing repos. In general, wrapping callbacks versus passing arguments should be done judiciously, but I believe it makes a lot of sense here. Benefits:

- `NewIndexedSearchRequest` is agnostic to `stream`, since it is just passing a function. This is the main motivation, as it allows to abstract over streaming earlier in the call chain.
- It is now clear that the argument (the call back function) is for one purpose only: to process any logic related to missing repositories (this is what cause make to make the PR, because I wondered previously "OK what do we actually need stream for later?")

Cons: Well, it's a callback so you have to keep in mind where it was instantiated (i.e., where the new callback `MissingRepoRevStatus` is passed). 

I think it's worth it. To help with the above con, if we can move towards concentrating all logic that requires `stream`, but wrap it very early in the call chain, then we will find what we're looking for in the right place, so that it's not that difficult to understand where things are instantiated.