### PR TITLE
Update 'select:' documentation in search reference

### DIFF
--- a/client/web/src/search/results/sidebar/SearchReference.module.scss
+++ b/client/web/src/search/results/sidebar/SearchReference.module.scss
@@ -68,6 +68,12 @@
     p > code {
         white-space: break-spaces;
     }
+
+    ul {
+        margin-bottom: 1rem;
+        padding-left: 1rem;
+        list-style-type: square;
+    }
 }
 
 .placeholder {

--- a/client/web/src/search/results/sidebar/SearchReference.module.scss
+++ b/client/web/src/search/results/sidebar/SearchReference.module.scss
@@ -70,6 +70,9 @@
     }
 
     ul {
+        // margin-bottom: 1rem is used to have the same bottom spacing as the p
+        // elements that (likely) surround this list (the description consists
+        // of mainly Markdown)
         margin-bottom: 1rem;
         padding-left: 1rem;
         list-style-type: square;

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -213,7 +213,7 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         ...createQueryExampleFromString('{result-types}'),
         field: FilterType.select,
         commonRank: 50,
-        description: `Shows only query results for a given type. For example, \`select:repo\` displays only distinct reopsitory paths from search results. The following values are available:
+        description: `Shows only query results for a given type. For example, \`select:repo\` displays only distinct repository paths from search results. The following values are available:
 
 - \`select:repo\`
 - \`select:commit.diff.added\`

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -213,9 +213,19 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         ...createQueryExampleFromString('{result-types}'),
         field: FilterType.select,
         commonRank: 50,
-        description:
-            'Shows only query results for a given type. For example, `select:repo` displays only distinct repository paths from search results. See [language definition](https://docs.sourcegraph.com/code_search/reference/language#select) for possible values.',
-        examples: ['fmt.Errorf select:repo'],
+        description: `Shows only query results for a given type. For example, \`select:repo\` displays only distinct reopsitory paths from search results. The following values are available:
+
+- \`select:repo\`
+- \`select:commit.diff.added\`
+- \`select:commit.diff.removed\`
+- \`select:file\`
+- \`select:file.directory\`
+- \`select:file.path\`
+- \`select:content\`
+- \`select:symbol.symboltype\`
+
+See [language definition](https://docs.sourcegraph.com/code_search/reference/language#select) for more information on possible values.`,
+        examples: ['fmt.Errorf select:repo', 'select:commit.diff.added //TODO', 'select:file.directory'],
     },
     {
         ...createQueryExampleFromString('{diff/commit/...}'),


### PR DESCRIPTION
I added a little bit of styling for the list (cc @rrhyne)

<img width="207" alt="2021-07-30_08-43" src="https://user-images.githubusercontent.com/179026/127627513-4067aadb-9700-4743-bda3-1313273ef950.png">
