### PR TITLE
locker: use non-overflowing keys and tx scoping

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/iface.go
@@ -10,15 +10,27 @@ import (
 
 type DBStore interface {
 	DirtyRepositories(ctx context.Context) (map[int]int, error)
-	CalculateVisibleUploads(ctx context.Context, repositoryID int, graph *gitserver.CommitGraph, refDescriptions map[string]gitserver.RefDescription, maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration, dirtyToken int, now time.Time) error
+	CalculateVisibleUploads(
+		ctx context.Context,
+		repositoryID int,
+		graph *gitserver.CommitGraph,
+		refDescriptions map[string]gitserver.RefDescription,
+		maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration,
+		dirtyToken int,
+		now time.Time,
+	) error
 	GetOldestCommitDate(ctx context.Context, repositoryID int) (time.Time, bool, error)
 }
 
 type Locker interface {
-	Lock(ctx context.Context, key int, blocking bool) (bool, locker.UnlockFunc, error)
+	Lock(ctx context.Context, key int32, blocking bool) (bool, locker.UnlockFunc, error)
 }
 
 type GitserverClient interface {
 	RefDescriptions(ctx context.Context, repositoryID int) (map[string]gitserver.RefDescription, error)
-	CommitGraph(ctx context.Context, repositoryID int, options gitserver.CommitGraphOptions) (*gitserver.CommitGraph, error)
+	CommitGraph(
+		ctx context.Context,
+		repositoryID int,
+		options gitserver.CommitGraphOptions,
+	) (*gitserver.CommitGraph, error)
 }

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
@@ -692,7 +692,7 @@ type MockLocker struct {
 func NewMockLocker() *MockLocker {
 	return &MockLocker{
 		LockFunc: &LockerLockFunc{
-			defaultHook: func(context.Context, int, bool) (bool, locker.UnlockFunc, error) {
+			defaultHook: func(context.Context, int32, bool) (bool, locker.UnlockFunc, error) {
 				return false, nil, nil
 			},
 		},
@@ -712,15 +712,15 @@ func NewMockLockerFrom(i Locker) *MockLocker {
 // LockerLockFunc describes the behavior when the Lock method of the parent
 // MockLocker instance is invoked.
 type LockerLockFunc struct {
-	defaultHook func(context.Context, int, bool) (bool, locker.UnlockFunc, error)
-	hooks       []func(context.Context, int, bool) (bool, locker.UnlockFunc, error)
+	defaultHook func(context.Context, int32, bool) (bool, locker.UnlockFunc, error)
+	hooks       []func(context.Context, int32, bool) (bool, locker.UnlockFunc, error)
 	history     []LockerLockFuncCall
 	mutex       sync.Mutex
 }
 
 // Lock delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockLocker) Lock(v0 context.Context, v1 int, v2 bool) (bool, locker.UnlockFunc, error) {
+func (m *MockLocker) Lock(v0 context.Context, v1 int32, v2 bool) (bool, locker.UnlockFunc, error) {
 	r0, r1, r2 := m.LockFunc.nextHook()(v0, v1, v2)
 	m.LockFunc.appendCall(LockerLockFuncCall{v0, v1, v2, r0, r1, r2})
 	return r0, r1, r2
@@ -728,7 +728,7 @@ func (m *MockLocker) Lock(v0 context.Context, v1 int, v2 bool) (bool, locker.Unl
 
 // SetDefaultHook sets function that is called when the Lock method of the
 // parent MockLocker instance is invoked and the hook queue is empty.
-func (f *LockerLockFunc) SetDefaultHook(hook func(context.Context, int, bool) (bool, locker.UnlockFunc, error)) {
+func (f *LockerLockFunc) SetDefaultHook(hook func(context.Context, int32, bool) (bool, locker.UnlockFunc, error)) {
 	f.defaultHook = hook
 }
 
@@ -736,7 +736,7 @@ func (f *LockerLockFunc) SetDefaultHook(hook func(context.Context, int, bool) (b
 // Lock method of the parent MockLocker instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *LockerLockFunc) PushHook(hook func(context.Context, int, bool) (bool, locker.UnlockFunc, error)) {
+func (f *LockerLockFunc) PushHook(hook func(context.Context, int32, bool) (bool, locker.UnlockFunc, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -745,7 +745,7 @@ func (f *LockerLockFunc) PushHook(hook func(context.Context, int, bool) (bool, l
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *LockerLockFunc) SetDefaultReturn(r0 bool, r1 locker.UnlockFunc, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, bool) (bool, locker.UnlockFunc, error) {
+	f.SetDefaultHook(func(context.Context, int32, bool) (bool, locker.UnlockFunc, error) {
 		return r0, r1, r2
 	})
 }
@@ -753,12 +753,12 @@ func (f *LockerLockFunc) SetDefaultReturn(r0 bool, r1 locker.UnlockFunc, r2 erro
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *LockerLockFunc) PushReturn(r0 bool, r1 locker.UnlockFunc, r2 error) {
-	f.PushHook(func(context.Context, int, bool) (bool, locker.UnlockFunc, error) {
+	f.PushHook(func(context.Context, int32, bool) (bool, locker.UnlockFunc, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LockerLockFunc) nextHook() func(context.Context, int, bool) (bool, locker.UnlockFunc, error) {
+func (f *LockerLockFunc) nextHook() func(context.Context, int32, bool) (bool, locker.UnlockFunc, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -796,7 +796,7 @@ type LockerLockFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 int32
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 bool

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/updater.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/updater.go
@@ -28,8 +28,10 @@ type Updater struct {
 	operations                *operations
 }
 
-var _ goroutine.Handler = &Updater{}
-var _ goroutine.ErrorHandler = &Updater{}
+var (
+	_ goroutine.Handler      = &Updater{}
+	_ goroutine.ErrorHandler = &Updater{}
+)
 
 // NewUpdater returns a background routine that periodically updates the commit graph
 // and visible uploads for each repository marked as dirty.
@@ -81,7 +83,7 @@ func (u *Updater) HandleError(err error) {
 // update procedure for this repository. If the lock is already held, this method will simply
 // do nothing.
 func (u *Updater) tryUpdate(ctx context.Context, repositoryID, dirtyToken int) (err error) {
-	ok, unlock, err := u.locker.Lock(ctx, repositoryID, false)
+	ok, unlock, err := u.locker.Lock(ctx, int32(repositoryID), false)
 	if err != nil || !ok {
 		return errors.Wrap(err, "locker.Lock")
 	}

--- a/internal/database/locker/locker.go
+++ b/internal/database/locker/locker.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 
 	"github.com/cockroachdb/errors"
-	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 	"github.com/segmentio/fasthash/fnv1"
 
@@ -23,7 +22,7 @@ type Locker struct {
 	namespace int32
 }
 
-// NewWithDB creates a new Locker with the given namespace.
+// NewWithDB creates a new Locker with the given namespace and dbutil.DB.
 func NewWithDB(db dbutil.DB, namespace string) *Locker {
 	return &Locker{
 		Store:     basestore.NewWithDB(db, sql.TxOptions{}),
@@ -52,15 +51,15 @@ func (l *Locker) Transact(ctx context.Context) (*Locker, error) {
 
 // UnlockFunc unlocks the advisory lock taken by a successful call to Lock. If an error
 // occurs during unlock, the error is added to the resulting error value.
-type UnlockFunc func(err error) error
+type UnlockFunc func(error) error
 
 // ErrTransaction occurs when Lock is called inside of a transaction.
 var ErrTransaction = errors.New("locker: in a transaction")
 
 // Lock creates a transactional store and calls its Lock method. This method expects that
 // the locker is outside of a transaction. The transaction's lifetime is linked to the lock,
-// so the internal locker will commit or rollback once the lock is released.
-func (l *Locker) Lock(ctx context.Context, key int, blocking bool) (locked bool, _ UnlockFunc, err error) {
+// so the internal locker will commit or rollback for the lock to be released.
+func (l *Locker) Lock(ctx context.Context, key int32, blocking bool) (locked bool, _ UnlockFunc, err error) {
 	if l.InTransaction() {
 		return false, nil, ErrTransaction
 	}
@@ -76,23 +75,27 @@ func (l *Locker) Lock(ctx context.Context, key int, blocking bool) (locked bool,
 		}
 	}()
 
-	locked, unlock, err := tx.LockInTransaction(ctx, key, blocking)
+	locked, err = tx.LockInTransaction(ctx, key, blocking)
 	if err != nil || !locked {
 		return false, nil, err
 	}
 
-	return true, func(err error) error { return tx.Done(unlock(err)) }, nil
+	return true, func(err error) error { return tx.Done(err) }, nil
 }
 
 // ErrNoTransaction occurs when LockInTransaction is called outside of a transaction.
 var ErrNoTransaction = errors.New("locker: not in a transaction")
 
 // LockInTransaction attempts to take an advisory lock on the given key. If successful, this method
-// will return a true-valued flag along with a function that must be called to release the lock. This
-// method assumes that the locker is currently in a transaction.
-func (l *Locker) LockInTransaction(ctx context.Context, key int, blocking bool) (locked bool, _ UnlockFunc, err error) {
+// will return a true-valued flag. This method assumes that the locker is currently in a transaction
+// and will return an error if not. The lock is released when the transaction is committed or rolled back.
+func (l *Locker) LockInTransaction(
+	ctx context.Context,
+	key int32,
+	blocking bool,
+) (locked bool, err error) {
 	if !l.InTransaction() {
-		return false, nil, ErrNoTransaction
+		return false, ErrNoTransaction
 	}
 
 	if blocking {
@@ -102,22 +105,14 @@ func (l *Locker) LockInTransaction(ctx context.Context, key int, blocking bool) 
 	}
 
 	if err != nil || !locked {
-		return false, nil, err
+		return false, err
 	}
 
-	unlock := func(err error) error {
-		if unlockErr := l.unlock(context.Background(), key); unlockErr != nil {
-			err = multierror.Append(err, unlockErr)
-		}
-
-		return err
-	}
-
-	return true, unlock, nil
+	return true, nil
 }
 
 // selectAdvisoryLock blocks until an advisory lock is taken on the given key.
-func (l *Locker) selectAdvisoryLock(ctx context.Context, key int) (bool, error) {
+func (l *Locker) selectAdvisoryLock(ctx context.Context, key int32) (bool, error) {
 	err := l.Store.Exec(ctx, sqlf.Sprintf(selectAdvisoryLockQuery, l.namespace, key))
 	if err != nil {
 		return false, err
@@ -127,13 +122,15 @@ func (l *Locker) selectAdvisoryLock(ctx context.Context, key int) (bool, error) 
 
 const selectAdvisoryLockQuery = `
 -- source: internal/database/locker/locker.go:selectAdvisoryLock
-SELECT pg_advisory_lock(%s, %s)
+SELECT pg_advisory_xact_lock(%s, %s)
 `
 
 // selectTryAdvisoryLock attempts to take an advisory lock on the given key. Returns true
 // on success and false on failure.
-func (l *Locker) selectTryAdvisoryLock(ctx context.Context, key int) (bool, error) {
-	ok, _, err := basestore.ScanFirstBool(l.Store.Query(ctx, sqlf.Sprintf(selectTryAdvisoryLockQuery, l.namespace, key)))
+func (l *Locker) selectTryAdvisoryLock(ctx context.Context, key int32) (bool, error) {
+	ok, _, err := basestore.ScanFirstBool(
+		l.Store.Query(ctx, sqlf.Sprintf(selectTryAdvisoryLockQuery, l.namespace, key)),
+	)
 	if err != nil || !ok {
 		return false, err
 	}
@@ -143,26 +140,5 @@ func (l *Locker) selectTryAdvisoryLock(ctx context.Context, key int) (bool, erro
 
 const selectTryAdvisoryLockQuery = `
 -- source: internal/database/locker/locker.go:selectTryAdvisoryLock
-SELECT pg_try_advisory_lock(%s, %s)
-`
-
-var ErrUnlock = errors.New("failed to unlock")
-
-// unlock releases the advisory lock on the given key.
-func (l *Locker) unlock(ctx context.Context, key int) error {
-	ok, _, err := basestore.ScanFirstBool(l.Store.Query(ctx, sqlf.Sprintf(unlockQuery, l.namespace, key)))
-	if !ok {
-		if err == nil {
-			err = ErrUnlock
-		}
-
-		return err
-	}
-
-	return nil
-}
-
-const unlockQuery = `
--- source: internal/database/locker/locker.go:unlock
-SELECT pg_advisory_unlock(%s, %s)
+SELECT pg_try_advisory_xact_lock(%s, %s)
 `

--- a/internal/database/locker/locker.go
+++ b/internal/database/locker/locker.go
@@ -80,7 +80,7 @@ func (l *Locker) Lock(ctx context.Context, key int32, blocking bool) (locked boo
 		return false, nil, err
 	}
 
-	return true, func(err error) error { return tx.Done(err) }, nil
+	return true, tx.Done, nil
 }
 
 // ErrNoTransaction occurs when LockInTransaction is called outside of a transaction.

--- a/internal/database/locker/locker_test.go
+++ b/internal/database/locker/locker_test.go
@@ -16,7 +16,7 @@ func TestLock(t *testing.T) {
 	db := dbtest.NewDB(t, "")
 	locker := NewWithDB(db, "test")
 
-	key := rand.Intn(1000)
+	key := rand.Int31n(1000)
 
 	// Start txn before acquiring locks outside of txn
 	tx, err := locker.Transact(context.Background())
@@ -32,7 +32,7 @@ func TestLock(t *testing.T) {
 		t.Errorf("expected lock to be acquired")
 	}
 
-	acquired, _, err = tx.LockInTransaction(context.Background(), key, false)
+	acquired, err = tx.LockInTransaction(context.Background(), key, false)
 	if err != nil {
 		t.Fatalf("unexpected error attempting to acquire lock: %s", err)
 	}
@@ -42,7 +42,7 @@ func TestLock(t *testing.T) {
 
 	unlock(nil)
 
-	acquired, _, err = tx.LockInTransaction(context.Background(), key, false)
+	acquired, err = tx.LockInTransaction(context.Background(), key, false)
 	if err != nil {
 		t.Fatalf("unexpected error attempting to acquire lock: %s", err)
 	}
@@ -58,7 +58,7 @@ func TestLockBlockingAcquire(t *testing.T) {
 	db := dbtest.NewDB(t, "")
 	locker := NewWithDB(db, "test")
 
-	key := rand.Intn(1000)
+	key := rand.Int31n(1000)
 
 	// Start txn before acquiring locks outside of txn
 	tx, err := locker.Transact(context.Background())
@@ -79,12 +79,12 @@ func TestLockBlockingAcquire(t *testing.T) {
 	go func() {
 		defer close(sync)
 
-		acquired, unlock, err := tx.LockInTransaction(context.Background(), key, true)
+		acquired, err := tx.LockInTransaction(context.Background(), key, true)
 		if err != nil {
 			t.Errorf("unexpected error attempting to acquire lock: %s", err)
 			return
 		}
-		defer unlock(nil)
+		defer tx.Done(nil)
 
 		if !acquired {
 			t.Errorf("expected lock to be acquired")
@@ -114,7 +114,7 @@ func TestLockBadTransactionState(t *testing.T) {
 	db := dbtest.NewDB(t, "")
 	locker := NewWithDB(db, "test")
 
-	key := rand.Intn(1000)
+	key := rand.Int31n(1000)
 
 	// Start txn before acquiring locks outside of txn
 	tx, err := locker.Transact(context.Background())
@@ -122,7 +122,7 @@ func TestLockBadTransactionState(t *testing.T) {
 		t.Fatalf("unexpected error starting transaction: %s", err)
 	}
 
-	if _, _, err := locker.LockInTransaction(context.Background(), key, true); err == nil {
+	if _, err := locker.LockInTransaction(context.Background(), key, true); err == nil {
 		t.Fatalf("expected an error calling LockInTransaction outside of transaction")
 	}
 


### PR DESCRIPTION
This commit introduces two changes:

1. Non overflowing keys from int(64) to int32 which is what an int in
   Postgres maps to (bigint maps to int64).
2. Use transaction scoped advisory locks (i.e. `pg_advisory_xact_lock`).
   This results in `LockInTransaction` no longer returning an
   UnlockFunc, since the lock is released when the tx is rolled back or
   committed.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
