### PR TITLE
Make calls to sentry.Init explicit, make conf.Init func visible

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -149,6 +150,7 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 		log.Fatalf("failed to apply site config overrides: %v", err)
 	}
 	globals.ConfigurationServerFrontendOnly = conf.InitConfigurationServerFrontendOnly(&configurationSource{})
+	conf.Init()
 	conf.MustValidateDefaults()
 
 	// now we can init the keyring, as it depends on site config
@@ -170,7 +172,8 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 	d, _ := time.ParseDuration(traceThreshold)
 	logging.Init(logging.Filter(loghandlers.Trace(strings.Fields(traceFields), d)))
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	// Create an out-of-band migration runner onto which each enterprise init function
 	// can register migration routines to run in the background while they still have

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -57,7 +58,8 @@ func main() {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	go func() {
 		c := make(chan os.Signal, 1)

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -56,9 +57,11 @@ func main() {
 		log.Fatalf("failed to start profiler: %v", err)
 	}
 
+	conf.Init()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	if reposDir == "" {
 		log.Fatal("git-server: SRC_REPOS_DIR is required")

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -20,10 +20,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/query-runner/queryrunnerapi"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -35,9 +37,12 @@ const port = "3183"
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
+
+	conf.Init()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	go func() {
 		c := make(chan os.Signal, 1)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -66,9 +67,11 @@ func Main(enterpriseInit EnterpriseInit) {
 		log.Fatalf("failed to start profiler: %v", err)
 	}
 
+	conf.Init()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	// Signals health of startup
 	ready := make(chan struct{})

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -18,10 +18,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/search"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -37,9 +39,11 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	log.SetFlags(0)
+	conf.Init()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -19,10 +19,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/sqliteutil"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -40,9 +42,11 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	log.SetFlags(0)
+	conf.Init()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	sqliteutil.MustRegisterSqlite3WithPcre()
 

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -13,12 +13,14 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -45,9 +47,11 @@ func Start(additionalJobs map[string]Job) {
 
 	env.Lock()
 	env.HandleHelpFlag()
+	conf.Init()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	// Start debug server
 	ready := make(chan struct{})

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -28,7 +28,7 @@ func main() {
 	env.HandleHelpFlag()
 
 	logging.Init()
-	trace.Init(false)
+	trace.Init()
 
 	if err := config.Validate(); err != nil {
 		log.Fatalf("failed to read config: %s", err)

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -44,9 +45,11 @@ func main() {
 
 	env.Lock()
 	env.HandleHelpFlag()
+	conf.Init()
 	logging.Init()
 	tracer.Init()
-	trace.Init(true)
+	sentry.Init()
+	trace.Init()
 
 	if err := config.Validate(); err != nil {
 		log.Fatalf("Failed to load config: %s", err)

--- a/internal/conf/init.go
+++ b/internal/conf/init.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-func init() {
+func Init() {
 	// This watch loop is here so that we don't introduce
 	// dependency cycles, since conf itself uses httpcli's internal
 	// client. This is gross, and the whole conf package is gross.

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -56,13 +56,9 @@ var requestHeartbeat = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Last time a request finished for a http endpoint.",
 }, metricLabels)
 
-func Init(shouldInitSentry bool) {
+func Init() {
 	if origin := os.Getenv("METRICS_TRACK_ORIGIN"); origin != "" {
 		trackOrigin = origin
-	}
-
-	if shouldInitSentry {
-		sentry.Init()
 	}
 }
 


### PR DESCRIPTION
Alright, how did we get here?

We found error messages in `executor` (deployed outside of a Sourcegraph
cluster) that said it can't connect to
`http://sourcegraph-frontend-internal` to fetch the configuration.

Why would `executor` even try to fetch the configuration?

Thanks to `./dev/depgraph` we found out that `executor` uses `trace` and
that imports `sentry` and that imports `conf` and `conf` has an `init()`
function that starts a goroutine that watches for configuration changes
with `conf.Watch`.

So, to :fingerquotes: improve :fingerquotes: on that we did a couple of things here:

1. Pull out the `sentry.Init()` calls from `trace.Init()` so they're
   visible.
2. Change `conf.init` into capital-case `Init()` and call that
   everywhere we suspect a `httpcli.ExternalClient` is used (because
   that's what the `Init` function updates)
3. Do not call any of that in `executor`

At this point I want to say "I don't know good from evil anymore", but I
do know that `conf` is evil, so I don't know, man



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
