### PR TITLE
 search: move internal structural search logic to own file

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -1,0 +1,57 @@
+package unindexed
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
+	"golang.org/x/sync/errgroup"
+)
+
+// StructuralSearchFilesInRepos searches a set of repos for a structural pattern.
+func StructuralSearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
+	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
+	defer cleanup()
+
+	indexed, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	if err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	if args.Mode != search.SearcherOnly {
+		// Run structural search on indexed repositories (fulfilled via searcher).
+		g.Go(func() error {
+			repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
+			for _, repo := range indexed.Repos() {
+				repos = append(repos, repo)
+			}
+			return callSearcherOverRepos(ctx, args, stream, repos, true)
+		})
+	}
+
+	// Concurrently run searcher for all unindexed repos regardless whether text, regexp, or structural search.
+	g.Go(func() error {
+		return callSearcherOverRepos(ctx, args, stream, indexed.Unindexed, false)
+	})
+
+	return g.Wait()
+}
+
+// StructuralSearchFilesInRepoBatch is a convenience function around
+// StructuralSearchFilesInRepos which collects the results from the stream.
+func StructuralSearchFilesInReposBatch(ctx context.Context, args *search.TextParameters) ([]*result.FileMatch, streaming.Stats, error) {
+	matches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
+		return StructuralSearchFilesInRepos(ctx, args, stream)
+	})
+
+	fms, fmErr := matchesToFileMatches(matches)
+	if fmErr != nil && err == nil {
+		err = errors.Wrap(fmErr, "StructuralSearchFilesInReposBatch failed to convert results")
+	}
+	return fms, stats, err
+}

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -51,37 +51,6 @@ func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissi
 	return zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.TextRequest, onMissing)
 }
 
-// StructuralSearchFilesInRepos searches a set of repos for a structural pattern.
-func StructuralSearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
-	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
-	defer cleanup()
-
-	indexed, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
-	if err != nil {
-		return err
-	}
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	if args.Mode != search.SearcherOnly {
-		// Run structural search on indexed repositories (fulfilled via searcher).
-		g.Go(func() error {
-			repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
-			for _, repo := range indexed.Repos() {
-				repos = append(repos, repo)
-			}
-			return callSearcherOverRepos(ctx, args, stream, repos, true)
-		})
-	}
-
-	// Concurrently run searcher for all unindexed repos regardless whether text, regexp, or structural search.
-	g.Go(func() error {
-		return callSearcherOverRepos(ctx, args, stream, indexed.Unindexed, false)
-	})
-
-	return g.Wait()
-}
-
 // SearchFilesInRepos searches a set of repos for a pattern.
 func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
 	if MockSearchFilesInRepos != nil {
@@ -121,26 +90,12 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		})
 	}
 
-	// Concurrently run searcher for all unindexed repos regardless whether text, regexp, or structural search.
+	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
 		return callSearcherOverRepos(ctx, args, stream, indexed.Unindexed, false)
 	})
 
 	return g.Wait()
-}
-
-// StructuralSearchFilesInRepoBatch is a convenience function around
-// StructuralSearchFilesInRepos which collects the results from the stream.
-func StructuralSearchFilesInReposBatch(ctx context.Context, args *search.TextParameters) ([]*result.FileMatch, streaming.Stats, error) {
-	matches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
-		return StructuralSearchFilesInRepos(ctx, args, stream)
-	})
-
-	fms, fmErr := matchesToFileMatches(matches)
-	if fmErr != nil && err == nil {
-		err = errors.Wrap(fmErr, "StructuralSearchFilesInReposBatch failed to convert results")
-	}
-	return fms, stats, err
 }
 
 // SearchFilesInRepoBatch is a convenience function around searchFilesInRepos


### PR DESCRIPTION
Following previous stack https://github.com/sourcegraph/sourcegraph/pull/23604 I want to separate the structural search logic and text/regex a bit more. I also wanted to see if I could separate state concerns a bit better within structural search logic. So starting with this PR I move most of the frontend structural search logic to its own `structural.go` file here, and then work on simplifications up the stack. I'm not a fan of the `unindexed` package name, but based on the dependencies it's best if the `structural.go` file lives here for now.

Key benefit of this PR: moves logic out of `aggregator.go` for structural search, so that `aggregator.go` is more pure (see separate commits).
