### PR TITLE
executor: Write queue metrics to GCP if configured

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/config"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/metrics"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/queues/batches"
 	codeintelqueue "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -68,8 +69,12 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 		return err
 	}
 
-	queueHandler, err := newExecutorQueueHandler(db, observationContext, queueOptions, handler)
+	queueHandler, err := newExecutorQueueHandler(queueOptions, handler)
 	if err != nil {
+		return err
+	}
+
+	if err := metrics.Init(observationContext, queueOptions); err != nil {
 		return err
 	}
 

--- a/enterprise/cmd/frontend/internal/executorqueue/metrics/gcp.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/metrics/gcp.go
@@ -14,6 +14,7 @@ import (
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
@@ -66,7 +67,7 @@ const (
 
 func makeGCPMetricRequest(config *GCPConfig, queueName string, count int) *monitoringpb.CreateTimeSeriesRequest {
 	pbMetric := &metricpb.Metric{Type: gcpMetricType, Labels: map[string]string{"queueName": queueName}}
-	now := &timestamp.Timestamp{Seconds: time.Now().UTC().Unix()}
+	now := &timestamp.Timestamp{Seconds: timeutil.Now().Unix()}
 	pbInterval := &monitoringpb.TimeInterval{StartTime: now, EndTime: now}
 	pbValue := &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{Int64Value: int64(count)}}
 	pbTimeSeriesPoints := []*monitoringpb.Point{{Interval: pbInterval, Value: pbValue}}

--- a/enterprise/cmd/frontend/internal/executorqueue/metrics/gcp.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/metrics/gcp.go
@@ -1,0 +1,91 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"github.com/cockroachdb/errors"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/inconshreveable/log15"
+	"google.golang.org/api/option"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+)
+
+func initGCPMetrics(config *GCPConfig, queueOptions map[string]handler.QueueOptions) error {
+	if config.ProjectID == "" {
+		return nil
+	}
+
+	metricClient, err := monitoring.NewMetricClient(context.Background(), gcsClientOptions(config)...)
+	if err != nil {
+		return err
+	}
+
+	for queueName, options := range queueOptions {
+		initGCPMetric(config, metricClient, queueName, options.Store)
+	}
+
+	return nil
+}
+
+func initGCPMetric(config *GCPConfig, metricClient *monitoring.MetricClient, queueName string, store store.Store) {
+	go func() {
+		for {
+			if err := sendGCPMetric(config, metricClient, queueName, store); err != nil {
+				log15.Error("Failed to send executor queue size metric to GCP", "queue", queueName, "error", err)
+			}
+
+			time.Sleep(time.Second * 5)
+		}
+	}()
+}
+
+func sendGCPMetric(config *GCPConfig, metricClient *monitoring.MetricClient, queueName string, store store.Store) error {
+	count, err := store.QueuedCount(context.Background(), nil)
+	if err != nil {
+		return errors.Wrap(err, "dbworkerstore.QueuedCount")
+	}
+
+	if err := metricClient.CreateTimeSeries(context.Background(), makeGCPMetricRequest(config, queueName, count)); err != nil {
+		return errors.Wrap(err, "metricClient.CreateTimeSeries")
+	}
+
+	return nil
+}
+
+const (
+	gcpMetricKind = metricpb.MetricDescriptor_GAUGE
+	gcpMetricType = "custom.googleapis.com/executors/queue/size"
+)
+
+func makeGCPMetricRequest(config *GCPConfig, queueName string, count int) *monitoringpb.CreateTimeSeriesRequest {
+	pbMetric := &metricpb.Metric{Type: gcpMetricType, Labels: map[string]string{"queueName": queueName}}
+	now := &timestamp.Timestamp{Seconds: time.Now().UTC().Unix()}
+	pbInterval := &monitoringpb.TimeInterval{StartTime: now, EndTime: now}
+	pbValue := &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{Int64Value: int64(count)}}
+	pbTimeSeriesPoints := []*monitoringpb.Point{{Interval: pbInterval, Value: pbValue}}
+	pbTimeSeries := &monitoringpb.TimeSeries{Metric: pbMetric, MetricKind: gcpMetricKind, Points: pbTimeSeriesPoints}
+
+	return &monitoringpb.CreateTimeSeriesRequest{
+		Name:       fmt.Sprintf("projects/%s", config.ProjectID),
+		TimeSeries: []*monitoringpb.TimeSeries{pbTimeSeries},
+	}
+}
+
+func gcsClientOptions(config *GCPConfig) []option.ClientOption {
+	if config.CredentialsFile != "" {
+		return []option.ClientOption{option.WithCredentialsFile(config.CredentialsFile)}
+	}
+
+	if config.CredentialsFileContents != "" {
+		return []option.ClientOption{option.WithCredentialsJSON([]byte(config.CredentialsFileContents))}
+	}
+
+	return nil
+}

--- a/enterprise/cmd/frontend/internal/executorqueue/metrics/gcp_config.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/metrics/gcp_config.go
@@ -1,0 +1,23 @@
+package metrics
+
+import "github.com/sourcegraph/sourcegraph/internal/env"
+
+type GCPConfig struct {
+	env.BaseConfig
+
+	ProjectID               string
+	CredentialsFile         string
+	CredentialsFileContents string
+}
+
+func (c *GCPConfig) Load() {
+	c.ProjectID = c.GetOptional("EXECUTOR_METRIC_GCP_PROJECT_ID", "The project containing the custom metric.")
+	c.CredentialsFile = c.GetOptional("EXECUTOR_METRIC_GOOGLE_APPLICATION_CREDENTIALS_FILE", "The path to a service account key file with access to metrics.")
+	c.CredentialsFileContents = c.GetOptional("EXECUTOR_METRIC_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT", "The contents of a service account key file with access to metrics.")
+}
+
+var gcpConfig = &GCPConfig{}
+
+func init() {
+	gcpConfig.Load()
+}

--- a/enterprise/cmd/frontend/internal/executorqueue/metrics/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/metrics/init.go
@@ -1,0 +1,14 @@
+package metrics
+
+import (
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func Init(observationContext *observation.Context, queueOptions map[string]handler.QueueOptions) error {
+	// Emit metrics to control alerts
+	initPrometheusMetrics(observationContext, queueOptions)
+
+	// Emit metrics to control executor auto-scaling
+	return initGCPMetrics(gcpConfig, queueOptions)
+}

--- a/enterprise/cmd/frontend/internal/executorqueue/metrics/prometheus.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/metrics/prometheus.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+)
+
+func initPrometheusMetrics(observationContext *observation.Context, queueOptions map[string]handler.QueueOptions) {
+	for queueName, options := range queueOptions {
+		initPrometheusMetric(observationContext, queueOptions, queueName, options.Store)
+	}
+}
+
+func initPrometheusMetric(observationContext *observation.Context, queueOptions map[string]handler.QueueOptions, queueName string, store store.Store) {
+	observationContext.Registerer.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_executor_total",
+		Help:        "Total number of jobs in the queued state.",
+		ConstLabels: map[string]string{"queue": queueName},
+	}, func() float64 {
+		count, err := store.QueuedCount(context.Background(), nil)
+		if err != nil {
+			log15.Error("Failed to get queued job count", "queue", queueName, "error", err)
+		}
+
+		return float64(count)
+	}))
+}

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.11.0
 	github.com/golang/gddo v0.0.0-20200831202555-721e228c7686
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+	github.com/golang/protobuf v1.5.2
 	github.com/gomodule/oauth1 v0.0.0-20181215000758-9a59ed3b0a84
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-cmp v0.5.5


### PR DESCRIPTION
This mirrors the metrics that we send for `src_executor_total` to Prometheus into the Google monitoring stack. This will be required so that the GCP auto-scaler can read a custom metric to determine if we need to scale up the number of instances.