### PR TITLE
batches: add publicationStates to the applyPreview query

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -171,7 +171,8 @@ type ChangesetApplyPreviewConnectionArgs struct {
 	// CurrentState is a value of type btypes.ChangesetState.
 	CurrentState *string
 	// Action is a value of type btypes.ReconcilerOperation.
-	Action *string
+	Action            *string
+	PublicationStates *[]ChangesetSpecPublicationStateInput
 }
 
 type BatchChangeArgs struct {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2623,9 +2623,9 @@ type BatchSpec implements Node {
         more than once in the array, or if a changeset spec ID returned within
         this page has a publication state set in its spec.
 
-        Note: Unlike createBatchChange(), this query will not validate the
-        entire set of changeset specs, as they may not all be loaded on the
-        current page.
+        Note: Unlike createBatchChange(), this query will not validate that all
+        changeset specs in the array correspond to valid changeset specs within
+        the batch spec, as they may not all be loaded on the current page.
         """
         publicationStates: [ChangesetSpecPublicationStateInput!]
     ): ChangesetApplyPreviewConnection!

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2623,7 +2623,7 @@ type BatchSpec implements Node {
         more than once in the array, or if a changeset spec ID returned within
         this page has a publication state set in its spec.
 
-        Note: Unlike createBatchChange(), this method will not validate the
+        Note: Unlike createBatchChange(), this query will not validate the
         entire set of changeset specs, as they may not all be loaded on the
         current page.
         """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2588,9 +2588,10 @@ type BatchSpec implements Node {
     description: BatchChangeDescription!
 
     """
-    Generates a preview what operations would be performed if the batch spec would be applied.
-    This preview is not a guarantee, since the state of the changesets can change between the time
-    the preview is generated and when the batch spec is applied.
+    Generates a preview showing the operations that would be performed if the
+    batch spec was applied. This preview is not a guarantee, since the state
+    of the changesets can change between the time the preview is generated and
+    when the batch spec is applied.
     """
     applyPreview(
         """
@@ -2613,6 +2614,20 @@ type BatchSpec implements Node {
         Search for changesets that will have the given action performed.
         """
         action: ChangesetSpecOperation
+        """
+        If set, it will be assumed that these changeset specs will have their
+        UI publication states set to the given values when the batch spec is
+        applied.
+
+        An error will be returned if the same changeset spec ID is included
+        more than once in the array, or if a changeset spec ID returned within
+        this page has a publication state set in its spec.
+
+        Note: Unlike createBatchChange(), this method will not validate the
+        entire set of changeset specs, as they may not all be loaded on the
+        current page.
+        """
+        publicationStates: [ChangesetSpecPublicationStateInput!]
     ): ChangesetApplyPreviewConnection!
 
     """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
 const batchSpecIDKind = "BatchSpec"
@@ -123,26 +121,9 @@ func (r *batchSpecResolver) ApplyPreview(ctx context.Context, args *graphqlbacke
 			return nil, errors.Errorf("invalid action %q", *args.Action)
 		}
 	}
-	// TODO: refactor into helper function for testing purposes.
-	publicationStates := map[string]batches.PublishedValue{}
-	if args.PublicationStates != nil {
-		var errs *multierror.Error
-		for _, ps := range *args.PublicationStates {
-			id, err := unmarshalChangesetSpecID(ps.ChangesetSpec)
-			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(err, "malformed changeset spec ID %q", string(ps.ChangesetSpec)))
-				continue
-			}
-
-			if _, ok := publicationStates[id]; ok {
-				errs = multierror.Append(errs, errors.Newf("duplicate changeset spec ID %q", string(ps.ChangesetSpec)))
-				continue
-			}
-			publicationStates[id] = ps.PublicationState
-		}
-		if err := errs.ErrorOrNil(); err != nil {
-			return nil, err
-		}
+	publicationStates, err := newPublicationStateMap(args.PublicationStates)
+	if err != nil {
+		return nil, err
 	}
 
 	return &changesetApplyPreviewConnectionResolver{

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
 type changesetApplyPreviewResolver struct {
@@ -23,6 +24,7 @@ type changesetApplyPreviewResolver struct {
 	preloadedNextSync    time.Time
 	preloadedBatchChange *btypes.BatchChange
 	batchSpecID          int64
+	publicationStates    map[string]batches.PublishedValue
 }
 
 var _ graphqlbackend.ChangesetApplyPreviewResolver = &changesetApplyPreviewResolver{}
@@ -40,6 +42,7 @@ func (r *changesetApplyPreviewResolver) ToVisibleChangesetApplyPreview() (graphq
 			preloadedNextSync:    r.preloadedNextSync,
 			preloadedBatchChange: r.preloadedBatchChange,
 			batchSpecID:          r.batchSpecID,
+			publicationStates:    r.publicationStates,
 		}, true
 	}
 	return nil, false
@@ -135,6 +138,7 @@ type visibleChangesetApplyPreviewResolver struct {
 	preloadedNextSync    time.Time
 	preloadedBatchChange *btypes.BatchChange
 	batchSpecID          int64
+	publicationStates    map[string]batches.PublishedValue
 
 	planOnce sync.Once
 	plan     *reconciler.Plan
@@ -226,6 +230,11 @@ func (r *visibleChangesetApplyPreviewResolver) computePlan(ctx context.Context) 
 			return
 		}
 		changeset := changesets[0]
+
+		// Set the changeset UI publication state if necessary.
+		if state, ok := r.publicationStates[mappingChangesetSpec.RandID]; ok {
+			changeset.UiPublicationState = btypes.ChangesetUiPublicationStateFromPublishedValue(state)
+		}
 
 		// Detached changesets would still appear here, but since they'll never match one of the new specs, they don't actually appear here.
 		// Once we have a way to have changeset specs for detached changesets, this would be the place to do a "will be detached" check.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
@@ -232,7 +232,7 @@ func (r *visibleChangesetApplyPreviewResolver) computePlan(ctx context.Context) 
 		changeset := changesets[0]
 
 		// Set the changeset UI publication state if necessary.
-		if r.publicationStates != nil {
+		if r.publicationStates != nil && mappingChangesetSpec != nil {
 			if state, ok := r.publicationStates[mappingChangesetSpec.RandID]; ok {
 				changeset.UiPublicationState = btypes.ChangesetUiPublicationStateFromPublishedValue(state)
 			}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
@@ -234,6 +234,10 @@ func (r *visibleChangesetApplyPreviewResolver) computePlan(ctx context.Context) 
 		// Set the changeset UI publication state if necessary.
 		if r.publicationStates != nil && mappingChangesetSpec != nil {
 			if state, ok := r.publicationStates[mappingChangesetSpec.RandID]; ok {
+				if !mappingChangesetSpec.Spec.Published.Nil() {
+					r.planErr = errors.Newf("changeset spec %q has the published field set in its spec", mappingChangesetSpec.RandID)
+					return
+				}
 				changeset.UiPublicationState = btypes.ChangesetUiPublicationStateFromPublishedValue(state)
 			}
 		}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
@@ -232,8 +232,10 @@ func (r *visibleChangesetApplyPreviewResolver) computePlan(ctx context.Context) 
 		changeset := changesets[0]
 
 		// Set the changeset UI publication state if necessary.
-		if state, ok := r.publicationStates[mappingChangesetSpec.RandID]; ok {
-			changeset.UiPublicationState = btypes.ChangesetUiPublicationStateFromPublishedValue(state)
+		if r.publicationStates != nil {
+			if state, ok := r.publicationStates[mappingChangesetSpec.RandID]; ok {
+				changeset.UiPublicationState = btypes.ChangesetUiPublicationStateFromPublishedValue(state)
+			}
 		}
 
 		// Detached changesets would still appear here, but since they'll never match one of the new specs, they don't actually appear here.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview.go
@@ -24,7 +24,7 @@ type changesetApplyPreviewResolver struct {
 	preloadedNextSync    time.Time
 	preloadedBatchChange *btypes.BatchChange
 	batchSpecID          int64
-	publicationStates    map[string]batches.PublishedValue
+	publicationStates    publicationStateMap
 }
 
 var _ graphqlbackend.ChangesetApplyPreviewResolver = &changesetApplyPreviewResolver{}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection.go
@@ -250,7 +250,7 @@ type rewirerMappingsFacade struct {
 
 	// Inputs from outside the resolver that we need to build other resolvers.
 	batchSpecID       int64
-	publicationStates map[string]batches.PublishedValue
+	publicationStates publicationStateMap
 	store             *store.Store
 
 	// This field is set when ReconcileBatchChange is called.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/batches/resolvers/apitest"
@@ -19,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
 func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
@@ -420,6 +422,80 @@ func TestRewirerMappings(t *testing.T) {
 		have = rmf.ResolverWithNextSync(mapping, nextSync).(*changesetApplyPreviewResolver)
 		want.preloadedNextSync = nextSync
 		compareResolvers(t, have, want)
+	})
+}
+
+func TestPublicationStateMap(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		for name, in := range map[string]*[]graphqlbackend.ChangesetSpecPublicationStateInput{
+			"invalid GraphQL ID": {
+				graphqlbackend.ChangesetSpecPublicationStateInput{
+					ChangesetSpec: "not a valid ID",
+				},
+			},
+			"duplicate GraphQL ID": {
+				graphqlbackend.ChangesetSpecPublicationStateInput{
+					ChangesetSpec: marshalChangesetSpecRandID("foo"),
+				},
+				graphqlbackend.ChangesetSpecPublicationStateInput{
+					ChangesetSpec: marshalChangesetSpecRandID("foo"),
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				have, err := newPublicationStateMap(in)
+				assert.Error(t, err)
+				assert.Nil(t, have)
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   *[]graphqlbackend.ChangesetSpecPublicationStateInput
+			want publicationStateMap
+		}{
+			"nil input": {
+				in:   nil,
+				want: publicationStateMap{},
+			},
+			"empty input": {
+				in:   &[]graphqlbackend.ChangesetSpecPublicationStateInput{},
+				want: publicationStateMap{},
+			},
+			"non-empty input": {
+				in: &[]graphqlbackend.ChangesetSpecPublicationStateInput{
+					{
+						ChangesetSpec:    marshalChangesetSpecRandID("true"),
+						PublicationState: batches.PublishedValue{Val: true},
+					},
+					{
+						ChangesetSpec:    marshalChangesetSpecRandID("false"),
+						PublicationState: batches.PublishedValue{Val: false},
+					},
+					{
+						ChangesetSpec:    marshalChangesetSpecRandID("draft"),
+						PublicationState: batches.PublishedValue{Val: "draft"},
+					},
+					{
+						ChangesetSpec:    marshalChangesetSpecRandID("nil"),
+						PublicationState: batches.PublishedValue{Val: nil},
+					},
+				},
+				want: publicationStateMap{
+					"true":  {Val: true},
+					"false": {Val: false},
+					"draft": {Val: "draft"},
+					"nil":   {Val: nil},
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				have, err := newPublicationStateMap(tc.in)
+				assert.NoError(t, err)
+				assert.EqualValues(t, tc.want, have)
+			})
+		}
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -194,7 +194,7 @@ func TestRewirerMappings(t *testing.T) {
 			publishA = &btypes.RewirerMapping{ChangesetSpecID: 4}
 			publishB = &btypes.RewirerMapping{ChangesetSpecID: 5}
 		)
-		rmf := newRewirerMappingsFacade(nil, 0)
+		rmf := newRewirerMappingsFacade(nil, 0, nil)
 		rmf.All = btypes.RewirerMappings{detach, hidden, noAction, publishA, publishB}
 		addResolverFixture(rmf, detach, &mockChangesetApplyPreviewResolver{
 			visible: &mockVisibleChangesetApplyPreviewResolver{
@@ -396,7 +396,7 @@ func TestRewirerMappings(t *testing.T) {
 		}
 
 		s := &store.Store{}
-		rmf := newRewirerMappingsFacade(s, 1)
+		rmf := newRewirerMappingsFacade(s, 1, nil)
 		rmf.batchChange = &btypes.BatchChange{}
 
 		mapping := &btypes.RewirerMapping{}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -412,7 +412,7 @@ func TestChangesetApplyPreviewResolverWithPublicationStates(t *testing.T) {
 			queryChangesetApplyPreview,
 		)
 
-		assert.Len(t, err, 1)
+		assert.Greater(t, len(err), 0)
 		assert.Error(t, err[0])
 	})
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -147,7 +147,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 }
 
 const queryChangesetApplyPreview = `
-query ($batchSpec: ID!, $first: Int, $after: String, $publicationStates: [ChangesetSpecPublicationStateInput!]) {
+query ($batchSpec: ID!, $first: Int = 50, $after: String, $publicationStates: [ChangesetSpecPublicationStateInput!]) {
     node(id: $batchSpec) {
       __typename
       ... on BatchSpec {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -424,7 +424,6 @@ func assertOperations(
 	previews []apitest.ChangesetApplyPreview,
 	spec *btypes.ChangesetSpec,
 	want []btypes.ReconcilerOperation,
-
 ) {
 	t.Helper()
 


### PR DESCRIPTION
Closes #23380.

The actual change here is pretty small: there's a new optional argument on the `applyPreview` query, and it gets plumbed through the resolver layers until we reach a point where we can annotate the rewired changeset spec with the desired publication state before determining the planned operations. Easy peasy.

The tests, on the other hand... :grimacing:

Basically, the unit tests for the resolver changes end up looking suspiciously like integration tests. I'm not _particularly_ bothered by that: there is a unit test for the one thing that actually is separable, but the rest is all pretty tightly coupled because GraphQL. At least the test coverage is good? :crossed_fingers: 