### PR TITLE
repos: Keep going after finding an error from GitHub

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -490,11 +490,10 @@ func (s *GithubSource) listRepos(ctx context.Context, repos []string, results ch
 			// 404 errors on external service config validation.
 			if github.IsNotFound(err) {
 				log15.Warn("skipping missing github.repos entry:", "name", nameWithOwner, "err", err)
-				continue
+			} else {
+				results <- &githubResult{err: errors.Wrapf(err, "Error getting GitHub repository: nameWithOwner=%s", nameWithOwner)}
 			}
-
-			results <- &githubResult{err: errors.Wrapf(err, "Error getting GitHub repository: nameWithOwner=%s", nameWithOwner)}
-			break
+			continue
 		}
 		log15.Debug("github sync: GetRepository", "repo", repo.NameWithOwner)
 


### PR DESCRIPTION
Customers using a long list of repo names in the `repos` config of a
github external service would abort after a single error. This fixes that.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
