### PR TITLE
executor: Remove teardown.firecracker.stop step in teardown

### DIFF
--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.story.tsx
@@ -83,15 +83,6 @@ const batchSpecExecutionCompleted = (): BatchSpecExecutionFields => ({
         },
         teardown: [
             {
-                key: 'teardown.firecracker.stop',
-                command: ['ignite', 'stop', 'USERNAME_REMOVED-c70e5459-a30d-43fe-ae6e-7a17b3adec51'],
-                startTime,
-                exitCode: 0,
-                durationMilliseconds: 2067,
-                out:
-                    'stdout: time="2021-08-02T18:02:21+02:00" level=info msg="Removing the container with ID \\"2dc3f3334dab94176aaed5b20e5ecefff383223ff1a63c3f9ea3b53130f18f2e\\" from the \\"docker-bridge\\" network"\nstdout: time="2021-08-02T18:02:23+02:00" level=info msg="Stopped VM with name \\"USERNAME_REMOVED-c70e5459-a30d-43fe-ae6e-7a17b3adec51\\" and ID \\"7c60f09688abdca1\\""\n',
-            },
-            {
                 key: 'teardown.firecracker.remove',
                 command: ['ignite', 'rm', '-f', 'USERNAME_REMOVED-c70e5459-a30d-43fe-ae6e-7a17b3adec51'],
                 startTime,
@@ -173,15 +164,6 @@ const batchSpecExecutionErrored = (): BatchSpecExecutionFields => ({
                 'stdout: {"operation":"BATCH_SPEC_EXECUTION","timestamp":"2021-08-02T14:50:21.68Z","status":"FAILURE","message":"failed to query Sourcegraph version to check for available features: Post \\"https://USERNAME_REMOVED:***@sourcegraph.test:3443/.api/graphql\\": dial tcp: lookup sourcegraph.test on 192.168.1.1:53: no such host"}\nstdout: time="2021-08-02T16:50:21+02:00" level=error msg="Process exited with status 1\\n"\n',
         },
         teardown: [
-            {
-                key: 'teardown.firecracker.stop',
-                command: ['ignite', 'stop', 'USERNAME_REMOVED-1c25d857-837e-4d16-bfd6-12b9034fcad3'],
-                startTime,
-                exitCode: 0,
-                durationMilliseconds: 701,
-                out:
-                    'stdout: time="2021-08-02T16:50:21+02:00" level=info msg="Removing the container with ID \\"e142627b331e3f0ff4fb2e0092c356fd8febd3cea9eb547b699e09c451d77ead\\" from the \\"docker-bridge\\" network"\nstdout: time="2021-08-02T16:50:22+02:00" level=info msg="Stopped VM with name \\"USERNAME_REMOVED-1c25d857-837e-4d16-bfd6-12b9034fcad3\\" and ID \\"32cc4f205cd58550\\""\n',
-            },
             {
                 key: 'teardown.firecracker.remove',
                 command: ['ignite', 'rm', '-f', 'USERNAME_REMOVED-1c25d857-837e-4d16-bfd6-12b9034fcad3'],

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -99,15 +99,6 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 // teardownFirecracker issues a stop and a remove request for the Firecracker VM with
 // the given name.
 func teardownFirecracker(ctx context.Context, runner commandRunner, logger *Logger, name string, options Options, operations *Operations) error {
-	stopCommand := command{
-		Key:       "teardown.firecracker.stop",
-		Command:   flatten("ignite", "stop", name),
-		Operation: operations.TeardownFirecrackerStop,
-	}
-	if err := runner.RunCommand(ctx, stopCommand, logger); err != nil {
-		log15.Error("Failed to stop firecracker vm", "name", name, "err", err)
-	}
-
 	removeCommand := command{
 		Key:       "teardown.firecracker.remove",
 		Command:   flatten("ignite", "rm", "-f", name),

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -159,7 +159,6 @@ func TestTeardownFirecracker(t *testing.T) {
 	}
 
 	expected := []string{
-		"ignite stop deadbeef",
 		"ignite rm -f deadbeef",
 	}
 	if diff := cmp.Diff(expected, actual); diff != "" {

--- a/enterprise/cmd/executor/internal/command/observability.go
+++ b/enterprise/cmd/executor/internal/command/observability.go
@@ -14,7 +14,6 @@ type Operations struct {
 	SetupGitCheckout          *observation.Operation
 	SetupFirecrackerStart     *observation.Operation
 	SetupStartupScript        *observation.Operation
-	TeardownFirecrackerStop   *observation.Operation
 	TeardownFirecrackerRemove *observation.Operation
 	Exec                      *observation.Operation
 }
@@ -42,7 +41,6 @@ func NewOperations(observationContext *observation.Context) *Operations {
 		SetupGitCheckout:          op("setup.git.checkout"),
 		SetupFirecrackerStart:     op("setup.firecracker.start"),
 		SetupStartupScript:        op("setup.startup-script"),
-		TeardownFirecrackerStop:   op("teardown.firecracker.stop"),
 		TeardownFirecrackerRemove: op("teardown.firecracker.remove"),
 		Exec:                      op("exec"),
 	}


### PR DESCRIPTION
We are somewhat sure this isn't required when we `rm -f` afterwards, so giving it a try and removing it. It should save around 10s on the average execution, if we're lucky.
