### PR TITLE
Only write required columns to changesets table in bulkProcessor

### DIFF
--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -1391,7 +1391,6 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		})
 
 		// Add 3 batch changes
-
 		c1.Attach(123)
 		c1.Attach(456)
 		c1.Attach(789)
@@ -1404,6 +1403,33 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		c1.ExternalServiceType = "external-service-type"
 
 		err := s.UpdateChangesetBatchChanges(ctx, c1)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		have := c1
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("invalid changeset: %s", diff)
+		}
+	})
+
+	t.Run("UpdateChangesetUiPublicationState", func(t *testing.T) {
+		c1 := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
+			ReconcilerState: btypes.ReconcilerStateCompleted,
+			Repo:            repo.ID,
+		})
+
+		// Update the UiPublicationState
+		c1.UiPublicationState = &btypes.ChangesetUiPublicationStateDraft
+
+		// This is what we expect after the update
+		want := c1.Clone()
+
+		// These two and other columsn should not be updated in the DB
+		c1.ReconcilerState = btypes.ReconcilerStateErrored
+		c1.ExternalServiceType = "external-service-type"
+
+		err := s.UpdateChangesetUiPublicationState(ctx, c1)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -1383,6 +1383,36 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			SyncErrorMessage: nil,
 		})
 	})
+
+	t.Run("UpdateChangesetBatchChanges", func(t *testing.T) {
+		c1 := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
+			ReconcilerState: btypes.ReconcilerStateCompleted,
+			Repo:            repo.ID,
+		})
+
+		// Add 3 batch changes
+
+		c1.Attach(123)
+		c1.Attach(456)
+		c1.Attach(789)
+
+		// This is what we expect after the update
+		want := c1.Clone()
+
+		// These two and other columsn should not be updated in the DB
+		c1.ReconcilerState = btypes.ReconcilerStateErrored
+		c1.ExternalServiceType = "external-service-type"
+
+		err := s.UpdateChangesetBatchChanges(ctx, c1)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		have := c1
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("invalid changeset: %s", diff)
+		}
+	})
 }
 
 func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {


### PR DESCRIPTION
This addresses some of the problems described in https://github.com/sourcegraph/sourcegraph/issues/22915, especially in this comment: https://github.com/sourcegraph/sourcegraph/issues/22915#issuecomment-889241304

It doesn't fix the problems completely, but it improves the situation by lessening the change of overwrites that lead to a loss of critical data.

What this PR specifically does:
* Introduce two new methods to the `*Store` that allow updating only single columns: `ui_publication_state` or `batch_change_ids`
* In the `(*bulkProcessor)` it uses them in `detach` and `publishChangeset` to make sure that no other state of the changeset is overwritten
* It adds a sanity check to the `(*bulkProcessor).process` method to ensure  that no changeset that's currently being processes by the reconciler is touched. There should be no good usecase where allowing that to go through makes sense, so I'd rather err on the side of safety here.

In other words: the changes here are a first step towards fixing the problems described in #22915. 