### PR TITLE
repo-updater: Run repo perms sync if a repo is added or modified

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -238,9 +238,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	if server.PermsSyncer != nil {
-		syncer.PermsSyncer = server.PermsSyncer
-	}
+	syncer.PermsSyncer = server.PermsSyncer
 
 	var gps *repos.GitolitePhabricatorMetadataSyncer
 	if !envvar.SourcegraphDotComMode() {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -232,13 +232,12 @@ func Main(enterpriseInit EnterpriseInit) {
 		Store:   store,
 		// We always want to listen on the Synced channel since external service syncing
 		// happens on both Cloud and non Cloud instances.
-		Synced:     make(chan repos.Diff),
-		Logger:     log15.Root(),
-		Now:        clock,
-		Registerer: prometheus.DefaultRegisterer,
+		Synced:      make(chan repos.Diff),
+		Logger:      log15.Root(),
+		Now:         clock,
+		Registerer:  prometheus.DefaultRegisterer,
+		PermsSyncer: server.PermsSyncer,
 	}
-
-	syncer.PermsSyncer = server.PermsSyncer
 
 	var gps *repos.GitolitePhabricatorMetadataSyncer
 	if !envvar.SourcegraphDotComMode() {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -238,6 +238,10 @@ func Main(enterpriseInit EnterpriseInit) {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
+	if server.PermsSyncer != nil {
+		syncer.PermsSyncer = server.PermsSyncer
+	}
+
 	var gps *repos.GitolitePhabricatorMetadataSyncer
 	if !envvar.SourcegraphDotComMode() {
 		gps = repos.NewGitolitePhabricatorMetadataSyncer(store)

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -38,6 +38,7 @@ func TestIntegration(t *testing.T) {
 		{"EnqueueSingleSyncJob", testStoreEnqueueSingleSyncJob},
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
+		{"Syncer/PermsSyncer", testSyncerPermsSyncer},
 		{"Syncer/SyncRepo", testSyncRepo},
 		{"Syncer/Run", testSyncRun},
 		{"Syncer/MultipleServices", testSyncerMultipleServices},

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -38,7 +38,7 @@ func TestIntegration(t *testing.T) {
 		{"EnqueueSingleSyncJob", testStoreEnqueueSingleSyncJob},
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
-		{"Syncer/PermsSyncer", testSyncerPermsSyncer},
+		{"Syncer/SyncRepoPermsSyncer", testSyncRepoPermsSyncer},
 		{"Syncer/SyncExternalServicePermsSync", testSyncExternalServicePermsSync},
 		{"Syncer/SyncRepo", testSyncRepo},
 		{"Syncer/Run", testSyncRun},

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -39,6 +39,7 @@ func TestIntegration(t *testing.T) {
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
 		{"Syncer/PermsSyncer", testSyncerPermsSyncer},
+		{"Syncer/SyncExternalServicePermsSync", testSyncExternalServicePermsSync},
 		{"Syncer/SyncRepo", testSyncRepo},
 		{"Syncer/Run", testSyncRun},
 		{"Syncer/MultipleServices", testSyncerMultipleServices},

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -522,13 +522,9 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		return d, nil
 	}
 
-	// We expect the length of d.Added to be either 0 or 1. Ranging over it is simpler.
-	for _, r := range d.Added {
-		s.PermsSyncer.ScheduleRepos(ctx, r.ID)
-	}
-
-	// We expect the length of d.Modified to be either 0 or 1. Ranging over it is simpler.
-	for _, r := range d.Modified {
+	// We expect the length of d.Added and d.Modified to be either 0 or 1.
+	// Ranging over it is simpler.
+	for _, r := range append(d.Added, d.Modified...) {
 		s.PermsSyncer.ScheduleRepos(ctx, r.ID)
 	}
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -37,8 +37,11 @@ type Syncer struct {
 	// Now is time.Now. Can be set by tests to get deterministic output.
 	Now func() time.Time
 
+	// Registerer is the interface to register / unregister prometheus metrics.
 	Registerer prometheus.Registerer
 
+	// PermsSyncer is the embedded interface to schedule permissions syncing without directly having
+	// access to the permissions syncer client.
 	PermsSyncer interface {
 		ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID)
 	}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -39,6 +39,10 @@ type Syncer struct {
 
 	Registerer prometheus.Registerer
 
+	PermsSyncer interface {
+		ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID)
+	}
+
 	// UserReposMaxPerUser can be used to override the value read from config.
 	// If zero, we'll read from config instead.
 	UserReposMaxPerUser int
@@ -427,7 +431,8 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		return Diff{}, errors.Wrap(err, "syncer: getting repo from the database")
 	}
 
-	switch len(stored) {
+	repoState := len(stored)
+	switch repoState {
 	case 2: // Existing repo with a naming conflict
 		// Pick this sourced repo to own the name by deleting the other repo. If it still exists, it'll have a different
 		// name when we source it from the same code host, and it will be re-created.
@@ -489,6 +494,28 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		d.Added = append(d.Added, sourced)
 	default: // Impossible since we have two separate unique constraints on name and external repo spec
 		panic("unreachable")
+	}
+
+	// PermsSyncer is available in enterprise mode only.
+	if s.PermsSyncer != nil {
+		switch repoState {
+		case 0: // New repo was created.
+			if sourced.Private {
+				s.PermsSyncer.ScheduleRepos(ctx, sourced.ID)
+			}
+		default:
+			// Other possible values for repoState are 1 and 2. Anything else is an impossible state. And in the off chance that any otehr value is encountered, the switch-case on repoState above will already panic and the code will never reach this step.
+
+			// If an existing repo was public and was now updated to private, we want to trigger a
+			// repo permissions sync.
+			//
+			// We do not need to check if an existing private repo was made public because public
+			// repos are on the quick path of authz checks and will be skipped even if we enqueue it
+			// for permissions syncing.
+			if !stored[0].Private && sourced.Private {
+				s.PermsSyncer.ScheduleRepos(ctx, stored[0].ID)
+			}
+		}
 	}
 
 	return d, nil

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -504,7 +504,9 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 				s.PermsSyncer.ScheduleRepos(ctx, sourced.ID)
 			}
 		default:
-			// Other possible values for repoState are 1 and 2. Anything else is an impossible state. And in the off chance that any otehr value is encountered, the switch-case on repoState above will already panic and the code will never reach this step.
+			// Other possible values for repoState are 1 and 2. Anything else is an impossible
+			// state. And in the off chance that any other value is encountered, the switch-case on
+			// repoState above will already panic and the code will never reach this step.
 
 			// If an existing repo was public and was now updated to private, we want to trigger a
 			// repo permissions sync.

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -595,7 +595,7 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		t.Run("new private repo triggers permsisions sync", func(t *testing.T) {
+		t.Run("new private repo triggers permissions sync", func(t *testing.T) {
 			permsSyncer := &PermsSyncer{testing: t}
 
 			clock := timeutil.NewFakeClock(time.Now(), 0)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -634,7 +634,9 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 					PermsSyncer: permsSyncer,
 				}
 
-				syncer.SyncRepo(context.Background(), repo)
+				if err := syncer.SyncRepo(context.Background(), repo); err != nil {
+					t.Fatal(err)
+				}
 
 				if permsSyncer.invoked != tc.expectedInvokedState {
 					t.Errorf(

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -659,7 +659,6 @@ func testSyncExternalServicePermsSync(store *repos.Store) func(t *testing.T) {
 			name                 string
 			private              bool
 			expectedInvokedState bool
-			testSetup            func(r *types.Repo) (*types.Repo, error)
 		}{
 			{
 				name:                 "new private repo triggers permissions sync",
@@ -693,13 +692,6 @@ func testSyncExternalServicePermsSync(store *repos.Store) func(t *testing.T) {
 				sourcer := repos.NewFakeSourcer(nil,
 					repos.NewFakeSource(githubService.Clone(), nil, repo.Clone()),
 				)
-
-				if tc.testSetup != nil {
-					var err error
-					if repo, err = tc.testSetup(repo); err != nil {
-						t.Fatal(err)
-					}
-				}
 
 				clock := timeutil.NewFakeClock(time.Now(), 0)
 				permsSyncer := &mockPermsSyncer{testing: t}

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -543,12 +543,12 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 	}
 }
 
-type PermsSyncer struct {
+type mockPermsSyncer struct {
 	testing *testing.T
 	invoked bool
 }
 
-func (p *PermsSyncer) ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID) {
+func (p *mockPermsSyncer) ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID) {
 	if p.invoked {
 		p.testing.Errorf("method ScheduleRepos already invoked, should not be called again")
 	}
@@ -596,7 +596,7 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 		}
 
 		t.Run("new private repo triggers permissions sync", func(t *testing.T) {
-			permsSyncer := &PermsSyncer{testing: t}
+			permsSyncer := &mockPermsSyncer{testing: t}
 
 			clock := timeutil.NewFakeClock(time.Now(), 0)
 
@@ -621,7 +621,7 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 		})
 
 		t.Run("existing public repo is made private and triggers permissions sync", func(t *testing.T) {
-			permsSyncer := &PermsSyncer{testing: t}
+			permsSyncer := &mockPermsSyncer{testing: t}
 
 			clock := timeutil.NewFakeClock(time.Now(), 0)
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -751,16 +751,11 @@ func testSyncRun(store *repos.Store) func(t *testing.T) {
 			}
 		}
 
-		// Our test will have 1 initial repo, and discover two new repos on sourcing - the first
-		// public, and the second private.
-		privateRepo := mk("private")
-		privateRepo.Private = true
-
+		// Our test will have 1 initial repo, and discover a new repo on sourcing.
 		stored := types.Repos{mk("initial")}.With(types.Opt.RepoSources(svc.URN()))
 		sourced := types.Repos{
 			mk("initial").With(func(r *types.Repo) { r.Description = "updated" }),
 			mk("new"),
-			privateRepo,
 		}
 
 		syncer := &repos.Syncer{
@@ -800,22 +795,16 @@ func testSyncRun(store *repos.Store) func(t *testing.T) {
 			t.Fatalf("Synced mismatch (-want +got):\n%s", d)
 		}
 
-		// Then the new public repo.
+		// Then the new repo.
 		diff = <-syncer.Synced
-		if d := cmp.Diff(repos.Diff{Added: sourced[1:2]}, diff, ignore); d != "" {
+		if d := cmp.Diff(repos.Diff{Added: sourced[1:]}, diff, ignore); d != "" {
 			t.Fatalf("Synced mismatch (-want +got):\n%s", d)
 		}
 
-		// Then the new private repo.
-		diff = <-syncer.Synced
-		if d := cmp.Diff(repos.Diff{Added: sourced[2:]}, diff, ignore); d != "" {
-			t.Fatalf("Synced mismatch (-want +got):\n%s", d)
-		}
-
-		// We check synced again to test us going around the Run loop 3 times in
+		// We check synced again to test us going around the Run loop 2 times in
 		// total.
 		diff = <-syncer.Synced
-		if d := cmp.Diff(repos.Diff{Unmodified: sourced[:2]}, diff, ignore); d != "" {
+		if d := cmp.Diff(repos.Diff{Unmodified: sourced[:1]}, diff, ignore); d != "" {
 			t.Fatalf("Synced mismatch (-want +got):\n%s", d)
 		}
 
@@ -1749,22 +1738,6 @@ func testDeleteExternalService(store *repos.Store) func(*testing.T) {
 		assertDeletedRepoCount(ctx, t, store, 1)
 	}
 }
-
-// func testSyncerPermsSync(t *testing.T) func(t *testing.T) {
-// 	return func(t *testing.T) {
-// 		ctx, cancel := context.WithCancel(context.Background())
-// 		defer cancel()
-
-// 		svc := &types.ExternalService{
-// 			Config: `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-// 			Kind:   extsvc.KindGitHub,
-// 		}
-
-// 		if err := store.ExternalServiceStore.Upsert(ctx, svc); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	}
-// }
 
 func assertSourceCount(ctx context.Context, t *testing.T, store *repos.Store, want int) {
 	t.Helper()

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -607,8 +607,6 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 				PermsSyncer: permsSyncer,
 			}
 
-			storedRepo.Private = true
-
 			syncer.SyncRepo(context.Background(), githubRepo)
 
 			if !permsSyncer.invoked {
@@ -628,6 +626,7 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 				PermsSyncer: permsSyncer,
 			}
 
+			storedRepo.Private = true
 			syncer.SyncRepo(context.Background(), storedRepo)
 
 			if !permsSyncer.invoked {

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -556,7 +556,7 @@ func (p *mockPermsSyncer) ScheduleRepos(ctx context.Context, repoIDs ...api.Repo
 	p.invoked = true
 }
 
-func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
+func testSyncRepoPermsSyncer(store *repos.Store) func(t *testing.T) {
 	return func(t *testing.T) {
 		servicesPerKind := createExternalServices(t, store, func(svc *types.ExternalService) { svc.CloudDefault = true })
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -607,10 +607,6 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 				PermsSyncer: permsSyncer,
 			}
 
-			if permsSyncer.invoked {
-				t.Errorf("initialisation error, PermsSyncer.invoked is already true")
-			}
-
 			storedRepo.Private = true
 
 			syncer.SyncRepo(context.Background(), githubRepo)
@@ -630,10 +626,6 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 				Store:       store,
 				Now:         clock.Now,
 				PermsSyncer: permsSyncer,
-			}
-
-			if permsSyncer.invoked {
-				t.Errorf("initialisation error, PermsSyncer.invoked is already true")
 			}
 
 			syncer.SyncRepo(context.Background(), storedRepo)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -549,7 +549,7 @@ type PermsSyncer struct {
 }
 
 func (p *PermsSyncer) ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID) {
-	if !p.invoked {
+	if p.invoked {
 		p.testing.Errorf("method ScheduleRepos already invoked, should not be called again")
 	}
 
@@ -558,7 +558,7 @@ func (p *PermsSyncer) ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID) 
 
 func testSyncerPermsSyncer(s *repos.Store) func(t *testing.T) {
 	return func(t *testing.T) {
-		servicesPerKind := createExternalServices(t, s)
+		servicesPerKind := createExternalServices(t, s, func(svc *types.ExternalService) { svc.CloudDefault = true })
 
 		githubService := servicesPerKind[extsvc.KindGitHub]
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -620,7 +620,7 @@ func testSyncerPermsSyncer(store *repos.Store) func(t *testing.T) {
 			}
 		})
 
-		t.Run("existing public repo is made private and triggers permsisions sync", func(t *testing.T) {
+		t.Run("existing public repo is made private and triggers permissions sync", func(t *testing.T) {
 			permsSyncer := &PermsSyncer{testing: t}
 
 			clock := timeutil.NewFakeClock(time.Now(), 0)


### PR DESCRIPTION
## Status

Ready for review. Tested locally.

## Shortest path to merging

- [x] Add tests
- [x] ~~Perform functional tests on dogfood to eliminate any obvious regressions~~ Tested locally.

## Description

In this commit we make an API change on the repo syncer so that it can
trigger a repo permissions sync without needing access to the
permissions syncing client. `repos.Syncer.PermsSyncer` interface only
defines the `ScheduleRepos` method because the syncer does not need
access to the `ScheduleUsers` method from the `PermsSyncer` yet.

Also, when a new repo is created or an existing one is modified we
trigger a repo permissions sync if the final state of the repo at the
end of the create / update operation indicates that it is private.






<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
