### PR TITLE
compute: GQL scaffolding

### DIFF
--- a/cmd/frontend/graphqlbackend/compute.go
+++ b/cmd/frontend/graphqlbackend/compute.go
@@ -1,0 +1,139 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/sourcegraph/internal/compute"
+)
+
+type ComputeArgs struct {
+	Query string
+}
+
+type ComputeResolver interface {
+	Compute(ctx context.Context, args *ComputeArgs) ([]*computeResultResolver, error)
+}
+
+// A dummy type to express the union of compute results. This how its done by the GQL library we use.
+// https://github.com/graph-gophers/graphql-go/blob/af5bb93e114f0cd4cc095dd8eae0b67070ae8f20/example/starwars/starwars.go#L485-L487
+//
+// union ComputeResult = ComputeMatchContext | ComputeText
+type computeResultResolver struct {
+	result interface{}
+}
+
+// ComputeMatchContext GQL result resolver definitions.
+
+type computeMatchContextResolver struct {
+	repository *RepositoryResolver
+	commit     string
+	path       string
+	matches    []*computeMatchResolver
+}
+
+func (c *computeMatchContextResolver) Repository() *RepositoryResolver  { return c.repository }
+func (c *computeMatchContextResolver) Commit() string                   { return c.commit }
+func (c *computeMatchContextResolver) Path() string                     { return c.path }
+func (c *computeMatchContextResolver) Matches() []*computeMatchResolver { return c.matches }
+
+// computeMatch resolvers.
+
+type computeMatchResolver struct {
+	m *compute.Match
+}
+
+func (r *computeMatchResolver) Value() string {
+	return r.m.Value
+}
+
+func (r *computeMatchResolver) Range() RangeResolver {
+	return NewRangeResolver(toLspRange(r.m.Range))
+}
+
+func (r *computeMatchResolver) Environment() []*computeEnvironmentEntryResolver {
+	var result []*computeEnvironmentEntryResolver
+	for variable, value := range r.m.Environment {
+		result = append(result, newEnvironmentEntryResolver(variable, value))
+	}
+	return result
+}
+
+// computeEnvironmentEntry resolvers.
+
+type computeEnvironmentEntryResolver struct {
+	variable string
+	value    string
+	range_   compute.Range
+}
+
+func newEnvironmentEntryResolver(variable string, value compute.Data) *computeEnvironmentEntryResolver {
+	return &computeEnvironmentEntryResolver{
+		variable: variable,
+		value:    value.Value,
+		range_:   value.Range,
+	}
+}
+
+func (r *computeEnvironmentEntryResolver) Variable() string {
+	return r.variable
+}
+
+func (r *computeEnvironmentEntryResolver) Value() string {
+	return r.value
+}
+
+func (r *computeEnvironmentEntryResolver) Range() RangeResolver {
+	return NewRangeResolver(toLspRange(r.range_))
+}
+
+func toLspRange(r compute.Range) lsp.Range {
+	return lsp.Range{
+		Start: lsp.Position{
+			Line:      r.Start.Line,
+			Character: r.Start.Column,
+		},
+		End: lsp.Position{
+			Line:      r.End.Line,
+			Character: r.End.Column,
+		},
+	}
+}
+
+// ComputeText GQL result resolver definitions.
+
+type computeTextResolver struct {
+	repository *RepositoryResolver //nolint
+	commit     string              //nolint
+	path       string              //nolint
+	t          *compute.Text
+}
+
+func (c *computeTextResolver) Repository() *RepositoryResolver { return nil }
+func (r *computeTextResolver) Commit() *string                 { return nil }
+func (r *computeTextResolver) Path() *string                   { return nil }
+func (r *computeTextResolver) Kind() *string                   { return nil }
+func (r *computeTextResolver) Value() string                   { return r.t.Value }
+
+// Definitions required by https://github.com/graph-gophers/graphql-go to resolve
+// a union type in GraphQL.
+
+func (r *computeResultResolver) ToComputeMatchContext() (*computeMatchContextResolver, bool) {
+	res, ok := r.result.(*computeMatchContextResolver)
+	return res, ok
+}
+
+func (r *computeResultResolver) ToComputeText() (*computeTextResolver, bool) {
+	res, ok := r.result.(*computeTextResolver)
+	return res, ok
+}
+
+// NewComputeImplementer is a function that abstracts away the need to have a
+// handle on (*schemaResolver) Compute.
+func NewComputeImplementer(ctx context.Context, args *ComputeArgs) ([]*computeResultResolver, error) {
+	return []*computeResultResolver{{&computeTextResolver{t: &compute.Text{Value: "value"}}}}, nil
+}
+
+func (r *schemaResolver) Compute(ctx context.Context, args *ComputeArgs) ([]*computeResultResolver, error) {
+	return NewComputeImplementer(ctx, args)
+}

--- a/cmd/frontend/graphqlbackend/compute.graphql
+++ b/cmd/frontend/graphqlbackend/compute.graphql
@@ -1,0 +1,103 @@
+# EXPERIMENTAL: Extends the query API with an endpoint that computes values from search results.
+extend type Query {
+    """
+    Computes valus from search results.
+    """
+    compute(
+        """
+        The search query.
+        """
+        query: String = ""
+    ): [ComputeResult!]!
+}
+
+"""
+A compute operation result.
+"""
+union ComputeResult = ComputeMatchContext | ComputeText
+
+"""
+The result of matching data that satisfy a search pattern, including an environment of submatches.
+"""
+type ComputeMatchContext {
+    """
+    The repository.
+    """
+    repository: Repository!
+    """
+    The commit.
+    """
+    commit: String!
+    """
+    The file path.
+    """
+    path: String!
+    """
+    Computed match results
+    """
+    matches: [ComputeMatch]!
+}
+
+"""
+Represents a value matched within file content, and an environment of submatches within this value corresponding to an input pattern (e.g., regular expression capture groups).
+"""
+type ComputeMatch {
+    """
+    The string value
+    """
+    value: String!
+    """
+    The range of this value within the file.
+    """
+    range: Range!
+    """
+    The environment of submatches within value.
+    """
+    environment: [ComputeEnvironmentEntry]!
+}
+
+"""
+An entry in match environment is a variable with a value spanning a range. Variable names correspond to
+a variable names in a pattern metasyntax. For regular expression patterns, named capture groups will use the variable
+specified. For unnamed capture groups, variable names correspond to capture '1', '2', etc.
+"""
+type ComputeEnvironmentEntry {
+    """
+    The variable name.
+    """
+    variable: String!
+    """
+    The value associated with this variable.
+    """
+    value: String!
+    """
+    The absolute range spanned by this value in the input.
+    """
+    range: Range!
+}
+
+"""
+A general computed result for arbitrary textual data. A result optionally specifies a related repository, commit, file path, or the kind of textual data.
+"""
+type ComputeText {
+    """
+    The repository.
+    """
+    repository: Repository
+    """
+    The commit.
+    """
+    commit: String
+    """
+    The file path.
+    """
+    path: String
+    """
+    An arbitrary label communicating the kind of data the value represents.
+    """
+    kind: String
+    """
+    The computed value.
+    """
+    value: String!
+}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -393,6 +393,8 @@ func NewSchema(db dbutil.DB, batchChanges BatchChangesResolver, codeIntel CodeIn
 		}
 	}
 
+	schemas = append(schemas, computeSchema)
+
 	return graphql.ParseSchema(
 		strings.Join(schemas, "\n"),
 		resolver,
@@ -408,6 +410,7 @@ type schemaResolver struct {
 	BatchChangesResolver
 	AuthzResolver
 	CodeIntelResolver
+	ComputeResolver
 	InsightsResolver
 	CodeMonitorsResolver
 	LicenseResolver
@@ -477,6 +480,7 @@ func newSchemaResolver(db dbutil.DB) *schemaResolver {
 // in enterprise mode. These resolver instances are nil when running as OSS.
 var EnterpriseResolvers = struct {
 	codeIntelResolver    CodeIntelResolver
+	computeResolver      ComputeResolver
 	insightsResolver     InsightsResolver
 	authzResolver        AuthzResolver
 	batchChangesResolver BatchChangesResolver

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -35,3 +35,7 @@ var insightsSchema string
 // authzSchema is the Authz raw graqhql schema.
 //go:embed authz.graphql
 var authzSchema string
+
+// computeSchema is an experimental graphql endpoint for computing values from search results.
+//go:embed compute.graphql
+var computeSchema string

--- a/internal/compute/match_context_result.go
+++ b/internal/compute/match_context_result.go
@@ -40,7 +40,7 @@ type Match struct {
 	Environment Environment `json:"environment"`
 }
 
-type Result struct {
+type MatchContext struct {
 	Matches []Match `json:"matches"`
 	Path    string  `json:"path"`
 }
@@ -93,7 +93,7 @@ func ofRegexpMatches(matches [][]int, namedGroups []string, lineValue string, li
 	return Match{Value: firstValue, Range: firstRange, Environment: env}
 }
 
-func ofFileMatches(fm *result.FileMatch, r *regexp.Regexp) *Result {
+func ofFileMatches(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 	matches := make([]Match, 0, len(fm.LineMatches))
 	for _, l := range fm.LineMatches {
 		regexpMatches := r.FindAllStringSubmatchIndex(l.Preview, -1)
@@ -101,5 +101,5 @@ func ofFileMatches(fm *result.FileMatch, r *regexp.Regexp) *Result {
 			matches = append(matches, ofRegexpMatches(regexpMatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
 		}
 	}
-	return &Result{Matches: matches, Path: fm.Path}
+	return &MatchContext{Matches: matches, Path: fm.Path}
 }

--- a/internal/compute/match_context_result_test.go
+++ b/internal/compute/match_context_result_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
-type serializer func(*Result) interface{}
+type serializer func(*MatchContext) interface{}
 
-func match(r *Result) interface{} {
+func match(r *MatchContext) interface{} {
 	return r
 }
 
-func environment(r *Result) interface{} {
+func environment(r *MatchContext) interface{} {
 	env := make(map[string]string)
 	for _, m := range r.Matches {
 		for k, v := range m.Environment {

--- a/internal/compute/text_result.go
+++ b/internal/compute/text_result.go
@@ -1,0 +1,6 @@
+package compute
+
+type Text struct {
+	Value string `json:"value"`
+	Kind  string `json:"kind"`
+}


### PR DESCRIPTION
GQL schema for the `compute` endpoint. Just scaffolding. To start, it will expose:

- A result type for matches and submatches corresponding to regular expression searches.
- A result type for arbitrary textual data for experimental purposes

PR also updates file names and type definitions in `internal/compute` to closely resemble the GQL definitions.

Part of https://github.com/sourcegraph/sourcegraph/issues/21579
