### PR TITLE
web: add delay to `CodeMonitoringPage.story` to avoid flaky screenshots

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -13,7 +13,12 @@ import { EnterpriseWebStory } from '../components/EnterpriseWebStory'
 import { CodeMonitoringPage } from './CodeMonitoringPage'
 import { mockCodeMonitorNodes } from './testing/util'
 
-const { add } = storiesOf('web/enterprise/code-monitoring/CodeMonitoringPage', module)
+const { add } = storiesOf('web/enterprise/code-monitoring/CodeMonitoringPage', module).addParameters({
+    chromatic: {
+        // Delay screenshot taking, so <CodeMonitoringPage /> is ready to show content.
+        delay: 600,
+    },
+})
 
 const additionalProps = {
     authenticatedUser: { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser,


### PR DESCRIPTION
## Context

I encountered a flaky Percy screenshot of the `CodeMonitoringPage` multiple times. It seems to be related to the mocked fetch delay.

## Changes

- Added Percy delay to all `CodeMonitoringPage` stories.