### PR TITLE
search: highlight all commit search results for expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The search reference will now show matching entries when using the filter input. [#23224](https://github.com/sourcegraph/sourcegraph/pull/23224)
 - Graceful termination periods have been added to database deployments. [#3358](https://github.com/sourcegraph/deploy-sourcegraph/pull/3358) & [#477](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/477)
+- All commit search results for `and`-expressions are now highlighted. [#23336](https://github.com/sourcegraph/sourcegraph/pull/23336)
 
 ### Removed
 

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -75,6 +75,17 @@ func (r *CommitMatch) Select(path filter.SelectPath) Match {
 	return nil
 }
 
+// AppendMatches merges highlight information for commit messages. Diff contents
+// are not currently supported. TODO(@team/search): Diff highlight information
+// cannot reliably merge this way because of offset issues with markdown
+// rendering.
+func (r *CommitMatch) AppendMatches(src *CommitMatch) {
+	if r.MessagePreview != nil && src.MessagePreview != nil {
+		r.MessagePreview.Highlights = append(r.MessagePreview.Highlights, src.MessagePreview.Highlights...)
+		r.Body.Highlights = append(r.Body.Highlights, src.Body.Highlights...)
+	}
+}
+
 // Key implements Match interface's Key() method
 func (r *CommitMatch) Key() Key {
 	typeRank := rankCommitMatch

--- a/internal/search/result/deduper.go
+++ b/internal/search/result/deduper.go
@@ -12,9 +12,12 @@ func (d deduper) Add(m Match) {
 	prev, seen := d[m.Key()]
 
 	if seen {
-		if prevFileMatch, isFileMatch := prev.(*FileMatch); isFileMatch {
-			// Merge file match lines
-			prevFileMatch.AppendMatches(m.(*FileMatch)) // key matches, so we know it's a file match
+		switch prevMatch := prev.(type) {
+		// key matches, so we know to convert to respective type
+		case *FileMatch:
+			prevMatch.AppendMatches(m.(*FileMatch))
+		case *CommitMatch:
+			prevMatch.AppendMatches(m.(*CommitMatch))
 		}
 		return
 	}

--- a/internal/search/result/merge.go
+++ b/internal/search/result/merge.go
@@ -28,8 +28,12 @@ func Intersect(left, right []Match) []Match {
 		if r == nil {
 			continue
 		}
-		if leftFileMatch, ok := l.(*FileMatch); ok {
-			leftFileMatch.AppendMatches(r.(*FileMatch)) // key matches, so we know it's a file match
+		switch leftMatch := l.(type) {
+		// key matches, so we know to convert to respective type
+		case *FileMatch:
+			leftMatch.AppendMatches(r.(*FileMatch))
+		case *CommitMatch:
+			leftMatch.AppendMatches(r.(*CommitMatch))
 		}
 		merged = append(merged, l)
 	}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/23328.

Previously:

<img width="1429" alt="Screen Shot 2021-07-28 at 4 29 00 PM" src="https://user-images.githubusercontent.com/888624/127411664-f65a44cc-e825-4b42-9f00-89df6a75c067.png">

Now:

<img width="1408" alt="Screen Shot 2021-07-28 at 4 28 31 PM" src="https://user-images.githubusercontent.com/888624/127411674-8666d7b7-691c-49af-ac45-1187dfefc5f4.png">

Unfortunately this only works for commit messages and not diffs, because appending the same info for diffs messes up the rendering. The diff highlight/markdown/rendering stuff is messy and I dealt with some of it before with `select`. I'm punting because this PR improves the state of things and the diff stuff would just take too much time right now.