### PR TITLE
all: log traceid in all HTTP handlers

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -89,8 +89,8 @@ func newExternalHTTPHandler(db dbutil.DB, schema *graphql.Schema, gitHubWebhook 
 	// change is explicitly made, to enable this token.
 	h = internalauth.OverrideAuthMiddleware(db, h)
 	h = internalauth.ForbidAllRequestsMiddleware(h)
-	h = tracepkg.HTTPTraceMiddleware(h)
 	h = ot.Middleware(h)
+	h = tracepkg.HTTPTraceMiddleware(h)
 	h = middleware.SourcegraphComGoGetHandler(h)
 	h = middleware.BlackHole(h)
 	h = secureHeadersMiddleware(h)

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -19,11 +19,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
 
@@ -124,6 +124,8 @@ func main() {
 		log15.Warn("proxy error", "status", resp.StatusCode, "body", string(b), "bodyErr", err)
 		_, _ = io.Copy(w, bytes.NewReader(b))
 	})
+	h = ot.Middleware(h)
+	h = trace.HTTPTraceMiddleware(h)
 	if logRequests {
 		h = handlers.LoggingHandler(os.Stdout, h)
 	}

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -172,7 +172,8 @@ func main() {
 	}
 
 	// Create Handler now since it also initializes state
-	handler := ot.Middleware(gitserver.Handler())
+
+	handler := trace.HTTPTraceMiddleware(ot.Middleware(gitserver.Handler()))
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -400,7 +400,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,
 		WriteTimeout: 10 * time.Minute,
-		Handler:      ot.Middleware(authzBypass(handler)),
+		Handler:      trace.HTTPTraceMiddleware(ot.Middleware(authzBypass(handler))),
 	})
 	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
 }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -65,7 +65,8 @@ func main() {
 		Log: log15.Root(),
 	}
 	service.Store.Start()
-	handler := ot.Middleware(service)
+
+	handler := trace.HTTPTraceMiddleware(ot.Middleware(service))
 
 	host := ""
 	if env.InsecureDev {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -71,7 +71,8 @@ func main() {
 	if err := service.Start(); err != nil {
 		log.Fatalln("Start:", err)
 	}
-	handler := ot.Middleware(service.Handler())
+
+	handler := trace.HTTPTraceMiddleware(ot.Middleware(service.Handler()))
 
 	host := ""
 	if env.InsecureDev {

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -194,11 +194,19 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 			return !gqlErr
 		})
 
-		log15.Debug("TRACE HTTP",
+		traceURL := SpanURL(span)
+		traceID := ""
+
+		if n := strings.LastIndex(traceURL, "/"); n != -1 {
+			traceID = traceURL[n+1:]
+		}
+
+		log15.Info("HTTP",
 			"method", r.Method,
 			"url", r.URL.String(),
 			"route_name", routeName,
-			"trace", SpanURL(span),
+			"trace", traceURL,
+			"traceid", traceID,
 			"user_agent", r.UserAgent(),
 			"user", userID,
 			"x_forwarded_for", r.Header.Get("X-Forwarded-For"),
@@ -225,6 +233,7 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 				"written":         strconv.FormatInt(m.Written, 10),
 				"duration":        m.Duration.String(),
 				"graphql_error":   strconv.FormatBool(gqlErr),
+				"trace":           traceURL,
 			})
 		}
 	}))


### PR DESCRIPTION
I am experimenting with using Grafana Cloud for traces and logs. Grafana Tempo, unlike Jaeger, can store a much higher amount of traces because it doesn't index them and uses object storage, which means we can see traces for requests that happened weeks in the past, with much less sampling.

However, we need to know a trace id to see a trace. Trace discovery through logs is the standard approach. Trace discovery through metric examplars can be set-up in the future (i.e. you click on a a few "examples" in a panel's graph). 

This changeset leverages our existing `trace.HTTPTraceMiddleware` in every service to log a traceid, not just frontend, and changes the default logging level to info rather than debug. The only concern I have is that the dev env can become quite noisy due to all the background polling that services do. Should we keep the debug log level, and set that level in production only? Seems off somehow.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

![image](https://user-images.githubusercontent.com/67471/127846788-81f6c3d6-706c-4aa9-8a42-7f7ac6183b43.png)
![image](https://user-images.githubusercontent.com/67471/127846847-db6c9be6-f65d-4ff3-bd74-91e205da4ff0.png)

