### PR TITLE
API docs: LSIF: correct race condition in documentation data queues

### DIFF
--- a/lib/codeintel/lsif/conversion/group_documentation.go
+++ b/lib/codeintel/lsif/conversion/group_documentation.go
@@ -62,6 +62,10 @@ func newDocumentationChannels() documentationChannels {
 				buf = buf[1:]
 			case v, ok := <-src:
 				if !ok {
+					// No more src values, flush all to dst and we're done.
+					for _, v := range buf {
+						dst <- v
+					}
 					close(dst)
 					return
 				}
@@ -87,6 +91,10 @@ func newDocumentationChannels() documentationChannels {
 				buf = buf[1:]
 			case v, ok := <-src:
 				if !ok {
+					// No more src values, flush all to dst and we're done.
+					for _, v := range buf {
+						dst <- v
+					}
 					close(dst)
 					return
 				}
@@ -112,6 +120,10 @@ func newDocumentationChannels() documentationChannels {
 				buf = buf[1:]
 			case v, ok := <-src:
 				if !ok {
+					// No more src values, flush all to dst and we're done.
+					for _, v := range buf {
+						dst <- v
+					}
 					close(dst)
 					return
 				}


### PR DESCRIPTION
There was a race condition here: If the `src` channel of the queue
was closed and had no more data, but the buffer had not yet been flushed,
then the `dst` channel would be closed - dropping all `buf` values that
were still waiting to be written to the `dst` channel.

This seems to have been one of the issues leading to inconsistent usage
examples on API docs pages (you'd get no results in such instances.)

This file is clearly the most complex part of the API docs backend
implementation, and as such I am rethinking how it is structured and
how to test it. I'll send more PRs for this later.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>