### PR TITLE
streaming searcher error cleanup

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -180,8 +180,12 @@ func (s *Service) streamSearch(ctx context.Context, w http.ResponseWriter, p pro
 	}
 
 	// Flush remaining matches before sending a different event
-	matchesBuf.Flush()
-	eventWriter.Event("done", doneEvent)
+	if err := matchesBuf.Flush(); err != nil {
+		log.Printf("failed to flush matches: %s", err)
+	}
+	if err := eventWriter.Event("done", doneEvent); err != nil {
+		log.Printf("failed to send done event: %s", err)
+	}
 }
 
 func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchSender) (deadlineHit bool, err error) {

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -208,8 +208,7 @@ func textSearchURLStream(ctx context.Context, url string, cb func([]*protocol.Fi
 			err = errors.Errorf("unknown event %q", event)
 		},
 	}
-	dec.ReadAll(resp.Body)
-	if err != nil {
+	if err := dec.ReadAll(resp.Body); err != nil {
 		return false, err
 	}
 	if ed.Error != "" {


### PR DESCRIPTION
This logs some errors that were previously swallowed, and removes the
OnUnknown function in favor of a hard error.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
