### PR TITLE
all: /bin/bash -> /usr/bin/env bash

### DIFF
--- a/cmd/symbols/universal-ctags-dev
+++ b/cmd/symbols/universal-ctags-dev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is a wrapper around `universal-ctags`.
 #

--- a/dev/check/docsite_redirects.sh
+++ b/dev/check/docsite_redirects.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/dev/db/add_migration.sh
+++ b/dev/db/add_migration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../migrations
 set -e

--- a/dev/db/drop-local-database.sh
+++ b/dev/db/drop-local-database.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 psql -c "drop schema public cascade; create schema public;"

--- a/dev/deployed-commit.sh
+++ b/dev/deployed-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script determines the commit of sourcegraph/sourcegraph that is currently
 # running on sourcegraph.com. The returned version has one of the following

--- a/dev/drop-entire-local-database-and-redis.sh
+++ b/dev/drop-entire-local-database-and-redis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 psql -c "drop schema public cascade; create schema public;"
 redis-cli -c flushall

--- a/dev/phabricator/stop.sh
+++ b/dev/phabricator/stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 unset CDPATH

--- a/dev/src-expose/release.sh
+++ b/dev/src-expose/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euf -o pipefail
 

--- a/doc/admin/install/docker/google_cloud.md
+++ b/doc/admin/install/docker/google_cloud.md
@@ -15,7 +15,7 @@ This tutorial shows you how to deploy [single-container Sourcegraph with Docker]
 - Open the **Management, disks, networking, and SSH keys** dropdown section and add the following in the **Startup script** field:
 
   ```
-  #!/bin/bash
+  #!/usr/bin/env bash
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   sudo apt-get update

--- a/doc/dev/background-information/architecture/generate.sh
+++ b/doc/dev/background-information/architecture/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/doc/dev/background-information/codeintel/diagrams/generate.sh
+++ b/doc/dev/background-information/codeintel/diagrams/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/docker-images/grafana/entry.sh
+++ b/docker-images/grafana/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export GF_PATHS_PROVISIONING=/sg_config_grafana/provisioning

--- a/lib/codeintel/tools/scripts/combine.sh
+++ b/lib/codeintel/tools/scripts/combine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ $# -le 0 ]]; then


### PR DESCRIPTION
I ran into issues setting up Sourcegraph on NixOS, because NixOS, like
some other distros, doesn't have a /bin/bash. We already use /usr/bin/env
in many of our scripts, so this improves consistency, too.
