### PR TITLE
search: Introduce pattern matcher for more complex query analysis

### DIFF
--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -48,11 +48,7 @@ const rules: PatternOf<Token[], Monaco.editor.IMarkerData[]>[] = [
     each({
         type: 'filter',
         $data: (token, context) => {
-            const diagnostics = checkFilter(token as Filter)
-            if (!context.data) {
-                context.data = []
-            }
-            context.data.push(...diagnostics)
+            context.data.push(...checkFilter(token as Filter))
         },
     }),
 ]

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -47,7 +47,7 @@ const rules: PatternOf<Token[], Monaco.editor.IMarkerData[]>[] = [
     // Validate the value of each filter
     each({
         type: 'filter',
-        $: (token, context) => {
+        $data: (token, context) => {
             const diagnostics = checkFilter(token as Filter)
             if (!context.data) {
                 context.data = []
@@ -61,5 +61,9 @@ const rules: PatternOf<Token[], Monaco.editor.IMarkerData[]>[] = [
  * Returns the diagnostics for a scanned search query to be displayed in the Monaco query input.
  */
 export function getDiagnostics(tokens: Token[], patternType: SearchPatternType): Monaco.editor.IMarkerData[] {
-    return matchesValue<Token[], Monaco.editor.IMarkerData[]>(tokens, eachOf(...rules)).data ?? []
+    const result = matchesValue<Token[], Monaco.editor.IMarkerData[]>(tokens, eachOf(...rules), [])
+    if (result.success) {
+        return result.data
+    }
+    return []
 }

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -4,6 +4,7 @@ import { SearchPatternType } from '../../graphql-operations'
 
 import { validateFilter } from './filters'
 import { toMonacoSingleLineRange } from './monaco'
+import { PatternOf, each, matchesValue, eachOf } from './patternMatcher'
 import { Filter, Token } from './token'
 
 type FilterCheck = (f: Filter) => Monaco.editor.IMarkerData[]
@@ -42,10 +43,23 @@ export function checkFilter(filter: Filter): Monaco.editor.IMarkerData[] {
     const checks: FilterCheck[] = [validFilterValue, emptyFilterValue]
     return checks.map(check => check(filter)).find(value => value.length !== 0) || []
 }
+const rules: PatternOf<Token[], Monaco.editor.IMarkerData[]>[] = [
+    // Validate the value of each filter
+    each({
+        type: 'filter',
+        $: (token, context) => {
+            const diagnostics = checkFilter(token as Filter)
+            if (!context.data) {
+                context.data = []
+            }
+            context.data.push(...diagnostics)
+        },
+    }),
+]
 
 /**
  * Returns the diagnostics for a scanned search query to be displayed in the Monaco query input.
  */
 export function getDiagnostics(tokens: Token[], patternType: SearchPatternType): Monaco.editor.IMarkerData[] {
-    return tokens.filter(token => token.type === 'filter').flatMap(filter => checkFilter(filter as Filter))
+    return matchesValue<Token[], Monaco.editor.IMarkerData[]>(tokens, eachOf(...rules)).data ?? []
 }

--- a/client/shared/src/search/query/patternMatcher.test.ts
+++ b/client/shared/src/search/query/patternMatcher.test.ts
@@ -1,0 +1,201 @@
+// Note: This tests the pattern matcher implementation but also acts as a
+// verifier that patterns are properly typed against their input value.
+// Usage of the @ts-expect-error is intentional and should be kept in place
+
+/* eslint-disable id-length */
+
+import { every, matchesValue, some, oneOf, allOf, not, PatternOfNoInfer } from './patternMatcher'
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace jest {
+        interface Matchers<R, T> {
+            toBeMatchedBy<Data>(pattern: PatternOfNoInfer<T, Data>, expectedData?: Data): R
+        }
+    }
+}
+
+expect.extend({
+    toBeMatchedBy(actual, pattern, expectedData) {
+        const options = {
+            comment: 'Pattern matching',
+            isNot: this.isNot,
+            promise: this.promise,
+        }
+        const result = matchesValue(actual, pattern)
+        let dataComparisonResult = false
+        if (result.success && expectedData) {
+            dataComparisonResult = this.equals(result.data, expectedData)
+        }
+
+        return {
+            actual,
+            message: () =>
+                `${this.utils.matcherHint('toMatchPattern', undefined, undefined, options)}\n\n` +
+                `Value: ${this.utils.printExpected(actual)}\n` +
+                `Pattern: ${this.utils.printExpected(pattern)}\n` +
+                `Match: ${this.utils.printReceived(result.success)} (expected: ${this.utils.printExpected(
+                    !result.success
+                )}))\n` +
+                (expectedData
+                    ? `Data received: ${this.utils.printReceived(result.data)}\n` +
+                      `Data expected: ${this.utils.printExpected(expectedData)}\n`
+                    : ''),
+            pass: result.success && (!expectedData || dataComparisonResult),
+        }
+    },
+})
+
+describe('matchValue', () => {
+    describe('base patterns', () => {
+        it('allows primtive values as patterns', () => {
+            expect(42).toBeMatchedBy(42)
+            expect(true).toBeMatchedBy(true)
+            expect(false).toBeMatchedBy(false)
+            expect('foo').toBeMatchedBy('foo')
+            expect('foo').toBeMatchedBy(/^f/)
+            expect(null).toBeMatchedBy(null)
+
+            expect(42).not.toBeMatchedBy(21)
+            expect(true).not.toBeMatchedBy(false)
+            expect(false).not.toBeMatchedBy(true)
+            expect('foo').not.toBeMatchedBy('bar')
+            // @ts-expect-error cannot use a string to match a number
+            expect(42).not.toBeMatchedBy('foo')
+            expect(42 as string | number).not.toBeMatchedBy('foo')
+        })
+
+        it('allows functions as patterns', () => {
+            expect(42).toBeMatchedBy(value => value === 42)
+            expect({ field: 42 }).toBeMatchedBy(value => value.field > 0)
+
+            expect(42).not.toBeMatchedBy(value => value < 0)
+            expect({ field: 42 }).not.toBeMatchedBy(value => value.field < 0)
+            // @ts-expect-error cannot use a number as a pattern for an object
+            expect({ field: 42 }).not.toBeMatchedBy(42)
+        })
+
+        it('allows objects as patterns', () => {
+            expect({ field1: 42, field2: 21 }).toBeMatchedBy({ field1: 42 })
+            expect({ field1: 42, field2: 21 }).toBeMatchedBy({ field1: value => value > 0 })
+            expect({ field1: 42, field2: 21 }).not.toBeMatchedBy({ field2: 42 })
+
+            // @ts-expect-error cannot use a non-existing field to match an object
+            expect({ field1: 42, field2: 21 }).not.toBeMatchedBy({ field3: 42 })
+        })
+
+        it('allows self reference objects as patterns', () => {
+            expect(42).toBeMatchedBy({ _: 42 })
+            // Self referenced objects must use a function as pattern
+            expect({ field1: 0 }).toBeMatchedBy({ _: ({ field1 }) => field1 === 0 })
+            expect({ field1: 0, field2: 21 }).toBeMatchedBy({ _: ({ field1 }) => field1 === 0, field2: 21 })
+            expect({ field1: 0, field2: 21 }).not.toBeMatchedBy({ _: ({ field1 }) => field1 === 0, field2: 42 })
+        })
+    })
+
+    describe('matching against union types', () => {
+        enum TestEnum {
+            A = 0,
+            B = 1,
+            C = 2,
+        }
+        type TestType = { a: number; b: string } | { a: string }
+
+        it('allows matching against primitve unions', () => {
+            expect('foo' as 'foo' | 'bar').toBeMatchedBy('foo')
+            expect('foo' as 'foo' | 'bar').not.toBeMatchedBy('bar')
+
+            expect(TestEnum.A as TestEnum).toBeMatchedBy(TestEnum.A)
+            expect(TestEnum.A as TestEnum).not.toBeMatchedBy(TestEnum.B)
+            // Shouldn't this throw a type error?
+            expect(TestEnum.A as TestEnum).not.toBeMatchedBy(10)
+        })
+
+        it('allows using a property in a pattern that does not exist in all union members', () => {
+            expect({ b: 'b' } as TestType).toBeMatchedBy({ b: /^b/ })
+            expect({ b: 'b' } as TestType).not.toBeMatchedBy({ a: 'a' })
+            expect({ a: 42 } as TestType).not.toBeMatchedBy({ a: 'a' })
+            expect({ a: 'a' } as TestType).toBeMatchedBy({ a: 'a' })
+        })
+
+        it('properly types function patterns for properties that do not exist in all union members', () => {
+            expect({ b: 'a' } as TestType).toBeMatchedBy({ b: v => v?.toUpperCase() === 'A' })
+            // @ts-expect-error v is type string|undefined
+            expect({ b: 'a' } as TestType).toBeMatchedBy({ b: v => v.toUpperCase() === 'A' })
+        })
+
+        it('disallows properties that do not exist on any union member', () => {
+            // @ts-expect-error property c doesn't exist
+            expect({ a: 'a' } as TestType).not.toBeMatchedBy({ c: 'c' })
+        })
+    })
+
+    describe('data extraction', () => {
+        it('extracts data when there is a match', () => {
+            expect(42).toBeMatchedBy({ _: x => x > 0, $: { larger: true } }, { larger: true })
+            expect({
+                field1: {
+                    field1: 42,
+                    field2: [{ field3: 42 }],
+                },
+            }).toBeMatchedBy(
+                { field1: { field1: 42, field2: some({ field3: x => x > 0, $: { larger: true } }) } },
+                { larger: true }
+            )
+        })
+
+        it('allows functions as data extractor', () => {
+            const extractData = (value: number, context: { data?: Set<number> }): void => {
+                if (!context.data) {
+                    context.data = new Set()
+                }
+                context.data.add(value)
+            }
+            expect({ a: 42, b: 21 }).toBeMatchedBy(
+                {
+                    a: { _: 42, $: extractData },
+                    b: { _: 21, $: extractData },
+                },
+                new Set([21, 42])
+            )
+        })
+    })
+
+    describe('some()', () => {
+        it('matches against an array of nodes', () => {
+            expect({ foo: [42, 21] }).toBeMatchedBy({ foo: some(42) })
+            expect({ foo: [42, 21] }).toBeMatchedBy({ foo: some(x => x < 42) })
+
+            expect([42, 21]).not.toBeMatchedBy(some(0))
+        })
+    })
+
+    describe('every()', () => {
+        it('matches against an array of nodes', () => {
+            expect({ foo: [42, 21] }).toBeMatchedBy({ foo: every(value => value > 0) })
+            expect([42, -1]).not.toBeMatchedBy(every(42))
+        })
+    })
+
+    describe('oneOf()', () => {
+        it('matches one or more patterns against a value', () => {
+            expect(42).toBeMatchedBy(oneOf(42, { _: 21 }, value => value > 0))
+
+            expect(42).not.toBeMatchedBy(oneOf(21, { _: 21 }, value => value < 0))
+        })
+    })
+
+    describe('allOf()', () => {
+        it('matches one ore more patterns against a value', () => {
+            expect(42).toBeMatchedBy(allOf(42, { _: 42 }, value => value > 0))
+
+            expect(42).not.toBeMatchedBy(allOf(21, { _: 42 }, value => value < 0))
+        })
+    })
+
+    describe('not()', () => {
+        it('matches against a single node', () => {
+            expect(42).toBeMatchedBy(not(21))
+        })
+    })
+})

--- a/client/shared/src/search/query/patternMatcher.test.ts
+++ b/client/shared/src/search/query/patternMatcher.test.ts
@@ -38,7 +38,7 @@ expect.extend({
                     !result.success
                 )}))\n` +
                 (expectedData
-                    ? `Data received: ${this.utils.printReceived(result.data)}\n` +
+                    ? `Data received: ${this.utils.printReceived(result.success ? result.data : '[no match]')}\n` +
                       `Data expected: ${this.utils.printExpected(expectedData)}\n`
                     : ''),
             pass: result.success && (!expectedData || dataComparisonResult),
@@ -85,11 +85,11 @@ describe('matchValue', () => {
         })
 
         it('allows self reference objects as patterns', () => {
-            expect(42).toBeMatchedBy({ _: 42 })
+            expect(42).toBeMatchedBy({ $pattern: 42, $data: {} })
             // Self referenced objects must use a function as pattern
-            expect({ field1: 0 }).toBeMatchedBy({ _: ({ field1 }) => field1 === 0 })
-            expect({ field1: 0, field2: 21 }).toBeMatchedBy({ _: ({ field1 }) => field1 === 0, field2: 21 })
-            expect({ field1: 0, field2: 21 }).not.toBeMatchedBy({ _: ({ field1 }) => field1 === 0, field2: 42 })
+            expect({ field1: 0 }).toBeMatchedBy({ $pattern: ({ field1 }) => field1 === 0 })
+            expect({ field1: 0, field2: 21 }).toBeMatchedBy({ $pattern: ({ field1 }) => field1 === 0, field2: 21 })
+            expect({ field1: 0, field2: 21 }).not.toBeMatchedBy({ $pattern: ({ field1 }) => field1 === 0, field2: 42 })
         })
     })
 
@@ -132,14 +132,14 @@ describe('matchValue', () => {
 
     describe('data extraction', () => {
         it('extracts data when there is a match', () => {
-            expect(42).toBeMatchedBy({ _: x => x > 0, $: { larger: true } }, { larger: true })
+            expect(42).toBeMatchedBy({ $pattern: x => x > 0, $data: { larger: true } }, { larger: true })
             expect({
                 field1: {
                     field1: 42,
                     field2: [{ field3: 42 }],
                 },
             }).toBeMatchedBy(
-                { field1: { field1: 42, field2: some({ field3: x => x > 0, $: { larger: true } }) } },
+                { field1: { field1: 42, field2: some({ field3: x => x > 0, $data: { larger: true } }) } },
                 { larger: true }
             )
         })
@@ -153,8 +153,8 @@ describe('matchValue', () => {
             }
             expect({ a: 42, b: 21 }).toBeMatchedBy(
                 {
-                    a: { _: 42, $: extractData },
-                    b: { _: 21, $: extractData },
+                    a: { $pattern: 42, $data: extractData },
+                    b: { $pattern: 21, $data: extractData },
                 },
                 new Set([21, 42])
             )
@@ -179,17 +179,17 @@ describe('matchValue', () => {
 
     describe('oneOf()', () => {
         it('matches one or more patterns against a value', () => {
-            expect(42).toBeMatchedBy(oneOf(42, { _: 21 }, value => value > 0))
+            expect(42).toBeMatchedBy(oneOf(42, { $pattern: 21, $data: {} }, value => value > 0))
 
-            expect(42).not.toBeMatchedBy(oneOf(21, { _: 21 }, value => value < 0))
+            expect(42).not.toBeMatchedBy(oneOf(21, { $pattern: 21, $data: {} }, value => value < 0))
         })
     })
 
     describe('allOf()', () => {
         it('matches one ore more patterns against a value', () => {
-            expect(42).toBeMatchedBy(allOf(42, { _: 42 }, value => value > 0))
+            expect(42).toBeMatchedBy(allOf(42, { $pattern: 42, $data: {} }, value => value > 0))
 
-            expect(42).not.toBeMatchedBy(allOf(21, { _: 42 }, value => value < 0))
+            expect(42).not.toBeMatchedBy(allOf(21, { $pattern: 42, $data: {} }, value => value < 0))
         })
     })
 

--- a/client/shared/src/search/query/patternMatcher.test.ts
+++ b/client/shared/src/search/query/patternMatcher.test.ts
@@ -10,19 +10,19 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace jest {
         interface Matchers<R, T> {
-            toBeMatchedBy<Data>(pattern: PatternOfNoInfer<T, Data>, expectedData?: Data): R
+            toBeMatchedBy<Data>(pattern: PatternOfNoInfer<T, Data>, expectedData?: Data, initialData?: Data): R
         }
     }
 }
 
 expect.extend({
-    toBeMatchedBy(actual, pattern, expectedData) {
+    toBeMatchedBy(actual, pattern, expectedData, initialData) {
         const options = {
             comment: 'Pattern matching',
             isNot: this.isNot,
             promise: this.promise,
         }
-        const result = matchesValue(actual, pattern)
+        const result = matchesValue(actual, pattern, initialData)
         let dataComparisonResult = false
         if (result.success && expectedData) {
             dataComparisonResult = this.equals(result.data, expectedData)
@@ -145,10 +145,7 @@ describe('matchValue', () => {
         })
 
         it('allows functions as data extractor', () => {
-            const extractData = (value: number, context: { data?: Set<number> }): void => {
-                if (!context.data) {
-                    context.data = new Set()
-                }
+            const extractData = (value: number, context: { data: Set<number> }): void => {
                 context.data.add(value)
             }
             expect({ a: 42, b: 21 }).toBeMatchedBy(
@@ -156,7 +153,8 @@ describe('matchValue', () => {
                     a: { $pattern: 42, $data: extractData },
                     b: { $pattern: 21, $data: extractData },
                 },
-                new Set([21, 42])
+                new Set([21, 42]),
+                new Set()
             )
         })
     })

--- a/client/shared/src/search/query/patternMatcher.ts
+++ b/client/shared/src/search/query/patternMatcher.ts
@@ -14,7 +14,7 @@
  * Here is a summary of possible pattern values:
  *
  * For primitive values, the pattern can be a value of the same type, a function
- * taken the value as argument and returning a boolean ("pattern function"), or
+ * taking the value as argument and returning a boolean ("pattern function"), or
  * a "wrapper pattern" which is an object of the form '{$pattern: PatternOf<...>}'.
  * See 'WrapperPattern' below for more information.
  *
@@ -246,7 +246,7 @@ export type PatternOfNoInfer<Value, Data> = PatternOf<NoInfer<Value>, NoInfer<Da
  * application. Currently only holds the extracted data.
  */
 interface MatchContext<Data> {
-    data?: Data
+    data: Data
 }
 
 type Result<Data> =
@@ -266,21 +266,10 @@ type Result<Data> =
  */
 export function matchesValue<Value, Data>(
     value: Value,
-    pattern: PatternOfNoInfer<Value, Data>
-): Result<Data | undefined>
-// This overload exists so that if an initial value is provided, the success
-// result will always contain data.
-export function matchesValue<Value, Data>(
-    value: Value,
     pattern: PatternOfNoInfer<Value, Data>,
-    initialData: Data
-): Result<Data>
-export function matchesValue<Value, Data>(
-    value: Value,
-    pattern: PatternOfNoInfer<Value, Data>,
-    initialData?: Data
-): Result<Data> | Result<Data | undefined> {
-    const context = { data: initialData }
+    initialData: Data = Object.create(null)
+): Result<Data> {
+    const context = { data: initialData ?? Object.create(null) }
     if (matches(context, value, pattern)) {
         return { success: true, data: context.data ?? initialData }
     }
@@ -336,9 +325,6 @@ function matches<Value, Data>(
                 // @ts-expect-error due to the type definition above, pattern.$data is a union of two functions
                 pattern.$data(value, context)
             } else {
-                if (!context.data) {
-                    context.data = Object.create(null)
-                }
                 for (const [key, captureValue] of Object.entries(pattern.$data)) {
                     // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'.  No index signature with a parameter of type 'string' was found on type 'unknown'
                     // @ts-expect-error context.data will likely not be an indexable type
@@ -426,6 +412,8 @@ export function debug<Value, Data>(pattern: PatternOfNoInfer<Value, Data>): Patt
     return (value, context, matches) => {
         // eslint-disable-next-line no-debugger
         debugger
+        // These are intentially two statements to make it easier to inspect the
+        // result of calling `matches` in the debugger.
         const result = matches(context, value, pattern)
         return result
     }

--- a/client/shared/src/search/query/patternMatcher.ts
+++ b/client/shared/src/search/query/patternMatcher.ts
@@ -1,0 +1,408 @@
+/* eslint-disable jsdoc/check-indentation */
+
+/**
+ * This module provides functions and TS types for pattern matching.
+ * Given an input value and a pattern, `matchesValue` returns true if the value
+ * is matched by the pattern.
+ *
+ * `PatternOf<...>` is the main TS type for a pattern.  What exactly can be used
+ * as a pattern depends on the input value. For example If the input value is a
+ * number value, then the pattern can be a function (returning a boolean) or a
+ * number value. Things get a bit more complex when the input value is an object
+ * or a union of objects.
+ *
+ * Here is a summary of possible pattern values:
+ *
+ * For primitive values, the pattern can be a value of the same type, a function
+ * taken the value as argument and returning a boolean ("pattern function"), or
+ * a "wrapper pattern" which is an object of the form '{_: PatternOf<...>}'. See
+ * 'WrapperPattern' below for more information.
+ *
+ *    matchesValue(42, 42)
+ *    matchesValue(42, x => x > 0)
+ *    matchesValue(42, {_: 42})
+ *
+ * Additionally string values can be matched by a regular expression:
+ *
+ *    matchesValue('foo', /^f/)
+ *    matchesValue('foo', {_: /^f/})
+ *
+ * Arrays can only be matched by pattern functions.
+ *
+ *    matchesValue([1,2,3], values => values.every(x => x > 0))
+ *
+ * An object can be matched by an "object pattern", a pattern function or a
+ * wrapper pattern.
+ * The corresponding object pattern for an object has the same properties as the
+ * input object, but they are all optional, and the values of those properties
+ * are themselves patterns of the corresponding type.
+ *
+ *
+ *    type O = {a: string; b: string|number}
+ *    let o: O = {...}
+ *    matchesValue(O, {a: 'foo'})
+ *    matchesValue(O, {b: 42})
+ *    matchesValue(O, {b: 'foo'})
+ *    matchesValue(O, {b: x => typeof x === 'string'})
+ *
+ * If the input type is a union of objects, the properties of all members are
+ * merged into into a single object. The type of every property is the union of
+ * the respective property types, including 'undefined' if one of the objects in
+ * the union doesn't have this property.
+ *
+ * Input type:
+ *     {t: 'foo', a: string, b: number} | {t: 'bar', a: number}
+ *
+ * Pattern type:
+ *     ObjectPattern<Input> = {
+ *       t?: PatternFunction<'foo'|'bar'> | WrapperPattern<'foo'|'bar'> | 'foo' | 'bar',
+ *       a?: PatternFunction<string|number> | WrapperPattern<string|number> | string | number
+ *       b?: PatternFunction<string|undefined> | WrapperPattern<string|undefined> | string
+ *     }
+ *
+ */
+
+/**
+ * ObjectPatterns and WrapperPattern can have an additional data annotation ($)
+ * to extract information if the corresponding pattern matches. The extracted
+ * data is returned from `matchesValue`.
+ *
+ * Example:
+ * matchesValue({a: 100}, {a: x => x > 50, $: {outOfBounds: true}})
+ *  => {
+ *      success: true,
+ *      data: {
+ *        outOfBounds: true,
+ *      }
+ *    }
+ */
+interface DataAnnotation<Value, Data> {
+    $?: ((value: Value, context: MatchContext<Data>) => void) | (Data extends any[] ? never : DataMapper<Value, Data>)
+}
+
+/**
+ * This allows the data annotation to extract data statically or from the matched
+ * value via a function.
+ *
+ * Example:
+ * {
+ *   $: {
+ *     static: 42,
+ *     dynamic: value => value.x,
+ *   }
+ * }
+ */
+type DataMapper<Value, Data> = {
+    [K in keyof Data]?: ((value: Value, context: MatchContext<Data>) => Data[K]) | Data[K]
+}
+
+/**
+ * Creates the union of all keys of each member.
+ *
+ * Example: {a,c}|{a,b,d} => (a|c)|(a|b|d) => a|c|b|d
+ */
+type UnionKeys<T> = T extends any ? keyof T : never
+
+/**
+ * Given a union type and a property, this type alias will create the union of
+ * property types from each union member, or 'undefined' if the property doesn't
+ * exist.
+ * Normally it's not possible to access a property on a union type that doesn't
+ * exist in all of the members but because we operate on a generic type and we
+ * extract all property names via 'UnionKeys', we can get away with it. However,
+ * doing just '{[K in UnionKeys<T>]: T[K]}' will result in 'unknown' if one of
+ * the members doesn't have the property.
+ * With 'UnionValues', we get '... | undefined' instead.
+ */
+type UnionValues<Value, K> = Value extends any ? (K extends keyof Value ? Value[K] : undefined) : never
+
+/**
+ * A ObjectPattern matches the input if all pattern properties (which are a
+ * subset of the input properties) match.
+ *
+ * Example: {foo: x => x > 0} matches {foo: 42}
+ *
+ * If the input type is a union of objects, the properties of all members are
+ * merged into into a single object. The type of every property is the union of
+ * the respective property types, including 'undefined' if one of the objects in
+ * the union doesn't have this property.
+ *
+ * Example:
+ * Input:
+ *     {t: 'foo', a: string, b: number} | {t: 'bar', a: number}
+ *
+ * Output:
+ *     ObjectPattern<Input> = {
+ *       t?: PatternFunction<'foo'|'bar'> | WrapperPattern<'foo'|'bar'> | 'foo' | 'bar',
+ *       a?: PatternFunction<string|number> | WrapperPattern<string|number> | string | number
+ *       b?: PatternFunction<string|undefined> | WrapperPattern<string|undefined> | string
+ *     }
+ */
+type ObjectPattern<Value, Data> =
+    // ObjectPattern is applied below with ObjectPattern<ObjectMembers<Value>>. The
+    // check against 'never' prevents empty unions.
+    [Value] extends [never]
+        ? never
+        : { [K in UnionKeys<Value>]?: PatternOf<UnionValues<Value, K>, Data> } & Partial<WrapperPattern<Value, Data>>
+
+/**
+ * A WrapperPattern makes it possible to add data annotations to patterns that
+ * are not object patterns. In the following example, it wouldn't be possible to
+ * attach additional data to the different values of "type":
+ *
+ * {type: oneOf("script", "module")}
+ *
+ * We could write
+ *
+ * {type: oneOf("script", "module"), $: {module: value => value.type === "module"}
+ *
+ * but in order to avoid precedural logic as much as possible, WrapperPattern
+ * allows us to write
+ *
+ * {type: oneOf("script", {_: "module", $: {module: true}})}
+ */
+interface WrapperPattern<Value, Data> extends DataAnnotation<Value, Data> {
+    _: PatternFunction<Value, Data> | PrimitivePattern<Value>
+}
+
+/**
+ * A PatternFunction accepts the value to match against, the current match
+ * context (which also holds the extracted data) and the internal match function
+ * for convenience. See the combinatorial helper functions below for examples.
+ */
+export type PatternFunction<Value, Data> = (
+    value: Value,
+    context: MatchContext<Data>,
+    matchfn: typeof matches
+) => boolean
+
+/**
+ * This type is used for matching against primitives. The main reason for it's
+ * existence is to allow first class support matching strings with regular
+ * expressions.
+ */
+type PrimitivePattern<Value> = Value extends string
+    ? RegExp | Value
+    : Value extends number | boolean | null
+    ? Value
+    : never
+
+/**
+ * Removes all non-object members from Value
+ */
+type ObjectMembers<Value> = Value extends object ? Value : never
+
+/**
+ * The main pattern type. What a valid pattern for a value is depends on the
+ * value:
+ * - For an array, the pattern has to be a function
+ * - For an object, the pattern can be an object pattern, a wrapper pattern or a
+ *   pattern function
+ * - For a primitive value, the pattern can be a value of the same type, a
+ *   wrapper pattern or a pattern function. For strings the pattern can also be
+ *   a regular expression.
+ */
+export type PatternOf<Value, Data = unknown> =
+    // A pattern function is always a valid value. The function receives the
+    // value to be matched as argument.
+    | PatternFunction<Value, Data>
+    | (// Arrays always have to matched with a pattern function
+      // The [...] around the types are necessary to avoid
+      // distributing union types.
+      [Value] extends [any[]]
+          ? never
+          :
+                | WrapperPattern<Value, Data>
+                // Note that we are not checking types here (Value extends ...). For
+                // one, union types of mixed types (e.g. number|{x: number}) makes
+                // this a bit annoying, and what we really want to do do here is
+                // _filter_ 'Value' and allow/create an ObjectPattern for the objects in
+                // the union, and PrimitivePatterns for the primtives.
+                // ObjectMembers does the object filtering and PrimitivePattern
+                // includes type checks itself.
+                | ObjectPattern<ObjectMembers<Value>, Data>
+                | PrimitivePattern<Value>)
+
+/**
+ * Utility type to prevent TS from inferring the type from a function parameter
+ * @see https://stackoverflow.com/questions/56687668
+ */
+type NoInfer<A extends any> = [A][A extends any ? 0 : never]
+
+/**
+ * Helper type to indicate to infer the values for Value, Data from other input
+ * and not from the pattern itself.
+ */
+export type PatternOfNoInfer<Value, Data> = PatternOf<NoInfer<Value>, NoInfer<Data>>
+
+/**
+ * Context that is passed to all pattern functions during a single pattern
+ * application. Currently only holds the extracted data.
+ */
+export interface MatchContext<Data> {
+    data?: Data
+}
+
+export interface Result<Data> {
+    success: boolean
+    data?: Data
+}
+
+/**
+ * "Applies" the 'pattern' to 'value'. It returns whether the pattern matched
+ * and all data extracted by patterns.
+ * If 'Data' is an object all of it's properties should be optional.
+ */
+export function matchesValue<Value, Data>(
+    value: Value,
+    pattern: PatternOfNoInfer<Value, Data>,
+    initialData?: Data
+): Result<Data> {
+    const context = { data: initialData }
+    const result = matches(context, value, pattern)
+    return { success: result, data: context.data }
+}
+
+const specialKeys: Set<string> = new Set(['_', '$'])
+
+/**
+ * Internal match function that does the heavy lifting and is passed to every
+ * pattern function.
+ */
+function matches<Value, Data>(
+    context: MatchContext<Data>,
+    value: Value,
+    pattern: PatternOfNoInfer<Value, Data> | undefined
+): boolean {
+    if (typeof pattern === 'function') {
+        return pattern(value, context, matches)
+    }
+    if (pattern instanceof RegExp) {
+        return typeof value === 'string' && pattern.test(value)
+    }
+    if (pattern && typeof pattern === 'object') {
+        // 'pattern' can be a wrapper pattern or an object pattern
+        let match = true
+
+        if (value && typeof value === 'object') {
+            const keys = Object.getOwnPropertyNames(pattern).filter(key => !specialKeys.has(key))
+            if (keys.length > 0) {
+                // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'.  No index signature with a parameter of type 'string' was found on type 'unknown'.
+                // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'WrapperPattern<NoInfer<Value>, NoInfer<Data>> | ...
+                // @ts-expect-error this will properly always error because 'value' and 'pattern' are normally not indexable
+                match = keys.every(
+                    property => property in value && matches(context, value[property], pattern[property])
+                )
+            }
+        }
+
+        // In case of object patterns, "real" keys have priority and we only check _
+        // if the real keys match.  Otherwise the context might get polluted with
+        // values that shouldn't exist.
+        if (match && pattern._) {
+            // TS2345:  Type 'RegExp' is not assignable to type '[NoInfer<Value>] extends [any[]] ? never : WrapperPattern<NoInfer<Value>, NoInfer<Data>> | ObjectPattern<ObjectMembers<NoInfer<Value>>, NoInfer<Data>> | PrimitivePattern<NoInfer<Value>>'
+            // @ts-expect-error TBH I don't know why RegExp is causing problems here
+            match = matches(context, value, pattern._)
+        }
+
+        // Special property to capture values
+        if (match && pattern.$) {
+            if (typeof pattern.$ === 'function') {
+                //  TS2345: Argument of type 'Value' is not assignable to parameter of type 'ObjectMembers<NoInfer<Value>>'
+                // @ts-expect-error due to the type definition above, pattern.$ is a union of two functions
+                pattern.$(value, context)
+            } else {
+                if (!context.data) {
+                    context.data = Object.create(null)
+                }
+                for (const [key, captureValue] of Object.entries(pattern.$)) {
+                    // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'.  No index signature with a parameter of type 'string' was found on type 'unknown'
+                    // @ts-expect-error context.data will likely not be an indexable type
+                    context.data[key] =
+                        typeof captureValue === 'function' ? captureValue(value, context.data) : captureValue
+                }
+            }
+        }
+        return match
+    }
+    return value === pattern
+}
+
+// Standard pattern functions
+
+// Combinators
+
+/**
+ * Matches if any of its elements match the provided pattern.
+ */
+export function some<Value, Data>(pattern: PatternOfNoInfer<Value, Data>): PatternFunction<Value[], Data> {
+    return (values, context) => values.some(value => matches(context, value, pattern))
+}
+
+/**
+ * Matches if all of the elements match the provided pattern.
+ */
+export function every<Value, Data>(pattern: PatternOfNoInfer<Value, Data>): PatternFunction<Value[], Data> {
+    return (values, context) => values.every(value => matches(context, value, pattern))
+}
+
+/**
+ * Always matches. It's main purpose is to apply a pattern to multiple input
+ * values to extract data from each of them.
+ */
+export function each<Value, Data>(pattern: PatternOfNoInfer<Value, Data>): PatternFunction<Value[], Data> {
+    return (values, context) => {
+        for (const value of values) {
+            matches(context, value, pattern)
+        }
+        return true
+    }
+}
+
+/**
+ * Matches if the value matches one of the patterns.
+ */
+export function oneOf<Value, Data>(...patterns: PatternOfNoInfer<Value, Data>[]): PatternFunction<Value, Data> {
+    return (value, context) => patterns.some(pattern => matches(context, value, pattern))
+}
+
+/**
+ * Matches if the value matches all of the patterns.
+ */
+export function allOf<Value, Data>(...patterns: PatternOfNoInfer<Value, Data>[]): PatternFunction<Value, Data> {
+    return (value, context) => patterns.every(pattern => matches(context, value, pattern))
+}
+
+/**
+ * Similar to each above but matching multiple patterns against a single value
+ * to extract information. Always returns true.
+ */
+export function eachOf<Value, Data>(...patterns: PatternOfNoInfer<Value, Data>[]): PatternFunction<Value, Data> {
+    return (value, context) => {
+        for (const pattern of patterns) {
+            matches(context, value, pattern)
+        }
+        return true
+    }
+}
+
+/**
+ * Matches if the value does not match the pattern.
+ */
+export function not<Value, Data>(pattern: PatternOfNoInfer<Value, Data>): PatternFunction<Value, Data> {
+    return (value, context) => !matches(context, value, pattern)
+}
+
+// Misc
+
+/**
+ * Helper function to debug patterns
+ */
+export function debug<Value, Data>(pattern: PatternOfNoInfer<Value, Data>): PatternFunction<Value, Data> {
+    return (value, context) => {
+        // eslint-disable-next-line no-debugger
+        debugger
+        const result = matches(context, value, pattern)
+        return result
+    }
+}

--- a/client/shared/src/search/query/patternMatcher.ts
+++ b/client/shared/src/search/query/patternMatcher.ts
@@ -287,10 +287,10 @@ function matches<Value, Data>(
         if (value && typeof value === 'object') {
             const keys = Object.getOwnPropertyNames(pattern).filter(key => !specialKeys.has(key))
             if (keys.length > 0) {
-                // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'.  No index signature with a parameter of type 'string' was found on type 'unknown'.
-                // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'WrapperPattern<NoInfer<Value>, NoInfer<Data>> | ...
-                // @ts-expect-error this will properly always error because 'value' and 'pattern' are normally not indexable
                 match = keys.every(
+                    // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'.  No index signature with a parameter of type 'string' was found on type 'unknown'.
+                    // TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'WrapperPattern<NoInfer<Value>, NoInfer<Data>> | ...
+                    // @ts-expect-error this will properly always error because 'value' and 'pattern' are normally not indexable
                     property => property in value && matches(context, value[property], pattern[property])
                 )
             }


### PR DESCRIPTION
This PR introduces a new way to define search diagnostics via patter matching. For now I just moved the existing query diagnostics over, and even for that I only did minimal changes to make it work. Over time we would use this for different kinds of "query intelligence" and probably integrate at a different place (e.g. global state).

The big comment in `patternMatcher.ts` and the tests  should provide enough information for what's going on there and why, but here are also the notes I took locally, explaining why the type definitions are the way they are (click the on the summary line to reveal the content). I went with approach 1.

<details>
<summary>Notes about pattern matching and type representation of union types</summary>

# Pattern matching

The idea is to implement a system to test whether a given value matches/looks like
a given pattern:

    matches(obj, {foo: 42})

In this example the result would be true if obj was an object that has a property
`foo` with value `42`.

The remainder of this section explains the "structure" of patterns.

### Primitives

In its simplest form a pattern is a value of a primitive data type
(boolean,number,string,..):

    matches(value, 42)
    matches(value, true)
    matches(value,"foo")

### Regular expressions

String input values can also be matched against regular expressions

    matches(value, /^ba/)

### Objects

Object input values can be matched against object patterns, whereas an object
pattern is a subset of the properties of the input object:

    matches({foo: 42, bar: 21}, {foo: 42})              // true
    matches({foo: 42, bar: 21}, {foo: 42, bar: 21})     // true
    matches({foo: 42, bar: 21}, {bar: 42})              // false
    matches({foo: 42, bar: 21}, {baz: 21})              // false, but should probably already be caught by Typescript; more below

The property value of an object *pattern* can be any other valid at that position.


### Functions

*Any* input value can be matched with a function pattern that takes the value as input and
returns a boolean value (`(input: any) => boolean`):

    matches(42, x => x > 0)                   // true

As mentioned above for object patterns, object pattern property values can be any
valid pattern at that position, so the following is also valid:

    matches({foo: 42}, {foo: x => x > 0)       // true

Allowing function makes it possible to create "pattern combinators". Imagine a
function. For example:

    matches("foo bar", every(str => str.length < 10, /^foo/))
    matches(value, {type: oneOf("Foo", "Bar")})

## Typescript

We could implement such a system without giving too much thoughts about type safty
and simply use `any` everywhere. But trying to add type safety will help us avoid
mistakes, can improve developer experience in the editor and lets us avoid to repeat
ourselves.

Creating a generic `Pattern` type definition would be relatively straightforward
(using advances features such as type mapping and conditional types), if it weren't
for **union types**. Union types introduce a certain amount of complexity and
ambiguity, which is why the rest of document present various possible approaches.

Consider the following input type:

    type Token =
      | {type: 'filter', kind: FilterType, value: string}
      | {type: 'pattern', value: string}

We could now implement `Pattern<Token>` in different ways:

NOTE: `F<X>` stands for the function pattern `(v: X) => boolean`

**1. Single object with union properties**

```
type Pattern<Token> = {
  type?: F<'filter'|'pattern'> | 'filter' | 'pattern',
  kind?: F<FilterType|undefined> | FilterType
  value?: F<string> | string
}
```

Advantage: Function pattern input is typed with the union of the property values
Disadvantage: No discriminating union, i.e. the following is a valid pattern:

```
{
  type: 'pattern',
  kind: ...,
}
```

Even worse if two members do have the same property but with different (union)
types. It's easy to create patterns that will never match.

**2. Discriminating union**
```
type Pattern<Token> =
| {
    type?: 'filter'|F<'filter'>
    kind?: FilterType|F<FilterType>
    value?:  string | F<string>
  }
| {
    type?: F<'pattern'> | 'pattern'
    value?: F<string> | string
  }
```

Advantage: Type refinement possible
Disadvantage: When using a function without using a discriminating type, the
function input value is typed `any` so explicit types are necessary:

```
{
  // F<'filter'>|F<'pattern'>
  type: x => true, // x has implicit any
}
```

*edit:* This seems to be the case even with a discriminating property as long as
the type of the discriminating property includes a function.

**3. Single object with unionized functions + discriminating union**

```
type Pattern<Token> =
| {
    type?: F<'filter'|'pattern'>
    kind?: F<FilterType|undefined>
    value?: F<string>
  }
| {
    type?: 'filter'
    kind?: FilterType
    value?: string
  }
| {
    type?: 'pattern'
    value?: string
  }
```
Advantage: Type refinement possible; typed functions possible
Disadvantage: Cannot use functions when one of the union member is used. If
functions where allowed we would have the same problem again as in 2.

**4. Single object with unionized properties + discriminating union + explicit property name**

If the discriminating property is specified, we can create a single object that
contains the union of all properties + individual pattern objects for every member
of the union, but making the discriminating property required.

```
type Pattern<Token> =
| {
    type?: F<'filter'|'pattern'>
    kind?: F<FilterType|undefined> | FilterType
    value?: F<string> | string
  }
| {
    type: 'filter'
    kind?: FilterType | F<FilterType>
    value?: string | F<string>
  }
| {
    type: 'pattern'
    value?: string | F<string>
  }
```

Advantage: `type` can be used to discriminate members; all possible patterns can
be used for each union member. 
Disadvantage: The discriminating property has to be specified, i.e. it has to be
known upfront whether a type is a union. (or could that be determined automatically?)

**5. Others**

There are other possible combinations, also using intersection (`&`) but all
other solutions seems to have similar drawbacks.

</details>