### PR TITLE
search: don't send repo count if count==0

### DIFF
--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -74,7 +74,9 @@ func (p *progressAggregator) Final() api.Progress {
 
 	// We only send RepositoriesCount at the end because the number is
 	// confusing to users to see while searching.
-	s.RepositoriesCount = intPtr(len(p.Stats.Repos))
+	if c := len(p.Stats.Repos); c > 0 {
+		s.RepositoriesCount = intPtr(c)
+	}
 
 	event := api.BuildProgressEvent(s)
 	event.Done = true


### PR DESCRIPTION
It is currently possible that we display stats like this

<img width="448" alt="Screenshot 2021-07-29 at 15 37 19" src="https://user-images.githubusercontent.com/26413131/127501878-564b23d4-e8c7-4ed4-a5d3-9214adfb4993.png">

The reason is that we always send the repo count, even
if we couldn't resolve repositories in time.

With this change we omit `RepositoriesCount` from the final progress
event if it is 0 and the client will simply not display the repository count.

This buys us some time while we work on a good solution of how to
efficiently return the number of repos in the global scope of the user.