### PR TITLE
repos: Handle the case where a public repos becomes private

### DIFF
--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"

--- a/internal/types/testing.go
+++ b/internal/types/testing.go
@@ -220,6 +220,7 @@ var Opt = struct {
 	RepoSources               func(...string) func(*Repo)
 	RepoMetadata              func(interface{}) func(*Repo)
 	RepoExternalID            func(string) func(*Repo)
+	RepoPrivate               func(bool) func(*Repo)
 }{
 	ExternalServiceID: func(n int64) func(*ExternalService) {
 		return func(e *ExternalService) {
@@ -284,6 +285,11 @@ var Opt = struct {
 	RepoExternalID: func(id string) func(*Repo) {
 		return func(r *Repo) {
 			r.ExternalRepo.ID = id
+		}
+	},
+	RepoPrivate: func(b bool) func(*Repo) {
+		return func(r *Repo) {
+			r.Private = b
 		}
 	},
 }


### PR DESCRIPTION
Specifically, when a repo was added using on of our cloud_default
external services we should ensure that if it later becomes private
we'll remove it.
