### PR TITLE
preserve order during deduplication

### DIFF
--- a/internal/search/result/deduper.go
+++ b/internal/search/result/deduper.go
@@ -1,15 +1,20 @@
 package result
 
-import "sort"
-
-type deduper map[Key]Match
-
-func NewDeduper() deduper {
-	return make(map[Key]Match)
+// deduper deduplicates matches added to it with Add(). Matches are deduplicated by their key,
+// and the return value of Results() is ordered in the same order results are added with Add().
+type deduper struct {
+	results []Match
+	seen    map[Key]Match
 }
 
-func (d deduper) Add(m Match) {
-	prev, seen := d[m.Key()]
+func NewDeduper() deduper {
+	return deduper{
+		seen: make(map[Key]Match),
+	}
+}
+
+func (d *deduper) Add(m Match) {
+	prev, seen := d.seen[m.Key()]
 
 	if seen {
 		switch prevMatch := prev.(type) {
@@ -22,19 +27,15 @@ func (d deduper) Add(m Match) {
 		return
 	}
 
-	d[m.Key()] = m
+	d.results = append(d.results, m)
+	d.seen[m.Key()] = m
 }
 
-func (d deduper) Seen(m Match) bool {
-	_, ok := d[m.Key()]
+func (d *deduper) Seen(m Match) bool {
+	_, ok := d.seen[m.Key()]
 	return ok
 }
 
-func (d deduper) Results() []Match {
-	matches := make([]Match, 0, len(d))
-	for _, match := range d {
-		matches = append(matches, match)
-	}
-	sort.Sort(Matches(matches))
-	return matches
+func (d *deduper) Results() []Match {
+	return d.results
 }

--- a/internal/search/result/merge_test.go
+++ b/internal/search/result/merge_test.go
@@ -2,7 +2,6 @@ package result
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"testing"
 
@@ -92,7 +91,7 @@ func TestUnionMerge(t *testing.T) {
 				fileResult("a", nil, nil),
 			},
 			right: []Match{},
-			want:  autogold.Want("LeftOnly", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a"),
+			want:  autogold.Want("LeftOnly", "Diff:/a/-/commit/a, Commit:/a/-/commit/a, Repo:/a, File{url:a/,symbols:[],lineMatches:[]}"),
 		},
 		{
 			left: []Match{
@@ -101,7 +100,7 @@ func TestUnionMerge(t *testing.T) {
 				repoResult("a"),
 				fileResult("a", nil, nil),
 			},
-			want: autogold.Want("RightOnly", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a"),
+			want: autogold.Want("RightOnly", "Diff:/a/-/commit/a, Commit:/a/-/commit/a, Repo:/a, File{url:a/,symbols:[],lineMatches:[]}"),
 		},
 		{
 			left: []Match{
@@ -116,7 +115,7 @@ func TestUnionMerge(t *testing.T) {
 				repoResult("b"),
 				fileResult("b", nil, nil),
 			},
-			want: autogold.Want("MergeAllDifferent", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a, File{url:b/,symbols:[],lineMatches:[]}, Repo:/b, Commit:/b/-/commit/b, Diff:/b/-/commit/b"),
+			want: autogold.Want("MergeAllDifferent", "Diff:/a/-/commit/a, Commit:/a/-/commit/a, Repo:/a, File{url:a/,symbols:[],lineMatches:[]}, Diff:/b/-/commit/b, Commit:/b/-/commit/b, Repo:/b, File{url:b/,symbols:[],lineMatches:[]}"),
 		},
 		{
 			left: []Match{
@@ -168,7 +167,6 @@ func TestUnionMerge(t *testing.T) {
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
 			got := Union(tc.left, tc.right)
-			sort.Sort(Matches(got))
 			tc.want.Equal(t, resultsToString(got))
 		})
 	}


### PR DESCRIPTION
This PR modifies the deduper to build the result slice as matches are added to it. This way, the order of results as streamed remains stable rather than being re-sorted by the result key.

I expect that there is a more efficient way to do this (without maintaining both an unordered map and an ordered slice), but we were already constructing the slice from the map in `Results()` (so memory overhead shouldn't change much), and I expect this might need further work after current efforts on streaming `and`/`or` search, so this felt like a reasonable quick fix. 

Fixes #23453 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
