### PR TITLE
Code Insights: Fix chart Percy screenshot tests 

### DIFF
--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -37,6 +37,8 @@ describe('[VISUAL] Code insights page', () => {
     afterEach(() => testContext?.dispose())
 
     async function takeChartSnapshot(name: string): Promise<void> {
+        // Move mouse cursor away from charts to avoid chart tooltip appearance
+        await driver.page.mouse.move(0,0)
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
         // Due to autosize of chart we have to wait 1s that window-resize be able
         // render chart with container size.


### PR DESCRIPTION
Currently, we have flaky code insights chart screenshot tests. And because of that, we have a lot of false-positive Percy failed pipelines (see screenshot below)

<img width="420" alt="Screenshot 2021-08-04 at 16 11 21" src="https://user-images.githubusercontent.com/18492575/128186846-3194e15c-dc3a-43a9-833f-34d1ddb7b41f.png">

My guess is that flakiness comes from the mouse position (perhaps the initial position is the viewport center) and then insight grid animation is happening and this may trigger tooltip appearance. A possible fix for it is to set mouse position for the visual screenshot tests of the insight grid explicitly.

