### PR TITLE
web: Fix repo search match behavior

### DIFF
--- a/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
+++ b/client/web/src/insights/components/form/repositories-field/RepositoriesField.tsx
@@ -33,7 +33,6 @@ const RepositoriesField = forwardRef((props: RepositoryFieldProps, reference: Re
         caretPosition,
     })
     const { searchValue, suggestions } = useRepoSuggestions({
-        excludedItems: repositories,
         search,
         disable: !panel,
     })

--- a/client/web/src/insights/components/form/repositories-field/RepositoryField.tsx
+++ b/client/web/src/insights/components/form/repositories-field/RepositoryField.tsx
@@ -18,7 +18,6 @@ export const RepositoryField = forwardRef((props: RepositoryFieldProps, referenc
     const inputReference = useRef<HTMLInputElement>(null)
 
     const { searchValue, suggestions } = useRepoSuggestions({
-        excludedItems: [value],
         search: getSanitizedRepositories(value)[0],
     })
 

--- a/client/web/src/insights/components/form/repositories-field/hooks/use-repo-suggestions.ts
+++ b/client/web/src/insights/components/form/repositories-field/hooks/use-repo-suggestions.ts
@@ -4,13 +4,11 @@ import { useDebounce } from '@sourcegraph/wildcard/src'
 
 import { InsightsApiContext } from '../../../../core/backend/api-provider'
 import { RepositorySuggestion } from '../../../../core/backend/requests/fetch-repository-suggestions'
-import { useDistinctValue } from '../../../../hooks/use-distinct-value'
 import { memoizeAsync } from '../utils/memoize-async'
 
 interface UseRepoSuggestionsProps {
     search: string | null
     disable?: boolean
-    excludedItems?: string[]
 }
 
 interface UseRepoSuggestionsResult {
@@ -35,16 +33,11 @@ function useFetchSuggestions(): (search: string) => Promise<RepositorySuggestion
  * Provides list of repository suggestions.
  */
 export function useRepoSuggestions(props: UseRepoSuggestionsProps): UseRepoSuggestionsResult {
-    const { search, disable = false, excludedItems = [] } = props
+    const { search, disable = false } = props
 
     const [suggestions, setSuggestions] = useState<RepositorySuggestion[] | Error | undefined>([])
     const debouncedSearchTerm = useDebounce(search, 1000)
     const fetchSuggestions = useFetchSuggestions()
-
-    // To not trigger use effect with fetching each render call
-    // we compare prev and next value for excludedItems and return
-    // prev value if value wasn't changed
-    const distinctExcludedItems = useDistinctValue(excludedItems)
 
     useEffect(() => {
         if (disable || !debouncedSearchTerm) {
@@ -72,7 +65,7 @@ export function useRepoSuggestions(props: UseRepoSuggestionsProps): UseRepoSugge
         return () => {
             wasCanceled = true
         }
-    }, [distinctExcludedItems, fetchSuggestions, disable, debouncedSearchTerm])
+    }, [fetchSuggestions, disable, debouncedSearchTerm])
 
     return { searchValue: debouncedSearchTerm, suggestions }
 }

--- a/client/web/src/insights/components/form/repositories-field/hooks/use-repo-suggestions.ts
+++ b/client/web/src/insights/components/form/repositories-field/hooks/use-repo-suggestions.ts
@@ -60,7 +60,7 @@ export function useRepoSuggestions(props: UseRepoSuggestionsProps): UseRepoSugge
         fetchSuggestions(debouncedSearchTerm)
             .then(suggestions => {
                 if (!wasCanceled) {
-                    setSuggestions(suggestions.filter(suggestion => !distinctExcludedItems.includes(suggestion.name)))
+                    setSuggestions(suggestions)
                 }
             })
             .catch(error => {


### PR DESCRIPTION
Remove exact match filter to meet user expectations.

Note: This doesn't technically "select" the first option, _but_ it still works as intended. Personally I think this is the better option, but I'm open to adding more code to make it actually "select".

## Before

https://user-images.githubusercontent.com/1855233/128103998-41256a57-6739-4984-89fd-47e9f23a737b.mov 

## After

https://user-images.githubusercontent.com/1855233/128104014-63dd97a1-2522-4c67-9f72-99d2e0b87132.mov

Fixes #22610 