### PR TITLE
repos: Refactor lazy repo syncing

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -351,15 +351,14 @@ func TestServer_RepoLookup(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name               string
-		args               protocol.RepoLookupArgs
-		stored             types.Repos
-		result             *protocol.RepoLookupResult
-		githubDotComSource *fakeRepoSource
-		gitlabDotComSource *fakeRepoSource
-		assert             types.ReposAssertion
-		assertDelay        time.Duration
-		err                string
+		name        string
+		args        protocol.RepoLookupArgs
+		stored      types.Repos
+		result      *protocol.RepoLookupResult
+		src         repos.Source
+		assert      types.ReposAssertion
+		assertDelay time.Duration
+		err         string
 	}{
 		{
 			name: "not found",
@@ -421,9 +420,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				Repo: api.RepoName("github.com/foo/bar"),
 			},
 			stored: []*types.Repo{},
-			githubDotComSource: &fakeRepoSource{
-				repo: githubRepository,
-			},
+			src:    repos.NewFakeSource(&githubSource, nil, githubRepository),
 			result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{
 				ExternalRepo: api.ExternalRepoSpec{
 					ID:          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
@@ -448,9 +445,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				Repo: api.RepoName("github.com/foo/bar"),
 			},
 			stored: []*types.Repo{githubRepository},
-			githubDotComSource: &fakeRepoSource{
-				repo: githubRepository,
-			},
+			src:    repos.NewFakeSource(&githubSource, nil, githubRepository),
 			result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{
 				ExternalRepo: api.ExternalRepoSpec{
 					ID:          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
@@ -473,9 +468,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			args: protocol.RepoLookupArgs{
 				Repo: api.RepoName("github.com/foo/bar"),
 			},
-			githubDotComSource: &fakeRepoSource{
-				err: github.ErrRepoNotFound,
-			},
+			src:    repos.NewFakeSource(&githubSource, github.ErrRepoNotFound),
 			result: &protocol.RepoLookupResult{ErrorNotFound: true},
 			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("github.com/foo/bar"), true),
 			assert: types.Assert.ReposEqual(),
@@ -485,9 +478,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			args: protocol.RepoLookupArgs{
 				Repo: api.RepoName("github.com/foo/bar"),
 			},
-			githubDotComSource: &fakeRepoSource{
-				err: &github.APIError{Code: http.StatusUnauthorized},
-			},
+			src:    repos.NewFakeSource(&githubSource, &github.APIError{Code: http.StatusUnauthorized}),
 			result: &protocol.RepoLookupResult{ErrorUnauthorized: true},
 			err:    fmt.Sprintf("not authorized (name=%s noauthz=%v)", api.RepoName("github.com/foo/bar"), true),
 			assert: types.Assert.ReposEqual(),
@@ -497,22 +488,20 @@ func TestServer_RepoLookup(t *testing.T) {
 			args: protocol.RepoLookupArgs{
 				Repo: api.RepoName("github.com/foo/bar"),
 			},
-			githubDotComSource: &fakeRepoSource{
-				err: &github.APIError{Message: "API rate limit exceeded"},
-			},
+			src:    repos.NewFakeSource(&githubSource, &github.APIError{Message: "API rate limit exceeded"}),
 			result: &protocol.RepoLookupResult{ErrorTemporarilyUnavailable: true},
-			err:    fmt.Sprintf("repository temporarily unavailable (name=%s istemporary=%v)", api.RepoName("github.com/foo/bar"), true),
+			err: fmt.Sprintf(
+				"repository temporarily unavailable (name=%s istemporary=%v)",
+				api.RepoName("github.com/foo/bar"),
+				true,
+			),
 			assert: types.Assert.ReposEqual(),
 		},
 		{
-			name: "found - gitlab.com on Sourcegraph.com",
-			args: protocol.RepoLookupArgs{
-				Repo: api.RepoName("gitlab.com/foo/bar"),
-			},
+			name:   "found - gitlab.com on Sourcegraph.com",
+			args:   protocol.RepoLookupArgs{Repo: gitlabRepository.Name},
 			stored: []*types.Repo{},
-			gitlabDotComSource: &fakeRepoSource{
-				repo: gitlabRepository,
-			},
+			src:    repos.NewFakeSource(&gitlabSource, nil, gitlabRepository),
 			result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{
 				Name:        "gitlab.com/gitlab-org/gitaly",
 				Description: "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
@@ -533,13 +522,9 @@ func TestServer_RepoLookup(t *testing.T) {
 		},
 		{
 			name: "found - gitlab.com on Sourcegraph.com already exists",
-			args: protocol.RepoLookupArgs{
-				Repo: api.RepoName("gitlab.com/foo/bar"),
-			},
+			args:   protocol.RepoLookupArgs{Repo: gitlabRepository.Name},
 			stored: []*types.Repo{gitlabRepository},
-			gitlabDotComSource: &fakeRepoSource{
-				repo: gitlabRepository,
-			},
+			src:    repos.NewFakeSource(&gitlabSource, nil, gitlabRepository),
 			result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{
 				Name:        "gitlab.com/gitlab-org/gitaly",
 				Description: "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
@@ -558,26 +543,13 @@ func TestServer_RepoLookup(t *testing.T) {
 			}},
 		},
 		{
-			name: "GithubDotcomSource on Sourcegraph.com ignores non-Github.com repos",
-			args: protocol.RepoLookupArgs{
-				Repo: api.RepoName("git-codecommit.us-west-1.amazonaws.com/stripe-go"),
-			},
-			githubDotComSource: &fakeRepoSource{
-				repo: githubRepository,
-			},
-			result: &protocol.RepoLookupResult{ErrorNotFound: true},
-			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("git-codecommit.us-west-1.amazonaws.com/stripe-go"), true),
-		},
-		{
 			name: "Private repos are not supported on sourcegraph.com",
 			args: protocol.RepoLookupArgs{
 				Repo: githubRepository.Name,
 			},
-			githubDotComSource: &fakeRepoSource{
-				repo: githubRepository.With(func(r *types.Repo) {
-					r.Private = true
-				}),
-			},
+			src: repos.NewFakeSource(&githubSource, nil, githubRepository.With(func(r *types.Repo) {
+				r.Private = true
+			})),
 			result: &protocol.RepoLookupResult{ErrorNotFound: true},
 			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", githubRepository.Name, true),
 		},
@@ -586,10 +558,10 @@ func TestServer_RepoLookup(t *testing.T) {
 			args: protocol.RepoLookupArgs{
 				Repo: githubRepository.Name,
 			},
-			githubDotComSource: &fakeRepoSource{
-				err: github.ErrRepoNotFound,
-			},
-			stored: []*types.Repo{githubRepository},
+			src:    repos.NewFakeSource(&githubSource, github.ErrRepoNotFound),
+			stored: []*types.Repo{githubRepository.With(func(r *types.Repo) {
+				r.UpdatedAt = r.UpdatedAt.Add(-time.Hour)
+			})},
 			result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{
 				ExternalRepo: api.ExternalRepoSpec{
 					ID:          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
@@ -617,43 +589,28 @@ func TestServer_RepoLookup(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			rs := tc.stored.Clone()
-			err := store.RepoStore.Create(ctx, rs...)
+			_, err := db.ExecContext(ctx, "DELETE FROM repo")
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Cleanup(func() {
-				_, err := db.ExecContext(ctx, "DELETE FROM repo")
-				if err != nil {
-					t.Fatal(err)
-				}
-			})
 
-			t.Cleanup(func() {
-				ids := make([]api.RepoID, 0, len(tc.stored))
-				for _, r := range tc.stored {
-					ids = append(ids, r.ID)
-				}
-				err := store.RepoStore.Delete(ctx, ids...)
-				if err != nil {
-					t.Fatal(err)
-				}
-			})
+			rs := tc.stored.Clone()
+			err = store.RepoStore.Create(ctx, rs...)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			clock := clock
 			syncer := &repos.Syncer{
-				Now:   clock.Now,
-				Store: store,
-			}
-			s := &Server{Syncer: syncer, Store: store}
-			if tc.githubDotComSource != nil {
-				s.SourcegraphDotComMode = true
-				s.GithubDotComSource = tc.githubDotComSource
+				Now:     clock.Now,
+				Store:   store,
+				Sourcer: repos.NewFakeSourcer(nil, tc.src),
 			}
 
-			if tc.gitlabDotComSource != nil {
-				s.SourcegraphDotComMode = true
-				s.GitLabDotComSource = tc.gitlabDotComSource
+			s := &Server{
+				Syncer:                syncer,
+				Store:                 store,
+				SourcegraphDotComMode: tc.src != nil,
 			}
 
 			srv := httptest.NewServer(s.Handler())
@@ -690,15 +647,6 @@ func TestServer_RepoLookup(t *testing.T) {
 			}
 		})
 	}
-}
-
-type fakeRepoSource struct {
-	repo *types.Repo
-	err  error
-}
-
-func (s *fakeRepoSource) GetRepo(context.Context, string) (*types.Repo, error) {
-	return s.repo.Clone(), s.err
 }
 
 type fakeScheduler struct{}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -521,7 +521,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			assert: types.Assert.ReposEqual(gitlabRepository),
 		},
 		{
-			name: "found - gitlab.com on Sourcegraph.com already exists",
+			name:   "found - gitlab.com on Sourcegraph.com already exists",
 			args:   protocol.RepoLookupArgs{Repo: gitlabRepository.Name},
 			stored: []*types.Repo{gitlabRepository},
 			src:    repos.NewFakeSource(&gitlabSource, nil, gitlabRepository),
@@ -558,7 +558,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			args: protocol.RepoLookupArgs{
 				Repo: githubRepository.Name,
 			},
-			src:    repos.NewFakeSource(&githubSource, github.ErrRepoNotFound),
+			src: repos.NewFakeSource(&githubSource, github.ErrRepoNotFound),
 			stored: []*types.Repo{githubRepository.With(func(r *types.Repo) {
 				r.UpdatedAt = r.UpdatedAt.Add(-time.Hour)
 			})},

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -154,9 +154,9 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	scheduler := repos.NewUpdateScheduler()
 	server := &repoupdater.Server{
-		Store:           store,
-		Scheduler:       scheduler,
-		GitserverClient: gitserver.DefaultClient,
+		Store:                 store,
+		Scheduler:             scheduler,
+		GitserverClient:       gitserver.DefaultClient,
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 	}
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/golang/gddo/httputil"
@@ -44,7 +43,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 const port = "3182"
@@ -159,6 +157,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		Store:           store,
 		Scheduler:       scheduler,
 		GitserverClient: gitserver.DefaultClient,
+		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 	}
 
 	rateLimitSyncer := repos.NewRateLimitSyncer(ratelimit.DefaultRegistry, store.ExternalServiceStore)
@@ -174,57 +173,6 @@ func Main(enterpriseInit EnterpriseInit) {
 	var debugDumpers []debugserver.Dumper
 	if enterpriseInit != nil {
 		debugDumpers = enterpriseInit(db, store, keyring.Default(), cf, server)
-	}
-
-	if envvar.SourcegraphDotComMode() {
-		server.SourcegraphDotComMode = true
-
-		es, err := store.ExternalServiceStore.List(ctx, database.ExternalServicesListOptions{
-			// On Cloud we only want to fetch site level external services here where the
-			// cloud_default flag has been set.
-			NoNamespace:      true,
-			OnlyCloudDefault: true,
-			Kinds: []string{
-				extsvc.KindGitHub,
-				extsvc.KindGitLab,
-				extsvc.KindJVMPackages,
-			},
-		})
-		if err != nil {
-			log.Fatalf("failed to list external services: %v", err)
-		}
-
-		for _, e := range es {
-			cfg, err := e.Configuration()
-			if err != nil {
-				log.Fatalf("bad external service config: %v", err)
-			}
-
-			switch c := cfg.(type) {
-			case *schema.GitHubConnection:
-				if strings.HasPrefix(c.Url, "https://github.com") && c.Token != "" {
-					server.GithubDotComSource, err = repos.NewGithubSource(e, cf)
-				}
-			case *schema.GitLabConnection:
-				if strings.HasPrefix(c.Url, "https://gitlab.com") && c.Token != "" {
-					server.GitLabDotComSource, err = repos.NewGitLabSource(e, cf)
-				}
-			case *schema.JVMPackagesConnection:
-				server.JVMPackagesSource, err = repos.NewJVMPackagesSource(e)
-			}
-
-			if err != nil {
-				log.Fatalf("failed to construct source: %v", err)
-			}
-		}
-
-		if server.GithubDotComSource == nil {
-			log.Fatalf("No github.com external service configured with a token")
-		}
-
-		if server.GitLabDotComSource == nil {
-			log.Fatalf("No gitlab.com external service configured with a token")
-		}
 	}
 
 	syncer := &repos.Syncer{

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -77,6 +77,10 @@ func ProvidersFromConfig(
 		opt.AfterID = svcs[len(svcs)-1].ID // Advance the cursor
 
 		for _, svc := range svcs {
+			if svc.CloudDefault { // Only public repos in CloudDefault services
+				continue
+			}
+
 			cfg, err := extsvc.ParseConfig(svc.Kind, svc.Config)
 			if err != nil {
 				seriousProblems = append(seriousProblems, fmt.Sprintf("Could not parse config of external service %d: %v", svc.ID, err))

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1534,13 +1534,19 @@ func urlIsGitHubDotCom(apiURL *url.URL) bool {
 	return hostname == "api.github.com" || hostname == "github.com" || hostname == "www.github.com" || apiURL.String() == githubProxyURL.String()
 }
 
-// ErrRepoNotFound is when the requested GitHub repository is not found.
-var ErrRepoNotFound = errors.New("GitHub repository not found")
+var ErrRepoNotFound = &RepoNotFoundError{}
+
+// RepoNotFoundError is when the requested GitHub repository is not found.
+type RepoNotFoundError struct{}
+
+func (e RepoNotFoundError) Error() string  { return "GitHub repository not found" }
+func (e RepoNotFoundError) NotFound() bool { return true }
 
 // IsNotFound reports whether err is a GitHub API error of type NOT_FOUND, the equivalent cached
 // response error, or HTTP 404.
 func IsNotFound(err error) bool {
-	if errors.Is(err, ErrRepoNotFound) || errors.HasType(err, ErrPullRequestNotFound(0)) || HTTPErrorCode(err) == http.StatusNotFound {
+	if errors.HasType(err, &RepoNotFoundError{}) || errors.HasType(err, ErrPullRequestNotFound(0)) ||
+		HTTPErrorCode(err) == http.StatusNotFound {
 		return true
 	}
 

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -203,6 +203,8 @@ func (e *APIError) AccountSuspended() bool {
 	return e.Code == http.StatusForbidden && strings.Contains(e.Message, "account was suspended")
 }
 
+func (e *APIError) Temporary() bool { return IsRateLimitExceeded(e) }
+
 // HTTPErrorCode returns err's HTTP status code, if it is an HTTP error from
 // this package. Otherwise it returns 0.
 func HTTPErrorCode(err error) int {

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -82,11 +82,10 @@ func loadVersions(ctx context.Context, db dbutil.DB, sourcer repos.Sourcer) ([]*
 	}
 
 	for _, svc := range unique {
-		sources, err := sourcer(svc)
+		src, err := sourcer(svc)
 		if err != nil {
 			return versions, err
 		}
-		src := sources[0]
 
 		versionSrc, ok := src.(repos.VersionSource)
 		if !ok {

--- a/internal/extsvc/versions/sync_test.go
+++ b/internal/extsvc/versions/sync_test.go
@@ -93,7 +93,7 @@ func (f *fakeVersionSource) Version(context.Context) (string, error) {
 }
 
 func newFakeSourcer(fakeSource *fakeVersionSource) repos.Sourcer {
-	return func(es ...*types.ExternalService) (repos.Sources, error) {
-		return repos.Sources([]repos.Source{fakeSource}), nil
+	return func(e *types.ExternalService) (repos.Source, error) {
+		return fakeSource, nil
 	}
 }

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
@@ -34,6 +37,7 @@ type observedSource struct {
 // SourceMetrics encapsulates the Prometheus metrics of a Source.
 type SourceMetrics struct {
 	ListRepos *metrics.OperationMetrics
+	GetRepo   *metrics.OperationMetrics
 }
 
 // MustRegister registers all metrics in SourceMetrics in the given
@@ -42,6 +46,9 @@ func (sm SourceMetrics) MustRegister(r prometheus.Registerer) {
 	r.MustRegister(sm.ListRepos.Count)
 	r.MustRegister(sm.ListRepos.Duration)
 	r.MustRegister(sm.ListRepos.Errors)
+	r.MustRegister(sm.GetRepo.Count)
+	r.MustRegister(sm.GetRepo.Duration)
+	r.MustRegister(sm.GetRepo.Errors)
 }
 
 // NewSourceMetrics returns SourceMetrics that need to be registered
@@ -60,6 +67,20 @@ func NewSourceMetrics() SourceMetrics {
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_source_errors_total",
 				Help: "Total number of sourcing errors",
+			}, []string{}),
+		},
+		GetRepo: &metrics.OperationMetrics{
+			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Name: "src_repoupdater_source_get_repo_duration_seconds",
+				Help: "Time spent calling GetRepo",
+			}, []string{}),
+			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_source_get_repo_total",
+				Help: "Total number of GetRepo calls",
+			}, []string{}),
+			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_source_get_repo_errors_total",
+				Help: "Total number of GetRepo errors",
 			}, []string{}),
 		},
 	}
@@ -95,6 +116,23 @@ func (o *observedSource) ListRepos(ctx context.Context, results chan SourceResul
 	if errs != nil {
 		err = errs.ErrorOrNil()
 	}
+}
+
+// GetRepo calls into the inner Source and registers the observed results.
+func (o *observedSource) GetRepo(ctx context.Context, path string) (sourced *types.Repo, err error) {
+	rg, ok := o.Source.(RepoGetter)
+	if !ok {
+		return nil, errors.New("RepoGetter not implemented")
+	}
+
+	defer func(began time.Time) {
+		secs := time.Since(began).Seconds()
+		o.metrics.GetRepo.Observe(secs, 1, &err)
+		log15.Info("source.get-repo", "name", path)
+		logging.Log(o.log, "source.get-repo", &err)
+	}(time.Now())
+
+	return rg.GetRepo(ctx, path)
 }
 
 // StoreMetrics encapsulates the Prometheus metrics of a Store.

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -218,7 +218,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					ExternalServiceSyncError: &ExternalServiceSyncError{
-						Message:           "1 error occurred:\n\t* github is down\n\n",
+						Message:           "github is down",
 						ExternalServiceId: siteLevelService.ID,
 					},
 				},

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -241,7 +241,8 @@ func (d Diff) Len() int {
 	return len(d.Deleted) + len(d.Modified) + len(d.Added) + len(d.Unmodified)
 }
 
-// On sourcegraph.com we don't sync our "cloud_default" code hosts in the background
+// SyncRepo syncs a single repository by name. It's only currently used on sourcegraph.com
+// because we don't sync our "cloud_default" code hosts in the background
 // since there are too many repos. Instead we use an incremental approach where we check for
 // changes everytime a user browses a repo.
 func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName) (repo *types.Repo, err error) {

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -240,28 +241,131 @@ func (d Diff) Len() int {
 	return len(d.Deleted) + len(d.Modified) + len(d.Added) + len(d.Unmodified)
 }
 
-// SyncRepo syncs a single repository with the first cloud default external service found for its type.
-func (s *Syncer) SyncRepo(ctx context.Context, sourced *types.Repo) (err error) {
+// On sourcegraph.com we don't sync our "cloud_default" code hosts in the background
+// since there are too many repos. Instead we use an incremental approach where we check for
+// changes everytime a user browses a repo.
+func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName) (repo *types.Repo, err error) {
+	tr, ctx := trace.New(ctx, "Syncer.SyncRepo", string(name))
+	defer tr.Finish()
+
+	repo, err = s.Store.RepoStore.GetByName(ctx, name)
+	if err != nil && !errcode.IsNotFound(err) {
+		return nil, err
+	}
+
+	if repo == nil {
+		// We don't have this repo yet, so block before returning.
+		return s.syncRepo(ctx, name, nil)
+	}
+
+	// Only public repos can be individually synced on sourcegraph.com
+	if repo.Private {
+		return nil, &database.RepoNotFoundErr{Name: name}
+	}
+	// Sync the repo in the background if it wasn't updated in 1 minute.
+	if s.Now().Sub(repo.UpdatedAt) >= time.Minute {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+			s.syncRepo(ctx, name, repo)
+		}()
+	}
+
+	return repo, nil
+}
+
+func (s *Syncer) syncRepo(ctx context.Context, name api.RepoName, stored *types.Repo) (repo *types.Repo, err error) {
 	var svc *types.ExternalService
-	ctx, save := s.observeSync(ctx, "Syncer.SyncRepo", string(sourced.Name))
+	ctx, save := s.observeSync(ctx, "Syncer.syncRepo", string(name))
 	defer func() { save(svc, err) }()
 
+	lk := locker.NewWithDB(nil, "repos.sync-repo").With(s.Store)
+
+	blocking := stored == nil
+	locked, unlock, err := lk.Lock(ctx, locker.StringKey(string(name)), blocking)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to acquire sync lock for %q", name)
+	}
+
+	if !locked {
+		return stored, nil
+	}
+
+	defer func() { err = unlock(err) }()
+
+	// We may have blocked waiting for another process to sync the repo, so let's fetch it from the database if
+	// it exists and return it.
+	if blocking {
+		repo, err = s.Store.RepoStore.GetByName(ctx, name)
+		if err == nil {
+			return repo, nil
+		}
+	}
+
+	codehost := extsvc.CodeHostOf(name, extsvc.PublicCodeHosts...)
+	if codehost == nil {
+		return nil, errors.Errorf("unsupported public code host for repo %q", name)
+	}
+
 	svcs, err := s.Store.ExternalServiceStore.List(ctx, database.ExternalServicesListOptions{
-		Kinds:            []string{extsvc.TypeToKind(sourced.ExternalRepo.ServiceType)},
+		Kinds:            []string{extsvc.TypeToKind(codehost.ServiceType)},
 		OnlyCloudDefault: true,
 		LimitOffset:      &database.LimitOffset{Limit: 1},
 	})
 	if err != nil {
-		return errors.Wrap(err, "listing external services")
+		return nil, errors.Wrap(err, "listing external services")
 	}
 
 	if len(svcs) != 1 {
-		return errors.Wrapf(err, "cloud default external service of type %q not found", sourced.ExternalRepo.ServiceType)
+		return nil, errors.Wrapf(err, "cloud default external service of type %q not found", codehost.ServiceType)
 	}
 
 	svc = svcs[0]
-	_, err = s.sync(ctx, svc, sourced)
-	return err
+
+	src, err := s.Sourcer(svc)
+	if err != nil {
+		return nil, err
+	}
+
+	rg, ok := src.(RepoGetter)
+	if !ok {
+		return nil, errors.Errorf("can't source repo %q", name)
+	}
+
+	path := strings.TrimPrefix(string(name), strings.TrimPrefix(codehost.ServiceID, "https://"))
+
+	if stored != nil {
+		defer func() {
+			if errcode.IsNotFound(err) || errcode.IsUnauthorized(err) ||
+				errcode.IsForbidden(err) || errcode.IsAccountSuspended(err) {
+				err2 := s.Store.DeleteExternalServiceRepo(ctx, svc, stored.ID)
+				if err2 != nil {
+					s.log().Error(
+						"SyncRepo failed to delete",
+						"svc", svc.DisplayName,
+						"repo", name,
+						"cause", err,
+						"error", err2,
+					)
+				}
+			}
+		}()
+	}
+
+	repo, err = rg.GetRepo(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if repo.Private {
+		return nil, &database.RepoNotFoundErr{Name: name}
+	}
+
+	if _, err = s.sync(ctx, svc, repo); err != nil {
+		return nil, err
+	}
+
+	return repo, nil
 }
 
 // SyncExternalService syncs repos using the supplied external service in a streaming fashion, rather than batch.

--- a/internal/repos/testing.go
+++ b/internal/repos/testing.go
@@ -2,8 +2,9 @@ package repos
 
 import (
 	"context"
-	"errors"
 	"strings"
+
+	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )

--- a/internal/repos/testing.go
+++ b/internal/repos/testing.go
@@ -2,28 +2,20 @@ package repos
 
 import (
 	"context"
-
-	"github.com/hashicorp/go-multierror"
+	"errors"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// NewFakeSourcer returns a Sourcer which always returns the given error and sources,
+// NewFakeSourcer returns a Sourcer which always returns the given error and source,
 // ignoring the given external services.
-func NewFakeSourcer(err error, srcs ...Source) Sourcer {
-	return func(svcs ...*types.ExternalService) (Sources, error) {
-		var errs *multierror.Error
-
+func NewFakeSourcer(err error, src Source) Sourcer {
+	return func(svc *types.ExternalService) (Source, error) {
 		if err != nil {
-			for _, svc := range svcs {
-				errs = multierror.Append(errs, &SourceError{Err: err, ExtSvc: svc})
-			}
-			if len(svcs) == 0 {
-				errs = multierror.Append(errs, &SourceError{Err: err, ExtSvc: nil})
-			}
+			return nil, &SourceError{Err: err, ExtSvc: svc}
 		}
-
-		return srcs, errs.ErrorOrNil()
+		return src, nil
 	}
 }
 
@@ -51,6 +43,20 @@ func (s FakeSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	for _, r := range s.repos {
 		results <- SourceResult{Source: s, Repo: r.With(types.Opt.RepoSources(s.svc.URN()))}
 	}
+}
+
+func (s FakeSource) GetRepo(ctx context.Context, name string) (*types.Repo, error) {
+	for _, r := range s.repos {
+		if strings.HasSuffix(string(r.Name), name) {
+			return r, s.err
+		}
+	}
+
+	if s.err == nil {
+		return nil, errors.New("not found")
+	}
+
+	return nil, s.err
 }
 
 // ExternalServices returns a singleton slice containing the external service.


### PR DESCRIPTION
The logic for syncing an individual repo on sourcegraph.com was spread
across repoupdater.Server and repos.Syncer. This changeset does the
following:

1. Consolidate that logic in repos.Syncer.SyncRepo
2. Add single-flighting of lazy repo updates using Postgres advisory locks.
3. Remove repos.Sources and simplify repos.Sourcer to deal with a single external service.

A follow up PR may entirely get rid of this server endpoint by calling
Syncer.SyncRepo directly in the frontend or wherever it's needed.

See #23676