### PR TITLE
Fix alertmanaged config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,14 @@ All notable changes to Sourcegraph are documented in this file.
 - The search reference will now show matching entries when using the filter input. [#23224](https://github.com/sourcegraph/sourcegraph/pull/23224)
 - Graceful termination periods have been added to database deployments. [#3358](https://github.com/sourcegraph/deploy-sourcegraph/pull/3358) & [#477](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/477)
 - All commit search results for `and`-expressions are now highlighted. [#23336](https://github.com/sourcegraph/sourcegraph/pull/23336)
+- Alertmanager (Prometheus) now respects `SMTPServerConfig.noVerifyTLS` field. [#23636](https://github.com/sourcegraph/sourcegraph/issues/23636)
 
 ### Removed
 
 - The old batch repository syncer was removed and can no longer be activated by setting `ENABLE_STREAMING_REPOS_SYNCER=false`. [#22949](https://github.com/sourcegraph/sourcegraph/pull/22949)
 - Email notifications for saved searches are now deprecated in favor of Code Monitoring. Email notifications can no longer be enabled for saved searches. Saved searches that already have notifications enabled will continue to work, but there is now a button users can click to migrate to code monitors. Notifications for saved searches will be removed entirely in the future. [#23275](https://github.com/sourcegraph/sourcegraph/pull/23275)
 - The `sg_service` Postgres role and `sg_repo_access_policy` policy on the `repo` table have been removed due to performance concerns. [#23622](https://github.com/sourcegraph/sourcegraph/pull/23622)
+- Deprecated field `SMTPServerConfig.DisableTLS` removed. [#23639](https://github.com/sourcegraph/sourcegraph/pull/23639).
 
 ## 3.30.3
 

--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -73,6 +73,7 @@ func changeSMTP(ctx context.Context, log log15.Logger, change ChangeContext, new
 		change.AMConfig.Global.SMTPAuthSecret = amconfig.Secret(email.SMTP.Password)
 	}
 	change.AMConfig.Global.SMTPRequireTLS = !email.SMTP.DisableTLS
+	change.AMConfig.Global.SMTPRequireTLS = !email.SMTP.NoVerifyTLS
 
 	return
 }

--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -72,7 +72,6 @@ func changeSMTP(ctx context.Context, log log15.Logger, change ChangeContext, new
 	case "CRAM-MD5":
 		change.AMConfig.Global.SMTPAuthSecret = amconfig.Secret(email.SMTP.Password)
 	}
-	change.AMConfig.Global.SMTPRequireTLS = !email.SMTP.DisableTLS
 	change.AMConfig.Global.SMTPRequireTLS = !email.SMTP.NoVerifyTLS
 
 	return

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -118,8 +118,7 @@ func Send(ctx context.Context, message Message) error {
 		return errors.Errorf("invalid SMTP authentication type %q", conf.EmailSmtp.Authentication)
 	}
 
-	// TODO: 2020/11/12 @arussellsaw, after next release delete DisableTLS option
-	if conf.EmailSmtp.DisableTLS || conf.EmailSmtp.NoVerifyTLS {
+	if conf.EmailSmtp.NoVerifyTLS {
 		return m.SendWithStartTLS(
 			net.JoinHostPort(conf.EmailSmtp.Host, strconv.Itoa(conf.EmailSmtp.Port)),
 			smtpAuth,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1231,8 +1231,6 @@ type SAMLAuthProvider struct {
 type SMTPServerConfig struct {
 	// Authentication description: The type of authentication to use for the SMTP server.
 	Authentication string `json:"authentication"`
-	// DisableTLS description: DEPRECATED: use noVerifyTLS instead, this field will be removed in a future release
-	DisableTLS bool `json:"disableTLS,omitempty"`
 	// Domain description: The HELO domain to provide to the SMTP server (if needed).
 	Domain string `json:"domain,omitempty"`
 	// Host description: The SMTP server host.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -670,10 +670,6 @@
           "description": "The HELO domain to provide to the SMTP server (if needed).",
           "type": "string"
         },
-        "disableTLS": {
-          "description": "DEPRECATED: use noVerifyTLS instead, this field will be removed in a future release",
-          "type": "boolean"
-        },
         "noVerifyTLS": {
           "description": "Disable TLS verification",
           "type": "boolean"


### PR DESCRIPTION
Alertmanager config depended on a deprecated field for email TLS

Fixes https://github.com/sourcegraph/sourcegraph/issues/23636



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
