### PR TITLE
httpcli: Expand usage across the codebase

### DIFF
--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	cf = httpcli.NewExternalHTTPClientFactory()
+	cf = httpcli.ExternalClientFactory
 )
 
 type affiliatedRepositoriesConnection struct {

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -43,7 +43,7 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	dir, err := gosrc.ResolveImportPath(httpcli.ExternalDoer(), spec.Pkg)
+	dir, err := gosrc.ResolveImportPath(httpcli.ExternalDoer, spec.Pkg)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -540,7 +540,7 @@ func check(db dbutil.DB) {
 		req.Header.Set("Content-Type", "application/json")
 		req = req.WithContext(ctx)
 
-		resp, err := httpcli.ExternalDoer().Do(req)
+		resp, err := httpcli.ExternalDoer.Do(req)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -651,19 +651,5 @@ func handlePing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, service := range r.Form["service"] {
-		switch service {
-		case "gitserver":
-			if err := gitserver.DefaultClient.WaitForGitServers(r.Context()); err != nil {
-				http.Error(w, "wait for gitservers failed: "+err.Error(), http.StatusBadGateway)
-				return
-			}
-
-		default:
-			http.Error(w, "unknown service: "+service, http.StatusBadRequest)
-			return
-		}
-	}
-
 	_, _ = w.Write([]byte("pong"))
 }

--- a/cmd/frontend/internal/vfsutil/zip.go
+++ b/cmd/frontend/internal/vfsutil/zip.go
@@ -5,10 +5,9 @@ import (
 	"io"
 	"net/http"
 
-	"golang.org/x/net/context/ctxhttp"
-
 	"github.com/cockroachdb/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 
 	"github.com/opentracing/opentracing-go/ext"
@@ -36,7 +35,7 @@ func NewZipVFS(url string, onFetchStart, onFetchFailed func(), evictOnClose bool
 				return nil, errors.Wrapf(err, "failed to construct a new request with URL %s", url)
 			}
 			request.Header.Add("Accept", "application/zip")
-			resp, err := ctxhttp.Do(ctx, nil, request)
+			resp, err := httpcli.InternalDoer.Do(request.WithContext(ctx))
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to fetch zip archive from %s", url)
 			}

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -99,7 +99,7 @@ func httpGet(ctx context.Context, op, urlStr string, result interface{}) (err er
 	req.Header.Set("User-Agent", "Sourcegraph registry client v"+APIVersion)
 	req = req.WithContext(ctx)
 
-	resp, err := httpcli.ExternalDoer().Do(req)
+	resp, err := httpcli.ExternalDoer.Do(req)
 	if err != nil {
 		return err
 	}

--- a/cmd/query-runner/graphql.go
+++ b/cmd/query-runner/graphql.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"net/http"
 	"net/url"
 	"runtime"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-
-	"golang.org/x/net/context/ctxhttp"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 
 	"github.com/cockroachdb/errors"
 )
@@ -135,7 +135,14 @@ func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
 		return nil, errors.Wrap(err, "constructing frontend URL")
 	}
 
-	resp, err := ctxhttp.Post(ctx, nil, url, "application/json", &buf)
+	req, err := http.NewRequest("POST", url, &buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "Post")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "Post")
 	}

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -53,10 +53,6 @@ func main() {
 
 	ctx := context.Background()
 
-	if err := api.InternalClient.WaitForFrontend(ctx); err != nil {
-		log15.Error("failed to wait for frontend", "error", err)
-	}
-
 	http.HandleFunc(queryrunnerapi.PathTestNotification, serveTestNotification)
 
 	go func() {

--- a/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
+++ b/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/cockroachdb/errors"
 
@@ -15,15 +14,18 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 var (
-	queryRunnerURL = env.Get("QUERY_RUNNER_URL", "http://query-runner", "URL at which the query-runner service can be reached")
+	queryRunnerURL = env.Get(
+		"QUERY_RUNNER_URL",
+		"http://query-runner",
+		"URL at which the query-runner service can be reached",
+	)
 
 	Client = &client{
-		client: &http.Client{
-			Timeout: 5 * time.Second,
-		},
+		client: httpcli.InternalClient,
 	}
 )
 
@@ -53,7 +55,12 @@ type SavedQueryWasCreatedOrUpdatedArgs struct {
 
 // SavedQueryWasCreated should be called whenever a saved query was created
 // or updated after the server has started.
-func (c *client) SavedQueryWasCreatedOrUpdated(ctx context.Context, subject api.SettingsSubject, config api.PartialConfigSavedQueries, disableSubscriptionNotifications bool) error {
+func (c *client) SavedQueryWasCreatedOrUpdated(
+	ctx context.Context,
+	subject api.SettingsSubject,
+	config api.PartialConfigSavedQueries,
+	disableSubscriptionNotifications bool,
+) error {
 	return c.post(PathSavedQueryWasCreatedOrUpdated, &SavedQueryWasCreatedOrUpdatedArgs{
 		SubjectAndConfig: &SubjectAndConfig{
 			Subject: subject,
@@ -70,7 +77,11 @@ type SavedQueryWasDeletedArgs struct {
 
 // SavedQueryWasDeleted should be called whenever a saved query was deleted
 // after the server has started.
-func (c *client) SavedQueryWasDeleted(ctx context.Context, spec api.SavedQueryIDSpec, disableSubscriptionNotifications bool) error {
+func (c *client) SavedQueryWasDeleted(
+	ctx context.Context,
+	spec api.SavedQueryIDSpec,
+	disableSubscriptionNotifications bool,
+) error {
 	return c.post(PathSavedQueryWasDeleted, &SavedQueryWasDeletedArgs{
 		Spec:                             spec,
 		DisableSubscriptionNotifications: disableSubscriptionNotifications,

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -211,7 +211,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		Kind:        req.ExternalService.Kind,
 		DisplayName: req.ExternalService.DisplayName,
 		Config:      req.ExternalService.Config,
-	}, httpcli.NewExternalHTTPClientFactory())
+	}, httpcli.ExternalClientFactory)
 	if err != nil {
 		log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
 		return

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -62,7 +61,7 @@ func (c *Config) Validate() error {
 	return c.BaseConfig.Validate()
 }
 
-func (c *Config) APIWorkerOptions(transport http.RoundTripper) apiworker.Options {
+func (c *Config) APIWorkerOptions() apiworker.Options {
 	return apiworker.Options{
 		VMPrefix:             c.VMPrefix,
 		QueueName:            c.QueueName,
@@ -71,7 +70,7 @@ func (c *Config) APIWorkerOptions(transport http.RoundTripper) apiworker.Options
 		ResourceOptions:      c.ResourceOptions(),
 		MaximumRuntimePerJob: c.MaximumRuntimePerJob,
 		GitServicePath:       "/.executors/git",
-		ClientOptions:        c.ClientOptions(transport),
+		ClientOptions:        c.ClientOptions(),
 		RedactedValues: map[string]string{
 			// 🚨 SECURITY: Catch uses of the shared frontend token used to clone
 			// git repositories that make it into commands or stdout/stderr streams.
@@ -106,7 +105,7 @@ func (c *Config) ResourceOptions() command.ResourceOptions {
 	}
 }
 
-func (c *Config) ClientOptions(transport http.RoundTripper) apiclient.Options {
+func (c *Config) ClientOptions() apiclient.Options {
 	hn := hostname.Get()
 
 	return apiclient.Options{
@@ -115,14 +114,12 @@ func (c *Config) ClientOptions(transport http.RoundTripper) apiclient.Options {
 		ExecutorHostname:  hn,
 		PathPrefix:        "/.executors/queue",
 		EndpointOptions:   c.EndpointOptions(),
-		BaseClientOptions: c.BaseClientOptions(transport),
+		BaseClientOptions: c.BaseClientOptions(),
 	}
 }
 
-func (c *Config) BaseClientOptions(transport http.RoundTripper) apiclient.BaseClientOptions {
-	return apiclient.BaseClientOptions{
-		Transport: transport,
-	}
+func (c *Config) BaseClientOptions() apiclient.BaseClientOptions {
+	return apiclient.BaseClientOptions{}
 }
 
 func (c *Config) EndpointOptions() apiclient.EndpointOptions {

--- a/enterprise/cmd/executor/internal/apiclient/baseclient.go
+++ b/enterprise/cmd/executor/internal/apiclient/baseclient.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 // BaseClient is an abstract HTTP API-backed data access layer. Instances of this
@@ -45,16 +47,12 @@ type BaseClient struct {
 type BaseClientOptions struct {
 	// UserAgent specifies the user agent string to supply on requests.
 	UserAgent string
-
-	// Transport is a configurable round tripper, which can include things like
-	// tracing, metrics, and request/response decoration.
-	Transport http.RoundTripper
 }
 
 // NewBaseClient creates a new BaseClient with the given transport.
 func NewBaseClient(options BaseClientOptions) *BaseClient {
 	return &BaseClient{
-		httpClient: makeHTTPClient(options.Transport),
+		httpClient: httpcli.InternalClient,
 		options:    options,
 	}
 }
@@ -122,12 +120,4 @@ func MakeJSONRequest(method string, url *url.URL, payload interface{}) (*http.Re
 
 	req.Header.Set("Content-Type", "application/json")
 	return req, nil
-}
-
-// makeHTTPClient creates an HTTP client with the given round tripper.
-func makeHTTPClient(transport http.RoundTripper) *http.Client {
-	if transport == nil {
-		return http.DefaultClient
-	}
-	return &http.Client{Transport: transport}
 }

--- a/enterprise/cmd/executor/internal/apiclient/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/client.go
@@ -36,7 +36,7 @@ type Options struct {
 	// EndpointOptions configures the target request URL.
 	EndpointOptions EndpointOptions
 
-	// BaseClientOptions configures the underlying HTTP client behavior.
+	// BaseClientOptions are the underlying HTTP client options.
 	BaseClientOptions BaseClientOptions
 }
 

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -49,7 +49,7 @@ func main() {
 	nameSet := janitor.NewNameSet()
 
 	routines := []goroutine.BackgroundRoutine{
-		worker.NewWorker(nameSet, config.APIWorkerOptions(nil), observationContext),
+		worker.NewWorker(nameSet, config.APIWorkerOptions(), observationContext),
 	}
 	if config.UseFirecracker {
 		routines = append(routines, janitor.NewOrphanedVMJanitor(

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -32,7 +32,7 @@ func NewHandler(db dbutil.DB, serviceType, authPrefix string, isAPIHandler bool,
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Delegate to the auth flow handler
 		if !isAPIHandler && strings.HasPrefix(r.URL.Path, authPrefix+"/") {
-			r = withOAuthExternalHTTPClient(r)
+			r = withOAuthExternalClient(r)
 			oauthFlowHandler.ServeHTTP(w, r)
 			return
 		}
@@ -126,11 +126,11 @@ func getExtraScopes(ctx context.Context, db dbutil.DB, serviceType string) ([]st
 	return scopes, nil
 }
 
-// withOAuthExternalHTTPClient updates client such that the
+// withOAuthExternalClient updates client such that the
 // golang.org/x/oauth2 package will use our http client which is configured
 // with proxy and TLS settings/etc.
-func withOAuthExternalHTTPClient(r *http.Request) *http.Request {
-	client := httpcli.ExternalHTTPClient()
+func withOAuthExternalClient(r *http.Request) *http.Request {
+	client := httpcli.ExternalClient
 	if traceLogEnabled {
 		loggingClient := *client
 		loggingClient.Transport = &loggingRoundTripper{underlying: client.Transport}

--- a/enterprise/cmd/frontend/internal/executorqueue/reverseproxy.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/reverseproxy.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-// TODO(efritz) - add tracing, metrics
-var client = http.DefaultClient
+var client = httpcli.InternalDoer
 
 // reverseProxy creates an HTTP handler that will proxy requests to the given target URL. See
 // makeProxyRequest for details on how the request URI is constructed.

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -30,7 +30,7 @@ func New(store *store.Store) *Service {
 // NewWithClock returns a Service the given clock used
 // to generate timestamps.
 func NewWithClock(store *store.Store, clock func() time.Time) *Service {
-	svc := &Service{store: store, sourcer: sources.NewSourcer(httpcli.NewExternalHTTPClientFactory()), clock: clock}
+	svc := &Service{store: store, sourcer: sources.NewSourcer(httpcli.ExternalClientFactory), clock: clock}
 
 	return svc
 }

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -34,7 +34,7 @@ func NewBitbucketServerSource(svc *types.ExternalService, cf *httpcli.Factory) (
 
 func newBitbucketServerSource(c *schema.BitbucketServerConnection, cf *httpcli.Factory, au auth.Authenticator) (*BitbucketServerSource, error) {
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	var opts []httpcli.Opt

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -43,7 +43,7 @@ func newGithubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Au
 	apiURL, _ := github.APIRoot(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	opts := []httpcli.Opt{

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -41,7 +41,7 @@ func newGitLabSource(c *schema.GitLabConnection, cf *httpcli.Factory, au auth.Au
 	baseURL = extsvc.NormalizeBaseURL(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	var opts []httpcli.Opt

--- a/enterprise/internal/insights/background/queryrunner/graphql.go
+++ b/enterprise/internal/insights/background/queryrunner/graphql.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/url"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-
-	"golang.org/x/net/context/ctxhttp"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 
 	"github.com/cockroachdb/errors"
 )
@@ -112,7 +112,14 @@ func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
 		return nil, errors.Wrap(err, "constructing frontend URL")
 	}
 
-	resp, err := ctxhttp.Post(ctx, nil, url, "application/json", &buf)
+	req, err := http.NewRequest("POST", url, &buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "Post")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "Post")
 	}

--- a/internal/conf/httpcli.go
+++ b/internal/conf/httpcli.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-
 func init() {
 	// This watch loop is here so that we don't introduce
 	// dependency cycles, since conf itself uses httpcli's internal

--- a/internal/conf/httpcli.go
+++ b/internal/conf/httpcli.go
@@ -11,7 +11,7 @@ func init() {
 	// This watch loop is here so that we don't introduce
 	// dependency cycles, since conf itself uses httpcli's internal
 	// client. This is gross, and the whole conf package is gross.
-	Watch(func() {
+	go Watch(func() {
 		before := httpcli.TLSExternalConfig()
 		after := Get().ExperimentalFeatures.TlsExternal
 		if !reflect.DeepEqual(before, after) {

--- a/internal/conf/httpcli.go
+++ b/internal/conf/httpcli.go
@@ -1,0 +1,21 @@
+package conf
+
+import (
+	"reflect"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+
+func init() {
+	// This watch loop is here so that we don't introduce
+	// dependency cycles, since conf itself uses httpcli's internal
+	// client. This is gross, and the whole conf package is gross.
+	Watch(func() {
+		before := httpcli.TLSExternalConfig()
+		after := Get().ExperimentalFeatures.TlsExternal
+		if !reflect.DeepEqual(before, after) {
+			httpcli.SetTLSExternalConfig(after)
+		}
+	})
+}

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -60,7 +60,7 @@ type Client struct {
 // required to be set before calling any APIs.
 func NewClient(apiURL *url.URL, httpClient httpcli.Doer) *Client {
 	if httpClient == nil {
-		httpClient = httpcli.ExternalDoer()
+		httpClient = httpcli.ExternalDoer
 	}
 
 	httpClient = requestCounter.Doer(httpClient, func(u *url.URL) string {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -120,7 +120,7 @@ func newClient(config *schema.BitbucketServerConnection, httpClient httpcli.Doer
 	}
 
 	if httpClient == nil {
-		httpClient = httpcli.ExternalDoer()
+		httpClient = httpcli.ExternalDoer
 	}
 	httpClient = requestCounter.Doer(httpClient, categorize)
 

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -82,7 +82,7 @@ func newV3Client(apiURL *url.URL, a auth.Authenticator, resource string, cli htt
 		cli = disabledClient{}
 	}
 	if cli == nil {
-		cli = httpcli.ExternalDoer()
+		cli = httpcli.ExternalDoer
 	}
 
 	cli = requestCounter.Doer(cli, func(u *url.URL) string {

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -62,7 +62,7 @@ func NewV4Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V4Cli
 		cli = disabledClient{}
 	}
 	if cli == nil {
-		cli = httpcli.ExternalDoer()
+		cli = httpcli.ExternalDoer
 	}
 
 	cli = requestCounter.Doer(cli, func(u *url.URL) string {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -85,7 +85,7 @@ type CommonOp struct {
 
 func NewClientProvider(baseURL *url.URL, cli httpcli.Doer) *ClientProvider {
 	if cli == nil {
-		cli = httpcli.ExternalDoer()
+		cli = httpcli.ExternalDoer
 	}
 	cli = requestCounter.Doer(cli, func(u *url.URL) string {
 		// The 3rd component of the Path (/api/v4/XYZ) mostly maps to the type of API

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -41,7 +41,7 @@ func (j *syncingJob) Routines(_ context.Context) ([]goroutine.BackgroundRoutine,
 		return nil, err
 	}
 
-	cf := httpcli.NewExternalHTTPClientFactory()
+	cf := httpcli.ExternalClientFactory
 	sourcer := repos.NewSourcer(cf)
 
 	handler := goroutine.NewHandlerWithErrorMessage("sync versions of external services", func(ctx context.Context) error {

--- a/internal/gitserver/proxy.go
+++ b/internal/gitserver/proxy.go
@@ -12,7 +12,9 @@ import (
 
 // DefaultReverseProxy is the default ReverseProxy. It uses the same transport and HTTP
 // limiter as the default client.
-var DefaultReverseProxy = NewReverseProxy(defaultTransport, DefaultClient.HTTPLimiter)
+var DefaultReverseProxy = NewReverseProxy(defaultClient.Transport, DefaultClient.HTTPLimiter)
+
+var defaultClient, _ = clientFactory.Client()
 
 // NewReverseProxy returns a new gitserver.ReverseProxy instantiated with the given
 // transport and HTTP limiter.

--- a/internal/httpcli/CODENOTIFY
+++ b/internal/httpcli/CODENOTIFY
@@ -1,1 +1,1 @@
-** @keegancsmith
+** @keegancsmith @tsenart

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -6,7 +6,9 @@ import (
 	"crypto/x509"
 	"net/http"
 	"net/url"
-	"sync"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/rehttp"
@@ -16,6 +18,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
@@ -69,11 +72,14 @@ type Factory struct {
 // too large.
 var redisCache = rcache.NewWithTTL("http", 604800)
 
-// NewExternalHTTPClientFactory returns an httpcli.Factory with common options
-// and middleware pre-set for communicating to external services.
-func NewExternalHTTPClientFactory() *Factory {
+// ExternalClientFactory is a httpcli.Factory with common options
+// and middleware pre-set for communicating with external services.
+var ExternalClientFactory = NewExternalClientFactory()
+
+// NewExternalClientFactory returns a httpcli.Factory with common options
+// and middleware pre-set for communicating with external services.
+func NewExternalClientFactory() *Factory {
 	return NewFactory(
-		// TODO(tsenart): Use middle for Prometheus instrumentation later.
 		NewMiddleware(
 			ContextErrorMiddleware,
 		),
@@ -83,7 +89,7 @@ func NewExternalHTTPClientFactory() *Factory {
 		// not a generic http.RoundTripper.
 		ExternalTransportOpt,
 		NewErrorResilientTransportOpt(
-			DefaultRetryPolicy,
+			NewRetryPolicy(MaxRetries()),
 			rehttp.ExpJitterDelay(200*time.Millisecond, 10*time.Second),
 		),
 		TracedTransportOpt,
@@ -91,47 +97,43 @@ func NewExternalHTTPClientFactory() *Factory {
 	)
 }
 
-var (
-	externalOnce       sync.Once
-	externalDoer       Doer
-	externalHTTPClient *http.Client
-)
-
-func externalInit() {
-	externalOnce.Do(func() {
-		var err error
-		externalDoer, err = NewExternalHTTPClientFactory().Doer()
-		if err != nil {
-			panic("httpcli: failed to create the default ExternalDoer. This should not happen: " + err.Error())
-		}
-		externalHTTPClient, err = NewExternalHTTPClientFactory().Client()
-		if err != nil {
-			panic("httpcli: failed to create the default ExternalHTTPClient. This should not happen: " + err.Error())
-		}
-	})
-}
-
-// ExternalDoer returns a shared client for external communication. This is a
+// ExternalDoer is a shared client for external communication. This is a
 // convenience for existing uses of http.DefaultClient.
-//
-// NOTE: Use this for legacy code. New code should generally take in a
-// httpcli.Doer and at a high level NewExternalHTTPClientFactory() is called
-// and passed down.
-func ExternalDoer() Doer {
-	externalInit()
-	return externalDoer
+var ExternalDoer, _ = ExternalClientFactory.Doer()
+
+// ExternalClient returns a shared client for external communication. This is
+// a convenience for existing uses of http.DefaultClient.
+var ExternalClient, _ = ExternalClientFactory.Client()
+
+// InternalClientFactory is a httpcli.Factory with common options
+// and middleware pre-set for communicating with internal services.
+var InternalClientFactory = NewInternalClientFactory("internal")
+
+// NewInternalClientFactory returns a httpcli.Factory with common options
+// and middleware pre-set for communicating with internal services.
+func NewInternalClientFactory(subsystem string) *Factory {
+	return NewFactory(
+		NewMiddleware(
+			ContextErrorMiddleware,
+		),
+		NewTimeoutOpt(time.Minute), // Needs to be high for retries.
+		NewMaxIdleConnsPerHostOpt(500),
+		NewErrorResilientTransportOpt(
+			NewRetryPolicy(MaxRetries()),
+			rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+		),
+		MeteredTransportOpt(subsystem),
+		TracedTransportOpt,
+	)
 }
 
-// ExternalHTTPClient returns a shared client for external communication. This is
+// InternalDoer is a shared client for external communication. This is a
+// convenience for existing uses of http.DefaultClient.
+var InternalDoer, _ = InternalClientFactory.Doer()
+
+// InternalClient returns a shared client for external communication. This is
 // a convenience for existing uses of http.DefaultClient.
-//
-// NOTE: Use this for legacy code. New code should generally take in a
-// httpcli.Doer and at a high level NewExternalHTTPClientFactory() is called
-// and passed down.
-func ExternalHTTPClient() *http.Client {
-	externalInit()
-	return externalHTTPClient
-}
+var InternalClient, _ = InternalClientFactory.Client()
 
 // Doer returns a new Doer wrapped with the middleware stack
 // provided in the Factory constructor and with the given common
@@ -316,6 +318,27 @@ func TracedTransportOpt(cli *http.Client) error {
 	return nil
 }
 
+// MeteredTransportOpt returns an opt that wraps an existing http.Transport of a http.Client with
+// metrics collection.
+func MeteredTransportOpt(subsystem string) Opt {
+	meter := metrics.NewRequestMeter(
+		subsystem,
+		"Total number of requests sent to "+subsystem,
+	)
+
+	return func(cli *http.Client) error {
+		if cli.Transport == nil {
+			cli.Transport = http.DefaultTransport
+		}
+
+		cli.Transport = meter.Transport(cli.Transport, func(u *url.URL) string {
+			return u.Path
+		})
+
+		return nil
+	}
+}
+
 // A regular expression to match the error returned by net/http when the
 // configured number of redirects is exhausted. This error isn't typed
 // specifically so we resort to matching on the error string.
@@ -329,73 +352,91 @@ var schemeErrorRe = lazyregexp.New(`unsupported protocol scheme`)
 // A regular expression to match a DNSError no such host.
 var noSuchHostErrorRe = lazyregexp.New(`no such host`)
 
-// DefaultRetryPolicy is the retry policy used in any Doer or Client returned
-// by NewExternalHTTPClientFactory.
-func DefaultRetryPolicy(a rehttp.Attempt) (retry bool) {
-	status := 0
+// MaxRetries returns the max retries to be attempted, which should be passed
+// to NewRetryPolicy. If we're in tests, it returns 1, otherwise it tries to
+// parse SRC_HTTP_CLI_MAX_RETRIES and return that. If it can't, it defaults to 20.
+func MaxRetries() int {
+	if strings.HasSuffix(os.Args[0], ".test") {
+		return 1
+	}
 
-	defer func() {
-		if !retry {
-			return
+	max, _ := strconv.Atoi(os.Getenv("SRC_HTTP_CLI_MAX_RETRIES"))
+	if max == 0 {
+		return 20
+	}
+
+	return max
+}
+
+// NewRetryPolicy returns a retry policy used in any Doer or Client returned
+// by NewExternalClientFactory.
+func NewRetryPolicy(max int) rehttp.RetryFn {
+	return func(a rehttp.Attempt) (retry bool) {
+		status := 0
+
+		defer func() {
+			if !retry {
+				return
+			}
+
+			log15.Error(
+				"retrying HTTP request",
+				"attempt", a.Index,
+				"method", a.Request.Method,
+				"url", a.Request.URL,
+				"status", status,
+				"err", a.Error,
+			)
+		}()
+
+		if a.Response != nil {
+			status = a.Response.StatusCode
 		}
 
-		log15.Error(
-			"external HTTP request",
-			"attempt", a.Index,
-			"method", a.Request.Method,
-			"url", a.Request.URL,
-			"status", status,
-			"err", a.Error,
-		)
-	}()
-
-	if a.Response != nil {
-		status = a.Response.StatusCode
-	}
-
-	if a.Index > 20 { // Max retries
-		return false
-	}
-
-	switch a.Error {
-	case nil:
-	case context.DeadlineExceeded, context.Canceled:
-		return false
-	default:
-		if v, ok := a.Error.(*url.Error); ok {
-			e := v.Error()
-			// Don't retry if the error was due to too many redirects.
-			if redirectsErrorRe.MatchString(e) {
-				return false
-			}
-
-			// Don't retry if the error was due to an invalid protocol scheme.
-			if schemeErrorRe.MatchString(e) {
-				return false
-			}
-
-			// Don't retry more than 3 times for no such host errors.
-			// This affords some resilience to dns unreliability while
-			// preventing 20 attempts with a non existing name.
-			if noSuchHostErrorRe.MatchString(e) && a.Index >= 3 {
-				return false
-			}
-
-			// Don't retry if the error was due to TLS cert verification failure.
-			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
-				return false
-			}
-
+		if a.Index > max { // Max retries
+			return false
 		}
-		// The error is likely recoverable so retry.
-		return true
-	}
 
-	if status == 0 || status == 429 || (status >= 500 && status != 501) {
-		return true
-	}
+		switch a.Error {
+		case nil:
+		case context.DeadlineExceeded, context.Canceled:
+			return false
+		default:
+			if v, ok := a.Error.(*url.Error); ok {
+				e := v.Error()
+				// Don't retry if the error was due to too many redirects.
+				if redirectsErrorRe.MatchString(e) {
+					return false
+				}
 
-	return false
+				// Don't retry if the error was due to an invalid protocol scheme.
+				if schemeErrorRe.MatchString(e) {
+					return false
+				}
+
+				// Don't retry more than 3 times for no such host errors.
+				// This affords some resilience to dns unreliability while
+				// preventing 20 attempts with a non existing name.
+				if noSuchHostErrorRe.MatchString(e) && a.Index >= 3 {
+					return false
+				}
+
+				// Don't retry if the error was due to TLS cert verification failure.
+				if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+					return false
+				}
+
+			}
+			// The error is likely recoverable so retry.
+			return true
+		}
+
+		if status == 0 || status == 429 || (status >= 500 && status != 501) {
+			return true
+		}
+
+		return false
+	}
 }
 
 // NewErrorResilientTransportOpt returns an Opt that wraps an existing
@@ -421,6 +462,21 @@ func NewIdleConnTimeoutOpt(timeout time.Duration) Opt {
 		}
 
 		tr.IdleConnTimeout = timeout
+
+		return nil
+	}
+}
+
+// NewMaxIdleConnsPerHostOpt returns a Opt that sets the MaxIdleConnsPerHost field of an
+// http.Client's transport.
+func NewMaxIdleConnsPerHostOpt(max int) Opt {
+	return func(cli *http.Client) error {
+		tr, err := getTransportForMutation(cli)
+		if err != nil {
+			return errors.Wrap(err, "httpcli.NewMaxIdleConnsOpt")
+		}
+
+		tr.MaxIdleConnsPerHost = max
 
 		return nil
 	}

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -119,7 +119,6 @@ func NewInternalClientFactory(subsystem string) *Factory {
 		NewMiddleware(
 			ContextErrorMiddleware,
 		),
-		NewTimeoutOpt(time.Minute), // Needs to be high for retries.
 		NewMaxIdleConnsPerHostOpt(500),
 		NewErrorResilientTransportOpt(
 			NewRetryPolicy(MaxRetries()),

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -378,12 +378,12 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 		status := 0
 
 		defer func() {
-			if !retry {
+			if retry || a.Error == nil {
 				return
 			}
 
 			log15.Error(
-				"retrying HTTP request",
+				"retrying HTTP request failed",
 				"attempt", a.Index,
 				"method", a.Request.Method,
 				"url", a.Request.URL,
@@ -457,8 +457,9 @@ func ExpJitterDelay(base, max time.Duration) rehttp.DelayFn {
 	return func(attempt rehttp.Attempt) time.Duration {
 		exp := math.Pow(2, float64(attempt.Index))
 		top := float64(base) * exp
+		n := int64(math.Min(float64(max), top))
 		mu.Lock()
-		delay := prng.Int63n(int64(math.Min(float64(max), top)))
+		delay := prng.Int63n(n)
 		mu.Unlock()
 		return time.Duration(delay)
 	}

--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -8,16 +8,35 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type externalTransport struct {
 	base *http.Transport
-
 	mu        sync.RWMutex
-	config    *schema.TlsExternal
+	config  *schema.TlsExternal
 	effective *http.Transport
+}
+
+var tlsExternalConfig struct {
+	sync.RWMutex
+	*schema.TlsExternal
+}
+
+
+// SetTLSExternalConfig is called by the conf package whenever TLSExternalConfig changes.
+// This is needed to avoid circular imports.
+func SetTLSExternalConfig(c *schema.TlsExternal) {
+	tlsExternalConfig.Lock()
+	tlsExternalConfig.TlsExternal = c
+	tlsExternalConfig.Unlock()
+}
+
+// TLSExternalConfig returns the current value of the global TLS external config.
+func TLSExternalConfig() *schema.TlsExternal {
+	tlsExternalConfig.RLock()
+	defer tlsExternalConfig.RUnlock()
+	return tlsExternalConfig.TlsExternal
 }
 
 func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -25,20 +44,19 @@ func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	config, effective := t.config, t.effective
 	t.mu.RUnlock()
 
-	if current := conf.Get().ExperimentalFeatures.TlsExternal; current == nil {
+	if current := TLSExternalConfig(); current == nil {
 		return t.base.RoundTrip(r)
 	} else if !reflect.DeepEqual(config, current) {
-		effective = t.update()
+		effective = t.update(current)
 	}
 
 	return effective.RoundTrip(r)
 }
 
-func (t *externalTransport) update() *http.Transport {
+func (t *externalTransport) update(config *schema.TlsExternal) *http.Transport {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	config := conf.Get().ExperimentalFeatures.TlsExternal
 	effective := t.base.Clone()
 
 	if effective.TLSClientConfig == nil {
@@ -55,7 +73,11 @@ func (t *externalTransport) update() *http.Transport {
 		if effective.TLSClientConfig.RootCAs == nil {
 			pool, err := x509.SystemCertPool() // safe to mutate, a clone is returned
 			if err != nil {
-				log15.Warn("httpcli external transport failed to load SystemCertPool. Communication with external HTTPS APIs may fail", "error", err)
+				log15.Warn(
+					"httpcli external transport failed to load SystemCertPool. Communication with external HTTPS APIs may fail",
+					"error",
+					err,
+				)
 				pool = x509.NewCertPool()
 			}
 			effective.TLSClientConfig.RootCAs = pool

--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -12,9 +12,9 @@ import (
 )
 
 type externalTransport struct {
-	base *http.Transport
+	base      *http.Transport
 	mu        sync.RWMutex
-	config  *schema.TlsExternal
+	config    *schema.TlsExternal
 	effective *http.Transport
 }
 
@@ -22,7 +22,6 @@ var tlsExternalConfig struct {
 	sync.RWMutex
 	*schema.TlsExternal
 }
-
 
 // SetTLSExternalConfig is called by the conf package whenever TLSExternalConfig changes.
 // This is needed to avoid circular imports.

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
@@ -94,11 +93,7 @@ func (r *Cache) SetMulti(keyvals ...[2]string) {
 	for _, kv := range keyvals {
 		k, v := kv[0], kv[1]
 		if !utf8.Valid([]byte(k)) {
-			if conf.IsDev(conf.DeployType()) {
-				panic(fmt.Sprintf("rcache: keys must be valid utf8 %v", []byte(k)))
-			} else {
-				log15.Error("rcache: keys must be valid utf8", "key", []byte(k))
-			}
+			log15.Error("rcache: keys must be valid utf8", "key", []byte(k))
 			continue
 		}
 		if r.ttlSeconds == 0 {
@@ -135,11 +130,7 @@ func (r *Cache) Set(key string, b []byte) {
 	defer c.Close()
 
 	if !utf8.Valid([]byte(key)) {
-		if conf.IsDev(conf.DeployType()) {
-			panic(fmt.Sprintf("rcache: keys must be valid utf8 %v", []byte(key)))
-		} else {
-			log15.Error("rcache: keys must be valid utf8", "key", []byte(key))
-		}
+		log15.Error("rcache: keys must be valid utf8", "key", []byte(key))
 	}
 
 	if r.ttlSeconds == 0 {

--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -46,7 +46,7 @@ func NewAWSCodeCommitSource(svc *types.ExternalService, cf *httpcli.Factory) (*A
 
 func newAWSCodeCommitSource(svc *types.ExternalService, c *schema.AWSCodeCommitConnection, cf *httpcli.Factory) (*AWSCodeCommitSource, error) {
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	cli, err := cf.Doer(func(c *http.Client) error {

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -48,7 +48,7 @@ func newBitbucketCloudSource(svc *types.ExternalService, c *schema.BitbucketClou
 	apiURL = extsvc.NormalizeBaseURL(apiURL)
 
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	cli, err := cf.Doer()

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -46,7 +46,7 @@ func NewBitbucketServerSource(svc *types.ExternalService, cf *httpcli.Factory) (
 
 func newBitbucketServerSource(svc *types.ExternalService, c *schema.BitbucketServerConnection, cf *httpcli.Factory) (*BitbucketServerSource, error) {
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	var opts []httpcli.Opt

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -85,7 +85,7 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 	apiURL, githubDotCom := github.APIRoot(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	opts := []httpcli.Opt{

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -69,7 +69,7 @@ func newGitLabSource(svc *types.ExternalService, c *schema.GitLabConnection, cf 
 	baseURL = extsvc.NormalizeBaseURL(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	var opts []httpcli.Opt

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -35,7 +35,7 @@ func NewOtherSource(svc *types.ExternalService, cf *httpcli.Factory) (*OtherSour
 	}
 
 	if cf == nil {
-		cf = httpcli.NewExternalHTTPClientFactory()
+		cf = httpcli.ExternalClientFactory
 	}
 
 	cli, err := cf.Doer()

--- a/internal/repos/phabricator.go
+++ b/internal/repos/phabricator.go
@@ -180,7 +180,7 @@ func (s *PhabricatorSource) client(ctx context.Context) (*phabricator.Client, er
 
 // RunPhabricatorRepositorySyncWorker runs the worker that syncs repositories from Phabricator to Sourcegraph
 func RunPhabricatorRepositorySyncWorker(ctx context.Context, s *Store) {
-	cf := httpcli.NewExternalHTTPClientFactory()
+	cf := httpcli.ExternalClientFactory
 
 	for {
 		phabs, err := s.ExternalServiceStore.List(ctx, database.ExternalServicesListOptions{

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -24,7 +24,7 @@ import (
 // environment variable.
 var DefaultClient = NewClient(env.Get("REPO_UPDATER_URL", "http://repo-updater:3182", "repo-updater server URL"))
 
-var defaultDoer, _ = httpcli.NewInternalClientFactory("repo_updater").Doer()
+var defaultDoer, _ = httpcli.NewInternalClientFactory("repoupdater").Doer()
 
 // Client is a repoupdater client.
 type Client struct {

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 
 	"github.com/cockroachdb/errors"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -15,17 +14,17 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
-
-var requestMeter = metrics.NewRequestMeter("repoupdater", "Total number of requests sent to repoupdater.")
 
 // DefaultClient is the default Client. Unless overwritten, it is
 // connected to the server specified by the REPO_UPDATER_URL
 // environment variable.
 var DefaultClient = NewClient(env.Get("REPO_UPDATER_URL", "http://repo-updater:3182", "repo-updater server URL"))
+
+var defaultDoer, _ = httpcli.NewInternalClientFactory("repo_updater").Doer()
 
 // Client is a repoupdater client.
 type Client struct {
@@ -33,30 +32,22 @@ type Client struct {
 	URL string
 
 	// HTTP client to use
-	HTTPClient *http.Client
+	HTTPClient httpcli.Doer
 }
 
 // NewClient will initiate a new repoupdater Client with the given serverURL.
 func NewClient(serverURL string) *Client {
 	return &Client{
-		URL: serverURL,
-		HTTPClient: &http.Client{
-			// ot.Transport will propagate opentracing spans and whether or not to trace
-			Transport: &ot.Transport{
-				RoundTripper: requestMeter.Transport(&http.Transport{
-					// Default is 2, but we can send many concurrent requests
-					MaxIdleConnsPerHost: 500,
-				}, func(u *url.URL) string {
-					// break it down by API function call (ie "/repo-update-scheduler-info", "/repo-lookup", etc)
-					return u.Path
-				}),
-			},
-		},
+		URL:        serverURL,
+		HTTPClient: defaultDoer,
 	}
 }
 
 // RepoUpdateSchedulerInfo returns information about the state of the repo in the update scheduler.
-func (c *Client) RepoUpdateSchedulerInfo(ctx context.Context, args protocol.RepoUpdateSchedulerInfoArgs) (result *protocol.RepoUpdateSchedulerInfoResult, err error) {
+func (c *Client) RepoUpdateSchedulerInfo(
+	ctx context.Context,
+	args protocol.RepoUpdateSchedulerInfoArgs,
+) (result *protocol.RepoUpdateSchedulerInfoResult, err error) {
 	resp, err := c.httpPost(ctx, "repo-update-scheduler-info", args)
 	if err != nil {
 		return nil, err
@@ -75,7 +66,10 @@ func (c *Client) RepoUpdateSchedulerInfo(ctx context.Context, args protocol.Repo
 var MockRepoLookup func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
 
 // RepoLookup retrieves information about the repository on repoupdater.
-func (c *Client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (result *protocol.RepoLookupResult, err error) {
+func (c *Client) RepoLookup(
+	ctx context.Context,
+	args protocol.RepoLookupArgs,
+) (result *protocol.RepoLookupResult, err error) {
 	if MockRepoLookup != nil {
 		return MockRepoLookup(args)
 	}
@@ -104,7 +98,12 @@ func (c *Client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 	if resp.StatusCode != http.StatusOK {
 		// best-effort inclusion of body in error message
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
-		return nil, errors.Errorf("RepoLookup for %+v failed with http status %d: %s", args, resp.StatusCode, string(body))
+		return nil, errors.Errorf(
+			"RepoLookup for %+v failed with http status %d: %s",
+			args,
+			resp.StatusCode,
+			string(body),
+		)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&result)
@@ -236,7 +235,10 @@ func (c *Client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncR
 }
 
 // SyncExternalService requests the given external service to be synced.
-func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error) {
+func (c *Client) SyncExternalService(
+	ctx context.Context,
+	svc api.ExternalService,
+) (*protocol.ExternalServiceSyncResult, error) {
 	req := &protocol.ExternalServiceSyncRequest{ExternalService: svc}
 	resp, err := c.httpPost(ctx, "sync-external-service", req)
 	if err != nil {

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -2,21 +2,15 @@ package backend
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/rpc"
 	zoektstream "github.com/google/zoekt/stream"
-
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-var zoektHTTPClient = &http.Client{
-	Transport: &ot.Transport{
-		RoundTripper: http.DefaultTransport,
-	},
-}
+var zoektHTTPClient, _ = httpcli.NewInternalClientFactory("zoekt_webserver").Client()
 
 // ZoektStreamFunc is a convenience function to create a stream receiver from a
 // function.
@@ -42,7 +36,12 @@ type StreamSearchAdapter struct {
 	zoekt.Searcher
 }
 
-func (s *StreamSearchAdapter) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoekt.Sender) error {
+func (s *StreamSearchAdapter) StreamSearch(
+	ctx context.Context,
+	q query.Q,
+	opts *zoekt.SearchOptions,
+	c zoekt.Sender,
+) error {
 	sr, err := s.Search(ctx, q, opts)
 	if err != nil {
 		return err

--- a/internal/sysreq/unix.go
+++ b/internal/sysreq/unix.go
@@ -8,8 +8,6 @@ import (
 	"context"
 
 	"golang.org/x/sys/unix"
-
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 )
 
 func rlimitCheck(ctx context.Context) (problem, fix string, err error) {
@@ -23,9 +21,7 @@ func rlimitCheck(ctx context.Context) (problem, fix string, err error) {
 	if limit.Cur < minLimit {
 		fix := fmt.Sprintf(`Please increase the open file limit by running "ulimit -n %d".`, minLimit)
 
-		if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
-			fix = fmt.Sprintf("Add --ulimit nofile=%d:%d to the docker run command", minLimit, minLimit)
-		}
+		fix = fmt.Sprintf("For Docker deployments, add --ulimit nofile=%d:%d to the docker run command", minLimit, minLimit)
 
 		return "Insufficient file descriptor limit", fix, nil
 	}

--- a/internal/sysreq/unix.go
+++ b/internal/sysreq/unix.go
@@ -19,9 +19,7 @@ func rlimitCheck(ctx context.Context) (problem, fix string, err error) {
 	}
 
 	if limit.Cur < minLimit {
-		fix := fmt.Sprintf(`Please increase the open file limit by running "ulimit -n %d".`, minLimit)
-
-		fix = fmt.Sprintf("For Docker deployments, add --ulimit nofile=%d:%d to the docker run command", minLimit, minLimit)
+		fix := fmt.Sprintf(`Please increase the open file limit by running "ulimit -n %[1]d" or adding --ulimit nofile=%[1]d:%[1]d to the docker run command"`, minLimit)
 
 		return "Insufficient file descriptor limit", fix, nil
 	}


### PR DESCRIPTION
This commit accomplishes three things:

1. Use the httpcli package for internal HTTP clients.
2. Use the httpcli for some remaining external use cases that weren't using it.
3. With retries in place, remove the `WaitForX` anti-pattern.

Why is `WaitForX` an anti-pattern? Because in production availability
isn't constant, and we should instead structure the code to retry when
needed, which this commit achieves.

I noticed that when repo-updater and gitservers were deployed at the
same time, repo-updater would go into a crash loop since it couldn't
wait for all gitservers to be up.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
