### PR TITLE
search: Improve no results message in repo section

### DIFF
--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { useHistory } from 'react-router'
 import StickyBox from 'react-sticky-box'
 
@@ -96,7 +96,10 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         [persistToggleState, props.telemetryService]
     )
 
-    const repoFilterLinks = getRepoFilterLinks(props.filters, onDynamicFilterClicked)
+    const repoFilterLinks = useMemo(() => getRepoFilterLinks(props.filters, onDynamicFilterClicked), [
+        props.filters,
+        onDynamicFilterClicked,
+    ])
 
     return (
         <div className={classNames(styles.searchSidebar, props.className)}>

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -96,6 +96,8 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         [persistToggleState, props.telemetryService]
     )
 
+    const repoFilterLinks = getRepoFilterLinks(props.filters, onDynamicFilterClicked)
+
     return (
         <div className={classNames(styles.searchSidebar, props.className)}>
             <StickyBox className={styles.searchSidebarStickyBox}>
@@ -122,8 +124,14 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     open={openSections[SectionID.REPOSITORIES] ?? true}
                     onToggle={open => persistToggleState(SectionID.REPOSITORIES, open)}
                     showSearch={true}
+                    noResultText={
+                        <span>
+                            None of the top {repoFilterLinks.length} repositories in your results match this filter. Try
+                            a <code>repo:</code> search in the main search bar instead.
+                        </span>
+                    }
                 >
-                    {getRepoFilterLinks(props.filters, onDynamicFilterClicked)}
+                    {repoFilterLinks}
                 </SearchSidebarSection>
                 <SearchSidebarSection
                     className={styles.searchSidebarItem}

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
@@ -14,7 +14,11 @@ export const SearchSidebarSection: React.FunctionComponent<{
     showSearch?: boolean // Search only works if children are FilterLink
     onToggle?: (open: boolean) => void
     open?: boolean
-}> = ({ header, children = [], className, showSearch = false, onToggle, open }) => {
+    /**
+     * Shown when the built-in search doesn't find any results.
+     */
+    noResultText?: React.ReactElement | string
+}> = ({ header, children = [], className, showSearch = false, onToggle, open, noResultText = 'No result' }) => {
     const [filter, setFilter] = useState('')
 
     // Clear filter when children change
@@ -50,7 +54,7 @@ export const SearchSidebarSection: React.FunctionComponent<{
                         <li key={child.key || index}>{child}</li>
                     ))}
                     {filteredChildren.length === 0 && (
-                        <li className={classNames('text-muted', styles.sidebarSectionNoResults)}>No results</li>
+                        <li className={classNames('text-muted', styles.sidebarSectionNoResults)}>{noResultText}</li>
                     )}
                 </ul>
             </>

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
@@ -18,7 +18,7 @@ export const SearchSidebarSection: React.FunctionComponent<{
      * Shown when the built-in search doesn't find any results.
      */
     noResultText?: React.ReactElement | string
-}> = ({ header, children = [], className, showSearch = false, onToggle, open, noResultText = 'No result' }) => {
+}> = ({ header, children = [], className, showSearch = false, onToggle, open, noResultText = 'No results' }) => {
     const [filter, setFilter] = useState('')
 
     // Clear filter when children change


### PR DESCRIPTION
I added a new prop to the SidebarSection component that allows for customizing the "No result" message.

<img width="199" alt="2021-07-30_13-44" src="https://user-images.githubusercontent.com/179026/127662622-808ade89-16af-4a93-bf18-707f34f49d53.png">
