### PR TITLE
insights: create migrations to clean up insights tables for 3.31 beta

### DIFF
--- a/migrations/codeinsights/1000000010_series_points_reset.down.sql
+++ b/migrations/codeinsights/1000000010_series_points_reset.down.sql
@@ -1,0 +1,11 @@
+
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+COMMIT;

--- a/migrations/codeinsights/1000000010_series_points_reset.up.sql
+++ b/migrations/codeinsights/1000000010_series_points_reset.up.sql
@@ -26,4 +26,6 @@ TRUNCATE series_points CASCADE;
 TRUNCATE commit_index;
 TRUNCATE commit_index_metadata;
 
+-- Update all of the underlying insights that may have been synced to reset metadata and rebuild their data.
+update insight_series set created_at = current_timestamp, backfill_queued_at = null, next_recording_after = date_trunc('month', current_date) + interval '1 month';
 COMMIT;

--- a/migrations/codeinsights/1000000010_series_points_reset.up.sql
+++ b/migrations/codeinsights/1000000010_series_points_reset.up.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+-- Prior to 3.31 this table stored points in two formats. Historical points were stored in a compressed
+-- format where samples were only recorded if the underlying repository changed. After 3.31 we are changing
+-- the semantic to require full vectors for each data point. To avoid any incompatibilities and to prepare for beta
+-- we are going to reset the stored data and all of the underlying Timescale chunks back to zero.
+-- Note: This data is by design reproducible, so there is no risk of permanent data loss here. Any and all data
+-- will be queued and regenerated as soon as code insights starts up.
+
+-- Drop all Timescale chunks prior to now. This will reduce a bloated number of partitions caused by old
+-- data generation patterns. This is a Timescale specific thing.
+SELECT drop_chunks('series_points', CURRENT_TIMESTAMP::DATE);
+
+-- Clean up the remaining records if any exist.
+TRUNCATE series_points;
+
+-- There is the possibility that the commit index has fallen out of sync with the primary postgres database in 3.30 due
+-- to a data corruption issue. We will regenerate it to be sure it is healthy for beta.
+TRUNCATE commit_index;
+TRUNCATE commit_index_metadata;
+
+-- I feel like Thanos
+TRUNCATE repo_names;
+COMMIT;

--- a/migrations/codeinsights/1000000010_series_points_reset.up.sql
+++ b/migrations/codeinsights/1000000010_series_points_reset.up.sql
@@ -19,13 +19,11 @@ BEGIN;
 SELECT drop_chunks('series_points', CURRENT_TIMESTAMP::DATE);
 
 -- Clean up the remaining records if any exist.
-TRUNCATE series_points;
+TRUNCATE series_points CASCADE;
 
 -- There is the possibility that the commit index has fallen out of sync with the primary postgres database in 3.30 due
 -- to a data corruption issue. We will regenerate it to be sure it is healthy for beta.
 TRUNCATE commit_index;
 TRUNCATE commit_index_metadata;
 
--- I feel like Thanos
-TRUNCATE repo_names;
 COMMIT;

--- a/migrations/frontend/1528395866_insights_queue_reset.down.sql
+++ b/migrations/frontend/1528395866_insights_queue_reset.down.sql
@@ -1,0 +1,11 @@
+
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+COMMIT;

--- a/migrations/frontend/1528395866_insights_queue_reset.up.sql
+++ b/migrations/frontend/1528395866_insights_queue_reset.up.sql
@@ -14,6 +14,6 @@ BEGIN;
 -- but customer instances are going to be full of millions of records that will need processing before we can start
 -- fresh. To avoid this problem, we are going to ship a 'reset' in 3.31 that will clear this queue entirely.
 -- Note: This data is by design ephemeral, so there is no risk of permanent data loss here.
-TRUNCATE insights_query_runner_jobs;
 
+TRUNCATE insights_query_runner_jobs CASCADE;
 COMMIT;

--- a/migrations/frontend/1528395866_insights_queue_reset.up.sql
+++ b/migrations/frontend/1528395866_insights_queue_reset.up.sql
@@ -1,0 +1,19 @@
+
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+-- This table is a queue of records that need processing for code insights. Historically this queue grows
+-- unbounded because the historical backfiller operated without state - every time it executed it would
+-- requeue all of the work again. Since then we have added enough state to the backfiller to remove this problem,
+-- but customer instances are going to be full of millions of records that will need processing before we can start
+-- fresh. To avoid this problem, we are going to ship a 'reset' in 3.31 that will clear this queue entirely.
+-- Note: This data is by design ephemeral, so there is no risk of permanent data loss here.
+TRUNCATE insights_query_runner_jobs;
+
+COMMIT;


### PR DESCRIPTION
Closes #23785

A little context:
Some of the tables that code insights use need to be reset as we go into 3.31 for beta. Some of this is due to the tables having a ton of garbage records blocking the queue, others are due to semantic changes in how we store the points, and others are to avoid any possible corruption caused by the 3.30 p1.

Adding distribution just to take a look and let me know if there is anything wrong with this plan for the 3.31 release. For example, is there any reason to think these migrations might block an upgrade if they were to fail?

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
