### PR TITLE
web: Remove start typing prompt

### DIFF
--- a/client/web/src/insights/components/form/repositories-field/components/suggestion-panel/SuggestionPanel.tsx
+++ b/client/web/src/insights/components/form/repositories-field/components/suggestion-panel/SuggestionPanel.tsx
@@ -49,12 +49,6 @@ export const SuggestionsPanel: React.FunctionComponent<SuggestionsPanelProps> = 
                 </ComboboxOption>
             ))}
 
-            {isValueEmpty && (
-                <span className={styles.suggestionsListItem}>
-                    <i>Start typing</i>
-                </span>
-            )}
-
             {!isValueEmpty && !suggestions.length && (
                 <span className={styles.suggestionsListItem}>No results found</span>
             )}


### PR DESCRIPTION
As per discussion, remove the "Start typing" prompt when creating a new search insight.

## Reproduce

Navigate to "Create new code insight": `/insights/create/search`

See how prompt is shown.

![Start typing prompt](https://user-images.githubusercontent.com/1855233/128086569-d3e67568-5487-45e3-a811-81edab3ae045.png)

## Correct behavior

Prompt is not shown.

![Prompt removed](https://user-images.githubusercontent.com/1855233/128086716-0d373d0e-ab16-44d0-89e9-412f50711ed7.png)

Fixes #22609 