### PR TITLE
search frontend: prioritize YAML and Terraform autocompletion

### DIFF
--- a/client/shared/src/search/query/languageFilter.ts
+++ b/client/shared/src/search/query/languageFilter.ts
@@ -40,9 +40,11 @@ export const POPULAR_LANGUAGES: string[] = [
     'Scala',
     'SQL',
     'Swift',
+    'Terraform',
     'TypeScript',
     'VBA',
     'XML',
+    'YAML',
     'Zig',
 ]
 


### PR DESCRIPTION
`YAML` and `Terraform` are common config languages that we should have in the default autocompletion list (previously the list was mostly informed by stackoverflow survey, which I don't think buckets these config languages in the same category).

More: https://sourcegraph.slack.com/archives/C022SPMNR0W/p1627495086014900