### PR TITLE
search: bring back repo count for fast global queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -269,7 +269,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, options search
 	// To send back proper search stats, we want to finish repository resolution
 	// even if we have already found enough results and the parent context was
 	// cancelled because we hit the limit.
-	ctx, cleanup := streaming.PickyContext(ctx, streaming.CanceledLimitHit)
+	ctx, cleanup := streaming.IgnoreContextCancellation(ctx, streaming.CanceledLimitHit)
 	defer cleanup()
 
 	tr, ctx := trace.New(ctx, "graphql.resolveRepositories", fmt.Sprintf("options: %+v", options))

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -266,6 +266,12 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, options search
 		return mockResolveRepositories()
 	}
 
+	// To send back proper search stats, we want to finish repository resolution
+	// even if we have already found enough results and the parent context was
+	// cancelled because we hit the limit.
+	ctx, cleanup := streaming.PickyContext(ctx, streaming.CanceledLimitHit)
+	defer cleanup()
+
 	tr, ctx := trace.New(ctx, "graphql.resolveRepositories", fmt.Sprintf("options: %+v", options))
 	defer func() {
 		tr.SetError(err)

--- a/internal/search/streaming/context.go
+++ b/internal/search/streaming/context.go
@@ -1,0 +1,79 @@
+package streaming
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+type mutValueCtxKey int64
+
+const (
+	CanceledLimitHit mutValueCtxKey = iota + 1
+)
+
+// WithMutableValue returns a context with a mutable key-value pair. Use the Set
+// method to set key and value.
+func WithMutableValue(ctx context.Context) *mutValueCtx {
+	return &mutValueCtx{Context: ctx}
+}
+
+// mutValueCtx is modelled after valueCtx in the standard library, but permits
+// to set a value after the context has been created.
+type mutValueCtx struct {
+	context.Context
+
+	// Mutable key and value.
+	key   atomic.Int64
+	value atomic.Bool
+}
+
+// Set atomically updates key and value stored in ctx.
+func (ctx *mutValueCtx) Set(key mutValueCtxKey, value bool) {
+	ctx.key.Store(int64(key))
+	ctx.value.Store(value)
+}
+
+func (ctx *mutValueCtx) Value(key interface{}) interface{} {
+	if mutValueCtxKey(ctx.key.Load()) == key {
+		return ctx.value.Load()
+	}
+	return ctx.Context.Value(key)
+}
+
+// PickyContext wraps a context and ignores context cancellations if any of the
+// parent contexts store a key:value pair with key=reason and value=true. Always
+// call defer cleanup() to clean up the goroutine created in Done().
+func PickyContext(parent context.Context, reason mutValueCtxKey) (context.Context, func()) {
+	done := make(chan struct{})
+
+	// once protects c from being closed twice.
+	once := sync.Once{}
+	c := make(chan struct{})
+
+	go func() {
+		select {
+		case <-parent.Done():
+			// Check if any parent context has a key:value pair ctx.reason=true.
+			val := parent.Value(reason)
+			if b, ok := val.(bool); ok && b {
+				// "done" will only be closed if the func() returned by PickyContext is called
+				// explicitly.
+				return
+			}
+		case <-c:
+		}
+		close(done)
+	}()
+	return &pickyCtx{Context: parent, d: done}, func() { once.Do(func() { close(c) }) }
+}
+
+type pickyCtx struct {
+	context.Context
+	d chan struct{}
+}
+
+func (ctx *pickyCtx) Done() <-chan struct{} {
+	return ctx.d
+}

--- a/internal/search/streaming/context.go
+++ b/internal/search/streaming/context.go
@@ -92,13 +92,8 @@ func (ctx *pickyCtx) Done() <-chan struct{} {
 }
 
 func (ctx *pickyCtx) Err() error {
-	select {
-	default:
-		return nil
-	case <-ctx.d:
-		ctx.mu.Lock()
-		err := ctx.err
-		ctx.mu.Unlock()
-		return err
-	}
+	ctx.mu.Lock()
+	err := ctx.err
+	ctx.mu.Unlock()
+	return err
 }

--- a/internal/search/streaming/context_test.go
+++ b/internal/search/streaming/context_test.go
@@ -20,7 +20,7 @@ func TestCancelWithReason(t *testing.T) {
 
 	select {
 	case <-parentCtx.Done():
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("parent context should have been canceled")
 	}
 
@@ -49,13 +49,13 @@ func TestCancelWithoutReason(t *testing.T) {
 
 	select {
 	case <-childCtx.Done():
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("child context should have been canceled")
 	}
 
 	select {
 	case <-grandchildCtx.Done():
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("child context should have been canceled")
 	}
 
@@ -77,7 +77,7 @@ func TestDeadlineExceeded(t *testing.T) {
 
 	select {
 	case <-childCtx.Done():
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("child context should have been canceled")
 	}
 
@@ -100,7 +100,7 @@ func TestCancelChildContext(t *testing.T) {
 
 	select {
 	case <-childCtx.Done():
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("child context should have been canceled")
 	}
 

--- a/internal/search/streaming/context_test.go
+++ b/internal/search/streaming/context_test.go
@@ -11,7 +11,7 @@ import (
 func TestCancelWithReason(t *testing.T) {
 	parentCtx, cancel := context.WithCancel(context.Background())
 	mutCtx := WithMutableValue(parentCtx)
-	childCtx, cancelChildCtx := PickyContext(mutCtx, CanceledLimitHit)
+	childCtx, cancelChildCtx := IgnoreContextCancellation(mutCtx, CanceledLimitHit)
 	defer cancelChildCtx()
 
 	// Cancel with reason.
@@ -38,7 +38,7 @@ func TestCancelWithReason(t *testing.T) {
 func TestCancelWithoutReason(t *testing.T) {
 	parentCtx, cancel := context.WithCancel(context.Background())
 	mutCtx := WithMutableValue(parentCtx)
-	childCtx, cancelChildCtx := PickyContext(mutCtx, CanceledLimitHit)
+	childCtx, cancelChildCtx := IgnoreContextCancellation(mutCtx, CanceledLimitHit)
 	defer cancelChildCtx()
 	// Check propagation to children.
 	type tmpType string
@@ -72,7 +72,7 @@ func TestDeadlineExceeded(t *testing.T) {
 	parentCtx, cancel := context.WithDeadline(context.Background(), time.Now())
 	defer cancel()
 	mutCtx := WithMutableValue(parentCtx)
-	childCtx, cleanup := PickyContext(mutCtx, CanceledLimitHit)
+	childCtx, cleanup := IgnoreContextCancellation(mutCtx, CanceledLimitHit)
 	defer cleanup()
 
 	select {
@@ -89,7 +89,7 @@ func TestDeadlineExceeded(t *testing.T) {
 func TestCancelChildContext(t *testing.T) {
 	parentCtx := context.Background()
 	mutCtx := WithMutableValue(parentCtx)
-	childCtx, cancelChildCtx := PickyContext(mutCtx, CanceledLimitHit)
+	childCtx, cancelChildCtx := IgnoreContextCancellation(mutCtx, CanceledLimitHit)
 	cancelChildCtx()
 
 	select {


### PR DESCRIPTION
This brings back the repo count for those queries that are faster than repo
resolution.

See https://github.com/sourcegraph/sourcegraph/pull/23366 for more background.

The idea is to use repository resolution as is, but unlike now we let it finish
even if we hit a limit early. To make this work, we introduce a wrapper for
contexts that let's us communicate the reason for a cancellation. Repo
resolution in turn ignores cancellation if the context was cancelled because we
hit a limit.

"Time to first result" will not change, but the spinning wheel will keep spinning
until repo resolution is done.

Other approaches considered:

1. Use existing cache for `ListAll`: We have to support all combinations of
`OnlyFork`, `NoFork`, `OnlyArchived`, `NoArchived`. There are 4 meaningful
disjoint combinations. The simplest approach would be to just extend the cache
by these 4 options which would effectively double the memory footprint (currently
below 1.28% of the Heap), which seems acceptable.

2. Implement a `/Count` endpoint on Zoekt (or an additional option on List)
which could efficiently cache the most frequent queries: There are a couple of
changes needed in Sourcegraph to handle just counts. For example, we want to
support the GraphQL API, which relies on the list of repos being not just
counts.

3. Call out to DB: precise counts are too slow: the query 
```sql
SELECT count(*) FROM repo WHERE not private;
``` 
takes 1031 ms to complete on production. Simple probalistic counts 

```sql
SELECT reltuples::bigint FROM pg_catalog.pg_class WHERE relname = 'repo';
```

are 8x faster  but don't support conditions. Additionally we don't store "indexed"
in the DB yet. Probalistic counts based on HyerLogLog seem possible but pose
other challenges, such as tunables or special casing to provide accurate results
for smaller customers.



