### PR TITLE
codeintel: Add button to infer index configuration

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.story.tsx
@@ -14,7 +14,27 @@ const { add } = storiesOf('web/codeintel/configuration/CodeIntelIndexConfigurati
         },
     })
 
-add('Page', () => (
+add('Empty', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CodeIntelIndexConfigurationPage
+                {...props}
+                repo={{ id: '42' }}
+                getConfiguration={() =>
+                    of({
+                        __typename: 'Repository',
+                        indexConfiguration: {
+                            configuration: '',
+                            inferredConfiguration: '',
+                        },
+                    })
+                }
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
+add('SavedConfiguration', () => (
     <EnterpriseWebStory>
         {props => (
             <CodeIntelIndexConfigurationPage
@@ -25,6 +45,27 @@ add('Page', () => (
                         __typename: 'Repository',
                         indexConfiguration: {
                             configuration: '{"foo": "bar"}',
+                            inferredConfiguration: '',
+                        },
+                    })
+                }
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
+add('InferredConfiguration', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CodeIntelIndexConfigurationPage
+                {...props}
+                repo={{ id: '42' }}
+                getConfiguration={() =>
+                    of({
+                        __typename: 'Repository',
+                        indexConfiguration: {
+                            configuration: '{"foo": "bar"}',
+                            inferredConfiguration: '{"baz": "bonk"}',
                         },
                     })
                 }

--- a/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.tsx
@@ -1,18 +1,19 @@
 import * as H from 'history'
-import React, { FunctionComponent, useCallback, useEffect, useState } from 'react'
+import { editor } from 'monaco-editor'
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 import { RouteComponentProps } from 'react-router'
 
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../../components/alerts'
-import { CodeIntelAutoIndexSaveToolbar, AutoIndexProps } from '../../../components/CodeIntelAutoIndexSaveToolbar'
 import { PageTitle } from '../../../components/PageTitle'
-import { SaveToolbarPropsGenerator, SaveToolbarProps } from '../../../components/SaveToolbar'
+import { SaveToolbar, SaveToolbarProps, SaveToolbarPropsGenerator } from '../../../components/SaveToolbar'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../../settings/DynamicallyImportedMonacoSettingsEditor'
 
-import { getConfiguration as defaultGetConfiguration, updateConfiguration, enqueueIndexJob } from './backend'
+import { getConfiguration as defaultGetConfiguration, updateConfiguration } from './backend'
 import allConfigSchema from './schema.json'
 
 export interface CodeIntelIndexConfigurationPageProps extends RouteComponentProps<{}>, ThemeProps, TelemetryProps {
@@ -21,10 +22,9 @@ export interface CodeIntelIndexConfigurationPageProps extends RouteComponentProp
     getConfiguration?: typeof defaultGetConfiguration
 }
 
-enum CodeIntelIndexEditorState {
+enum State {
     Idle,
     Saving,
-    Queueing,
 }
 
 export const CodeIntelIndexConfigurationPage: FunctionComponent<CodeIntelIndexConfigurationPageProps> = ({
@@ -36,116 +36,139 @@ export const CodeIntelIndexConfigurationPage: FunctionComponent<CodeIntelIndexCo
 }) => {
     useEffect(() => telemetryService.logViewEvent('CodeIntelIndexConfigurationPage'), [telemetryService])
 
-    const [fetchError, setFetchError] = useState<Error>()
-    const [saveError, setSaveError] = useState<Error>()
-    const [state, setState] = useState(() => CodeIntelIndexEditorState.Idle)
     const [configuration, setConfiguration] = useState<string>()
-    const [dirty, setDirty] = useState<boolean>()
+    const [inferredConfiguration, setInferredConfiguration] = useState<string>()
+    const [fetchError, setFetchError] = useState<Error>()
 
     useEffect(() => {
-        const subscription = getConfiguration({ id: repo.id }).subscribe(configuration => {
-            setConfiguration(configuration?.indexConfiguration?.configuration || '')
+        const subscription = getConfiguration({ id: repo.id }).subscribe(config => {
+            setConfiguration(config?.indexConfiguration?.configuration || '')
+            setInferredConfiguration(config?.indexConfiguration?.inferredConfiguration || '')
         }, setFetchError)
 
         return () => subscription.unsubscribe()
     }, [repo, getConfiguration])
 
+    const [saveError, setSaveError] = useState<Error>()
+    const [state, setState] = useState(() => State.Idle)
+
     const save = useCallback(
         async (content: string) => {
-            setState(CodeIntelIndexEditorState.Saving)
+            setState(State.Saving)
             setSaveError(undefined)
 
             try {
                 await updateConfiguration({ id: repo.id, content }).toPromise()
+                setDirty(false)
                 setConfiguration(content)
             } catch (error) {
                 setSaveError(error)
             } finally {
-                setState(CodeIntelIndexEditorState.Idle)
+                setState(State.Idle)
             }
         },
         [repo]
     )
-    const enqueue = useCallback(async () => {
-        setState(CodeIntelIndexEditorState.Queueing)
-        setSaveError(undefined)
 
-        try {
-            await enqueueIndexJob(repo.id, 'HEAD').toPromise()
-        } catch (error) {
-            setSaveError(error)
-        } finally {
-            setState(CodeIntelIndexEditorState.Idle)
-        }
-    }, [repo])
+    const [dirty, setDirty] = useState<boolean>()
+    const [editor, setEditor] = useState<editor.ICodeEditor>()
+    const infer = useCallback(() => editor?.setValue(inferredConfiguration || ''), [editor, inferredConfiguration])
 
-    const onDirtyChange = useCallback((dirty: boolean) => {
-        setDirty(dirty)
-    }, [])
-
-    const saving = state === CodeIntelIndexEditorState.Saving
-    const queueing = state === CodeIntelIndexEditorState.Queueing
-
-    const customToolbar: {
-        propsGenerator: SaveToolbarPropsGenerator<AutoIndexProps>
+    const customToolbar = useMemo<{
         saveToolbar: React.FunctionComponent<SaveToolbarProps & AutoIndexProps>
-    } = {
-        propsGenerator: (props: Readonly<SaveToolbarProps> & Readonly<{}>): SaveToolbarProps & AutoIndexProps => {
-            const autoIndexProps: AutoIndexProps = {
-                onQueueJob: enqueue,
-                enqueueing: queueing,
-            }
+        propsGenerator: SaveToolbarPropsGenerator<AutoIndexProps>
+    }>(
+        () => ({
+            saveToolbar: CodeIntelAutoIndexSaveToolbar,
+            propsGenerator: props => {
+                const mergedProps = {
+                    ...props,
+                    onInfer: infer,
+                    inferEnabled: !!inferredConfiguration && configuration !== inferredConfiguration,
+                }
+                mergedProps.willShowError = () => !mergedProps.saving
+                mergedProps.saveDiscardDisabled = () => mergedProps.saving || !dirty
 
-            const mergedProps = { ...props, ...autoIndexProps }
-            mergedProps.willShowError = (): boolean => !queueing && !mergedProps.saving
-            mergedProps.saveDiscardDisabled = (): boolean => saving || !dirty || queueing
-            return mergedProps
-        },
-        saveToolbar: CodeIntelAutoIndexSaveToolbar,
-    }
+                return mergedProps
+            },
+        }),
+        [dirty, configuration, inferredConfiguration, infer]
+    )
 
     return fetchError ? (
         <ErrorAlert prefix="Error fetching index configuration" error={fetchError} />
     ) : (
         <div className="code-intel-index-configuration">
-            <PageTitle title="Code intelligence index configuration" />
+            <PageTitle title="Auto-indexing configuration" />
 
             <PageHeader
                 headingElement="h2"
                 path={[
                     {
-                        text: <>Code intelligence index configuration</>,
+                        text: <>Auto-indexing configuration</>,
                     },
                 ]}
-                description={
-                    <>
-                        Override the inferred configuration when automatically indexing repositories on{' '}
-                        <a href="https://sourcegraph.com" target="_blank" rel="noreferrer noopener">
-                            Sourcegraph.com
-                        </a>
-                        .
-                    </>
-                }
                 className="mb-3"
             />
 
             <Container>
                 {saveError && <ErrorAlert prefix="Error saving index configuration" error={saveError} />}
 
-                <DynamicallyImportedMonacoSettingsEditor
-                    value={configuration || ''}
-                    jsonSchema={allConfigSchema}
-                    canEdit={true}
-                    onSave={save}
-                    saving={saving}
-                    height={600}
-                    isLightTheme={isLightTheme}
-                    history={history}
-                    telemetryService={telemetryService}
-                    customSaveToolbar={customToolbar}
-                    onDirtyChange={onDirtyChange}
-                />
+                {configuration === undefined ? (
+                    <LoadingSpinner className="icon-inline" />
+                ) : (
+                    <DynamicallyImportedMonacoSettingsEditor
+                        value={configuration}
+                        jsonSchema={allConfigSchema}
+                        canEdit={true}
+                        onSave={save}
+                        saving={state === State.Saving}
+                        height={600}
+                        isLightTheme={isLightTheme}
+                        history={history}
+                        telemetryService={telemetryService}
+                        customSaveToolbar={customToolbar}
+                        onDirtyChange={setDirty}
+                        onEditor={setEditor}
+                    />
+                )}
             </Container>
         </div>
     )
 }
+
+interface AutoIndexProps {
+    inferEnabled: boolean
+    onInfer?: () => void
+}
+
+const CodeIntelAutoIndexSaveToolbar: React.FunctionComponent<SaveToolbarProps & AutoIndexProps> = ({
+    dirty,
+    saving,
+    error,
+    onSave,
+    onDiscard,
+    inferEnabled,
+    onInfer,
+    saveDiscardDisabled,
+}) => (
+    <SaveToolbar
+        dirty={dirty}
+        saving={saving}
+        onSave={onSave}
+        error={error}
+        saveDiscardDisabled={saveDiscardDisabled}
+        onDiscard={onDiscard}
+    >
+        {inferEnabled && (
+            <button
+                type="button"
+                title="Infer index configuration from HEAD"
+                className="btn btn-link"
+                onClick={onInfer}
+            >
+                Infer index configuration from HEAD
+            </button>
+        )}
+    </SaveToolbar>
+)

--- a/client/web/src/enterprise/codeintel/configuration/backend.ts
+++ b/client/web/src/enterprise/codeintel/configuration/backend.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs'
-import { map, mapTo } from 'rxjs/operators'
+import { map } from 'rxjs/operators'
 
 import {
     createInvalidGraphQLMutationResponseError,
@@ -14,8 +14,6 @@ import {
     RepositoryIndexConfigurationFields,
     UpdateRepositoryIndexConfigurationResult,
     UpdateRepositoryIndexConfigurationVariables,
-    QueueAutoIndexJobForRepoResult,
-    QueueAutoIndexJobForRepoVariables,
 } from '../../../graphql-operations'
 
 export function getConfiguration({ id }: { id: string }): Observable<RepositoryIndexConfigurationFields | null> {
@@ -30,6 +28,7 @@ export function getConfiguration({ id }: { id: string }): Observable<RepositoryI
             __typename
             indexConfiguration {
                 configuration
+                inferredConfiguration
             }
         }
     `
@@ -68,19 +67,4 @@ export function updateConfiguration({ id, content }: { id: string; content: stri
             }
         })
     )
-}
-
-export function enqueueIndexJob(id: string, revision: string): Observable<void> {
-    const query = gql`
-        mutation QueueAutoIndexJobForRepo($id: ID!, $rev: String) {
-            queueAutoIndexJobForRepo(repository: $id, rev: $rev) {
-                alwaysNil
-            }
-        }
-    `
-
-    return requestGraphQL<QueueAutoIndexJobForRepoResult, QueueAutoIndexJobForRepoVariables>(query, {
-        id,
-        rev: revision,
-    }).pipe(map(dataOrThrowErrors), mapTo(undefined))
 }

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -43,6 +43,7 @@ interface Props<T extends object>
     onSave?: (value: string) => void
     onChange?: (value: string) => void
     onDirtyChange?: (dirty: boolean) => void
+    onEditor?: (editor: _monaco.editor.ICodeEditor) => void
 
     customSaveToolbar?: {
         propsGenerator: SaveToolbarPropsGenerator<T & { children?: React.ReactNode }>
@@ -192,6 +193,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
                 disposableToFn(
                     this.monaco.editor.onDidCreateEditor(editor => {
                         this.configEditor = editor
+                        this.props.onEditor?.(editor)
                     })
                 )
             )


### PR DESCRIPTION
Remove the `Enqueue Job` button in place of an `Infer index configuration from HEAD` link that will replace the current editor contents with the inferred configuration (if it differs from the current saved configuration).

The enqueue button will be reintroduced https://github.com/sourcegraph/sourcegraph/pull/23788.