### PR TITLE
symbols: compute symbol offsets on indexed symbol endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Graceful termination periods have been added to database deployments. [#3358](https://github.com/sourcegraph/deploy-sourcegraph/pull/3358) & [#477](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/477)
 - All commit search results for `and`-expressions are now highlighted. [#23336](https://github.com/sourcegraph/sourcegraph/pull/23336)
 - Email notifiers in `observability.alerts` now correctly respect the `email.smtp.noVerifyTLS` site configuration field. [#23636](https://github.com/sourcegraph/sourcegraph/issues/23636)
+- Alertmanager (Prometheus) now respects `SMTPServerConfig.noVerifyTLS` field. [#23636](https://github.com/sourcegraph/sourcegraph/issues/23636)
+- Clicking on symbols in the left search pane now renders hover tooltips for indexed repositories. [#23664](https://github.com/sourcegraph/sourcegraph/pull/23664)
 
 ### Removed
 

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -286,18 +286,17 @@ func searchZoekt(ctx context.Context, repoName types.RepoName, commitID api.Comm
 					continue
 				}
 
-				res = append(res, &result.SymbolMatch{
-					Symbol: result.Symbol{
-						Name:       m.SymbolInfo.Sym,
-						Kind:       m.SymbolInfo.Kind,
-						Parent:     m.SymbolInfo.Parent,
-						ParentKind: m.SymbolInfo.ParentKind,
-						Path:       file.FileName,
-						Line:       l.LineNumber,
-						Language:   file.Language,
-					},
-					File: newFile,
-				})
+				res = append(res, result.NewSymbolMatch(
+					newFile,
+					l.LineNumber,
+					m.SymbolInfo.Sym,
+					m.SymbolInfo.Kind,
+					m.SymbolInfo.Parent,
+					m.SymbolInfo.ParentKind,
+					file.Language,
+					string(l.Line),
+					false,
+				))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/23134. So the issue is that, it's exactly the same problem as https://github.com/sourcegraph/sourcegraph/pull/17258. It's just that in https://github.com/sourcegraph/sourcegraph/pull/17258 I fixed this from the Zoekt result side. _I didn't realize we have a SEPARATE endpoint for indexed symbols_. I shall quote what I said before:

> I fear that being smart and calculating the offset/range inside the zoekt.go code will only fragment where computation is done (i.e., on the unindexed path, we do it in this one place, and then in another place on the indexed path, seems like madness.

Little had I known, there is not just this one place, and indeed, madness :zany_face:

This PR factors out symbol result construction and unifies code paths that construct these, forcing them to include all the members that matter (in particular, this `Pattern` value that we use to compute offsets). 

There isn't a test for `symbols.go`, presumably because it is insanely cumbersome to mock this. An integration test is also obnoxious. So I'm actually not going to write a test for this 😲  The "other half" remains tested from https://github.com/sourcegraph/sourcegraph/pull/17258 that goes via this constructor.