### PR TITLE
batches: add a DropdownButton component

### DIFF
--- a/client/web/src/enterprise/batches/DropdownButton.module.scss
+++ b/client/web/src/enterprise/batches/DropdownButton.module.scss
@@ -1,0 +1,5 @@
+.dropdown-button {
+    &__item {
+        min-width: min(90vw, 350px);
+    }
+}

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -1,0 +1,57 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { EnterpriseWebStory } from '../components/EnterpriseWebStory'
+
+import { Action, DropdownButton } from './DropdownButton'
+
+const { add } = storiesOf('web/batches/DropdownButton', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+// eslint-disable-next-line @typescript-eslint/require-await
+const onTrigger = async (onDone: () => void) => onDone()
+
+const action: Action = {
+    type: 'action-type',
+    buttonLabel: 'Action',
+    dropdownTitle: 'Action',
+    dropdownDescription: 'Perform an action',
+    isAvailable: () => true,
+    onTrigger,
+}
+
+const disabledAction: Action = {
+    type: 'disabled-action-type',
+    buttonLabel: 'Disabled action',
+    dropdownTitle: 'Disabled action',
+    dropdownDescription: 'Perform an action, if only this were enabled',
+    isAvailable: () => false,
+    onTrigger,
+}
+
+const experimentalAction: Action = {
+    type: 'experimental-action-type',
+    buttonLabel: 'Experimental action',
+    dropdownTitle: 'Experimental action',
+    dropdownDescription: 'Perform a super cool action that might explode',
+    isAvailable: () => true,
+    onTrigger,
+    experimental: true,
+}
+
+add('No actions', () => <EnterpriseWebStory>{() => <DropdownButton actions={[]} />}</EnterpriseWebStory>)
+
+add('Single action', () => <EnterpriseWebStory>{() => <DropdownButton actions={[action]} />}</EnterpriseWebStory>)
+
+add('Multiple actions without default', () => (
+    <EnterpriseWebStory>
+        {() => <DropdownButton actions={[action, disabledAction, experimentalAction]} />}
+    </EnterpriseWebStory>
+))
+
+add('Multiple actions with default', () => (
+    <EnterpriseWebStory>
+        {() => <DropdownButton actions={[action, disabledAction, experimentalAction]} defaultAction={1} />}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -18,7 +18,6 @@ const action: Action = {
     buttonLabel: 'Action',
     dropdownTitle: 'Action',
     dropdownDescription: 'Perform an action',
-    isAvailable: () => true,
     onTrigger,
 }
 
@@ -27,7 +26,6 @@ const disabledAction: Action = {
     buttonLabel: 'Disabled action',
     dropdownTitle: 'Disabled action',
     dropdownDescription: 'Perform an action, if only this were enabled',
-    isAvailable: () => false,
     onTrigger,
 }
 
@@ -36,7 +34,6 @@ const experimentalAction: Action = {
     buttonLabel: 'Experimental action',
     dropdownTitle: 'Experimental action',
     dropdownDescription: 'Perform a super cool action that might explode',
-    isAvailable: () => true,
     onTrigger,
     experimental: true,
 }

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -1,9 +1,10 @@
+import { boolean, select } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
 import { EnterpriseWebStory } from '../components/EnterpriseWebStory'
 
-import { Action, DropdownButton } from './DropdownButton'
+import { Action, DropdownButton, Props } from './DropdownButton'
 
 const { add } = storiesOf('web/batches/DropdownButton', module).addDecorator(story => (
     <div className="p-3 container">{story()}</div>
@@ -40,18 +41,41 @@ const experimentalAction: Action = {
     experimental: true,
 }
 
-add('No actions', () => <EnterpriseWebStory>{() => <DropdownButton actions={[]} />}</EnterpriseWebStory>)
+const commonKnobs: () => Pick<Props, 'disabled' | 'dropdownMenuPosition'> = () => ({
+    disabled: boolean('Disabled', false),
+    dropdownMenuPosition: select(
+        'Dropdown menu position',
+        {
+            None: undefined,
+            Left: 'left',
+            Right: 'right',
+        },
+        undefined
+    ),
+})
 
-add('Single action', () => <EnterpriseWebStory>{() => <DropdownButton actions={[action]} />}</EnterpriseWebStory>)
+add('No actions', () => (
+    <EnterpriseWebStory>{() => <DropdownButton actions={[]} {...commonKnobs()} />}</EnterpriseWebStory>
+))
+
+add('Single action', () => (
+    <EnterpriseWebStory>{() => <DropdownButton actions={[action]} {...commonKnobs()} />}</EnterpriseWebStory>
+))
 
 add('Multiple actions without default', () => (
     <EnterpriseWebStory>
-        {() => <DropdownButton actions={[action, disabledAction, experimentalAction]} />}
+        {() => <DropdownButton actions={[action, disabledAction, experimentalAction]} {...commonKnobs()} />}
     </EnterpriseWebStory>
 ))
 
 add('Multiple actions with default', () => (
     <EnterpriseWebStory>
-        {() => <DropdownButton actions={[action, disabledAction, experimentalAction]} defaultAction={1} />}
+        {() => (
+            <DropdownButton
+                actions={[action, disabledAction, experimentalAction]}
+                defaultAction={1}
+                {...commonKnobs()}
+            />
+        )}
     </EnterpriseWebStory>
 ))

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -28,6 +28,7 @@ export interface Props {
     actions: Action[]
     defaultAction?: number
     disabled?: boolean
+    dropdownMenuPosition?: 'left' | 'right'
     initiallyOpen?: boolean
     onLabel?: (label: string | undefined) => void
     placeholder?: string
@@ -38,6 +39,7 @@ export const DropdownButton: React.FunctionComponent<Props> = ({
     actions,
     defaultAction,
     disabled,
+    dropdownMenuPosition,
     initiallyOpen,
     onLabel,
     placeholder,
@@ -137,12 +139,18 @@ export const DropdownButton: React.FunctionComponent<Props> = ({
                         <button
                             type="button"
                             onClick={toggleIsOpen}
+                            disabled={isDisabled}
                             className="btn btn-primary dropdown-toggle dropdown-toggle-split"
                         />
                         <div
                             className={classNames(
-                                'dropdown-menu dropdown-menu-right',
+                                'dropdown-menu',
                                 isOpen && 'show',
+                                dropdownMenuPosition === 'left'
+                                    ? 'dropdown-menu-left'
+                                    : dropdownMenuPosition === 'right'
+                                    ? 'dropdown-menu-right'
+                                    : null,
                                 styles.dropdownButtonItem
                             )}
                         >

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -43,7 +43,6 @@ export const DropdownButton: React.FunctionComponent<Props> = ({
     placeholder = 'Select action',
     tooltip,
 }) => {
-
     const [isDisabled, setIsDisabled] = useState(!!disabled)
 
     const [isOpen, setIsOpen] = useState(!!initiallyOpen)

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -40,10 +40,9 @@ export const DropdownButton: React.FunctionComponent<Props> = ({
     dropdownMenuPosition,
     initiallyOpen,
     onLabel,
-    placeholder,
+    placeholder = 'Select action',
     tooltip,
 }) => {
-    placeholder ??= 'Select action'
 
     const [isDisabled, setIsDisabled] = useState(!!disabled)
 

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -1,0 +1,190 @@
+import classNames from 'classnames'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+import styles from './DropdownButton.module.scss'
+
+export interface Action {
+    /* The type of action. Used internally. */
+    type: string
+    /* The button label for the action. */
+    buttonLabel: string
+    /* The title in the dropdown menu item. */
+    dropdownTitle: string
+    /* The description in the dropdown menu item. */
+    dropdownDescription: string
+    /* Conditionally display the action based on the given query arguments. */
+    isAvailable: () => boolean
+    /**
+     * Invoked when the action is triggered. Either onDone or onCancel need to
+     * be called eventually. Can return a JSX.Element to be rendered adjacent to
+     * the button (i.e. a modal).
+     */
+    onTrigger: (onDone: () => void, onCancel: () => void) => Promise<void | JSX.Element>
+    /** If set, displays an experimental badge next to the dropdown title. */
+    experimental?: boolean
+}
+
+export interface Props {
+    actions: Action[]
+    defaultAction?: number
+    disabled?: boolean
+    initiallyOpen?: boolean
+    onLabel?: (label: string | undefined) => void
+    placeholder?: string
+    tooltip?: string
+}
+
+export const DropdownButton: React.FunctionComponent<Props> = ({
+    actions,
+    defaultAction,
+    disabled,
+    initiallyOpen,
+    onLabel,
+    placeholder,
+    tooltip,
+}) => {
+    placeholder ??= 'Select action'
+
+    actions = useMemo(() => actions.filter(action => action.isAvailable()), [actions])
+
+    const [isDisabled, setIsDisabled] = useState(!!disabled)
+
+    const [isOpen, setIsOpen] = useState(!!initiallyOpen)
+    const toggleIsOpen = useCallback(() => setIsOpen(open => !open), [])
+
+    const [selected, setSelected] = useState<number | undefined>(undefined)
+    const selectedAction = useMemo(() => {
+        if (actions.length === 1) {
+            return actions[0]
+        }
+
+        const id = selected !== undefined ? selected : defaultAction
+        if (id !== undefined && id >= 0 && id < actions.length && actions[id].isAvailable()) {
+            return actions[id]
+        }
+        return undefined
+    }, [actions, defaultAction, selected])
+
+    const onSelectedTypeSelect = useCallback(
+        (type: string) => {
+            const index = actions.findIndex(action => action.type === type)
+            if (index >= 0) {
+                setSelected(actions.findIndex(action => action.type === type))
+            } else {
+                setSelected(undefined)
+            }
+
+            setIsOpen(false)
+        },
+        [actions, setIsOpen, setSelected]
+    )
+
+    const [renderedElement, setRenderedElement] = useState<JSX.Element | undefined>()
+    const onTriggerAction = useCallback(async () => {
+        if (selectedAction === undefined) {
+            return
+        }
+
+        // Right now, we don't handle onDone or onCancel separately, but we may
+        // want to expose this at a later stage.
+        setIsDisabled(true)
+        const element = await selectedAction.onTrigger(
+            () => {
+                setIsDisabled(false)
+                setRenderedElement(undefined)
+            },
+            () => {
+                setIsDisabled(false)
+                setRenderedElement(undefined)
+            }
+        )
+        if (element !== undefined) {
+            setRenderedElement(element)
+        }
+    }, [selectedAction])
+
+    const label = useMemo(() => {
+        const label = selectedAction?.isAvailable()
+            ? selectedAction.buttonLabel + (selectedAction.experimental ? ' (Experimental)' : '')
+            : undefined
+
+        return label ?? placeholder
+    }, [placeholder, selectedAction])
+
+    useEffect(() => {
+        if (onLabel) {
+            if (selectedAction?.isAvailable()) {
+                onLabel(selectedAction.buttonLabel + (selectedAction.experimental ? ' (Experimental)' : ''))
+            }
+        }
+    })
+
+    return (
+        <>
+            {renderedElement}
+            <div className="btn-group">
+                <button
+                    type="button"
+                    className="btn btn-primary text-nowrap"
+                    onClick={onTriggerAction}
+                    disabled={isDisabled || actions.length === 0 || selectedAction === undefined}
+                    data-tooltip={tooltip}
+                >
+                    {label}
+                </button>
+                {actions.length > 1 && (
+                    <>
+                        <button
+                            type="button"
+                            onClick={toggleIsOpen}
+                            className="btn btn-primary dropdown-toggle dropdown-toggle-split"
+                        />
+                        <div
+                            className={classNames(
+                                'dropdown-menu dropdown-menu-right',
+                                isOpen && 'show',
+                                styles.dropdownButtonItem
+                            )}
+                        >
+                            {actions.map((action, index) => (
+                                <React.Fragment key={action.type}>
+                                    <DropdownItem action={action} setSelectedType={onSelectedTypeSelect} />
+                                    {index !== actions.length - 1 && <div className="dropdown-divider" />}
+                                </React.Fragment>
+                            ))}
+                        </div>
+                    </>
+                )}
+            </div>
+        </>
+    )
+}
+
+interface DropdownItemProps {
+    setSelectedType: (type: string) => void
+    action: Action
+}
+
+const DropdownItem: React.FunctionComponent<DropdownItemProps> = ({ action, setSelectedType }) => {
+    const onClick = useCallback<React.MouseEventHandler>(() => {
+        setSelectedType(action.type)
+    }, [setSelectedType, action.type])
+    return (
+        <div className="dropdown-item">
+            <button type="button" className="btn text-left" onClick={onClick}>
+                <h4 className="mb-1">
+                    {action.dropdownTitle}
+                    {action.experimental && (
+                        <>
+                            {' '}
+                            <small className="badge badge-info">Experimental</small>
+                        </>
+                    )}
+                </h4>
+                <p className="text-wrap text-muted mb-0">
+                    <small>{action.dropdownDescription}</small>
+                </p>
+            </button>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.module.scss
@@ -1,5 +1,0 @@
-.changeset-select-row {
-    &__dropdown-item {
-        min-width: min(90vw, 350px);
-    }
-}


### PR DESCRIPTION
Closes #23381.

This adds a new `DropdownButton` component (originally written in #22658), and ports `ChangesetSelectRow` (which heavily inspired the component from its embedded button) to use it.