### PR TITLE
batches observability: filter out ErrNoResults

### DIFF
--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -231,7 +231,7 @@ func newOperations(observationContext *observation.Context) *operations {
 				MetricLabels: []string{name},
 				Metrics:      m,
 				ErrorFilter: func(err error) bool {
-					return !errors.Is(err, ErrNoResults)
+					return errors.Is(err, ErrNoResults)
 				},
 			})
 		}

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -230,6 +230,9 @@ func newOperations(observationContext *observation.Context) *operations {
 				Name:         fmt.Sprintf("batches.dbstore.%s", name),
 				MetricLabels: []string{name},
 				Metrics:      m,
+				ErrorFilter: func(err error) bool {
+					return !errors.Is(err, ErrNoResults)
+				},
 			})
 		}
 

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -86,7 +86,7 @@ type Op struct {
 	MetricLabels []string
 	// LogFields that apply for for every invocation of this operation.
 	LogFields []log.Field
-	// ErrorFilter returns false for any error that should be converted to nil
+	// ErrorFilter returns true for any error that should be converted to nil
 	// for the purposes of metrics and tracing. If this field is not set then
 	// error values are unaltered.
 	//


### PR DESCRIPTION
If we don't filter them out we get an error message in the logs for
every "ErrNoResults".