### PR TITLE
batches: implement and use MultiSelectContext

### DIFF
--- a/client/web/src/enterprise/batches/MultiSelectContext.test.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.test.tsx
@@ -11,7 +11,6 @@ describe('MultiSelectContextProvider', () => {
         const { selected } = getContext()
         if (selected === 'all') {
             fail()
-            return
         }
 
         expect(selected.size).toBe(0)
@@ -29,7 +28,6 @@ describe('MultiSelectContextProvider', () => {
             ({ areAllVisibleSelected, isSelected, selected }) => {
                 if (selected === 'all') {
                     fail()
-                    return
                 }
 
                 expect(selected.size).toBe(1)
@@ -45,7 +43,6 @@ describe('MultiSelectContextProvider', () => {
             ({ areAllVisibleSelected, isSelected, selected }) => {
                 if (selected === 'all') {
                     fail()
-                    return
                 }
 
                 expect(selected.size).toBe(2)
@@ -61,7 +58,6 @@ describe('MultiSelectContextProvider', () => {
             ({ areAllVisibleSelected, isSelected, selected }) => {
                 if (selected === 'all') {
                     fail()
-                    return
                 }
 
                 expect(selected.size).toBe(1)
@@ -81,7 +77,6 @@ describe('MultiSelectContextProvider', () => {
             ({ areAllVisibleSelected, isSelected, selected }) => {
                 if (selected === 'all') {
                     fail()
-                    return
                 }
 
                 expect(selected.size).toBe(0)
@@ -99,7 +94,6 @@ describe('MultiSelectContextProvider', () => {
                 ({ areAllVisibleSelected, isSelected, selected }) => {
                     if (selected === 'all') {
                         fail()
-                        return
                     }
 
                     expect(selected.size).toBe(2)
@@ -117,7 +111,6 @@ describe('MultiSelectContextProvider', () => {
                 ({ areAllVisibleSelected, isSelected, selected }) => {
                     if (selected === 'all') {
                         fail()
-                        return
                     }
 
                     expect(selected.size).toBe(0)
@@ -160,7 +153,6 @@ describe('MultiSelectContextProvider', () => {
                 ({ areAllVisibleSelected, isSelected, selected }) => {
                     if (selected === 'all') {
                         fail()
-                        return
                     }
 
                     expect(selected.size).toBe(0)
@@ -181,7 +173,6 @@ describe('MultiSelectContextProvider', () => {
             ({ areAllVisibleSelected, isSelected, selected }) => {
                 if (selected === 'all') {
                     fail()
-                    return
                 }
 
                 expect(selected.size).toBe(0)
@@ -198,7 +189,6 @@ describe('MultiSelectContextProvider', () => {
             ({ areAllVisibleSelected, isSelected, selected }) => {
                 if (selected === 'all') {
                     fail()
-                    return
                 }
 
                 expect(selected.size).toBe(2)
@@ -215,7 +205,6 @@ describe('MultiSelectContextProvider', () => {
             ({ areAllVisibleSelected, isSelected, selected }) => {
                 if (selected === 'all') {
                     fail()
-                    return
                 }
 
                 expect(selected.size).toBe(1)

--- a/client/web/src/enterprise/batches/MultiSelectContext.test.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.test.tsx
@@ -1,0 +1,280 @@
+import { mount } from 'enzyme'
+import React, { useContext, useEffect } from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { MultiSelectContext, MultiSelectContextProvider, MultiSelectContextState } from './MultiSelectContext'
+
+describe('MultiSelectContextProvider', () => {
+    test('providers are initially empty', () => {
+        const getContext = mountContext()
+
+        const { selected } = getContext()
+        if (selected === 'all') {
+            fail()
+            return
+        }
+
+        expect(selected.size).toBe(0)
+    })
+
+    test('selecting and deselecting single IDs works', () => {
+        const getContext = mountContext()
+
+        mutateAndAssert(
+            getContext,
+            context => {
+                context.setVisible(['1', '2'])
+                context.selectSingle('1')
+            },
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                if (selected === 'all') {
+                    fail()
+                    return
+                }
+
+                expect(selected.size).toBe(1)
+                expect(isSelected('1')).toBe(true)
+                expect(isSelected('2')).toBe(false)
+                expect(areAllVisibleSelected()).toBe(false)
+            }
+        )
+
+        mutateAndAssert(
+            getContext,
+            context => context.selectSingle('2'),
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                if (selected === 'all') {
+                    fail()
+                    return
+                }
+
+                expect(selected.size).toBe(2)
+                expect(isSelected('1')).toBe(true)
+                expect(isSelected('2')).toBe(true)
+                expect(areAllVisibleSelected()).toBe(true)
+            }
+        )
+
+        mutateAndAssert(
+            getContext,
+            context => context.deselectSingle('1'),
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                if (selected === 'all') {
+                    fail()
+                    return
+                }
+
+                expect(selected.size).toBe(1)
+                expect(isSelected('1')).toBe(false)
+                expect(isSelected('2')).toBe(true)
+                expect(areAllVisibleSelected()).toBe(false)
+            }
+        )
+    })
+
+    test('selecting and deselecting visible works', () => {
+        const getContext = mountContext()
+
+        mutateAndAssert(
+            getContext,
+            context => context.setVisible(['1', '2']),
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                if (selected === 'all') {
+                    fail()
+                    return
+                }
+
+                expect(selected.size).toBe(0)
+                expect(isSelected('1')).toBe(false)
+                expect(isSelected('2')).toBe(false)
+                expect(areAllVisibleSelected()).toBe(false)
+            }
+        )
+
+        // Repeat the test twice to ensure it's idempotent.
+        repeat(2, () =>
+            mutateAndAssert(
+                getContext,
+                context => context.selectVisible(),
+                ({ areAllVisibleSelected, isSelected, selected }) => {
+                    if (selected === 'all') {
+                        fail()
+                        return
+                    }
+
+                    expect(selected.size).toBe(2)
+                    expect(isSelected('1')).toBe(true)
+                    expect(isSelected('2')).toBe(true)
+                    expect(areAllVisibleSelected()).toBe(true)
+                }
+            )
+        )
+
+        repeat(2, () =>
+            mutateAndAssert(
+                getContext,
+                context => context.deselectVisible(),
+                ({ areAllVisibleSelected, isSelected, selected }) => {
+                    if (selected === 'all') {
+                        fail()
+                        return
+                    }
+
+                    expect(selected.size).toBe(0)
+                    expect(isSelected('1')).toBe(false)
+                    expect(isSelected('2')).toBe(false)
+                    expect(areAllVisibleSelected()).toBe(false)
+                }
+            )
+        )
+    })
+
+    test('selecting and deselecting all works', () => {
+        const getContext = mountContext()
+
+        mutateAndAssert(
+            getContext,
+            context => context.setVisible(['1', '2']),
+            ({ selected }) => {
+                expect(selected).not.toBe('all')
+            }
+        )
+
+        repeat(2, () =>
+            mutateAndAssert(
+                getContext,
+                context => context.selectAll(),
+                ({ areAllVisibleSelected, isSelected, selected }) => {
+                    expect(selected).toBe('all')
+                    expect(isSelected('1')).toBe(true)
+                    expect(isSelected('2')).toBe(true)
+                    expect(areAllVisibleSelected()).toBe(true)
+                }
+            )
+        )
+
+        repeat(2, () =>
+            mutateAndAssert(
+                getContext,
+                context => context.deselectAll(),
+                ({ areAllVisibleSelected, isSelected, selected }) => {
+                    if (selected === 'all') {
+                        fail()
+                        return
+                    }
+
+                    expect(selected.size).toBe(0)
+                    expect(isSelected('1')).toBe(false)
+                    expect(isSelected('2')).toBe(false)
+                    expect(areAllVisibleSelected()).toBe(false)
+                }
+            )
+        )
+
+        // Now let's reselect all, let that settle, and test some of the funkier
+        // combinations around selecting and deselecting other items or
+        // collections.
+        act(() => getContext().selectAll())
+        mutateAndAssert(
+            getContext,
+            context => context.deselectVisible(),
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                if (selected === 'all') {
+                    fail()
+                    return
+                }
+
+                expect(selected.size).toBe(0)
+                expect(isSelected('1')).toBe(false)
+                expect(isSelected('2')).toBe(false)
+                expect(areAllVisibleSelected()).toBe(false)
+            }
+        )
+
+        act(() => getContext().selectAll())
+        mutateAndAssert(
+            getContext,
+            context => context.selectVisible(),
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                if (selected === 'all') {
+                    fail()
+                    return
+                }
+
+                expect(selected.size).toBe(2)
+                expect(isSelected('1')).toBe(true)
+                expect(isSelected('2')).toBe(true)
+                expect(areAllVisibleSelected()).toBe(true)
+            }
+        )
+
+        act(() => getContext().selectAll())
+        mutateAndAssert(
+            getContext,
+            context => context.deselectSingle('1'),
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                if (selected === 'all') {
+                    fail()
+                    return
+                }
+
+                expect(selected.size).toBe(1)
+                expect(isSelected('1')).toBe(false)
+                expect(isSelected('2')).toBe(true)
+                expect(areAllVisibleSelected()).toBe(false)
+            }
+        )
+
+        act(() => getContext().selectAll())
+        mutateAndAssert(
+            getContext,
+            context => context.selectSingle('2'),
+            ({ areAllVisibleSelected, isSelected, selected }) => {
+                expect(selected).toBe('all')
+                expect(isSelected('1')).toBe(true)
+                expect(isSelected('2')).toBe(true)
+                expect(areAllVisibleSelected()).toBe(true)
+            }
+        )
+    })
+})
+
+const mountContext = (): (() => MultiSelectContextState) => {
+    let context: MultiSelectContextState | undefined
+    mount(
+        <MultiSelectContextProvider>
+            <Reflektor onContext={inner => (context = inner)} />
+        </MultiSelectContextProvider>
+    )
+
+    return () => {
+        if (context === undefined) {
+            throw new Error('context did not get populated')
+        }
+        return context
+    }
+}
+
+const mutateAndAssert = (
+    getContext: () => MultiSelectContextState,
+    mutate: (context: MultiSelectContextState) => void,
+    assert: (context: MultiSelectContextState) => void
+) => {
+    act(() => mutate(getContext()))
+    assert(getContext())
+}
+
+const repeat = (times: number, test: () => void) => {
+    for (let index = 0; index < times; index++) {
+        test()
+    }
+}
+
+const Reflektor: React.FunctionComponent<{ onContext: (inner: MultiSelectContextState) => void }> = ({ onContext }) => {
+    const context = useContext(MultiSelectContext)
+    useEffect(() => {
+        onContext(context)
+    }, [context, onContext])
+
+    return <>reflektor</>
+}

--- a/client/web/src/enterprise/batches/MultiSelectContext.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback, useState } from 'react'
+
+/**
+ * The current selection state: either a set of IDs or "all", in which case all
+ * possible IDs will be considered selected.
+ *
+ * Note that there is no special case for "visible": when all visible items are
+ * selected and a new page is loaded, the expectation is that those new items
+ * will not be selected by default.
+ */
+export type MultiSelectContextSelected = Set<string> | 'all'
+
+export interface MultiSelectContextState {
+    // State fields. These must not be mutated other than through the mutator
+    // functions below, but may be read at any time.
+    selected: MultiSelectContextSelected
+    totalCount?: number
+    visible: Set<string>
+
+    areAllVisibleSelected: () => boolean
+    isSelected: (id: string) => boolean
+
+    // General state mutators to select and deselect items.
+    deselectAll: () => void
+    deselectVisible: () => void
+    deselectSingle: (id: string) => void
+    selectAll: () => void
+    selectVisible: () => void
+    selectSingle: (id: string) => void
+
+    // Sets the total number of possible selections, if known.
+    setTotalCount: (count?: number) => void
+
+    // Sets the current set of visible IDs. This needs to happen in a single
+    // call to avoid unnecessary re-renders: consumers are responsible for
+    // aggregating the existing state from visible if required (for example, if
+    // pagination is being performed by appending to the existing list in an
+    // infinite scrolling style approach).
+    setVisible: (ids: string[]) => void
+}
+
+// eslint-disable @typescript-eslint/no-unused-vars
+const defaultState = (): MultiSelectContextState => ({
+    selected: new Set(),
+    totalCount: undefined,
+    visible: new Set(),
+    areAllVisibleSelected: () => false,
+    isSelected: () => false,
+    deselectAll: () => {},
+    deselectVisible: () => {},
+    deselectSingle: () => {},
+    selectAll: () => {},
+    selectVisible: () => {},
+    selectSingle: () => {},
+    setTotalCount: () => {},
+    setVisible: () => {},
+})
+// eslint-enable @typescript-eslint/no-unused-vars
+
+/**
+ * MultiSelectContext is a context that tracks which checkboxes in a paginated
+ * list have been selected, providing options to select visible and select all.
+ * Options are tracked by opaque string IDs.
+ *
+ * Use MultiSelectContextProvider to instantiate a MultiSelectContext: this will
+ * set up the appropriate internal state.
+ */
+export const MultiSelectContext = React.createContext<MultiSelectContextState>(defaultState())
+
+export const MultiSelectContextProvider: React.FunctionComponent<{
+    initialVisible?: string[]
+}> = ({ children, initialVisible }) => {
+    // Set up state and callbacks for the visible items.
+    const [visible, setVisibleInternal] = useState<Set<string>>(new Set())
+    const setVisible = useCallback((ids: string[]) => {
+        setVisibleInternal(new Set(ids))
+    }, [])
+
+    const [selected, setSelected] = useState<MultiSelectContextSelected>(new Set(initialVisible ?? []))
+    const selectAll = useCallback(() => setSelected('all'), [setSelected])
+    const deselectAll = useCallback(() => setSelected(new Set()), [setSelected])
+
+    const [totalCount, setTotalCountInternal] = useState<number | undefined>(undefined)
+    const setTotalCount = useCallback((totalCount?: number) => {
+        setTotalCountInternal(totalCount)
+    }, [])
+
+    const selectVisible = useCallback(() => {
+        if (selected === 'all') {
+            // If all items are currently selected, we're going to switch to
+            // only selecting the visible items.
+            setSelected(new Set([...visible]))
+        } else {
+            // Otherwise, we can merge the visible items with any previously
+            // selected items.
+            setSelected(new Set([...visible, ...selected]))
+        }
+    }, [selected, visible])
+
+    const deselectVisible = useCallback(() => {
+        if (selected === 'all') {
+            // If all items are currently selected, there isn't a sensible way
+            // to say "except for this specific subset" within the current data
+            // model, so we'll just interpret that as "deselect them all".
+            setSelected(new Set())
+        } else {
+            // Otherwise, we remove the items and create a new set.
+            setSelected(new Set([...selected].filter(id => !visible.has(id))))
+        }
+    }, [selected, visible])
+
+    const selectSingle = useCallback(
+        (id: string) => {
+            const updated = new Set(selected)
+            updated.add(id)
+
+            setSelected(updated)
+        },
+        [selected]
+    )
+
+    const deselectSingle = useCallback(
+        (id: string) => {
+            const updated = new Set(selected)
+            updated.delete(id)
+
+            setSelected(updated)
+        },
+        [selected]
+    )
+
+    const areAllVisibleSelected = useCallback(() => {
+        if (selected === 'all') {
+            return true
+        }
+
+        for (const id of visible) {
+            if (!selected.has(id)) {
+                return false
+            }
+        }
+
+        return true
+    }, [selected, visible])
+
+    const isSelected = useCallback((id: string) => selected === 'all' || selected.has(id), [selected])
+
+    return (
+        <MultiSelectContext.Provider
+            value={{
+                selected,
+                totalCount,
+                visible,
+                areAllVisibleSelected,
+                isSelected,
+                deselectAll,
+                deselectVisible,
+                deselectSingle,
+                selectAll,
+                selectVisible,
+                selectSingle,
+                setTotalCount,
+                setVisible,
+            }}
+        >
+            {children}
+        </MultiSelectContext.Provider>
+    )
+}

--- a/client/web/src/enterprise/batches/MultiSelectContext.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.tsx
@@ -74,21 +74,26 @@ export const MultiSelectContext = React.createContext<MultiSelectContextState>(d
  * various callbacks that are used by consumers.
  */
 export const MultiSelectContextProvider: React.FunctionComponent<{
+    // These props are only for testing purposes.
+    initialSelected?: MultiSelectContextSelected | string[]
+    initialTotalCount?: number
     initialVisible?: string[]
-}> = ({ children, initialVisible }) => {
+}> = ({ children, initialSelected, initialTotalCount, initialVisible }) => {
     // Set up state and callbacks for the visible items.
-    const [visible, setVisibleInternal] = useState<Set<string>>(new Set())
+    const [visible, setVisibleInternal] = useState<Set<string>>(new Set(initialVisible ?? []))
     const setVisible = useCallback((ids: string[]) => {
         setVisibleInternal(new Set(ids))
     }, [])
 
     // Now for selected items.
-    const [selected, setSelected] = useState<MultiSelectContextSelected>(new Set(initialVisible ?? []))
+    const [selected, setSelected] = useState<MultiSelectContextSelected>(
+        initialSelected === 'all' ? 'all' : new Set(initialSelected)
+    )
     const selectAll = useCallback(() => setSelected('all'), [setSelected])
     const deselectAll = useCallback(() => setSelected(new Set()), [setSelected])
 
     // Total count handling.
-    const [totalCount, setTotalCountInternal] = useState<number | undefined>(undefined)
+    const [totalCount, setTotalCountInternal] = useState<number | undefined>(initialTotalCount)
     const setTotalCount = useCallback((totalCount?: number) => {
         setTotalCountInternal(totalCount)
     }, [])

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import React, { useState, useCallback, useMemo, useEffect, useContext } from 'react'
 import { Subject } from 'rxjs'
 import { repeatWhen, delay, withLatestFrom, map, filter, tap } from 'rxjs/operators'
 
@@ -20,6 +20,7 @@ import { getHover, getDocumentHighlights } from '../../../../backend/features'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
 import { WebHoverOverlay } from '../../../../components/shared'
 import { AllChangesetIDsVariables, ChangesetFields, Scalars } from '../../../../graphql-operations'
+import { MultiSelectContext, MultiSelectContextProvider } from '../../MultiSelectContext'
 import { getLSPTextDocumentPositionParameters } from '../../utils'
 import {
     queryChangesets as _queryChangesets,
@@ -52,10 +53,16 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     expandByDefault?: boolean
 }
 
+export const BatchChangeChangesets: React.FunctionComponent<Props> = props => (
+    <MultiSelectContextProvider>
+        <BatchChangeChangesetsImpl {...props} />
+    </MultiSelectContextProvider>
+)
+
 /**
  * A list of a batch change's changesets.
  */
-export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
+export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
     batchChangeID,
     viewerCanAdminister,
     history,
@@ -70,65 +77,59 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
     expandByDefault,
     onlyArchived,
 }) => {
+    const {
+        selected,
+        deselectAll,
+        deselectSingle,
+        areAllVisibleSelected,
+        isSelected,
+        selectAll,
+        selectSingle,
+        selectVisible,
+        setTotalCount,
+        setVisible,
+    } = useContext(MultiSelectContext)
+
     // Whether all the changesets are selected, beyond the scope of what's on screen right now.
-    const [allSelected, setAllSelected] = useState<boolean>(false)
+    // const [allSelected, setAllSelected] = useState<boolean>(false)
     // The overall amount of all changesets in the connection.
-    const [totalChangesetCount, setTotalChangesetCount] = useState<number>(0)
+    // const [totalChangesetCount, setTotalChangesetCount] = useState<number>(0)
     // All changesets that are currently in view and can be selected. That currently
     // just means they are visible.
-    const [availableChangesets, setAvailableChangesets] = useState<Set<Scalars['ID']>>(new Set())
+    // const [availableChangesets, setAvailableChangesets] = useState<Set<Scalars['ID']>>(new Set())
     // The list of all selected changesets. This list does not reflect the selection
     // when `allSelected` is true.
-    const [selectedChangesets, setSelectedChangesets] = useState<Set<Scalars['ID']>>(new Set())
+    // const [selectedChangesets, setSelectedChangesets] = useState<Set<Scalars['ID']>>(new Set())
 
-    const onSelect = useCallback((id: string, selected: boolean): void => {
-        if (selected) {
-            setSelectedChangesets(previous => {
-                const newSet = new Set(previous).add(id)
-                return newSet
-            })
-            return
-        }
-        setSelectedChangesets(previous => {
-            const newSet = new Set(previous)
-            newSet.delete(id)
-            return newSet
-        })
-        setAllSelected(false)
-    }, [])
+    const onSelect = useCallback(
+        (id: string, isSelected: boolean): void => {
+            // If all items are currently selected, we'll treat a click on a single
+            // item as deselecting all, selecting visible, and then deselecting this
+            // item, since we can't easily represent "all except this".
+            if (selected === 'all') {
+                deselectAll()
+                selectVisible()
+                deselectSingle(id)
 
-    /**
-     * Whether the given changeset is currently selected. Returns always true, if `allSelected` is true.
-     */
-    const changesetSelected = useCallback((id: Scalars['ID']): boolean => allSelected || selectedChangesets.has(id), [
-        allSelected,
-        selectedChangesets,
-    ])
+                return
+            }
 
-    const deselectAll = useCallback((): void => {
-        setSelectedChangesets(new Set())
-        setAllSelected(false)
-    }, [setSelectedChangesets])
+            if (isSelected) {
+                selectSingle(id)
+            } else {
+                deselectSingle(id)
+            }
+        },
+        [deselectAll, deselectSingle, selectSingle, selectVisible, selected]
+    )
 
-    const selectAll = useCallback((): void => {
-        setSelectedChangesets(availableChangesets)
-    }, [availableChangesets, setSelectedChangesets])
-
-    // True when all in the current list are selected. It ticks the header row
-    // checkbox when true.
-    const allSelectedCheckboxChecked = allSelected || selectedChangesets.size === availableChangesets.size
-
-    const toggleSelectAll = useCallback((): void => {
-        if (allSelectedCheckboxChecked) {
-            deselectAll()
+    const toggleSelectVisible = useCallback(() => {
+        if (areAllVisibleSelected()) {
+            deselectVisible()
         } else {
-            selectAll()
+            selectVisible()
         }
-    }, [allSelectedCheckboxChecked, selectAll, deselectAll])
-
-    const onSelectAll = useCallback(() => {
-        setAllSelected(true)
-    }, [])
+    }, [areAllVisibleSelected, deselectAll, selectVisible])
 
     const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
         checkState: null,
@@ -167,25 +168,25 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                         setQueryArguments(passedArguments)
                         // Available changesets are all changesets that the user
                         // can view.
-                        setAvailableChangesets(
-                            new Set(
-                                data.nodes.filter(node => node.__typename === 'ExternalChangeset').map(node => node.id)
-                            )
+                        setVisible(
+                            data.nodes.filter(node => node.__typename === 'ExternalChangeset').map(node => node.id)
                         )
                         // Remember the totalCount.
-                        setTotalChangesetCount(data.totalCount)
+                        setTotalCount(data.totalCount)
                     })
                 )
                 .pipe(repeatWhen(notifier => notifier.pipe(delay(5000))))
         },
         [
-            batchChangeID,
             changesetFilters.state,
             changesetFilters.reviewState,
             changesetFilters.checkState,
             changesetFilters.search,
-            queryChangesets,
+            batchChangeID,
             onlyArchived,
+            queryChangesets,
+            setVisible,
+            setTotalCount,
         ]
     )
 
@@ -243,7 +244,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
         componentRerenders.next()
     }, [componentRerenders, hoverState])
 
-    const showSelectRow = viewerCanAdminister && selectedChangesets.size > 0
+    const showSelectRow = viewerCanAdminister && (selected === 'all' || selected.size > 0)
 
     return (
         <Container>
@@ -257,12 +258,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
             {showSelectRow && queryArguments && (
                 <ChangesetSelectRow
                     batchChangeID={batchChangeID}
-                    selected={selectedChangesets}
                     onSubmit={deselectAll}
-                    totalCount={totalChangesetCount}
-                    allVisibleSelected={allSelectedCheckboxChecked}
-                    allSelected={allSelected}
-                    setAllSelected={onSelectAll}
                     queryArguments={queryArguments}
                 />
             )}
@@ -277,7 +273,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                         extensionInfo: { extensionsController, hoverifier },
                         expandByDefault,
                         queryExternalChangesetWithFileDiffs,
-                        selectable: { onSelect, isSelected: changesetSelected },
+                        selectable: { onSelect, isSelected },
                     }}
                     queryConnection={queryChangesetsConnection}
                     hideSearch={true}
@@ -292,8 +288,8 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                     className="filtered-connection__centered-summary"
                     headComponent={BatchChangeChangesetsHeader}
                     headComponentProps={{
-                        allSelected: allSelectedCheckboxChecked,
-                        toggleSelectAll,
+                        allSelected: areAllVisibleSelected(),
+                        toggleSelectAll: toggleSelectVisible,
                         disabled: !viewerCanAdminister,
                     }}
                     // Only show the empty element, if no filters are selected.

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -77,50 +77,33 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
     expandByDefault,
     onlyArchived,
 }) => {
+    // You might look at this destructuring statement and wonder why this isn't
+    // just a single context consumer object. The reason is because making it a
+    // single object makes it hard to have hooks that depend on individual
+    // callbacks and objects within the context. Therefore, we'll have a nice,
+    // ugly destructured set of variables here.
     const {
         selected,
         deselectAll,
         deselectSingle,
+        deselectVisible,
         areAllVisibleSelected,
         isSelected,
-        selectAll,
         selectSingle,
         selectVisible,
         setTotalCount,
         setVisible,
     } = useContext(MultiSelectContext)
 
-    // Whether all the changesets are selected, beyond the scope of what's on screen right now.
-    // const [allSelected, setAllSelected] = useState<boolean>(false)
-    // The overall amount of all changesets in the connection.
-    // const [totalChangesetCount, setTotalChangesetCount] = useState<number>(0)
-    // All changesets that are currently in view and can be selected. That currently
-    // just means they are visible.
-    // const [availableChangesets, setAvailableChangesets] = useState<Set<Scalars['ID']>>(new Set())
-    // The list of all selected changesets. This list does not reflect the selection
-    // when `allSelected` is true.
-    // const [selectedChangesets, setSelectedChangesets] = useState<Set<Scalars['ID']>>(new Set())
-
     const onSelect = useCallback(
         (id: string, isSelected: boolean): void => {
-            // If all items are currently selected, we'll treat a click on a single
-            // item as deselecting all, selecting visible, and then deselecting this
-            // item, since we can't easily represent "all except this".
-            if (selected === 'all') {
-                deselectAll()
-                selectVisible()
-                deselectSingle(id)
-
-                return
-            }
-
             if (isSelected) {
                 selectSingle(id)
             } else {
                 deselectSingle(id)
             }
         },
-        [deselectAll, deselectSingle, selectSingle, selectVisible, selected]
+        [deselectSingle, selectSingle]
     )
 
     const toggleSelectVisible = useCallback(() => {
@@ -129,7 +112,7 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
         } else {
             selectVisible()
         }
-    }, [areAllVisibleSelected, deselectAll, selectVisible])
+    }, [areAllVisibleSelected, deselectVisible, selectVisible])
 
     const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
         checkState: null,

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 
 import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+import { MultiSelectContextProvider } from '../../MultiSelectContext'
 
 import { ChangesetSelectRow } from './ChangesetSelectRow'
 
@@ -15,126 +16,108 @@ add('all states', () => (
     <EnterpriseWebStory>
         {props => (
             <>
-                <ChangesetSelectRow
-                    {...props}
-                    onSubmit={onSubmit}
-                    selected={new Set(['id-1', 'id-2'])}
-                    allSelected={false}
-                    batchChangeID="test-123"
-                    allVisibleSelected={false}
-                    setAllSelected={() => undefined}
-                    totalCount={100}
-                    queryArguments={{
-                        batchChange: 'test-123',
-                        checkState: null,
-                        onlyArchived: null,
-                        onlyPublishedByThisBatchChange: null,
-                        reviewState: null,
-                        search: null,
-                        state: null,
-                    }}
-                />
+                <MultiSelectContextProvider
+                    initialSelected={[]}
+                    initialVisible={['id-1', 'id-2']}
+                    initialTotalCount={100}
+                >
+                    <ChangesetSelectRow
+                        {...props}
+                        onSubmit={onSubmit}
+                        batchChangeID="test-123"
+                        queryArguments={{
+                            batchChange: 'test-123',
+                            checkState: null,
+                            onlyArchived: null,
+                            onlyPublishedByThisBatchChange: null,
+                            reviewState: null,
+                            search: null,
+                            state: null,
+                        }}
+                    />
+                </MultiSelectContextProvider>
                 <hr />
-                <ChangesetSelectRow
-                    {...props}
-                    onSubmit={onSubmit}
-                    selected={new Set(['id-1', 'id-2'])}
-                    allSelected={false}
-                    batchChangeID="test-123"
-                    allVisibleSelected={false}
-                    setAllSelected={() => undefined}
-                    totalCount={100}
-                    queryArguments={{
-                        batchChange: 'test-123',
-                        checkState: null,
-                        onlyArchived: null,
-                        onlyPublishedByThisBatchChange: null,
-                        reviewState: null,
-                        search: null,
-                        state: null,
-                    }}
-                />
+                <MultiSelectContextProvider
+                    initialSelected={['id-1', 'id-2']}
+                    initialVisible={['id-1', 'id-2']}
+                    initialTotalCount={100}
+                >
+                    <ChangesetSelectRow
+                        {...props}
+                        onSubmit={onSubmit}
+                        batchChangeID="test-123"
+                        queryArguments={{
+                            batchChange: 'test-123',
+                            checkState: null,
+                            onlyArchived: null,
+                            onlyPublishedByThisBatchChange: null,
+                            reviewState: null,
+                            search: null,
+                            state: null,
+                        }}
+                    />
+                </MultiSelectContextProvider>
                 <hr />
-                <ChangesetSelectRow
-                    {...props}
-                    onSubmit={onSubmit}
-                    selected={new Set(['id-1', 'id-2'])}
-                    allSelected={false}
-                    batchChangeID="test-123"
-                    allVisibleSelected={false}
-                    setAllSelected={() => undefined}
-                    totalCount={100}
-                    queryArguments={{
-                        batchChange: 'test-123',
-                        checkState: null,
-                        onlyArchived: null,
-                        onlyPublishedByThisBatchChange: null,
-                        reviewState: null,
-                        search: null,
-                        state: null,
-                    }}
-                />
+                {/* No total count, just to make sure that's handled. */}
+                <MultiSelectContextProvider initialSelected={['id-1', 'id-2']} initialVisible={['id-1', 'id-2']}>
+                    <ChangesetSelectRow
+                        {...props}
+                        onSubmit={onSubmit}
+                        batchChangeID="test-123"
+                        queryArguments={{
+                            batchChange: 'test-123',
+                            checkState: null,
+                            onlyArchived: null,
+                            onlyPublishedByThisBatchChange: null,
+                            reviewState: null,
+                            search: null,
+                            state: null,
+                        }}
+                    />
+                </MultiSelectContextProvider>
                 <hr />
-                <ChangesetSelectRow
-                    {...props}
-                    onSubmit={onSubmit}
-                    selected={new Set(['id-1', 'id-2'])}
-                    allSelected={false}
-                    batchChangeID="test-123"
-                    allVisibleSelected={true}
-                    setAllSelected={() => undefined}
-                    totalCount={100}
-                    queryArguments={{
-                        batchChange: 'test-123',
-                        checkState: null,
-                        onlyArchived: null,
-                        onlyPublishedByThisBatchChange: null,
-                        reviewState: null,
-                        search: null,
-                        state: null,
-                    }}
-                />
+                <MultiSelectContextProvider
+                    initialSelected="all"
+                    initialVisible={['id-1', 'id-2']}
+                    initialTotalCount={100}
+                >
+                    <ChangesetSelectRow
+                        {...props}
+                        onSubmit={onSubmit}
+                        batchChangeID="test-123"
+                        queryArguments={{
+                            batchChange: 'test-123',
+                            checkState: null,
+                            onlyArchived: null,
+                            onlyPublishedByThisBatchChange: null,
+                            reviewState: null,
+                            search: null,
+                            state: null,
+                        }}
+                    />
+                </MultiSelectContextProvider>
                 <hr />
-                <ChangesetSelectRow
-                    {...props}
-                    onSubmit={onSubmit}
-                    selected={new Set(['id-1', 'id-2'])}
-                    allSelected={true}
-                    batchChangeID="test-123"
-                    allVisibleSelected={true}
-                    setAllSelected={() => undefined}
-                    totalCount={100}
-                    queryArguments={{
-                        batchChange: 'test-123',
-                        checkState: null,
-                        onlyArchived: null,
-                        onlyPublishedByThisBatchChange: null,
-                        reviewState: null,
-                        search: null,
-                        state: null,
-                    }}
-                />
-                <hr />
-                <ChangesetSelectRow
-                    {...props}
-                    onSubmit={onSubmit}
-                    selected={new Set(['id-1', 'id-2'])}
-                    allSelected={false}
-                    batchChangeID="test-123"
-                    allVisibleSelected={false}
-                    setAllSelected={() => undefined}
-                    totalCount={100}
-                    queryArguments={{
-                        batchChange: 'test-123',
-                        checkState: null,
-                        onlyArchived: true,
-                        onlyPublishedByThisBatchChange: null,
-                        reviewState: null,
-                        search: null,
-                        state: null,
-                    }}
-                    dropDownInitiallyOpen={true}
-                />
+                <MultiSelectContextProvider
+                    initialSelected={['id-1', 'id-2']}
+                    initialVisible={['id-1', 'id-2']}
+                    initialTotalCount={100}
+                >
+                    <ChangesetSelectRow
+                        {...props}
+                        onSubmit={onSubmit}
+                        batchChangeID="test-123"
+                        queryArguments={{
+                            batchChange: 'test-123',
+                            checkState: null,
+                            onlyArchived: true,
+                            onlyPublishedByThisBatchChange: null,
+                            reviewState: null,
+                            search: null,
+                            state: null,
+                        }}
+                        dropDownInitiallyOpen={true}
+                    />
+                </MultiSelectContextProvider>
             </>
         )}
     </EnterpriseWebStory>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -191,9 +191,6 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
         [batchChangeID, onSubmit, queryArguments, selected]
     )
 
-    // If we have ALL all selected, we take the totalCount in the current connection, otherwise the count of selected changeset IDs.
-    const selectedAmount = selected === 'all' ? totalCount : selected.size
-
     return (
         <>
             <div className="row align-items-center no-gutters">

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -1,5 +1,5 @@
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
-import React, { useMemo } from 'react'
+import React, { useMemo, useContext } from 'react'
 
 import { ChangesetState } from '@sourcegraph/shared/src/graphql-operations'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
@@ -7,6 +7,7 @@ import { pluralize } from '@sourcegraph/shared/src/util/strings'
 import { AllChangesetIDsVariables, Scalars } from '../../../../graphql-operations'
 import { eventLogger } from '../../../../tracking/eventLogger'
 import { Action, DropdownButton } from '../../DropdownButton'
+import { MultiSelectContext } from '../../MultiSelectContext'
 import { queryAllChangesetIDs } from '../backend'
 
 import { CloseChangesetsModal } from './CloseChangesetsModal'
@@ -136,13 +137,8 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
 ]
 
 export interface ChangesetSelectRowProps {
-    selected: Set<Scalars['ID']>
     batchChangeID: Scalars['ID']
     onSubmit: () => void
-    allVisibleSelected: boolean
-    totalCount: number
-    allSelected: boolean
-    setAllSelected: () => void
     queryArguments: Omit<AllChangesetIDsVariables, 'after'>
 
     /** For testing only. */
@@ -154,16 +150,13 @@ export interface ChangesetSelectRowProps {
  * label. Provides select ALL functionality.
  */
 export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps> = ({
-    selected,
     batchChangeID,
     onSubmit,
-    allVisibleSelected,
-    totalCount,
-    allSelected,
-    setAllSelected,
     queryArguments,
     dropDownInitiallyOpen = false,
 }) => {
+    const { areAllVisibleSelected, selected, selectAll, totalCount } = useContext(MultiSelectContext)
+
     const actions = useMemo(
         () =>
             AVAILABLE_ACTIONS.filter(action => action.isAvailable(queryArguments)).map(action => {
@@ -173,7 +166,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                         // Depending on the selection, we need to construct a loader function for
                         // the changeset IDs.
                         let ids: () => Promise<Scalars['ID'][]>
-                        if (allSelected) {
+                        if (selected === 'all') {
                             // We asynchronously fetch all the IDs for ALL all.
                             ids = () => queryAllChangesetIDs(queryArguments).toPromise()
                         } else {
@@ -195,23 +188,29 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
 
                 return dropdownAction
             }),
-        [allSelected, batchChangeID, onSubmit, queryArguments, selected]
+        [batchChangeID, onSubmit, queryArguments, selected]
     )
 
     // If we have ALL all selected, we take the totalCount in the current connection, otherwise the count of selected changeset IDs.
-    const selectedAmount = allSelected ? totalCount : selected.size
+    const selectedAmount = selected === 'all' ? totalCount : selected.size
 
     return (
         <>
             <div className="row align-items-center no-gutters">
                 <div className="ml-2 col d-flex align-items-center">
                     <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
-                    {selectedAmount} {pluralize('changeset', selectedAmount)} selected
-                    {allVisibleSelected && totalCount > selectedAmount && (
-                        <button type="button" className="btn btn-link py-0 px-1" onClick={setAllSelected}>
-                            (Select all {totalCount})
-                        </button>
+                    {selected === 'all' ? (
+                        <AllSelectedLabel count={totalCount} />
+                    ) : (
+                        `${selected.size} ${pluralize('changeset', selected.size)}`
                     )}
+                    {selected !== 'all' &&
+                        areAllVisibleSelected() &&
+                        (totalCount === undefined ? true : totalCount > selected.size) && (
+                            <button type="button" className="btn btn-link py-0 px-1" onClick={selectAll}>
+                                (Select all {totalCount})
+                            </button>
+                        )}
                 </div>
                 <div className="w-100 d-block d-md-none" />
                 <div className="m-0 col col-md-auto">
@@ -227,6 +226,18 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                     </div>
                 </div>
             </div>
+        </>
+    )
+}
+
+const AllSelectedLabel: React.FunctionComponent<{ count?: number }> = ({ count }) => {
+    if (count === undefined) {
+        return <>All changesets selected</>
+    }
+
+    return (
+        <>
+            All {count} {pluralize('changeset', count)} selected
         </>
     )
 }

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -205,7 +205,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                         areAllVisibleSelected() &&
                         (totalCount === undefined ? true : totalCount > selected.size) && (
                             <button type="button" className="btn btn-link py-0 px-1" onClick={selectAll}>
-                                (Select all {totalCount})
+                                (Select all{totalCount !== undefined && ` ${totalCount}`})
                             </button>
                         )}
                 </div>


### PR DESCRIPTION
This PR adds a React context that manages selection state across a paginated list of... well, whatevers, as long as they're identified by a string ID. (I briefly flirted with making it generic, but, uh, generic context providers and React are not best friends.)

I've ported `BatchChangeChangesets` and friends to use it, and it seems OK. Most importantly, we can now reuse it on the preview page and get the same behaviour.