### PR TITLE
Improve quickstart dependencies install script

### DIFF
--- a/doc/dev/getting-started/quickstart_1_install_dependencies.md
+++ b/doc/dev/getting-started/quickstart_1_install_dependencies.md
@@ -159,21 +159,27 @@ The following are two recommendations for installing these dependencies:
     ```
     sudo apt install -y make git-all libpcre3-dev libsqlite3-dev pkg-config golang-go musl-tools docker-ce docker-ce-cli containerd.io yarn jq libnss3-tools
 
-    # (without docker) install PostgreSQL and/or Redis if you don't want to run them as docker containers
+    # (without docker) Install PostgreSQL and/or Redis if you don't want to run them as docker containers
     sudo apt install -y redis-server
     sudo apt install -y postgresql postgresql-contrib
 
-    # install golang-migrate (you must rename the extracted binary to `golang-migrate` and move the binary into your $PATH)
+    # Install golang-migrate
     curl -L https://github.com/golang-migrate/migrate/releases/download/v4.7.0/migrate.linux-amd64.tar.gz | tar xvz
+
+    # The extracted binary must be in your $PATH available as `golang-migrate`.
+    # Here's how you'd move it to `/usr/local/bin` (which is most likely in your `$PATH`):
     chmod +x migrate.linux-amd64
     mv migrate.linux-amd64 /usr/local/bin/golang-migrate
 
-    # install comby (you must rename the extracted binary to `comby` and move the binary into your $PATH)
+    # Install comby
     curl -L https://github.com/comby-tools/comby/releases/download/0.11.3/comby-0.11.3-x86_64-linux.tar.gz | tar xvz
+
+    # The extracted binary must be in your $PATH available as `comby`.
+    # Here's how you'd move it to `/usr/local/bin` (which is most likely in your `$PATH`):
     chmod +x comby-*-linux
     mv comby-*-linux /usr/local/bin/comby
 
-    # install watchman (you must put the binary and shared libraries on your $PATH and $LD_LIBRARY_PATH)
+    # Install watchman (you must put the binary and shared libraries on your $PATH and $LD_LIBRARY_PATH)
     curl -LO https://github.com/facebook/watchman/releases/download/v2020.07.13.00/watchman-v2020.07.13.00-linux.zip
     unzip watchman-*-linux.zip
     sudo mkdir -p /usr/local/var/run/watchman
@@ -184,12 +190,12 @@ The following are two recommendations for installing these dependencies:
     # On Linux, you may need to run the following in addition:
     watchman watch <path to sourcegraph repository>
 
-    # nvm (to manage Node.js)
+    # Install nvm (to manage Node.js)
     NVM_VERSION="$(curl https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name)"
     curl -L https://raw.githubusercontent.com/nvm-sh/nvm/"$NVM_VERSION"/install.sh -o install-nvm.sh
     sh install-nvm.sh
 
-    # in repo dir: install current recommendend version of Node JS
+    # In sourcegraph repository directory: install current recommendend version of Node JS
     nvm install
     ```
 

--- a/doc/dev/getting-started/quickstart_1_install_dependencies.md
+++ b/doc/dev/getting-started/quickstart_1_install_dependencies.md
@@ -165,16 +165,20 @@ The following are two recommendations for installing these dependencies:
 
     # install golang-migrate (you must rename the extracted binary to `golang-migrate` and move the binary into your $PATH)
     curl -L https://github.com/golang-migrate/migrate/releases/download/v4.7.0/migrate.linux-amd64.tar.gz | tar xvz
+    chmod +x migrate.linux-amd64
+    mv migrate.linux-amd64 /usr/local/bin/golang-migrate
 
     # install comby (you must rename the extracted binary to `comby` and move the binary into your $PATH)
     curl -L https://github.com/comby-tools/comby/releases/download/0.11.3/comby-0.11.3-x86_64-linux.tar.gz | tar xvz
+    chmod +x comby-*-linux
+    mv comby-*-linux /usr/local/bin/comby
 
     # install watchman (you must put the binary and shared libraries on your $PATH and $LD_LIBRARY_PATH)
     curl -LO https://github.com/facebook/watchman/releases/download/v2020.07.13.00/watchman-v2020.07.13.00-linux.zip
     unzip watchman-*-linux.zip
-    sudo mkdir -p /usr/local/{bin,lib} /usr/local/var/run/watchman
-    sudo cp bin/* /usr/local/bin
-    sudo cp lib/* /usr/local/lib
+    sudo mkdir -p /usr/local/var/run/watchman
+    sudo cp watchman-*-linux/bin/* /usr/local/bin
+    sudo cp watchman-*-linux/lib/* /usr/local/lib
     sudo chmod 755 /usr/local/bin/watchman
     sudo chmod 2777 /usr/local/var/run/watchman
     # On Linux, you may need to run the following in addition:


### PR DESCRIPTION
### Description

This PR adds a few minor changes to quick start dependencies installation script:

1. It adds convenience commands to move `golang-migrate` and `comby` into `/usr/local/bin`
2. It fixes `cp` commands used to move `watchman` binary and libraries into `/usr/local/{bin, lib}` that were broken.
3. It removes the command that creates `/usr/local/{bin,lib}` as these directories should be always available on a fresh Ubuntu installation (including `ubuntu:latest` Docker container).