### PR TITLE
sg: capture output for error reporting even if IngoreStd*

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -112,11 +112,13 @@ func startCmd(ctx context.Context, dir string, cmd Command, globalEnv map[string
 	logger := newCmdLogger(cmd.Name, stdout.Out)
 	if cmd.IgnoreStdout {
 		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "Ignoring stdout of %s", cmd.Name))
+		sc.Cmd.Stdout = sc.stdoutBuf
 	} else {
 		sc.Cmd.Stdout = io.MultiWriter(logger, sc.stdoutBuf)
 	}
 	if cmd.IgnoreStderr {
 		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "Ignoring stderr of %s", cmd.Name))
+		sc.Cmd.Stderr = sc.stderrBuf
 	} else {
 		sc.Cmd.Stderr = io.MultiWriter(logger, sc.stderrBuf)
 	}


### PR DESCRIPTION
This fixes the issue where a command fails to start but the reported
output is empty.

Now if, say, caddy fails to start, we don't print its output to
stdout/stderr but print the error message.

Before the output would look like this:

![before](https://user-images.githubusercontent.com/1185253/128163177-c5ed7b2f-9071-400b-a794-aaa42b410a45.png)


With this change it looks like this:

![after](https://user-images.githubusercontent.com/1185253/128163206-c329d523-045e-4207-bed7-d3dfb2b9103d.png)


Much more helpful.