### PR TITLE
web: sort top-level folders in Storybook to keep reusable components at the top

### DIFF
--- a/client/storybook/src/preview.ts
+++ b/client/storybook/src/preview.ts
@@ -17,6 +17,11 @@ const withConsoleDecorator: DecoratorFunction<ReactElement> = (storyFn, context)
 export const decorators = [withDesign, withConsoleDecorator]
 
 export const parameters = {
+    options: {
+        storySort: {
+            order: ['wildcard', 'shared', 'branded', '*'],
+        },
+    },
     darkMode: {
         stylePreview: true,
         lightClass: THEME_LIGHT_CLASS,


### PR DESCRIPTION
## Context

Our primary source of reusable components should be the Wildcard library, but at the moment, it's at the bottom of the list in Storybook UI. This PR moves folders with reusable components to the top of the list, with the Wildcard being the first option to catch an eye. 

<img width="350" alt="Screenshot 2021-08-09 at 12 54 59" src="https://user-images.githubusercontent.com/3846380/128689137-a08cdef0-7864-44fc-b537-a69e36e59abd.png">

## Changes

- Folder stories are now sorted as: `['wildcard', 'shared', 'branded', '*']`