### PR TITLE
docs: clarify commit author is determined from local git config

### DIFF
--- a/doc/batch_changes/explanations/permissions_in_batch_changes.md
+++ b/doc/batch_changes/explanations/permissions_in_batch_changes.md
@@ -42,7 +42,7 @@ All users are automatically given read permissions to a batch change. Granular p
 
 ## Code host interactions in Batch Changes
 
-Interactions with a code host are made possible by [configuring credentials](../how-tos/configuring_credentials.md) for that code host. When writing a commit or a changeset to the code host with Batch Changes, the author and permissions will reflect the token used (e.g., on GitHub, the commit or pull request author will be you).
+Interactions with a code host are made possible by [configuring credentials](../how-tos/configuring_credentials.md) for that code host. When publishing a changeset to the code host with Batch Changes, the author and permissions will reflect the token used (e.g., on GitHub, the pull request author will be you).
 
 ## Repository permissions for Batch Changes
 

--- a/doc/batch_changes/how-tos/configuring_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_credentials.md
@@ -34,7 +34,7 @@ Closing a changeset | 🟢 | 🟡 | 🔴
 [Importing a changeset](./tracking_existing_changesets.md) | 🔴 | 🟢 | 🟡
 Syncing a changeset | 🔴 | 🟢 | 🟡
 
-When writing a commit or a changeset to the code host, the author will reflect the token used (e.g., on GitHub, the commit or pull request author will be you). It is for this reason that a personal access token is preferred for most operations.
+When writing a changeset to the code host, the author will reflect the token used (e.g., on GitHub, the pull request author will be you). It is for this reason that a personal access token is preferred for most operations.
 
 > WARNING: Using the code host connection token with Batch Changes will be deprecated in the future; therefore, we highly recommend that admins configure a global service account token for Batch Changes instead.
 
@@ -42,7 +42,9 @@ When writing a commit or a changeset to the code host, the author will reflect t
 
 ### Do I need to add a personal access token?
 
-Personal access tokens are not required if a global access token has also been configured, but users should add one if they want Sourcegraph to create commits and changesets under their name.
+Personal access tokens are not required if a global access token has also been configured, but users should add one if they want Sourcegraph to create changesets under their name.
+
+> NOTE: Commit author is determined by your spec file or local git config at the time of running `src batch [apply|preview]`, completely independent from code host credentials.
 
 ### Adding a token
 

--- a/doc/batch_changes/how-tos/creating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/creating_a_batch_change.md
@@ -35,6 +35,8 @@ changesetTemplate:
   published: false # Do not publish any changes to the code hosts yet
 ```
 
+The commits created from your spec will use the git config values for `user.name` and `user.email` from your local environment, or "batch-changes@sourcegraph.com" if no user is set. Alternatively, you can also [specify an `author`](../references/batch_spec_yaml_reference.md#changesettemplate-commit-author) in this spec.
+
 See the ["batch spec YAML reference"](../references/batch_spec_yaml_reference.md) and the [tutorials](../tutorials/index.md) for more details on how to write batch specs.
 
 ## Creating a batch change after previewing

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -70,6 +70,8 @@ changesetTemplate:
   published: false
 ```
 
+The commits you create here will use the git config values for `user.name` and `user.email` from your local environment, or "batch-changes@sourcegraph.com" if no user is set. Alternatively, you can also [specify an `author`](./references/batch_spec_yaml_reference.md#changesettemplate-commit-author) in this spec.
+
 ## Create the batch change
 
 Let's see the changes that will be made. Don't worry---no commits, branches, or changesets will be published yet (the repositories on your code host will be untouched).

--- a/doc/batch_changes/references/faq.md
+++ b/doc/batch_changes/references/faq.md
@@ -68,3 +68,7 @@ ${{ "${{ leave me alone! }}" }}
 ```
 
 Keep in mind the context in which the inner `${{ }}` will be evaluated and be sure to escape characters as is appropriate. Check out the cheatsheet for an [example](batch_spec_cheat_sheet.md#write-a-github-actions-workflow-that-includes-github-expression-syntax) within a shell script.
+
+### How is commit author determined for commits produced from Batch Changes?
+
+Commit author is determined at the time of running `src batch [apply|preview]`. If no [author](./batch_spec_yaml_reference.md#changesettemplate-commit-author) key is defined in the batch spec, `src` will try to use the git config values for `user.name` and `user.email` from your local environment, or "batch-changes@sourcegraph.com" if no user is set.


### PR DESCRIPTION
Another piece of the PAT docs update that I should have double-checked was the language around commit authorship, which it turns out we don't use the PAT for but rather take from the git config of the local environment. In retrospect, that does make more sense knowing how `src` and the batch spec execution works, but I also think it's easy to assume commit author should match changeset author if you're the only person creating a batch change.

Since there's been some confusion around this with at least one customer, here's me taking a stab at removing the erroneous suggestions and making this extra explicit in our docs. 😅
