### PR TITLE
web: Refactor className to menuButtonClassName

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/InsightContentCard.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/InsightContentCard.tsx
@@ -106,7 +106,11 @@ export const InsightContentCard: React.FunctionComponent<InsightCardProps> = pro
                         </div>
 
                         {hasMenu && (
-                            <InsightCardMenu className="mr-n2 d-inline-flex" insightID={id} onDelete={handleDelete} />
+                            <InsightCardMenu
+                                menuButtonClassName="mr-n2 d-inline-flex"
+                                insightID={id}
+                                onDelete={handleDelete}
+                            />
                         )}
                     </header>
 

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
@@ -9,7 +9,7 @@ import { positionRight } from '../../../../../context-menu/utils'
 import styles from './InsightCardMenu.module.scss'
 
 export interface InsightCardMenuProps {
-    className?: string
+    menuButtonClassName?: string
     onDelete: (insightID: string) => void
     insightID: string
 }
@@ -18,7 +18,7 @@ export interface InsightCardMenuProps {
  * Renders context menu (three dots menu) for particular insight card.
  */
 export const InsightCardMenu: React.FunctionComponent<InsightCardMenuProps> = props => {
-    const { insightID, className, onDelete } = props
+    const { insightID, menuButtonClassName, onDelete } = props
     const history = useHistory()
 
     const handleEditClick = (event: MouseEvent): void => {
@@ -28,7 +28,10 @@ export const InsightCardMenu: React.FunctionComponent<InsightCardMenuProps> = pr
 
     return (
         <Menu>
-            <MenuButton data-testid="InsightContextMenuButton" className={classnames(className, 'btn btn-outline p-1')}>
+            <MenuButton
+                data-testid="InsightContextMenuButton"
+                className={classnames(menuButtonClassName, 'btn btn-outline p-1')}
+            >
                 <DotsVerticalIcon size={16} />
             </MenuButton>
             <MenuPopover portal={true} position={positionRight}>


### PR DESCRIPTION
Refactor prop name to be more descriptive of its actual intent.

`className` -> `menuButtonClasses`