### PR TITLE
core: Add env var to quickly disable access granted logging

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	regexpsyntax "regexp/syntax"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -138,9 +139,10 @@ var counterAccessGranted = promauto.NewCounter(prometheus.CounterOpts{
 })
 
 func logPrivateRepoAccessGranted(ctx context.Context, db dbutil.DB, ids []api.RepoID) {
-	if os.Getenv("SRC_DISABLE_LOG_PRIVATE_REPO_ACCESS") != "" {
+	if disabled, _ := strconv.ParseBool(os.Getenv("SRC_DISABLE_LOG_PRIVATE_REPO_ACCESS")); disabled {
 		return
 	}
+
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
 		Resource string       `json:"resource"`

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	regexpsyntax "regexp/syntax"
 	"strings"
 	"sync"
@@ -137,6 +138,9 @@ var counterAccessGranted = promauto.NewCounter(prometheus.CounterOpts{
 })
 
 func logPrivateRepoAccessGranted(ctx context.Context, db dbutil.DB, ids []api.RepoID) {
+	if os.Getenv("SRC_DISABLE_LOG_PRIVATE_REPO_ACCESS") != "" {
+		return
+	}
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
 		Resource string       `json:"resource"`


### PR DESCRIPTION
In case the feature had a detrimental effect on our database.
