### PR TITLE
web: Fix button layout

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/InsightContentCard.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/InsightContentCard.tsx
@@ -105,7 +105,9 @@ export const InsightContentCard: React.FunctionComponent<InsightCardProps> = pro
                             {view.subtitle && <div className={styles.insightCardSubtitle}>{view.subtitle}</div>}
                         </div>
 
-                        {hasMenu && <InsightCardMenu className="mr-n2" insightID={id} onDelete={handleDelete} />}
+                        {hasMenu && (
+                            <InsightCardMenu className="mr-n2 d-inline-flex" insightID={id} onDelete={handleDelete} />
+                        )}
                     </header>
 
                     <InsightViewContent


### PR DESCRIPTION
Bootstrap adds a `line-height` to buttons that is greater than 1. When rendering an SVG it is aligning to the bottom such that a `line-height` greater than 1 will appear to have padding on top.

Setting this to flex "resets" the "line box" that the browser is using.

More info here: https://stackoverflow.com/a/34703809

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1855233/127710956-15ee0b1f-333d-4b41-9bc7-1d604ce3ba9c.png) |  ![image](https://user-images.githubusercontent.com/1855233/127711017-0b3144f0-f69a-42e3-bd56-d865a6517985.png) |

Fixes #21518