### PR TITLE
insights: experimenting with different repo set for historical insights

### DIFF
--- a/enterprise/internal/insights/discovery/all_repos_iterator_test.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/hexops/autogold"
-	"github.com/hexops/valast"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -57,17 +55,18 @@ func TestAllReposIterator(t *testing.T) {
 		autogold.Want("items0", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}).Equal(t, each)
 	}
 
+	trueP := true
 	// Were the RepoStore.List calls as we expected?
 	autogold.Want("repoStoreListCalls0", []database.ReposListOptions{
 		{
-			Index: valast.Addr(true).(*bool),
+			Index: &trueP,
 			OrderBy: database.RepoListOrderBy{database.RepoListSort{
 				Field: database.RepoListColumn("name"),
 			}},
 			LimitOffset: &database.LimitOffset{Limit: 1000},
 		},
 		{
-			Index:   valast.Addr(true).(*bool),
+			Index:   &trueP,
 			OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
@@ -75,7 +74,7 @@ func TestAllReposIterator(t *testing.T) {
 			},
 		},
 		{
-			Index:   valast.Addr(true).(*bool),
+			Index:   &trueP,
 			OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
@@ -83,7 +82,7 @@ func TestAllReposIterator(t *testing.T) {
 			},
 		},
 		{
-			Index:   valast.Addr(true).(*bool),
+			Index:   &trueP,
 			OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
@@ -118,31 +117,31 @@ func TestAllReposIterator(t *testing.T) {
 		autogold.Want("items2", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}).Equal(t, each)
 		autogold.Want("repoStoreListCalls2", []database.ReposListOptions{
 			{
-				OnlyCloned: true,
+				Index: &trueP,
 				OrderBy: database.RepoListOrderBy{database.RepoListSort{
 					Field: database.RepoListColumn("name"),
 				}},
 				LimitOffset: &database.LimitOffset{Limit: 1000},
 			},
 			{
-				OnlyCloned: true,
-				OrderBy:    database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
+				Index:   &trueP,
+				OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 				LimitOffset: &database.LimitOffset{
 					Limit:  1000,
 					Offset: 3,
 				},
 			},
 			{
-				OnlyCloned: true,
-				OrderBy:    database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
+				Index:   &trueP,
+				OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 				LimitOffset: &database.LimitOffset{
 					Limit:  1000,
 					Offset: 6,
 				},
 			},
 			{
-				OnlyCloned: true,
-				OrderBy:    database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
+				Index:   &trueP,
+				OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 				LimitOffset: &database.LimitOffset{
 					Limit:  1000,
 					Offset: 9,

--- a/enterprise/internal/insights/discovery/all_repos_iterator_test.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hexops/autogold"
+	"github.com/hexops/valast"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -59,31 +60,31 @@ func TestAllReposIterator(t *testing.T) {
 	// Were the RepoStore.List calls as we expected?
 	autogold.Want("repoStoreListCalls0", []database.ReposListOptions{
 		{
-			OnlyCloned: true,
+			Index: valast.Addr(true).(*bool),
 			OrderBy: database.RepoListOrderBy{database.RepoListSort{
 				Field: database.RepoListColumn("name"),
 			}},
 			LimitOffset: &database.LimitOffset{Limit: 1000},
 		},
 		{
-			OnlyCloned: true,
-			OrderBy:    database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
+			Index:   valast.Addr(true).(*bool),
+			OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
 				Offset: 3,
 			},
 		},
 		{
-			OnlyCloned: true,
-			OrderBy:    database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
+			Index:   valast.Addr(true).(*bool),
+			OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
 				Offset: 6,
 			},
 		},
 		{
-			OnlyCloned: true,
-			OrderBy:    database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
+			Index:   valast.Addr(true).(*bool),
+			OrderBy: database.RepoListOrderBy{database.RepoListSort{Field: database.RepoListColumn("name")}},
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
 				Offset: 9,


### PR DESCRIPTION
To troubleshoot some discrepancies between historical and indexed insights we are modifying the repository set to match what Zoekt indexes.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
