### PR TITLE
search: don't surface ctx error from repo resolution

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1384,10 +1384,13 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 // regardless of what `type:` is specified in the query string.
 //
 // Partial results AND an error may be returned.
-func (r *searchResolver) doResults(ctx context.Context, args *search.TextParameters) (_ *SearchResults, err error) {
+func (r *searchResolver) doResults(ctx context.Context, args *search.TextParameters) (res *SearchResults, err error) {
 	tr, ctx := trace.New(ctx, "doResults", r.rawQuery())
 	defer func() {
 		tr.SetError(err)
+		if res != nil {
+			tr.LazyPrintf("matches=%d %s", len(res.Matches), &res.Stats)
+		}
 		tr.Finish()
 	}()
 
@@ -1425,36 +1428,6 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	}
 
 	agg := run.NewAggregator(r.db, stream)
-
-	// finalize converts the content of the aggregator to a proper return value.
-	// finalize relies on all WaitGroups being done since it relies on collecting
-	// from the streams.
-	finalize := func() (*SearchResults, error) {
-		matches, common, aggErrs := agg.Get()
-
-		if aggErrs == nil {
-			return nil, errors.New("aggErrs should never be nil")
-		}
-
-		ao := alertObserver{
-			Inputs:     r.SearchInputs,
-			hasResults: len(matches) > 0,
-		}
-		for _, err := range aggErrs.Errors {
-			ao.Error(ctx, err)
-		}
-		alert, err := ao.Done(&common)
-
-		tr.LazyPrintf("matches=%d %s", len(matches), &common)
-
-		r.sortResults(matches)
-
-		return &SearchResults{
-			Matches: matches,
-			Stats:   common,
-			Alert:   alert,
-		}, err
-	}
 
 	// This ensures we properly cleanup in the case of an early return. In
 	// particular we want to cancel global searches before returning early.
@@ -1512,7 +1485,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			tr.LazyPrintf("context canceled during repo resolution: %v", err)
 			optionalWg.Wait()
 			requiredWg.Wait()
-			return finalize()
+			return r.toSearchResults(ctx, agg)
 		}
 		return nil, err
 	}
@@ -1612,7 +1585,36 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	timer.Stop()
 
-	return finalize()
+	return r.toSearchResults(ctx, agg)
+}
+
+// toSearchResults converts an Aggregator to SearchResults.
+//
+// toSearchResults relies on all WaitGroups being done since it relies on
+// collecting from the streams.
+func (r *searchResolver) toSearchResults(ctx context.Context, agg *run.Aggregator) (*SearchResults, error) {
+	matches, common, aggErrs := agg.Get()
+
+	if aggErrs == nil {
+		return nil, errors.New("aggErrs should never be nil")
+	}
+
+	ao := alertObserver{
+		Inputs:     r.SearchInputs,
+		hasResults: len(matches) > 0,
+	}
+	for _, err := range aggErrs.Errors {
+		ao.Error(ctx, err)
+	}
+	alert, err := ao.Done(&common)
+
+	r.sortResults(matches)
+
+	return &SearchResults{
+		Matches: matches,
+		Stats:   common,
+		Alert:   alert,
+	}, err
 }
 
 // isContextError returns true if ctx.Err() is not nil or if err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1426,6 +1426,36 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	agg := run.NewAggregator(r.db, stream)
 
+	// finalize converts the content of the aggregator to a proper return value.
+	// finalize relies on all WaitGroups being done since it relies on collecting
+	// from the streams.
+	finalize := func() (*SearchResults, error) {
+		matches, common, aggErrs := agg.Get()
+
+		if aggErrs == nil {
+			return nil, errors.New("aggErrs should never be nil")
+		}
+
+		ao := alertObserver{
+			Inputs:     r.SearchInputs,
+			hasResults: len(matches) > 0,
+		}
+		for _, err := range aggErrs.Errors {
+			ao.Error(ctx, err)
+		}
+		alert, err := ao.Done(&common)
+
+		tr.LazyPrintf("matches=%d %s", len(matches), &common)
+
+		r.sortResults(matches)
+
+		return &SearchResults{
+			Matches: matches,
+			Stats:   common,
+			Alert:   alert,
+		}, err
+	}
+
 	// This ensures we properly cleanup in the case of an early return. In
 	// particular we want to cancel global searches before returning early.
 	hasStartedAllBackends := false
@@ -1476,6 +1506,13 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	if err != nil {
 		if alert, err := errorToAlert(err); alert != nil {
 			return alert.wrapResults(), err
+		}
+		// Don't surface context errors to the user.
+		if errors.Is(err, context.Canceled) {
+			tr.LazyPrintf("context canceled during repo resolution: %v", err)
+			optionalWg.Wait()
+			requiredWg.Wait()
+			return finalize()
 		}
 		return nil, err
 	}
@@ -1575,28 +1612,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	timer.Stop()
 
-	// We have to call get once all waitgroups are done since it relies on
-	// collecting from the streams.
-	matches, common, aggErrs := agg.Get()
-
-	ao := alertObserver{
-		Inputs:     r.SearchInputs,
-		hasResults: len(matches) > 0,
-	}
-	for _, err := range aggErrs.Errors {
-		ao.Error(ctx, err)
-	}
-	alert, err := ao.Done(&common)
-
-	tr.LazyPrintf("matches=%d %s", len(matches), &common)
-
-	r.sortResults(matches)
-
-	return &SearchResults{
-		Matches: matches,
-		Stats:   common,
-		Alert:   alert,
-	}, err
+	return finalize()
 }
 
 // isContextError returns true if ctx.Err() is not nil or if err


### PR DESCRIPTION
This adds a check to handle context errors returned by repo
resolution.

For a very fast global search, it can happen that the context is
canceled before repo resolution is complete, in which case
resolveRepositories returns a wrapped `Context.Canceled`.

So far we returned context errors from repo resolution directly
to the user.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
