### PR TITLE
Insights: prevent repeated and unnecessary backfills

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -274,7 +274,11 @@ func (h *historicalEnqueuer) Handler(ctx context.Context) error {
 
 func (h *historicalEnqueuer) markInsightsComplete(ctx context.Context, completed []itypes.InsightSeries) {
 	for _, series := range completed {
-		_, _ = h.dataSeriesStore.StampBackfill(ctx, series)
+		_, err := h.dataSeriesStore.StampBackfill(ctx, series)
+		if err != nil {
+			// do nothing to preserve at least once semantics
+			continue
+		}
 		log15.Info("Insight marked backfill complete.", "series_id", series.SeriesID)
 	}
 }

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -279,7 +279,7 @@ func (h *historicalEnqueuer) markInsightsComplete(ctx context.Context, completed
 			// do nothing to preserve at least once semantics
 			continue
 		}
-		log15.Info("Insight marked backfill complete.", "series_id", series.SeriesID)
+		log15.Info("insights: Insight marked backfill complete.", "series_id", series.SeriesID)
 	}
 }
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -484,7 +484,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 	hardErr = h.enqueueQueryRunnerJob(ctx, &queryrunner.Job{
 		SeriesID:    bctx.seriesID,
 		SearchQuery: query,
-		RecordTime:  &nearestCommit.Committer.Date,
+		RecordTime:  &bctx.from,
 		State:       "queued",
 		Priority:    int(priority.FromTimeInterval(bctx.from, bctx.series.CreatedAt)),
 		Cost:        int(priority.Unindexed),

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -193,14 +193,14 @@ func Test_historicalEnqueuer(t *testing.T) {
 		want := autogold.Want("no_data", &testResults{
 			allReposIteratorCalls: 1, reposGetByName: 2,
 			operations: []string{
-				`enqueueQueryRunnerJob("2020-06-30T12:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2019-12-31T00:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-06-30T12:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2019-12-31T00:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
-				`enqueueQueryRunnerJob("2020-06-30T12:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
-				`enqueueQueryRunnerJob("2019-12-31T00:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
-				`enqueueQueryRunnerJob("2020-06-30T12:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
-				`enqueueQueryRunnerJob("2019-12-31T00:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
+				`enqueueQueryRunnerJob("2020-07-02T12:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-01-02T00:00:01Z", "query1 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-07-02T12:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-01-02T00:00:01Z", "query2 count:9999999 repo:^repo/0$@")`,
+				`enqueueQueryRunnerJob("2020-07-02T12:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
+				`enqueueQueryRunnerJob("2020-01-02T00:00:01Z", "query1 count:9999999 repo:^repo/1$@")`,
+				`enqueueQueryRunnerJob("2020-07-02T12:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
+				`enqueueQueryRunnerJob("2020-01-02T00:00:01Z", "query2 count:9999999 repo:^repo/1$@")`,
 			},
 		})
 		want.Equal(t, testHistoricalEnqueuer(t, &testParams{

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -51,5 +51,6 @@ type InsightSeries struct {
 	OldestHistoricalAt    time.Time
 	LastRecordedAt        time.Time
 	NextRecordingAfter    time.Time
+	BackfillQueuedAt      time.Time
 	RecordingIntervalDays int
 }

--- a/migrations/codeinsights/1000000009_backfiller_state.down.sql
+++ b/migrations/codeinsights/1000000009_backfiller_state.down.sql
@@ -1,0 +1,13 @@
+
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+ALTER TABLE insight_series DROP COLUMN IF EXISTS backfill_queued_at;
+
+COMMIT;

--- a/migrations/codeinsights/1000000009_backfiller_state.up.sql
+++ b/migrations/codeinsights/1000000009_backfiller_state.up.sql
@@ -1,0 +1,15 @@
+
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+ALTER TABLE insight_series ADD COLUMN backfill_queued_at TIMESTAMP;
+COMMENT ON COLUMN insight_series.series_id IS
+    'Timestamp that this series completed a full repository iteration for backfill. This flag has limited semantic value, and only means it tried to queue up queries for each repository. It does not guarantee success on those queries.';
+
+COMMIT;


### PR DESCRIPTION
Closes #23642 
Closes #22324

Introduce a simple state mechanism to prevent series from being backfilled multiple times unnecessarily.

Also rolling back the changes to the sample time to return to the interval time instead of commit time. This turned out to be far too noisy, and we get lots of value from times being aligned.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
