### PR TITLE
Code Insights: Fix unequal series length charts for BE insights

### DIFF
--- a/client/web/src/insights/core/backend/utils/create-view-content.ts
+++ b/client/web/src/insights/core/backend/utils/create-view-content.ts
@@ -12,6 +12,8 @@ export function createViewContent(
             if (!dataObject) {
                 dataObject = {
                     dateTime: Date.parse(point.dateTime),
+                    // Initialize all series to null (empty chart) value
+                    ...Object.fromEntries(insight.series.map((series, index) => [`series${index}`, null])),
                 }
                 dataByXValue.set(point.dateTime, dataObject)
             }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/23257

This PR adds series initial value (null value) for the points that don't have a real value for the date-time point that other series have. By adding thins null initial value we adding visual gray line background (see screenshot below)

<table>
<tr><th>Before</th><th>After</th></tr>

<tr>
  <td>
   
<img width="475" alt="Screenshot 2021-08-03 at 19 12 36" src="https://user-images.githubusercontent.com/18492575/128049825-97cae94d-732f-4df7-bfbe-da9fb32584fa.png">

  </td>
  <td>
  
<img width="475" alt="Screenshot 2021-08-03 at 19 13 11" src="https://user-images.githubusercontent.com/18492575/128049899-e11d0768-ad45-4cef-a540-004d67319ec4.png">
  </td>
</tr>
</table>