### PR TITLE
database: Log errors writing security logs to sentry

### DIFF
--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"runtime"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -13,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
@@ -102,11 +102,9 @@ func (s *SecurityEventLogStore) LogEvent(ctx context.Context, e *SecurityEvent) 
 
 	if err := s.Insert(ctx, e); err != nil {
 		j, _ := json.Marshal(e)
-
-		// Temporary: Log the stack so we can track this down
-		buf := make([]byte, 2048)
-		runtime.Stack(buf, false)
-
-		log15.Error(string(e.Name), "event", string(j), "traceID", trace.ID(ctx), "stack", string(buf), "err", err)
+		log15.Error(string(e.Name), "event", string(j), "traceID", trace.ID(ctx), "err", err)
+		// We want to capture in sentry as it includes a stack trace which will allow us
+		// to track down the root cause.
+		sentry.CaptureError(err, map[string]string{})
 	}
 }


### PR DESCRIPTION
Instead of manually including a stack trace in our normal logs.
