### PR TITLE
API docs: LSIF: add basic heuristics for usage examples

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
@@ -9,6 +9,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
+// defaultReferencesPageSize is the reference result page size when no limit is supplied in the
+// GraphQL layer. This is used as an approximation for an acceptable page size as we make multiple
+// references requests to discover references _not_ in the same file as the definition for API
+// docs.
+const defaultReferencesPageSize = 100
+
 // DocumentationReferences returns the list of source locations that reference the symbol found at
 // the given documentation path ID, if any.
 func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID string, limit int, rawCursor string) (_ []AdjustedLocation, _ string, err error) {
@@ -46,7 +52,7 @@ func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID stri
 			)
 			for len(references) < limit {
 				var candidates []AdjustedLocation
-				candidates, rawCursor, err = r.References(ctx, location.Range.Start.Line, location.Range.Start.Character, 10, rawCursor)
+				candidates, rawCursor, err = r.References(ctx, location.Range.Start.Line, location.Range.Start.Character, defaultReferencesPageSize, rawCursor)
 				if err != nil {
 					return nil, rawCursor, err
 				}


### PR DESCRIPTION
For usage examples to be added to API docs, I've encountered two problems:

1. The first reference found is often the definition itself, which is definitely useless.
2. The other references found are often in the same file as the definition - which don't show usage of the API very effectively.

What I've done here is hacked around the problem a bit by adding some very minimal heuristics that exclude these two types of references in `DocumentationReferences` requests.

Longer term, I will make this an option in the GraphQL layer (`examples: true`) and begin thinking about how we can apply ranking to usage examples (and, how that should apply to codeintel references more generally - not just in the context of API docs.) -- but for now, this small change means we can start having usage examples on Sourcegraph.com today - which seems a great win.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>