### PR TITLE
Move user check earlier

### DIFF
--- a/internal/search/repos/repo_groups.go
+++ b/internal/search/repos/repo_groups.go
@@ -50,14 +50,14 @@ func ResolveRepoGroups(ctx context.Context, settings *schema.Settings) (groups m
 
 	groups = ResolveRepoGroupsFromSettings(settings)
 
-	if mode, err := database.GlobalUsers.CurrentUserAllowedExternalServices(ctx); err != nil {
-		return groups, err
-	} else if mode == conf.ExternalServiceModeDisabled {
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
 		return groups, nil
 	}
 
-	a := actor.FromContext(ctx)
-	if !a.IsAuthenticated() {
+	if mode, err := database.GlobalUsers.CurrentUserAllowedExternalServices(ctx); err != nil {
+		return groups, err
+	} else if mode == conf.ExternalServiceModeDisabled {
 		return groups, nil
 	}
 


### PR DESCRIPTION
We can return early as soon as we know we don't have an authenticated
user
