### PR TITLE
search: fix query intelligence hook

### DIFF
--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -15,7 +15,7 @@ import { SearchPatternType } from '../graphql-operations'
 import { fetchSuggestions } from './backend'
 import { LATEST_VERSION } from './results/StreamingSearchResults'
 import { StreamingSearchResultsList, StreamingSearchResultsListProps } from './results/StreamingSearchResultsList'
-import { SOURCEGRAPH_SEARCH, useQueryIntelligence, useQueryDiagnostics } from './useQueryIntelligence'
+import { useQueryIntelligence, useQueryDiagnostics } from './useQueryIntelligence'
 
 import { parseSearchURLQuery, parseSearchURLPatternType, SearchStreamingProps } from '.'
 
@@ -82,7 +82,7 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
         }, [patternType, props.location.search, streamSearch])
     )
 
-    useQueryIntelligence(fetchSuggestions, {
+    const sourcegraphSearchLanguageId = useQueryIntelligence(fetchSuggestions, {
         patternType,
         globbing,
         interpretComments: true,
@@ -128,7 +128,7 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                     </div>
                     <MonacoEditor
                         {...props}
-                        language={SOURCEGRAPH_SEARCH}
+                        language={sourcegraphSearchLanguageId}
                         options={options}
                         height={600}
                         editorWillMount={noop}

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -18,7 +18,7 @@ import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keybo
 import { observeResize } from '../../util/dom'
 import { fetchSuggestions } from '../backend'
 import { QueryChangeSource, QueryState } from '../helpers'
-import { SOURCEGRAPH_SEARCH, useQueryIntelligence, useQueryDiagnostics } from '../useQueryIntelligence'
+import { useQueryIntelligence, useQueryDiagnostics } from '../useQueryIntelligence'
 
 export interface MonacoQueryInputProps
     extends ThemeProps,
@@ -141,7 +141,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
         [selectedSearchContextSpec, versionContext]
     )
 
-    useQueryIntelligence(fetchSuggestionsWithContext, {
+    const sourcegraphSearchLanguageId = useQueryIntelligence(fetchSuggestionsWithContext, {
         patternType,
         globbing,
         interpretComments,
@@ -362,7 +362,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
         >
             <MonacoEditor
                 id="monaco-query-input"
-                language={SOURCEGRAPH_SEARCH}
+                language={sourcegraphSearchLanguageId}
                 value={queryState.query}
                 height={17}
                 isLightTheme={isLightTheme}

--- a/client/web/src/search/notebook/SearchNotebook.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.tsx
@@ -185,7 +185,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
         }
     }, [notebook, selectedBlockId, onMoveBlockSelection, setSelectedBlockId])
 
-    useQueryIntelligence(fetchSuggestions, {
+    const sourcegraphSearchLanguageId = useQueryIntelligence(fetchSuggestions, {
         patternType: SearchPatternType.literal,
         globbing: props.globbing,
         interpretComments: true,
@@ -232,6 +232,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
                                 {...props}
                                 {...block}
                                 {...blockCallbackProps}
+                                sourcegraphSearchLanguageId={sourcegraphSearchLanguageId}
                                 isReadOnly={isReadOnly}
                                 isSelected={selectedBlockId === block.id}
                                 isOtherBlockSelected={selectedBlockId !== null && selectedBlockId !== block.id}

--- a/client/web/src/search/notebook/SearchNotebookQueryBlock.story.tsx
+++ b/client/web/src/search/notebook/SearchNotebookQueryBlock.story.tsx
@@ -50,6 +50,7 @@ add('default', () => (
                 isReadOnly={false}
                 isOtherBlockSelected={false}
                 isMacPlatform={true}
+                sourcegraphSearchLanguageId="sourcegraphSearch"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
@@ -71,6 +72,7 @@ add('selected', () => (
                 isOtherBlockSelected={false}
                 isReadOnly={false}
                 isMacPlatform={true}
+                sourcegraphSearchLanguageId="sourcegraphSearch"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
@@ -92,6 +94,7 @@ add('read-only selected', () => (
                 isReadOnly={true}
                 isOtherBlockSelected={false}
                 isMacPlatform={true}
+                sourcegraphSearchLanguageId="sourcegraphSearch"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}

--- a/client/web/src/search/notebook/SearchNotebookQueryBlock.tsx
+++ b/client/web/src/search/notebook/SearchNotebookQueryBlock.tsx
@@ -16,7 +16,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { MonacoEditor } from '@sourcegraph/web/src/components/MonacoEditor'
 
 import { StreamingSearchResultsList } from '../results/StreamingSearchResultsList'
-import { SOURCEGRAPH_SEARCH, useQueryDiagnostics } from '../useQueryIntelligence'
+import { useQueryDiagnostics } from '../useQueryIntelligence'
 
 import blockStyles from './SearchNotebookBlock.module.scss'
 import { SearchNotebookBlockMenu } from './SearchNotebookBlockMenu'
@@ -35,6 +35,7 @@ interface SearchNotebookQueryBlockProps
         SettingsCascadeProps,
         TelemetryProps {
     isMacPlatform: boolean
+    sourcegraphSearchLanguageId: string
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
@@ -48,6 +49,7 @@ export const SearchNotebookQueryBlock: React.FunctionComponent<SearchNotebookQue
     isSelected,
     isOtherBlockSelected,
     isMacPlatform,
+    sourcegraphSearchLanguageId,
     fetchHighlightedFileLineRanges,
     onRunBlock,
     onSelectBlock,
@@ -132,7 +134,7 @@ export const SearchNotebookQueryBlock: React.FunctionComponent<SearchNotebookQue
                     )}
                 >
                     <MonacoEditor
-                        language={SOURCEGRAPH_SEARCH}
+                        language={sourcegraphSearchLanguageId}
                         value={input}
                         height="auto"
                         isLightTheme={isLightTheme}

--- a/client/web/src/search/useQueryIntelligence.ts
+++ b/client/web/src/search/useQueryIntelligence.ts
@@ -27,7 +27,7 @@ export function useQueryIntelligence(
     // language for each editor and register the providers for the new language. This ensures that there is no cross-contamination
     // between different editors using the query intelligence hook. The main issue with using a single language id
     // is when a component using the hook gets unmounted. When navigating between pages that both contain a search box (homepage -> search results page),
-    // the unmounted useEffect hook below would trigger cleanup after the search results hook already registered it's providers. This effectively
+    // the unmounted useEffect hook below would trigger cleanup after the search results hook already registered its providers. This effectively
     // removes query intelligence from all editors.
     const sourcegraphSearchLanguageId = useMemo(() => `${SOURCEGRAPH_SEARCH}-${uuid.v4()}`, [])
 

--- a/client/web/src/search/useQueryIntelligence.ts
+++ b/client/web/src/search/useQueryIntelligence.ts
@@ -1,6 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { useEffect, useMemo } from 'react'
 import { Observable } from 'rxjs'
+import * as uuid from 'uuid'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql/schema'
 import { getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
@@ -8,7 +9,7 @@ import { getProviders } from '@sourcegraph/shared/src/search/query/providers'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { SearchSuggestion } from '@sourcegraph/shared/src/search/suggestions'
 
-export const SOURCEGRAPH_SEARCH = 'sourcegraphSearch' as const
+const SOURCEGRAPH_SEARCH = 'sourcegraphSearch' as const
 
 /**
  * Adds code intelligence for the Sourcegraph search syntax to Monaco.
@@ -21,7 +22,15 @@ export function useQueryIntelligence(
         interpretComments?: boolean
         isSourcegraphDotCom?: boolean
     }
-): void {
+): string {
+    // Due to the global nature of Monaco (tokens, hover, completion) providers we have to create a unique
+    // language for each editor and register the providers for the new language. This ensures that there is no cross-contamination
+    // between different editors using the query intelligence hook. The main issue with using a single language id
+    // is when a component using the hook gets unmounted. When navigating between pages that both contain a search box (homepage -> search results page),
+    // the unmounted useEffect hook below would trigger cleanup after the search results hook already registered it's providers. This effectively
+    // removes query intelligence from all editors.
+    const sourcegraphSearchLanguageId = useMemo(() => `${SOURCEGRAPH_SEARCH}-${uuid.v4()}`, [])
+
     const memoizedOptions = useMemo(
         () => ({
             patternType: options.patternType,
@@ -33,22 +42,26 @@ export function useQueryIntelligence(
     )
 
     useEffect(() => {
-        // Register language ID
-        Monaco.languages.register({ id: SOURCEGRAPH_SEARCH })
+        if (Monaco.languages.getEncodedLanguageId(sourcegraphSearchLanguageId) === 0) {
+            // Register language ID
+            Monaco.languages.register({ id: sourcegraphSearchLanguageId })
+        }
 
         // Register providers
         const providers = getProviders(fetchSuggestions, memoizedOptions)
         const disposables = [
-            Monaco.languages.setTokensProvider(SOURCEGRAPH_SEARCH, providers.tokens),
-            Monaco.languages.registerHoverProvider(SOURCEGRAPH_SEARCH, providers.hover),
-            Monaco.languages.registerCompletionItemProvider(SOURCEGRAPH_SEARCH, providers.completion),
+            Monaco.languages.setTokensProvider(sourcegraphSearchLanguageId, providers.tokens),
+            Monaco.languages.registerHoverProvider(sourcegraphSearchLanguageId, providers.hover),
+            Monaco.languages.registerCompletionItemProvider(sourcegraphSearchLanguageId, providers.completion),
         ]
         return () => {
             for (const disposable of disposables) {
                 disposable.dispose()
             }
         }
-    }, [fetchSuggestions, memoizedOptions])
+    }, [fetchSuggestions, sourcegraphSearchLanguageId, memoizedOptions])
+
+    return sourcegraphSearchLanguageId
 }
 
 /**


### PR DESCRIPTION
Due to the global nature of Monaco (tokens, hover, completion) providers we have to create a unique
language for each editor and register the providers for the new language. This ensures that there is no cross-contamination
between different editors using the query intelligence hook. The main issue with using a single language id
is when a component using the hook gets unmounted. When navigating between pages that both contain a search box (homepage -> search results page), the unmounted useEffect hook below would trigger cleanup after the search results hook already registered its providers. This effectively removes query intelligence from all editors.

Fixes #23539