### PR TITLE
search: stopgap fix for early ctx cancellation

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -101,11 +101,8 @@ func StructuralSearch(ctx context.Context, args *search.TextParameters, stream s
 	fileMatches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
 		return StructuralSearchFilesInRepos(ctx, args, stream)
 	})
-	if err != nil {
-		return err
-	}
 
-	if len(fileMatches) == 0 {
+	if len(fileMatches) == 0 && err == nil {
 		// No results for structural search? Automatically search again and force Zoekt
 		// to resolve more potential file matches by setting a higher FileMatchLimit.
 		patternCopy := *(args.PatternInfo)


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/23703 introduced a change which checks `err` early. Apparently `err` is non nil with an early context cancellation that stops the search prematurely. This PR is a stopgap that reverts the original change. I'll investigate the root cause and add something to integration tests once I've been down the issue.