### PR TITLE
dotcom: Hide organizations in public cloud

### DIFF
--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -1,4 +1,5 @@
 import AddIcon from 'mdi-react/AddIcon'
+import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import * as React from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
 
@@ -82,9 +83,15 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                     ))}
                     {!siteAdminViewingOtherUser && (
                         <div className="user-settings-sidebar__new-org-btn-wrapper">
-                            <Link to="/organizations/new" className="btn btn-outline-secondary btn-sm">
-                                <AddIcon className="icon-inline" /> New organization
-                            </Link>
+                            {!window.context.sourcegraphDotComMode ? (
+                                <Link to="/organizations/new" className="btn btn-outline-secondary btn-sm">
+                                    <AddIcon className="icon-inline" /> New organization
+                                </Link>
+                            ) : (
+                                <a href="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud" target="_blank" rel="noopener">
+                                    Learn More <ExternalLinkIcon className="icon-inline" />
+                                </a>
+                            )}
                         </div>
                     )}
                 </SidebarGroup>

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -88,7 +88,11 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                                     <AddIcon className="icon-inline" /> New organization
                                 </Link>
                             ) : (
-                                <a href="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud" target="_blank" rel="noopener">
+                                <a
+                                    href="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud"
+                                    target="_blank"
+                                    rel="noopener"
+                                >
                                     Learn More <ExternalLinkIcon className="icon-inline" />
                                 </a>
                             )}

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -91,7 +91,7 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                                 <a
                                     href="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud"
                                     target="_blank"
-                                    rel="noopener"
+                                    rel="noopener noreferrer"
                                 >
                                     Learn More <ExternalLinkIcon className="icon-inline" />
                                 </a>

--- a/doc/code_search/explanations/sourcegraph_cloud.md
+++ b/doc/code_search/explanations/sourcegraph_cloud.md
@@ -4,6 +4,8 @@
 
 Note that you can search across a maximum of 50 repositories at once using Sourcegraph Cloud. To search across more than 50 repositories at once or to search your organization's internal code, [run your own Sourcegraph instance](../../../admin/install/index.md).
 
+Note that **Organizations** feature is disabled in Sourcegraph Cloud. If you want to use it, you also need to [run your own Sourcegraph instance](../../../admin/install/index.md).
+
 ## Search contexts
 
 >NOTE: This feature is still in active development.


### PR DESCRIPTION
This feature was confusing customers in public cloud. We have decided
to hide it in dotcom and instead show a link to the documentation.

Changing the behavior in sourcegraph.com from:
<img width="225" alt="Screenshot 2021-08-12 at 10 07 07" src="https://user-images.githubusercontent.com/9974711/129164561-d2a746ff-d715-4d21-a4b3-7977b8e6acd5.png">

to:
<img width="211" alt="Screenshot 2021-08-12 at 10 21 02" src="https://user-images.githubusercontent.com/9974711/129164583-710139f6-b5c6-4d3a-b7ca-94450c3207ff.png">


## TODO:
- [x] update docs
- [ ] update changelog?
- [ ] tests?
