### PR TITLE
eventLogger: copy public arguments into public arguments field

### DIFF
--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -22,7 +22,7 @@ import { MatchGroup, calculateMatchGroups } from './FileMatchContext'
 import { Link } from './Link'
 
 export interface EventLogger {
-    log: (eventLabel: string, eventProperties?: any) => void
+    log: (eventLabel: string, eventProperties?: any, publicEventProperties?: any) => void
 }
 
 interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
@@ -108,7 +108,11 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                         onFirstResultLoad()
                     }
                     if (eventLogger) {
-                        eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime })
+                        eventLogger.log(
+                            'search.latencies.frontend.code-load',
+                            { durationMs: Date.now() - startTime },
+                            { durationMs: Date.now() - startTime }
+                        )
                     }
                     return optimizeHighlighting
                         ? lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]

--- a/client/web/src/insights/components/insight-view-content/InsightViewContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/InsightViewContent.tsx
@@ -43,7 +43,11 @@ export const InsightViewContent: React.FunctionComponent<InsightViewContentProps
             // view, as opposed to accidentally moving past it. If the mouse leaves
             // the view quickly, clear the timeout for logging the event
             timeoutID = window.setTimeout(() => {
-                props.telemetryService.log('InsightHover', { insightType: viewID.split('.')[0] })
+                props.telemetryService.log(
+                    'InsightHover',
+                    { insightType: viewID.split('.')[0] },
+                    { insightType: viewID.split('.')[0] }
+                )
             }, 500)
 
             viewContentElement?.addEventListener('mouseleave', onMouseLeave)

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/ChartViewContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/ChartViewContent.tsx
@@ -29,7 +29,11 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
     const { content, className = '', viewID, telemetryService } = props
 
     const handleDatumLinkClick = useCallback((): void => {
-        telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
+        telemetryService.log(
+            'InsightDataPointClick',
+            { insightType: getInsightTypeByViewId(viewID) },
+            { insightType: getInsightTypeByViewId(viewID) }
+        )
     }, [viewID, telemetryService])
 
     // Click link-zone handler for line chart only. Catch click around point and redirect user by
@@ -41,7 +45,11 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
                 return
             }
 
-            telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
+            telemetryService.log(
+                'InsightDataPointClick',
+                { insightType: getInsightTypeByViewId(viewID) },
+                { insightType: getInsightTypeByViewId(viewID) }
+            )
 
             window.open(event.link, '_blank', 'noopener')?.focus()
         },

--- a/client/web/src/insights/components/insights-view-grid/components/view-grid/ViewGrid.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/view-grid/ViewGrid.tsx
@@ -68,7 +68,11 @@ export const ViewGrid: React.FunctionComponent<PropsWithChildren<ViewGridProps>>
     const onResizeOrDragStart: ReactGridLayout.ItemCallback = useCallback(
         (_layout, item) => {
             try {
-                telemetryService.log('InsightUICustomization', { insightType: item.i.split('.')[0] })
+                telemetryService.log(
+                    'InsightUICustomization',
+                    { insightType: item.i.split('.')[0] },
+                    { insightType: item.i.split('.')[0] }
+                )
             } catch {
                 // noop
             }

--- a/client/web/src/insights/core/analytics.ts
+++ b/client/web/src/insights/core/analytics.ts
@@ -39,7 +39,7 @@ export function logCodeInsightsCount(
             const newGroupedInsights = getInsightsGroupedByType(newSettings, authUser)
 
             if (!isEqual(oldGroupedInsights, newGroupedInsights)) {
-                telemetryService.log('InsightsGroupedCount', newGroupedInsights)
+                telemetryService.log('InsightsGroupedCount', newGroupedInsights, newGroupedInsights)
             }
         }
     } catch {
@@ -61,7 +61,7 @@ export function logSearchBasedInsightStepSize(
             const newGroupedStepSizes = getGroupedStepSizes(newSettings.final)
 
             if (!isEqual(oldGroupedStepSizes, newGroupedStepSizes)) {
-                telemetryService.log('InsightsGroupedStepSizes', newGroupedStepSizes)
+                telemetryService.log('InsightsGroupedStepSizes', newGroupedStepSizes, newGroupedStepSizes)
             }
         }
     } catch {
@@ -164,7 +164,7 @@ export function logCodeInsightsChanges(
 
         if (oldSettings && newSettings) {
             for (const { action, insightType } of diffCodeInsightsSettings(oldSettings, newSettings)) {
-                telemetryService.log(`Insight${action}`, { insightType })
+                telemetryService.log(`Insight${action}`, { insightType }, { insightType })
             }
         }
     } catch {

--- a/client/web/src/marketing/SurveyToast.tsx
+++ b/client/web/src/marketing/SurveyToast.tsx
@@ -34,7 +34,7 @@ export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
     }
 
     const handleChange = (score: number): void => {
-        eventLogger.log('SurveyButtonClicked', { score })
+        eventLogger.log('SurveyButtonClicked', { score }, { score })
         history.push(`/survey/${score}`)
 
         if (props.onChange) {

--- a/client/web/src/repogroups/RepogroupPage.tsx
+++ b/client/web/src/repogroups/RepogroupPage.tsx
@@ -198,7 +198,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
 }
 
 const RepoLinkClicked = (repoName: string) => (): void =>
-    eventLogger.log('RepogroupPageRepoLinkClicked', { repo_name: repoName })
+    eventLogger.log('RepogroupPageRepoLinkClicked', { repo_name: repoName }, { repo_name: repoName })
 
 const RepoLink: React.FunctionComponent<{ repo: string }> = ({ repo }) => (
     <li className="repogroup-page__repo-item list-unstyled mb-3" key={repo}>

--- a/client/web/src/search/input/SearchOnboardingTour.ts
+++ b/client/web/src/search/input/SearchOnboardingTour.ts
@@ -51,7 +51,7 @@ function generateStep(options: { tour: Shepherd.Tour; stepNumber: number; conten
     element.append(close)
     element.querySelector('.tour-card__close')?.addEventListener('click', () => {
         options.tour.cancel()
-        eventLogger.log('CloseOnboardingTourClicked', { stage: options.stepNumber })
+        eventLogger.log('CloseOnboardingTourClicked', { stage: options.stepNumber }, { stage: options.stepNumber })
     })
 
     return element

--- a/client/web/src/search/notebook/SearchNotebook.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.tsx
@@ -59,7 +59,11 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
             notebook.runBlockById(id)
             updateBlocks()
 
-            props.telemetryService.log('SearchNotebookRunBlock', { type: notebook.getBlockById(id)?.type })
+            props.telemetryService.log(
+                'SearchNotebookRunBlock',
+                { type: notebook.getBlockById(id)?.type },
+                { type: notebook.getBlockById(id)?.type }
+            )
         },
         [notebook, props.telemetryService, updateBlocks]
     )
@@ -85,7 +89,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
             setSelectedBlockId(addedBlock.id)
             updateBlocks()
 
-            props.telemetryService.log('SearchNotebookAddBlock', { type: addedBlock.type })
+            props.telemetryService.log('SearchNotebookAddBlock', { type: addedBlock.type }, { type: addedBlock.type })
         },
         [notebook, isReadOnly, props.telemetryService, updateBlocks, setSelectedBlockId]
     )
@@ -102,7 +106,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
             setSelectedBlockId(blockToFocusAfterDelete)
             updateBlocks()
 
-            props.telemetryService.log('SearchNotebookDeleteBlock', { type: block?.type })
+            props.telemetryService.log('SearchNotebookDeleteBlock', { type: block?.type }, { type: block?.type })
         },
         [notebook, isReadOnly, props.telemetryService, setSelectedBlockId, updateBlocks]
     )
@@ -116,7 +120,11 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
             notebook.moveBlockById(id, direction)
             updateBlocks()
 
-            props.telemetryService.log('SearchNotebookMoveBlock', { type: notebook.getBlockById(id)?.type, direction })
+            props.telemetryService.log(
+                'SearchNotebookMoveBlock',
+                { type: notebook.getBlockById(id)?.type, direction },
+                { type: notebook.getBlockById(id)?.type, direction }
+            )
         },
         [notebook, isReadOnly, props.telemetryService, updateBlocks]
     )
@@ -136,7 +144,11 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
             }
             updateBlocks()
 
-            props.telemetryService.log('SearchNotebookDuplicateBlock', { type: duplicateBlock?.type })
+            props.telemetryService.log(
+                'SearchNotebookDuplicateBlock',
+                { type: duplicateBlock?.type },
+                { type: duplicateBlock?.type }
+            )
         },
         [notebook, isReadOnly, props.telemetryService, setSelectedBlockId, updateBlocks]
     )

--- a/client/web/src/search/panels/RecentFilesPanel.tsx
+++ b/client/web/src/search/panels/RecentFilesPanel.tsx
@@ -50,7 +50,11 @@ export const RecentFilesPanel: React.FunctionComponent<Props> = ({
     useEffect(() => {
         // Only log the first load (when items to load is equal to the page size)
         if (processedResults && itemsToLoad === pageSize) {
-            telemetryService.log('RecentFilesPanelLoaded', { empty: processedResults.length === 0 })
+            telemetryService.log(
+                'RecentFilesPanelLoaded',
+                { empty: processedResults.length === 0 },
+                { empty: processedResults.length === 0 }
+            )
         }
     }, [processedResults, telemetryService, itemsToLoad])
 

--- a/client/web/src/search/panels/RecentSearchesPanel.tsx
+++ b/client/web/src/search/panels/RecentSearchesPanel.tsx
@@ -63,7 +63,11 @@ export const RecentSearchesPanel: React.FunctionComponent<Props> = ({
     useEffect(() => {
         // Only log the first load (when items to load is equal to the page size)
         if (processedResults && itemsToLoad === pageSize) {
-            telemetryService.log('RecentSearchesPanelLoaded', { empty: processedResults.length === 0 })
+            telemetryService.log(
+                'RecentSearchesPanelLoaded',
+                { empty: processedResults.length === 0 },
+                { empty: processedResults.length === 0 }
+            )
         }
     }, [processedResults, telemetryService, itemsToLoad])
 

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -78,7 +78,11 @@ export const RepositoriesPanel: React.FunctionComponent<Props> = ({
     useEffect(() => {
         // Only log the first load (when items to load is equal to the page size)
         if (repoFilterValues && itemsToLoad === pageSize) {
-            telemetryService.log('RepositoriesPanelLoaded', { empty: repoFilterValues.length === 0 })
+            telemetryService.log(
+                'RepositoriesPanelLoaded',
+                { empty: repoFilterValues.length === 0 },
+                { empty: repoFilterValues.length === 0 }
+            )
         }
     }, [repoFilterValues, telemetryService, itemsToLoad])
 

--- a/client/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.tsx
@@ -35,7 +35,11 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
     useEffect(() => {
         // Only log the first load (when items to load is equal to the page size)
         if (savedSearches) {
-            telemetryService.log('SavedSearchesPanelLoaded', { empty: savedSearches.length === 0, showAllSearches })
+            telemetryService.log(
+                'SavedSearchesPanelLoaded',
+                { empty: savedSearches.length === 0, showAllSearches },
+                { empty: savedSearches.length === 0, showAllSearches }
+            )
         }
     }, [savedSearches, telemetryService, showAllSearches])
 

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -122,6 +122,13 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         })
     }, [fetchExternalServices])
 
+    const logAddRepositoriesClicked = useCallback(
+        (source: string) => () => {
+            eventLogger.log('AddRepositoriesLinkClicked', null, { source })
+        },
+        []
+    )
+
     const getGitHubUpdateAuthBanner = (needsUpdate: boolean): JSX.Element | null =>
         needsUpdate ? (
             <div className="alert alert-info mb-4" role="alert" key="update-github">
@@ -140,7 +147,11 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         services.length > 0 ? (
             <div className="alert alert-success mb-4" role="alert" key="add-repos">
                 Connected with {services.join(', ')}. Next,{' '}
-                <Link className="alert-link" to={`${routingPrefix}/repositories/manage`}>
+                <Link
+                    className="alert-link"
+                    to={`${routingPrefix}/repositories/manage`}
+                    onClick={logAddRepositoriesClicked('banner')}
+                >
                     add your repositories →
                 </Link>
             </div>
@@ -242,8 +253,13 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                 description={
                     <>
                         Connect with your code hosts. Then,{' '}
-                        <Link to={`${routingPrefix}/repositories/manage`}>add repositories</Link> to search with
-                        Sourcegraph.
+                        <Link
+                            to={`${routingPrefix}/repositories/manage`}
+                            onClick={logAddRepositoriesClicked('description')}
+                        >
+                            add repositories
+                        </Link>{' '}
+                        to search with Sourcegraph.
                     </>
                 }
                 className="mb-3"

--- a/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
+++ b/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
@@ -66,7 +66,7 @@ export const UserCodeHosts: React.FunctionComponent<UserCodeHosts> = ({
 
             if (authProvider) {
                 onNavigation?.(true)
-                eventLogger.log('UserAttemptConnectCodeHost', { kind })
+                eventLogger.log('UserAttemptConnectCodeHost', { kind }, { kind })
                 window.location.assign(
                     `${authProvider.authenticationURL as string}&redirect=${
                         window.location.href


### PR DESCRIPTION
Now that we have a `publicArgument` db column and argument, this PR copies any public arguments in existing eventLogger.log callsites into the publicArgument column so that we can send the event arguments to Amplitude.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
