### PR TITLE
perf: API docs: fix needless rerendering of page

### DIFF
--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -255,24 +255,53 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
     },
     {
         path: '/-/docs/:pathID*',
-        condition: ({ settingsCascade }) => {
+        condition: ({ settingsCascade }): boolean => {
             if (settingsCascade.final === null || isErrorLike(settingsCascade.final)) {
                 return false
             }
             const settings: Settings = settingsCascade.final
             return settings.experimentalFeatures?.apiDocs !== false
         },
-        render: ({ resolvedRev: { commitID }, match, repoHeaderContributionsLifecycleProps, ...context }: any) => (
+        render: ({
+            useBreadcrumb,
+            setBreadcrumb,
+            settingsCascade,
+            versionContext,
+            repo,
+            history,
+            location,
+            isLightTheme,
+            fetchHighlightedFileLineRanges,
+            resolvedRev: { commitID },
+            match,
+            ...context
+        }) => (
             <>
+                {/*
+                    IMPORTANT: do NOT use `{...context}` expansion to pass props to page components
+                    here. Doing so adds other props that exist in `context` that are NOT required
+                    or specified by the component props, but TypeScript will NOT strip them out.
+                    For example, the navbarSearchQueryState - meaning every time a user types into
+                    the search input our React component props would change despite it being a field
+                    that we are absolutely not using in any way. See:
+                    https://github.com/sourcegraph/sourcegraph/issues/21200
+                */}
                 <RepositoryDocumentationPage
-                    {...context}
-                    match={match}
-                    commitID={commitID}
+                    useBreadcrumb={useBreadcrumb}
+                    setBreadcrumb={setBreadcrumb}
+                    settingsCascade={settingsCascade}
+                    versionContext={versionContext}
+                    repo={repo}
+                    history={history}
+                    location={location}
+                    isLightTheme={isLightTheme}
+                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                     pathID={match.params.pathID ? '/' + decodeURIComponent(match.params.pathID) : '/'}
+                    commitID={commitID}
                 />
                 <ActionItemsBar
                     useActionItemsBar={context.useActionItemsBar}
-                    location={context.location}
+                    location={location}
                     extensionsController={context.extensionsController}
                     platformContext={context.platformContext}
                     telemetryService={context.telemetryService}


### PR DESCRIPTION
This was incredibly difficult for me to track down, probably 9h of my time overall.
See #21200 for details.

We'll need to apply this same fix to other pages in this `routes.tsx` file, because
they are 100% affected by this. Also, this isn't a complete fix - there are other
issues (like not using `React.memo` on this page) that mean typing in the search bar
is still incredibly sluggish.

Helps #21200

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
