### PR TITLE
perf: API docs: reduce number of React hooks on large pages by ~1,000

### DIFF
--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom'
 
 import { ResolvedRevisionSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 
-import { useScrollToLocationHash } from '../../components/useScrollToLocationHash'
 import { RepositoryFields } from '../../graphql-operations'
 import { toDocumentationURL } from '../../util/url'
 
@@ -34,7 +33,6 @@ interface Props extends Partial<RevisionSpec>, ResolvedRevisionSpec {
 }
 
 export const DocumentationIndexNode: React.FunctionComponent<Props> = ({ node, depth, ...props }) => {
-    useScrollToLocationHash(props.location)
     const repoRevision = {
         repoName: props.repo.name,
         revision: props.revision || '',

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -11,7 +11,6 @@ import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 import { ResolvedRevisionSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { useScrollToLocationHash } from '../../components/useScrollToLocationHash'
 import { RepositoryFields } from '../../graphql-operations'
 import { toDocumentationURL } from '../../util/url'
 
@@ -47,7 +46,6 @@ interface Props
 }
 
 export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrumb, node, depth, ...props }) => {
-    useScrollToLocationHash(props.location)
     const repoRevision = {
         repoName: props.repo.name,
         revision: props.revision || '',

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -20,6 +20,7 @@ import { Container } from '@sourcegraph/wildcard'
 import { Badge } from '../../components/Badge'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { PageTitle } from '../../components/PageTitle'
+import { useScrollToLocationHash } from '../../components/useScrollToLocationHash'
 import { RepositoryFields } from '../../graphql-operations'
 import { FeedbackPrompt } from '../../nav/Feedback/FeedbackPrompt'
 import { routes } from '../../routes'
@@ -75,6 +76,7 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ us
     useEffect(() => {
         eventLogger.logViewEvent('RepositoryDocs')
     }, [])
+    useScrollToLocationHash(props.location)
 
     const thisPage = toDocumentationURL({ repoName: props.repo.name, revision: props.revision || '', pathID: '' })
     useBreadcrumb(useMemo(() => ({ key: 'node', element: <Link to={thisPage}>API docs</Link> }), [thisPage]))


### PR DESCRIPTION
We don't need `useScrollToLocationHash` per node (symbol, section, etc),
we just need one to be on the page when it's rerendered (location change);
the root of the page is good enough for achieving that.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>