### PR TITLE
tracer: Use customer logger

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
-	jaegerlog "github.com/uber/jaeger-client-go/log"
 	jaegermetrics "github.com/uber/jaeger-lib/metrics"
 )
 
@@ -156,7 +155,7 @@ func newTracer(opts *jaegerOpts) (opentracing.Tracer, io.Closer, error) {
 		cfg.Sampler.Param = 1
 	}
 	tracer, closer, err := cfg.NewTracer(
-		jaegercfg.Logger(jaegerlog.StdLogger),
+		jaegercfg.Logger(log15Logger{}),
 		jaegercfg.Metrics(jaegermetrics.NullFactory),
 	)
 	if err != nil {
@@ -164,6 +163,14 @@ func newTracer(opts *jaegerOpts) (opentracing.Tracer, io.Closer, error) {
 	}
 
 	return tracer, closer, nil
+}
+
+type log15Logger struct{}
+
+func (l log15Logger) Error(msg string) { log15.Error(msg) }
+
+func (l log15Logger) Infof(msg string, args ...interface{}) {
+	log15.Info(fmt.Sprintf(msg, args...))
 }
 
 // switchableTracer implements opentracing.Tracer. The underlying tracer used is switchable (set via


### PR DESCRIPTION
The default includes debug logging which is super noisy at high sampling rates.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
