### PR TITLE
fix: hover border color secondary button css class

### DIFF
--- a/client/branded/src/global-styles/buttons.scss
+++ b/client/branded/src/global-styles/buttons.scss
@@ -242,6 +242,7 @@
         &:not(:disabled):not(.disabled) {
             &:hover:not(.focus):not(:focus) {
                 color: var(--body-color);
+                border-color: var(--secondary);
 
                 svg {
                     fill: var(--icon-color);


### PR DESCRIPTION
**Before**
![Screen Shot 2021-08-11 at 2 55 07 PM](https://user-images.githubusercontent.com/989826/129094480-25faed50-6f6e-493e-9360-dd40e616001c.png)
![Screen Shot 2021-08-11 at 2 55 16 PM](https://user-images.githubusercontent.com/989826/129094490-aab38b6f-1a2e-4a32-b44d-60ffda117037.png)


**After**
![Screen Shot 2021-08-11 at 2 54 10 PM](https://user-images.githubusercontent.com/989826/129094349-3479e2cf-9e46-4ab8-8307-9f0c31c4a76f.png)
![Screen Shot 2021-08-11 at 2 53 54 PM](https://user-images.githubusercontent.com/989826/129094358-86073ee6-4d6b-4610-8a01-f552d39268a5.png)
