### PR TITLE
backend: remove authz bypass and always use internal actors

### DIFF
--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -33,7 +34,7 @@ func CheckOrgAccess(ctx context.Context, db dbutil.DB, orgID int32) error {
 // checkOrgAccess is a helper method used above which allows optionally allowing
 // site admins to access all organisations.
 func checkOrgAccess(ctx context.Context, db dbutil.DB, orgID int32, allowAdmin bool) error {
-	if hasAuthzBypass(ctx) {
+	if actor.FromContext(ctx).IsInternal() {
 		return nil
 	}
 	currentUser, err := CurrentUser(ctx, db)

--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -17,7 +17,7 @@ var ErrMustBeSiteAdmin = errors.New("must be site admin")
 
 // CheckCurrentUserIsSiteAdmin returns an error if the current user is NOT a site admin.
 func CheckCurrentUserIsSiteAdmin(ctx context.Context, db dbutil.DB) error {
-	if hasAuthzBypass(ctx) {
+	if actor.FromContext(ctx).IsInternal() {
 		return nil
 	}
 	user, err := CurrentUser(ctx, db)
@@ -35,7 +35,7 @@ func CheckCurrentUserIsSiteAdmin(ctx context.Context, db dbutil.DB) error {
 
 // CheckUserIsSiteAdmin returns an error if the user is NOT a site admin.
 func CheckUserIsSiteAdmin(ctx context.Context, db dbutil.DB, userID int32) error {
-	if hasAuthzBypass(ctx) {
+	if actor.FromContext(ctx).IsInternal() {
 		return nil
 	}
 	user, err := database.Users(db).GetByID(ctx, userID)
@@ -69,11 +69,8 @@ func (e *InsufficientAuthorizationError) Unauthorized() bool { return true }
 //
 // Returns an error containing the name of the given user.
 func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID int32) error {
-	if hasAuthzBypass(ctx) {
-		return nil
-	}
 	a := actor.FromContext(ctx)
-	if a.IsAuthenticated() && a.UID == subjectUserID {
+	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {
 		return nil
 	}
 	isSiteAdminErr := CheckCurrentUserIsSiteAdmin(ctx, db)
@@ -90,11 +87,8 @@ func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID i
 // CheckSameUser returns an error if the user is not the user specified by
 // subjectUserID.
 func CheckSameUser(ctx context.Context, subjectUserID int32) error {
-	if hasAuthzBypass(ctx) {
-		return nil
-	}
 	a := actor.FromContext(ctx)
-	if a.IsAuthenticated() && a.UID == subjectUserID {
+	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {
 		return nil
 	}
 	return &InsufficientAuthorizationError{Message: fmt.Sprintf("Must be authenticated as user with id %d", subjectUserID)}
@@ -112,20 +106,3 @@ func CurrentUser(ctx context.Context, db dbutil.DB) (*types.User, error) {
 	}
 	return user, nil
 }
-
-// WithAuthzBypass returns a context that backend.CheckXyz funcs report as being a site admin. It
-// is used to bypass the backend.CheckXyz access control funcs when needed.
-//
-// 🚨 SECURITY: The caller MUST ensure that it performs its own access controls or removal of
-// sensitive data.
-func WithAuthzBypass(ctx context.Context) context.Context {
-	return context.WithValue(ctx, authzBypass, struct{}{})
-}
-
-func hasAuthzBypass(ctx context.Context) bool {
-	return ctx.Value(authzBypass) != nil
-}
-
-type contextKey int
-
-const authzBypass contextKey = iota

--- a/cmd/frontend/internal/app/debugproxies/handler_test.go
+++ b/cmd/frontend/internal/app/debugproxies/handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 )
 
 func TestReverseProxyRequestPaths(t *testing.T) {
@@ -35,7 +35,7 @@ func TestReverseProxyRequestPaths(t *testing.T) {
 	displayName := displayNameFromEndpoint(ep)
 	rph.Populate([]Endpoint{ep})
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 
 	link := fmt.Sprintf("%s/-/debug/proxies/%s/metrics", proxiedServer.URL, displayName)
 	req := httptest.NewRequest("GET", link, nil)
@@ -75,7 +75,7 @@ func TestIndexLinks(t *testing.T) {
 	displayName := displayNameFromEndpoint(ep)
 	rph.Populate([]Endpoint{ep})
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 
 	link := fmt.Sprintf("%s/-/debug/", proxiedServer.URL)
 	req := httptest.NewRequest("GET", link, nil)

--- a/cmd/frontend/internal/app/ping_test.go
+++ b/cmd/frontend/internal/app/ping_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -61,7 +61,7 @@ func TestLatestPingHandler(t *testing.T) {
 
 			req, _ := http.NewRequest("GET", "/site-admin/pings/latest", nil)
 			rec := httptest.NewRecorder()
-			latestPingHandler(db)(rec, req.WithContext(backend.WithAuthzBypass(context.Background())))
+			latestPingHandler(db)(rec, req.WithContext(actor.WithInternalActor(context.Background())))
 
 			resp := rec.Result()
 			body, err := io.ReadAll(resp.Body)

--- a/cmd/frontend/internal/app/usage_stats_test.go
+++ b/cmd/frontend/internal/app/usage_stats_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
@@ -36,7 +36,7 @@ func TestUsageStatsArchiveHandler(t *testing.T) {
 	t.Run("admins can download archive", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "", nil)
 		rec := httptest.NewRecorder()
-		usageStatsArchiveHandler(db)(rec, req.WithContext(backend.WithAuthzBypass(context.Background())))
+		usageStatsArchiveHandler(db)(rec, req.WithContext(actor.WithInternalActor(context.Background())))
 
 		contentType := rec.Header().Get("Content-Type")
 		if have, want := contentType, "application/zip"; have != want {

--- a/doc/dev/background-information/security_patterns.md
+++ b/doc/dev/background-information/security_patterns.md
@@ -24,10 +24,51 @@ In Sourcegraph, there are two places to enforce authorization, both equally impo
 
 - At the GraphQL layer:
     - Some endpoints are restricted to certain users (e.g. site admins or the same user).
-    - Be aware that any backend failure has potential to indicate unauthorized information about private resources. Therefore, halt the process as soon as we identify an unauthorized request, and behave as if the resource does not exist at all.
+    - Be aware that any backend failure has the potential to indicate unauthorized information about private resources. Therefore, halt the process as soon as we identify an unauthorized request, and behave as if the resource does not exist at all.
 - At the database layer:
     - The database is our source of truth for authorization, especially for repository and batch changes permissions. Enforcing authorization at this layer is absolutely necessary.
 
-### Secret management
+### Authorization implementation
+
+Within our Go code, such as the frontend and repo-updater services, metadata representing the current user or actor is kept within the current context. It can be accessed using `actor.FromContext(ctx)`.
+
+#### Actors
+
+The [`Actor`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@c764844ef9574cef5533147d756ae98e613d0ae6/-/blob/internal/actor/actor.go?L15&subtree=true) type represents the current actor. In most cases, this is the user who issued the request.
+
+More specifically, an actor will be one of these three cases:
+
+1. An authenticated user, in which case the `UID` field will be set to a non-zero value.
+2. A guest user, in which case the `UID` field will be zero.
+3. An internal actor, which indicates that the current operation was started by an internal Sourcegraph process.
+
+#### Checking authorization
+
+Care must be taken when checking an actor: it's possible to have a context that doesn't have an actor at all, in which case `actor.FromContext()` will return `nil`.
+
+Code in `cmd/frontend` and `enterprise/cmd/frontend` can take advantage of [the helper functions available in `cmd/frontend/backend`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@c764844/-/docs/cmd/frontend/backend#func) such as `CheckCurrentUserIsSiteAdmin` and `CheckSiteAdminOrSameUser`. These functions already take the details of internal and user actors into account, and are the safest way to perform authorization checks at the frontend level (for example, in GraphQL resolvers).
+
+Below the frontend level, or in other commands, you'll need to implement more of your own authorization logic. Two `nil`-safe methods are provided on the `Actor` type: `IsAuthenticated()` and `IsInternal()`, which are always safe to call. The `UID` field must only be accessed after calling `IsAuthenticated()`.
+
+As a general rule, internal actors should always be considered authorized, so your checks will often take this general form:
+
+```go
+func isAuthorized(ctx context.Context, uid int32) bool {
+    actor := actor.FromContext(ctx)
+    if actor.IsInternal() {
+        return true
+    }
+    if !actor.IsAuthenticated() {
+        return false
+    }
+    if actor.UID == uid {
+        return true
+    }
+
+    // Get the user by ID and check admin status if necessary.
+}
+```
+
+## Secret management
 
 Secrets used by our applications are stored in GCP Secret Manager, *never* in source code unless it is mock/test data. Internal documentation on how to store/consume secrets for development can be found in [this document](https://docs.google.com/document/d/1Qm5P4KbyVMP_KyPvud0qyqUb43RK3lTFMjAeE6623Nw/edit).

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -635,7 +635,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 }
 
 func TestLoadChangesetSource(t *testing.T) {
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 	token := &auth.OAuthBearerToken{Token: "abcdef"}
 
@@ -796,7 +796,7 @@ func TestLoadChangesetSource(t *testing.T) {
 }
 
 func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, et.TestKey{})

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -21,7 +21,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	store := store.New(db, nil)

--- a/enterprise/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/internal/batches/resolvers/batch_change_connection_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -24,7 +23,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID

--- a/enterprise/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/internal/batches/resolvers/batch_change_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -24,7 +24,7 @@ func TestBatchChangeResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID

--- a/enterprise/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/internal/batches/resolvers/batch_spec_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -26,7 +25,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, nil)

--- a/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -24,7 +23,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID

--- a/enterprise/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -25,7 +25,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID

--- a/enterprise/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -23,7 +23,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID

--- a/enterprise/internal/batches/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_connection_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -24,7 +23,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID

--- a/enterprise/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_counts_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
@@ -70,7 +69,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 	rcache.SetupForTest(t)
 

--- a/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -26,7 +25,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID

--- a/enterprise/internal/batches/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec_connection_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -23,7 +23,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID

--- a/enterprise/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -25,7 +25,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID

--- a/enterprise/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -27,7 +27,7 @@ func TestChangesetResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID

--- a/enterprise/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/batches/resolvers/code_host_connection_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -26,7 +25,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	pruneUserCredentials(t, db, nil)

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sourcegraph/batch-change-utils/overridable"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search"
@@ -44,7 +43,7 @@ func TestNullIDResilience(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 
 	ids := []graphql.ID{
 		marshalBatchChangeID(0),

--- a/enterprise/internal/batches/service/service_apply_batch_change_test.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/reconciler"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
@@ -24,7 +23,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	admin := ct.CreateTestUser(t, db, true)

--- a/enterprise/internal/batches/service/service_apply_batch_change_test.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change_test.go
@@ -681,7 +681,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			ct.MockRepoPermissions(t, db, user.ID, repos[0].ID, repos[2].ID, repos[3].ID)
 
-			// NOTE: We cannot use a context that has authz bypassed.
+			// NOTE: We cannot use a context with an internal actor.
 			batchSpec := ct.CreateBatchSpec(t, userCtx, store, "missing-permissions", user.ID)
 
 			ct.CreateChangesetSpec(t, userCtx, store, ct.TestSpecOpts{

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -33,7 +33,7 @@ func TestServicePermissionLevels(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	s := store.New(db, nil)
@@ -175,7 +175,7 @@ func TestService(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtest.NewDB(t, "")
 
 	admin := ct.CreateTestUser(t, db, true)

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -288,12 +288,12 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("EnqueueChangesetSync", func(t *testing.T) {
-		spec := testBatchSpec(admin.ID)
+		spec := testBatchSpec(user.ID)
 		if err := s.CreateBatchSpec(ctx, spec); err != nil {
 			t.Fatal(err)
 		}
 
-		batchChange := testBatchChange(admin.ID, spec)
+		batchChange := testBatchChange(user.ID, spec)
 		if err := s.CreateBatchChange(ctx, batchChange); err != nil {
 			t.Fatal(err)
 		}
@@ -313,7 +313,7 @@ func TestService(t *testing.T) {
 		}
 		t.Cleanup(func() { repoupdater.MockEnqueueChangesetSync = nil })
 
-		if err := svc.EnqueueChangesetSync(ctx, changeset.ID); err != nil {
+		if err := svc.EnqueueChangesetSync(userCtx, changeset.ID); err != nil {
 			t.Fatal(err)
 		}
 
@@ -325,18 +325,18 @@ func TestService(t *testing.T) {
 		ct.MockRepoPermissions(t, db, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
 
 		// should result in a not found error
-		if err := svc.EnqueueChangesetSync(ctx, changeset.ID); !errcode.IsNotFound(err) {
+		if err := svc.EnqueueChangesetSync(userCtx, changeset.ID); !errcode.IsNotFound(err) {
 			t.Fatalf("expected not-found error but got %v", err)
 		}
 	})
 
 	t.Run("ReenqueueChangeset", func(t *testing.T) {
-		spec := testBatchSpec(admin.ID)
+		spec := testBatchSpec(user.ID)
 		if err := s.CreateBatchSpec(ctx, spec); err != nil {
 			t.Fatal(err)
 		}
 
-		batchChange := testBatchChange(admin.ID, spec)
+		batchChange := testBatchChange(user.ID, spec)
 		if err := s.CreateBatchChange(ctx, batchChange); err != nil {
 			t.Fatal(err)
 		}
@@ -348,7 +348,7 @@ func TestService(t *testing.T) {
 
 		ct.SetChangesetFailed(t, ctx, s, changeset)
 
-		if _, _, err := svc.ReenqueueChangeset(ctx, changeset.ID); err != nil {
+		if _, _, err := svc.ReenqueueChangeset(userCtx, changeset.ID); err != nil {
 			t.Fatal(err)
 		}
 
@@ -369,7 +369,7 @@ func TestService(t *testing.T) {
 		ct.MockRepoPermissions(t, db, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
 
 		// should result in a not found error
-		if _, _, err := svc.ReenqueueChangeset(ctx, changeset.ID); !errcode.IsNotFound(err) {
+		if _, _, err := svc.ReenqueueChangeset(userCtx, changeset.ID); !errcode.IsNotFound(err) {
 			t.Fatalf("expected not-found error but got %v", err)
 		}
 	})
@@ -596,7 +596,7 @@ func TestService(t *testing.T) {
 		t.Run("missing repository permissions", func(t *testing.T) {
 			ct.MockRepoPermissions(t, db, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
 
-			_, err := svc.CreateChangesetSpec(ctx, rawSpec, admin.ID)
+			_, err := svc.CreateChangesetSpec(userCtx, rawSpec, admin.ID)
 			if !errcode.IsNotFound(err) {
 				t.Fatalf("expected not-found error but got %v", err)
 			}

--- a/enterprise/internal/codemonitors/main_test.go
+++ b/enterprise/internal/codemonitors/main_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
@@ -60,7 +59,7 @@ func (s *Store) insertTestMonitor(ctx context.Context, t *testing.T) (*Monitor, 
 }
 
 func newTestStore(t *testing.T) (context.Context, *Store) {
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtesting.GetDB(t)
 	now := time.Now().Truncate(time.Microsecond)
 	return ctx, NewStoreWithClock(db, func() time.Time { return now })

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	batchesApitest "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	cm "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
@@ -32,7 +31,7 @@ func TestCreateCodeMonitor(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtesting.GetDB(t)
 	r := newTestResolver(t, db)
 
@@ -89,7 +88,7 @@ func TestListCodeMonitors(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtesting.GetDB(t)
 	r := newTestResolver(t, db)
 
@@ -311,7 +310,7 @@ func TestQueryMonitor(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtesting.GetDB(t)
 	r := newTestResolver(t, db)
 
@@ -583,7 +582,7 @@ func TestEditCodeMonitor(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtesting.GetDB(t)
 	r := newTestResolver(t, db)
 
@@ -1162,7 +1161,7 @@ func TestTriggerTestEmailAction(t *testing.T) {
 		return nil
 	}
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	r := newTestResolver(t, nil)
 
 	userID := 1

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -1164,10 +1164,8 @@ func TestTriggerTestEmailAction(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	r := newTestResolver(t, nil)
 
-	userID := 1
 	namespaceID := relay.MarshalID("User", actor.FromContext(ctx).UID)
 
-	ctx = actor.WithActor(ctx, actor.FromUser(int32(userID)))
 	_, err := r.TriggerTestEmailAction(ctx, &graphqlbackend.TriggerTestEmailActionArgs{
 		Namespace:   namespaceID,
 		Description: "A code monitor name",

--- a/enterprise/internal/codemonitors/storetest/monitor_creator.go
+++ b/enterprise/internal/codemonitors/storetest/monitor_creator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -65,7 +64,7 @@ func (s *TestStore) InsertTestMonitor(ctx context.Context, t *testing.T) (*codem
 }
 
 func NewTestStoreWithStore(t *testing.T, store *codemonitors.Store) (context.Context, *TestStore) {
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	db := dbtesting.GetDB(t)
 	now := time.Now().Truncate(time.Microsecond)
 	return ctx, &TestStore{codemonitors.NewStoreWithClock(db, func() time.Time { return now })}

--- a/enterprise/internal/insights/background/queryrunner/worker_test.go
+++ b/enterprise/internal/insights/background/queryrunner/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
@@ -25,7 +25,7 @@ func TestJobQueue(t *testing.T) {
 	}
 	//t.Parallel() // TODO: dbtesting.GetDB is not parallel-safe, yuck.
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 
 	mainAppDB := dbtesting.GetDB(t)
 	workerBaseStore := basestore.NewWithDB(mainAppDB, sql.TxOptions{})

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
@@ -38,7 +37,7 @@ func TestResolver_InsightConnection(t *testing.T) {
 
 	testSetup := func(t *testing.T) (context.Context, graphqlbackend.InsightConnectionResolver) {
 		// Setup the GraphQL resolver.
-		ctx := backend.WithAuthzBypass(context.Background())
+		ctx := actor.WithInternalActor(context.Background())
 		now := time.Now().UTC().Truncate(time.Microsecond)
 		clock := func() time.Time { return now }
 

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
@@ -26,7 +26,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 
 	testSetup := func(t *testing.T) (context.Context, [][]graphqlbackend.InsightSeriesResolver, *store.MockInterface, func()) {
 		// Setup the GraphQL resolver.
-		ctx := backend.WithAuthzBypass(context.Background())
+		ctx := actor.WithInternalActor(context.Background())
 		now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 		clock := func() time.Time { return now }
 		timescale, cleanup := insightsdbtesting.TimescaleDB(t)

--- a/enterprise/internal/insights/resolvers/resolver_test.go
+++ b/enterprise/internal/insights/resolvers/resolver_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
@@ -22,7 +22,7 @@ func TestResolver_Insights(t *testing.T) {
 	}
 	//t.Parallel() // TODO: dbtesting.GetDB is not parallel-safe, yuck.
 
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	clock := func() time.Time { return now }
 	timescale, cleanup := insightsdbtesting.TimescaleDB(t)

--- a/enterprise/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/internal/licensing/resolvers/resolvers_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 )
 
 func TestEnterpriseLicenseHasFeature(t *testing.T) {
@@ -18,7 +18,7 @@ func TestEnterpriseLicenseHasFeature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := backend.WithAuthzBypass(context.Background())
+	ctx := actor.WithInternalActor(context.Background())
 
 	buildMock := func(allow ...licensing.Feature) func(feature licensing.Feature) error {
 		return func(feature licensing.Feature) error {

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -41,6 +41,11 @@ func (a *Actor) IsAuthenticated() bool {
 	return a != nil && a.UID != 0
 }
 
+// IsInternal returns true if the Actor is an internal actor.
+func (a *Actor) IsInternal() bool {
+	return a != nil && a.Internal
+}
+
 type key int
 
 const actorKey key = iota
@@ -54,6 +59,7 @@ func FromContext(ctx context.Context) *Actor {
 	return a
 }
 
+// WithActor returns a new context with the given Actor instance.
 func WithActor(ctx context.Context, a *Actor) context.Context {
 	if a != nil && a.UID != 0 {
 		trace.User(ctx, a.UID)
@@ -61,6 +67,10 @@ func WithActor(ctx context.Context, a *Actor) context.Context {
 	return context.WithValue(ctx, actorKey, a)
 }
 
+// WithInternalActor returns a new context with its actor set to be internal.
+//
+// 🚨 SECURITY: The caller MUST ensure that it performs its own access controls
+// or removal of sensitive data.
 func WithInternalActor(ctx context.Context) context.Context {
 	return context.WithValue(ctx, actorKey, &Actor{Internal: true})
 }


### PR DESCRIPTION
This came out of a [Slack discussion](https://sourcegraph.slack.com/archives/C07KZF47K/p1627523918075400), where it was agreed that we could unify the existing authz bypass and internal actor mechanisms. Therefore:

_Internal actors (as provisioned by `actor.WithInternalActor()`) are now the only supported way of bypassing authorisation checks._

I've added documentation to that effect, along with a potted description of how to use our authorization primitives as they stand. There's a fairly obvious hole in that we have some great helpers in `cmd/frontend/backend` that would be more generally applicable if we could untangle the circular `internal/database` dependency that naïvely copying them to `internal/actor` would create, but I'm saving dealing with that for a future rainy day. (Or someone else's rainy day.)

Reviews have been broadly requested, as this touches code (well, mostly tests) from a bunch of different teams, but I don't think this is particularly spicy overall. (It would actually be a net reduction in lines if I hadn't written a bunch of Markdown.)