### PR TITLE
oobmigration: always use an internal actor

### DIFF
--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -43,7 +44,7 @@ func NewRunnerWithDB(db dbutil.DB, refreshInterval time.Duration, observationCon
 }
 
 func newRunner(store storeIface, refreshTicker glock.Ticker, observationContext *observation.Context) *Runner {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(actor.WithInternalActor(context.Background()))
 
 	return &Runner{
 		store:         store,

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -44,6 +44,7 @@ func NewRunnerWithDB(db dbutil.DB, refreshInterval time.Duration, observationCon
 }
 
 func newRunner(store storeIface, refreshTicker glock.Ticker, observationContext *observation.Context) *Runner {
+    // IMPORTANT: actor.WithInternalActor prevents issues caused by database-level authz checks: migration tasks should always be privileged.
 	ctx, cancel := context.WithCancel(actor.WithInternalActor(context.Background()))
 
 	return &Runner{

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -44,7 +44,9 @@ func NewRunnerWithDB(db dbutil.DB, refreshInterval time.Duration, observationCon
 }
 
 func newRunner(store storeIface, refreshTicker glock.Ticker, observationContext *observation.Context) *Runner {
-    // IMPORTANT: actor.WithInternalActor prevents issues caused by database-level authz checks: migration tasks should always be privileged.
+	// IMPORTANT: actor.WithInternalActor prevents issues caused by
+	// database-level authz checks: migration tasks should always be
+	// privileged.
 	ctx, cancel := context.WithCancel(actor.WithInternalActor(context.Background()))
 
 	return &Runner{


### PR DESCRIPTION
While we don't have any migrations that have this issue today, this prevents issues in the future caused by database-level authz checks: migration tasks should always be privileged.