### PR TITLE
compute: don't initialize empty data for no submatches

### DIFF
--- a/internal/compute/match.go
+++ b/internal/compute/match.go
@@ -91,7 +91,9 @@ func ofFileMatches(fm *result.FileMatch, r *regexp.Regexp) *Result {
 	matches := make([]Match, 0, len(fm.LineMatches))
 	for _, l := range fm.LineMatches {
 		regexpMatches := r.FindAllStringSubmatchIndex(l.Preview, -1)
-		matches = append(matches, ofRegexpMatches(regexpMatches, l.Preview, int(l.LineNumber)))
+		if len(regexpMatches) > 0 {
+			matches = append(matches, ofRegexpMatches(regexpMatches, l.Preview, int(l.LineNumber)))
+		}
 	}
 	return &Result{Matches: matches, Path: fm.Path}
 }

--- a/internal/compute/match_test.go
+++ b/internal/compute/match_test.go
@@ -27,7 +27,12 @@ func TestOfLineMatches(t *testing.T) {
 		return string(v)
 	}
 
-	autogold.Want("compute regexp submatch environment", `{
+	autogold.Want("compute regexp submatch empty environment", `{
+  "matches": [],
+  "path": "bedge"
+}`).Equal(t, test("nothing"))
+
+	autogold.Want("compute regexp submatch nonempty environment", `{
   "matches": [
     {
       "value": "abcdefgh",


### PR DESCRIPTION
Simple change: previously we would add a default-valued `Match` even when there are no submatches. 