### PR TITLE
search: Ensure we have a user before fetching repo groups

### DIFF
--- a/internal/search/repos/repo_groups.go
+++ b/internal/search/repos/repo_groups.go
@@ -57,6 +57,10 @@ func ResolveRepoGroups(ctx context.Context, settings *schema.Settings) (groups m
 	}
 
 	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return groups, nil
+	}
+
 	repos, err := database.GlobalRepos.ListRepoNames(ctx, database.ReposListOptions{UserID: a.UID})
 	if err != nil {
 		log15.Warn("getting user added repos", "err", err)


### PR DESCRIPTION
It's possible that we are searching as a non authenticated user in which
case we should not try to fetch repo groups for that user.

If we do, we actually default to searching ALL repos since a UserID of zero
is equivalent to no filtering.