### PR TITLE
executors: Outsource docker image cache

### DIFF
--- a/enterprise/cmd/executor/cloudbuild/build.sh
+++ b/enterprise/cmd/executor/cloudbuild/build.sh
@@ -63,7 +63,7 @@ function install_docker() {
 
   if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]; then
     mkdir -p "$(dirname "${DOCKER_DAEMON_CONFIG_FILE}")"
-    cat '{"log-driver": "journald"}' >"${DOCKER_DAEMON_CONFIG_FILE}"
+    echo '{"log-driver": "journald"}' >"${DOCKER_DAEMON_CONFIG_FILE}"
   fi
 
   ## Restart Docker daemon to pick up our changes.

--- a/enterprise/cmd/executor/cloudbuild/build.sh
+++ b/enterprise/cmd/executor/cloudbuild/build.sh
@@ -6,7 +6,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 export IGNITE_VERSION=v0.10.0
 export CNI_VERSION=v0.9.1
 export EXECUTOR_FIRECRACKER_IMAGE="sourcegraph/ignite-ubuntu:insiders"
-export EXECUTOR_IMAGE_ARCHIVE_PATH=/images
 
 function cleanup() {
   apt-get -y autoremove
@@ -148,11 +147,6 @@ function generate_ignite_base_image() {
   docker image rm "$EXECUTOR_FIRECRACKER_IMAGE"
 }
 
-# Ensure image archive path exists
-function ensure_image_archive_path() {
-  mkdir "${EXECUTOR_IMAGE_ARCHIVE_PATH}"
-}
-
 # Write systemd unit file for indexer service
 function install_executor_service() {
   # Create stub environment file.
@@ -168,9 +162,9 @@ Description=User code executor
 ExecStart=/usr/local/bin/executor
 Restart=always
 EnvironmentFile=/etc/systemd/system/executor.env
-Environment=SRC_LOG_LEVEL=dbug
-Environment=EXECUTOR_IMAGE_ARCHIVE_PATH="${EXECUTOR_IMAGE_ARCHIVE_PATH}" EXECUTOR_FIRECRACKER_IMAGE="${EXECUTOR_FIRECRACKER_IMAGE}"
 Environment=HOME="%h"
+Environment=SRC_LOG_LEVEL=dbug
+Environment=EXECUTOR_FIRECRACKER_IMAGE="${EXECUTOR_FIRECRACKER_IMAGE}"
 
 [Install]
 WantedBy=multi-user.target
@@ -189,6 +183,5 @@ setup_pull_through_docker_cache
 install_ignite
 install_executor
 generate_ignite_base_image
-ensure_image_archive_path
 install_executor_service
 cleanup

--- a/enterprise/cmd/executor/cloudbuild/ignite-ubuntu/Dockerfile
+++ b/enterprise/cmd/executor/cloudbuild/ignite-ubuntu/Dockerfile
@@ -8,8 +8,6 @@ RUN set -ex && \
     docker.io \
     git
 
-RUN mkdir -p /etc/docker/ && echo '{"registry-mirrors": ["http://localhost:5000"] }' >/etc/docker/daemon.json
-
 ARG SRC_CLI_VERSION
 
 RUN set -ex && \

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -24,12 +24,12 @@ type Config struct {
 	QueuePollInterval    time.Duration
 	MaximumNumJobs       int
 	FirecrackerImage     string
+	VMStartupScriptPath  string
 	VMPrefix             string
 	UseFirecracker       bool
 	FirecrackerNumCPUs   int
 	FirecrackerMemory    string
 	FirecrackerDiskSpace string
-	ImageArchivesPath    string
 	MaximumRuntimePerJob time.Duration
 	CleanupTaskInterval  time.Duration
 }
@@ -43,11 +43,11 @@ func (c *Config) Load() {
 	c.MaximumNumJobs = c.GetInt("EXECUTOR_MAXIMUM_NUM_JOBS", "1", "Number of virtual machines or containers that can be running at once.")
 	c.UseFirecracker = c.GetBool("EXECUTOR_USE_FIRECRACKER", "true", "Whether to isolate commands in virtual machines.")
 	c.FirecrackerImage = c.Get("EXECUTOR_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu:insiders", "The base image to use for virtual machines.")
+	c.VMStartupScriptPath = c.Get("EXECUTOR_VM_STARTUP_SCRIPT_PATH", "", "A path to a file on the host that is loaded into a fresh virtual machine and executed on startup.")
 	c.VMPrefix = c.Get("EXECUTOR_VM_PREFIX", "executor", "A name prefix for virtual machines controlled by this instance.")
 	c.FirecrackerNumCPUs = c.GetInt("EXECUTOR_FIRECRACKER_NUM_CPUS", "4", "How many CPUs to allocate to each virtual machine or container.")
 	c.FirecrackerMemory = c.Get("EXECUTOR_FIRECRACKER_MEMORY", "12G", "How much memory to allocate to each virtual machine or container.")
 	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine or container.")
-	c.ImageArchivesPath = c.Get("EXECUTOR_IMAGE_ARCHIVE_PATH", "", "Where to store tar archives of docker images shared by virtual machines.")
 	c.MaximumRuntimePerJob = c.GetInterval("EXECUTOR_MAXIMUM_RUNTIME_PER_JOB", "30m", "The maximum wall time that can be spent on a single job.")
 	c.CleanupTaskInterval = c.GetInterval("EXECUTOR_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic cleanup tasks.")
 }
@@ -91,9 +91,9 @@ func (c *Config) WorkerOptions() workerutil.WorkerOptions {
 
 func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 	return command.FirecrackerOptions{
-		Enabled:           c.UseFirecracker,
-		Image:             c.FirecrackerImage,
-		ImageArchivesPath: c.ImageArchivesPath,
+		Enabled:             c.UseFirecracker,
+		Image:               c.FirecrackerImage,
+		VMStartupScriptPath: c.VMStartupScriptPath,
 	}
 }
 

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -43,7 +43,7 @@ func (c *Config) Load() {
 	c.MaximumNumJobs = c.GetInt("EXECUTOR_MAXIMUM_NUM_JOBS", "1", "Number of virtual machines or containers that can be running at once.")
 	c.UseFirecracker = c.GetBool("EXECUTOR_USE_FIRECRACKER", "true", "Whether to isolate commands in virtual machines.")
 	c.FirecrackerImage = c.Get("EXECUTOR_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu:insiders", "The base image to use for virtual machines.")
-	c.VMStartupScriptPath = c.Get("EXECUTOR_VM_STARTUP_SCRIPT_PATH", "", "A path to a file on the host that is loaded into a fresh virtual machine and executed on startup.")
+	c.VMStartupScriptPath = c.GetOptional("EXECUTOR_VM_STARTUP_SCRIPT_PATH", "A path to a file on the host that is loaded into a fresh virtual machine and executed on startup.")
 	c.VMPrefix = c.Get("EXECUTOR_VM_PREFIX", "executor", "A name prefix for virtual machines controlled by this instance.")
 	c.FirecrackerNumCPUs = c.GetInt("EXECUTOR_FIRECRACKER_NUM_CPUS", "4", "How many CPUs to allocate to each virtual machine or container.")
 	c.FirecrackerMemory = c.Get("EXECUTOR_FIRECRACKER_MEMORY", "12G", "How much memory to allocate to each virtual machine or container.")

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -3,8 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,56 +57,9 @@ func formatFirecrackerCommand(spec CommandSpec, name, repoDir string, options Op
 var igniteRunLock sync.Mutex
 
 // setupFirecracker invokes a set of commands to provision and prepare a Firecracker virtual
-// machine instance. This is done in several steps:
-//
-//   - For each of the docker images supplied, issue a `docker pull` and a `docker save`
-//     to ensure we have an up-to-date tar archive of the requested image on the host.
-//     These can be shared between different jobs.
-//   - Provision a Firecracker VM (via ignite) subject to the resource limits specified
-//     in the given options, and copy the contents of the working directory as well as
-//     the docker image tar archives.
-//   - Inside of the Firecracker VM, run docker load over all of the copied tarfiles so
-//     that we do not need to pull the images from inside the VM, which has an empty
-//     docker cache and would require us to pull images on every job.
-func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger, name, repoDir string, imageNames, scriptPaths []string, options Options, operations *Operations) error {
-	imageMap := map[string]string{}
-	for i, image := range imageNames {
-		imageMap[fmt.Sprintf("image%d", i)] = image
-	}
-
-	imageKeys := make([]string, 0, len(imageMap))
-	for k := range imageMap {
-		imageKeys = append(imageKeys, k)
-	}
-	sort.Strings(imageKeys)
-
-	// Pull and archive each image that isn't already archived on the host
-	for _, key := range imageKeys {
-		if _, err := os.Stat(tarfilePathOnHost(key, options)); err == nil {
-			continue
-		} else if !os.IsNotExist(err) {
-			return err
-		}
-
-		pullCommand := command{
-			Key:       fmt.Sprintf("setup.docker.pull.%s", key),
-			Command:   flatten("docker", "pull", imageMap[key]),
-			Operation: operations.SetupDockerPull,
-		}
-		if err := runner.RunCommand(ctx, pullCommand, logger); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to pull %s", imageMap[key]))
-		}
-
-		saveCommand := command{
-			Key:       fmt.Sprintf("setup.docker.save.%s", key),
-			Command:   flatten("docker", "save", "-o", tarfilePathOnHost(key, options), imageMap[key]),
-			Operation: operations.SetupDockerSave,
-		}
-		if err := runner.RunCommand(ctx, saveCommand, logger); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to save %s", imageMap[key]))
-		}
-	}
-
+// machine instance. If a startup script path (an executable file on the host) is supplied,
+// it will be mounted into the new virtual machine instance and executed.
+func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger, name, repoDir string, options Options, operations *Operations) error {
 	// Start the VM and wait for the SSH server to become available
 	startCommand := command{
 		Key: "setup.firecracker.start",
@@ -117,7 +68,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 			"--runtime", "docker",
 			"--network-plugin", "docker-bridge",
 			firecrackerResourceFlags(options.ResourceOptions),
-			firecrackerCopyfileFlags(repoDir, imageKeys, options),
+			firecrackerCopyfileFlags(repoDir, options.FirecrackerOptions.VMStartupScriptPath),
 			"--ssh",
 			"--name", name,
 			sanitizeImage(options.FirecrackerOptions.Image),
@@ -131,30 +82,14 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 		return err
 	}
 
-	// Load images from tar files
-	for _, key := range imageKeys {
-		loadCommand := command{
-			Key:       fmt.Sprintf("setup.docker.load.%s", key),
-			Command:   flatten("ignite", "exec", name, "--", "docker", "load", "-i", tarfilePathInVM(key)),
-			Operation: operations.SetupDockerLoad,
+	if options.FirecrackerOptions.VMStartupScriptPath != "" {
+		startupScriptCommand := command{
+			Key:       fmt.Sprintf("setup.startup-script"),
+			Command:   flatten("ignite", "exec", name, "--", options.FirecrackerOptions.VMStartupScriptPath),
+			Operation: operations.SetupStartupScript,
 		}
-		if err := runner.RunCommand(ctx, loadCommand, logger); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to load %s", imageMap[key]))
-		}
-	}
-
-	// Remove tar files to give more working space
-	for _, key := range imageKeys {
-		rmCommand := command{
-			Key: fmt.Sprintf("setup.rm.%s", key),
-			Command: flatten(
-				"ignite", "exec", name, "--",
-				"rm", tarfilePathInVM(key),
-			),
-			Operation: operations.SetupRm,
-		}
-		if err := runner.RunCommand(ctx, rmCommand, logger); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to remove tarfile for %s", imageMap[key]))
+		if err := runner.RunCommand(ctx, startupScriptCommand, logger); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to run startup script"))
 		}
 	}
 
@@ -193,31 +128,17 @@ func firecrackerResourceFlags(options ResourceOptions) []string {
 	}
 }
 
-func firecrackerCopyfileFlags(dir string, imageKeys []string, options Options) []string {
-	copyfiles := make([]string, 0, len(imageKeys)+1)
-	for _, imageKey := range imageKeys {
-		copyfiles = append(copyfiles, fmt.Sprintf(
-			"%s:%s",
-			tarfilePathOnHost(imageKey, options),
-			tarfilePathInVM(imageKey),
-		))
-	}
-
+func firecrackerCopyfileFlags(dir, vmStartupScriptPath string) []string {
+	copyfiles := make([]string, 0, 2)
 	if dir != "" {
 		copyfiles = append(copyfiles, fmt.Sprintf("%s:%s", dir, firecrackerContainerDir))
 	}
+	if vmStartupScriptPath != "" {
+		copyfiles = append(copyfiles, fmt.Sprintf("%s:%s", vmStartupScriptPath, vmStartupScriptPath))
+	}
+
 	sort.Strings(copyfiles)
-
 	return intersperse("--copy-files", copyfiles)
-}
-
-// NOTE: The options.FirecreackerOptions.ImageArchivesPath needs to exist on the host
-func tarfilePathOnHost(key string, options Options) string {
-	return filepath.Join(options.FirecrackerOptions.ImageArchivesPath, fmt.Sprintf("%s.tar", key))
-}
-
-func tarfilePathInVM(key string) string {
-	return fmt.Sprintf("/%s.tar", key)
 }
 
 var imagePattern = lazyregexp.New(`([^:@]+)(?::([^@]+))?(?:@sha256:([a-z0-9]{64}))?`)

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -84,12 +84,12 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 
 	if options.FirecrackerOptions.VMStartupScriptPath != "" {
 		startupScriptCommand := command{
-			Key:       fmt.Sprintf("setup.startup-script"),
+			Key:       "setup.startup-script",
 			Command:   flatten("ignite", "exec", name, "--", options.FirecrackerOptions.VMStartupScriptPath),
 			Operation: operations.SetupStartupScript,
 		}
 		if err := runner.RunCommand(ctx, startupScriptCommand, logger); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to run startup script"))
+			return errors.Wrap(err, "failed to run startup script")
 		}
 	}
 

--- a/enterprise/cmd/executor/internal/command/observability.go
+++ b/enterprise/cmd/executor/internal/command/observability.go
@@ -12,11 +12,8 @@ type Operations struct {
 	SetupGitFetch             *observation.Operation
 	SetupAddRemote            *observation.Operation
 	SetupGitCheckout          *observation.Operation
-	SetupDockerPull           *observation.Operation
-	SetupDockerSave           *observation.Operation
-	SetupDockerLoad           *observation.Operation
 	SetupFirecrackerStart     *observation.Operation
-	SetupRm                   *observation.Operation
+	SetupStartupScript        *observation.Operation
 	TeardownFirecrackerStop   *observation.Operation
 	TeardownFirecrackerRemove *observation.Operation
 	Exec                      *observation.Operation
@@ -43,11 +40,8 @@ func NewOperations(observationContext *observation.Context) *Operations {
 		SetupGitFetch:             op("setup.git.fetch"),
 		SetupAddRemote:            op("setup.git.add-remote"),
 		SetupGitCheckout:          op("setup.git.checkout"),
-		SetupDockerPull:           op("setup.docker.pull"),
-		SetupDockerSave:           op("setup.docker.save"),
-		SetupDockerLoad:           op("setup.docker.load"),
-		SetupRm:                   op("setup.rm"),
 		SetupFirecrackerStart:     op("setup.firecracker.start"),
+		SetupStartupScript:        op("setup.startup-script"),
 		TeardownFirecrackerStop:   op("teardown.firecracker.stop"),
 		TeardownFirecrackerRemove: op("teardown.firecracker.remove"),
 		Exec:                      op("exec"),

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -43,7 +43,6 @@ export EXECUTOR_FRONTEND_URL=http://localhost:3080
 export EXECUTOR_FRONTEND_USERNAME=executor
 export EXECUTOR_FRONTEND_PASSWORD=hunter2
 export EXECUTOR_USE_FIRECRACKER=false
-export EXECUTOR_IMAGE_ARCHIVE_PATH=$HOME/.sourcegraph/images
 
 export WATCH_ADDITIONAL_GO_DIRS="enterprise/cmd enterprise/dev enterprise/internal"
 export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-worker executor "

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -94,6 +94,7 @@ env:
 
   # Disable firecracker inside executor in dev
   EXECUTOR_USE_FIRECRACKER: false
+  EXECUTOR_IMAGE_ARCHIVE_PATH: $HOME/.sourcegraph/images
 
   # Disable auto-indexing the CNCF repo group (this only works in Cloud)
   # This setting will be going away soon
@@ -399,12 +400,13 @@ commands:
       - enterprise/internal
       - lib/codeintel
 
-  executor-template:
-    &executor_template # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
+  executor-template: &executor_template
+    # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
     cmd: |
       env TMPDIR="$HOME/.sourcegraph/executor-temp" .bin/executor
     install: |
       go build -o .bin/executor github.com/sourcegraph/sourcegraph/enterprise/cmd/executor &&
+      mkdir -p $EXECUTOR_IMAGE_ARCHIVE_PATH
     checkBinary: .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: TEMPLATE
@@ -420,7 +422,7 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/indexer-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: codeintel
-      SRC_PROF_HTTP: ':6092'
+      SRC_PROF_HTTP: ":6092"
 
   batches-executor:
     <<: *executor_template
@@ -428,7 +430,7 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: batches
-      SRC_PROF_HTTP: ':6093'
+      SRC_PROF_HTTP: ":6093"
 
   # If you want to use this, either start it with `sg run batches-executor-firecracker` or
   # modify the `commandsets.batches` in your local `sg.config.overwrite.yaml`
@@ -436,12 +438,12 @@ commands:
     <<: *executor_template
     cmd: |
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" \
-        sudo --preserve-env=TMPDIR,EXECUTOR_QUEUE_NAME,SRC_PROF_HTTP,EXECUTOR_FRONTEND_URL,EXECUTOR_FRONTEND_USERNAME,EXECUTOR_FRONTEND_PASSWORD,EXECUTOR_USE_FIRECRACKER \
+        sudo --preserve-env=TMPDIR,EXECUTOR_QUEUE_NAME,SRC_PROF_HTTP,EXECUTOR_FRONTEND_URL,EXECUTOR_FRONTEND_USERNAME,EXECUTOR_FRONTEND_PASSWORD,EXECUTOR_USE_FIRECRACKER,EXECUTOR_IMAGE_ARCHIVE_PATH \
           .bin/executor
     env:
       EXECUTOR_USE_FIRECRACKER: true
       EXECUTOR_QUEUE_NAME: batches
-      SRC_PROF_HTTP: ':6093'
+      SRC_PROF_HTTP: ":6093"
 
   minio:
     cmd: |
@@ -573,8 +575,8 @@ commands:
       CONTAINER: grafana
       PORT: 3370
       # docker containers must access things via docker host on non-linux platforms
-      DOCKER_USER: ''
-      ADD_HOST_FLAG: ''
+      DOCKER_USER: ""
+      ADD_HOST_FLAG: ""
       DISABLE_SOURCEGRAPH_CONFIG: false
 
   prometheus:
@@ -622,11 +624,11 @@ commands:
       CONTAINER: prometheus
       PORT: 9090
       CONFIG_DIR: docker-images/prometheus/config
-      DOCKER_USER: ''
-      DOCKER_NET: ''
+      DOCKER_USER: ""
+      DOCKER_NET: ""
       PROM_TARGETS: dev/prometheus/all/prometheus_targets.yml
       SRC_FRONTEND_INTERNAL: host.docker.internal:3090
-      ADD_HOST_FLAG: ''
+      ADD_HOST_FLAG: ""
       DISABLE_SOURCEGRAPH_CONFIG: false
 
   postgres_exporter:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -94,7 +94,6 @@ env:
 
   # Disable firecracker inside executor in dev
   EXECUTOR_USE_FIRECRACKER: false
-  EXECUTOR_IMAGE_ARCHIVE_PATH: $HOME/.sourcegraph/images
 
   # Disable auto-indexing the CNCF repo group (this only works in Cloud)
   # This setting will be going away soon
@@ -400,13 +399,12 @@ commands:
       - enterprise/internal
       - lib/codeintel
 
-  executor-template: &executor_template
-    # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
+  executor-template:
+    &executor_template # TMPDIR is set here so it's not set in the `install` process, which would trip up `go build`.
     cmd: |
       env TMPDIR="$HOME/.sourcegraph/executor-temp" .bin/executor
     install: |
       go build -o .bin/executor github.com/sourcegraph/sourcegraph/enterprise/cmd/executor &&
-      mkdir -p $EXECUTOR_IMAGE_ARCHIVE_PATH
     checkBinary: .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: TEMPLATE
@@ -422,7 +420,7 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/indexer-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: codeintel
-      SRC_PROF_HTTP: ":6092"
+      SRC_PROF_HTTP: ':6092'
 
   batches-executor:
     <<: *executor_template
@@ -430,7 +428,7 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" .bin/executor
     env:
       EXECUTOR_QUEUE_NAME: batches
-      SRC_PROF_HTTP: ":6093"
+      SRC_PROF_HTTP: ':6093'
 
   # If you want to use this, either start it with `sg run batches-executor-firecracker` or
   # modify the `commandsets.batches` in your local `sg.config.overwrite.yaml`
@@ -438,12 +436,12 @@ commands:
     <<: *executor_template
     cmd: |
       env TMPDIR="$HOME/.sourcegraph/batches-executor-temp" \
-        sudo --preserve-env=TMPDIR,EXECUTOR_QUEUE_NAME,SRC_PROF_HTTP,EXECUTOR_FRONTEND_URL,EXECUTOR_FRONTEND_USERNAME,EXECUTOR_FRONTEND_PASSWORD,EXECUTOR_USE_FIRECRACKER,EXECUTOR_IMAGE_ARCHIVE_PATH \
+        sudo --preserve-env=TMPDIR,EXECUTOR_QUEUE_NAME,SRC_PROF_HTTP,EXECUTOR_FRONTEND_URL,EXECUTOR_FRONTEND_USERNAME,EXECUTOR_FRONTEND_PASSWORD,EXECUTOR_USE_FIRECRACKER \
           .bin/executor
     env:
       EXECUTOR_USE_FIRECRACKER: true
       EXECUTOR_QUEUE_NAME: batches
-      SRC_PROF_HTTP: ":6093"
+      SRC_PROF_HTTP: ':6093'
 
   minio:
     cmd: |
@@ -575,8 +573,8 @@ commands:
       CONTAINER: grafana
       PORT: 3370
       # docker containers must access things via docker host on non-linux platforms
-      DOCKER_USER: ""
-      ADD_HOST_FLAG: ""
+      DOCKER_USER: ''
+      ADD_HOST_FLAG: ''
       DISABLE_SOURCEGRAPH_CONFIG: false
 
   prometheus:
@@ -624,11 +622,11 @@ commands:
       CONTAINER: prometheus
       PORT: 9090
       CONFIG_DIR: docker-images/prometheus/config
-      DOCKER_USER: ""
-      DOCKER_NET: ""
+      DOCKER_USER: ''
+      DOCKER_NET: ''
       PROM_TARGETS: dev/prometheus/all/prometheus_targets.yml
       SRC_FRONTEND_INTERNAL: host.docker.internal:3090
-      ADD_HOST_FLAG: ""
+      ADD_HOST_FLAG: ''
       DISABLE_SOURCEGRAPH_CONFIG: false
 
   postgres_exporter:


### PR DESCRIPTION
Remove the pull/save/load/rm dance from the executors that was meant to keep a registry mirror "hot". Now, we instead deploy a shared registry so we can just configure that from inside the VMs. Deployed by https://github.com/sourcegraph/infrastructure/pull/2717.