### PR TITLE
repo-updater: Remove redundant repo lookup call-sites

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -92,15 +92,13 @@ func (r *repositoryMirrorInfoResolver) RemoteURL(ctx context.Context) (string, e
 	}
 
 	{
-		// Look up the remote URL in repo-updater.
-		result, err := repoupdater.DefaultClient.RepoLookup(ctx, repoupdaterprotocol.RepoLookupArgs{
-			Repo: r.repository.RepoName(),
-		})
+		repo, err := r.repository.repo(ctx)
 		if err != nil {
 			return "", err
 		}
-		if result.Repo != nil {
-			return removeUserinfo(result.Repo.VCS.URL), nil
+
+		if cloneURLs := repo.CloneURLs(); len(cloneURLs) > 0 {
+			return removeUserinfo(cloneURLs[0]), nil
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/repository_mirror_test.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -187,15 +186,12 @@ func TestCheckMirrorRepositoryRemoteURL(t *testing.T) {
 			}
 
 			backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
-				return &types.Repo{Name: repoName}, nil
-			}
-
-			repoupdater.MockRepoLookup = func(args protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error) {
-				return &protocol.RepoLookupResult{
-					Repo: &protocol.RepoInfo{Name: repoName, VCS: protocol.VCSInfo{URL: tc.repoURL}},
+				return &types.Repo{
+					Name:      repoName,
+					CreatedAt: time.Now(),
+					Sources:   map[string]*types.SourceInfo{"1": {CloneURL: tc.repoURL}},
 				}, nil
 			}
-			defer func() { repoupdater.MockRepoLookup = nil }()
 
 			RunTests(t, []*Test{
 				{


### PR DESCRIPTION
This fixes the 404s on the settings pages of private repos as a side effect of not calling repo lookup anymore where it's not needed. 

Part of #23676.

Fixes https://sourcegraph.atlassian.net/browse/COREAPP-195

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
