### PR TITLE
search: factor out search IndexedRequest logic to function

### DIFF
--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -33,6 +33,24 @@ var textSearchLimiter = mutablelimiter.New(32)
 
 var MockSearchFilesInRepos func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error)
 
+func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissing zoektutil.OnMissingRepoRevs) (*zoektutil.IndexedSearchRequest, error) {
+	// performance: for global searches, we avoid calling NewIndexedSearchRequest
+	// because zoekt will anyway have to search all its shards.
+	if args.Mode == search.ZoektGlobalSearch {
+		q, err := search.QueryToZoektQuery(args.PatternInfo, false)
+		if err != nil {
+			return nil, err
+		}
+		return &zoektutil.IndexedSearchRequest{
+			Args:     args,
+			Query:    q,
+			Typ:      zoektutil.TextRequest,
+			RepoRevs: &zoektutil.IndexedRepoRevs{},
+		}, nil
+	}
+	return zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.TextRequest, onMissing)
+}
+
 // SearchFilesInRepos searches a set of repos for a pattern.
 func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
 	if MockSearchFilesInRepos != nil {
@@ -58,25 +76,9 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		trace.Stringer("global_search_mode", args.Mode),
 	)
 
-	// performance: for global searches, we avoid calling NewIndexedSearchRequest
-	// because zoekt will anyway have to search all its shards.
-	var indexed *zoektutil.IndexedSearchRequest
-	if args.Mode == search.ZoektGlobalSearch {
-		q, err := search.QueryToZoektQuery(args.PatternInfo, false)
-		if err != nil {
-			return err
-		}
-		indexed = &zoektutil.IndexedSearchRequest{
-			Args:     args,
-			Query:    q,
-			Typ:      zoektutil.TextRequest,
-			RepoRevs: &zoektutil.IndexedRepoRevs{},
-		}
-	} else {
-		indexed, err = zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.TextRequest, zoektutil.MissingRepoRevStatus(stream))
-		if err != nil {
-			return err
-		}
+	indexed, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	if err != nil {
+		return err
 	}
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -208,9 +208,9 @@ func (s *IndexedSearchRequest) Search(ctx context.Context, c streaming.Sender) e
 
 const maxUnindexedRepoRevSearchesPerQuery = 200
 
-type onMissingRepoRevs func([]*search.RepositoryRevisions)
+type OnMissingRepoRevs func([]*search.RepositoryRevisions)
 
-func MissingRepoRevStatus(stream streaming.Sender) onMissingRepoRevs {
+func MissingRepoRevStatus(stream streaming.Sender) OnMissingRepoRevs {
 	return func(repoRevs []*search.RepositoryRevisions) {
 		var status search.RepoStatusMap
 		for _, r := range repoRevs {
@@ -224,7 +224,7 @@ func MissingRepoRevStatus(stream streaming.Sender) onMissingRepoRevs {
 	}
 }
 
-func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ IndexedRequestType, onMissing onMissingRepoRevs) (_ *IndexedSearchRequest, err error) {
+func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ IndexedRequestType, onMissing OnMissingRepoRevs) (_ *IndexedSearchRequest, err error) {
 	tr, ctx := trace.New(ctx, "newIndexedSearchRequest", string(typ))
 	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {
@@ -784,7 +784,7 @@ func zoektIndexedRepos(indexedSet map[string]*zoekt.Repository, revs []*search.R
 // excluded.
 //
 // A slice to the input list is returned, it is not copied.
-func limitUnindexedRepos(unindexed []*search.RepositoryRevisions, limit int, onMissing onMissingRepoRevs) []*search.RepositoryRevisions {
+func limitUnindexedRepos(unindexed []*search.RepositoryRevisions, limit int, onMissing OnMissingRepoRevs) []*search.RepositoryRevisions {
 	var missing []*search.RepositoryRevisions
 
 	for i, repoRevs := range unindexed {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23287.

Semantics preserving. This just moves out a block of code that computes the `IndexedSearchRequest` object that is local to the text search code path (i.e., called by `SearchFilesInRepos`. There are a couple of reasons behind this separation:

- `SearchFilesInRepos` does a bit too much work itself deciding how to call searchers/zoekt/backends, particularly in the overlap of structural and non-structural code paths. I want to separate the structural code path. The aim is for `SearchFilesInRepos` to still play a generic role here, but without having to deal with control flow decisions around when something is structural search or not--it can deal with the important parts of, for example, constructing that `IndexedSearchRequest` and repo partitioning.

- It helps to isolate the ad-hoc construction for global search optimizations, related to https://github.com/sourcegraph/sourcegraph/pull/23154#discussion_r675592519. 

- It's going to help a ton to have a place to locally factor out/simplify dependencies on `PatternInfo` and other things in `args` that Zoekt downstream code will not need to know about--this will finally let me cleanly introduce `ZoektParameters` earlier in the call chain.

- Using the `OnMissingRepoRevs` callback, this local code is agnostic to `stream` (better separation of concerns).