### PR TITLE
insights: refactor search query results to extract repository name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Code Insights queries will now extract repository name out of the GraphQL response instead of going to the database. [#23388](https://github.com/sourcegraph/sourcegraph/pull/23388) 
 - Code Insights backend has moved from the `repo-updater` service to the `worker` service. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 - Code Insights feature flag `DISABLE_CODE_INSIGHTS` environment variable has moved from the `repo-updater` service to the `worker` service. Any users of this flag will need to update their `worker` service configuration to continue using it. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Code Insights queries will now extract repository name out of the GraphQL response instead of going to the database. [#23388](https://github.com/sourcegraph/sourcegraph/pull/23388) 
+- Code Insights queries will now extract repository name out of the GraphQL response instead of going to the database. [#23388](https://github.com/sourcegraph/sourcegraph/pull/23388)
 - Code Insights backend has moved from the `repo-updater` service to the `worker` service. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 - Code Insights feature flag `DISABLE_CODE_INSIGHTS` environment variable has moved from the `repo-updater` service to the `worker` service. Any users of this flag will need to update their `worker` service configuration to continue using it. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 

--- a/enterprise/internal/insights/background/queryrunner/graphql.go
+++ b/enterprise/internal/insights/background/queryrunner/graphql.go
@@ -37,6 +37,7 @@ const gqlSearchQuery = `query Search(
 				... on FileMatch {
 					repository {
 						id
+						name
 					}
 					lineMatches {
 						offsetAndLengths
@@ -54,11 +55,13 @@ const gqlSearchQuery = `query Search(
 					commit {
 						repository {
 							id
+							name
 						}
 					}
 				}
 				... on Repository {
 					id
+					name
 				}
 			}
 			alert {

--- a/enterprise/internal/insights/background/queryrunner/graphql_results.go
+++ b/enterprise/internal/insights/background/queryrunner/graphql_results.go
@@ -74,6 +74,7 @@ import (
 type result interface {
 	repoID() string
 	matchCount() int
+	repoName() string
 }
 
 func decodeResult(result json.RawMessage) (result, error) {
@@ -109,7 +110,8 @@ func decodeResult(result json.RawMessage) (result, error) {
 
 type fileMatch struct {
 	Repository struct {
-		ID string
+		ID   string
+		Name string
 	}
 	LineMatches []struct {
 		OffsetAndLengths [][]int
@@ -117,6 +119,10 @@ type fileMatch struct {
 	Symbols []struct {
 		Name string
 	}
+}
+
+func (r *fileMatch) repoName() string {
+	return r.Repository.Name
 }
 
 func (r *fileMatch) matchCount() int {
@@ -142,9 +148,14 @@ type commitSearchResult struct {
 	}
 	Commit struct {
 		Repository struct {
-			ID string
+			ID   string
+			Name string
 		}
 	}
+}
+
+func (r *commitSearchResult) repoName() string {
+	return r.Commit.Repository.Name
 }
 
 func (r *commitSearchResult) repoID() string {
@@ -160,7 +171,12 @@ func (r *commitSearchResult) matchCount() int {
 }
 
 type repository struct {
-	ID string
+	ID   string
+	Name string
+}
+
+func (r *repository) repoName() string {
+	return r.Name
 }
 
 func (r *repository) repoID() string {

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+
 	"golang.org/x/time/rate"
 
 	"github.com/cockroachdb/errors"
@@ -13,7 +15,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
@@ -107,39 +108,40 @@ func (r *workHandler) Handle(ctx context.Context, record workerutil.Record) (err
 	// Figure out how many matches we got for every unique repository returned in the search
 	// results.
 	matchesPerRepo := make(map[string]int, len(results.Data.Search.Results.Results)*4)
+	repoNames := make(map[string]string, len(matchesPerRepo))
 	for _, result := range results.Data.Search.Results.Results {
 		decoded, err := decodeResult(result)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf(`for query "%s"`, job.SearchQuery))
 		}
+		repoNames[decoded.repoID()] = decoded.repoName()
 		matchesPerRepo[decoded.repoID()] = matchesPerRepo[decoded.repoID()] + decoded.matchCount()
 	}
 
 	// Record the number of results we got, one data point per-repository.
-	repoStore := database.Repos(r.workerBaseStore.Handle().DB())
 	for graphQLRepoID, matchCount := range matchesPerRepo {
-		dbRepoID, err := graphqlbackend.UnmarshalRepositoryID(graphql.ID(graphQLRepoID))
-		if err != nil {
-			return errors.Wrap(err, "UnmarshalRepositoryID")
+		dbRepoID, idErr := graphqlbackend.UnmarshalRepositoryID(graphql.ID(graphQLRepoID))
+		if idErr != nil {
+			err = multierror.Append(err, errors.Wrap(idErr, "UnmarshalRepositoryID"))
+			continue
 		}
-		repo, err := repoStore.Get(ctx, dbRepoID)
-		if err != nil {
-			return errors.Wrap(err, "RepoStore.GetByID")
+		repoName := repoNames[graphQLRepoID]
+		if len(repoName) == 0 {
+			// this really should never happen, expect if for some reason the gql response is broken
+			err = multierror.Append(err, errors.Newf("MissingRepositoryName for repo_id: %v", string(dbRepoID)))
+			continue
 		}
-
-		repoName := string(repo.Name)
-		err = r.insightsStore.RecordSeriesPoint(ctx, store.RecordSeriesPointArgs{
+		if recordErr := r.insightsStore.RecordSeriesPoint(ctx, store.RecordSeriesPointArgs{
 			SeriesID: job.SeriesID,
 			Point: store.SeriesPoint{
 				Time:  recordTime,
 				Value: float64(matchCount),
 			},
 			RepoName: &repoName,
-			RepoID:   &repo.ID,
-		})
-		if err != nil {
-			return errors.Wrap(err, "RecordSeriesPoint")
+			RepoID:   &dbRepoID,
+		}); recordErr != nil {
+			err = multierror.Append(err, errors.Wrap(recordErr, "RecordSeriesPoint"))
 		}
 	}
-	return nil
+	return err
 }


### PR DESCRIPTION
Closes # #23386

Refactors the search query handler for code insights to drop a commonly used db call in favor of extracting the result out of the search result.

As a bonus, this refactors the search query handler to skip errors during recording and capture them as a multierror, stopping some inconsistent behavior where results can fail midway through processing.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
