### PR TITLE
Code Insights: Add a click to trigger the disappearance of chart tooltip (fix flaky screenshot test)

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/components/view-grid/ViewGrid.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/view-grid/ViewGrid.tsx
@@ -88,6 +88,7 @@ export const ViewGrid: React.FunctionComponent<PropsWithChildren<ViewGridProps>>
     return (
         <div className={classNames(className, styles.viewGrid)}>
             <ResponsiveGridLayout
+                measureBeforeMount={true}
                 breakpoints={breakpoints}
                 layouts={viewsToReactGridLayouts(viewIds)}
                 cols={columns}

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -37,8 +37,10 @@ describe('[VISUAL] Code insights page', () => {
     afterEach(() => testContext?.dispose())
 
     async function takeChartSnapshot(name: string): Promise<void> {
-        // Move mouse cursor away from charts to avoid chart tooltip appearance
+        // Move mouse cursor away from charts and click to avoid chart tooltip appearance
         await driver.page.mouse.move(0, 0)
+        await driver.page.click('body')
+
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
         // Due to autosize of chart we have to wait 1s that window-resize be able
         // render chart with container size.


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/23669

This PR adds two things
1. Adds a click before taking a screenshot to ensure that we didn't trigger any tooltip appearance over the chart
2. Turns off the grid layout animation on mount to avoid random unwanted clicks

