### PR TITLE
Only redact first source URL info for Sourcegraph.com URLs

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -5,7 +5,7 @@ import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetrySer
 
 import { browserExtensionMessageReceived, handleQueryEvents, pageViewQueryParameters } from './analyticsUtils'
 import { serverAdmin } from './services/serverAdminWrapper'
-import { getPreviousMonday, redactSensitiveInfoFromURL } from './util'
+import { getPreviousMonday, redactSensitiveInfoFromAppURL } from './util'
 
 export const ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
 export const COHORT_ID_KEY = 'sourcegraphCohortId'
@@ -103,7 +103,7 @@ export class EventLogger implements TelemetryService {
     public getFirstSourceURL(): string {
         const firstSourceURL = this.firstSourceURL || cookies.get(FIRST_SOURCE_URL_KEY) || location.href
 
-        const redactedURL = redactSensitiveInfoFromURL(firstSourceURL)
+        const redactedURL = redactSensitiveInfoFromAppURL(firstSourceURL)
 
         // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
         // Always set to renew expiry and migrate from localStorage

--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -1,16 +1,16 @@
-import { getPreviousMonday, redactSensitiveInfoFromURL } from './util'
+import { getPreviousMonday, redactSensitiveInfoFromAppURL } from './util'
 
 describe('tracking/util', () => {
-    describe(`${redactSensitiveInfoFromURL.name}()`, () => {
+    describe(`${redactSensitiveInfoFromAppURL.name}()`, () => {
         it('removes search queries from URLs', () => {
-            expect(redactSensitiveInfoFromURL('https://sourcegraph.com/search?q=test+query')).toEqual(
+            expect(redactSensitiveInfoFromAppURL('https://sourcegraph.com/search?q=test+query')).toEqual(
                 'https://sourcegraph.com/redacted?q=redacted'
             )
         })
 
         it('removes search queries from URLs but maintains marketing query params', () => {
             expect(
-                redactSensitiveInfoFromURL(
+                redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/search?q=test+query&utm_source=test&utm_campaign=test'
                 )
             ).toEqual('https://sourcegraph.com/redacted?q=redacted&utm_source=test&utm_campaign=test')
@@ -18,7 +18,7 @@ describe('tracking/util', () => {
 
         it('removes all query params from URLs but maintains marketing query params', () => {
             expect(
-                redactSensitiveInfoFromURL(
+                redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/search?some_query_param=test+query&utm_source=test&utm_campaign=test&utm_content=test&utm_medium=test&utm_medium=test'
                 )
             ).toEqual(
@@ -28,7 +28,7 @@ describe('tracking/util', () => {
 
         it('removes repo information from URLs', () => {
             expect(
-                redactSensitiveInfoFromURL(
+                redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/github.com/test/test?utm_source=test&utm_campaign=test'
                 )
             ).toEqual('https://sourcegraph.com/redacted?utm_source=test&utm_campaign=test')
@@ -36,10 +36,18 @@ describe('tracking/util', () => {
 
         it('removes repo and file information from URLs', () => {
             expect(
-                redactSensitiveInfoFromURL(
+                redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/test?utm_source=test&utm_campaign=test'
                 )
             ).toEqual('https://sourcegraph.com/redacted?utm_source=test&utm_campaign=test')
+        })
+
+        it('does not redact pathnames from marketing site URLs', () => {
+            expect(
+                redactSensitiveInfoFromAppURL(
+                    'https://about.sourcegraph.com/case-studies?utm_source=test&utm_campaign=test'
+                )
+            ).toEqual('https://about.sourcegraph.com/case-studies?utm_source=test&utm_campaign=test')
         })
     })
 

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -14,18 +14,23 @@ export function stripURLParameters(url: string, parametersToRemove: string[] = [
 }
 
 /**
- * Redact the pathname and search query from URLs to avoid
- * leaking sensitive information, while maintaining
+ * Redact the pathname and search query from sourcegraph.com URLs to avoid
+ * leaking sensitive information from Sourcegraph Cloud, while maintaining
  * non-sensitive query parameters used for attribution tracking.
  *
  * @param url the original, full URL
  */
-export function redactSensitiveInfoFromURL(url: string): string {
-    const marketingQueryParameters = new Set(['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content'])
-    // Ensure we do not leak repo and file names in the URL
+export function redactSensitiveInfoFromAppURL(url: string): string {
     const sourceURL = new URL(url)
+
+    if (sourceURL.hostname !== 'sourcegraph.com') {
+        return url
+    }
+
+    // Ensure we do not leak repo and file names in the URL
     sourceURL.pathname = '/redacted'
 
+    const marketingQueryParameters = new Set(['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content'])
     // Ensure we do not leak search queries or other sensitive info in the URL
     // by only maintaining UTM parameters for attribution.
     for (const [parameter] of sourceURL.searchParams) {


### PR DESCRIPTION
We redacted all pathnames and UTM information from all first source URLs in order to prevent leaking private information. However, it was actually unnecessarily restrictive, because it also removed pathnames from marketing sites, which aren't private.

This limits us to redacting pathnames from only Sourcegraph Cloud URLs.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
