### PR TITLE
create JSONArrayBuf with larger initial buffer

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -117,15 +117,11 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Store marshalled matches and flush periodically or when we go over
-	// 32kb.
-	matchesBuf := &streamhttp.JSONArrayBuf{
-		// 32kb chosen to be smaller than bufio.MaxTokenSize. Note: we can
-		// still write more than that.
-		FlushSize: 32 * 1024,
-		Write: func(data []byte) error {
-			return eventWriter.EventBytes("matches", data)
-		},
-	}
+	// 32kb. 32kb chosen to be smaller than bufio.MaxTokenSize. Note: we can
+	// still write more than that.
+	matchesBuf := streamhttp.NewJSONArrayBuf(32*1024, func(data []byte) error {
+		return eventWriter.EventBytes("matches", data)
+	})
 	matchesFlush := func() {
 		if err := matchesBuf.Flush(); err != nil {
 			// EOF

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -156,12 +156,9 @@ func (s *Service) streamSearch(ctx context.Context, w http.ResponseWriter, p pro
 	}
 
 	var bufMux sync.Mutex
-	matchesBuf := &streamhttp.JSONArrayBuf{
-		FlushSize: 32 * 1024,
-		Write: func(data []byte) error {
-			return eventWriter.EventBytes("matches", data)
-		},
-	}
+	matchesBuf := streamhttp.NewJSONArrayBuf(32*1024, func(data []byte) error {
+		return eventWriter.EventBytes("matches", data)
+	})
 	onMatches := func(match protocol.FileMatch) {
 		bufMux.Lock()
 		if err := matchesBuf.Append(match); err != nil {

--- a/internal/search/streaming/http/json_array_buf.go
+++ b/internal/search/streaming/http/json_array_buf.go
@@ -15,6 +15,17 @@ type JSONArrayBuf struct {
 	buf bytes.Buffer
 }
 
+func NewJSONArrayBuf(flushSize int, write func([]byte) error) *JSONArrayBuf {
+	b := &JSONArrayBuf{
+		FlushSize: flushSize,
+		Write:     write,
+	}
+	// Grow the buffer to flushSize to reduce the number of small allocations
+	// caused by repeatedly growing the buffer
+	b.buf.Grow(flushSize)
+	return b
+}
+
 // Append marshals v and adds it to the json array buffer. If the size of the
 // buffer exceed FlushSize the buffer is written out.
 func (j *JSONArrayBuf) Append(v interface{}) error {


### PR DESCRIPTION
This allocates the initial buffer for a JSONArrayBuf to its flush size.
Since we will very frequently have enough results to hit the flush size,
this saves a large number of small allocations used to grow the buffer
in intermediate steps.

This change was guided by searcher profiles that showed a large
number of live byte slices allocated by `buffer.Grow()`. It should help
reduce memory pressure on searcher while streaming large result sets.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
