### PR TITLE
Remove health server from executor

### DIFF
--- a/dev/Procfile
+++ b/dev/Procfile
@@ -23,8 +23,8 @@ grafana: ./dev/grafana.sh
 postgres_exporter: ./dev/postgres_exporter.sh
 
 # Enterprise executor services
-codeintel-executor: test "$ENTERPRISE" != 1 || env EXECUTOR_QUEUE_NAME=codeintel EXECUTOR_HEALTH_SERVER_PORT=3192 SRC_PROF_HTTP=":6092" TMPDIR=$HOME/.sourcegraph/indexer-temp executor
-batches-executor: test "$ENTERPRISE" != 1 || env EXECUTOR_QUEUE_NAME=batches EXECUTOR_HEALTH_SERVER_PORT=3193 SRC_PROF_HTTP=":6093" TMPDIR=$HOME/.sourcegraph/batches-executor-temp executor
+codeintel-executor: test "$ENTERPRISE" != 1 || env EXECUTOR_QUEUE_NAME=codeintel SRC_PROF_HTTP=":6092" TMPDIR=$HOME/.sourcegraph/indexer-temp executor
+batches-executor: test "$ENTERPRISE" != 1 || env EXECUTOR_QUEUE_NAME=batches SRC_PROF_HTTP=":6093" TMPDIR=$HOME/.sourcegraph/batches-executor-temp executor
 
 # Enterprise code intelligence services
 precise-code-intel-worker: test "$ENTERPRISE" != 1 || precise-code-intel-worker

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -31,8 +31,6 @@ type Config struct {
 	FirecrackerMemory    string
 	FirecrackerDiskSpace string
 	ImageArchivesPath    string
-	DisableHealthServer  bool
-	HealthServerPort     int
 	MaximumRuntimePerJob time.Duration
 	CleanupTaskInterval  time.Duration
 }
@@ -51,8 +49,6 @@ func (c *Config) Load() {
 	c.FirecrackerMemory = c.Get("EXECUTOR_FIRECRACKER_MEMORY", "12G", "How much memory to allocate to each virtual machine or container.")
 	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine or container.")
 	c.ImageArchivesPath = c.Get("EXECUTOR_IMAGE_ARCHIVE_PATH", "", "Where to store tar archives of docker images shared by virtual machines.")
-	c.DisableHealthServer = c.GetBool("EXECUTOR_DISABLE_HEALTHSERVER", "false", "Whether or not to disable the health server.")
-	c.HealthServerPort = c.GetInt("EXECUTOR_HEALTH_SERVER_PORT", "3192", "The port to listen on for the health server.")
 	c.MaximumRuntimePerJob = c.GetInterval("EXECUTOR_MAXIMUM_RUNTIME_PER_JOB", "30m", "The maximum wall time that can be spent on a single job.")
 	c.CleanupTaskInterval = c.GetInterval("EXECUTOR_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic cleanup tasks.")
 }

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"net/http"
-	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
@@ -16,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -62,14 +58,6 @@ func main() {
 			janitor.NewMetrics(observationContext),
 		))
 	}
-	if !config.DisableHealthServer {
-		routines = append(routines, httpserver.NewFromAddr(fmt.Sprintf(":%d", config.HealthServerPort), &http.Server{
-			ReadTimeout:  75 * time.Second,
-			WriteTimeout: 10 * time.Minute,
-			Handler:      httpserver.NewHandler(nil),
-		}))
-	}
-
 	goroutine.MonitorBackgroundRoutines(context.Background(), routines...)
 }
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -419,7 +419,6 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/indexer-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: codeintel
-      EXECUTOR_HEALTH_SERVER_PORT: "3192"
       SRC_PROF_HTTP: ":6092"
 
   batches-executor:
@@ -428,7 +427,6 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: batches
-      EXECUTOR_HEALTH_SERVER_PORT: "3193"
       SRC_PROF_HTTP: ":6093"
 
   # If you want to use this, either start it with `sg run batches-executor-firecracker` or
@@ -437,12 +435,11 @@ commands:
     <<: *executor_template
     cmd: |
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" \
-        sudo --preserve-env=TMPDIR,EXECUTOR_QUEUE_NAME,EXECUTOR_HEALTH_SERVER_PORT,SRC_PROF_HTTP,EXECUTOR_FRONTEND_URL,EXECUTOR_FRONTEND_USERNAME,EXECUTOR_FRONTEND_PASSWORD,EXECUTOR_USE_FIRECRACKER,EXECUTOR_IMAGE_ARCHIVE_PATH \
+        sudo --preserve-env=TMPDIR,EXECUTOR_QUEUE_NAME,SRC_PROF_HTTP,EXECUTOR_FRONTEND_URL,EXECUTOR_FRONTEND_USERNAME,EXECUTOR_FRONTEND_PASSWORD,EXECUTOR_USE_FIRECRACKER,EXECUTOR_IMAGE_ARCHIVE_PATH \
           .bin/executor
     env:
       EXECUTOR_USE_FIRECRACKER: true
       EXECUTOR_QUEUE_NAME: batches
-      EXECUTOR_HEALTH_SERVER_PORT: "3193"
       SRC_PROF_HTTP: ":6093"
 
   minio:


### PR DESCRIPTION
It's not needed, we already have the debugserver and never probe this endpoint anywhere.