### PR TITLE
search frontend: warn on filters followed by space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Syntax highlighting support for the [Cue](https://cuelang.org) language.
 - Reintroduced a revised version of the Search Types sidebar section. [#23170](https://github.com/sourcegraph/sourcegraph/pull/23170)
 - Add a new environment variable `SRC_HTTP_CLI_EXTERNAL_TIMEOUT` to control the timeout for all external HTTP requests. [#23620](https://github.com/sourcegraph/sourcegraph/pull/23620)
+- Improved usability where filters followed by a space in the search query will warn users that the filter value is empty. [#23646](https://github.com/sourcegraph/sourcegraph/pull/23646)
 
 ### Changed
 

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -19,22 +19,19 @@ describe('getDiagnostics()', () => {
     })
 
     test('invalid filter value', () => {
-        expect(
-            getDiagnostics(toSuccess(scanSearchQuery('case:maybe')), SearchPatternType.literal)
-        ).toMatchInlineSnapshot(
-            `
+        expect(getDiagnostics(toSuccess(scanSearchQuery('case:maybe')), SearchPatternType.literal))
+            .toMatchInlineSnapshot(`
             [
               {
                 "severity": 8,
-                "message": "Invalid filter value, expected one of: yes, no.",
+                "message": "Error: Invalid filter value, expected one of: yes, no.",
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 1,
                 "endColumn": 5
               }
             ]
-        `
-        )
+        `)
     })
 
     test('search query containing colon, literal pattern type, do not raise error', () => {
@@ -53,5 +50,37 @@ describe('getDiagnostics()', () => {
         expect(
             getDiagnostics(toSuccess(scanSearchQuery('repo:a (file:b and c)')), SearchPatternType.regexp)
         ).toMatchInlineSnapshot('[]')
+    })
+
+    test('search query with empty filter diagnostic', () => {
+        expect(getDiagnostics(toSuccess(scanSearchQuery('meatadata file: ')), SearchPatternType.regexp))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "severity": 4,
+                "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., file:\\" a term\\".",
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 11,
+                "endColumn": 15
+              }
+            ]
+        `)
+    })
+
+    test('search query with both invalid filter and empty filter returns only one diagnostic for the first issue', () => {
+        expect(getDiagnostics(toSuccess(scanSearchQuery('meatadata type: ')), SearchPatternType.regexp))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "severity": 8,
+                "message": "Error: Invalid filter value, expected one of: diff, commit, symbol, repo, path, file.",
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 11,
+                "endColumn": 15
+              }
+            ]
+        `)
     })
 })


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21302.

<img width="786" alt="Screen Shot 2021-08-05 at 1 40 56 PM" src="https://user-images.githubusercontent.com/888624/128420753-fe24be94-6234-431b-9b78-027e6dbec574.png">

@rrhyne can you comment on the message we should show on hover here? I just went with something I think works but it's maybe a bit verbose. Don't feel strongly about phrasing.

Also, we can make the squiggles yellow or blue if you think that's better?