### PR TITLE
throttle stream search events instead of debouncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Email notifiers in `observability.alerts` now correctly respect the `email.smtp.noVerifyTLS` site configuration field. [#23636](https://github.com/sourcegraph/sourcegraph/issues/23636)
 - Alertmanager (Prometheus) now respects `SMTPServerConfig.noVerifyTLS` field. [#23636](https://github.com/sourcegraph/sourcegraph/issues/23636)
 - Clicking on symbols in the left search pane now renders hover tooltips for indexed repositories. [#23664](https://github.com/sourcegraph/sourcegraph/pull/23664)
+- Fixed a result streaming throttling issue that was causing significantly increased latency for some searches. [#23736](https://github.com/sourcegraph/sourcegraph/pull/23736)
 
 ### Removed
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import * as H from 'history'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Observable } from 'rxjs'
-import { debounceTime } from 'rxjs/operators'
+import { throttleTime } from 'rxjs/operators'
 
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
 import { Link } from '@sourcegraph/shared/src/components/Link'
@@ -127,7 +127,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     caseSensitive,
                     versionContext: resolveVersionContext(versionContext, availableVersionContexts),
                     trace,
-                }).pipe(debounceTime(500)),
+                }).pipe(throttleTime(500, undefined, { leading: true, trailing: true })),
             [streamSearch, query, patternType, caseSensitive, versionContext, availableVersionContexts, trace]
         )
     )


### PR DESCRIPTION
This fixes an issue with our streaming search rendering pipeline that
was, in some cases, causing no results to be rendered until the entire
search was complete.

When reducing the stream of search events, we were rate-limiting the
number of UI updates by piping them through `debounceTime`. The problem
with `debounceTime` in this case is it will not emit an event until the
configured time has passed and there have been no events observed. With
streaming search though, we are sending a progress event every 100
milliseconds, so the condition to emit an update event was never met. In
effect, this made it so no results were rendered on the page until the
search was complete, after which 500 milliseconds would pass and the
page would render.

This commit replaces `debounceTime` with `throttleTime`, which, instead
of waiting for a period of no events, always emits an event after the
interval if the value has changed. This change significantly improves
the time to first rendered results.

Before:

https://user-images.githubusercontent.com/12631702/128783646-d8b855f3-83b5-4e74-b096-dab93b1ca54d.mov


After:

https://user-images.githubusercontent.com/12631702/128783642-9639cc34-31a6-42b5-9382-394d873a31fa.mov

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
