### PR TITLE
executor: Do not deadlock on writing logs

### DIFF
--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -29,6 +29,8 @@ type command struct {
 // runCommand invokes the given command on the host machine. The standard output and
 // standard error streams of the invoked command are written to the given logger.
 func runCommand(ctx context.Context, command command, logger *Logger) (err error) {
+    // The `ctx` here is used below as a guard against the command finishing before we close the stdout and 
+    // stderr pipes. This context may never be canceled, so we enforce a cancellation of a child context at function exit.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -29,6 +29,9 @@ type command struct {
 // runCommand invokes the given command on the host machine. The standard output and
 // standard error streams of the invoked command are written to the given logger.
 func runCommand(ctx context.Context, command command, logger *Logger) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	ctx, endObservation := command.Operation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 

--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -30,7 +30,7 @@ type command struct {
 // standard error streams of the invoked command are written to the given logger.
 func runCommand(ctx context.Context, command command, logger *Logger) (err error) {
     // The `ctx` here is used below as a guard against the command finishing before we close the stdout and 
-    // stderr pipes. This context may never be canceled, so we enforce a cancellation of a child context at function exit.
+// stderr pipes. This context may be very slow to cancel, so we enforce a cancellation of a child context at function exit.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -29,8 +29,9 @@ type command struct {
 // runCommand invokes the given command on the host machine. The standard output and
 // standard error streams of the invoked command are written to the given logger.
 func runCommand(ctx context.Context, command command, logger *Logger) (err error) {
-    // The `ctx` here is used below as a guard against the command finishing before we close the stdout and 
-// stderr pipes. This context may be very slow to cancel, so we enforce a cancellation of a child context at function exit.
+	// The `ctx` here is used below as a guard against the command finishing before we close the stdout and 
+	// stderr pipes. This context may be very slow to cancel, so we enforce a cancellation of a child context 
+	// at function exit to clean the goroutine up eagerly.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -29,9 +29,10 @@ type command struct {
 // runCommand invokes the given command on the host machine. The standard output and
 // standard error streams of the invoked command are written to the given logger.
 func runCommand(ctx context.Context, command command, logger *Logger) (err error) {
-	// The `ctx` here is used below as a guard against the command finishing before we close the stdout and 
-	// stderr pipes. This context may be very slow to cancel, so we enforce a cancellation of a child context 
-	// at function exit to clean the goroutine up eagerly.
+	// The context here is used below as a guard against the command finishing before we close 
+	// the stdout and stderr pipes. This context may not cancel until after logs for the job
+	// have been flushed, or after the 30m job deadline, so we enforce a cancellation of a 
+	// child context at function exit to clean the goroutine up eagerly.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -29,9 +29,9 @@ type command struct {
 // runCommand invokes the given command on the host machine. The standard output and
 // standard error streams of the invoked command are written to the given logger.
 func runCommand(ctx context.Context, command command, logger *Logger) (err error) {
-	// The context here is used below as a guard against the command finishing before we close 
+	// The context here is used below as a guard against the command finishing before we close
 	// the stdout and stderr pipes. This context may not cancel until after logs for the job
-	// have been flushed, or after the 30m job deadline, so we enforce a cancellation of a 
+	// have been flushed, or after the 30m job deadline, so we enforce a cancellation of a
 	// child context at function exit to clean the goroutine up eagerly.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
The `ctx` here is used below as a guard against the command finishing before we close the stdout and stderr pipes. This context may never be canceled, so we enforce a cancellation of a child context at function exit.