### PR TITLE
codeintel: dont escape < > in lsif-visualize

### DIFF
--- a/lib/codeintel/tools/lsif-visualize/internal/visualization/visualizer.go
+++ b/lib/codeintel/tools/lsif-visualize/internal/visualization/visualizer.go
@@ -32,6 +32,7 @@ func (v *Visualizer) Visualize(indexFile io.Reader, fromID, subgraphDepth int, e
 
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
 	_ = v.Context.Stasher.Vertices(func(lineContext reader.LineContext) bool {
 		if _, ok := vertices[lineContext.Element.ID]; !ok {
 			return true


### PR DESCRIPTION
lsif-java monikers can contain < > for constructors. This PR changes the json encoding in lsif-visualize to not escape those characters.

![image](https://user-images.githubusercontent.com/18282288/127773377-7ca4e020-d19e-478d-9401-b1e4444f67ab.png)
