### PR TITLE
executors: Preload kernel and sandbox image

### DIFF
--- a/enterprise/cmd/executor/cloudbuild/build.sh
+++ b/enterprise/cmd/executor/cloudbuild/build.sh
@@ -3,6 +3,7 @@ set -ex -o nounset -o pipefail
 
 export IGNITE_VERSION=v0.10.0
 export CNI_VERSION=v0.9.1
+export KERNEL_IMAGE="weaveworks/ignite-kernel:5.10.51"
 export EXECUTOR_FIRECRACKER_IMAGE="sourcegraph/ignite-ubuntu:insiders"
 
 ## Install ops agent
@@ -75,12 +76,20 @@ EOF
   echo 'THIS_ENV_IS="unconfigured"' >>/etc/systemd/system/executor.env
 }
 
-## Build the ignite-ubuntu image for use in firecracker.
-## Set SRC_CLI_VERSION to the minimum required version in internal/src-cli/consts.go
+# Build the ignite-ubuntu image for use in firecracker.
+# Set SRC_CLI_VERSION to the minimum required version in internal/src-cli/consts.go
 function generate_ignite_base_image() {
   docker build -t "${EXECUTOR_FIRECRACKER_IMAGE}" --build-arg SRC_CLI_VERSION="${SRC_CLI_VERSION}" /tmp/ignite-ubuntu
   ignite image import --runtime docker "${EXECUTOR_FIRECRACKER_IMAGE}"
   docker image rm "${EXECUTOR_FIRECRACKER_IMAGE}"
+  # Remove intermediate layers and base image used in ignite-ubuntu.
+  docker system prune --force
+}
+
+# Loads the required kernel image so it doesn't have to happen on the first VM start.
+function preheat_kernel_image() {
+  ignite kernel import --runtime docker "${KERNEL_IMAGE}"
+  docker pull "weaveworks/ignite:${IGNITE_VERSION}"
 }
 
 function cleanup() {
@@ -102,4 +111,5 @@ install_executor
 
 # Service prep and cleanup
 generate_ignite_base_image
+preheat_kernel_image
 cleanup

--- a/enterprise/cmd/executor/cloudbuild/build.sh
+++ b/enterprise/cmd/executor/cloudbuild/build.sh
@@ -76,8 +76,8 @@ EOF
   echo 'THIS_ENV_IS="unconfigured"' >>/etc/systemd/system/executor.env
 }
 
-# Build the ignite-ubuntu image for use in firecracker.
-# Set SRC_CLI_VERSION to the minimum required version in internal/src-cli/consts.go
+## Build the ignite-ubuntu image for use in firecracker.
+## Set SRC_CLI_VERSION to the minimum required version in internal/src-cli/consts.go
 function generate_ignite_base_image() {
   docker build -t "${EXECUTOR_FIRECRACKER_IMAGE}" --build-arg SRC_CLI_VERSION="${SRC_CLI_VERSION}" /tmp/ignite-ubuntu
   ignite image import --runtime docker "${EXECUTOR_FIRECRACKER_IMAGE}"
@@ -86,7 +86,7 @@ function generate_ignite_base_image() {
   docker system prune --force
 }
 
-# Loads the required kernel image so it doesn't have to happen on the first VM start.
+## Loads the required kernel image so it doesn't have to happen on the first VM start.
 function preheat_kernel_image() {
   ignite kernel import --runtime docker "${KERNEL_IMAGE}"
   docker pull "weaveworks/ignite:${IGNITE_VERSION}"


### PR DESCRIPTION
Should reduce jitter and initial startup time. Especially important when we start to do more aggressive auto scaling.