### PR TITLE
insights: default to 12 months of data if no specific time range is provided

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -31,7 +31,7 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 
 	if args.From == nil {
 		// Default to last 12mo of data
-		args.From = &graphqlbackend.DateTime{Time: time.Now().Add(-12 * 30 * 24 * time.Hour)}
+		args.From = &graphqlbackend.DateTime{Time: time.Now().AddDate(-1, 0, 0)}
 	}
 	if args.From != nil {
 		opts.From = &args.From.Time

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -30,8 +30,8 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 	opts.SeriesID = &seriesID
 
 	if args.From == nil {
-		// Default to last 6mo of data.
-		args.From = &graphqlbackend.DateTime{Time: time.Now().Add(-6 * 30 * 24 * time.Hour)}
+		// Default to last 12mo of data
+		args.From = &graphqlbackend.DateTime{Time: time.Now().Add(-12 * 30 * 24 * time.Hour)}
 	}
 	if args.From != nil {
 		opts.From = &args.From.Time


### PR DESCRIPTION
Closes #23766
Defaults the insights query to 12 months if the GraphQL query has no time range args.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
