### PR TITLE
search: separate top function for structural search [1/4]

### DIFF
--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -104,7 +104,7 @@ func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextPa
 		// Service structural search via SearchFilesInRepos when we have
 		// an explicit `count` value that differs from the default value
 		// (e.g., user sets higher counts).
-		return unindexed.SearchFilesInRepos(ctx, args, a)
+		return unindexed.StructuralSearchFilesInRepos(ctx, args, a)
 	}
 
 	// For structural search with default limits we retry if we get no results.

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -51,6 +51,66 @@ func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissi
 	return zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.TextRequest, onMissing)
 }
 
+// StructuralSearchFilesInRepos searches a set of repos for a structural pattern.
+func StructuralSearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
+	if MockSearchFilesInRepos != nil {
+		matches, mockStats, err := MockSearchFilesInRepos(args)
+		stream.Send(streaming.SearchEvent{
+			Results: matches,
+			Stats:   mockStats.Deref(),
+		})
+		return err
+	}
+
+	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
+	defer cleanup()
+
+	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %s", args.PatternInfo.Pattern))
+	defer func() {
+		tr.SetErrorIfNotContext(err)
+		tr.Finish()
+	}()
+	tr.LogFields(
+		trace.Stringer("query", args.Query),
+		trace.Stringer("info", args.PatternInfo),
+		trace.Stringer("global_search_mode", args.Mode),
+	)
+
+	indexed, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	if err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	if args.Mode != search.SearcherOnly {
+		// Run searches on indexed repositories.
+
+		if !args.PatternInfo.IsStructuralPat {
+			// Run literal and regexp searches.
+			g.Go(func() error {
+				return indexed.Search(ctx, stream)
+			})
+		} else {
+			// Run structural search (fulfilled via searcher).
+			g.Go(func() error {
+				repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
+				for _, repo := range indexed.Repos() {
+					repos = append(repos, repo)
+				}
+				return callSearcherOverRepos(ctx, args, stream, repos, true)
+			})
+		}
+	}
+
+	// Concurrently run searcher for all unindexed repos regardless whether text, regexp, or structural search.
+	g.Go(func() error {
+		return callSearcherOverRepos(ctx, args, stream, indexed.Unindexed, false)
+	})
+
+	return g.Wait()
+}
+
 // SearchFilesInRepos searches a set of repos for a pattern.
 func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
 	if MockSearchFilesInRepos != nil {


### PR DESCRIPTION
I would like the split for literal/regexp and structural search to happen earlier. This because structural search logic only relies on searcher, and doesn't need to know about optimized Zoekt queries, which is what I want on the literal/regexp path.

This is part 1 of 4 PRs to separate this. The end result is in the last PR, which is the real goal: https://github.com/sourcegraph/sourcegraph/pull/23604.

I had 2 attempts trying to do too much at once to get there. So ended up tackling this by breaking it up with smaller changes. Didn't originally mean for it to be this many PRs, but I wanted to test each little step because things kept breaking.

This PR wholesale duplicates `SearchFilesInRepo` -> `StructuralSearchFilesInRepo` and changes a call site in the structural search path.
