### PR TITLE
search frontend: query diagnostic tests use inline snapshots

### DIFF
--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -4,43 +4,54 @@ import { getDiagnostics } from './diagnostics'
 import { scanSearchQuery, ScanSuccess, ScanResult } from './scanner'
 import { Token } from './token'
 
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value, null, 2),
+    test: () => true,
+})
+
 const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
 
 describe('getDiagnostics()', () => {
     test('do not raise invalid filter type', () => {
         expect(
             getDiagnostics(toSuccess(scanSearchQuery('repos:^github.com/sourcegraph')), SearchPatternType.literal)
-        ).toStrictEqual([])
+        ).toMatchInlineSnapshot('[]')
     })
 
     test('invalid filter value', () => {
-        expect(getDiagnostics(toSuccess(scanSearchQuery('case:maybe')), SearchPatternType.literal)).toStrictEqual([
-            {
-                endColumn: 5,
-                endLineNumber: 1,
-                message: 'Invalid filter value, expected one of: yes, no.',
-                severity: 8,
-                startColumn: 1,
-                startLineNumber: 1,
-            },
-        ])
+        expect(
+            getDiagnostics(toSuccess(scanSearchQuery('case:maybe')), SearchPatternType.literal)
+        ).toMatchInlineSnapshot(
+            `
+            [
+              {
+                "severity": 8,
+                "message": "Invalid filter value, expected one of: yes, no.",
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 5
+              }
+            ]
+        `
+        )
     })
 
     test('search query containing colon, literal pattern type, do not raise error', () => {
         expect(
             getDiagnostics(toSuccess(scanSearchQuery('Configuration::doStuff(...)')), SearchPatternType.literal)
-        ).toStrictEqual([])
+        ).toMatchInlineSnapshot('[]')
     })
 
     test('search query containing quoted token, regexp pattern type', () => {
         expect(
             getDiagnostics(toSuccess(scanSearchQuery('"Configuration::doStuff(...)"')), SearchPatternType.regexp)
-        ).toStrictEqual([])
+        ).toMatchInlineSnapshot('[]')
     })
 
     test('search query containing parenthesized parameterss', () => {
         expect(
             getDiagnostics(toSuccess(scanSearchQuery('repo:a (file:b and c)')), SearchPatternType.regexp)
-        ).toStrictEqual([])
+        ).toMatchInlineSnapshot('[]')
     })
 })


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23644. 

Prep for #21302, just uses inline test snapshots so I can more easily add new tests.