### PR TITLE
perf: API docs: do not rerender entire page when searching

### DIFF
--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -62,7 +62,10 @@ interface Props
 const LOADING = 'loading' as const
 
 /** A page that shows a repository's documentation at the current revision. */
-export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ useBreadcrumb, ...props }) => {
+export const RepositoryDocumentationPage: React.FunctionComponent<Props> = React.memo(function Render({
+    useBreadcrumb,
+    ...props
+}) {
     // TODO(slimsag): nightmare: there is _something_ in the props that causes this entire page to
     // rerender whenever you type in the search bar. In fact, this also appears to happen on all other
     // pages!
@@ -235,4 +238,4 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = ({ us
             ) : null}
         </div>
     )
-}
+})


### PR DESCRIPTION
`React.FunctionComponent` always rerenders the component, even if props
have not changed. This is an issue with a LOT of components in Sourcegraph,
and in the case of API docs surfaces as "typing in the search bar makes the
entire page stall/stutter/lag"

This fixes it by using `React.memo`, see #21200 for details.

Helps #21200

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
