### PR TITLE
CI: Fix executor build

### DIFF
--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -34,6 +34,7 @@ steps:
   - name: index.docker.io/hashicorp/packer:1.6.6
     env:
       - 'VERSION=$(git log -n1 --pretty=format:%h)'
+      - 'BUILD_TIMESTAMP=$BUILD_TIMESTAMP'
       - 'SRC_CLI_VERSION=$SRC_CLI_VERSION'
     args: ['build', 'executor.json']
 EOF

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -447,7 +447,7 @@ func addExecutorPackerStep(c Config, final bool) func(*bk.Pipeline) {
 					bk.Cmd("./enterprise/cmd/executor/release.sh"),
 				}
 
-				pipeline.AddStep(":packer: :construction: executor image", cmds...)
+				pipeline.AddStep(":packer: :white_check_mark: executor image", cmds...)
 			}
 		} else {
 			cmds := []bk.StepOpt{

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -430,7 +430,7 @@ func addCandidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 	}
 }
 
-var currentBuildTimestamp = time.Now().UTC().Format(time.RFC3339)
+var currentBuildTimestamp = strconv.Itoa(int(time.Now().UTC().Unix()))
 
 func addExecutorPackerStep(c Config, final bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {


### PR DESCRIPTION
`-u` didn't catch anything, but strong input validation sure did!