### PR TITLE
workerutil: Add automatic shutdown configuration

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	FirecrackerDiskSpace string
 	MaximumRuntimePerJob time.Duration
 	CleanupTaskInterval  time.Duration
+	NumTotalJobs         int
+	MaxActiveTime        time.Duration
 }
 
 func (c *Config) Load() {
@@ -50,6 +52,8 @@ func (c *Config) Load() {
 	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine or container.")
 	c.MaximumRuntimePerJob = c.GetInterval("EXECUTOR_MAXIMUM_RUNTIME_PER_JOB", "30m", "The maximum wall time that can be spent on a single job.")
 	c.CleanupTaskInterval = c.GetInterval("EXECUTOR_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic cleanup tasks.")
+	c.NumTotalJobs = c.GetInt("EXECUTOR_NUM_TOTAL_JOBS", "0", "The maximum number of jobs that will be dequeued by the worker.")
+	c.MaxActiveTime = c.GetInterval("EXECUTOR_MAX_ACTIVE_TIME", "0", "The maximum time that can be spent by the worker dequeueing records to be handled.")
 }
 
 func (c *Config) Validate() error {
@@ -86,6 +90,8 @@ func (c *Config) WorkerOptions() workerutil.WorkerOptions {
 		Interval:          c.QueuePollInterval,
 		HeartbeatInterval: 1 * time.Second,
 		Metrics:           makeWorkerMetrics(c.QueueName),
+		NumTotalJobs:      c.NumTotalJobs,
+		MaxActiveTime:     c.MaxActiveTime,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -61,7 +61,7 @@ type Options struct {
 // as a heartbeat routine that will periodically hit the remote API with the work that is
 // currently being performed, which is necessary so the job queue API doesn't hand out jobs
 // it thinks may have been dropped.
-func NewWorker(nameSet *janitor.NameSet, options Options, observationContext *observation.Context) goroutine.BackgroundRoutine {
+func NewWorker(nameSet *janitor.NameSet, options Options, observationContext *observation.Context) goroutine.WaitableBackgroundRoutine {
 	queueStore := apiclient.New(options.ClientOptions, observationContext)
 	store := &storeShim{queueName: options.QueueName, queueStore: queueStore}
 

--- a/internal/goroutine/background.go
+++ b/internal/goroutine/background.go
@@ -33,6 +33,13 @@ type BackgroundRoutine interface {
 	Stop()
 }
 
+// WaitableBackgroundRoutine enhances BackgroundRoutine with a Wait method that
+// blocks until the value's Start method has returned.
+type WaitableBackgroundRoutine interface {
+	BackgroundRoutine
+	Wait()
+}
+
 // MonitorBackgroundRoutines will start the given background routines in their own
 // goroutine. If the given context is canceled or a signal is received, the Stop
 // method of each routine will be called. This method blocks until the Stop methods

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -22,7 +22,10 @@ type Worker struct {
 	store            Store
 	handler          Handler
 	options          WorkerOptions
-	clock            glock.Clock
+	dequeueClock     glock.Clock
+	heartbeatClock   glock.Clock
+	shutdownClock    glock.Clock
+	numDequeues      int             // tracks number of dequeue attempts
 	handlerSemaphore chan struct{}   // tracks available handler slots
 	ctx              context.Context // root context passed to the handler
 	cancel           func()          // cancels the root context
@@ -47,6 +50,18 @@ type WorkerOptions struct {
 	// number of handlers exceeds this value.
 	NumHandlers int
 
+	// NumTotalJobs is the maximum number of jobs that will be dequeued by the worker.
+	// After this number of dequeue attempts has been made, no more dequeues will be
+	// attempted. Currently dequeued jobs will finish, and the Start method of the
+	// worker will unblock. If not set, there is no limit.
+	NumTotalJobs int
+
+	// MaxActiveTime is the maximum time that can be spent by the worker dequeueing
+	// records to be handled. After this duration has elapsed, no more dequeues will
+	// be attempted. Currently dequeued jobs will finish, and the Start method of the
+	// worker will unblock. If not set, there is no limit.
+	MaxActiveTime time.Duration
+
 	// Interval is the frequency to poll the underlying store for new work.
 	Interval time.Duration
 
@@ -60,10 +75,11 @@ type WorkerOptions struct {
 }
 
 func NewWorker(ctx context.Context, store Store, handler Handler, options WorkerOptions) *Worker {
-	return newWorker(ctx, store, handler, options, glock.NewRealClock())
+	clock := glock.NewRealClock()
+	return newWorker(ctx, store, handler, options, clock, clock, clock)
 }
 
-func newWorker(ctx context.Context, store Store, handler Handler, options WorkerOptions, clock glock.Clock) *Worker {
+func newWorker(ctx context.Context, store Store, handler Handler, options WorkerOptions, mainClock, heartbeatClock, shutdownClock glock.Clock) *Worker {
 	if options.Name == "" {
 		panic("no name supplied to github.com/sourcegraph/sourcegraph/internal/workerutil:newWorker")
 	}
@@ -83,7 +99,9 @@ func newWorker(ctx context.Context, store Store, handler Handler, options Worker
 		store:            store,
 		handler:          handler,
 		options:          options,
-		clock:            clock,
+		dequeueClock:     mainClock,
+		heartbeatClock:   heartbeatClock,
+		shutdownClock:    shutdownClock,
 		handlerSemaphore: handlerSemaphore,
 		ctx:              ctx,
 		cancel:           cancel,
@@ -104,7 +122,7 @@ func (w *Worker) Start() {
 			select {
 			case <-w.ctx.Done():
 				return
-			case <-w.clock.After(w.options.HeartbeatInterval):
+			case <-w.heartbeatClock.After(w.options.HeartbeatInterval):
 			}
 
 			ids := w.runningIDSet.Slice()
@@ -126,8 +144,22 @@ func (w *Worker) Start() {
 		}
 	}()
 
+	var shutdownChan <-chan time.Time
+	if w.options.MaxActiveTime > 0 {
+		shutdownChan = w.shutdownClock.After(w.options.MaxActiveTime)
+	} else {
+		shutdownChan = make(chan time.Time)
+	}
+
+	var reason string
+
 loop:
 	for {
+		if w.options.NumTotalJobs != 0 && w.numDequeues >= w.options.NumTotalJobs {
+			reason = "NumTotalJobs dequeued"
+			break loop
+		}
+
 		ok, err := w.dequeueAndHandle()
 		if err != nil {
 			if w.ctx.Err() != nil && errors.Is(err, w.ctx.Err()) {
@@ -144,15 +176,25 @@ loop:
 			// Just attempt to get another handler routine and process the next
 			// unit of work immediately.
 			delay = 0
+
+			// Count the number of successful dequeues, but do not count only
+			// attempts. As we do this on a timed loop, we will end up just
+			// sloppily counting the active time instead of the number of jobs
+			// (with data) that were seen.
+			w.numDequeues++
 		}
 
 		select {
-		case <-w.clock.After(delay):
+		case <-w.dequeueClock.After(delay):
 		case <-w.ctx.Done():
+			break loop
+		case <-shutdownChan:
+			reason = "MaxActiveTime elapsed"
 			break loop
 		}
 	}
 
+	log15.Info("Shutting down dequeue loop", "name", w.options.Name, "reason", reason)
 	w.wg.Wait()
 }
 
@@ -161,6 +203,11 @@ loop:
 // unit of work to fail). This method blocks until all handler goroutines have exited.
 func (w *Worker) Stop() {
 	w.cancel()
+	w.Wait()
+}
+
+// Wait blocks until all handler goroutines have exited.
+func (w *Worker) Wait() {
 	<-w.finished
 }
 


### PR DESCRIPTION
This PR adds optional configuration `NumTotalJobs` and `MaxActiveTime` that will cease job dequeues after the number of jobs have been processed or the given time has elapsed since the start of the worker, respectively.

This will enable us to have executors and dedicated job consumers which we only need to worry about scaling _up_ when there are unprocessed jobs. Configuring a service to shut down automatically after (say) 4 hours of activity is a good way to boost capacity during a surge and naturally remove the instances that are no longer contributing to keeping load down. No app-level graceful-shutdown signal processing logic to worry about!