### PR TITLE
all: simplify Go error wrapping

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -354,11 +354,7 @@ func serveSavedQueriesListAll(db dbutil.DB) func(w http.ResponseWriter, r *http.
 			})
 		}
 
-		if err := json.NewEncoder(w).Encode(queries); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-
-		return nil
+		return errors.Wrap(json.NewEncoder(w).Encode(queries), "Encode")
 	}
 }
 
@@ -373,10 +369,7 @@ func serveSavedQueriesGetInfo(db dbutil.DB) func(w http.ResponseWriter, r *http.
 		if err != nil {
 			return errors.Wrap(err, "SavedQueries.Get")
 		}
-		if err := json.NewEncoder(w).Encode(info); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
+		return errors.Wrap(json.NewEncoder(w).Encode(info), "Encode")
 	}
 }
 
@@ -429,10 +422,7 @@ func serveSettingsGetForSubject(db dbutil.DB) func(w http.ResponseWriter, r *htt
 		if err != nil {
 			return errors.Wrap(err, "Settings.GetLatest")
 		}
-		if err := json.NewEncoder(w).Encode(settings); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
+		return errors.Wrap(json.NewEncoder(w).Encode(settings), "Encode")
 	}
 }
 
@@ -451,10 +441,7 @@ func serveOrgsListUsers(db dbutil.DB) func(w http.ResponseWriter, r *http.Reques
 		for _, member := range orgMembers {
 			users = append(users, member.UserID)
 		}
-		if err := json.NewEncoder(w).Encode(users); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
+		return errors.Wrap(json.NewEncoder(w).Encode(users), "Encode")
 	}
 }
 
@@ -469,10 +456,7 @@ func serveOrgsGetByName(db dbutil.DB) func(w http.ResponseWriter, r *http.Reques
 		if err != nil {
 			return errors.Wrap(err, "Orgs.GetByName")
 		}
-		if err := json.NewEncoder(w).Encode(org.ID); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
+		return errors.Wrap(json.NewEncoder(w).Encode(org.ID), "Encode")
 	}
 }
 
@@ -486,10 +470,7 @@ func serveUsersGetByUsername(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Users.GetByUsername")
 	}
-	if err := json.NewEncoder(w).Encode(user.ID); err != nil {
-		return errors.Wrap(err, "Encode")
-	}
-	return nil
+	return errors.Wrap(json.NewEncoder(w).Encode(user.ID), "Encode")
 }
 
 func serveUserEmailsGetEmail(w http.ResponseWriter, r *http.Request) error {
@@ -502,24 +483,15 @@ func serveUserEmailsGetEmail(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "UserEmails.GetEmail")
 	}
-	if err := json.NewEncoder(w).Encode(email); err != nil {
-		return errors.Wrap(err, "Encode")
-	}
-	return nil
+	return errors.Wrap(json.NewEncoder(w).Encode(email), "Encode")
 }
 
 func serveExternalURL(w http.ResponseWriter, r *http.Request) error {
-	if err := json.NewEncoder(w).Encode(globals.ExternalURL().String()); err != nil {
-		return errors.Wrap(err, "Encode")
-	}
-	return nil
+	return errors.Wrap(json.NewEncoder(w).Encode(globals.ExternalURL().String()), "Encode")
 }
 
 func serveCanSendEmail(w http.ResponseWriter, r *http.Request) error {
-	if err := json.NewEncoder(w).Encode(conf.CanSendEmail()); err != nil {
-		return errors.Wrap(err, "Encode")
-	}
-	return nil
+	return errors.Wrap(json.NewEncoder(w).Encode(conf.CanSendEmail()), "Encode")
 }
 
 func serveSendEmail(w http.ResponseWriter, r *http.Request) error {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1706,11 +1706,7 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 	}
 
 	// Update the DB with the last fetched time
-	if err := s.setLastFetched(ctx, repo, time.Now()); err != nil {
-		return errors.Wrap(err, "update last fetched time")
-	}
-
-	return nil
+	return errors.Wrap(s.setLastFetched(ctx, repo, time.Now()), "update last fetched time")
 }
 
 var (

--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -44,11 +44,7 @@ func (s *Serve) Start() error {
 		return errors.Wrap(err, "configuring server")
 	}
 
-	if err := (&http.Server{Handler: h}).Serve(ln); err != nil {
-		return errors.Wrap(err, "serving")
-	}
-
-	return nil
+	return errors.Wrap((&http.Server{Handler: h}).Serve(ln), "serving")
 }
 
 var indexHTML = template.Must(template.New("").Parse(`<html>
@@ -270,11 +266,7 @@ func configurePostUpdateHook(logger *log.Logger, gitDir string) error {
 	if err := os.MkdirAll(filepath.Dir(postUpdatePath), 0755); err != nil {
 		return errors.Wrap(err, "create git hooks dir")
 	}
-	if err := os.WriteFile(postUpdatePath, postUpdateHook, 0755); err != nil {
-		return errors.Wrap(err, "setting post-update hook")
-	}
-
-	return nil
+	return errors.Wrap(os.WriteFile(postUpdatePath, postUpdateHook, 0755), "setting post-update hook")
 }
 
 func updateServerInfo(gitDir string) error {

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -161,11 +161,7 @@ func (h *handler) handle(ctx context.Context, upload store.Upload) (requeued boo
 			// the entire set of data from scratch and we want to be able to coalesce requests for the same
 			// repository rather than having a set of uploads for the same repo re-calculate nearly identical
 			// data multiple times.
-			if err := tx.MarkRepositoryAsDirty(ctx, upload.RepositoryID); err != nil {
-				return errors.Wrap(err, "store.MarkRepositoryDirty")
-			}
-
-			return nil
+			return errors.Wrap(tx.MarkRepositoryAsDirty(ctx, upload.RepositoryID), "store.MarkRepositoryDirty")
 		})
 	})
 }
@@ -267,11 +263,7 @@ func writeData(ctx context.Context, lsifStore LSIFStore, id int, groupedBundleDa
 	if err := tx.WriteDocumentationPathInfo(ctx, id, groupedBundleData.DocumentationPathInfo); err != nil {
 		return errors.Wrap(err, "store.WriteDocumentationPathInfo")
 	}
-	if err := tx.WriteDocumentationMappings(ctx, id, groupedBundleData.DocumentationMappings); err != nil {
-		return errors.Wrap(err, "store.WriteDocumentationMappings")
-	}
-
-	return nil
+	return errors.Wrap(tx.WriteDocumentationMappings(ctx, id, groupedBundleData.DocumentationMappings), "store.WriteDocumentationMappings")
 }
 
 func isUniqueConstraintViolation(err error) bool {

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/updater.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/updater.go
@@ -126,11 +126,7 @@ func (u *Updater) update(ctx context.Context, repositoryID, dirtyToken int) (err
 	// Decorate the commit graph with the set of processed uploads are visible from each commit,
 	// then bulk update the denormalized view in Postgres. We call this with an empty graph as well
 	// so that we end up clearing the stale data and bulk inserting nothing.
-	if err := u.dbStore.CalculateVisibleUploads(ctx, repositoryID, commitGraph, refDescriptions, u.maxAgeForNonStaleBranches, u.maxAgeForNonStaleTags, dirtyToken, time.Now()); err != nil {
-		return errors.Wrap(err, "dbstore.CalculateVisibleUploads")
-	}
-
-	return nil
+	return errors.Wrap(u.dbStore.CalculateVisibleUploads(ctx, repositoryID, commitGraph, refDescriptions, u.maxAgeForNonStaleBranches, u.maxAgeForNonStaleTags, dirtyToken, time.Now()), "dbstore.CalculateVisibleUploads")
 }
 
 // getCommitGraph builds a partial commit graph that includes the most recent commits on each branch

--- a/enterprise/cmd/worker/internal/codeintel/janitor/hard_delete.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/hard_delete.go
@@ -88,11 +88,7 @@ func (d *hardDeleter) deleteBatch(ctx context.Context, ids []int) (err error) {
 		return errors.Wrap(err, "Clear")
 	}
 
-	if err := tx.HardDeleteUploadByID(ctx, ids...); err != nil {
-		return errors.Wrap(err, "HardDeleteUploadByID")
-	}
-
-	return nil
+	return errors.Wrap(tx.HardDeleteUploadByID(ctx, ids...), "HardDeleteUploadByID")
 }
 
 func uploadIDs(uploads []store.Upload) []int {

--- a/enterprise/internal/batches/background/spec_expire.go
+++ b/enterprise/internal/batches/background/spec_expire.go
@@ -18,10 +18,7 @@ func newSpecExpireWorker(ctx context.Context, cstore *store.Store) goroutine.Bac
 		}
 		// ... and then the BatchSpecs, due to the batch_spec_id
 		// foreign key on changeset_specs.
-		if err := cstore.DeleteExpiredBatchSpecs(ctx); err != nil {
-			return errors.Wrap(err, "DeleteExpiredBatchSpecs")
-		}
-		return nil
+		return errors.Wrap(cstore.DeleteExpiredBatchSpecs(ctx), "DeleteExpiredBatchSpecs")
 	})
 	return goroutine.NewPeriodicGoroutine(ctx, 2*time.Minute, expireSpecs)
 }

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -264,20 +264,13 @@ func (e *executor) updateChangeset(ctx context.Context) (err error) {
 		return errors.Wrapf(err, "decorating body for changeset %d", e.ch.ID)
 	}
 
-	if err := e.css.UpdateChangeset(ctx, &cs); err != nil {
-		return errors.Wrap(err, "updating changeset")
-	}
-
-	return nil
+	return errors.Wrap(e.css.UpdateChangeset(ctx, &cs), "updating changeset")
 }
 
 // reopenChangeset reopens the given changeset attribute on the code host.
 func (e *executor) reopenChangeset(ctx context.Context) (err error) {
 	cs := sources.Changeset{Repo: e.repo, Changeset: e.ch}
-	if err := e.css.ReopenChangeset(ctx, &cs); err != nil {
-		return errors.Wrap(err, "updating changeset")
-	}
-	return nil
+	return errors.Wrap(e.css.ReopenChangeset(ctx, &cs), "updating changeset")
 }
 
 func (e *executor) detachChangeset() {
@@ -308,10 +301,7 @@ func (e *executor) closeChangeset(ctx context.Context) (err error) {
 
 	cs := &sources.Changeset{Changeset: e.ch, Repo: e.repo}
 
-	if err := e.css.CloseChangeset(ctx, cs); err != nil {
-		return errors.Wrap(err, "closing changeset")
-	}
-	return nil
+	return errors.Wrap(e.css.CloseChangeset(ctx, cs), "closing changeset")
 }
 
 // undraftChangeset marks the given changeset on its code host as ready for review.
@@ -330,10 +320,7 @@ func (e *executor) undraftChangeset(ctx context.Context) (err error) {
 		Changeset: e.ch,
 	}
 
-	if err := draftCss.UndraftChangeset(ctx, cs); err != nil {
-		return errors.Wrap(err, "undrafting changeset")
-	}
-	return nil
+	return errors.Wrap(draftCss.UndraftChangeset(ctx, cs), "undrafting changeset")
 }
 
 // sleep sleeps for 3 seconds.

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -197,11 +197,7 @@ func (s BitbucketServerSource) loadPullRequestData(ctx context.Context, pr *bitb
 		return errors.Wrap(err, "loading pr commits")
 	}
 
-	if err := s.client.LoadPullRequestBuildStatuses(ctx, pr); err != nil {
-		return errors.Wrap(err, "loading pr build status")
-	}
-
-	return nil
+	return errors.Wrap(s.client.LoadPullRequestBuildStatuses(ctx, pr), "loading pr build status")
 }
 
 func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset) error {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -198,11 +198,7 @@ func (s GithubSource) LoadChangeset(ctx context.Context, cs *Changeset) error {
 		return err
 	}
 
-	if err := cs.SetMetadata(pr); err != nil {
-		return errors.Wrap(err, "setting changeset metadata")
-	}
-
-	return nil
+	return errors.Wrap(cs.SetMetadata(pr), "setting changeset metadata")
 }
 
 // UpdateChangeset updates the given *Changeset in the code host.

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -185,10 +185,7 @@ func (s *GitLabSource) CloseChangeset(ctx context.Context, c *Changeset) error {
 		return errors.Wrapf(err, "retrieving additional data for merge request %d", mr.IID)
 	}
 
-	if err := c.SetMetadata(updated); err != nil {
-		return errors.Wrap(err, "setting changeset metadata")
-	}
-	return nil
+	return errors.Wrap(c.SetMetadata(updated), "setting changeset metadata")
 }
 
 // LoadChangeset loads the given merge request from GitLab and updates it.
@@ -244,10 +241,7 @@ func (s *GitLabSource) ReopenChangeset(ctx context.Context, c *Changeset) error 
 		return errors.Wrapf(err, "retrieving additional data for merge request %d", mr.IID)
 	}
 
-	if err := c.SetMetadata(updated); err != nil {
-		return errors.Wrap(err, "setting changeset metadata")
-	}
-	return nil
+	return errors.Wrap(c.SetMetadata(updated), "setting changeset metadata")
 }
 
 func (s *GitLabSource) decorateMergeRequestData(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) error {

--- a/enterprise/internal/batches/webhooks/gitlab.go
+++ b/enterprise/internal/batches/webhooks/gitlab.go
@@ -222,11 +222,7 @@ func (h *GitLabWebhook) enqueueChangesetSyncFromEvent(ctx context.Context, esID 
 		return errors.Wrap(err, "getting changeset")
 	}
 
-	if err := repoupdater.DefaultClient.EnqueueChangesetSync(ctx, []int64{c.ID}); err != nil {
-		return errors.Wrap(err, "enqueuing changeset sync")
-	}
-
-	return nil
+	return errors.Wrap(repoupdater.DefaultClient.EnqueueChangesetSync(ctx, []int64{c.ID}), "enqueuing changeset sync")
 }
 
 func (h *GitLabWebhook) handlePipelineEvent(ctx context.Context, esID string, event *webhooks.PipelineEvent) error {
@@ -242,10 +238,7 @@ func (h *GitLabWebhook) handlePipelineEvent(ctx context.Context, esID string, ev
 	}
 
 	pr := gitlabToPR(&event.Project, event.MergeRequest)
-	if err := h.upsertChangesetEvent(ctx, esID, pr, &event.Pipeline); err != nil {
-		return errors.Wrap(err, "upserting changeset event")
-	}
-	return nil
+	return errors.Wrap(h.upsertChangesetEvent(ctx, esID, pr, &event.Pipeline), "upserting changeset event")
 }
 
 func (h *GitLabWebhook) getChangesetForPR(ctx context.Context, tx *store.Store, pr *PR, repo *types.Repo) (*btypes.Changeset, error) {

--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
@@ -93,11 +93,7 @@ func (m *committedAtMigrator) handleSourcedCommits(ctx context.Context, tx *dbst
 	}
 
 	// Mark repository as dirty so the commit graph is recalculated with fresh data
-	if err := tx.MarkRepositoryAsDirty(ctx, sourcedCommits.RepositoryID); err != nil {
-		return errors.Wrap(err, "dbstore.MarkRepositoryAsDirty")
-	}
-
-	return nil
+	return errors.Wrap(tx.MarkRepositoryAsDirty(ctx, sourcedCommits.RepositoryID), "dbstore.MarkRepositoryAsDirty")
 
 }
 

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client.go
@@ -71,21 +71,13 @@ func (s *gcsStore) Init(ctx context.Context) error {
 
 	if _, err := bucket.Attrs(ctx); err != nil {
 		if err == storage.ErrBucketNotExist {
-			if err := s.create(ctx, bucket); err != nil {
-				return errors.Wrap(err, "failed to create bucket")
-			}
-
-			return nil
+			return errors.Wrap(s.create(ctx, bucket), "failed to create bucket")
 		}
 
 		return errors.Wrap(err, "failed to get bucket attributes")
 	}
 
-	if err := s.update(ctx, bucket); err != nil {
-		return errors.Wrap(err, "failed to update bucket attributes")
-	}
-
-	return nil
+	return errors.Wrap(s.update(ctx, bucket), "failed to update bucket attributes")
 }
 
 func (s *gcsStore) Get(ctx context.Context, key string) (_ io.ReadCloser, err error) {
@@ -199,11 +191,7 @@ func (s *gcsStore) lifecycle() storage.Lifecycle {
 
 func (s *gcsStore) deleteSources(ctx context.Context, bucket gcsBucketHandle, sources []string) error {
 	return goroutine.RunWorkersOverStrings(sources, func(index int, source string) error {
-		if err := bucket.Object(source).Delete(ctx); err != nil {
-			return errors.Wrap(err, "failed to delete source object")
-		}
-
-		return nil
+		return errors.Wrap(bucket.Object(source).Delete(ctx), "failed to delete source object")
 	})
 }
 

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
@@ -83,11 +83,7 @@ func (s *s3Store) Init(ctx context.Context) error {
 		return errors.Wrap(err, "failed to create bucket")
 	}
 
-	if err := s.update(ctx); err != nil {
-		return errors.Wrap(err, "failed to update bucket attributes")
-	}
-
-	return nil
+	return errors.Wrap(s.update(ctx), "failed to update bucket attributes")
 }
 
 // maxZeroReads is the maximum number of no-progress iterations (due to connection reset errors)

--- a/internal/database/dbconn/migration.go
+++ b/internal/database/dbconn/migration.go
@@ -59,10 +59,7 @@ func MigrateDB(db *sql.DB, database *Database) error {
 	if err != nil {
 		return err
 	}
-	if err := DoMigrate(m); err != nil {
-		return errors.Wrap(err, "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
-	}
-	return nil
+	return errors.Wrap(DoMigrate(m), "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
 }
 
 // NewMigrate returns a new configured migration object for the given database. The migration can


### PR DESCRIPTION
Mechanical change based on @camdencheek [comment](https://github.com/sourcegraph/sourcegraph/pull/23431/files#r680963045). 

Any stylistic concerns or is this good to merge (tests pass)?

```
FYI from the cockroachdb/errors docs:

// The following:
// if err := foo(); err != nil {
//    return errors.Wrap(err, "foo")
// }
// return nil
//
// is not needed. Instead, you can use this:
return errors.Wrap(foo(), "foo")
I know this is just copy/paste, so feel free to ignore to keep the change more isolated, but I've been attempting to evangelize some cleaner error patterns.
```

There are some other `Wrapf` and `errors.Errorf` calls that also simplify. I'll do those if this PR is positively received :-). [query](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+if+err+:%3D+:%5Bv:e%5D%3B+err+%21%3D+nil+%7B+return+errors.:%5Brest%5D+%7D+return+nil+count:all&patternType=structural)

---

Command:


```bash
comby \
'if err := :[v:e]; err != nil { return errors.Wrap(:[w], :[s]) } return nil' \
'return errors.Wrap(:[v], :[s])' \
'' \
-rg "-g '*.go'" -i
```