### PR TITLE
symbols: don't compute zero offsets for indexed symbols on symbols endpoint

### DIFF
--- a/cmd/symbols/internal/symbols/search.go
+++ b/cmd/symbols/internal/symbols/search.go
@@ -250,7 +250,7 @@ func symbolToSymbolInDB(symbol result.Symbol) symbolInDB {
 		Parent:        symbol.Parent,
 		ParentKind:    symbol.ParentKind,
 		Signature:     symbol.Signature,
-		Pattern:       symbol.Pattern,
+		Pattern:       fmt.Sprintf("/^%s$/", escape(string(symbol.Line))),
 
 		FileLimited: symbol.FileLimited,
 	}
@@ -266,7 +266,7 @@ func symbolInDBToSymbol(symbolInDB symbolInDB) result.Symbol {
 		Parent:     symbolInDB.Parent,
 		ParentKind: symbolInDB.ParentKind,
 		Signature:  symbolInDB.Signature,
-		Pattern:    symbolInDB.Pattern,
+		Pattern:    fmt.Sprintf("/^%s$/", escape(string(symbolInDB.Line))),
 
 		FileLimited: symbolInDB.FileLimited,
 	}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/23134. So the issue is that, it's exactly the same problem as https://github.com/sourcegraph/sourcegraph/pull/17258. It's just that in https://github.com/sourcegraph/sourcegraph/pull/17258 I fixed this from the Zoekt result side. _I didn't realize we have a SEPARATE endpoint for indexed symbols_. I shall quote what I said before:

> I fear that being smart and calculating the offset/range inside the zoekt.go code will only fragment where computation is done (i.e., on the unindexed path, we do it in this one place, and then in another place on the indexed path, seems like madness.

Little had I known, there is not just this one place, and indeed, madness lives in this codebase.

Confirmed fix by clicking stuff.

---

Draft because I will add tests and unify the `escape` code and also the `pattern` computation to something like `createIndexedSymbolResult` or somethinggggggggggggggg