### PR TITLE
monitoring: Make all panels in new group constructors optional

### DIFF
--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -319,10 +319,12 @@ func Frontend() *monitoring.Container {
 					},
 				},
 
-				Total:     shared.NoAlertsOption("none"),
-				Duration:  shared.NoAlertsOption("none"),
-				Errors:    shared.NoAlertsOption("none"),
-				ErrorRate: shared.NoAlertsOption("none"),
+				SharedObservationGroupOptions: shared.SharedObservationGroupOptions{
+					Total:     shared.NoAlertsOption("none"),
+					Duration:  shared.NoAlertsOption("none"),
+					Errors:    shared.NoAlertsOption("none"),
+					ErrorRate: shared.NoAlertsOption("none"),
+				},
 			}),
 
 			// src_oobmigration_total
@@ -341,10 +343,12 @@ func Frontend() *monitoring.Container {
 					},
 				},
 
-				Total:     shared.NoAlertsOption("none"),
-				Duration:  shared.NoAlertsOption("none"),
-				Errors:    shared.NoAlertsOption("none"),
-				ErrorRate: shared.NoAlertsOption("none"),
+				SharedObservationGroupOptions: shared.SharedObservationGroupOptions{
+					Total:     shared.NoAlertsOption("none"),
+					Duration:  shared.NoAlertsOption("none"),
+					Errors:    shared.NoAlertsOption("none"),
+					ErrorRate: shared.NoAlertsOption("none"),
+				},
 			}),
 
 			{

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -27,14 +27,18 @@ func (codeIntelligence) NewResolversGroup(containerName string) monitoring.Group
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -79,11 +83,13 @@ func (codeIntelligence) NewUploadProcessorGroup(containerName string) monitoring
 			},
 		},
 
-		Total:     NoAlertsOption("none"),
-		Duration:  NoAlertsOption("none"),
-		Errors:    NoAlertsOption("none"),
-		ErrorRate: NoAlertsOption("none"),
-		Handlers:  NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Handlers: NoAlertsOption("none"),
 	})
 }
 
@@ -129,10 +135,12 @@ func (codeIntelligence) NewCommitGraphProcessorGroup(containerName string) monit
 			},
 		},
 
-		Total:     NoAlertsOption("none"),
-		Duration:  NoAlertsOption("none"),
-		Errors:    NoAlertsOption("none"),
-		ErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -153,14 +161,18 @@ func (codeIntelligence) NewIndexSchedulerGroup(containerName string) monitoring.
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -207,11 +219,13 @@ func (codeIntelligence) NewDependencyIndexProcessorGroup(containerName string) m
 			},
 		},
 
-		Total:     NoAlertsOption("none"),
-		Duration:  NoAlertsOption("none"),
-		Errors:    NoAlertsOption("none"),
-		ErrorRate: NoAlertsOption("none"),
-		Handlers:  NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Handlers: NoAlertsOption("none"),
 	})
 }
 
@@ -260,11 +274,13 @@ func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitori
 			},
 		},
 
-		Total:     NoAlertsOption("none"),
-		Duration:  NoAlertsOption("none"),
-		Errors:    NoAlertsOption("none"),
-		ErrorRate: NoAlertsOption("none"),
-		Handlers:  NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Handlers: NoAlertsOption("none"),
 	})
 }
 
@@ -286,14 +302,18 @@ func (codeIntelligence) NewExecutorSetupCommandGroup(containerName string) monit
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -315,14 +335,18 @@ func (codeIntelligence) NewExecutorExecutionCommandGroup(containerName string) m
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -344,14 +368,18 @@ func (codeIntelligence) NewExecutorTeardownCommandGroup(containerName string) mo
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -373,14 +401,18 @@ func (codeIntelligence) NewExecutorAPIClientGroup(containerName string) monitori
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -401,14 +433,18 @@ func (codeIntelligence) NewDBStoreGroup(containerName string) monitoring.Group {
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -428,10 +464,12 @@ func (codeIntelligence) NewUploadDBWorkerStoreGroup(containerName string) monito
 			},
 		},
 
-		Total:     NoAlertsOption("none"),
-		Duration:  NoAlertsOption("none"),
-		Errors:    NoAlertsOption("none"),
-		ErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -451,10 +489,12 @@ func (codeIntelligence) NewIndexDBWorkerStoreGroup(containerName string) monitor
 			},
 		},
 
-		Total:     NoAlertsOption("none"),
-		Duration:  NoAlertsOption("none"),
-		Errors:    NoAlertsOption("none"),
-		ErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -474,10 +514,12 @@ func (codeIntelligence) NewDependencyIndexDBWorkerStoreGroup(containerName strin
 			},
 		},
 
-		Total:     NoAlertsOption("none"),
-		Duration:  NoAlertsOption("none"),
-		Errors:    NoAlertsOption("none"),
-		ErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -498,14 +540,18 @@ func (codeIntelligence) NewLSIFStoreGroup(containerName string) monitoring.Group
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -526,14 +572,18 @@ func (codeIntelligence) NewGitserverClientGroup(containerName string) monitoring
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -554,14 +604,18 @@ func (codeIntelligence) NewUploadStoreGroup(containerName string) monitoring.Gro
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 
@@ -582,14 +636,18 @@ func (codeIntelligence) NewAutoIndexEnqueuerGroup(containerName string) monitori
 			},
 		},
 
-		Total:              NoAlertsOption("none"),
-		Duration:           NoAlertsOption("none"),
-		Errors:             NoAlertsOption("none"),
-		ErrorRate:          NoAlertsOption("none"),
-		AggregateTotal:     NoAlertsOption("none"),
-		AggregateDuration:  NoAlertsOption("none"),
-		AggregateErrors:    NoAlertsOption("none"),
-		AggregateErrorRate: NoAlertsOption("none"),
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
 	})
 }
 


### PR DESCRIPTION
From previous PR feedback:

- Making Aggregate{Total,Error,Duration,ErrorRate} a nested option
- Make each panel optional and panic if the group would be empty. Reduces clutter on panels that aren't useful/alertable/describable.