### PR TITLE
search: simplify structural search code path

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1559,22 +1559,12 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	}
 
 	if args.ResultTypes.Has(result.TypeStructural) {
-		isDefaultStructuralSearch := args.PatternInfo.FileMatchLimit == search.DefaultMaxSearchResults
-		if isDefaultStructuralSearch {
-			wg := waitGroup(true)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-				_ = agg.DoStructuralSearch(ctx, args)
-			})
-		} else {
-			wg := waitGroup(true)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-				_ = agg.DoFilePathSearch(ctx, args)
-			})
-		}
+		wg := waitGroup(true)
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+			_ = agg.DoStructuralSearch(ctx, args)
+		})
 	}
 
 	if args.ResultTypes.Has(result.TypeDiff) {

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -100,6 +100,13 @@ func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextPa
 		tr.Finish()
 	}()
 
+	if args.PatternInfo.FileMatchLimit != search.DefaultMaxSearchResults {
+		// Service structural search via SearchFilesInRepos when we have
+		// an explicit `count` value that differs from the default value
+		// (e.g., user sets higher counts).
+		return unindexed.SearchFilesInRepos(ctx, args, a)
+	}
+
 	// For structural search with default limits we retry if we get no results.
 	fileMatches, stats, err := unindexed.SearchFilesInReposBatch(ctx, args)
 


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23293. 

Addresses the mechanical duplication introduced as per https://github.com/sourcegraph/sourcegraph/pull/23292/files#r677886364. 