### PR TITLE
search: Fix duplicate React key error in search reference

### DIFF
--- a/client/web/src/search/helpers/queryExample.test.ts
+++ b/client/web/src/search/helpers/queryExample.test.ts
@@ -25,12 +25,6 @@ describe('example helpers', () => {
                 Object {
                   "tokens": Array [
                     Object {
-                      "end": 0,
-                      "start": 0,
-                      "type": "text",
-                      "value": "",
-                    },
-                    Object {
                       "end": 3,
                       "start": 0,
                       "type": "placeholder",

--- a/client/web/src/search/helpers/queryExample.ts
+++ b/client/web/src/search/helpers/queryExample.ts
@@ -143,7 +143,8 @@ function parse(value: string): { tokens: QueryExample['tokens']; value: string }
             case 'text': {
                 const start = index
                 index = consumeTillCharacter(value, '{', index)
-                if (value.length > 0) {
+                if (index > start) {
+                    // exclude empty strings
                     tokens.push({
                         type: 'text',
                         value: value.slice(start, index),


### PR DESCRIPTION
I must have forgotten to update the condition in one of the refactors. Currently this creates a lot of `Warning: Encountered two children with the same key, 0.` errors because every example that is like `{test}` will contain an empty token that starts at the same position as the placeholder token.
