### PR TITLE
API docs: partial implementation of new design

### DIFF
--- a/client/web/src/repo/docs/DocumentationExamples.tsx
+++ b/client/web/src/repo/docs/DocumentationExamples.tsx
@@ -30,7 +30,7 @@ export const DocumentationExamples: React.FunctionComponent<Props> = props => {
 
     return (
         <VisibilitySensor partialVisibility={true} onChange={onVisibilityChange}>
-            <div className="documentation-examples mt-3 mb-3 px-2">
+            <div className="documentation-examples mt-3 mb-3">
                 {visible && <DocumentationExamplesList {...props} />}
             </div>
         </VisibilitySensor>

--- a/client/web/src/repo/docs/DocumentationExamplesListItem.scss
+++ b/client/web/src/repo/docs/DocumentationExamplesListItem.scss
@@ -1,5 +1,5 @@
 .documentation-examples-list-item {
-    border: 1px solid var(--border-color);
+    border: 1.5px solid var(--border-color);
     border-radius: var(--border-radius);
     background-color: var(--code-bg);
 
@@ -7,7 +7,7 @@
         display: inline-block;
     }
     &__code-excerpt {
-        border-top: 1px solid var(--border-color);
+        border-top: 1.5px solid var(--border-color-2);
         text-decoration: none; // don't use cascading link style
         display: flex;
         align-items: center;
@@ -20,14 +20,6 @@
 
         &:hover {
             text-decoration: none;
-        }
-
-        &-code-wrapper {
-            position: relative;
-            overflow-x: auto;
-            &:not(:first-child) {
-                border-top: 1px solid var(--border-color-2);
-            }
         }
 
         // Needed to correct syntax highlighted code blocks so they can have text copied/pasted

--- a/client/web/src/repo/docs/DocumentationExamplesListItem.tsx
+++ b/client/web/src/repo/docs/DocumentationExamplesListItem.tsx
@@ -104,7 +104,7 @@ export const DocumentationExamplesListItem: React.FunctionComponent<Props> = ({
                 />
                 {blameHunks !== LOADING && !isErrorLike(blameHunks) && blameHunks.length > 0 && (
                     <span className="float-right text-muted">
-                        by <PersonLink person={blameHunks[0].author.person} className="font-weight-bold" />{' '}
+                        by <PersonLink person={blameHunks[0].author.person} />{' '}
                         <Link to={blameHunks[0].commit.url}>
                             <Timestamp date={blameHunks[0].author.date} />
                         </Link>

--- a/client/web/src/repo/docs/DocumentationIcons.tsx
+++ b/client/web/src/repo/docs/DocumentationIcons.tsx
@@ -23,15 +23,16 @@ function pickIconTags(tags: Tag[]): Tag[] {
 
 interface Props {
     tags: Tag[]
+    className?: string
 }
 
 /**
  * Renders icons for the given documentation tags on a single node.
  */
-export const DocumentationIcons: React.FunctionComponent<Props> = ({ tags }) => (
+export const DocumentationIcons: React.FunctionComponent<Props> = ({ tags, className }) => (
     <>
         {pickIconTags(tags).map(tag => (
-            <DocumentationIcon key={tag} tag={tag} />
+            <DocumentationIcon key={tag} tag={tag} className={className} />
         ))}
     </>
 )

--- a/client/web/src/repo/docs/DocumentationNode.scss
+++ b/client/web/src/repo/docs/DocumentationNode.scss
@@ -1,0 +1,46 @@
+.documentation-node {
+    margin-bottom: 3rem;
+    hr {
+        border-width: 1.5px;
+    }
+    &__heading {
+        position: relative;
+        left: -1.5rem;
+        &:hover {
+            .documentation-node__heading-anchor-link {
+                visibility: visible;
+            }
+        }
+        &-anchor-link {
+            width: 1rem;
+            margin-right: 0.5rem;
+            visibility: hidden;
+
+            // We want consistent anchor size links, regardless of heading size.
+            // stylelint-disable-next-line declaration-property-unit-whitelist
+            font-size: 14px;
+        }
+    }
+    &__pill {
+        font-size: 0.75rem;
+        border-radius: 12px;
+        border: 1.5px solid var(--border-color-2);
+        padding-top: 0.15rem;
+        padding-bottom: 0.15rem;
+    }
+    &__pill-icon {
+        color: var(--gray-06);
+    }
+    &__pill-divider {
+        height: 0.75rem;
+        background: var(--border-color-2);
+
+        // stylelint-disable-next-line declaration-property-unit-whitelist
+        width: 1.5px;
+    }
+
+    // TODO(slimsag): make this our global Markdown style
+    .markdown pre {
+        border: 1.5px solid var(--border-color);
+    }
+}

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -1,15 +1,20 @@
 import * as H from 'history'
+import BookOpenVariantIcon from 'mdi-react/BookOpenVariantIcon'
+import HelpCircleOutlineIcon from 'mdi-react/HelpCircleOutlineIcon'
+import LinkVariantIcon from 'mdi-react/LinkVariantIcon'
 import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { Observable } from 'rxjs'
 
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
+import { AnchorLink } from '@sourcegraph/shared/src/components/Link'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 import { ResolvedRevisionSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 
+import { Badge } from '../../components/Badge'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { RepositoryFields } from '../../graphql-operations'
 import { toDocumentationURL } from '../../util/url'
@@ -38,6 +43,9 @@ interface Props
     /** How far deep we are in the tree of documentation nodes */
     depth: number
 
+    /** Whether or not this is the first child of a parent node */
+    isFirstChild: boolean
+
     /** The pathID of the page containing this documentation node */
     pagePathID: string
 
@@ -45,7 +53,13 @@ interface Props
     excludingTags: Tag[]
 }
 
-export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrumb, node, depth, ...props }) => {
+export const DocumentationNode: React.FunctionComponent<Props> = ({
+    useBreadcrumb,
+    node,
+    depth,
+    isFirstChild,
+    ...props
+}) => {
     const repoRevision = {
         repoName: props.repo.name,
         revision: props.revision || '',
@@ -72,13 +86,54 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
         }
     }
 
+    const Heading = `h${depth + 1 < 4 ? depth + 1 : 4}` as keyof JSX.IntrinsicElements
+
+    const topMargin =
+        depth === 0
+            ? '' // Level 0 header ("Package foo")
+            : depth === 1
+            ? ' mt-5' // Level 1 headers ("Constants", "Variables", etc.)
+            : isFirstChild
+            ? ' mt-4'
+            : ' mt-5' // Lowest level headers
+
     return (
-        <div className="documentation-node">
-            <Link className={`h${depth + 1 < 4 ? depth + 1 : 4}`} id={hash} to={thisPage}>
-                <DocumentationIcons tags={node.documentation.tags} /> {node.label.value}
-            </Link>
+        <div className={`documentation-node mb-5${topMargin}`}>
+            <Heading className="d-flex align-items-center documentation-node__heading">
+                <AnchorLink className="documentation-node__heading-anchor-link" to={thisPage}>
+                    <LinkVariantIcon className="icon-inline" />
+                </AnchorLink>
+                {depth !== 0 && <DocumentationIcons className="mr-1" tags={node.documentation.tags} />}
+                <Link className="h" id={hash} to={thisPage}>
+                    {node.label.value}
+                </Link>
+            </Heading>
+            {depth === 0 && (
+                <>
+                    <div className="d-flex align-items-center mb-3">
+                        <span className="documentation-node__pill d-flex justify-content-center align-items-center px-2">
+                            <BookOpenVariantIcon className="icon-inline text-muted mr-1" /> Generated API docs
+                            <span className="documentation-node__pill-divider mx-2" />
+                            <a
+                                // eslint-disable-next-line react/jsx-no-target-blank
+                                target="_blank"
+                                rel="noopener"
+                                href="https://docs.sourcegraph.com/code_intelligence/apidocs"
+                            >
+                                Learn more
+                            </a>
+                        </span>
+                        {/*
+                        TODO(apidocs): add support for indicating time the API docs were updated
+                        <span className="ml-2">Last updated 2 days ago</span>
+                    */}
+                        <Badge status="experimental" className="text-uppercase ml-2" />
+                    </div>
+                    <hr />
+                </>
+            )}
             {node.detail.value !== '' && (
-                <div className="px-2 pt-2">
+                <div className="pt-2">
                     <Markdown dangerousInnerHTML={renderMarkdown(node.detail.value)} />
                 </div>
             )}
@@ -86,13 +141,19 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
             {!isExcluded(node, ['test', 'benchmark', 'example', 'license', 'owner', 'package']) &&
                 node.documentation.tags.length !== 0 && (
                     <>
-                        <span className="h5 text-muted ml-2">Usage examples</span>
+                        <h4 className="mt-4">
+                            Usage examples
+                            <HelpCircleOutlineIcon
+                                className="icon-inline ml-1"
+                                data-tooltip="Usage examples from precise LSIF code intelligence index"
+                            />
+                        </h4>
                         <DocumentationExamples {...props} pathID={node.pathID} />
                     </>
                 )}
 
             {node.children?.map(
-                child =>
+                (child, index) =>
                     child.node &&
                     !isExcluded(child.node, props.excludingTags) && (
                         <DocumentationNode
@@ -100,6 +161,7 @@ export const DocumentationNode: React.FunctionComponent<Props> = ({ useBreadcrum
                             {...props}
                             node={child.node}
                             depth={depth + 1}
+                            isFirstChild={index === 0}
                             useBreadcrumb={useBreadcrumb}
                         />
                     )

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.scss
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.scss
@@ -2,6 +2,7 @@
 @import './DocumentationWelcomeAlert';
 @import './DocumentationIcon';
 @import './DocumentationExamples';
+@import './DocumentationNode';
 
 .repository-docs-page {
     width: 100%;
@@ -17,23 +18,6 @@
             margin: auto;
             &--sidebar-visible {
                 margin: unset;
-            }
-        }
-    }
-    &__feedback-container {
-        width: 0;
-        height: 0;
-        z-index: 1;
-        &-content {
-            display: block;
-            width: 19rem;
-            margin-top: 1rem;
-            float: right;
-            .btn {
-                background-color: var(--color-bg-1);
-            }
-            .feedback-prompt {
-                display: inline-block;
             }
         }
     }

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -202,7 +202,11 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = React
                                 sidebarVisible ? ' repository-docs-page__container-content--sidebar-visible' : ''
                             }`}
                         >
-                            <DocumentationWelcomeAlert />
+                            {/*
+                                TODO(apidocs): Eventually this welcome alert should go away entirely, but for now
+                                it's the best thing we have for the sometimes empty root landing page.
+                            */}
+                            {page.tree.detail.value === '' && <DocumentationWelcomeAlert />}
                             {isExcluded(page.tree, excludingTags) ? (
                                 <div className="m-3">
                                     <h2 className="text-muted">Looks like there's nothing to see here.</h2>
@@ -215,23 +219,9 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = React
                                 node={page.tree}
                                 pagePathID={pagePathID}
                                 depth={0}
+                                isFirstChild={true}
                                 excludingTags={excludingTags}
                             />
-                        </div>
-                    </div>
-                    <div className="repository-docs-page__feedback-container">
-                        <div className="repository-docs-page__feedback-container-content">
-                            <Badge status="experimental" className="text-uppercase mr-2" />
-                            <a
-                                // eslint-disable-next-line react/jsx-no-target-blank
-                                target="_blank"
-                                rel="noopener"
-                                href="https://docs.sourcegraph.com/code_intelligence/apidocs"
-                                className="mr-1 btn btn-sm text-decoration-none btn-link btn-outline-secondary"
-                            >
-                                Learn more
-                            </a>
-                            <FeedbackPrompt routes={routes} />
                         </div>
                     </div>
                 </>


### PR DESCRIPTION
* Implements most padding/spacing/font-size changes.
* Removes floating `[Experimental] [Learn more] [Feedback]` trio.
* Adds `(Generated API docs | Learn more)` badge.
* Adjusts border colors and thickness for better accessibility and contrast.
* Adds anchor links on hover.

Not yet addressed:

* Anything about the sidebar.
* Usage example loading states.
* Feedback widgets at bottom of page (for now, people will have to use the "Feedback" in the top navbar.)

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
