### PR TITLE
insights: disabling queue cleaner job for debugging visibility

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -53,7 +53,8 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 		// results to TimescaleDB.
 		queryrunner.NewWorker(ctx, workerBaseStore, insightsStore, queryRunnerWorkerMetrics),
 		queryrunner.NewResetter(ctx, workerBaseStore, queryRunnerResetterMetrics),
-		queryrunner.NewCleaner(ctx, workerBaseStore, observationContext),
+		// disabling the cleaner job while we debug mismatched results from historical insights
+		// queryrunner.NewCleaner(ctx, workerBaseStore, observationContext),
 
 		// TODO(slimsag): future: register another worker here for webhook querying.
 	}


### PR DESCRIPTION
To debug some count mismatches we need to inspect the entire log of queries performed to backfill the insight.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
