### PR TITLE
API docs: LSIF: remove unused method implementation

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -55,7 +55,6 @@ type LSIFStore interface {
 	DocumentationPage(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPageData, error)
 	DocumentationPathInfo(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPathInfoData, error)
 	DocumentationDefinitions(ctx context.Context, bundleID int, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
-	DocumentationReferences(ctx context.Context, bundleID int, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
 	DocumentationAtPosition(ctx context.Context, bundleID int, path string, line, character int) ([]string, error)
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4736,9 +4736,6 @@ type MockLSIFStore struct {
 	// DocumentationPathInfoFunc is an instance of a mock function object
 	// controlling the behavior of the method DocumentationPathInfo.
 	DocumentationPathInfoFunc *LSIFStoreDocumentationPathInfoFunc
-	// DocumentationReferencesFunc is an instance of a mock function object
-	// controlling the behavior of the method DocumentationReferences.
-	DocumentationReferencesFunc *LSIFStoreDocumentationReferencesFunc
 	// ExistsFunc is an instance of a mock function object controlling the
 	// behavior of the method Exists.
 	ExistsFunc *LSIFStoreExistsFunc
@@ -4798,11 +4795,6 @@ func NewMockLSIFStore() *MockLSIFStore {
 				return nil, nil
 			},
 		},
-		DocumentationReferencesFunc: &LSIFStoreDocumentationReferencesFunc{
-			defaultHook: func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
-				return nil, 0, nil
-			},
-		},
 		ExistsFunc: &LSIFStoreExistsFunc{
 			defaultHook: func(context.Context, int, string) (bool, error) {
 				return false, nil
@@ -4860,9 +4852,6 @@ func NewMockLSIFStoreFrom(i LSIFStore) *MockLSIFStore {
 		},
 		DocumentationPathInfoFunc: &LSIFStoreDocumentationPathInfoFunc{
 			defaultHook: i.DocumentationPathInfo,
-		},
-		DocumentationReferencesFunc: &LSIFStoreDocumentationReferencesFunc{
-			defaultHook: i.DocumentationReferences,
 		},
 		ExistsFunc: &LSIFStoreExistsFunc{
 			defaultHook: i.Exists,
@@ -5727,130 +5716,6 @@ func (c LSIFStoreDocumentationPathInfoFuncCall) Args() []interface{} {
 // invocation.
 func (c LSIFStoreDocumentationPathInfoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// LSIFStoreDocumentationReferencesFunc describes the behavior when the
-// DocumentationReferences method of the parent MockLSIFStore instance is
-// invoked.
-type LSIFStoreDocumentationReferencesFunc struct {
-	defaultHook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
-	hooks       []func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
-	history     []LSIFStoreDocumentationReferencesFuncCall
-	mutex       sync.Mutex
-}
-
-// DocumentationReferences delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) DocumentationReferences(v0 context.Context, v1 int, v2 string, v3 int, v4 int) ([]lsifstore.Location, int, error) {
-	r0, r1, r2 := m.DocumentationReferencesFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DocumentationReferencesFunc.appendCall(LSIFStoreDocumentationReferencesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
-	return r0, r1, r2
-}
-
-// SetDefaultHook sets function that is called when the
-// DocumentationReferences method of the parent MockLSIFStore instance is
-// invoked and the hook queue is empty.
-func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// DocumentationReferences method of the parent MockLSIFStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
-		return r0, r1, r2
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *LSIFStoreDocumentationReferencesFunc) PushReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
-		return r0, r1, r2
-	})
-}
-
-func (f *LSIFStoreDocumentationReferencesFunc) nextHook() func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LSIFStoreDocumentationReferencesFunc) appendCall(r0 LSIFStoreDocumentationReferencesFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LSIFStoreDocumentationReferencesFuncCall
-// objects describing the invocations of this function.
-func (f *LSIFStoreDocumentationReferencesFunc) History() []LSIFStoreDocumentationReferencesFuncCall {
-	f.mutex.Lock()
-	history := make([]LSIFStoreDocumentationReferencesFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LSIFStoreDocumentationReferencesFuncCall is an object that describes an
-// invocation of method DocumentationReferences on an instance of
-// MockLSIFStore.
-type LSIFStoreDocumentationReferencesFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 int
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []lsifstore.Location
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 int
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LSIFStoreDocumentationReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LSIFStoreDocumentationReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreExistsFunc describes the behavior when the Exists method of the

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -295,21 +295,10 @@ func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, path
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.DefinitionResultID }
 	operation := s.operations.documentationDefinitions
-	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, pathID, resultID, limit, offset)
+	return s.documentationDefinitions(ctx, extractor, operation, bundleID, pathID, resultID, limit, offset)
 }
 
-// DocumentationReferences returns the set of locations referencing the symbol found at the given path ID, if any.
-func (s *Store) DocumentationReferences(ctx context.Context, bundleID int, pathID string, limit, offset int) (_ []Location, _ int, err error) {
-	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
-	if resultID == "" || err != nil {
-		return nil, 0, err
-	}
-	extractor := func(r semantic.RangeData) semantic.ID { return r.ReferenceResultID }
-	operation := s.operations.documentationReferences
-	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, pathID, resultID, limit, offset)
-}
-
-func (s *Store) documentationDefinitionsReferences(
+func (s *Store) documentationDefinitions(
 	ctx context.Context,
 	extractor func(r semantic.RangeData) semantic.ID,
 	operation *observation.Operation,


### PR DESCRIPTION
This code is entirely unused; I had originally intended to use it but forgot
to remove it after making the actual resolver `DocumentationReferences` implementation
merely be a `DocumentationDefinition` location lookup + regular `References` from there.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>