### PR TITLE
search: remove bufferedSender

### DIFF
--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/binary"
-	"fmt"
 	"testing"
 	"time"
 
@@ -461,28 +460,6 @@ func TestZoektResultCountFactor(t *testing.T) {
 			}
 		})
 	}
-}
-
-func generateZoektMatches(count int) []zoekt.FileMatch {
-	var zoektFileMatches []zoekt.FileMatch
-	for i := 1; i <= count; i++ {
-		repoName := fmt.Sprintf("repo-%d", i)
-		fileName := fmt.Sprintf("foobar-%d.go", i)
-
-		zoektFileMatches = append(zoektFileMatches, zoekt.FileMatch{
-			Score:      5.0,
-			FileName:   fileName,
-			Repository: repoName, // Important: this needs to match a name in `repos`
-			Branches:   []string{"master"},
-			LineMatches: []zoekt.LineMatch{
-				{
-					Line: nil,
-				},
-			},
-			Checksum: []byte{0, 1, 2},
-		})
-	}
-	return zoektFileMatches
 }
 
 func TestZoektIndexedRepos_single(t *testing.T) {

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -704,35 +704,6 @@ func TestContextWithoutDeadline_cancel(t *testing.T) {
 	}
 }
 
-func TestBufferedSender(t *testing.T) {
-	// We create an unbuffered Sender, which means a call to Send blocks if there is
-	// no consumer.
-	c := make(chan *zoekt.SearchResult)
-	defer close(c)
-	unbufferedMockSender := searchbackend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
-		c <- event
-	})
-
-	// We add a buffer to unbufferedMockSender. A call to Send should not block anymore.
-	bufferedMockSender, cleanup := bufferedSender(1, unbufferedMockSender)
-	defer cleanup()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		// Should not block.
-		bufferedMockSender.Send(&zoekt.SearchResult{Files: generateZoektMatches(1)})
-
-	}()
-	select {
-	case <-done:
-	case <-time.After(1 * time.Second):
-		t.Errorf("bufferedMockSender.Send did not return in time")
-	}
-	// Drain the buffer to make sure that cleanup() can return.
-	<-c
-}
-
 func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 	r := make([]*search.RepositoryRevisions, len(repos))
 	for i, repospec := range repos {


### PR DESCRIPTION
The purpose of `bufferedSender` was to buffer results for a global
search while we wait for repo resolution. Since #23118 we don't need it
anymore.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
