### PR TITLE
sg: Better looking errors

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -125,12 +125,17 @@ func printCmdError(out *output.Output, cmdName string, err error) {
 		cmdOut = e.output
 	case runErr:
 		message = "Failed to run " + cmdName
-		cmdOut = e.stderr
+		cmdOut = fmt.Sprintf("Exit code: %d\n\n", e.exitCode)
 
-		formattedStdout := "\t" + strings.Join(strings.Split(e.stdout, "\n"), "\n\t")
-		formattedStderr := "\t" + strings.Join(strings.Split(e.stderr, "\n"), "\n\t")
+		if len(strings.TrimSpace(e.stdout)) > 0 {
+			formattedStdout := "\t" + strings.Join(strings.Split(e.stdout, "\n"), "\n\t")
+			cmdOut += fmt.Sprintf("Standard out:\n%s\n", formattedStdout)
+		}
 
-		cmdOut = fmt.Sprintf("Exit code: %d\n\nStandard out:\n%s\nStandard err:\n%s\n", e.exitCode, formattedStdout, formattedStderr)
+		if len(strings.TrimSpace(e.stderr)) > 0 {
+			formattedStderr := "\t" + strings.Join(strings.Split(e.stderr, "\n"), "\n\t")
+			cmdOut += fmt.Sprintf("Standard err:\n%s\n", formattedStderr)
+		}
 
 	default:
 		message = fmt.Sprintf("Failed to run %s: %s", cmdName, err)


### PR DESCRIPTION
No need to print `Standard out: ` when there was nothing on stdout.