### PR TITLE
handle database I/O time out

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1127,7 +1127,7 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context, args 
 	//
 	// In this case, or if we got a partial timeout where ALL repositories timed out,
 	// we do not return partial results and instead display a timeout alert.
-	shouldShowAlert := errors.Is(err, context.DeadlineExceeded) || errors.Is(err, database.IoTimeout)
+	shouldShowAlert := errors.Is(err, context.DeadlineExceeded)
 	if err == nil && rr.Stats.AllReposTimedOut() {
 		shouldShowAlert = true
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1127,7 +1127,7 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context, args 
 	//
 	// In this case, or if we got a partial timeout where ALL repositories timed out,
 	// we do not return partial results and instead display a timeout alert.
-	shouldShowAlert := err == context.DeadlineExceeded
+	shouldShowAlert := errors.Is(err, context.DeadlineExceeded) || errors.Is(err, database.IoTimeout)
 	if err == nil && rr.Stats.AllReposTimedOut() {
 		shouldShowAlert = true
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -19,7 +19,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -59,8 +58,6 @@ func (e *RepoNotFoundErr) Error() string {
 func (e *RepoNotFoundErr) NotFound() bool {
 	return true
 }
-
-var IoTimeout = errors.New("I/O timeout")
 
 // RepoStore handles access to the repo table
 type RepoStore struct {
@@ -714,7 +711,7 @@ func (s *RepoStore) list(ctx context.Context, tr *trace.Trace, opt ReposListOpti
 	rows, err := s.Query(ctx, q)
 	if err != nil {
 		if e, ok := err.(*net.OpError); ok && e.Timeout() {
-			return errors.Wrap(IoTimeout, err.Error())
+			return errors.Wrapf(context.DeadlineExceeded, "RepoStore.list: %s", err.Error())
 		}
 		return err
 	}


### PR DESCRIPTION
With this change we return a time out alert instead of a plain error in
case of a db i/o time out.

Locally, we reliably get an I/O Error from the db for extremely short
timeouts, like `router timeout:1ms index:no`. Currently we don't
handle the error and simply surface it to the user. 

<img width="1731" alt="Screenshot 2021-08-03 at 11 22 30" src="https://user-images.githubusercontent.com/26413131/127999605-54da64ef-f69a-47ad-982b-0dc50fecc538.png">

This is unlikely to occur for a normal user, but the integration tests
are flaky because of that.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
