### PR TITLE
search-blitz: add gauge for matchCount

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -85,6 +85,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 				tsv.Log(group, qc.Name, c.clientType(), m.trace, m.matchCount, tookSeconds, firstResultSeconds)
 				durationSearchSeconds.WithLabelValues(group, qc.Name, c.clientType()).Observe(tookSeconds)
 				firstResultSearchSeconds.WithLabelValues(group, qc.Name, c.clientType()).Observe(firstResultSeconds)
+				matchCount.WithLabelValues(group, qc.Name, c.clientType()).Set(float64(m.matchCount))
 
 				go func() {
 					select {

--- a/internal/cmd/search-blitz/prometheus.go
+++ b/internal/cmd/search-blitz/prometheus.go
@@ -9,14 +9,19 @@ var Buckets = []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 30, 45, 
 
 var durationSearchSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "search_blitz_duration_seconds",
-	Help:    "e2e duration search-blitz where search_type is either stream or batch",
+	Help:    "e2e duration search-blitz where client is either stream or batch",
 	Buckets: Buckets,
 }, []string{"group", "query_name", "client"})
 
 var firstResultSearchSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "search_blitz_first_result_seconds",
-	Help:    "e2e time to first result search-blitz where search_type is either stream or batch",
+	Help:    "e2e time to first result search-blitz where client is either stream or batch",
 	Buckets: Buckets,
+}, []string{"group", "query_name", "client"})
+
+var matchCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "search_blitz_match_count",
+	Help: "the match count where client is either stream or batch",
 }, []string{"group", "query_name", "client"})
 
 var fetchDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
This adds a gauge to track the match count per query and client over
time.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
