### PR TITLE
search: top function batched structural search [3/4]

### DIFF
--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -108,7 +108,7 @@ func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextPa
 	}
 
 	// For structural search with default limits we retry if we get no results.
-	fileMatches, stats, err := unindexed.SearchFilesInReposBatch(ctx, args)
+	fileMatches, stats, err := unindexed.StructuralSearchFilesInReposBatch(ctx, args)
 
 	if len(fileMatches) == 0 && err == nil {
 		// No results for structural search? Automatically search again and force Zoekt
@@ -119,7 +119,7 @@ func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextPa
 		argsCopy.PatternInfo = &patternCopy
 		args = &argsCopy
 
-		fileMatches, stats, err = unindexed.SearchFilesInReposBatch(ctx, args)
+		fileMatches, stats, err = unindexed.StructuralSearchFilesInReposBatch(ctx, args)
 
 		if len(fileMatches) == 0 {
 			// Still no results? Give up.

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -142,6 +142,20 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 	return g.Wait()
 }
 
+// StructuralSearchFilesInRepoBatch is a convenience function around
+// StructuralSearchFilesInRepos which collects the results from the stream.
+func StructuralSearchFilesInReposBatch(ctx context.Context, args *search.TextParameters) ([]*result.FileMatch, streaming.Stats, error) {
+	matches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
+		return StructuralSearchFilesInRepos(ctx, args, stream)
+	})
+
+	fms, fmErr := matchesToFileMatches(matches)
+	if fmErr != nil && err == nil {
+		err = errors.Wrap(fmErr, "StructuralSearchFilesInReposBatch failed to convert results")
+	}
+	return fms, stats, err
+}
+
 // SearchFilesInRepoBatch is a convenience function around searchFilesInRepos
 // which collects the results from the stream.
 func SearchFilesInReposBatch(ctx context.Context, args *search.TextParameters) ([]*result.FileMatch, streaming.Stats, error) {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23602.

This wholesale copies `SearchFilesInReposBatch` -> `StructuralSearchFilesInReposBatch` and updates callsites along the structural search path. A wrapper around streaming will be generalized/simplified later (this is something I tried to do all at once and it's just too much).

