### PR TITLE
executor: Refuse to dequeue new job when len(vms) >= numHandlers

### DIFF
--- a/enterprise/cmd/executor/internal/ignite/list.go
+++ b/enterprise/cmd/executor/internal/ignite/list.go
@@ -1,0 +1,32 @@
+package ignite
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// CurrentlyRunningVMs returns the set of VMs existant on the host as a map from VM names
+// to VM identifiers. VMs starting with a prefix distinct from the given prefix are ignored.
+func CurrentlyRunningVMs(ctx context.Context, prefix string) (map[string]string, error) {
+	cmd := exec.CommandContext(ctx, "ignite", "ps", "-a", "-t", "{{ .Name }}:{{ .UID }}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseIgniteList(prefix, string(out)), nil
+}
+
+// parseIgniteList parses the output from the `ignite ps` invocation in CurrentlyRunningVMs.
+// VMs starting with a prefix distinct from the given prefix are ignored.
+func parseIgniteList(prefix, out string) map[string]string {
+	activeVMsMap := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		if parts := strings.Split(line, ":"); len(parts) == 2 && strings.HasPrefix(parts[0], prefix) {
+			activeVMsMap[parts[0]] = parts[1]
+		}
+	}
+
+	return activeVMsMap
+}

--- a/enterprise/cmd/executor/internal/ignite/list_test.go
+++ b/enterprise/cmd/executor/internal/ignite/list_test.go
@@ -1,0 +1,37 @@
+package ignite
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var testIgniteOut = `
+xa:100
+yb:101
+xc:102
+yd:103
+xe:104
+yf:105
+[WARN] Test that we ignore annoying log/stderr text
+`
+
+func TestParseIgniteList(t *testing.T) {
+	expectedForX := map[string]string{
+		"xa": "100",
+		"xc": "102",
+		"xe": "104",
+	}
+	if diff := cmp.Diff(expectedForX, parseIgniteList("x", testIgniteOut)); diff != "" {
+		t.Fatalf("unexpected active VMs (-want +got):\n%s", diff)
+	}
+
+	expectedForY := map[string]string{
+		"yb": "101",
+		"yd": "103",
+		"yf": "105",
+	}
+	if diff := cmp.Diff(expectedForY, parseIgniteList("y", testIgniteOut)); diff != "" {
+		t.Fatalf("unexpected active VMs (-want +got):\n%s", diff)
+	}
+}

--- a/enterprise/cmd/executor/internal/janitor/orphaned_vms_test.go
+++ b/enterprise/cmd/executor/internal/janitor/orphaned_vms_test.go
@@ -6,36 +6,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-var testIgniteOut = `
-xa:100
-yb:101
-xc:102
-yd:103
-xe:104
-yf:105
-[WARN] Test that we ignore annoying log/stderr text
-`
-
-func TestParseIgniteList(t *testing.T) {
-	expectedForX := map[string]string{
-		"xa": "100",
-		"xc": "102",
-		"xe": "104",
-	}
-	if diff := cmp.Diff(expectedForX, parseIgniteList("x", testIgniteOut)); diff != "" {
-		t.Fatalf("unexpected active VMs (-want +got):\n%s", diff)
-	}
-
-	expectedForY := map[string]string{
-		"yb": "101",
-		"yd": "103",
-		"yf": "105",
-	}
-	if diff := cmp.Diff(expectedForY, parseIgniteList("y", testIgniteOut)); diff != "" {
-		t.Fatalf("unexpected active VMs (-want +got):\n%s", diff)
-	}
-}
-
 func TestFindOrphanedVMs(t *testing.T) {
 	orphans := findOrphanedVMs(
 		map[string]string{

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/ignite"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/janitor"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -31,6 +32,31 @@ type handler struct {
 }
 
 var _ workerutil.Handler = &handler{}
+var _ workerutil.WithPreDequeue = &handler{}
+
+// PreDequeue determines if the number of VMs with the current instance's VM Prefix is less than
+// the maximum number of concurrent handlers. If so, then a new job can be dequeued. Otherwise,
+// we have an orphaned VM somewhere on the host that will be cleaned up by the background janitor
+// process - refuse to dequeue a job for now so that we do not over-commit on VMs and cause issues
+// with keeping our heartbeats due to machine load. We'll continue to check this condition on the
+// polling interval
+func (h *handler) PreDequeue(ctx context.Context) (dequeueable bool, extraDequeueArguments interface{}, err error) {
+	if !h.options.FirecrackerOptions.Enabled {
+		return true, nil, nil
+	}
+
+	currentVMs, err := ignite.CurrentlyRunningVMs(context.Background(), h.options.VMPrefix)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if len(currentVMs) < h.options.WorkerOptions.NumHandlers {
+		return true, nil, nil
+	}
+
+	log15.Warn("Orphaned VMs detected - refusing to dequeue a new job", "numCurrentVMs", len(currentVMs), "numHandlers", h.options.WorkerOptions.NumHandlers)
+	return false, nil, nil
+}
 
 // Handle clones the target code into a temporary directory, invokes the target indexer in a
 // fresh docker container, and uploads the results to the external frontend API.
@@ -101,7 +127,8 @@ func (h *handler) Handle(ctx context.Context, record workerutil.Record) (err err
 
 	// Construct a unique name for the VM prefixed by something that differentiates
 	// VMs created by this executor instance and another one that happens to run on
-	// the same host (as is the case in dev).
+	// the same host (as is the case in dev). This prefix is expected to match the
+	// prefix given to ignite.CurrentlyRunningVMs in other parts of this service.
 	name := fmt.Sprintf("%s-%s", h.options.VMPrefix, vmNameSuffix.String())
 
 	// Before we setup a VM (and after we teardown), mark the name as in-use so that

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -54,7 +54,7 @@ func (h *handler) PreDequeue(ctx context.Context) (dequeueable bool, extraDequeu
 		return true, nil, nil
 	}
 
-	log15.Warn("Orphaned VMs detected - refusing to dequeue a new job", "numCurrentVMs", len(currentVMs), "numHandlers", h.options.WorkerOptions.NumHandlers)
+	log15.Warn("Orphaned VMs detected - refusing to dequeue a new job until it's cleaned up", "numCurrentVMs", len(currentVMs), "numHandlers", h.options.WorkerOptions.NumHandlers)
 	return false, nil, nil
 }
 


### PR DESCRIPTION
Prevent unbounded number of VMs from spinning up when ignite is having an issue shutting down or removing existing VMs.

Metrics to come later.