### PR TITLE
gomod: final bump for the day

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210805091256-d5f1250b10c7
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210805133658-68b5aae78586
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1338,8 +1338,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210805091256-d5f1250b10c7 h1:vLnRyCtPJA7nCEMe6IAEY6Uiyki8toVaaK4O24p0Tds=
-github.com/sourcegraph/zoekt v0.0.0-20210805091256-d5f1250b10c7/go.mod h1:dVU673p1lKpZK6Joobq6cqbfq9Mkf4vPEEsj91yZqHM=
+github.com/sourcegraph/zoekt v0.0.0-20210805133658-68b5aae78586 h1:it2ljlDFvoCgSi0V5Gu63vKXZ5KoxLnC1WuFs9JkRag=
+github.com/sourcegraph/zoekt v0.0.0-20210805133658-68b5aae78586/go.mod h1:dVU673p1lKpZK6Joobq6cqbfq9Mkf4vPEEsj91yZqHM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
GitHub actions seems a bit flakey today, so CI wasn't passing for Zoekt
=> couldn't include the docker images it build in our CI. This bump
is pointing to a zoekt commit that did have CI run successfully.
