### PR TITLE
insights: record historical samples using committer timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights backend has moved from the `repo-updater` service to the `worker` service. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 - Code Insights feature flag `DISABLE_CODE_INSIGHTS` environment variable has moved from the `repo-updater` service to the `worker` service. Any users of this flag will need to update their `worker` service configuration to continue using it. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 - Updated Docker-Compose Caddy Image to v2.0.0-alpine. [#468](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/468)
+- Code Insights historical samples will record using the timestamp of the commit that was searched. [#23520](https://github.com/sourcegraph/sourcegraph/pull/23520)
 
 ### Fixed
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -467,7 +467,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 		hardErr = errors.Wrap(err, "FindNearestCommit")
 		return
 	}
-	if nearestCommit == nil {
+	if nearestCommit == nil || nearestCommit.Committer == nil {
 		return // repository has no commits / is empty. Maybe not yet pushed to code host.
 	}
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -478,7 +478,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 	hardErr = h.enqueueQueryRunnerJob(ctx, &queryrunner.Job{
 		SeriesID:    bctx.seriesID,
 		SearchQuery: query,
-		RecordTime:  &frameMidpoint,
+		RecordTime:  &nearestCommit.Committer.Date,
 		State:       "queued",
 		Priority:    int(priority.FromTimeInterval(frameMidpoint, time.Now())), // eventually we will use the end of the historical range, for now current time works fine
 		Cost:        int(priority.Unindexed),

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -120,15 +120,15 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 	gitFirstEverCommit := func(ctx context.Context, repoName api.RepoName) (*git.Commit, error) {
 		if repoName == "repo/1" {
 			daysAgo := clock().Add(-3 * 24 * time.Hour)
-			return &git.Commit{Author: git.Signature{Date: daysAgo}}, nil
+			return &git.Commit{Committer: &git.Signature{Date: daysAgo}}, nil
 		}
 		yearsAgo := clock().Add(-2 * 365 * 24 * time.Hour)
-		return &git.Commit{Author: git.Signature{Date: yearsAgo}}, nil
+		return &git.Commit{Committer: &git.Signature{Date: yearsAgo}}, nil
 	}
 
 	gitFindNearestCommit := func(ctx context.Context, repoName api.RepoName, revSpec string, target time.Time) (*git.Commit, error) {
 		nearby := target.Add(-2 * 24 * time.Hour)
-		return &git.Commit{Author: git.Signature{Date: nearby}}, nil
+		return &git.Commit{Committer: &git.Signature{Date: nearby}}, nil
 	}
 
 	limiter := rate.NewLimiter(10, 1)
@@ -193,14 +193,14 @@ func Test_historicalEnqueuer(t *testing.T) {
 		want := autogold.Want("no_data", &testResults{
 			allReposIteratorCalls: 1, reposGetByName: 2,
 			operations: []string{
-				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-04-02T06:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-04-02T06:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
-				`recordSeriesPoint(point=SeriesPoint{Time: "2020-04-02 06:00:01 +0000 UTC", Value: 0, Metadata: }, repoName=repo/1)`,
-				`enqueueQueryRunnerJob("2020-10-01T18:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
-				`recordSeriesPoint(point=SeriesPoint{Time: "2020-04-02 06:00:01 +0000 UTC", Value: 0, Metadata: }, repoName=repo/1)`,
+				`enqueueQueryRunnerJob("2020-09-29T18:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-03-31T06:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-09-29T18:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-03-31T06:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-09-29T18:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
+				`enqueueQueryRunnerJob("2020-03-31T06:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
+				`enqueueQueryRunnerJob("2020-09-29T18:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
+				`enqueueQueryRunnerJob("2020-03-31T06:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
 			},
 		})
 		want.Equal(t, testHistoricalEnqueuer(t, &testParams{


### PR DESCRIPTION
Closes #23515

Change historical samples to record timestamps based on the committed time, rather than the generated interval time.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
