### PR TITLE
insights: resolve next insight recording as the first of the next month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The copy icon displayed next to files and repositories will now copy the file or repository path. Previously, this action copied the URL to clipboard. [#23390](https://github.com/sourcegraph/sourcegraph/pull/23390)
 - Sourcegraph's Prometheus dependency has been upgraded to v2.28.1. [23663](https://github.com/sourcegraph/sourcegraph/pull/23663)
 - Sourcegraph's Alertmanager dependency has been upgraded to v0.22.2. [23663](https://github.com/sourcegraph/sourcegraph/pull/23714)
+- Code Insights will now schedule sample recordings for the first of the next month after creation or a previous recording. [#23799](https://github.com/sourcegraph/sourcegraph/pull/23799)
 
 ### Fixed
 

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -204,6 +204,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 			SeriesID:              Encode(timeSeries),
 			Query:                 timeSeries.Query,
 			RecordingIntervalDays: 1,
+			NextRecordingAfter:    insights.NextRecording(time.Now()),
 		}
 		result, err := tx.CreateSeries(ctx, temp)
 		if err != nil {

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/insights"
+
 	"github.com/inconshreveable/log15"
 
 	"github.com/cockroachdb/errors"
@@ -255,7 +257,7 @@ type InsightMetadataStore interface {
 // StampRecording will update the recording metadata for this series and return the InsightSeries struct with updated values.
 func (s *InsightStore) StampRecording(ctx context.Context, series types.InsightSeries) (types.InsightSeries, error) {
 	current := s.Now()
-	next := current.Add(time.Hour * 24 * time.Duration(series.RecordingIntervalDays))
+	next := insights.NextRecording(current)
 	if err := s.Exec(ctx, sqlf.Sprintf(stampRecordingSql, current, next, series.ID)); err != nil {
 		return types.InsightSeries{}, err
 	}

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -378,7 +378,7 @@ func TestInsightStore_GetDataSeries(t *testing.T) {
 func TestInsightStore_StampRecording(t *testing.T) {
 	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
 	defer cleanup()
-	now := time.Now().Round(0).Truncate(time.Microsecond)
+	now := time.Date(2020, 1, 5, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 	ctx := context.Background()
 
 	store := NewInsightStore(timescale)
@@ -402,7 +402,7 @@ func TestInsightStore_StampRecording(t *testing.T) {
 
 		want := created
 		want.LastRecordedAt = now
-		want.NextRecordingAfter = now.Add(time.Hour * 24 * time.Duration(want.RecordingIntervalDays))
+		want.NextRecordingAfter = time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)
 
 		got, err := store.StampRecording(ctx, created)
 		if err != nil {

--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -260,6 +260,6 @@ const (
 
 // NextRecording calculates the time that a series recording should occur given the current or most recent recording time.
 func NextRecording(current time.Time) time.Time {
-	year, month, _ := current.Date()
+	year, month, _ := current.In(time.UTC).Date()
 	return time.Date(year, month+1, 1, 0, 0, 0, 0, time.UTC)
 }

--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/inconshreveable/log15"
 
@@ -256,3 +257,9 @@ const (
 	User SettingFilter = "user"
 	All  SettingFilter = "all"
 )
+
+// NextRecording calculates the time that a series recording should occur given the current or most recent recording time.
+func NextRecording(current time.Time) time.Time {
+	year, month, _ := current.Date()
+	return time.Date(year, month+1, 1, 0, 0, 0, 0, time.UTC)
+}

--- a/internal/insights/insights_test.go
+++ b/internal/insights/insights_test.go
@@ -2,9 +2,11 @@ package insights
 
 import (
 	"context"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/inconshreveable/log15"
 
@@ -174,3 +176,25 @@ const insightSettingSimple = `{"searchInsights.insight.global.simple": {
       "weeks": 2
     }
   }}`
+
+func TestNextRecording(t *testing.T) {
+	type args struct {
+		current time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Time
+	}{
+		{name: "given first get next first", args: struct{ current time.Time }{current: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}, want: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "given december first get jan first", args: struct{ current time.Time }{current: time.Date(2020, 12, 1, 0, 0, 0, 0, time.UTC)}, want: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "given december 31 get jan first", args: struct{ current time.Time }{current: time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC)}, want: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NextRecording(tt.args.current); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NextRecording() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #23767
We are changing the recording scheduler to use a fixed 1st of every month.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
