### PR TITLE
postgres-alpine: reindex all databases on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights will now generate 12 months of historical data during a backfill instead of 6. [#23860](https://github.com/sourcegraph/sourcegraph/pull/23860)
 - The `sourcegraph-frontend.Role` in Kubernetes deployments was updated to permit statefulsets access in the Kubernetes API. This is needed to better support stable service discovery for stateful sets during deployments, which isn't currently possible by using service endpoints. [#3670](https://github.com/sourcegraph/deploy-sourcegraph/pull/3670) [#23889](https://github.com/sourcegraph/sourcegraph/pull/23889)
 - The copy icon displayed next to files and repositories will now copy the file or repository path. Previously, this action copied the URL to clipboard. [#23390](https://github.com/sourcegraph/sourcegraph/pull/23390
+- The copy icon displayed next to files and repositories will now copy the file or repository path. Previously, this action copied the URL to clipboard. [#23390](https://github.com/sourcegraph/sourcegraph/pull/23390)
 - For Docker-Compose and Kubernetes users, the built-in main Postgres and codeintel databases have switched to an alpine Docker image. This requires re-indexing the entire database. This process can take up to a few hours on systems with large datasets. [#23697](https://github.com/sourcegraph/sourcegraph/pull/23697)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights GraphQL query `insights` will now fetch 12 months of data instead of 6 if a specific time range is not provided. [#23786](https://github.com/sourcegraph/sourcegraph/pull/23786)
 - Code Insights will now generate 12 months of historical data during a backfill instead of 6. [#23860](https://github.com/sourcegraph/sourcegraph/pull/23860)
 - The `sourcegraph-frontend.Role` in Kubernetes deployments was updated to permit statefulsets access in the Kubernetes API. This is needed to better support stable service discovery for stateful sets during deployments, which isn't currently possible by using service endpoints. [#3670](https://github.com/sourcegraph/deploy-sourcegraph/pull/3670) [#23889](https://github.com/sourcegraph/sourcegraph/pull/23889)
-- The copy icon displayed next to files and repositories will now copy the file or repository path. Previously, this action copied the URL to clipboard. [#23390](https://github.com/sourcegraph/sourcegraph/pull/23390
-- The copy icon displayed next to files and repositories will now copy the file or repository path. Previously, this action copied the URL to clipboard. [#23390](https://github.com/sourcegraph/sourcegraph/pull/23390)
 - For Docker-Compose and Kubernetes users, the built-in main Postgres and codeintel databases have switched to an alpine Docker image. This requires re-indexing the entire database. This process can take up to a few hours on systems with large datasets. [#23697](https://github.com/sourcegraph/sourcegraph/pull/23697)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights GraphQL query `insights` will now fetch 12 months of data instead of 6 if a specific time range is not provided. [#23786](https://github.com/sourcegraph/sourcegraph/pull/23786)
 - Code Insights will now generate 12 months of historical data during a backfill instead of 6. [#23860](https://github.com/sourcegraph/sourcegraph/pull/23860)
 - The `sourcegraph-frontend.Role` in Kubernetes deployments was updated to permit statefulsets access in the Kubernetes API. This is needed to better support stable service discovery for stateful sets during deployments, which isn't currently possible by using service endpoints. [#3670](https://github.com/sourcegraph/deploy-sourcegraph/pull/3670) [#23889](https://github.com/sourcegraph/sourcegraph/pull/23889)
+- The copy icon displayed next to files and repositories will now copy the file or repository path. Previously, this action copied the URL to clipboard. [#23390](https://github.com/sourcegraph/sourcegraph/pull/23390
+- For Docker-Compose and Kubernetes users, the built-in main Postgres and codeintel databases have switched to an alpine Docker image. This requires re-indexing the entire database. This process can take up to a few hours on systems with large datasets. [#23697](https://github.com/sourcegraph/sourcegraph/pull/23697)
 
 ### Fixed
 

--- a/doc/admin/migration/3_31.md
+++ b/doc/admin/migration/3_31.md
@@ -1,0 +1,42 @@
+# Migrating to Sourcegraph 3.31.x
+
+> NOTE: The following applies only users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected, and can ignore this page.
+
+In Sourcegraph 3.31.x, both the **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. This process requires some preparation, so please read through **all** of the instructions on the rest of the page beforehand.
+
+## Preparations
+
+### Check for prior index corruption before upgrading
+
+There is a possibility that prior Sourcegraph upgrades inadvertently introduced a major glibc change. This can cause corruption in indexes that have collatable key columns (e.g. any index with a `text` column). Read more about this [here](https://postgresql.verite.pro/blog/2018/08/27/glibc-upgrade.html).
+
+If your index is corrupt, then there is also a possibility that there is bad data in your database that would cause the re-indexing process (and thus the 3.31.x upgrade) to fail. In order to check for corrupt indexes, please run the following SQL query against **both** of the following instances **before** upgrading to 3.31.x:
+
+1. `pgsql`
+2. `codeintel-db`
+
+```sql
+create extension amcheck;
+
+select bt_index_parent_check(c.oid, true), c.relname, c.relpages
+from pg_index i
+join pg_opclass op ON i.indclass[0] = op.oid
+join pg_am am ON op.opcmethod = am.oid
+join pg_class c ON i.indexrelid = c.oid
+join pg_namespace n ON c.relnamespace = n.oid
+where am.amname = 'btree'
+-- Don't check temp tables, which may be from another session:
+and c.relpersistence != 't'
+-- Function may throw an error when this is omitted:
+and i.indisready AND i.indisvalid;
+```
+
+If no errors are reported, then your indexes are not corrupted. You can proceed to ["Prepare for downtime"](#prepare-for-downtime).
+
+If any errors are reported, please contact customer support to help you repair your database.
+
+### Prepare for downtime
+
+For systems with large datasets, re-indexing can take **1-2+ hours**.
+
+**Sourcegraph will be unavailable until the re-indexing process has completed.** If the database containers are restarted/killed during the re-indexing process (for example, as a result of automated deployments), re-indexing will have to start over from scratch. Please plan accordingly, and communicate this downtime to your users.

--- a/doc/admin/migration/index.md
+++ b/doc/admin/migration/index.md
@@ -30,3 +30,4 @@ See [How to troubleshoot an unfinished migration](../how-to/unfinished_migration
 - [Migrating from Sourcegraph 3.x to 3.7.2+](3_7.md)
 - [Migrating from Sourcegraph 3.x to 3.11](3_11.md)
 - [Migrating from Sourcegraph 3.30.0, 3.30.1, and 3.30.2](3_30.md)
+- [Migrating from Sourcegraph 3.31.x](3_31.md)

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -10,7 +10,7 @@ Each section comprehensively describes the steps needed to upgrade, and any manu
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
-# 3.30.3 -> 3.31
+# 3.30.x -> 3.31
 
 The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. For systems with large datasets, re-indexing can take 1-2+ hours.
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -10,6 +10,13 @@ Each section comprehensively describes the steps needed to upgrade, and any manu
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+# 3.30.3 -> 3.31
+
+The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. For systems with large datasets, re-indexing can take 1-2+ hours.
+
+**Sourcegraph will be unavailable until the re-indexing process has completed.** If the database containers are restarted/killed during the re-indexing process (for example, as a result of automated deployments), re-indexing will have to start over from scratch. Please plan accordingly, and communicate this downtime to your users.
+
+> Note: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
 ## 3.29 -> 3.30.3
 
 **⚠️ Users on 3.29.x are advised to upgrade directly to 3.30.3**. If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2 please follow [this migration guide](../migration/3_30.md).

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -16,7 +16,8 @@ The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) database
 
 **Sourcegraph will be unavailable until the re-indexing process has completed.** If the database containers are restarted/killed during the re-indexing process (for example, as a result of automated deployments), re-indexing will have to start over from scratch. Please plan accordingly, and communicate this downtime to your users.
 
-> Note: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
+> NOTE: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
+
 ## 3.29 -> 3.30.3
 
 **⚠️ Users on 3.29.x are advised to upgrade directly to 3.30.3**. If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2 please follow [this migration guide](../migration/3_30.md).

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -12,9 +12,9 @@ Each section comprehensively describes the steps needed to upgrade, and any manu
 
 # 3.30.x -> 3.31
 
-The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. For systems with large datasets, re-indexing can take 1-2+ hours.
+The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database.
 
-**Sourcegraph will be unavailable until the re-indexing process has completed.** If the database containers are restarted/killed during the re-indexing process (for example, as a result of automated deployments), re-indexing will have to start over from scratch. Please plan accordingly, and communicate this downtime to your users.
+All users that use our bundled database instances **must** read through the [3.31 upgrade guide](../migration/3_31.md) _before_ upgrading.
 
 > NOTE: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -10,7 +10,7 @@ and any manual migration steps you must perform.
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
-# 3.30.3 -> 3.31
+# 3.30.x -> 3.31
 
 The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. For systems with large datasets, re-indexing can take 1-2+ hours.
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -16,7 +16,8 @@ The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) database
 
 **Sourcegraph will be unavailable until the re-indexing process has completed.** If the database pods are restarted/killed during the re-indexing process (for example, as a result of automated deployments), re-indexing will have to start over from scratch. Please plan accordingly, and communicate this downtime to your users.
 
-> Note: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
+> NOTE: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
+
 ## 3.29 -> 3.30.3
 
 **⚠️ Users on 3.29.x are advised to upgrade directly to 3.30.3**. If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2 please follow [this migration guide](../migration/3_30.md).

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -12,9 +12,9 @@ and any manual migration steps you must perform.
 
 # 3.30.x -> 3.31
 
-The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. For systems with large datasets, re-indexing can take 1-2+ hours.
+The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database.
 
-**Sourcegraph will be unavailable until the re-indexing process has completed.** If the database pods are restarted/killed during the re-indexing process (for example, as a result of automated deployments), re-indexing will have to start over from scratch. Please plan accordingly, and communicate this downtime to your users.
+All users that use our bundled database instances **must** read through the [3.31 upgrade guide](../migration/3_31.md) _before_ upgrading.
 
 > NOTE: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -10,6 +10,13 @@ and any manual migration steps you must perform.
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+# 3.30.3 -> 3.31
+
+The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. For systems with large datasets, re-indexing can take 1-2+ hours.
+
+**Sourcegraph will be unavailable until the re-indexing process has completed.** If the database pods are restarted/killed during the re-indexing process (for example, as a result of automated deployments), re-indexing will have to start over from scratch. Please plan accordingly, and communicate this downtime to your users.
+
+> Note: The above only applies to users that use our built-in databases. Users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.) are not affected.
 ## 3.29 -> 3.30.3
 
 **⚠️ Users on 3.29.x are advised to upgrade directly to 3.30.3**. If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2 please follow [this migration guide](../migration/3_30.md).

--- a/docker-images/postgres-12.6-alpine/rootfs/env.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/env.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export REINDEX_COMPLETED_FILE="${PGDATA}/3.31-reindex.completed"

--- a/docker-images/postgres-12.6-alpine/rootfs/liveness.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/liveness.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 
 set -euxo pipefail
+# shellcheck source=./env.sh
+source /env.sh
 
 # This script checks to see if postgres is alive. It uses the ready check, but
 # additionally ignores upgrades to give the container enough time to
-# upgrade. It is expected to be used by a Kubernetes liveness probe.
+# re-calculate any . It is expected to be used by a Kubernetes liveness probe.
 
 # Ensure we are in the same dir ready.sh
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-if [ -s "$PGDATA/PG_VERSION" ] && [ ! -s "$PGDATA.upgraded" ]; then
-  echo "[INFO] Postgres is upgrading"
+if [ -s "${PGDATA}/PG_VERSION" ] && [ ! -s "${REINDEX_COMPLETED_FILE}" ]; then
+  echo "[INFO] Postgres is re-indexing..."
   exit 0
 fi
 

--- a/docker-images/postgres-12.6-alpine/rootfs/liveness.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/liveness.sh
@@ -6,7 +6,7 @@ source /env.sh
 
 # This script checks to see if postgres is alive. It uses the ready check, but
 # additionally ignores upgrades to give the container enough time to
-# re-calculate any . It is expected to be used by a Kubernetes liveness probe.
+# re-compute indexes. It is expected to be used by a Kubernetes liveness probe.
 
 # Ensure we are in the same dir ready.sh
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/docker-images/postgres-12.6-alpine/rootfs/postgres.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/postgres.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 set -euxo pipefail
-
 cd /var/lib/postgresql
+
+# shellcheck source=./env.sh
+source /env.sh
 
 # Allow the container to be started with root in Kubernetes and change permissions
 # of the parent volume directory to be owned entirely by the postgres user.
@@ -19,5 +21,10 @@ if [ ! -s "$PGDATA/PG_VERSION" ]; then
 fi
 
 /conf.sh
+
+if [ ! -s "${REINDEX_COMPLETED_FILE}" ]; then
+  echo "[INFO] Re-creating all indexes from for database '$POSTGRES_DB'"
+  /reindex.sh
+fi
 
 exec postgres

--- a/docker-images/postgres-12.6-alpine/rootfs/postgres.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/postgres.sh
@@ -23,7 +23,7 @@ fi
 /conf.sh
 
 if [ ! -s "${REINDEX_COMPLETED_FILE}" ]; then
-  echo "[INFO] Re-creating all indexes from for database '$POSTGRES_DB'"
+  echo "[INFO] Re-creating all indexes for database '$POSTGRES_DB'"
   /reindex.sh
 fi
 

--- a/docker-images/postgres-12.6-alpine/rootfs/ready.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/ready.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 # a Kubernetes ready probe.
 
 # We check if the TCP port is available since that is how clients will
-# connect. While upgrading only the unix port will be available, so we
+# connect. While re-indexing only the unix port will be available, so we
 # specifically want to avoid reporting ready in that case.
 
 if [ -n "$POSTGRES_PASSWORD" ]; then

--- a/docker-images/postgres-12.6-alpine/rootfs/reindex.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/reindex.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+set -Eexo pipefail
+
+# shellcheck source=./env.sh
+source /env.sh
+
+file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  local val="$def"
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(<"${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
+prepare_env() {
+  file_env 'POSTGRES_USER' 'postgres'
+  file_env 'POSTGRES_PASSWORD'
+  export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+  export PGUSER="${PGUSER:-$POSTGRES_USER}"
+}
+
+unset_env() {
+  unset PGPASSWORD
+}
+
+postgres_start() {
+  # internal start of server in order to allow set-up using psql-client
+  # - does not listen on external TCP/IP and waits until start finishes
+  # - "-P" prevents Postgres from using indexes for system catalog lookups -
+  #        see https://www.postgresql.org/docs/12/sql-reindex.html
+
+  pg_ctl -D "$PGDATA" \
+    -o "-c listen_addresses=''" \
+    -o "-P" \
+    -w start
+}
+
+postgres_stop() {
+  pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+cleanup() {
+  postgres_stop
+  unset_env
+}
+
+reindex() {
+  reindexdb --no-password --verbose --echo "$@"
+}
+
+# allow the container to be started with `--user`
+if [ "$(id -u)" = '0' ]; then
+  # TODO@davejrt is this fix what you meant?
+  su-exec postgres "${BASH_SOURCE[0]}" "$@"
+fi
+
+# look specifically for REINDEX_COMPLETED_FILE, as it is expected in the DB dir
+if [ ! -s "${REINDEX_COMPLETED_FILE}" ]; then
+  prepare_env
+  postgres_start
+  trap cleanup EXIT
+
+  echo
+  echo 'PostgresSQL must rebuild its indexes. This process can take up to a few hours on systems with a large dataset.'
+  echo
+
+  reindex --system
+  reindex --all
+
+  # mark reindexing process as done
+  echo "Re-indexing for 3.31 release completed successfully at $(date)" >"${REINDEX_COMPLETED_FILE}"
+
+  echo
+  echo 'PostgreSQL reindexing process complete - ready for start up.'
+  echo
+fi

--- a/docker-images/postgres-12.6-alpine/rootfs/reindex.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/reindex.sh
@@ -92,7 +92,6 @@ reindex() {
 
 # allow the container to be started with `--user`
 if [ "$(id -u)" = '0' ]; then
-  # TODO@davejrt is this fix what you meant?
   su-exec postgres "${BASH_SOURCE[0]}" "$@"
 fi
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/23310

(albeit not ideally - see caveats)

# script outline

1. check for a marker file in `PGDATADIR` (`3.31-reindexing.completed`) - its presence indicates that re-indexing process has already been performed. (the following steps assume that the marker file is missing) 
2. prepare the postgres environment variables (in the same way as `initdb.sh` does)
3. start up the postgres server with the following options
	- the `listen_address` is set to empty ('') - this prevents all external TCP connections to the DB, and allows only local connections via a unix socket
	- `-P` prevents postgres from using system catalog indexes for lookups (since these will need to be re-created for the same reasons that we are re-indexing the other databases). This follows the advice provided by https://www.postgresql.org/docs/12/sql-reindex.html
4. re-index the system catalogs (`--system`), _then_ the rest of the databases (`--all`)
5. write the marker file to signal that the process has completed 
6. shut down postgres

---

The liveness script has been altered to check for the presence of the marker file. If it's absent, that means that the re-indexing process is still underway - so it'll return a `0` exit code so that k8s doesn't kill the pod. 

(The readiness script doesn't need to be altered, it still works in the same way that it always did since postgres doesn't listen to external TCP connections during the re-indexing process)

# still to be done:

- need to verify that all permutations of specifying postgres credentials work with this script (`PGPASSWORD`, etc.). I suspect this will work since it uses the same machinery that `initdb.sh` uses


# caveats

Reindexing the entire database can take a long time if you have a lot of data. k8s.sdev.org's codeintel-db instance takes **1-2 hours to re-index**. I've been experimenting with using the `CONCURRENTLY` option that's described on https://www.postgresql.org/docs/12/app-reindexdb.html. If we can pull it off, it's possible that we can do this without incurring downtime. I haven't been able to figure out a clean way around the caveats described in the above document for that option though (a uniqueness violation means that the process will exit early, and we'll have to manually clean that up). I put this PR up in the meantime for discussion, even though I know it's not ideal. 


