### PR TITLE
Redirect line number hashes

### DIFF
--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -90,6 +90,51 @@ describe('Blob viewer', () => {
         })
     })
 
+    describe('line number redirects', () => {
+        it('should redirect from line number hash to query parameter', async () => {
+            testContext.overrideGraphQL({
+                ...commonBlobGraphQlResults,
+                Blob: () => ({
+                    repository: {
+                        commit: {
+                            file: {
+                                content: '// Log to console\nconsole.log("Hello world")\n// Third line',
+                                richHTML: '',
+                                highlight: {
+                                    aborted: false,
+                                    html:
+                                        // Note: whitespace in this string is significant.
+                                        '<table class="test-log-token"><tbody><tr><td class="line" data-line="1"/>' +
+                                        '<td class="code"><span class="hl-source hl-js hl-react"><span class="hl-comment hl-line hl-double-slash hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-comment hl-js">//</span> ' +
+                                        'Log to console\n</span></span></td></tr>' +
+                                        '<tr><td class="line" data-line="2"/><td class="code"><span class="hl-source hl-js hl-react">' +
+                                        '<span class="hl-meta hl-function-call hl-method hl-js">' +
+                                        '<span class="hl-support hl-type hl-object hl-console hl-js">console</span>' +
+                                        '<span class="hl-punctuation hl-accessor hl-js">.</span>' +
+                                        '<span class="hl-support hl-function hl-console hl-js test-log-token">log</span>' +
+                                        '<span class="hl-meta hl-group hl-js"><span class="hl-punctuation hl-section hl-group hl-begin hl-js">(</span>' +
+                                        '<span class="hl-meta hl-string hl-js"><span class="hl-string hl-quoted hl-double hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-begin hl-js">&quot;</span>Hello world' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-end hl-js">&quot;</span></span></span>' +
+                                        '<span class="hl-punctuation hl-section hl-group hl-end hl-js">)</span></span>\n</span></span></td></tr>' +
+                                        '<tr><td class="line" data-line="3"/><td class="code"><span class="hl-source hl-js hl-react">' +
+                                        '<span class="hl-meta hl-function-call hl-method hl-js"></span>' +
+                                        '<span class="hl-comment hl-line hl-double-slash hl-js"><span class="hl-punctuation hl-definition hl-comment hl-js">//</span> ' +
+                                        'Third line\n</span></span></td></tr></tbody></table>',
+                                },
+                            },
+                        },
+                    },
+                }),
+            })
+
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}#2`)
+            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.assertWindowLocation(`/${repositoryName}/-/blob/${fileName}?L2`)
+        })
+    })
+
     // Describes the ways the blob viewer can be extended through Sourcegraph extensions.
     describe('extensibility', () => {
         const getHoverContents = async (): Promise<string[]> => {

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -91,7 +91,7 @@ describe('Blob viewer', () => {
     })
 
     describe('line number redirects', () => {
-        it('should redirect from line number hash to query parameter', async () => {
+        beforeEach(() => {
             testContext.overrideGraphQL({
                 ...commonBlobGraphQlResults,
                 Blob: () => ({
@@ -128,10 +128,18 @@ describe('Blob viewer', () => {
                     },
                 }),
             })
+        })
 
+        it('should redirect from line number hash to query parameter', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}#2`)
             await driver.page.waitForSelector('.test-repo-blob')
             await driver.assertWindowLocation(`/${repositoryName}/-/blob/${fileName}?L2`)
+        })
+
+        it('should redirect from line range hash to query parameter', async () => {
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}#1-3`)
+            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.assertWindowLocation(`/${repositoryName}/-/blob/${fileName}?L1-3`)
         })
     })
 

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -151,6 +151,17 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
 
             const mode = getModeFromPath(filePath)
 
+            // Redirect OpenGrok-style line number hashes (#123) to query parameter (?L123)
+            const hashLineNumberMatch = window.location.hash.match(/^#?(\d+)$/)
+            if (objectType === 'blob' && hashLineNumberMatch) {
+                const lineNumber = parseInt(hashLineNumberMatch[1], 10)
+                const url = appendLineRangeQueryParameter(
+                    window.location.pathname + window.location.search,
+                    `L${lineNumber}`
+                )
+                return <Redirect to={url} />
+            }
+
             // For blob pages with legacy URL fragment hashes like "#L17:19-21:23$foo:bar"
             // redirect to the modern URL fragment hashes like "#L17:19-21:23&tab=foo:bar"
             if (!hideRepoRevisionContent && objectType === 'blob' && isLegacyFragment(window.location.hash)) {

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -151,13 +151,14 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
 
             const mode = getModeFromPath(filePath)
 
-            // Redirect OpenGrok-style line number hashes (#123) to query parameter (?L123)
-            const hashLineNumberMatch = window.location.hash.match(/^#?(\d+)$/)
+            // Redirect OpenGrok-style line number hashes (#123, #123-321) to query parameter (?L123, ?L123-321)
+            const hashLineNumberMatch = window.location.hash.match(/^#?(\d+)(-\d+)?$/)
             if (objectType === 'blob' && hashLineNumberMatch) {
-                const lineNumber = parseInt(hashLineNumberMatch[1], 10)
+                const startLineNumber = parseInt(hashLineNumberMatch[1], 10)
+                const endLineNumber = hashLineNumberMatch[2] ? parseInt(hashLineNumberMatch[2].slice(1), 10) : undefined
                 const url = appendLineRangeQueryParameter(
                     window.location.pathname + window.location.search,
-                    `L${lineNumber}`
+                    `L${startLineNumber}` + (endLineNumber ? `-${endLineNumber}` : '')
                 )
                 return <Redirect to={url} />
             }


### PR DESCRIPTION
Adds redirect for OpenGrok-style line number hashes (`#123`, `#123-321`) to query parameter (`?L123`, `?L123-321`)

Fixes #23271

Context: https://sourcegraph.slack.com/archives/C022SPMNR0W/p1627394466486500