### PR TITLE
extensibility: fix installed firefox extension detection

### DIFF
--- a/client/web/src/tracking/analyticsUtils.tsx
+++ b/client/web/src/tracking/analyticsUtils.tsx
@@ -1,10 +1,9 @@
 import { fromEvent, concat, Observable, of } from 'rxjs'
 import { fromFetch } from 'rxjs/fetch'
-import { catchError, filter, map, mapTo, publishReplay, refCount, take, timeout } from 'rxjs/operators'
-
-import { asError } from '@sourcegraph/shared/src/util/errors'
+import { catchError, filter, map, mapTo, publishReplay, refCount, take } from 'rxjs/operators'
 
 import { IS_CHROME } from '../marketing/util'
+import { observeQuerySelector } from '../util/dom'
 
 import { eventLogger } from './eventLogger'
 import { stripURLParameters } from './util'
@@ -61,15 +60,8 @@ const checkChromeExtensionInstalled = (): Observable<boolean> => {
  */
 export const browserExtensionInstalled: Observable<boolean> = concat(
     checkChromeExtensionInstalled().pipe(filter(isInstalled => isInstalled)),
-    browserExtensionMessageReceived.pipe(
+    observeQuerySelector({ selector: '#sourcegraph-app-background', timeoutMs: 1000 }).pipe(
         mapTo(true),
-        timeout(500),
-        catchError(error => {
-            if (asError(error).name === 'TimeoutError') {
-                return [false]
-            }
-            throw error
-        }),
         catchError(() => [false])
     )
 ).pipe(

--- a/client/web/src/tracking/analyticsUtils.tsx
+++ b/client/web/src/tracking/analyticsUtils.tsx
@@ -55,8 +55,8 @@ const checkChromeExtensionInstalled = (): Observable<boolean> => {
 }
 
 /**
- * Indicates if the current user has the browser extension installed. It waits 500ms for the browser
- * extension to fire a registration event, and if it doesn't, emits false
+ * Indicates if the current user has the browser extension installed. It waits 1000ms for the browser
+ * extension to inject a DOM marker element, and if it doesn't, emits false
  */
 export const browserExtensionInstalled: Observable<boolean> = concat(
     checkChromeExtensionInstalled().pipe(filter(isInstalled => isInstalled)),


### PR DESCRIPTION
It seems like we intended to detect that the Firefox extension was installed through [`CustomEvent`s](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/browser/src/shared/code-hosts/sourcegraph/inject.tsx?L41-43). Unfortunately, `CustomEvent`s from extensions [cannot be read by webpages](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#firing_from_privileged_code_to_non-privileged_code). MDN suggests a workaround, but that API seems to only be available to XPCOM extensions, not WebExtensions.

This issue lead to us showing "Install the browser extension" popovers/alerts to users that already had it installed.

Fix: Wait for the extension marker element injected by the browser extension (kind of like `Page#waitForSelector` in Puppeteer). If it shows up, don't show popovers/alerts meant for non-extension users.

<details>
<summary>GIF of before/after</summary>
<img src="https://user-images.githubusercontent.com/37420160/128062454-6b218f36-8084-4121-b468-f658a49a4ba2.gif" />
</details>