### PR TITLE
monitoring: remove repos_priorities graph

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4554,16 +4554,6 @@ Sudden changes should be caused by indexing configuration changes.
 
 <br />
 
-#### zoekt-indexserver: repos_priorities
-
-This panel indicates total number of repos with priorities for ranking.
-
-Sudden changes should be caused by indexing configuration changes.
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
 #### zoekt-indexserver: repo_index_state
 
 This panel indicates indexing results over 5m (noop=no changes, empty=no branches to index).

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -43,15 +43,6 @@ func ZoektIndexServer() *monitoring.Container {
 							Owner:          monitoring.ObservableOwnerSearch,
 							Interpretation: "Sudden changes should be caused by indexing configuration changes.",
 						},
-						{
-							Name:           "repos_priorities",
-							Description:    "total number of repos with priorities for ranking",
-							Query:          `sum(index_priorities_total)`,
-							NoAlert:        true,
-							Panel:          monitoring.Panel(),
-							Owner:          monitoring.ObservableOwnerSearch,
-							Interpretation: "Sudden changes should be caused by indexing configuration changes.",
-						},
 					},
 					{
 						{


### PR DESCRIPTION
This series behind this graph is no longer populated.
