### PR TITLE
metrics: Adjust src_access_granted_private_repo

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -663,7 +663,7 @@ func (s *RepoStore) ListRepoNames(ctx context.Context, opt ReposListOptions) (re
 	}
 
 	// TODO: Actually log event here
-	counterAccessGranted.Add(float64(len(privateIDs)))
+	counterAccessGranted.Inc()
 
 	return repos, nil
 }
@@ -686,7 +686,7 @@ func (s *RepoStore) listRepos(ctx context.Context, tr *trace.Trace, opt ReposLis
 
 	if len(privateIDs) > 0 {
 		// TODO: Actually log event here
-		counterAccessGranted.Add(float64(len(privateIDs)))
+		counterAccessGranted.Inc()
 	}
 
 	return rs, err


### PR DESCRIPTION
Instead of counting the number of repos when listing, we just need to
increase the count by 1. The intention of this metric for now is to get
a feel for how often we'd need to log access granted events and we only
have one event per access, not one event for each repo.
