### PR TITLE
insights: set historical query priority based on series created_at

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -480,7 +480,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 		SearchQuery: query,
 		RecordTime:  &nearestCommit.Committer.Date,
 		State:       "queued",
-		Priority:    int(priority.FromTimeInterval(frameMidpoint, time.Now())), // eventually we will use the end of the historical range, for now current time works fine
+		Priority:    int(priority.FromTimeInterval(frameMidpoint, bctx.series.CreatedAt)),
 		Cost:        int(priority.Unindexed),
 	})
 	return


### PR DESCRIPTION
Recently we updated the historical recorder to use DB state, this will update the relevant query priority to take that state into account.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
