### PR TITLE
Bump src cli minimum version

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.30.0"
+const MinimumVersion = "3.30.2"


### PR DESCRIPTION
We need the new version in ignite, so we get additional logging from src batch preview.
