### PR TITLE
all: fix http middleware order

### DIFF
--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -124,12 +124,12 @@ func main() {
 		log15.Warn("proxy error", "status", resp.StatusCode, "body", string(b), "bodyErr", err)
 		_, _ = io.Copy(w, bytes.NewReader(b))
 	})
-	h = ot.Middleware(h)
-	h = trace.HTTPTraceMiddleware(h)
 	if logRequests {
 		h = handlers.LoggingHandler(os.Stdout, h)
 	}
 	h = instrumentHandler(prometheus.DefaultRegisterer, h)
+	h = trace.HTTPTraceMiddleware(h)
+	h = ot.Middleware(h)
 	http.Handle("/", h)
 
 	host := ""

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -173,7 +173,7 @@ func main() {
 
 	// Create Handler now since it also initializes state
 
-	handler := trace.HTTPTraceMiddleware(ot.Middleware(gitserver.Handler()))
+	handler := ot.Middleware(trace.HTTPTraceMiddleware(gitserver.Handler()))
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -400,7 +400,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,
 		WriteTimeout: 10 * time.Minute,
-		Handler:      trace.HTTPTraceMiddleware(ot.Middleware(authzBypass(handler))),
+		Handler:      ot.Middleware(trace.HTTPTraceMiddleware(authzBypass(handler))),
 	})
 	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
 }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 	service.Store.Start()
 
-	handler := trace.HTTPTraceMiddleware(ot.Middleware(service))
+	handler := ot.Middleware(trace.HTTPTraceMiddleware(service))
 
 	host := ""
 	if env.InsecureDev {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -72,7 +72,7 @@ func main() {
 		log.Fatalln("Start:", err)
 	}
 
-	handler := trace.HTTPTraceMiddleware(ot.Middleware(service.Handler()))
+	handler := ot.Middleware(trace.HTTPTraceMiddleware(service.Handler()))
 
 	host := ""
 	if env.InsecureDev {

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -129,7 +129,10 @@ func RequestSource(ctx context.Context) SourceType {
 func HTTPTraceMiddleware(next http.Handler) http.Handler {
 	shouldLog := func(r *http.Request) bool {
 		switch r.URL.Path {
-		case "/.internal/configuration", "/.internal/saved-queries/list-all": // Exclude super noisy logs
+		case "/.internal/configuration",
+			 "/.internal/saved-queries/list-all",
+			 "/.api/graphql?SiteProductVersion",
+			 "/.internal/search/configuration": // Exclude super noisy logs
 			return false
 		}
 		return true
@@ -217,15 +220,8 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 				"duration", m.Duration,
 			)
 
-			if routeName != "unknown" {
-				kvs = append(kvs, "route", routeName)
-			}
-
 			if traceID != "" {
-				kvs = append(kvs,
-					"trace", traceURL,
-					"traceid", traceID,
-				)
+				kvs = append(kvs, "traceid", traceID)
 			}
 
 			if v := r.Header.Get("X-Forwarded-For"); v != "" {

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -130,9 +130,9 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 	shouldLog := func(r *http.Request) bool {
 		switch r.URL.Path {
 		case "/.internal/configuration",
-			 "/.internal/saved-queries/list-all",
-			 "/.api/graphql?SiteProductVersion",
-			 "/.internal/search/configuration": // Exclude super noisy logs
+			"/.internal/saved-queries/list-all",
+			"/.api/graphql?SiteProductVersion",
+			"/.internal/search/configuration": // Exclude super noisy logs
 			return false
 		}
 		return true


### PR DESCRIPTION
It was upside down. Noticed this since ot.Middleware sets a ctx key for
determining if a request should be traced, and that was being done after
HTTPTraceMiddleware ran.

It also makes some additional improvements to HTTPAuthMiddleware.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
