### PR TITLE
perforce: support 'git p4 --use-client-spec' passthrough

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -136,7 +136,8 @@ func main() {
 				}
 
 				return &server.PerforceDepotSyncer{
-					MaxChanges: int(c.MaxChanges),
+					MaxChanges:    int(c.MaxChanges),
+					UseClientSpec: c.UseClientSpec,
 				}, nil
 			case extsvc.TypeJVMPackages:
 				var c schema.JVMPackagesConnection

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -34,6 +34,11 @@
       "default": 1000,
       "minimum": 1
     },
+    "useClientSpec": {
+      "description": "Use a client spec to find the list of interesting files in p4 (git p4 clone --max-changes).",
+      "type": "boolean",
+      "default": false
+    },
     "rateLimit": {
       "description": "Rate limit applied when making background API requests to Perforce.",
       "title": "PerforceRateLimit",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1135,6 +1135,8 @@ type PerforceConnection struct {
 	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.
 	RepositoryPathPattern string `json:"repositoryPathPattern,omitempty"`
+	// UseClientSpec description: Use a client spec to find the list of interesting files in p4 (git p4 clone --max-changes).
+	UseClientSpec bool `json:"useClientSpec,omitempty"`
 }
 
 // PerforceRateLimit description: Rate limit applied when making background API requests to Perforce.


### PR DESCRIPTION
Support passthrough of [`git p4`'s `--use-client-spec` option](https://git-scm.com/docs/git-p4/2.9.5#Documentation/git-p4.txt---use-client-spec)

To be frank I'm not entirely 100% sure what this does after reading [the p4 docs](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_client.html#Description_..884) a few times, but from the docs above it seems `git p4` only supports a subset of that functionality and if we support `git p4`... this should be fine? It's also an opt-in feature so can be used at one's own risk.

This is apparently a [highly requested feature](https://sourcegraph.slack.com/archives/C01Q57DU4TX/p1628766016086900?thread_ts=1628765312.085800&cid=C01Q57DU4TX). More specifically, closes https://github.com/sourcegraph/customer/issues/445

Hopefully, someone more knowledgeable can correct me if I'm wrong! Not sure if there's any tests worth adding here either

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
