### PR TITLE
Insights/record from interval start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights feature flag `DISABLE_CODE_INSIGHTS` environment variable has moved from the `repo-updater` service to the `worker` service. Any users of this flag will need to update their `worker` service configuration to continue using it. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 - Updated Docker-Compose Caddy Image to v2.0.0-alpine. [#468](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/468)
 - Code Insights historical samples will record using the timestamp of the commit that was searched. [#23520](https://github.com/sourcegraph/sourcegraph/pull/23520)
+- Code Insights historical samples will record using the most recent commit to the start of the frame instead of the middle of the frame. [#23573](https://github.com/sourcegraph/sourcegraph/pull/23573)
 
 ### Fixed
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -277,13 +277,11 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, uniqueSeries map[s
 	}
 	var multi error
 
-	frames := Frames(h.framesToBackfill(), h.frameLength(), h.now())
-
-	hardErr := h.allReposIterator(ctx, h.buildForRepo(ctx, uniqueSeries, sortedSeriesIDs, frames, multi))
+	hardErr := h.allReposIterator(ctx, h.buildForRepo(ctx, uniqueSeries, sortedSeriesIDs, multi))
 	return hardErr
 }
 
-func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[string]itypes.InsightSeries, sortedSeriesIDs []string, frames []compression.Frame, softErr error) func(repoName string) error {
+func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[string]itypes.InsightSeries, sortedSeriesIDs []string, softErr error) func(repoName string) error {
 	return func(repoName string) error {
 		// Lookup the repository (we need its database ID)
 		repo, err := h.repoStore.GetByName(ctx, api.RepoName(repoName))
@@ -303,9 +301,9 @@ func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[
 			duration := h.now().Sub(series.OldestHistoricalAt) / time.Duration(h.framesToBackfill())
 			frames := Frames(h.framesToBackfill(), duration, series.CreatedAt)
 
-			log15.Info("insights: starting frames", "series_id", series.SeriesID, "starting_frames", frames)
+			log15.Debug("insights: starting frames", "repo_id", repo.ID, "series_id", series.SeriesID, "frames", frames)
 			filtered := h.frameFilter.FilterFrames(ctx, frames, repo.ID)
-			log15.Info("insights: sampling historical data frames", "series_id", series.SeriesID, "repo_id", repo.ID, "frames", frames)
+			log15.Debug("insights: sampling historical data frames", "repo_id", repo.ID, "series_id", series.SeriesID, "frames", frames)
 
 			// Find the first commit made to the repository on the default branch.
 			firstHEADCommit, err := h.gitFirstEverCommit(ctx, api.RepoName(repoName))
@@ -469,9 +467,15 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 	if len(recentCommits) > 0 {
 		nearestCommit = recentCommits[0]
 	}
-	if nearestCommit == nil || nearestCommit.Committer == nil {
+	if nearestCommit == nil {
+		log15.Error("null commit", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.from, "to", bctx.to)
 		return // repository has no commits / is empty. Maybe not yet pushed to code host.
 	}
+	if nearestCommit.Committer == nil {
+		log15.Error("null committer", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.from, "to", bctx.to)
+		return
+	}
+	log15.Debug("nearest_commit", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.from, "to", bctx.to, "revhash", nearestCommit.ID.Short(), "time", nearestCommit.Committer.Date)
 
 	// Build the search query we will run. The most important part here is
 	query = withCountUnlimited(query)

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -486,7 +486,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 		SearchQuery: query,
 		RecordTime:  &nearestCommit.Committer.Date,
 		State:       "queued",
-		Priority:    int(priority.FromTimeInterval(bctx.from, bctx.series.CreatedAt)), // eventually we will use the end of the historical range, for now current time works fine
+		Priority:    int(priority.FromTimeInterval(bctx.from, bctx.series.CreatedAt)),
 		Cost:        int(priority.Unindexed),
 	})
 	return

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -81,7 +81,7 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 
 	// The last frame will always be excluded because this is the frame closest to now. In this case, we will allow
 	// the most recent sample to be resolved from the 'present day recorder' insight_enqueuer.go
-	for i := 1; i < len(frames)-1; i++ {
+	for i := 1; i < len(frames); i++ {
 		frame := frames[i]
 
 		if metadata.LastIndexedAt.Before(frame.To) {

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -79,8 +79,6 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 	// horizon of the indexer
 	include = append(include, frames[0])
 
-	// The last frame will always be excluded because this is the frame closest to now. In this case, we will allow
-	// the most recent sample to be resolved from the 'present day recorder' insight_enqueuer.go
 	for i := 1; i < len(frames); i++ {
 		frame := frames[i]
 

--- a/enterprise/internal/insights/compression/compression_test.go
+++ b/enterprise/internal/insights/compression/compression_test.go
@@ -68,9 +68,14 @@ func TestFilterFrames(t *testing.T) {
 			maxHistorical, maxHistorical.Add(time.Second * 500), "fedcba",
 		}}
 
-		want := []Frame{{
-			maxHistorical, maxHistorical.Add(time.Second * 500), "abcdef",
-		}}
+		want := []Frame{
+			{
+				maxHistorical, maxHistorical.Add(time.Second * 500), "abcdef",
+			},
+			{
+				maxHistorical, maxHistorical.Add(time.Second * 500), "fedcba",
+			},
+		}
 
 		got := commitFilter.FilterFrames(ctx, input, 1)
 
@@ -127,7 +132,7 @@ func TestFilterFrames(t *testing.T) {
 
 		commitStore.GetFunc.PushReturn([]CommitStamp{}, nil)
 
-		want := []Frame{input[0], input[1]}
+		want := []Frame{input[0], input[1], input[2]}
 
 		got := commitFilter.FilterFrames(ctx, input, 1)
 


### PR DESCRIPTION
Closes #23516

Historical data frames were being calculated by selecting a time at the middle of the frame and trying to find the "nearest" commit. This behavior led to some confusing / unexpected insight charts.

This change makes all historical frames select the start time as the recording time, and will pick the commit which occurred most recently. This way we will always generate a chart with the start of each frame being sampled at the appropriate commit.

This causes the initial data frames to sometimes be quite old if the repo has few updates, but that doesn't actually impact our storage or performance needs.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
