### PR TITLE
codeintel: Supply rev to queue job resolver

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.tsx
@@ -71,7 +71,7 @@ export const CodeIntelIndexConfigurationPage: FunctionComponent<CodeIntelIndexCo
         setSaveError(undefined)
 
         try {
-            await enqueueIndexJob(repo.id).toPromise()
+            await enqueueIndexJob(repo.id, 'HEAD').toPromise()
         } catch (error) {
             setSaveError(error)
         } finally {

--- a/client/web/src/enterprise/codeintel/configuration/backend.ts
+++ b/client/web/src/enterprise/codeintel/configuration/backend.ts
@@ -70,17 +70,17 @@ export function updateConfiguration({ id, content }: { id: string; content: stri
     )
 }
 
-export function enqueueIndexJob(id: string): Observable<void> {
+export function enqueueIndexJob(id: string, revision: string): Observable<void> {
     const query = gql`
-        mutation QueueAutoIndexJobForRepo($id: ID!) {
-            queueAutoIndexJobForRepo(repository: $id) {
+        mutation QueueAutoIndexJobForRepo($id: ID!, $rev: String) {
+            queueAutoIndexJobForRepo(repository: $id, rev: $rev) {
                 alwaysNil
             }
         }
     `
 
-    return requestGraphQL<QueueAutoIndexJobForRepoResult, QueueAutoIndexJobForRepoVariables>(query, { id }).pipe(
-        map(dataOrThrowErrors),
-        mapTo(undefined)
-    )
+    return requestGraphQL<QueueAutoIndexJobForRepoResult, QueueAutoIndexJobForRepoVariables>(query, {
+        id,
+        rev: revision,
+    }).pipe(map(dataOrThrowErrors), mapTo(undefined))
 }

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -22,7 +22,7 @@ type CodeIntelResolver interface {
 	IndexConfiguration(ctx context.Context, id graphql.ID) (IndexConfigurationResolver, error) // TODO - rename ...ForRepo
 	UpdateRepositoryIndexConfiguration(ctx context.Context, args *UpdateRepositoryIndexConfigurationArgs) (*EmptyResponse, error)
 	CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error)
-	QueueAutoIndexJobForRepo(ctx context.Context, args *struct{ Repository graphql.ID }) (*EmptyResponse, error)
+	QueueAutoIndexJobForRepo(ctx context.Context, args *QueueAutoIndexJobForRepoArgs) (*EmptyResponse, error)
 	GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
@@ -125,6 +125,11 @@ type IndexConfigurationResolver interface {
 type UpdateRepositoryIndexConfigurationArgs struct {
 	Repository    graphql.ID
 	Configuration string
+}
+
+type QueueAutoIndexJobForRepoArgs struct {
+	Repository graphql.ID
+	Rev        *string
 }
 
 type QueueAutoIndexJobArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -5,9 +5,11 @@ extend type Mutation {
     updateRepositoryIndexConfiguration(repository: ID!, configuration: String!): EmptyResponse
 
     """
-    Queues the index jobs for a repository for execution.
+    Queues the index jobs for a repository for execution. An optional resolvable revhash
+    (commit, branch name, or tag name) can be specified; by default the tip of the default
+    branch will be used.
     """
-    queueAutoIndexJobForRepo(repository: ID!): EmptyResponse
+    queueAutoIndexJobForRepo(repository: ID!, rev: String): EmptyResponse
 
     """
     Deletes an LSIF upload.

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -246,7 +246,7 @@ func (r *Resolver) CommitGraph(ctx context.Context, id graphql.ID) (gql.CodeInte
 	return r.resolver.CommitGraph(ctx, int(repositoryID))
 }
 
-func (r *Resolver) QueueAutoIndexJobForRepo(ctx context.Context, args *struct{ Repository graphql.ID }) (*gql.EmptyResponse, error) {
+func (r *Resolver) QueueAutoIndexJobForRepo(ctx context.Context, args *gql.QueueAutoIndexJobForRepoArgs) (*gql.EmptyResponse, error) {
 	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
@@ -256,7 +256,7 @@ func (r *Resolver) QueueAutoIndexJobForRepo(ctx context.Context, args *struct{ R
 		return nil, err
 	}
 
-	return &gql.EmptyResponse{}, r.resolver.QueueAutoIndexJobForRepo(ctx, int(repositoryID))
+	return &gql.EmptyResponse{}, r.resolver.QueueAutoIndexJobForRepo(ctx, int(repositoryID), args.Rev)
 }
 
 func (r *Resolver) GitBlobLSIFData(ctx context.Context, args *gql.GitBlobLSIFDataArgs) (gql.GitBlobLSIFDataResolver, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -59,7 +59,7 @@ type LSIFStore interface {
 }
 
 type IndexEnqueuer interface {
-	ForceQueueIndexesForRepository(ctx context.Context, repositoryID int) error
+	ForceQueueIndexesForRepository(ctx context.Context, repositoryID int, commit string) error
 	InferIndexConfiguration(ctx context.Context, repositoryID int) (*config.IndexConfiguration, error)
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4461,7 +4461,7 @@ type MockIndexEnqueuer struct {
 func NewMockIndexEnqueuer() *MockIndexEnqueuer {
 	return &MockIndexEnqueuer{
 		ForceQueueIndexesForRepositoryFunc: &IndexEnqueuerForceQueueIndexesForRepositoryFunc{
-			defaultHook: func(context.Context, int) error {
+			defaultHook: func(context.Context, int, string) error {
 				return nil
 			},
 		},
@@ -4491,24 +4491,24 @@ func NewMockIndexEnqueuerFrom(i IndexEnqueuer) *MockIndexEnqueuer {
 // when the ForceQueueIndexesForRepository method of the parent
 // MockIndexEnqueuer instance is invoked.
 type IndexEnqueuerForceQueueIndexesForRepositoryFunc struct {
-	defaultHook func(context.Context, int) error
-	hooks       []func(context.Context, int) error
+	defaultHook func(context.Context, int, string) error
+	hooks       []func(context.Context, int, string) error
 	history     []IndexEnqueuerForceQueueIndexesForRepositoryFuncCall
 	mutex       sync.Mutex
 }
 
 // ForceQueueIndexesForRepository delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockIndexEnqueuer) ForceQueueIndexesForRepository(v0 context.Context, v1 int) error {
-	r0 := m.ForceQueueIndexesForRepositoryFunc.nextHook()(v0, v1)
-	m.ForceQueueIndexesForRepositoryFunc.appendCall(IndexEnqueuerForceQueueIndexesForRepositoryFuncCall{v0, v1, r0})
+func (m *MockIndexEnqueuer) ForceQueueIndexesForRepository(v0 context.Context, v1 int, v2 string) error {
+	r0 := m.ForceQueueIndexesForRepositoryFunc.nextHook()(v0, v1, v2)
+	m.ForceQueueIndexesForRepositoryFunc.appendCall(IndexEnqueuerForceQueueIndexesForRepositoryFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // ForceQueueIndexesForRepository method of the parent MockIndexEnqueuer
 // instance is invoked and the hook queue is empty.
-func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) SetDefaultHook(hook func(context.Context, int) error) {
+func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) SetDefaultHook(hook func(context.Context, int, string) error) {
 	f.defaultHook = hook
 }
 
@@ -4517,7 +4517,7 @@ func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) SetDefaultHook(hook fu
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) PushHook(hook func(context.Context, int) error) {
+func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) PushHook(hook func(context.Context, int, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4526,7 +4526,7 @@ func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) PushHook(hook func(con
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int) error {
+	f.SetDefaultHook(func(context.Context, int, string) error {
 		return r0
 	})
 }
@@ -4534,12 +4534,12 @@ func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) SetDefaultReturn(r0 er
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int) error {
+	f.PushHook(func(context.Context, int, string) error {
 		return r0
 	})
 }
 
-func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) nextHook() func(context.Context, int) error {
+func (f *IndexEnqueuerForceQueueIndexesForRepositoryFunc) nextHook() func(context.Context, int, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4580,6 +4580,9 @@ type IndexEnqueuerForceQueueIndexesForRepositoryFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -4588,7 +4591,7 @@ type IndexEnqueuerForceQueueIndexesForRepositoryFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c IndexEnqueuerForceQueueIndexesForRepositoryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -113,7 +113,7 @@ func NewMockResolver() *MockResolver {
 			},
 		},
 		QueueAutoIndexJobForRepoFunc: &ResolverQueueAutoIndexJobForRepoFunc{
-			defaultHook: func(context.Context, int) error {
+			defaultHook: func(context.Context, int, *string) error {
 				return nil
 			},
 		},
@@ -1281,24 +1281,24 @@ func (c ResolverQueryResolverFuncCall) Results() []interface{} {
 // QueueAutoIndexJobForRepo method of the parent MockResolver instance is
 // invoked.
 type ResolverQueueAutoIndexJobForRepoFunc struct {
-	defaultHook func(context.Context, int) error
-	hooks       []func(context.Context, int) error
+	defaultHook func(context.Context, int, *string) error
+	hooks       []func(context.Context, int, *string) error
 	history     []ResolverQueueAutoIndexJobForRepoFuncCall
 	mutex       sync.Mutex
 }
 
 // QueueAutoIndexJobForRepo delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockResolver) QueueAutoIndexJobForRepo(v0 context.Context, v1 int) error {
-	r0 := m.QueueAutoIndexJobForRepoFunc.nextHook()(v0, v1)
-	m.QueueAutoIndexJobForRepoFunc.appendCall(ResolverQueueAutoIndexJobForRepoFuncCall{v0, v1, r0})
+func (m *MockResolver) QueueAutoIndexJobForRepo(v0 context.Context, v1 int, v2 *string) error {
+	r0 := m.QueueAutoIndexJobForRepoFunc.nextHook()(v0, v1, v2)
+	m.QueueAutoIndexJobForRepoFunc.appendCall(ResolverQueueAutoIndexJobForRepoFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // QueueAutoIndexJobForRepo method of the parent MockResolver instance is
 // invoked and the hook queue is empty.
-func (f *ResolverQueueAutoIndexJobForRepoFunc) SetDefaultHook(hook func(context.Context, int) error) {
+func (f *ResolverQueueAutoIndexJobForRepoFunc) SetDefaultHook(hook func(context.Context, int, *string) error) {
 	f.defaultHook = hook
 }
 
@@ -1307,7 +1307,7 @@ func (f *ResolverQueueAutoIndexJobForRepoFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *ResolverQueueAutoIndexJobForRepoFunc) PushHook(hook func(context.Context, int) error) {
+func (f *ResolverQueueAutoIndexJobForRepoFunc) PushHook(hook func(context.Context, int, *string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1316,7 +1316,7 @@ func (f *ResolverQueueAutoIndexJobForRepoFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *ResolverQueueAutoIndexJobForRepoFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int) error {
+	f.SetDefaultHook(func(context.Context, int, *string) error {
 		return r0
 	})
 }
@@ -1324,12 +1324,12 @@ func (f *ResolverQueueAutoIndexJobForRepoFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *ResolverQueueAutoIndexJobForRepoFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int) error {
+	f.PushHook(func(context.Context, int, *string) error {
 		return r0
 	})
 }
 
-func (f *ResolverQueueAutoIndexJobForRepoFunc) nextHook() func(context.Context, int) error {
+func (f *ResolverQueueAutoIndexJobForRepoFunc) nextHook() func(context.Context, int, *string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1369,6 +1369,9 @@ type ResolverQueueAutoIndexJobForRepoFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -1377,7 +1380,7 @@ type ResolverQueueAutoIndexJobForRepoFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ResolverQueueAutoIndexJobForRepoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -31,7 +31,7 @@ type Resolver interface {
 	IndexConfiguration(ctx context.Context, repositoryID int) ([]byte, error)
 	UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, configuration string) error
 	CommitGraph(ctx context.Context, repositoryID int) (gql.CodeIntelligenceCommitGraphResolver, error)
-	QueueAutoIndexJobForRepo(ctx context.Context, repositoryID int) error
+	QueueAutoIndexJobForRepo(ctx context.Context, repositoryID int, rev *string) error
 	QueryResolver(ctx context.Context, args *gql.GitBlobLSIFDataArgs) (QueryResolver, error)
 }
 
@@ -151,8 +151,13 @@ func (r *resolver) CommitGraph(ctx context.Context, repositoryID int) (gql.CodeI
 	return NewCommitGraphResolver(stale, updatedAt), nil
 }
 
-func (r *resolver) QueueAutoIndexJobForRepo(ctx context.Context, repositoryID int) error {
-	return r.indexEnqueuer.ForceQueueIndexesForRepository(ctx, repositoryID)
+func (r *resolver) QueueAutoIndexJobForRepo(ctx context.Context, repositoryID int, rev *string) error {
+	revOrDefault := "HEAD"
+	if rev != nil {
+		revOrDefault = *rev
+	}
+
+	return r.indexEnqueuer.ForceQueueIndexesForRepository(ctx, repositoryID, revOrDefault)
 }
 
 const slowQueryResolverRequestThreshold = time.Second

--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -49,14 +49,14 @@ func NewIndexEnqueuer(
 // repository. If this repository and commit already has an index or upload record associated with it, this method
 // does nothing.
 func (s *IndexEnqueuer) QueueIndexesForRepository(ctx context.Context, repositoryID int) error {
-	return s.queueIndexForRepository(ctx, repositoryID, false)
+	return s.queueIndexForRepository(ctx, repositoryID, "HEAD", false)
 }
 
 // ForceQueueIndexesForRepository attempts to queue an index for the lastest commit on the default branch of the given
 // repository. If this repository and commit already has an index or upload record associated with it, a new index job
 // record will still be enqueued.
-func (s *IndexEnqueuer) ForceQueueIndexesForRepository(ctx context.Context, repositoryID int) error {
-	return s.queueIndexForRepository(ctx, repositoryID, true)
+func (s *IndexEnqueuer) ForceQueueIndexesForRepository(ctx context.Context, repositoryID int, rev string) error {
+	return s.queueIndexForRepository(ctx, repositoryID, rev, true)
 }
 
 // InferIndexConfiguration looks at the repository contents at the lastest commit on the default branch of the given
@@ -135,7 +135,7 @@ func (s *IndexEnqueuer) QueueIndexesForPackage(ctx context.Context, pkg semantic
 // If the force flag is false, then the presence of an upload or index record for this given repository and commit
 // will cause this method to no-op. Note that this is NOT a guarantee that there will never be any duplicate records
 // when the flag is false.
-func (s *IndexEnqueuer) queueIndexForRepository(ctx context.Context, repositoryID int, force bool) (err error) {
+func (s *IndexEnqueuer) queueIndexForRepository(ctx context.Context, repositoryID int, rev string, force bool) (err error) {
 	ctx, traceLog, endObservation := s.operations.QueueIndex.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),
@@ -143,10 +143,11 @@ func (s *IndexEnqueuer) queueIndexForRepository(ctx context.Context, repositoryI
 	})
 	defer endObservation(1, observation.Args{})
 
-	commit, ok, err := s.gitserverClient.Head(ctx, repositoryID)
-	if err != nil || !ok {
-		return errors.Wrap(err, "gitserver.Head")
+	commitID, err := s.gitserverClient.ResolveRevision(ctx, repositoryID, rev)
+	if err != nil {
+		return errors.Wrap(err, "gitserver.ResolveRevision")
 	}
+	commit := string(commitID)
 	traceLog(log.String("commit", commit))
 
 	return s.queueIndexForRepositoryAndCommit(ctx, repositoryID, commit, force, traceLog)

--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer_test.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer_test.go
@@ -65,8 +65,8 @@ func TestQueueIndexesForRepositoryInDatabase(t *testing.T) {
 	mockDBStore.GetIndexConfigurationByRepositoryIDFunc.SetDefaultReturn(indexConfiguration, true, nil)
 
 	mockGitserverClient := NewMockGitserverClient()
-	mockGitserverClient.HeadFunc.SetDefaultHook(func(ctx context.Context, repositoryID int) (string, bool, error) {
-		return fmt.Sprintf("c%d", repositoryID), true, nil
+	mockGitserverClient.ResolveRevisionFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, rev string) (api.CommitID, error) {
+		return api.CommitID(fmt.Sprintf("c%d", repositoryID)), nil
 	})
 
 	scheduler := NewIndexEnqueuer(mockDBStore, mockGitserverClient, nil, &testConfig, &observation.TestContext)
@@ -180,8 +180,8 @@ func TestQueueIndexesForRepositoryInRepository(t *testing.T) {
 	mockDBStore.GetRepositoriesWithIndexConfigurationFunc.SetDefaultReturn([]int{42}, nil)
 
 	mockGitserverClient := NewMockGitserverClient()
-	mockGitserverClient.HeadFunc.SetDefaultHook(func(ctx context.Context, repositoryID int) (string, bool, error) {
-		return fmt.Sprintf("c%d", repositoryID), true, nil
+	mockGitserverClient.ResolveRevisionFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, rev string) (api.CommitID, error) {
+		return api.CommitID(fmt.Sprintf("c%d", repositoryID)), nil
 	})
 	mockGitserverClient.FileExistsFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit, file string) (bool, error) {
 		return file == "sourcegraph.yaml", nil
@@ -264,8 +264,8 @@ func TestQueueIndexesForRepositoryInferred(t *testing.T) {
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 
 	mockGitserverClient := NewMockGitserverClient()
-	mockGitserverClient.HeadFunc.SetDefaultHook(func(ctx context.Context, repositoryID int) (string, bool, error) {
-		return fmt.Sprintf("c%d", repositoryID), true, nil
+	mockGitserverClient.ResolveRevisionFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, rev string) (api.CommitID, error) {
+		return api.CommitID(fmt.Sprintf("c%d", repositoryID)), nil
 	})
 	mockGitserverClient.ListFilesFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) ([]string, error) {
 		switch repositoryID {
@@ -329,8 +329,8 @@ func TestQueueIndexesForRepositoryInferredTooLarge(t *testing.T) {
 	}
 
 	mockGitserverClient := NewMockGitserverClient()
-	mockGitserverClient.HeadFunc.SetDefaultHook(func(ctx context.Context, repositoryID int) (string, bool, error) {
-		return fmt.Sprintf("c%d", repositoryID), true, nil
+	mockGitserverClient.ResolveRevisionFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, rev string) (api.CommitID, error) {
+		return api.CommitID(fmt.Sprintf("c%d", repositoryID)), nil
 	})
 	mockGitserverClient.ListFilesFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) ([]string, error) {
 		if repositoryID == 42 {


### PR DESCRIPTION
Add a way to pass a rev (default `HEAD`) down through the graphql resolvers.