### PR TITLE
secrets: Redact GitCredentials/password in AWSCODECOMMIT config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Alertmanager (Prometheus) now respects `SMTPServerConfig.noVerifyTLS` field. [#23636](https://github.com/sourcegraph/sourcegraph/issues/23636)
 - Clicking on symbols in the left search pane now renders hover tooltips for indexed repositories. [#23664](https://github.com/sourcegraph/sourcegraph/pull/23664)
 - Fixed a result streaming throttling issue that was causing significantly increased latency for some searches. [#23736](https://github.com/sourcegraph/sourcegraph/pull/23736)
+- GitCredentials passwords stored in AWS CodeCommit configuration is now redacted. [#23832](https://github.com/sourcegraph/sourcegraph/pull/23832)
 
 ### Removed
 

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -228,12 +228,14 @@ func (e *ExternalServiceStore) ValidateConfig(ctx context.Context, opt ValidateE
 		return nil, errors.Wrapf(err, "unable to normalize JSON")
 	}
 
-	// Check for any redacted secrets, in graphqlbackend/external_service.go:externalServiceByID() we call
-	// svc.RedactConfigSecrets() replacing any secret fields in the JSON with types.RedactedSecret, this is to
-	// prevent us leaking tokens that users add. Here we check that the config we've been passed doesn't
-	// contain any redacted secrets in order to avoid breaking configs by writing the redacted version to
-	// the database. we should have called svc.UnredactConfig(oldSvc) before this point, eg in the Update
-	// method of the ExternalServiceStore. talk to @arussellsaw or the cloud team if you have any questions
+	// Check for any redacted secrets, in
+	// graphqlbackend/external_service.go:externalServiceByID() we call
+	// svc.RedactConfigSecrets() replacing any secret fields in the JSON with
+	// types.RedactedSecret, this is to prevent us leaking tokens that users add.
+	// Here we check that the config we've been passed doesn't contain any redacted
+	// secrets in order to avoid breaking configs by writing the redacted version to
+	// the database. we should have called svc.UnredactConfig(oldSvc) before this
+	// point, e.g. in the Update method of the ExternalServiceStore.
 	if bytes.Contains(normalized, []byte(types.RedactedSecret)) {
 		return nil, errors.Errorf(
 			"unable to write external service config as it contains redacted fields, this is likely a bug rather than a problem with your config",

--- a/internal/jsonc/jsonc.go
+++ b/internal/jsonc/jsonc.go
@@ -74,9 +74,9 @@ func Edit(input string, v interface{}, path ...string) (string, error) {
 
 // ReadProperty attempts to read the value of the specified path, ignoring parse errors. it will only error if the path
 // doesn't exist
-func ReadProperty(input, path string) (interface{}, error) {
+func ReadProperty(input string, path ...string) (interface{}, error) {
 	root, _ := jsonx.ParseTree(input, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
-	node := jsonx.FindNodeAtLocation(root, jsonx.PropertyPath(path))
+	node := jsonx.FindNodeAtLocation(root, jsonx.PropertyPath(path...))
 	if node == nil {
 		return nil, errors.Errorf("couldn't find node: %s", path)
 	}

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -1,12 +1,15 @@
 /*
-	The functions in this file are used to redact secrets from ExternalServices in transit, eg when written back and
-	forth between the client and API, as we don't want to leak an access token once it's been configured. Any config
-	written back from the client with a redacted token should then be updated with the real token from the database,
-	the validation in the ExternalService DB methods will check for this field and throw an error if it's not been
-	replaced, to prevent us accidentally blanking tokens in the DB.
-	This is risky, hacky, and ugly, and we fully intend to replace it ASAP, once our Vault tooling is ready we will
-	migrate external services into their own tables for each kind, and encrypt secrets using Vault's KMS.
-	if you wanna speak to someone about this talk to @arussellsaw or the Cloud team.
+	The functions in this file are used to redact secrets from ExternalServices in
+	transit, eg when written back and forth between the client and API, as we don't
+	want to leak an access token once it's been configured. Any config written back
+	from the client with a redacted token should then be updated with the real token
+	from the database, the validation in the ExternalService DB methods will check
+	for this field and throw an error if it's not been replaced, to prevent us
+	accidentally blanking tokens in the DB.
+
+	This is risky, hacky, and ugly, and we fully intend to replace it ASAP, once our
+	Vault tooling is ready we will migrate external services into their own tables
+	for each kind, and encrypt secrets using Vault's KMS.
 */
 
 package types
@@ -15,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
-
 	"github.com/fatih/structs"
 	jsoniter "github.com/json-iterator/go"
 
@@ -42,32 +44,32 @@ func (e *ExternalService) RedactConfigSecrets() error {
 	}
 	switch cfg := cfg.(type) {
 	case *schema.GitHubConnection:
-		newCfg, err = redactField(e.Config, "token")
+		newCfg, err = redactField(e.Config, []string{"token"})
 	case *schema.GitLabConnection:
-		newCfg, err = redactField(e.Config, "token")
+		newCfg, err = redactField(e.Config, []string{"token"})
 	case *schema.BitbucketServerConnection:
 		// BitbucketServer can have a token OR password
-		var fields []string
+		var fields [][]string
 		if cfg.Password != "" {
-			fields = append(fields, "password")
+			fields = append(fields, []string{"password"})
 		}
 		if cfg.Token != "" {
-			fields = append(fields, "token")
+			fields = append(fields, []string{"token"})
 		}
 		newCfg, err = redactField(e.Config, fields...)
 	case *schema.BitbucketCloudConnection:
-		newCfg, err = redactField(e.Config, "appPassword")
+		newCfg, err = redactField(e.Config, []string{"appPassword"})
 	case *schema.AWSCodeCommitConnection:
-		newCfg, err = redactField(e.Config, "secretAccessKey")
+		newCfg, err = redactField(e.Config, []string{"secretAccessKey"}, []string{"gitCredentials", "password"})
 	case *schema.PhabricatorConnection:
-		newCfg, err = redactField(e.Config, "token")
+		newCfg, err = redactField(e.Config, []string{"token"})
 	case *schema.PerforceConnection:
-		newCfg, err = redactField(e.Config, "p4.passwd")
+		newCfg, err = redactField(e.Config, []string{"p4.passwd"})
 	case *schema.GitoliteConnection:
 		// Gitolite has no secret fields
 		newCfg, err = redactField(e.Config)
 	case *schema.OtherExternalServiceConnection:
-		newCfg, err = redactField(e.Config, "url")
+		newCfg, err = redactField(e.Config, []string{"url"})
 	case *schema.JVMPackagesConnection:
 		newCfg, err = e.Config, nil
 	default:
@@ -84,10 +86,10 @@ func (e *ExternalService) RedactConfigSecrets() error {
 // redactField will unmarshal the passed JSON string into the passed value, and then replace the pointer fields you pass
 // with RedactedSecret, see RedactExternalServiceConfig for usage examples.
 // who needs generics anyway?
-func redactField(buf string, fields ...string) (string, error) {
+func redactField(buf string, paths ...[]string) (string, error) {
 	var err error
-	for _, field := range fields {
-		buf, err = jsonc.Edit(buf, RedactedSecret, field)
+	for _, path := range paths {
+		buf, err = jsonc.Edit(buf, RedactedSecret, path...)
 		if err != nil {
 			return buf, err
 		}
@@ -119,32 +121,37 @@ func (e *ExternalService) UnredactConfig(old *ExternalService) error {
 	}
 	switch cfg := cfg.(type) {
 	case *schema.GitHubConnection:
-		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"token", &cfg.Token})
+		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{[]string{"token"}, &cfg.Token})
 	case *schema.GitLabConnection:
-		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"token", &cfg.Token})
+		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{[]string{"token"}, &cfg.Token})
 	case *schema.BitbucketServerConnection:
 		// BitbucketServer can have a token OR password
 		var fields []jsonStringField
 		if cfg.Password != "" {
-			fields = append(fields, jsonStringField{"password", &cfg.Password})
+			fields = append(fields, jsonStringField{[]string{"password"}, &cfg.Password})
 		}
 		if cfg.Token != "" {
-			fields = append(fields, jsonStringField{"token", &cfg.Token})
+			fields = append(fields, jsonStringField{[]string{"token"}, &cfg.Token})
 		}
 		unredacted, err = unredactField(old.Config, e.Config, &cfg, fields...)
 	case *schema.BitbucketCloudConnection:
-		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"appPassword", &cfg.AppPassword})
+		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{[]string{"appPassword"}, &cfg.AppPassword})
 	case *schema.AWSCodeCommitConnection:
-		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"secretAccessKey", &cfg.SecretAccessKey})
+		unredacted, err = unredactField(old.Config,
+			e.Config,
+			&cfg,
+			jsonStringField{[]string{"secretAccessKey"}, &cfg.SecretAccessKey},
+			jsonStringField{[]string{"gitCredentials", "password"}, &cfg.GitCredentials.Password},
+		)
 	case *schema.PhabricatorConnection:
-		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"token", &cfg.Token})
+		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{[]string{"token"}, &cfg.Token})
 	case *schema.PerforceConnection:
-		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"p4.passwd", &cfg.P4Passwd})
+		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{[]string{"p4.passwd"}, &cfg.P4Passwd})
 	case *schema.GitoliteConnection:
 		// no secret fields?
 		unredacted, err = unredactField(old.Config, e.Config, &cfg)
 	case *schema.OtherExternalServiceConnection:
-		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"url", &cfg.Url})
+		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{[]string{"url"}, &cfg.Url})
 	case *schema.JVMPackagesConnection:
 		unredacted, err = e.Config, nil
 	default:
@@ -159,7 +166,7 @@ func (e *ExternalService) UnredactConfig(old *ExternalService) error {
 }
 
 type jsonStringField struct {
-	path string
+	path []string
 	ptr  *string
 }
 
@@ -176,7 +183,7 @@ func unredactField(old, new string, cfg interface{}, fields ...jsonStringField) 
 	// and apply edits to update those fields in the new config
 	var err error
 	for _, field := range fields {
-		v, err := jsonc.ReadProperty(new, field.path)
+		v, err := jsonc.ReadProperty(new, field.path...)
 		if err != nil {
 			return new, err
 		}
@@ -186,14 +193,14 @@ func unredactField(old, new string, cfg interface{}, fields ...jsonStringField) 
 		}
 		if stringValue != RedactedSecret {
 			// using unicode zero width space might mean the user includes it when editing still, we strip that out here
-			new, err = jsonc.Edit(new, strings.ReplaceAll(stringValue, RedactedSecret, ""), field.path)
+			new, err = jsonc.Edit(new, strings.ReplaceAll(stringValue, RedactedSecret, ""), field.path...)
 			if err != nil {
 				return new, err
 			}
 			// if the field has been edited we should skip unredaction to allow edits
 			continue
 		}
-		new, err = jsonc.Edit(new, *field.ptr, field.path)
+		new, err = jsonc.Edit(new, *field.ptr, field.path...)
 		if err != nil {
 			return new, err
 		}

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -1,16 +1,10 @@
-/*
-	The functions in this file are used to redact secrets from ExternalServices in
-	transit, eg when written back and forth between the client and API, as we don't
-	want to leak an access token once it's been configured. Any config written back
-	from the client with a redacted token should then be updated with the real token
-	from the database, the validation in the ExternalService DB methods will check
-	for this field and throw an error if it's not been replaced, to prevent us
-	accidentally blanking tokens in the DB.
-
-	This is risky, hacky, and ugly, and we fully intend to replace it ASAP, once our
-	Vault tooling is ready we will migrate external services into their own tables
-	for each kind, and encrypt secrets using Vault's KMS.
-*/
+// The functions in this file are used to redact secrets from ExternalServices in
+// transit, eg when written back and forth between the client and API, as we
+// don't want to leak an access token once it's been configured. Any config
+// written back from the client with a redacted token should then be updated with
+// the real token from the database, the validation in the ExternalService DB
+// methods will check for this field and throw an error if it's not been
+// replaced, to prevent us accidentally blanking tokens in the DB.
 
 package types
 

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -35,6 +35,10 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 	awsCodeCommitConfig := schema.AWSCodeCommitConnection{
 		SecretAccessKey: someSecret,
 		Region:          "us-east-9000z",
+		GitCredentials: schema.AWSCodeCommitGitCredentials{
+			Username: "username",
+			Password: "password",
+		},
 	}
 	phabricatorConfig := schema.PhabricatorConnection{
 		Token: someSecret,
@@ -93,6 +97,12 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 			config:      &awsCodeCommitConfig,
 			editField:   &awsCodeCommitConfig.Region,
 			secretField: &awsCodeCommitConfig.SecretAccessKey,
+		},
+		{
+			kind:        extsvc.KindAWSCodeCommit,
+			config:      &awsCodeCommitConfig,
+			editField:   &awsCodeCommitConfig.Region,
+			secretField: &awsCodeCommitConfig.GitCredentials.Password,
 		},
 		{
 			kind:        extsvc.KindPhabricator,


### PR DESCRIPTION
Previously we were only redacting the secret key.

This change also alters our redaction code so that we can deal with keys
that are more than one level deep and updates some comments.

Fixes: https://github.com/sourcegraph/customer/issues/453
