### PR TITLE
web: Change button text to "Save insight"

### DIFF
--- a/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -112,7 +112,7 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
                     alwaysShowLabel={true}
                     data-testid="insight-save-button"
                     loading={submitting}
-                    label={submitting ? 'Submitting' : isEditMode ? 'Edit insight' : 'Create code insight'}
+                    label={submitting ? 'Submitting' : isEditMode ? 'Save insight' : 'Create code insight'}
                     type="submit"
                     disabled={submitting}
                     className="btn btn-primary mr-2 mb-2"

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -259,7 +259,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 <LoaderButton
                     alwaysShowLabel={true}
                     loading={submitting}
-                    label={submitting ? 'Submitting' : isEditMode ? 'Edit insight' : 'Create code insight'}
+                    label={submitting ? 'Submitting' : isEditMode ? 'Save insight' : 'Create code insight'}
                     type="submit"
                     disabled={submitting}
                     data-testid="insight-save-button"


### PR DESCRIPTION
Note: We use "Create code insight" when creating a new insight. Should we be consistent here and use "Save code insight" as well? 🤔 

![image](https://user-images.githubusercontent.com/1855233/127407863-e8db02e3-136e-4894-bcca-6f93c16635ce.png)
