### PR TITLE
usagestats: Reinstate argument field in BigQuery events, add allowlist for events with public arguments

### DIFF
--- a/internal/usagestats/bigquery_event_argument_allowlist.go
+++ b/internal/usagestats/bigquery_event_argument_allowlist.go
@@ -1,0 +1,41 @@
+package usagestats
+
+// bigqueryEventsWithArgumentsAllowlist contains the event names of events
+// that have arguments (event properties) that contain *only* public data. If you have an event log
+// that has attached event properties, and you want the event properties data sent to our BigQuery
+// instance for Cloud data, the event name must be added to this list.
+//
+// 🚨 PRIVACY: Do NOT add an event to this list if the event properties contain any explicitly or
+// potentially private data, including but not limited to repository names, file names, search queries,
+// and clone URLs.
+var bigqueryEventsWithArgumentsAllowlist map[string]string = map[string]string{
+	"ExtensionToggled":          "ExtensionToggled",
+	"ExternalAuthSignupClicked": "ExternalAuthSignupClicked",
+	"DynamicFilterClicked":      "DynamicFilterClicked",
+	"InsightHover":              "InsightHover",
+	"InsightUICustomization":    "InsightUICustomization",
+	"InsightDataPointClick":     "InsightDataPointClick",
+	"InsightsGroupedCount":      "InsightsGroupedCount",
+	"InsightGroupedStepSizes":   "InsightGroupedStepSizes",
+	"InsightRemoval":            "InsightRemoval",
+	"InsightAddition":           "InsightAddition",
+	"InsightEdit":               "InsightEdit",
+	// RepogroupPageRepoLinkClicked passes the repo_name, but these are all public repos defined by Sourcegraph.
+	// If we start allowing Cloud users to create private repogroups, we must remove this from the allowlist.
+	"RepogroupPageRepoLinkClicked":          "RepogroupPageRepoLinkClicked",
+	"CloseOnboardingTourClicked":            "CloseOnboardingTourClicked",
+	"SearchNotebookRunBlock":                "SearchNotebookRunBlock",
+	"SearchNotebookAddBlock":                "SearchNotebookAddBlock",
+	"SearchNotebookMoveBlock":               "SearchNotebookMoveBlock",
+	"SearchNotebookDuplicateBlock":          "SearchNotebookDuplicateBlock",
+	"RecentFilesPanelLoaded":                "RecentFilesPanelLoaded",
+	"RecentSearchesPanelLoaded":             "RecentSearchesPanelLoaded",
+	"RepositoriesPanelLoaded":               "RepositoriesPanelLoaded",
+	"SavedSearchesPanelLoaded":              "SavedSearchesPanelLoaded",
+	"SavedSearchesPanelCreateButtonClicked": "SavedSearchesPanelCreateButtonClicked",
+	"SavedQueriesToggleCreating":            "SavedQueriesToggleCreating",
+	"search.latencies.frontend.code-load":   "search.latencies.frontend.code-load",
+	"SearchResultsFetch":                    "SearchResultsFetch",
+	"SearchResultsFetchFailed":              "SearchResultsFetchFailed",
+	"SurveyButtonClicked":                   "SurveyButtonClicked",
+}

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -114,6 +114,8 @@ func publishSourcegraphDotComEvent(args Event) error {
 	}
 
 	if _, ok := bigqueryEventsWithArgumentsAllowlist[args.EventName]; ok {
+		// 🚨 PRIVACY: Only include arguments for events that are on the BigQuery allowlist
+		// to ensure no private data is sent to BigQuery.
 		arguments := string(args.Argument)
 		event.PublicArguments = &arguments
 	}

--- a/internal/usagestats/event_handlers_test.go
+++ b/internal/usagestats/event_handlers_test.go
@@ -1,0 +1,94 @@
+package usagestats
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCreateBigQueryEvent(t *testing.T) {
+	testUrl := "https://sourcegraph.com/test"
+	event := Event{
+		EventName:      "ExtensionToggled",
+		UserID:         1,
+		UserCookieID:   "abcd",
+		FirstSourceURL: &testUrl,
+		URL:            "https://sourcegraph.com/extensions",
+		Source:         "test",
+		FeatureFlags:   map[string]bool{},
+		CohortID:       nil,
+		Referrer:       &testUrl,
+		Argument:       json.RawMessage("\"extension_id\":\"sourcegraph/codecov\""),
+	}
+
+	got, err := createBigQueryEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2021, 1, 28, 0, 0, 0, 0, time.UTC)
+	mockTimeNow(now)
+	argumentField := "\"extension_id\":\"sourcegraph/codecov\""
+	want := &bigQueryEvent{
+		EventName:       "ExtensionToggled",
+		UserID:          1,
+		AnonymousUserID: "abcd",
+		FirstSourceURL:  testUrl,
+		Source:          "test",
+		Timestamp:       time.Now().UTC().Format(time.RFC3339),
+		FeatureFlags:    "{}",
+		CohortID:        nil,
+		Version:         "0.0.0+dev",
+		Referrer:        testUrl,
+		PublicArguments: &argumentField,
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
+
+}
+func TestCreateBigQueryEvent_PrivateEvent(t *testing.T) {
+	testUrl := "https://sourcegraph.com/test"
+	now := time.Date(2021, 1, 28, 0, 0, 0, 0, time.UTC)
+	mockTimeNow(now)
+	privateArgumentField := "\"code_search\": { \"query_data\": { \"query\": \"test\", \"combined\": \"something private\", \"empty\": \"false\"}"
+	eventWithPrivateArgs := Event{
+		EventName:      "SearchResultsFetched",
+		UserID:         1,
+		UserCookieID:   "abcd",
+		FirstSourceURL: &testUrl,
+		URL:            "https://sourcegraph.com/extensions",
+		Source:         "test",
+		FeatureFlags:   map[string]bool{},
+		CohortID:       nil,
+		Referrer:       &testUrl,
+		Argument:       json.RawMessage(privateArgumentField),
+	}
+	got, err := createBigQueryEvent(eventWithPrivateArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &bigQueryEvent{
+		EventName:       "SearchResultsFetched",
+		UserID:          1,
+		AnonymousUserID: "abcd",
+		FirstSourceURL:  testUrl,
+		Source:          "test",
+		Timestamp:       time.Now().UTC().Format(time.RFC3339),
+		FeatureFlags:    "{}",
+		CohortID:        nil,
+		Version:         "0.0.0+dev",
+		Referrer:        testUrl,
+		// PublicArguments should be nil because
+		// SearchResultsFetched is not in the BigQuery
+		// allowlist.
+		PublicArguments: nil,
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
+
+}


### PR DESCRIPTION
Addresses [RFC 437](https://docs.google.com/document/d/1_tYPVYRW-pVhDdJRcF7umcV-2tQ3GCJz6DHBrq5oKb8/edit#). 

We currently do not send the `argument` column to BigQuery at all. This was to avoid potentially sending private data from event logs on Cloud into our analytics systems. However, we do need the non-private data from this column. This PR adds an allowlist of event names that don't log any private data, and sends arguments along with these events to BigQuery.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
