### PR TITLE
endpoint: include not ready k8s endpoints

### DIFF
--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -92,7 +92,7 @@ func zoektAddr(environ []string) string {
 
 	// Not set, use the default (service discovery on the indexed-search
 	// statefulset)
-	return "k8s+rpc://indexed-search:6070"
+	return "k8s+rpc://indexed-search:6070?include_not_ready=true"
 }
 
 func getEnv(environ []string, key string) (string, bool) {

--- a/internal/search/env_test.go
+++ b/internal/search/env_test.go
@@ -13,7 +13,7 @@ func TestZoektAddr(t *testing.T) {
 		want    string
 	}{{
 		name: "default",
-		want: "k8s+rpc://indexed-search:6070",
+		want: "k8s+rpc://indexed-search:6070?include_not_ready=true",
 	}, {
 		name:    "old",
 		environ: []string{"ZOEKT_HOST=127.0.0.1:3070"},


### PR DESCRIPTION
This commit adds support for including not ready kubernetes endpoints discovered via the k8s api, which we need to avoid temporary reshuffling of repo assignments to indexed search replicas while deployments (or any other unavailability causing event) happen.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
