### PR TITLE
Fix missing key error in search reference

### DIFF
--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -466,7 +466,11 @@ const SearchReferenceExample: React.FunctionComponent<SearchReferenceExampleProp
                                 </React.Fragment>
                             )
                         case 'keyword':
-                            return <span className="search-filter-keyword">{term.value}</span>
+                            return (
+                                <span key={index} className="search-filter-keyword">
+                                    {term.value}
+                                </span>
+                            )
                         default:
                             return example.slice(term.range.start, term.range.end)
                     }


### PR DESCRIPTION
A quick fix to keep the console and tests quiet.