### PR TITLE
Don't depend on handbook redirects - update roadmap link to be direct

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -99,7 +99,7 @@ For next steps, visit the [Docker installation documentation](admin/install/dock
 - [Sourcegraph handbook](https://about.sourcegraph.com/handbook)
 - [Sourcegraph blog](https://about.sourcegraph.com/blog/)
 - [@sourcegraph on Twitter](https://twitter.com/sourcegraph)
-- [Product Roadmap](https://about.sourcegraph.com/direction)
+- [Product Roadmap](https://about.sourcegraph.com/handbook/direction)
 
 ## Get help
 


### PR DESCRIPTION
We migrated everything handbook on about.sourcegraph.com to a /handbook and set up redirects, but we get periodic intermittent reports of broken links and it seems the redirects sometimes break (not consistently reproducible), so fixing this since a user pointed it out.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
