### PR TITLE
sg: accept multiple commands in 'run'

### DIFF
--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -106,6 +106,9 @@ sg run-set enterprise
 sg run gitserver
 sg run frontend
 
+# Run multiple commands:
+sg run gitserver frontend repo-updater
+
 # List available commands:
 sg run -help
 


### PR DESCRIPTION
Little quality of life improvement. Allows one to do this:

```
sg run enterprise-frontend gitserver
```

which can sometimes be helpful for debugging and doesn't require
defining a new `commandSet` in `sg.config.overwrite.yaml`