### PR TITLE
search: factor out structural search code path

### DIFF
--- a/internal/search/result/result_type.go
+++ b/internal/search/result/result_type.go
@@ -17,15 +17,17 @@ const (
 	TypePath
 	TypeDiff
 	TypeCommit
+	TypeStructural
 )
 
 var TypeFromString = map[string]Types{
-	"repo":   TypeRepo,
-	"symbol": TypeSymbol,
-	"file":   TypeFile,
-	"path":   TypePath,
-	"diff":   TypeDiff,
-	"commit": TypeCommit,
+	"repo":       TypeRepo,
+	"symbol":     TypeSymbol,
+	"file":       TypeFile,
+	"path":       TypePath,
+	"diff":       TypeDiff,
+	"commit":     TypeCommit,
+	"structural": TypeStructural,
 }
 
 func (r Types) Has(t Types) bool {

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -92,6 +92,14 @@ func (a *Aggregator) DoSymbolSearch(ctx context.Context, args *search.TextParame
 }
 
 func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextParameters) (err error) {
+	tr, ctx := trace.New(ctx, "doStructuralSearch", "")
+	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
+	defer func() {
+		a.Error(err)
+		tr.SetErrorIfNotContext(err)
+		tr.Finish()
+	}()
+
 	// For structural search with default limits we retry if we get no results.
 	fileMatches, stats, err := unindexed.SearchFilesInReposBatch(ctx, args)
 
@@ -133,11 +141,6 @@ func (a *Aggregator) DoFilePathSearch(ctx context.Context, args *search.TextPara
 		tr.SetErrorIfNotContext(err)
 		tr.Finish()
 	}()
-
-	isDefaultStructuralSearch := args.PatternInfo.IsStructuralPat && args.PatternInfo.FileMatchLimit == search.DefaultMaxSearchResults
-	if isDefaultStructuralSearch {
-		return a.DoStructuralSearch(ctx, args)
-	}
 
 	return unindexed.SearchFilesInRepos(ctx, args, a)
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23289

This PR introduces a separate structural search path at the top of the search call chain, in our `doResults` function. Intended to be semantics preserving, but adds some control flow logic.

Previously:

- `DoFilePathSearch` cases out on some condition to call a special case function `aggregator.DoStructuralSearch` or else continues control flow as usual.

Now:

- A dedicated result type will call `DoStructuralSearch` directly, and continue with `DoFilePathSearch` as usual--we don't route via `DoFilePathSearch` to call `DoStructuralSearch`.

Background for upcoming changes:

The `agg.DoStructuralSearch` is really just a special case function when the user puts no result count. It should really be called `agg.DoStructuralSearchWithNoResultCount`. If the user does specify a result count, the `DoFilePathSearch` route is still taken, and we end up figuring out how to call searcher based on structural search stuff. 

In upcoming changes, I will factor out the need to continue along this `DoFilePathSearch` so that we truly can just call `DoStructuralSearch`. The mechanisms behind structural search is enough to motivate evaluation via a function like `DoStructuralSearch` and separate to `DoFilePathSearch` (paths are irrelevant to structural search, and we service queries via searcher, not the frontend).

