### PR TITLE
web: Fix Y-Axis labels

### DIFF
--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -26,7 +26,7 @@ import { TooltipContent } from './TooltipContent'
 // Chart configuration
 const WIDTH_PER_TICK = 70
 const HEIGHT_PER_TICK = 40
-const MARGIN = { top: 10, left: 30, bottom: 26, right: 20 }
+const MARGIN = { top: 10, left: 40, bottom: 26, right: 20 }
 const SCALES_CONFIG = {
     x: {
         type: 'time' as const,


### PR DESCRIPTION
Naive implementation. Just make the padding bigger 🤷 

Check these screenshots 🔍  notice that the left text doesn't line up perfectly. I don't _think_ that's an issue, but I defer to design for that one.

However, coding up a dynamic solution may be non-trivial. Not hard, but we'd have to find if any number in any of the data arrays is greater than 999 then adjust padding upward if so. Not a big deal on small data arrays, but we don't have absolute control over how big these might be 😬 

## Original

![original](https://user-images.githubusercontent.com/1855233/128243992-0eb75773-960d-4522-99cb-2a923540a12c.png)

## Padding < 1000

![padding](https://user-images.githubusercontent.com/1855233/128244022-c07d1374-03a0-4334-961a-8fa58ba4af45.png)

## Padding > 1000

![padding-k](https://user-images.githubusercontent.com/1855233/128244064-bc0fe4ef-7845-4468-bc53-4dc7b251d9e0.png)

## Padding > 1,000,000

![padding-m](https://user-images.githubusercontent.com/1855233/128244102-a5d5b81a-5a1f-4885-aceb-e6c77d0e598b.png)

Note regarding the above. D3 intelligently caps this at 3 digits + 1 character. So that is the maximum width Y will ever be.

Fixes #21958 