### PR TITLE
web: fix global navbar text-wrap

### DIFF
--- a/client/wildcard/src/components/NavBar/NavItem.module.scss
+++ b/client/wildcard/src/components/NavBar/NavItem.module.scss
@@ -3,7 +3,7 @@
 .item {
     display: flex;
     align-items: stretch;
-    margin: 0 0.75rem;
+    margin: 0 0.5rem;
     &:first-child {
         margin-left: 0;
     }


### PR DESCRIPTION
## Context

When all items in the global navbar are displayed, there's not enough space for them to render without text-wrap, which looks bad. This PR shrinks the horizontal margin between nav links by 4 pixels to fix the issue. 

@sourcegraph/design, let me know if you see a better quick fix here.

## Screenshots

### Before

<img width="1088" alt="Screenshot 2021-08-11 at 15 56 46" src="https://user-images.githubusercontent.com/3846380/129032501-da2af221-1851-46a6-b534-e06ca9c8097b.png">

### After

<img width="1089" alt="Screenshot 2021-08-11 at 15 55 29" src="https://user-images.githubusercontent.com/3846380/129032322-48d78d84-3b90-4f69-97c8-009c5858e00d.png">

Closes https://github.com/sourcegraph/sourcegraph/issues/23781.