### PR TITLE
workerutil: Re-enable skipped test

### DIFF
--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -145,8 +145,6 @@ func TestWorkerHandlerNonRetryableFailure(t *testing.T) {
 }
 
 func TestWorkerConcurrent(t *testing.T) {
-	t.Skip("Disabled because it's flaky. See: https://github.com/sourcegraph/sourcegraph/issues/22595")
-
 	NumTestRecords := 50
 
 	for numHandlers := 1; numHandlers < NumTestRecords; numHandlers++ {


### PR DESCRIPTION
We've recently introduced multiple mock clocks that should stop the flake previously reported on this text. Fixes https://github.com/sourcegraph/sourcegraph/issues/22595.