### PR TITLE
searcher: send JSON body rather than using URL parameters

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -71,18 +71,13 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	running.Inc()
 	defer running.Dec()
 
-	err := r.ParseForm()
-	if err != nil {
-		http.Error(w, "failed to parse form: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	var p protocol.Request
-	err = decoder.Decode(&p, r.Form)
-	if err != nil {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&p); err != nil {
 		http.Error(w, "failed to decode form: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+
 	if p.Deadline != "" {
 		var deadline time.Time
 		if err := deadline.UnmarshalText([]byte(p.Deadline)); err != nil {
@@ -98,7 +93,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// search file content in that case.
 		p.PatternMatchesContent = true
 	}
-	if err = validateParams(&p); err != nil {
+	if err := validateParams(&p); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -403,44 +402,11 @@ func TestSearch_badrequest(t *testing.T) {
 }
 
 func doSearch(u string, p *protocol.Request) ([]protocol.FileMatch, error) {
-	form := url.Values{
-		"Repo":            []string{string(p.Repo)},
-		"URL":             []string{p.URL},
-		"Commit":          []string{string(p.Commit)},
-		"Pattern":         []string{p.Pattern},
-		"FetchTimeout":    []string{p.FetchTimeout},
-		"IncludePatterns": p.IncludePatterns,
-		"ExcludePattern":  []string{p.ExcludePattern},
-		"CombyRule":       []string{p.CombyRule},
+	reqBody, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
 	}
-	if p.IsRegExp {
-		form.Set("IsRegExp", "true")
-	}
-	if p.IsStructuralPat {
-		form.Set("IsStructuralPat", "true")
-	}
-	if p.IsWordMatch {
-		form.Set("IsWordMatch", "true")
-	}
-	if p.IsCaseSensitive {
-		form.Set("IsCaseSensitive", "true")
-	}
-	if p.PathPatternsAreRegExps {
-		form.Set("PathPatternsAreRegExps", "true")
-	}
-	if p.PathPatternsAreCaseSensitive {
-		form.Set("PathPatternsAreCaseSensitive", "true")
-	}
-	if p.PatternMatchesContent {
-		form.Set("PatternMatchesContent", "true")
-	}
-	if p.PatternMatchesPath {
-		form.Set("PatternMatchesPath", "true")
-	}
-	if p.IsNegated {
-		form.Set("IsNegated", "true")
-	}
-	resp, err := http.PostForm(u, form)
+	resp, err := http.Post(u, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -3,13 +3,12 @@
 package searcher
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -53,58 +52,47 @@ func Search(
 		tr.Finish()
 	}()
 
-	q := url.Values{
-		"Repo":            []string{string(repo)},
-		"Commit":          []string{string(commit)},
-		"Branch":          []string{branch},
-		"Pattern":         []string{p.Pattern},
-		"ExcludePattern":  []string{p.ExcludePattern},
-		"IncludePatterns": p.IncludePatterns,
-		"FetchTimeout":    []string{fetchTimeout.String()},
-		"Languages":       p.Languages,
-		"CombyRule":       []string{p.CombyRule},
-
-		"PathPatternsAreRegExps": []string{"true"},
-		"IndexerEndpoints":       indexerEndpoints,
-		"Select":                 []string{p.Select.Root()},
+	r := protocol.Request{
+		Repo:   repo,
+		Commit: commit,
+		Branch: branch,
+		PatternInfo: protocol.PatternInfo{
+			Pattern:                      p.Pattern,
+			ExcludePattern:               p.ExcludePattern,
+			IncludePatterns:              p.IncludePatterns,
+			Languages:                    p.Languages,
+			CombyRule:                    p.CombyRule,
+			PathPatternsAreRegExps:       true,
+			Select:                       p.Select.Root(),
+			Limit:                        int(p.FileMatchLimit),
+			IsRegExp:                     p.IsRegExp,
+			IsStructuralPat:              p.IsStructuralPat,
+			IsWordMatch:                  p.IsWordMatch,
+			IsCaseSensitive:              p.IsCaseSensitive,
+			PathPatternsAreCaseSensitive: p.PathPatternsAreCaseSensitive,
+			IsNegated:                    p.IsNegated,
+			PatternMatchesContent:        p.PatternMatchesContent,
+			PatternMatchesPath:           p.PatternMatchesPath,
+		},
+		Indexed:          indexed,
+		FetchTimeout:     fetchTimeout.String(),
+		IndexerEndpoints: indexerEndpoints,
 	}
+
 	if deadline, ok := ctx.Deadline(); ok {
 		t, err := deadline.MarshalText()
 		if err != nil {
 			return nil, false, err
 		}
-		q.Set("Deadline", string(t))
-	}
-	q.Set("Limit", strconv.FormatInt(int64(p.FileMatchLimit), 10))
-	if p.IsRegExp {
-		q.Set("IsRegExp", "true")
-	}
-	if p.IsStructuralPat {
-		q.Set("IsStructuralPat", "true")
-	}
-	if indexed {
-		q.Set("Indexed", "true")
-	}
-	if p.IsWordMatch {
-		q.Set("IsWordMatch", "true")
-	}
-	if p.IsCaseSensitive {
-		q.Set("IsCaseSensitive", "true")
-	}
-	if p.PathPatternsAreCaseSensitive {
-		q.Set("PathPatternsAreCaseSensitive", "true")
-	}
-	if p.IsNegated {
-		q.Set("IsNegated", "true")
+		r.Deadline = string(t)
 	}
 	if onMatches != nil {
-		q.Set("Stream", "true")
+		r.Stream = true
 	}
-	// TEMP BACKCOMPAT: always set even if false so that searcher can distinguish new frontends that send
-	// these fields from old frontends that do not (and provide a default in the latter case).
-	q.Set("PatternMatchesContent", strconv.FormatBool(p.PatternMatchesContent))
-	q.Set("PatternMatchesPath", strconv.FormatBool(p.PatternMatchesPath))
-	rawQuery := q.Encode()
+	body, err := json.Marshal(r)
+	if err != nil {
+		return nil, false, err
+	}
 
 	// Searcher caches the file contents for repo@commit since it is
 	// relatively expensive to fetch from gitserver. So we use consistent
@@ -121,29 +109,28 @@ func Search(
 	for {
 		attempt++
 
-		searcherURL, err := searcherURLs.Get(consistentHashKey, excludedSearchURLs)
+		url, err := searcherURLs.Get(consistentHashKey, excludedSearchURLs)
 		if err != nil {
 			return nil, false, err
 		}
 
 		// Fallback to a bad host if nothing is left
-		if searcherURL == "" {
+		if url == "" {
 			tr.LazyPrintf("failed to find endpoint, trying again without excludes")
-			searcherURL, err = searcherURLs.Get(consistentHashKey, nil)
+			url, err = searcherURLs.Get(consistentHashKey, nil)
 			if err != nil {
 				return nil, false, err
 			}
 		}
 
-		url := searcherURL + "?" + rawQuery
 		tr.LazyPrintf("attempt %d: %s", attempt, url)
 		if onMatches != nil {
-			limitHit, err = textSearchURLStream(ctx, url, onMatches)
+			limitHit, err = textSearchStream(ctx, url, body, onMatches)
 			if err == nil || errcode.IsTimeout(err) {
 				return nil, limitHit, err
 			}
 		} else {
-			matches, limitHit, err = textSearchURL(ctx, url)
+			matches, limitHit, err = textSearch(ctx, url, body)
 			if err == nil || errcode.IsTimeout(err) {
 				return matches, limitHit, err
 			}
@@ -161,12 +148,12 @@ func Search(
 
 		tr.LazyPrintf("transient error %s", err.Error())
 		// Retry search on another searcher instance (if possible)
-		excludedSearchURLs[searcherURL] = true
+		excludedSearchURLs[url] = true
 	}
 }
 
-func textSearchURLStream(ctx context.Context, url string, cb func([]*protocol.FileMatch)) (bool, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func textSearchStream(ctx context.Context, url string, body []byte, cb func([]*protocol.FileMatch)) (bool, error) {
+	req, err := http.NewRequest("GET", url, bytes.NewReader(body))
 	if err != nil {
 		return false, err
 	}
@@ -221,8 +208,8 @@ func textSearchURLStream(ctx context.Context, url string, cb func([]*protocol.Fi
 	return ed.LimitHit, err
 }
 
-func textSearchURL(ctx context.Context, url string) ([]*protocol.FileMatch, bool, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func textSearch(ctx context.Context, url string, body []byte) ([]*protocol.FileMatch, bool, error) {
+	req, err := http.NewRequest("GET", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
Searcher is one of the few services whose endpoint isn't a JSON API. It currently encodes arguments as query parameters, which breaks the flow of navigating by types, is more error prone than encoding to JSON (working with strings, not types), and is more difficult to read. 

This PR modifies searcher to use a JSON request body for arguments rather than encoding them as URL parameters. 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
