### PR TITLE
search: simplify literal/regexp search over repos logic [4/4]

### DIFF
--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -115,23 +115,10 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 	g, ctx := errgroup.WithContext(ctx)
 
 	if args.Mode != search.SearcherOnly {
-		// Run searches on indexed repositories.
-
-		if !args.PatternInfo.IsStructuralPat {
-			// Run literal and regexp searches.
-			g.Go(func() error {
-				return indexed.Search(ctx, stream)
-			})
-		} else {
-			// Run structural search (fulfilled via searcher).
-			g.Go(func() error {
-				repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
-				for _, repo := range indexed.Repos() {
-					repos = append(repos, repo)
-				}
-				return callSearcherOverRepos(ctx, args, stream, repos, true)
-			})
-		}
+		// Run literal and regexp searches on indexed repositories.
+		g.Go(func() error {
+			return indexed.Search(ctx, stream)
+		})
 	}
 
 	// Concurrently run searcher for all unindexed repos regardless whether text, regexp, or structural search.


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23603.

The previous PRs make structural search vs literal/regexp search disjoint, so we can now simplify the 'structural search' control flow in this function.

In general: We do want to keep search literal/regexp/structural search concerns together but not this deep in the call chain where we figure out the backends for each. This isn't the end, I'll simplify/remove/dedupe things I did to get here.
