### PR TITLE
API docs: sidebar: clicking "Constants", "Variables", etc. behave as buttons

### DIFF
--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -171,11 +171,10 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = React.memo
                             ) : (
                                 <ChevronRightIcon className="icon-inline" aria-label="Expand section" />
                             )}
+                            {node.detail.value === '' && <strong id={'index-' + hash}>{node.label.value}</strong>}
                         </button>
                     )}
-                    <Link id={'index-' + hash} to={thisPage} onClick={scrollToFast} className="pr-3">
-                        {node.label.value}
-                    </Link>
+                    {node.detail.value !== '' && <Link id={'index-' + hash} to={thisPage} onClick={scrollToFast} className="pr-3">{node.label.value}</Link>}
                 </span>
                 {expanded && (
                     <ul className="pl-3">

--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -174,7 +174,11 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = React.memo
                             {node.detail.value === '' && <strong id={'index-' + hash}>{node.label.value}</strong>}
                         </button>
                     )}
-                    {node.detail.value !== '' && <Link id={'index-' + hash} to={thisPage} onClick={scrollToFast} className="pr-3">{node.label.value}</Link>}
+                    {node.detail.value !== '' && (
+                        <Link id={'index-' + hash} to={thisPage} onClick={scrollToFast} className="pr-3">
+                            {node.label.value}
+                        </Link>
+                    )}
                 </span>
                 {expanded && (
                     <ul className="pl-3">


### PR DESCRIPTION
Previously, the dropdown button and `Constants` text in `> Constants` were two
seperate functions: one expands the area, the other jumps to the "Constants"
section of the page. This is a bit confusing, though, because jumping to the
section of the page _also_ means it gets automatically expanded. This makes
some users think clicking the text makes the area expand, which is not true.

So, make clicking on "Constants", "Variables", etc. do what the user expects:
expand/collapse.

The only caveat to this is that _some expandable sections_, like `type Foo struct`
with methods below it, will continue to act as having two seperate buttons.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>