### PR TITLE
executor: Don't install ignited

### DIFF
--- a/enterprise/cmd/executor/cloudbuild/build.sh
+++ b/enterprise/cmd/executor/cloudbuild/build.sh
@@ -61,11 +61,6 @@ function install_ignite() {
   chmod +x ignite
   mv ignite /usr/local/bin
 
-  # Install ignited
-  curl -sfLo ignited https://github.com/weaveworks/ignite/releases/download/${IGNITE_VERSION}/ignited-amd64
-  chmod +x ignited
-  mv ignited /usr/local/bin
-
   # Install container network interface
   mkdir -p /opt/cni/bin
   curl -sSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz | tar -xz -C /opt/cni/bin


### PR DESCRIPTION
I _believe_ we don't need this. Let's build an image and try in dogfood.
