### PR TITLE
run racy test non-parallel

### DIFF
--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -141,7 +141,6 @@ func TestUsers_BuiltinAuthPasswordResetRateLimit(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	t.Parallel()
 	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 


### PR DESCRIPTION
Since this test modifies global state (passwordResetRateLimit), it can't
be run in parallel with other tests that read that value. This commit
just removes `t.Parallel()` from the test.

Fixes flake seen [here](https://buildkite.com/sourcegraph/sourcegraph/builds/104339#a8d00253-0860-42cd-9518-c11b269ba197)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
