### PR TITLE
Don't expire batch specs if batch spec execution points to them

### DIFF
--- a/enterprise/internal/batches/store/batch_spec_execution.go
+++ b/enterprise/internal/batches/store/batch_spec_execution.go
@@ -41,6 +41,7 @@ var BatchSpecExecutionColumns = []*sqlf.Query{
 var batchSpecExecutionInsertColumns = []*sqlf.Query{
 	sqlf.Sprintf("rand_id"),
 	sqlf.Sprintf("batch_spec"),
+	sqlf.Sprintf("batch_spec_id"),
 	sqlf.Sprintf("user_id"),
 	sqlf.Sprintf("namespace_user_id"),
 	sqlf.Sprintf("namespace_org_id"),
@@ -71,7 +72,7 @@ func (s *Store) CreateBatchSpecExecution(ctx context.Context, b *btypes.BatchSpe
 var createBatchSpecExecutionQueryFmtstr = `
 -- source: enterprise/internal/batches/store/batch_spec_executions.go:CreateBatchSpecExecution
 INSERT INTO batch_spec_executions (%s)
-VALUES (%s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING %s`
 
 func createBatchSpecExecutionQuery(c *btypes.BatchSpecExecution) (*sqlf.Query, error) {
@@ -87,6 +88,7 @@ func createBatchSpecExecutionQuery(c *btypes.BatchSpecExecution) (*sqlf.Query, e
 		sqlf.Join(batchSpecExecutionInsertColumns, ", "),
 		c.RandID,
 		c.BatchSpec,
+		nullInt64Column(c.BatchSpecID),
 		c.UserID,
 		nullInt32Column(c.NamespaceUserID),
 		nullInt32Column(c.NamespaceOrgID),

--- a/enterprise/internal/batches/store/batch_spec_execution_test.go
+++ b/enterprise/internal/batches/store/batch_spec_execution_test.go
@@ -21,13 +21,14 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 			BatchSpec:       testBatchSpec,
 			UserID:          int32(i + 123),
 			NamespaceUserID: int32(i + 345),
+			BatchSpecID:     int64(i + 567),
 		}
 
 		execs = append(execs, c)
 	}
 
 	t.Run("Create", func(t *testing.T) {
-		for i, exec := range execs {
+		for _, exec := range execs {
 			if err := s.CreateBatchSpecExecution(ctx, exec); err != nil {
 				t.Fatal(err)
 			}
@@ -39,9 +40,10 @@ func testStoreChangesetSpecExecutions(t *testing.T, ctx context.Context, s *Stor
 				CreatedAt:       clock.Now(),
 				UpdatedAt:       clock.Now(),
 				State:           btypes.BatchSpecExecutionStateQueued,
-				BatchSpec:       testBatchSpec,
-				UserID:          int32(i + 123),
-				NamespaceUserID: int32(i + 345),
+				BatchSpec:       have.BatchSpec,
+				UserID:          have.UserID,
+				NamespaceUserID: have.NamespaceUserID,
+				BatchSpecID:     have.BatchSpecID,
 			}
 
 			if have.ID == 0 {

--- a/enterprise/internal/batches/store/batch_specs.go
+++ b/enterprise/internal/batches/store/batch_specs.go
@@ -368,12 +368,14 @@ DELETE FROM
   batch_specs
 WHERE
   created_at < %s
-AND
-NOT EXISTS (
+AND NOT EXISTS (
   SELECT 1 FROM batch_changes WHERE batch_spec_id = batch_specs.id
 )
 AND NOT EXISTS (
   SELECT 1 FROM changeset_specs WHERE batch_spec_id = batch_specs.id
+)
+AND NOT EXISTS (
+  SELECT 1 FROM batch_spec_executions WHERE batch_spec_id = batch_specs.id
 );
 `
 

--- a/enterprise/internal/batches/store/batch_specs_test.go
+++ b/enterprise/internal/batches/store/batch_specs_test.go
@@ -287,19 +287,26 @@ func testStoreBatchSpecs(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		overTTL := clock.Now().Add(-btypes.BatchSpecTTL - 1*time.Minute)
 
 		tests := []struct {
-			createdAt         time.Time
-			hasBatchChange    bool
-			hasChangesetSpecs bool
-			wantDeleted       bool
+			createdAt             time.Time
+			hasBatchChange        bool
+			hasChangesetSpecs     bool
+			hasBatchSpecExecution bool
+			wantDeleted           bool
 		}{
-			{hasBatchChange: false, hasChangesetSpecs: false, createdAt: underTTL, wantDeleted: false},
-			{hasBatchChange: false, hasChangesetSpecs: false, createdAt: overTTL, wantDeleted: true},
+			{createdAt: underTTL, wantDeleted: false},
+			{createdAt: overTTL, wantDeleted: true},
 
-			{hasBatchChange: false, hasChangesetSpecs: true, createdAt: underTTL, wantDeleted: false},
-			{hasBatchChange: false, hasChangesetSpecs: true, createdAt: overTTL, wantDeleted: false},
+			{hasChangesetSpecs: true, createdAt: underTTL, wantDeleted: false},
+			{hasChangesetSpecs: true, createdAt: overTTL, wantDeleted: false},
 
 			{hasBatchChange: true, hasChangesetSpecs: true, createdAt: underTTL, wantDeleted: false},
 			{hasBatchChange: true, hasChangesetSpecs: true, createdAt: overTTL, wantDeleted: false},
+
+			{hasBatchSpecExecution: true, createdAt: underTTL, wantDeleted: false},
+			{hasBatchSpecExecution: true, createdAt: overTTL, wantDeleted: false},
+
+			{hasBatchChange: true, hasBatchSpecExecution: true, hasChangesetSpecs: true, createdAt: underTTL, wantDeleted: false},
+			{hasBatchChange: true, hasBatchSpecExecution: true, hasChangesetSpecs: true, createdAt: overTTL, wantDeleted: false},
 		}
 
 		for _, tc := range tests {
@@ -333,6 +340,16 @@ func testStoreBatchSpecs(t *testing.T, ctx context.Context, s *Store, clock ct.C
 					BatchSpecID: batchSpec.ID,
 				}
 				if err := s.CreateChangesetSpec(ctx, changesetSpec); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if tc.hasBatchSpecExecution {
+				batchSpecExecution := &btypes.BatchSpecExecution{
+					NamespaceUserID: 1,
+					BatchSpecID:     batchSpec.ID,
+				}
+				if err := s.CreateBatchSpecExecution(ctx, batchSpecExecution); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -105,7 +105,7 @@ Indexes:
 Check constraints:
     "batch_spec_executions_has_1_namespace" CHECK ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))
 Foreign-key constraints:
-    "batch_spec_executions_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id)
+    "batch_spec_executions_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) DEFERRABLE
     "batch_spec_executions_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) DEFERRABLE
     "batch_spec_executions_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) DEFERRABLE
     "batch_spec_executions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
@@ -134,7 +134,7 @@ Foreign-key constraints:
     "batch_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
 Referenced by:
     TABLE "batch_changes" CONSTRAINT "batch_changes_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) DEFERRABLE
-    TABLE "batch_spec_executions" CONSTRAINT "batch_spec_executions_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id)
+    TABLE "batch_spec_executions" CONSTRAINT "batch_spec_executions_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) DEFERRABLE
     TABLE "changeset_specs" CONSTRAINT "changeset_specs_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) DEFERRABLE
 
 ```

--- a/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.down.sql
+++ b/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.down.sql
@@ -1,0 +1,6 @@
+
+BEGIN;
+
+ALTER TABLE IF EXISTS batch_spec_executions ALTER CONSTRAINT batch_spec_executions_batch_spec_id_fkey NOT DEFERRABLE;
+
+COMMIT;

--- a/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.up.sql
+++ b/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.up.sql
@@ -1,0 +1,6 @@
+
+BEGIN;
+
+ALTER TABLE IF EXISTS batch_spec_executions ALTER CONSTRAINT batch_spec_executions_batch_spec_id_fkey DEFERRABLE;
+
+COMMIT;


### PR DESCRIPTION
This fixes #23502 but not in the way I originally thought I would fix
it.

My first idea was to make the `DELETE` cascade and also delete the
`batch_spec_execution` when the `batch_spec` is deleted.

But then I was unsure whether that is what we want. Since we'll have a
list view of executions (which we don't have for batch specs) I'm not
sure whether we want to delete those.

So I'm deferring on that and instead changed the code to not delete
batch specs if they're attached to a batch spec execution.

I think that's fine for now and then we can think about how we want to
clean up batch spec executions.

I also changed `CreateBatchSpecExecution` to set `batch_spec_id` (if
set) because that cost me 30min of debugging my tests.

And in order to get this working in the tests I had to make the foreign
key constraint deferrable. That's what the migration is for.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
