### PR TITLE
Mitigate security issue 163

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -327,17 +327,26 @@ func unzipJarFile(jarPath, destination string) error {
 		if err = os.MkdirAll(path.Dir(outputPath), os.ModePerm); err != nil {
 			return err
 		}
-		outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}
 
 		_, err = io.Copy(outputFile, inputFile)
-		inputFile.Close()
-		outputFile.Close()
+		err1 := inputFile.Close()
+		err2 := outputFile.Close()
+
 		if err != nil {
 			return err
 		}
+		if err1 != nil {
+			return err1
+		}
+		if err2 != nil {
+			return err2
+		}
+		return nil
+
 	}
 
 	return nil

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -324,10 +324,10 @@ func unzipJarFile(jarPath, destination string) error {
 			return err
 		}
 
-		if err = os.MkdirAll(path.Dir(outputPath), os.ModePerm); err != nil {
+		if err = os.MkdirAll(path.Dir(outputPath), 0700); err != nil {
 			return err
 		}
-		outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -244,9 +246,8 @@ func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 // A `*.jar` file works the same way as a `*.zip` file, it can even be uncompressed with the `unzip` command-line tool.
 func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource.MavenDependency,
 	workingDirectory, sourceCodeJarPath string, connection *schema.JVMPackagesConnection) error {
-	cmd := exec.CommandContext(ctx, "unzip", sourceCodeJarPath)
-	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory); err != nil {
-		return err
+	if err := unzipJarFile(sourceCodeJarPath, workingDirectory); err != nil {
+		return errors.Wrapf(err, "failed to unzip jar file %v", sourceCodeJarPath)
 	}
 
 	file, err := os.Create(filepath.Join(workingDirectory, "lsif-java.json"))
@@ -274,7 +275,7 @@ func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource
 		return err
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "add", ".")
+	cmd := exec.CommandContext(ctx, "git", "add", ".")
 	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory); err != nil {
 		return err
 	}
@@ -287,6 +288,56 @@ func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource
 	cmd = exec.CommandContext(ctx, "git", "tag", "-m", dependency.CoursierSyntax(), dependency.GitTagFromVersion())
 	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func unzipJarFile(jarPath, destination string) error {
+	reader, err := zip.OpenReader(jarPath)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	destinationDirectory := strings.TrimSuffix(destination, string(os.PathSeparator)) + string(os.PathSeparator)
+	for _, file := range reader.File {
+		if strings.HasPrefix(file.Name, ".git/") {
+			// For security reasons, don't unzip files under the `.git/`
+			// directory. See https://github.com/sourcegraph/security-issues/issues/163
+			continue
+		}
+		if strings.HasSuffix(file.Name, "/") {
+			// Skip directory entries. Directory entries must end
+			// with a forward slash (even on Windows) according to
+			// `file.Name` docstring.
+			continue
+		}
+		outputPath := path.Join(destination, file.Name)
+		if !strings.HasPrefix(outputPath, destinationDirectory) {
+			// For security reasons, skip file if it's not a child
+			// of the target directory. See "Zip Slip Vulnerability".
+			continue
+		}
+
+		inputFile, err := reader.Open(file.Name)
+		if err != nil {
+			return err
+		}
+
+		if err = os.MkdirAll(path.Dir(outputPath), os.ModePerm); err != nil {
+			return err
+		}
+		outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(outputFile, inputFile)
+		inputFile.Close()
+		outputFile.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Previously, we shelled out to the `unzip` command-line tool to extract
sources from a JVM dependency source jar. Now, we use the Go stdlib
`zip` package instead. For security reasons, we don't extract files
- that are under the `.git/` directory (can include pre-commit hooks).
- that extract outside the target directory.
Addresses the most urgent security concerns from
https://github.com/sourcegraph/security-issues/issues/163



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
