### PR TITLE
search: simplify conditional implied by structural search type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1559,7 +1559,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	}
 
 	if args.ResultTypes.Has(result.TypeStructural) {
-		isDefaultStructuralSearch := args.PatternInfo.IsStructuralPat && args.PatternInfo.FileMatchLimit == search.DefaultMaxSearchResults
+		isDefaultStructuralSearch := args.PatternInfo.FileMatchLimit == search.DefaultMaxSearchResults
 		if isDefaultStructuralSearch {
 			wg := waitGroup(true)
 			wg.Add(1)


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23292

After mechanical change in https://github.com/sourcegraph/sourcegraph/pull/23292 `args.ResultTypes.Has(result.TypeStructural)` implies `args.PatternInfo.IsStructuralPat`. Doing this separately for testing.