### PR TITLE
database: use an ephemeral postgres for test

### DIFF
--- a/internal/database/main_test.go
+++ b/internal/database/main_test.go
@@ -1,10 +1,18 @@
 package database
 
 import (
+	"bufio"
+	"bytes"
 	"flag"
+	"io"
+	"log"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
@@ -19,5 +27,160 @@ func TestMain(m *testing.M) {
 	if !testing.Verbose() {
 		log15.Root().SetHandler(log15.DiscardHandler())
 	}
-	os.Exit(m.Run())
+
+	// An ephemeral DB. Targetting this test package first as an experiment,
+	// will make more general so all tests benefit from it.
+	//
+	// 2021-07-29(keegan) - testing on my machine this pkg goes from 78s to
+	// 4s.
+	dsn, cleanup, err := startEphemeralDB()
+	if err != nil && testing.Verbose() {
+		log.Println("failed to setup ephemeral db:", err)
+	}
+	if dsn != "" {
+		// Hack, this is the first envvar we read for dbtest.NewDB.
+		os.Setenv("PGDATASOURCE", dsn)
+	}
+
+	code := m.Run()
+
+	if cleanup != nil {
+		cleanup()
+	}
+
+	os.Exit(code)
+}
+
+func startEphemeralDB() (dsn string, _ func(), _ error) {
+	// Like defer, but runs in the returned cleanup function.
+	var cleanup deferList
+
+	// If we fail, run any cleanups we may have.
+	defer func() {
+		if dsn == "" {
+			cleanup.Run()
+		}
+	}()
+
+	// This only works if postgres is on PATH.
+	if _, err := exec.LookPath("postgres"); err != nil {
+		return "", nil, err
+	}
+
+	// Create an environment without outside PG*
+	var env []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "PG") {
+			env = append(env, e)
+		}
+	}
+
+	// Store postgres data in a temp dir
+	pgHost, err := os.MkdirTemp("", filepath.Base(os.Args[0])+"-pghost-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup.Add(func() { os.RemoveAll(pgHost) })
+	pgData := filepath.Join(pgHost, "data")
+	env = append(env,
+		"PGHOST="+pgHost,
+		"PGDATA="+pgData,
+		"PGDATABASE=postgres",
+	)
+
+	// Create the database without auth and without fsync.
+	cmd := exec.Command("initdb", pgData, "--nosync", "-E", "UNICODE", "--auth=trust")
+	cmd.Env = env
+	if err := cmd.Run(); err != nil {
+		return "", nil, err
+	}
+
+	// Tune configuration for speed with ephemeral test data.
+	if err := appendFile(filepath.Join(pgData, "postgresql.conf"), []byte(`
+unix_socket_directories = '`+pgHost+`'
+listen_addresses = ''
+shared_buffers = 12MB
+fsync = off
+synchronous_commit = off
+full_page_writes = off
+log_min_duration_statement = 0
+`), 0644); err != nil {
+		return "", nil, err
+	}
+
+	// start postgres as a subprocess. If the test process dies hopefully the
+	// OS will come in and cleanup. We parse stderr looking for the log
+	// message saying it is ready.
+	cmd = exec.Command("postgres", "-D", pgData)
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup.Add(func() { stderr.Close() })
+
+	// Postgres logs with test output \o/
+	var r io.Reader = stderr
+	if testing.Verbose() {
+		r = io.TeeReader(r, os.Stderr)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", nil, err
+	}
+
+	// We use ready to signal that postgres has started.
+	ready := make(chan bool, 1)
+	cleanup.Add(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+		// make sure scanner goroutine has stopped
+		<-ready
+	})
+
+	go func() {
+		defer close(ready)
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			if bytes.Contains(scanner.Bytes(), []byte("listening on Unix socket")) {
+				ready <- true
+				break
+			}
+		}
+		io.Copy(io.Discard, r) // drain r
+	}()
+
+	ok := <-ready
+	if !ok {
+		return "", nil, errors.New("failed to find ready message in log output")
+	}
+
+	// This DSN points to the directory postgres will put unix sockets.
+	return "postgresql:///postgres?host=" + pgHost, cleanup.Run, nil
+}
+
+type deferList []func()
+
+func (l *deferList) Add(f func()) {
+	*l = append(*l, f)
+}
+
+func (l *deferList) Run() {
+	for i := len(*l) - 1; i >= 0; i-- {
+		(*l)[i]()
+	}
+}
+
+// WriteFile but with os.O_APPEND
+func appendFile(name string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(data)
+	if err1 := f.Close(); err1 != nil && err == nil {
+		err = err1
+	}
+	return err
 }

--- a/internal/database/main_test.go
+++ b/internal/database/main_test.go
@@ -177,7 +177,7 @@ log_min_duration_statement = 0
 	// We use ready to signal that postgres has started.
 	ready := make(chan bool, 1)
 	cleanup.Add(func() {
-		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 		// make sure scanner goroutine has stopped
 		<-ready


### PR DESCRIPTION
Instead of using the system postgres, we can use an ephemeral postgres which is tuned for performance on ephemeral data. The main optimization here is turning off file syncing. On my system the runtime for "go test ./internal/database" goes from 78s to 4s.

I quite like this approach and believe we should always use it for tests, rather than optionally. This removes the requirement of having postgres running and configured for access. For this initial commit I just focussed on not breaking existing use cases and only doing it for our slowest package.

The code for this is based on pg_tmp. There is also integresql which uses a daemon based approach where each test case can get its own DB. That may be an interesting future direction.
