### PR TITLE
search: rework err logic in structural.go

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -55,8 +55,11 @@ func StructuralSearch(ctx context.Context, args *search.TextParameters, stream s
 	fileMatches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
 		return StructuralSearchFilesInRepos(ctx, args, stream)
 	})
+	if err != nil {
+		return err
+	}
 
-	if len(fileMatches) == 0 && err == nil {
+	if len(fileMatches) == 0 {
 		// No results for structural search? Automatically search again and force Zoekt
 		// to resolve more potential file matches by setting a higher FileMatchLimit.
 		patternCopy := *(args.PatternInfo)
@@ -68,6 +71,9 @@ func StructuralSearch(ctx context.Context, args *search.TextParameters, stream s
 		fileMatches, stats, err = streaming.CollectStream(func(stream streaming.Sender) error {
 			return StructuralSearchFilesInRepos(ctx, args, stream)
 		})
+		if err != nil {
+			return err
+		}
 
 		if len(fileMatches) == 0 {
 			// Still no results? Give up.


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23702. 

After the previous PR, it became kind of obvious that we weren't checking all `err` values which was originally the case. This PR addresses error checking and a simplification.
