### PR TITLE
web: Name some anonymouse components

### DIFF
--- a/client/web/src/insights/components/form/form-input/FormInput.tsx
+++ b/client/web/src/insights/components/form/form-input/FormInput.tsx
@@ -32,7 +32,7 @@ interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
 /**
  * Displays the input with description, error message, visual invalid and valid states.
  */
-export const FormInput = forwardRef((props, reference) => {
+const FormInput = forwardRef((props, reference) => {
     const {
         as: Component = 'input',
         type = 'text',
@@ -77,3 +77,7 @@ export const FormInput = forwardRef((props, reference) => {
         </label>
     )
 }) as ForwardReferenceComponent<'input', FormInputProps>
+
+FormInput.displayName = 'FormInput'
+
+export { FormInput }

--- a/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
+++ b/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
@@ -20,7 +20,7 @@ import { getSuggestionsSearchTerm } from './utils/get-suggestions-search-term'
 /**
  * Renders multi repositories input with suggestions.
  */
-export const RepositoriesField = forwardRef((props: RepositoryFieldProps, reference: Ref<HTMLInputElement | null>) => {
+const RepositoriesField = forwardRef((props: RepositoryFieldProps, reference: Ref<HTMLInputElement | null>) => {
     const { value, onChange, onBlur, ...otherProps } = props
 
     const inputReference = useRef<HTMLInputElement>(null)
@@ -131,3 +131,7 @@ export const RepositoriesField = forwardRef((props: RepositoryFieldProps, refere
         </Combobox>
     )
 })
+
+RepositoriesField.displayName = 'RepositoriesField'
+
+export { RepositoriesField }


### PR DESCRIPTION
forwardRef does not surface the component
name in React DevTools. This refactor makes
our dev lives just a little nicer.

Note in the screenshots below, that hurtful Anonymous component is from a library and beyond our reach 😭 

| Before ☹️  | After 😄  |
|---|---|
| ![anon-components](https://user-images.githubusercontent.com/1855233/128094448-996d14bb-ec50-4f3c-bc3b-a5d772eea29b.png) | ![named-components](https://user-images.githubusercontent.com/1855233/128094466-1c5d1e51-6ea6-4671-b313-d9bec864e128.png) |