### PR TITLE
eventLogger: add new events

### DIFF
--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -128,7 +128,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
         (serviceType: string): React.MouseEventHandler<HTMLAnchorElement> => () => {
             // TODO: Log events with keepalive=true to ensure they always outlive the webpage
             // https://github.com/sourcegraph/sourcegraph/issues/19174
-            eventLogger.log('externalAuthSignupClicked', { type: serviceType })
+            eventLogger.log('ExternalAuthSignupClicked', { type: serviceType })
         },
         []
     )

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -128,7 +128,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
         (serviceType: string): React.MouseEventHandler<HTMLAnchorElement> => () => {
             // TODO: Log events with keepalive=true to ensure they always outlive the webpage
             // https://github.com/sourcegraph/sourcegraph/issues/19174
-            eventLogger.log('ExternalAuthSignupClicked', { type: serviceType })
+            eventLogger.log('ExternalAuthSignupClicked', { type: serviceType }, { type: serviceType })
         },
         []
     )

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -46,8 +46,9 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<CreateCodeMoni
     )
 
     const createMonitorRequest = useCallback(
-        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> =>
-            createCodeMonitor({
+        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
+            eventLogger.log('CreateCodeMonitorFormSubmitted')
+            return createCodeMonitor({
                 monitor: {
                     namespace: authenticatedUser.id,
                     description: codeMonitor.description,
@@ -63,7 +64,8 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<CreateCodeMoni
                         header: '',
                     },
                 })),
-            }),
+            })
+        },
         [authenticatedUser.id, createCodeMonitor]
     )
 

--- a/client/web/src/search/input/LoggedOutHomepage.tsx
+++ b/client/web/src/search/input/LoggedOutHomepage.tsx
@@ -44,7 +44,11 @@ export const LoggedOutHomepage: React.FunctionComponent<LoggedOutHomepageProps> 
     )
 
     const onClickInstallSubtext = useCallback(() => {
-        props.telemetryService.log('HomepageInstallSourcegraphCTAClicked', { name: 'InstallSourcegraphSubtext' })
+        props.telemetryService.log(
+            'HomepageInstallSourcegraphCTAClicked',
+            { name: 'InstallSourcegraphSubtext' },
+            { name: 'InstallSourcegraphSubtext' }
+        )
     }, [props.telemetryService])
 
     return (

--- a/client/web/src/search/input/LoggedOutHomepage.tsx
+++ b/client/web/src/search/input/LoggedOutHomepage.tsx
@@ -43,6 +43,10 @@ export const LoggedOutHomepage: React.FunctionComponent<LoggedOutHomepageProps> 
         [props.telemetryService]
     )
 
+    const onClickInstallSubtext = useCallback(() => {
+        props.telemetryService.log('HomepageInstallSourcegraphCTAClicked', { name: 'InstallSourcegraphSubtext' })
+    }, [props.telemetryService])
+
     return (
         <div className={styles.loggedOutHomepage}>
             <div className={styles.helpContent}>
@@ -90,7 +94,12 @@ export const LoggedOutHomepage: React.FunctionComponent<LoggedOutHomepageProps> 
                     <SignUpCta className={styles.loggedOutHomepageCta} telemetryService={props.telemetryService} />
                     <div className="mt-2 text-center">
                         Search private code by{' '}
-                        <a href="https://docs.sourcegraph.com/admin/install" target="_blank" rel="noopener noreferrer">
+                        <a
+                            href="https://docs.sourcegraph.com/admin/install"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={onClickInstallSubtext}
+                        >
                             installing Sourcegraph locally.
                         </a>
                     </div>

--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -10,7 +10,6 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 
 import { CaseSensitivityProps, PatternTypeProps, SearchContextInputProps } from '..'
 import { AuthenticatedUser } from '../../auth'
-import { eventLogger } from '../../tracking/eventLogger'
 import styles from '../FeatureTour.module.scss'
 import { SubmitSearchParameters } from '../helpers'
 import { getTourOptions, HAS_SEEN_SEARCH_CONTEXTS_FEATURE_TOUR_KEY, useFeatureTour } from '../useFeatureTour'

--- a/client/web/src/search/input/SearchContextMenu.tsx
+++ b/client/web/src/search/input/SearchContextMenu.tsx
@@ -21,6 +21,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { SearchContextInputProps } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { SearchContextFields } from '../../graphql-operations'
+import { eventLogger } from '../../tracking/eventLogger'
 
 import { HighlightedSearchContextSpec } from './HighlightedSearchContextSpec'
 
@@ -33,6 +34,7 @@ export const SearchContextMenuItem: React.FunctionComponent<{
     searchFilter: string
 }> = ({ spec, description, selected, isDefault, selectSearchContextSpec, searchFilter }) => {
     const setContext = useCallback(() => {
+        eventLogger.log('SearchContextSelected')
         selectSearchContextSpec(spec)
     }, [selectSearchContextSpec, spec])
     return (

--- a/client/web/src/search/input/SearchHelpDropdownButton.tsx
+++ b/client/web/src/search/input/SearchHelpDropdownButton.tsx
@@ -6,6 +6,8 @@ import { DropdownItem, DropdownMenu, DropdownToggle, ButtonDropdown } from 'reac
 
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
+import { eventLogger } from '../../tracking/eventLogger'
+
 /**
  * A dropdown button that shows a menu with reference documentation for Sourcegraph search query
  * syntax.
@@ -13,6 +15,10 @@ import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggl
 export const SearchHelpDropdownButton: React.FunctionComponent = () => {
     const [isOpen, setIsOpen] = useState(false)
     const toggleIsOpen = useCallback(() => setIsOpen(!isOpen), [isOpen])
+    const onQueryDocumentationLinkClicked = useCallback(() => {
+        eventLogger.log('SearchHelpDropdownQueryDocsLinkClicked')
+        toggleIsOpen()
+    }, [toggleIsOpen])
     const [isRedesignEnabled] = useRedesignToggle()
     const documentationUrlPrefix = window.context?.sourcegraphDotComMode ? 'https://docs.sourcegraph.com' : '/help'
 
@@ -110,7 +116,7 @@ export const SearchHelpDropdownButton: React.FunctionComponent = () => {
                     rel="noopener"
                     href={`${documentationUrlPrefix}/code_search/reference/queries`}
                     className="dropdown-item"
-                    onClick={toggleIsOpen}
+                    onClick={onQueryDocumentationLinkClicked}
                 >
                     <ExternalLinkIcon className="icon-inline small" /> All search keywords
                 </a>

--- a/client/web/src/search/input/SearchPageFooter.tsx
+++ b/client/web/src/search/input/SearchPageFooter.tsx
@@ -11,7 +11,7 @@ export const SearchPageFooter: React.FunctionComponent<{ className?: string }> =
             // TODO(farhan): these events are named with the name of the CTA because
             // we currently can't collect arguments in BQ. Remove the name of CTA
             // once we can collect arguments.
-            eventLogger.log(`HomepageFooterCTASelected:${name}`, { name })
+            eventLogger.log('HomepageFooterCTASelected', { name }, { name })
         },
         []
     )

--- a/client/web/src/search/input/SearchPageFooter.tsx
+++ b/client/web/src/search/input/SearchPageFooter.tsx
@@ -1,46 +1,68 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 
-export const SearchPageFooter: React.FunctionComponent<{ className?: string }> = ({ className }) => (
-    <footer className={classNames(className, 'd-flex flex-column flex-lg-row align-items-center')}>
-        <h4 className="mb-2 mb-lg-0">Explore and extend</h4>
-        <span className="d-flex flex-column flex-md-row align-items-center">
-            <span className="d-flex flex-row mb-2 mb-md-0">
-                <Link
-                    className="px-3"
-                    to="https://docs.sourcegraph.com/integration/browser_extension"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                >
-                    Browser extensions
-                </Link>
-                <span aria-hidden="true" className="border-right d-none d-md-inline" />
-                <Link className="px-3" to="/extensions" target="_blank">
-                    Sourcegraph extensions
-                </Link>
-                <span aria-hidden="true" className="border-right d-none d-md-inline" />
+import { eventLogger } from '../../tracking/eventLogger'
+
+export const SearchPageFooter: React.FunctionComponent<{ className?: string }> = ({ className }) => {
+    const logLinkClicked = useCallback(
+        (name: string) => () => {
+            // TODO(farhan): these events are named with the name of the CTA because
+            // we currently can't collect arguments in BQ. Remove the name of CTA
+            // once we can collect arguments.
+            eventLogger.log(`HomepageFooterCTASelected:${name}`, { name })
+        },
+        []
+    )
+
+    return (
+        <footer className={classNames(className, 'd-flex flex-column flex-lg-row align-items-center')}>
+            <h4 className="mb-2 mb-lg-0">Explore and extend</h4>
+            <span className="d-flex flex-column flex-md-row align-items-center">
+                <span className="d-flex flex-row mb-2 mb-md-0">
+                    <Link
+                        className="px-3"
+                        to="https://docs.sourcegraph.com/integration/browser_extension"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        onClick={logLinkClicked('BrowserExtensions')}
+                    >
+                        Browser extensions
+                    </Link>
+                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                    <Link
+                        className="px-3"
+                        to="/extensions"
+                        target="_blank"
+                        onClick={logLinkClicked('SourcegraphExtensions')}
+                    >
+                        Sourcegraph extensions
+                    </Link>
+                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                </span>
+                <span className="d-flex flex-row">
+                    <Link
+                        className="px-3"
+                        to="https://docs.sourcegraph.com/integration/editor"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        onClick={logLinkClicked('EditorPlugins')}
+                    >
+                        Editor plugins
+                    </Link>
+                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                    <Link
+                        className="pl-3"
+                        to="https://docs.sourcegraph.com/admin/external_service"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        onClick={logLinkClicked('CodeHostIntegrations')}
+                    >
+                        Code host integrations
+                    </Link>
+                </span>
             </span>
-            <span className="d-flex flex-row">
-                <Link
-                    className="px-3"
-                    to="https://docs.sourcegraph.com/integration/editor"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                >
-                    Editor plugins
-                </Link>
-                <span aria-hidden="true" className="border-right d-none d-md-inline" />
-                <Link
-                    className="pl-3"
-                    to="https://docs.sourcegraph.com/admin/external_service"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                >
-                    Code host integrations
-                </Link>
-            </span>
-        </span>
-    </footer>
-)
+        </footer>
+    )
+}

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -222,7 +222,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
             const authProvider = authProvidersByKind[kind]
 
             if (authProvider) {
-                eventLogger.log('ConnectUserCodeHostClicked', { kind })
+                eventLogger.log('ConnectUserCodeHostClicked', { kind }, { kind })
                 window.location.assign(
                     `${authProvider.authenticationURL as string}&redirect=${
                         window.location.href

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -222,7 +222,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
             const authProvider = authProvidersByKind[kind]
 
             if (authProvider) {
-                eventLogger.log('UserAttemptConnectCodeHost', { kind })
+                eventLogger.log('ConnectUserCodeHostClicked', { kind })
                 window.location.assign(
                     `${authProvider.authenticationURL as string}&redirect=${
                         window.location.href


### PR DESCRIPTION
Part of https://github.com/sourcegraph/analytics/issues/246.

Adds the following events to event logger:
- [x] `installing Sourcegraph locally` link under the "improve your workflow" CTA on /search
- [x] `Explore and extend` section links at the bottom of /search
- [x] `All search keywords` button within the `?` button on the right of the search bar
- [x] Clicking/changing search contexts (if this is possible)
- [x] Code monitor created button

For these events, the event already existed. I just updated the event names to match our new conventions:
- [ ] The two `Connect` buttons on the /settings/code-hosts page -- updated from ` UserAttemptConnectCodeHost` to `ConnectUserCodeHostClicked`
- [ ] `Continue with GitHub` and `Continue with GitLab` buttons on the sign-up page -- updated from `externalAuthSignupClicked` to `ExternalAuthSignupClicked`


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

