### PR TITLE
insights: use database state for historical dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Code Insights will now always backfill from the time the data series was created. [#23430](https://github.com/sourcegraph/sourcegraph/pull/23430)
 - Code Insights queries will now extract repository name out of the GraphQL response instead of going to the database. [#23388](https://github.com/sourcegraph/sourcegraph/pull/23388)
 - Code Insights backend has moved from the `repo-updater` service to the `worker` service. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 - Code Insights feature flag `DISABLE_CODE_INSIGHTS` environment variable has moved from the `repo-updater` service to the `worker` service. Any users of this flag will need to update their `worker` service configuration to continue using it. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -294,10 +294,6 @@ func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[
 				return nil
 			}
 		}
-
-		// when we create an insight, queue up the work for it's backfill
-		// in this thing, we will join insights to their backfill intervals
-
 		// For every series that we want to potentially gather historical data for, try.
 		for _, seriesID := range sortedSeriesIDs {
 			series := uniqueSeries[seriesID]

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -295,28 +295,33 @@ func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[
 			}
 		}
 
-		log15.Info("insights: starting frames", "starting_frames", frames)
-
-		filtered := h.frameFilter.FilterFrames(ctx, frames, repo.ID)
-		log15.Info("insights: sampling historical data frames", "repo_id", repo.ID, "frames", frames)
-
-		// Find the first commit made to the repository on the default branch.
-		firstHEADCommit, err := h.gitFirstEverCommit(ctx, api.RepoName(repoName))
-		if err != nil {
-			if errors.HasType(err, &gitserver.RevisionNotFoundError{}) || vcs.IsRepoNotExist(err) {
-				return nil // no error - repo may not be cloned yet (or not even pushed to code host yet)
-			}
-			if strings.Contains(err.Error(), `failed (output: "usage: git rev-list [OPTION] <commit-id>...`) {
-				return nil // repository is empty
-			}
-			// soft error, repo may be in a bad state but others might be OK.
-			softErr = multierror.Append(softErr, errors.Wrap(err, "FirstEverCommit "+repoName))
-			return nil
-		}
+		// when we create an insight, queue up the work for it's backfill
+		// in this thing, we will join insights to their backfill intervals
 
 		// For every series that we want to potentially gather historical data for, try.
 		for _, seriesID := range sortedSeriesIDs {
 			series := uniqueSeries[seriesID]
+
+			duration := h.now().Sub(series.OldestHistoricalAt) / time.Duration(h.framesToBackfill())
+			frames := Frames(h.framesToBackfill(), duration, series.CreatedAt)
+
+			log15.Info("insights: starting frames", "series_id", series.SeriesID, "starting_frames", frames)
+			filtered := h.frameFilter.FilterFrames(ctx, frames, repo.ID)
+			log15.Info("insights: sampling historical data frames", "series_id", series.SeriesID, "repo_id", repo.ID, "frames", frames)
+
+			// Find the first commit made to the repository on the default branch.
+			firstHEADCommit, err := h.gitFirstEverCommit(ctx, api.RepoName(repoName))
+			if err != nil {
+				if errors.HasType(err, &gitserver.RevisionNotFoundError{}) || vcs.IsRepoNotExist(err) {
+					return nil // no error - repo may not be cloned yet (or not even pushed to code host yet)
+				}
+				if strings.Contains(err.Error(), `failed (output: "usage: git rev-list [OPTION] <commit-id>...`) {
+					return nil // repository is empty
+				}
+				// soft error, repo may be in a bad state but others might be OK.
+				softErr = multierror.Append(softErr, errors.Wrap(err, "FirstEverCommit "+repoName))
+				return nil
+			}
 
 			for i := len(filtered) - 1; i >= 0; i-- {
 				currentFrame := filtered[i]

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -59,6 +59,8 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 			SeriesID:              "series1",
 			Query:                 "query1",
 			NextRecordingAfter:    clock().Add(-1 * time.Hour),
+			CreatedAt:             clock(),
+			OldestHistoricalAt:    clock().Add(-time.Hour * 24 * 365),
 			RecordingIntervalDays: 1,
 		},
 		{
@@ -66,6 +68,8 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 			SeriesID:              "series2",
 			Query:                 "query2",
 			NextRecordingAfter:    clock().Add(1 * time.Hour),
+			CreatedAt:             clock(),
+			OldestHistoricalAt:    clock().Add(-time.Hour * 24 * 365),
 			RecordingIntervalDays: 1,
 		},
 	}, nil)
@@ -189,14 +193,14 @@ func Test_historicalEnqueuer(t *testing.T) {
 		want := autogold.Want("no_data", &testResults{
 			allReposIteratorCalls: 1, reposGetByName: 2,
 			operations: []string{
-				`enqueueQueryRunnerJob("2020-12-28T12:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-12-21T12:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-12-28T12:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-12-21T12:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-12-28T12:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
-				`recordSeriesPoint(point=SeriesPoint{Time: "2020-12-21 12:00:01 +0000 UTC", Value: 0, Metadata: }, repoName=repo/1)`,
-				`enqueueQueryRunnerJob("2020-12-28T12:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
-				`recordSeriesPoint(point=SeriesPoint{Time: "2020-12-21 12:00:01 +0000 UTC", Value: 0, Metadata: }, repoName=repo/1)`,
+				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-04-02T06:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-04-02T06:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
+				`recordSeriesPoint(point=SeriesPoint{Time: "2020-04-02 06:00:01 +0000 UTC", Value: 0, Metadata: }, repoName=repo/1)`,
+				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
+				`recordSeriesPoint(point=SeriesPoint{Time: "2020-04-02 06:00:01 +0000 UTC", Value: 0, Metadata: }, repoName=repo/1)`,
 			},
 		})
 		want.Equal(t, testHistoricalEnqueuer(t, &testParams{

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -218,7 +218,7 @@ func (s *InsightStore) CreateSeries(ctx context.Context, series types.InsightSer
 	}
 	if series.OldestHistoricalAt.IsZero() {
 		// TODO(insights): this value should probably somewhere more discoverable / obvious than here
-		series.OldestHistoricalAt = s.Now().Add(-time.Hour * 24 * 365)
+		series.OldestHistoricalAt = s.Now().Add(-time.Hour * 24 * 7 * 26)
 	}
 	row := s.QueryRow(ctx, sqlf.Sprintf(createInsightSeriesSql,
 		series.SeriesID,


### PR DESCRIPTION
Closes #22821

Historical recordings will now build dataframes starting from the created date for an insight series. This provides some determinism about which dates and commits will be searched, as well as sets some groundwork for reducing duplicated and unnecessary searches.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
