### PR TITLE
compute: support named regexp groups for submatches

### DIFF
--- a/internal/compute/match.go
+++ b/internal/compute/match.go
@@ -80,8 +80,11 @@ func ofRegexpMatches(matches [][]int, namedGroups []string, lineValue string, li
 				firstRange = range_
 				continue
 			}
-			v := fmt.Sprintf("$%d", j/2)
-			if namedGroups[j/2] != "" {
+
+			var v string
+			if namedGroups[j/2] == "" {
+				v = fmt.Sprintf("$%d", j/2)
+			} else {
 				v = namedGroups[j/2]
 			}
 			env[v] = Data{Value: value, Range: range_}

--- a/internal/compute/match.go
+++ b/internal/compute/match.go
@@ -60,7 +60,7 @@ func newRange(startLine, endLine, startColumn, endColumn int) Range {
 	}
 }
 
-func ofRegexpMatches(matches [][]int, lineValue string, lineNumber int) Match {
+func ofRegexpMatches(matches [][]int, namedGroups []string, lineValue string, lineNumber int) Match {
 	env := make(Environment)
 	var firstValue string
 	var firstRange Range
@@ -81,6 +81,9 @@ func ofRegexpMatches(matches [][]int, lineValue string, lineNumber int) Match {
 				continue
 			}
 			v := fmt.Sprintf("$%d", j/2)
+			if namedGroups[j/2] != "" {
+				v = namedGroups[j/2]
+			}
 			env[v] = Data{Value: value, Range: range_}
 		}
 	}
@@ -92,7 +95,7 @@ func ofFileMatches(fm *result.FileMatch, r *regexp.Regexp) *Result {
 	for _, l := range fm.LineMatches {
 		regexpMatches := r.FindAllStringSubmatchIndex(l.Preview, -1)
 		if len(regexpMatches) > 0 {
-			matches = append(matches, ofRegexpMatches(regexpMatches, l.Preview, int(l.LineNumber)))
+			matches = append(matches, ofRegexpMatches(regexpMatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
 		}
 	}
 	return &Result{Matches: matches, Path: fm.Path}


### PR DESCRIPTION
Populates the match environment with named variables if they exist in the regexp. Passing along the [SubexpNames](https://pkg.go.dev/regexp#Regexp.SubexpNames) from the Go library seems the most straightforward.

Added serializers for test output so we don't see noisy range input for this test. I wish the Go formatter made multiline output a bit more pretty but what you gonna do 🤷 

Part of https://github.com/sourcegraph/sourcegraph/issues/21579