### PR TITLE
Update code docs for batch changes code after refactor

### DIFF
--- a/doc/dev/background-information/batch_changes/index.md
+++ b/doc/dev/background-information/batch_changes/index.md
@@ -92,7 +92,7 @@ The following is a list of Go packages in the [`sourcegraph/sourcegraph`](https:
     Type definitions of common `batches` types, such as `BatchChange`, `BatchSpec`, `Changeset`, etc. A few helper functions and methods, but no real business logic.
 - `enterprise/internal/batches`:
 
-    The hook `InitBackgroundJobs` to inject Batch Changes code into `enterprise/repo-updater`. This is the "glue" in "glue code".
+    The hook `InitBackgroundJobs` injects Batch Changes code into `enterprise/repo-updater`. This is the "glue" in "glue code".
 - `enterprise/internal/batches/background`
 
     Another bit of glue code that starts background goroutines: the changeset reconciler, the stuck-reconciler resetter, the old-changeset-spec expirer.

--- a/doc/dev/background-information/batch_changes/index.md
+++ b/doc/dev/background-information/batch_changes/index.md
@@ -49,10 +49,10 @@ When you then click the "Preview the batch change" link that `src-cli` printed, 
 1. Once you hit the "Apply spec" button, the component [uses the `applyBatchChange`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/backend.ts#L140-L159) to apply the batch spec and create a batch change.
 1. You're then redirected to the [`BatchChangeDetailsPage` component](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx#L65) that shows you you're newly-created batch change.
 
-In the backend, all Batch Changes related GraphQL queries and mutations start in the [`Resolver` of the `batches/resolver` package](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/resolvers/resolver.go):
+In the backend, all Batch Changes related GraphQL queries and mutations start in the [`Resolver` package](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go):
 
-1. The [`CreateChangesetSpec`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/resolvers/resolver.go#L461) and [`CreateBatchSpec`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/resolvers/resolver.go#L401) mutations that `src-cli` called to create the changeset and batch specs are defined here.
-1. When you clicked "Apply Spec" the [`ApplyBatchChange` resolver](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/resolvers/resolver.go#L349) was executed to create the batch change.
+1. The [`CreateChangesetSpec`](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L545) and [`CreateBatchSpec`](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L489) mutations that `src-cli` called to create the changeset and batch specs are defined here.
+1. When you clicked "Apply Spec" the [`ApplyBatchChange` resolver](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L404) was executed to create the batch change.
 1. Most of that doesn't happen in the resolver layer, but in the service layer: [here is the `(*Service).ApplyBatchChange` method](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/service/service_apply_batch_change.go#L48:19) that talks to the database to create an entry in the `batch_changes` table.
 1. The most important thing that happens in `(*Service).ApplyBatchChange` is that [it calls the `rewirer`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/service/service_apply_batch_change.go#L119-L135) to wire the entries in the `changesets` table to the correct `changeset_specs`.
 1. Once that is done, the `changesets` are created or updated to point to the new `changeset_specs` that you created with `src-cli`.
@@ -92,7 +92,7 @@ The following is a list of Go packages in the [`sourcegraph/sourcegraph`](https:
     Type definitions of common `batches` types, such as `BatchChange`, `BatchSpec`, `Changeset`, etc. A few helper functions and methods, but no real business logic.
 - `enterprise/internal/batches`:
 
-    The two hooks, `InitBackgroundJobs` and `InitFrontend`, to inject batch changes code into `enterprise/{repo-updater,frontend}`. This is the "glue" in "glue code".
+    The hook `InitBackgroundJobs` to inject Batch Changes code into `enterprise/repo-updater`. This is the "glue" in "glue code".
 - `enterprise/internal/batches/background`
 
     Another bit of glue code that starts background goroutines: the changeset reconciler, the stuck-reconciler resetter, the old-changeset-spec expirer.
@@ -108,10 +108,10 @@ The following is a list of Go packages in the [`sourcegraph/sourcegraph`](https:
 - `enterprise/internal/batches/search/syntax`:
 
     The old Sourcegraph-search-query parser we inherited from the search team a week or two back (the plan is _not_ to keep it, but switch to the new one when we have time)
-- `enterprise/internal/batches/resolvers`:
+- `enterprise/cmd/frontend/internal/batches/resolvers`:
 
-    The GraphQL resolvers that are injected into the `enterprise/frontend` by the aforementioned `InitFrontend`. They mostly concern themselves with input/argument parsing/validation, (bulk-)reading (and paginating) from the database via the `batches/store`, but delegate most business logic to `batches/service`.
-- `enterprise/internal/batches/resolvers/apitest`:
+    The GraphQL resolvers that are injected into the `enterprise/frontend` in `enterprise/cmd/frontend/internal/batches/init.go`. They mostly concern themselves with input/argument parsing/validation, (bulk-)reading (and paginating) from the database via the `batches/store`, but delegate most business logic to `batches/service`.
+- `enterprise/cmd/frontend/internal/batches/resolvers/apitest`:
 
     A package that helps with testing the resolvers by defining types that match the GraphQL schema.
 - `enterprise/internal/batches/testing`:
@@ -126,7 +126,7 @@ The following is a list of Go packages in the [`sourcegraph/sourcegraph`](https:
 - `enterprise/internal/batches/service`:
 
     This is what's often called the "service layer" in web architectures and contains a lot of the business logic: creating a batch change and validating whether the user can create one, applying new batch specs, calling the `rewirer`, deleting batch changes, closing batch changes, etc.
-- `enterprise/internal/batches/webhooks`:
+- `enterprise/cmd/frontend/internal/batches/webhooks`:
 
     These `webhooks` endpoints are injected by `InitFrontend` into the `frontend` and implement the `cmd/frontend/webhooks` interfaces.
 - `enterprise/internal/batches/store`:


### PR DESCRIPTION
Follow up PR to adjust docs after moving the resolver layer into the frontend cmd directory. 