### PR TITLE
search: Add revision sidebar section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- The search sidebar shows a revisions section if all search results are from a single repository. This makes it easier to search in and switch between different revisions. [#23835](https://github.com/sourcegraph/sourcegraph/pull/23835)
+
 ### Changed
 
 - `allowGroupsPermissionsSync` in the GitHub authorization provider is now required to enable the experimental GitHub teams and organization permissions caching. [#24561](https://github.com/sourcegraph/sourcegraph/pull/24561)

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -8,7 +8,7 @@ import { FetchFeatureFlagsResult } from '../graphql-operations'
 
 // A union of all feature flags we currently have.
 // If there are no feature flags at the moment, this should be `never`.
-export type FeatureFlagName = 'search-notebook-onboarding'
+export type FeatureFlagName = 'search-notebook-onboarding' | 'search-sidebar-revisions'
 
 export type FlagSet = Map<FeatureFlagName, boolean>
 

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -8,7 +8,7 @@ import { FetchFeatureFlagsResult } from '../graphql-operations'
 
 // A union of all feature flags we currently have.
 // If there are no feature flags at the moment, this should be `never`.
-export type FeatureFlagName = 'search-notebook-onboarding' | 'search-sidebar-revisions'
+export type FeatureFlagName = 'search-notebook-onboarding'
 
 export type FlagSet = Map<FeatureFlagName, boolean>
 

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -27,6 +27,7 @@ describe('Search onboarding', () => {
             SearchSidebarGitRefs: () => ({
                 repository: {
                     __typename: 'Repository',
+                    id: 'repo',
                     gitRefs: {
                         __typename: 'GitRefConnection',
                         nodes: [],

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -24,20 +24,6 @@ describe('Search onboarding', () => {
         })
         testContext.overrideGraphQL({
             ...commonWebGraphQlResults,
-            SearchSidebarGitRefs: () => ({
-                repository: {
-                    __typename: 'Repository',
-                    id: 'repo',
-                    gitRefs: {
-                        __typename: 'GitRefConnection',
-                        nodes: [],
-                        pageInfo: {
-                            hasNextPage: false,
-                        },
-                        totalCount: 0,
-                    },
-                },
-            }),
             SearchSuggestions: () => ({
                 search: {
                     suggestions: [{ __typename: 'Repository', name: '^github\\.com/sourcegraph/sourcegraph$' }],
@@ -76,6 +62,20 @@ describe('Search onboarding', () => {
                         },
                     ],
                     final: JSON.stringify({}),
+                },
+            }),
+            SearchSidebarGitRefs: () => ({
+                repository: {
+                    __typename: 'Repository',
+                    id: 'repo',
+                    gitRefs: {
+                        __typename: 'GitRefConnection',
+                        nodes: [],
+                        pageInfo: {
+                            hasNextPage: false,
+                        },
+                        totalCount: 0,
+                    },
                 },
             }),
         })

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -24,6 +24,19 @@ describe('Search onboarding', () => {
         })
         testContext.overrideGraphQL({
             ...commonWebGraphQlResults,
+            SearchSidebarGitRefs: () => ({
+                repository: {
+                    __typename: 'Repository',
+                    gitRefs: {
+                        __typename: 'GitRefConnection',
+                        nodes: [],
+                        pageInfo: {
+                            hasNextPage: false,
+                        },
+                        totalCount: 0,
+                    },
+                },
+            }),
             SearchSuggestions: () => ({
                 search: {
                     suggestions: [{ __typename: 'Repository', name: '^github\\.com/sourcegraph/sourcegraph$' }],

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -33,9 +33,17 @@ const mockDefaultStreamEvents: SearchEvent[] = [
         data: [
             { label: 'archived:yes', value: 'archived:yes', count: 5, kind: 'generic', limitHit: true },
             { label: 'fork:yes', value: 'fork:yes', count: 46, kind: 'generic', limitHit: true },
+            // Two repo filters to trigger the repository sidebar section
             {
                 label: 'github.com/Algorilla/manta-ray',
                 value: 'repo:^github\\.com/Algorilla/manta-ray$',
+                count: 1,
+                kind: 'repo',
+                limitHit: true,
+            },
+            {
+                label: 'github.com/Algorilla/manta-ray2',
+                value: 'repo:^github\\.com/Algorilla/manta-ray2$',
                 count: 1,
                 kind: 'repo',
                 limitHit: true,
@@ -54,20 +62,6 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
     }),
     RepoGroups: (): RepoGroupsResult => ({
         repoGroups: [],
-    }),
-    SearchSidebarGitRefs: () => ({
-        repository: {
-            __typename: 'Repository',
-            id: 'repo',
-            gitRefs: {
-                __typename: 'GitRefConnection',
-                nodes: [],
-                pageInfo: {
-                    hasNextPage: false,
-                },
-                totalCount: 0,
-            },
-        },
     }),
 }
 

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -531,6 +531,12 @@ describe('Search', () => {
                     ) !== null
             )
 
+        beforeEach(() => {
+            testContext.overrideGraphQL({
+                ...commonSearchGraphQLResults,
+            })
+        })
+
         test('Do not show create code monitor button feature tour with missing search type', async () => {
             testContext.overrideSearchStreamEvents(mockDefaultStreamEvents)
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test', {

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -55,6 +55,20 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
     RepoGroups: (): RepoGroupsResult => ({
         repoGroups: [],
     }),
+    SearchSidebarGitRefs: () => ({
+        repository: {
+            __typename: 'Repository',
+            id: 'repo',
+            gitRefs: {
+                __typename: 'GitRefConnection',
+                nodes: [],
+                pageInfo: {
+                    hasNextPage: false,
+                },
+                totalCount: 0,
+            },
+        },
+    }),
 }
 
 describe('Search', () => {

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -11,6 +11,7 @@ import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     extensionsController,
@@ -74,15 +75,17 @@ describe('StreamingSearchResults', () => {
 
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults
-                    {...defaultProps}
-                    parsedSearchQuery="r:golang/oauth2 test f:travis"
-                    patternType={SearchPatternType.regexp}
-                    caseSensitive={true}
-                    versionContext="test"
-                    streamSearch={searchSpy}
-                    availableVersionContexts={[{ name: 'test', revisions: [] }]}
-                />
+                <MockedTestProvider>
+                    <StreamingSearchResults
+                        {...defaultProps}
+                        parsedSearchQuery="r:golang/oauth2 test f:travis"
+                        patternType={SearchPatternType.regexp}
+                        caseSensitive={true}
+                        versionContext="test"
+                        streamSearch={searchSpy}
+                        availableVersionContexts={[{ name: 'test', revisions: [] }]}
+                    />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -107,15 +110,17 @@ describe('StreamingSearchResults', () => {
 
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults
-                    {...defaultProps}
-                    parsedSearchQuery="r:golang/oauth2 test f:travis"
-                    patternType={SearchPatternType.regexp}
-                    caseSensitive={false}
-                    versionContext="test"
-                    streamSearch={searchSpy}
-                    availableVersionContexts={[{ name: 'something', revisions: [] }]}
-                />
+                <MockedTestProvider>
+                    <StreamingSearchResults
+                        {...defaultProps}
+                        parsedSearchQuery="r:golang/oauth2 test f:travis"
+                        patternType={SearchPatternType.regexp}
+                        caseSensitive={false}
+                        versionContext="test"
+                        streamSearch={searchSpy}
+                        availableVersionContexts={[{ name: 'something', revisions: [] }]}
+                    />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -135,7 +140,9 @@ describe('StreamingSearchResults', () => {
     it('should render progress with data from API', () => {
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -148,7 +155,9 @@ describe('StreamingSearchResults', () => {
     it('should expand and collapse results when event from infobar is triggered', () => {
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -182,16 +191,18 @@ describe('StreamingSearchResults', () => {
 
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults
-                    {...defaultProps}
-                    history={history}
-                    location={history.location}
-                    previousVersionContext={null}
-                    availableVersionContexts={[
-                        { name: 'test', revisions: [] },
-                        { name: 'other', revisions: [] },
-                    ]}
-                />
+                <MockedTestProvider>
+                    <StreamingSearchResults
+                        {...defaultProps}
+                        history={history}
+                        location={history.location}
+                        previousVersionContext={null}
+                        availableVersionContexts={[
+                            { name: 'test', revisions: [] },
+                            { name: 'other', revisions: [] },
+                        ]}
+                    />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -207,16 +218,18 @@ describe('StreamingSearchResults', () => {
 
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults
-                    {...defaultProps}
-                    history={history}
-                    location={history.location}
-                    previousVersionContext={null}
-                    availableVersionContexts={[
-                        { name: 'test', revisions: [] },
-                        { name: 'other', revisions: [] },
-                    ]}
-                />
+                <MockedTestProvider>
+                    <StreamingSearchResults
+                        {...defaultProps}
+                        history={history}
+                        location={history.location}
+                        previousVersionContext={null}
+                        availableVersionContexts={[
+                            { name: 'test', revisions: [] },
+                            { name: 'other', revisions: [] },
+                        ]}
+                    />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -233,7 +246,9 @@ describe('StreamingSearchResults', () => {
         }
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} streamSearch={() => of(results)} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} streamSearch={() => of(results)} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -257,7 +272,9 @@ describe('StreamingSearchResults', () => {
 
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -277,7 +294,9 @@ describe('StreamingSearchResults', () => {
 
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -292,7 +311,9 @@ describe('StreamingSearchResults', () => {
     it('should not show saved search modal on first load', () => {
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -303,7 +324,9 @@ describe('StreamingSearchResults', () => {
     it('should open saved search modal when triggering event from infobar', () => {
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -318,7 +341,9 @@ describe('StreamingSearchResults', () => {
     it('should close saved search modal if close event triggers', () => {
         const element = mount(
             <BrowserRouter>
-                <StreamingSearchResults {...defaultProps} />
+                <MockedTestProvider>
+                    <StreamingSearchResults {...defaultProps} />
+                </MockedTestProvider>
             </BrowserRouter>
         )
 
@@ -356,7 +381,9 @@ describe('StreamingSearchResults', () => {
         for (const [index, test] of tests.entries()) {
             const element = mount(
                 <BrowserRouter>
-                    <StreamingSearchResults {...defaultProps} parsedSearchQuery={test.parsedSearchQuery} />
+                    <MockedTestProvider>
+                        <StreamingSearchResults {...defaultProps} parsedSearchQuery={test.parsedSearchQuery} />
+                    </MockedTestProvider>
                 </BrowserRouter>
             )
 

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -11,8 +11,8 @@ import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
-import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import {
     extensionsController,
     HIGHLIGHTED_FILE_LINES_REQUEST,

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -8,7 +8,7 @@ import sinon from 'sinon'
 
 import { FileMatch } from '@sourcegraph/shared/src/components/FileMatch'
 import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
-import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { GitRefType, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -28,6 +28,7 @@ import * as helpers from '../helpers'
 
 import { StreamingProgress } from './progress/StreamingProgress'
 import { SearchResultsInfoBar } from './SearchResultsInfoBar'
+import { generateMockedResponses } from './sidebar/Revisions.mocks'
 import { StreamingSearchResults, StreamingSearchResultsProps } from './StreamingSearchResults'
 import { VersionContextWarning } from './VersionContextWarning'
 
@@ -70,23 +71,29 @@ describe('StreamingSearchResults', () => {
         extensionViews: () => null,
     }
 
+    const revisionsMockResponses = generateMockedResponses(GitRefType.GIT_BRANCH, 5, 'github.com/golang/oauth2')
+
+    function render(component: React.ReactElement<StreamingSearchResultsProps>) {
+        return mount(
+            <BrowserRouter>
+                <MockedTestProvider mocks={revisionsMockResponses}>{component}</MockedTestProvider>
+            </BrowserRouter>
+        )
+    }
+
     it('should call streaming search API with the right parameters from URL', () => {
         const searchSpy = sinon.spy(defaultProps.streamSearch)
 
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults
-                        {...defaultProps}
-                        parsedSearchQuery="r:golang/oauth2 test f:travis"
-                        patternType={SearchPatternType.regexp}
-                        caseSensitive={true}
-                        versionContext="test"
-                        streamSearch={searchSpy}
-                        availableVersionContexts={[{ name: 'test', revisions: [] }]}
-                    />
-                </MockedTestProvider>
-            </BrowserRouter>
+        const element = render(
+            <StreamingSearchResults
+                {...defaultProps}
+                parsedSearchQuery="r:golang/oauth2 test f:travis"
+                patternType={SearchPatternType.regexp}
+                caseSensitive={true}
+                versionContext="test"
+                streamSearch={searchSpy}
+                availableVersionContexts={[{ name: 'test', revisions: [] }]}
+            />
         )
 
         sinon.assert.calledOnce(searchSpy)
@@ -108,20 +115,16 @@ describe('StreamingSearchResults', () => {
 
         const searchSpy = sinon.spy(defaultProps.streamSearch)
 
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults
-                        {...defaultProps}
-                        parsedSearchQuery="r:golang/oauth2 test f:travis"
-                        patternType={SearchPatternType.regexp}
-                        caseSensitive={false}
-                        versionContext="test"
-                        streamSearch={searchSpy}
-                        availableVersionContexts={[{ name: 'something', revisions: [] }]}
-                    />
-                </MockedTestProvider>
-            </BrowserRouter>
+        const element = render(
+            <StreamingSearchResults
+                {...defaultProps}
+                parsedSearchQuery="r:golang/oauth2 test f:travis"
+                patternType={SearchPatternType.regexp}
+                caseSensitive={false}
+                versionContext="test"
+                streamSearch={searchSpy}
+                availableVersionContexts={[{ name: 'something', revisions: [] }]}
+            />
         )
 
         sinon.assert.calledOnce(searchSpy)
@@ -138,13 +141,7 @@ describe('StreamingSearchResults', () => {
     })
 
     it('should render progress with data from API', () => {
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} />)
 
         const progress = element.find(StreamingProgress)
         expect(progress.prop('progress')).toEqual(streamingSearchResult.progress)
@@ -153,13 +150,7 @@ describe('StreamingSearchResults', () => {
     })
 
     it('should expand and collapse results when event from infobar is triggered', () => {
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} />)
 
         let infobar = element.find(SearchResultsInfoBar)
         expect(infobar.prop('allExpanded')).toBe(false)
@@ -189,21 +180,17 @@ describe('StreamingSearchResults', () => {
         const history = createBrowserHistory()
         history.replace({ search: 'q=r:golang/oauth2+test+f:travis&c=test' })
 
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults
-                        {...defaultProps}
-                        history={history}
-                        location={history.location}
-                        previousVersionContext={null}
-                        availableVersionContexts={[
-                            { name: 'test', revisions: [] },
-                            { name: 'other', revisions: [] },
-                        ]}
-                    />
-                </MockedTestProvider>
-            </BrowserRouter>
+        const element = render(
+            <StreamingSearchResults
+                {...defaultProps}
+                history={history}
+                location={history.location}
+                previousVersionContext={null}
+                availableVersionContexts={[
+                    { name: 'test', revisions: [] },
+                    { name: 'other', revisions: [] },
+                ]}
+            />
         )
 
         const warning = element.find(VersionContextWarning)
@@ -216,21 +203,17 @@ describe('StreamingSearchResults', () => {
         const history = createBrowserHistory()
         history.replace({ search: 'q=r:golang/oauth2+test+f:travis&c=test&from-context-toggle=true' })
 
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults
-                        {...defaultProps}
-                        history={history}
-                        location={history.location}
-                        previousVersionContext={null}
-                        availableVersionContexts={[
-                            { name: 'test', revisions: [] },
-                            { name: 'other', revisions: [] },
-                        ]}
-                    />
-                </MockedTestProvider>
-            </BrowserRouter>
+        const element = render(
+            <StreamingSearchResults
+                {...defaultProps}
+                history={history}
+                location={history.location}
+                previousVersionContext={null}
+                availableVersionContexts={[
+                    { name: 'test', revisions: [] },
+                    { name: 'other', revisions: [] },
+                ]}
+            />
         )
 
         const warning = element.find(VersionContextWarning)
@@ -244,13 +227,7 @@ describe('StreamingSearchResults', () => {
             ...streamingSearchResult,
             results: [RESULT, REPO_MATCH_RESULT],
         }
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} streamSearch={() => of(results)} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} streamSearch={() => of(results)} />)
 
         const listComponent = element.find<VirtualList<GQL.SearchResult>>(VirtualList)
         const renderedResultsList = listComponent.prop('items')
@@ -270,13 +247,7 @@ describe('StreamingSearchResults', () => {
             logViewEvent: logViewEventSpy,
         }
 
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />)
 
         sinon.assert.calledOnceWithExactly(logViewEventSpy, 'SearchResults')
         sinon.assert.calledWith(logSpy, 'SearchResultsQueried')
@@ -292,13 +263,7 @@ describe('StreamingSearchResults', () => {
             log: logSpy,
         }
 
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />)
 
         const item = element.find(FileMatch).first()
         act(() => item.prop('onSelect')())
@@ -309,26 +274,14 @@ describe('StreamingSearchResults', () => {
     })
 
     it('should not show saved search modal on first load', () => {
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} />)
 
         const modal = element.find(SavedSearchModal)
         expect(modal.length).toBe(0)
     })
 
     it('should open saved search modal when triggering event from infobar', () => {
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} />)
 
         const infobar = element.find(SearchResultsInfoBar)
         act(() => infobar.prop('onSaveQueryClick')())
@@ -339,13 +292,7 @@ describe('StreamingSearchResults', () => {
     })
 
     it('should close saved search modal if close event triggers', () => {
-        const element = mount(
-            <BrowserRouter>
-                <MockedTestProvider>
-                    <StreamingSearchResults {...defaultProps} />
-                </MockedTestProvider>
-            </BrowserRouter>
-        )
+        const element = render(<StreamingSearchResults {...defaultProps} />)
 
         const infobar = element.find(SearchResultsInfoBar)
         act(() => infobar.prop('onSaveQueryClick')())
@@ -379,12 +326,8 @@ describe('StreamingSearchResults', () => {
             },
         ]
         for (const [index, test] of tests.entries()) {
-            const element = mount(
-                <BrowserRouter>
-                    <MockedTestProvider>
-                        <StreamingSearchResults {...defaultProps} parsedSearchQuery={test.parsedSearchQuery} />
-                    </MockedTestProvider>
-                </BrowserRouter>
+            const element = render(
+                <StreamingSearchResults {...defaultProps} parsedSearchQuery={test.parsedSearchQuery} />
             )
 
             const progress = element.find(StreamingProgress)

--- a/client/web/src/search/results/sidebar/FilterLink.tsx
+++ b/client/web/src/search/results/sidebar/FilterLink.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
@@ -10,6 +11,7 @@ import { pluralize } from '@sourcegraph/shared/src/util/strings'
 import { SyntaxHighlightedSearchQuery } from '../../../components/SyntaxHighlightedSearchQuery'
 import { Settings } from '../../../schema/settings.schema'
 
+import { getFiltersOfKind } from './helpers'
 import styles from './SearchSidebarSection.module.scss'
 
 export interface FilterLinkProps {
@@ -74,16 +76,14 @@ export const getRepoFilterLinks = (
         )
     }
 
-    return (filters || [])
-        .filter(filter => filter.kind === 'repo' && filter.value !== '')
-        .map(filter => (
-            <FilterLink
-                {...filter}
-                key={`${filter.label}-${filter.value}`}
-                labelConverter={repoLabelConverter}
-                onFilterChosen={onFilterChosen}
-            />
-        ))
+    return getFiltersOfKind(filters, FilterType.repo).map(filter => (
+        <FilterLink
+            {...filter}
+            key={`${filter.label}-${filter.value}`}
+            labelConverter={repoLabelConverter}
+            onFilterChosen={onFilterChosen}
+        />
+    ))
 }
 
 export const getDynamicFilterLinks = (

--- a/client/web/src/search/results/sidebar/Revisions.mocks.ts
+++ b/client/web/src/search/results/sidebar/Revisions.mocks.ts
@@ -1,0 +1,120 @@
+import { MockedResponse } from '@apollo/client/testing'
+
+import { getDocumentNode } from '@sourcegraph/shared/src/graphql/graphql'
+import { GraphQLError } from 'graphql'
+import { GitRefType } from '../../../../../shared/src/graphql-operations'
+
+import {
+    SearchSidebarGitRefsResult,
+    // SearchSidebarGitRefsVariables,
+    SearchSidebarGitRefFields,
+} from '../../../graphql-operations'
+
+import { GIT_REVS_QUERY, RevisionsProps } from './Revisions'
+
+export const MOCK_PROPS: RevisionsProps = {
+    query: '',
+    repoName: 'testorg/testrepo',
+    onFilterClick: () => {},
+}
+
+export const FILTERED_MOCK_PROPS: RevisionsProps = {
+    query: 'test',
+    repoName: 'testorg/testrepo',
+    onFilterClick: () => {},
+}
+
+function generateMockedRequest(
+    type: GitRefType,
+    first = 10,
+    query = ''
+): MockedResponse<SearchSidebarGitRefsResult>['request'] {
+    return {
+        query: getDocumentNode(GIT_REVS_QUERY),
+        variables: {
+            repo: MOCK_PROPS.repoName,
+            first,
+            query,
+            type,
+        },
+    }
+}
+
+function generateMockedResponses(
+    type: GitRefType,
+    totalCount: number,
+    query = ''
+): MockedResponse<SearchSidebarGitRefsResult>[] {
+    const nodes: SearchSidebarGitRefFields[] = Array.from({ length: totalCount }, (_value, index) => {
+        const id = `${type}-${index}`
+        return {
+            id,
+            __typename: 'GitRef',
+            name: `refs/heads/${id}-name`,
+            displayName: `${id}-display-name`,
+        }
+    })
+    return Array.from({ length: Math.max(1, Math.ceil(totalCount / 10)) }, (_value, index) => {
+        const first = Math.min((index + 1) * 10, Math.max(totalCount, 10))
+        return {
+            request: generateMockedRequest(type, first, query),
+            result: {
+                data: {
+                    repository: {
+                        __typename: 'Repository',
+                        id: 'repo',
+                        gitRefs: {
+                            __typename: 'GitRefConnection',
+                            nodes: nodes.slice(0, first),
+                            totalCount,
+                            pageInfo: {
+                                hasNextPage: first < totalCount,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    })
+}
+
+// For empty state tests
+const emptyBranchesMocks = generateMockedResponses(GitRefType.GIT_BRANCH, 0)
+console.log(emptyBranchesMocks)
+const emptyTagsMocks = generateMockedResponses(GitRefType.GIT_TAG, 0)
+
+// For tests with multiple fetches
+const branchesMocks = generateMockedResponses(GitRefType.GIT_BRANCH, 16)
+const tagsMocks = generateMockedResponses(GitRefType.GIT_TAG, 12)
+
+// For tests with less than 10 results
+const fewBranchesMocks = generateMockedResponses(GitRefType.GIT_BRANCH, 5)
+const fewTagsMocks = generateMockedResponses(GitRefType.GIT_TAG, 2)
+
+// For tests with filtered results
+const filteredBranchesMocks = generateMockedResponses(GitRefType.GIT_BRANCH, 5, FILTERED_MOCK_PROPS.query)
+const filteredTagsMocks = generateMockedResponses(GitRefType.GIT_TAG, 2, FILTERED_MOCK_PROPS.query)
+
+// For tests with filtered but empty results
+const emptyFilteredBranchesMocks = generateMockedResponses(GitRefType.GIT_BRANCH, 0, FILTERED_MOCK_PROPS.query)
+const emptyFilteredTagsMocks = generateMockedResponses(GitRefType.GIT_TAG, 0, FILTERED_MOCK_PROPS.query)
+
+export const EMPTY_MOCKS = [...emptyBranchesMocks, ...emptyTagsMocks]
+
+export const DEFAULT_MOCKS = [...branchesMocks, ...tagsMocks]
+
+export const FEW_RESULTS_MOCKS = [...fewBranchesMocks, ...fewTagsMocks]
+
+export const FILTERED_MOCKS = [...filteredBranchesMocks, ...filteredTagsMocks]
+
+export const EMPTY_FILTERED_MOCKS = [...emptyFilteredBranchesMocks, ...emptyFilteredTagsMocks]
+
+export const GRAPHQL_ERROR_MOCKS = [
+    { request: generateMockedRequest(GitRefType.GIT_BRANCH), result: { errors: [new GraphQLError('GraphQL error')] } },
+    { request: generateMockedRequest(GitRefType.GIT_TAG), result: { errors: [new GraphQLError('GraphQL error')] } },
+]
+
+export const NETWORK_ERROR_MOCKS = [
+    { request: generateMockedRequest(GitRefType.GIT_BRANCH), error: new Error('Network error') },
+    { request: generateMockedRequest(GitRefType.GIT_TAG), error: new Error('Network error') },
+]

--- a/client/web/src/search/results/sidebar/Revisions.mocks.ts
+++ b/client/web/src/search/results/sidebar/Revisions.mocks.ts
@@ -40,7 +40,7 @@ function generateMockedRequest(
     }
 }
 
-function generateMockedResponses(
+export function generateMockedResponses(
     type: GitRefType,
     totalCount: number,
     query = ''

--- a/client/web/src/search/results/sidebar/Revisions.mocks.ts
+++ b/client/web/src/search/results/sidebar/Revisions.mocks.ts
@@ -1,9 +1,9 @@
 import { MockedResponse } from '@apollo/client/testing'
+import { GraphQLError } from 'graphql'
 
 import { getDocumentNode } from '@sourcegraph/shared/src/graphql/graphql'
-import { GraphQLError } from 'graphql'
-import { GitRefType } from '../../../../../shared/src/graphql-operations'
 
+import { GitRefType } from '../../../../../shared/src/graphql-operations'
 import {
     SearchSidebarGitRefsResult,
     // SearchSidebarGitRefsVariables,
@@ -55,7 +55,7 @@ function generateMockedResponses(
         }
     })
     return Array.from({ length: Math.max(1, Math.ceil(totalCount / 10)) }, (_value, index) => {
-        const first = Math.min((index + 1) * 10, Math.max(totalCount, 10))
+        const first = (index + 1) * 10
         return {
             request: generateMockedRequest(type, first, query),
             result: {
@@ -65,7 +65,7 @@ function generateMockedResponses(
                         id: 'repo',
                         gitRefs: {
                             __typename: 'GitRefConnection',
-                            nodes: nodes.slice(0, first),
+                            nodes: nodes.slice(0, Math.min(first, totalCount)),
                             totalCount,
                             pageInfo: {
                                 hasNextPage: first < totalCount,
@@ -80,7 +80,6 @@ function generateMockedResponses(
 
 // For empty state tests
 const emptyBranchesMocks = generateMockedResponses(GitRefType.GIT_BRANCH, 0)
-console.log(emptyBranchesMocks)
 const emptyTagsMocks = generateMockedResponses(GitRefType.GIT_TAG, 0)
 
 // For tests with multiple fetches

--- a/client/web/src/search/results/sidebar/Revisions.story.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.story.tsx
@@ -1,0 +1,129 @@
+import { Meta, Story } from '@storybook/react'
+import React from 'react'
+
+import { WebStory } from '../../../components/WebStory'
+
+import { Revisions, RevisionsProps, TabIndex } from './Revisions'
+import { MockedProviderProps } from '@apollo/client/testing'
+import sidebarStyles from './SearchSidebar.module.scss'
+
+import {
+    EMPTY_MOCKS,
+    FEW_RESULTS_MOCKS,
+    FILTERED_MOCKS,
+    MOCK_PROPS,
+    FILTERED_MOCK_PROPS,
+    DEFAULT_MOCKS,
+    EMPTY_FILTERED_MOCKS,
+    NETWORK_ERROR_MOCKS,
+    GRAPHQL_ERROR_MOCKS,
+} from './Revisions.mocks'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+export default {
+    title: 'web/search/results/sidebar/Revisions',
+    component: Revisions,
+    decorators: [
+        Story => (
+            <div className={sidebarStyles.searchSidebar}>
+                <Story />
+            </div>
+        ),
+    ],
+    argTypes: { onFilterClick: { action: 'onFilterClick' } },
+} as Meta
+
+const Template: Story<RevisionsProps & Partial<Pick<MockedProviderProps, 'mocks'>>> = ({ mocks, ...props }) => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider mocks={mocks}>
+                <Revisions {...props} />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+export const EmptyBranches = Template.bind({})
+EmptyBranches.args = {
+    ...MOCK_PROPS,
+    _initialTab: TabIndex.BRANCHES,
+    mocks: EMPTY_MOCKS,
+}
+export const EmptyTags = Template.bind({})
+EmptyTags.args = {
+    ...EmptyBranches.args,
+    _initialTab: TabIndex.TAGS,
+}
+
+export const FewResultsBranches = Template.bind({})
+FewResultsBranches.args = {
+    ...MOCK_PROPS,
+    _initialTab: TabIndex.BRANCHES,
+    mocks: FEW_RESULTS_MOCKS,
+}
+export const FewResultsTags = Template.bind({})
+FewResultsTags.args = {
+    ...FewResultsBranches.args,
+    _initialTab: TabIndex.TAGS,
+}
+
+export const ManyResultsBranches = Template.bind({})
+ManyResultsBranches.args = {
+    ...MOCK_PROPS,
+    _initialTab: TabIndex.BRANCHES,
+    mocks: DEFAULT_MOCKS,
+}
+
+export const ManyResultsTags = Template.bind({})
+ManyResultsTags.args = {
+    ...ManyResultsBranches.args,
+    _initialTab: TabIndex.TAGS,
+}
+
+export const SearchBranches = Template.bind({})
+SearchBranches.args = {
+    ...FILTERED_MOCK_PROPS,
+    _initialTab: TabIndex.BRANCHES,
+    mocks: FILTERED_MOCKS,
+}
+export const SearchTags = Template.bind({})
+SearchTags.args = {
+    ...SearchBranches.args,
+    _initialTab: TabIndex.TAGS,
+}
+
+export const EmptySearchBranches = Template.bind({})
+EmptySearchBranches.args = {
+    ...FILTERED_MOCK_PROPS,
+    _initialTab: TabIndex.BRANCHES,
+    mocks: EMPTY_FILTERED_MOCKS,
+}
+export const EmptySearchTags = Template.bind({})
+EmptySearchTags.args = {
+    ...EmptySearchBranches.args,
+    _initialTab: TabIndex.TAGS,
+}
+
+export const NetworkErrorBranches = Template.bind({})
+NetworkErrorBranches.args = {
+    ...MOCK_PROPS,
+    _initialTab: TabIndex.BRANCHES,
+    mocks: NETWORK_ERROR_MOCKS,
+}
+export const NetworkErrorTags = Template.bind({})
+NetworkErrorTags.args = {
+    ...NetworkErrorBranches.args,
+    _initialTab: TabIndex.TAGS,
+}
+
+export const GraphqlErrorBranches = Template.bind({})
+GraphqlErrorBranches.args = {
+    ...MOCK_PROPS,
+    _initialTab: TabIndex.BRANCHES,
+    mocks: GRAPHQL_ERROR_MOCKS,
+}
+export const GraphqlErrorTags = Template.bind({})
+GraphqlErrorTags.args = {
+    ...GraphqlErrorBranches.args,
+    _initialTab: TabIndex.TAGS,
+}

--- a/client/web/src/search/results/sidebar/Revisions.story.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.story.tsx
@@ -1,12 +1,12 @@
+import { MockedProviderProps } from '@apollo/client/testing'
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
+
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { Revisions, RevisionsProps, TabIndex } from './Revisions'
-import { MockedProviderProps } from '@apollo/client/testing'
-import sidebarStyles from './SearchSidebar.module.scss'
-
 import {
     EMPTY_MOCKS,
     FEW_RESULTS_MOCKS,
@@ -18,7 +18,7 @@ import {
     NETWORK_ERROR_MOCKS,
     GRAPHQL_ERROR_MOCKS,
 } from './Revisions.mocks'
-import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import sidebarStyles from './SearchSidebar.module.scss'
 
 export default {
     title: 'web/search/results/sidebar/Revisions',

--- a/client/web/src/search/results/sidebar/Revisions.test.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, within, fireEvent, act, RenderResult } from '@testing-library/react'
+import React from 'react'
+
+import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
+import { renderWithRouter, RenderWithRouterResult } from '@sourcegraph/shared/src/testing/render-with-router'
+
+import { Revisions, RevisionsProps } from './Revisions'
+import { DEFAULT_MOCKS, MOCK_PROPS } from './Revisions.mocks'
+
+describe('Search Sidebar > Revisions', () => {
+    const renderRevisions = (props?: Partial<RevisionsProps>, mocks = DEFAULT_MOCKS): RenderWithRouterResult =>
+        renderWithRouter(
+            <MockedTestProvider mocks={mocks}>
+                <Revisions {...MOCK_PROPS} {...props} />
+            </MockedTestProvider>
+        )
+
+    afterEach(cleanup)
+
+    describe('Branches', () => {
+        async function renderBranchesTab() {
+            const result = renderRevisions()
+            await waitForNextApolloResponse()
+            return result.getByRole('tabpanel', { name: 'Branches' })
+        }
+
+        it('renders the correct number of results', async () => {
+            const branchTab = await renderBranchesTab()
+
+            expect(within(branchTab).getAllByTestId('filter-link')).toHaveLength(10)
+            expect(within(branchTab).getByTestId('summary')).toHaveTextContent('10 of 16 branches')
+            expect(within(branchTab).getByText('Show more')).toBeVisible()
+        })
+
+        it('fetches remaining branches', async () => {
+            const branchTab = await renderBranchesTab()
+
+            fireEvent.click(within(branchTab).getByText('Show more'))
+            await waitForNextApolloResponse()
+            expect(within(branchTab).getAllByTestId('filter-link')).toHaveLength(16)
+            expect(within(branchTab).getByTestId('summary')).toHaveTextContent('16 of 16 branches')
+            expect(within(branchTab).queryByText('Show more')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('Tags', () => {
+        async function renderBranchesTab() {
+            const result = renderRevisions()
+            fireEvent.click(result.getByText('Tags'))
+            await waitForNextApolloResponse()
+            return result.getByRole('tabpanel', { name: 'Tags' })
+        }
+
+        it('renders the correct number of results', async () => {
+            const branchTab = await renderBranchesTab()
+
+            expect(within(branchTab).getAllByTestId('filter-link')).toHaveLength(10)
+            expect(within(branchTab).getByTestId('summary')).toHaveTextContent('10 of 12 tags')
+            expect(within(branchTab).getByText('Show more')).toBeVisible()
+        })
+
+        it('fetches remaining tags', async () => {
+            const branchTab = await renderBranchesTab()
+
+            fireEvent.click(within(branchTab).getByText('Show more'))
+            await waitForNextApolloResponse()
+            expect(within(branchTab).getAllByTestId('filter-link')).toHaveLength(12)
+            expect(within(branchTab).getByTestId('summary')).toHaveTextContent('12 of 12 tags')
+            expect(within(branchTab).queryByText('Show more')).not.toBeInTheDocument()
+        })
+    })
+})

--- a/client/web/src/search/results/sidebar/Revisions.test.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, within, fireEvent, act, RenderResult } from '@testing-library/react'
+import { cleanup, within, fireEvent } from '@testing-library/react'
 import React from 'react'
 
 import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'

--- a/client/web/src/search/results/sidebar/Revisions.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.tsx
@@ -1,0 +1,171 @@
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@reach/tabs'
+import React from 'react'
+import { from, Observable } from 'rxjs'
+import { useHistory, useLocation } from 'react-router'
+import { map } from 'rxjs/operators'
+
+import { createAggregateError } from '@sourcegraph/shared/src/util/errors'
+import { getDocumentNode, gql } from '@sourcegraph/shared/src/graphql/graphql'
+import { memoizeObservable } from '@sourcegraph/shared/src/util/memoizeObservable'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
+import { GitRefType } from '@sourcegraph/shared/src/graphql/schema'
+
+import {
+    SearchSidebarGitRefsResult,
+    SearchSidebarGitRefsVariables,
+    SearchSidebarGitRefsConnectionFields,
+    SearchSidebarGitRefFields,
+} from '../../../graphql-operations'
+import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
+import { SyntaxHighlightedSearchQuery } from '../../../components/SyntaxHighlightedSearchQuery'
+import { client } from '../../../backend/graphql'
+
+import styles from './SearchSidebarSection.module.scss'
+import { FilterLink } from './FilterLink'
+
+const queryGitBranches = memoizeObservable(
+    (args: {
+        repo: string
+        type: GitRefType
+        first?: number
+        query?: string
+    }): Observable<SearchSidebarGitRefsConnectionFields> =>
+        from(
+            client.query<SearchSidebarGitRefsResult, SearchSidebarGitRefsVariables>({
+                query: getDocumentNode(gql`
+                    query SearchSidebarGitRefs($repo: String, $first: Int, $query: String, $type: GitRefType) {
+                        repository(name: $repo) {
+                            ... on Repository {
+                                __typename
+                                id
+                                gitRefs(first: $first, query: $query, type: $type, orderBy: AUTHORED_OR_COMMITTED_AT) {
+                                    ...SearchSidebarGitRefsConnectionFields
+                                }
+                            }
+                        }
+                    }
+
+                    fragment SearchSidebarGitRefsConnectionFields on GitRefConnection {
+                        nodes {
+                            ...SearchSidebarGitRefFields
+                        }
+                        totalCount
+                        pageInfo {
+                            hasNextPage
+                        }
+                    }
+
+                    fragment SearchSidebarGitRefFields on GitRef {
+                        __typename
+                        id
+                        name
+                        displayName
+                    }
+                `),
+                variables: {
+                    query: args.query ?? null,
+                    first: args.first ?? null,
+                    repo: args.repo,
+                    type: args.type,
+                },
+            })
+        ).pipe(
+            map(({ data, errors }) => {
+                if (!data?.repository?.gitRefs) {
+                    throw createAggregateError(errors)
+                }
+                return data.repository.gitRefs
+            })
+        ),
+    args => `${args.repo}:${String(args.first)}:${String(args.query)}:${String(args.type)}`
+)
+
+const revLabel = (value: string) => <SyntaxHighlightedSearchQuery query={`rev:${value}`} />
+
+interface RevisionListProps {
+    repoName: string
+    type: GitRefType
+    onFilterClick: (value: string) => void
+    noun: string
+    pluralNoun: string
+}
+
+const RevisionList: React.FunctionComponent<RevisionListProps> = ({
+    repoName,
+    type,
+    onFilterClick,
+    noun,
+    pluralNoun,
+}) => {
+    const history = useHistory()
+    const location = useLocation()
+    const query = (args: FilteredConnectionQueryArguments): Observable<SearchSidebarGitRefsConnectionFields> =>
+        queryGitBranches({ ...args, repo: repoName, type })
+
+    return (
+        <FilteredConnection<SearchSidebarGitRefFields, any>
+            history={history}
+            location={location}
+            defaultFirst={10}
+            compact={true}
+            inputClassName="form-control-sm"
+            noun={noun}
+            pluralNoun={pluralNoun}
+            queryConnection={query}
+            nodeComponent={({ node, onFilterClick }) => {
+                return (
+                    <FilterLink
+                        label={node.displayName}
+                        value={node.name}
+                        labelConverter={revLabel}
+                        onFilterChosen={onFilterClick}
+                    />
+                )
+            }}
+            nodeComponentProps={{
+                onFilterClick,
+            }}
+            useURLQuery={false}
+        />
+    )
+}
+
+const REVISION_TAB_KEY = 'SearchProduct.Sidebar.Revisions.Tab'
+
+interface RevisionsProps {
+    repoName: string
+    onFilterClick: (filter: string, value: string) => void
+}
+
+export const Revisions: React.FunctionComponent<RevisionsProps> = ({ repoName, onFilterClick }) => {
+    const [selectedTab, setSelectedTab] = useLocalStorage(REVISION_TAB_KEY, 0)
+    const onRevFilterClick = (value: string) => onFilterClick('rev', value)
+    return (
+        <Tabs index={selectedTab} onChange={setSelectedTab}>
+            <TabList className={styles.sidebarSectionTabsHeader}>
+                <Tab>Branches</Tab>
+                <Tab>Tags</Tab>
+            </TabList>
+            <TabPanels>
+                <TabPanel>
+                    <RevisionList
+                        noun="branche"
+                        pluralNoun="branches"
+                        repoName={repoName}
+                        type={GitRefType.GIT_BRANCH}
+                        onFilterClick={onRevFilterClick}
+                    />
+                </TabPanel>
+                <TabPanel>
+                    <RevisionList
+                        noun="tag"
+                        pluralNoun="tags"
+                        repoName={repoName}
+                        type={GitRefType.GIT_TAG}
+                        onFilterClick={onRevFilterClick}
+                    />
+                </TabPanel>
+            </TabPanels>
+        </Tabs>
+    )
+}

--- a/client/web/src/search/results/sidebar/Revisions.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.tsx
@@ -1,132 +1,146 @@
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@reach/tabs'
+import classNames from 'classnames'
 import React from 'react'
-import { from, Observable } from 'rxjs'
-import { useHistory, useLocation } from 'react-router'
-import { map } from 'rxjs/operators'
 
-import { createAggregateError } from '@sourcegraph/shared/src/util/errors'
-import { getDocumentNode, gql } from '@sourcegraph/shared/src/graphql/graphql'
-import { memoizeObservable } from '@sourcegraph/shared/src/util/memoizeObservable'
-import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { GitRefType } from '@sourcegraph/shared/src/graphql/schema'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
+import { useConnection } from '../../../components/FilteredConnection/hooks/useConnection'
+import { SyntaxHighlightedSearchQuery } from '../../../components/SyntaxHighlightedSearchQuery'
 import {
     SearchSidebarGitRefsResult,
     SearchSidebarGitRefsVariables,
-    SearchSidebarGitRefsConnectionFields,
     SearchSidebarGitRefFields,
 } from '../../../graphql-operations'
-import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
-import { SyntaxHighlightedSearchQuery } from '../../../components/SyntaxHighlightedSearchQuery'
-import { client } from '../../../backend/graphql'
 
-import styles from './SearchSidebarSection.module.scss'
 import { FilterLink } from './FilterLink'
+import styles from './SearchSidebarSection.module.scss'
 
-const queryGitBranches = memoizeObservable(
-    (args: {
-        repo: string
-        type: GitRefType
-        first?: number
-        query?: string
-    }): Observable<SearchSidebarGitRefsConnectionFields> =>
-        from(
-            client.query<SearchSidebarGitRefsResult, SearchSidebarGitRefsVariables>({
-                query: getDocumentNode(gql`
-                    query SearchSidebarGitRefs($repo: String, $first: Int, $query: String, $type: GitRefType) {
-                        repository(name: $repo) {
-                            ... on Repository {
-                                __typename
-                                id
-                                gitRefs(first: $first, query: $query, type: $type, orderBy: AUTHORED_OR_COMMITTED_AT) {
-                                    ...SearchSidebarGitRefsConnectionFields
-                                }
-                            }
-                        }
+const GIT_REVS_QUERY = gql`
+    query SearchSidebarGitRefs($repo: String, $first: Int, $query: String, $type: GitRefType) {
+        repository(name: $repo) {
+            ... on Repository {
+                __typename
+                id
+                gitRefs(first: $first, query: $query, type: $type, orderBy: AUTHORED_OR_COMMITTED_AT) {
+                    nodes {
+                        ...SearchSidebarGitRefFields
                     }
-
-                    fragment SearchSidebarGitRefsConnectionFields on GitRefConnection {
-                        nodes {
-                            ...SearchSidebarGitRefFields
-                        }
-                        totalCount
-                        pageInfo {
-                            hasNextPage
-                        }
+                    totalCount
+                    pageInfo {
+                        hasNextPage
                     }
-
-                    fragment SearchSidebarGitRefFields on GitRef {
-                        __typename
-                        id
-                        name
-                        displayName
-                    }
-                `),
-                variables: {
-                    query: args.query ?? null,
-                    first: args.first ?? null,
-                    repo: args.repo,
-                    type: args.type,
-                },
-            })
-        ).pipe(
-            map(({ data, errors }) => {
-                if (!data?.repository?.gitRefs) {
-                    throw createAggregateError(errors)
                 }
-                return data.repository.gitRefs
-            })
-        ),
-    args => `${args.repo}:${String(args.first)}:${String(args.query)}:${String(args.type)}`
-)
+            }
+        }
+    }
 
-const revLabel = (value: string) => <SyntaxHighlightedSearchQuery query={`rev:${value}`} />
+    fragment SearchSidebarGitRefFields on GitRef {
+        __typename
+        id
+        name
+        displayName
+    }
+`
+
+const revisionLabel = (value: string): React.ReactElement => <SyntaxHighlightedSearchQuery query={`rev:${value}`} />
 
 interface RevisionListProps {
     repoName: string
     type: GitRefType
     onFilterClick: (value: string) => void
-    noun: string
     pluralNoun: string
+    query: string
 }
 
 const RevisionList: React.FunctionComponent<RevisionListProps> = ({
     repoName,
     type,
     onFilterClick,
-    noun,
     pluralNoun,
+    query,
 }) => {
-    const history = useHistory()
-    const location = useLocation()
-    const query = (args: FilteredConnectionQueryArguments): Observable<SearchSidebarGitRefsConnectionFields> =>
-        queryGitBranches({ ...args, repo: repoName, type })
+    const { connection, fetchMore, hasNextPage } = useConnection<
+        SearchSidebarGitRefsResult,
+        SearchSidebarGitRefsVariables,
+        SearchSidebarGitRefFields
+    >({
+        query: GIT_REVS_QUERY,
+        variables: {
+            first: 10,
+            repo: repoName,
+            query,
+            type,
+        },
+        getConnection: result => {
+            const data = dataOrThrowErrors(result)
+            if (!data?.repository?.gitRefs) {
+                throw new Error('Unable to fetch repo revisions.')
+            }
+            return data?.repository?.gitRefs
+        },
+    })
+
+    if (!connection) {
+        return (
+            <div className={classNames('d-flex justify-content-center mt-4', styles.sidebarSectionNoResults)}>
+                <LoadingSpinner className="icon-inline" />
+            </div>
+        )
+    }
+
+    if (connection?.error) {
+        return (
+            <p className={classNames('text-muted', styles.sidebarSectionNoResults)}>
+                <span className="text-muted">Unable to fetch repository revisions.</span>
+            </p>
+        )
+    }
+
+    if (connection.nodes.length === 0) {
+        return (
+            <p className={classNames('text-muted', styles.sidebarSectionNoResults)}>
+                {query
+                    ? `None of the ${pluralNoun} in this repository match this filter.`
+                    : `This repository doesn't have any ${pluralNoun}.`}
+            </p>
+        )
+    }
 
     return (
-        <FilteredConnection<SearchSidebarGitRefFields, any>
-            history={history}
-            location={location}
-            defaultFirst={10}
-            compact={true}
-            inputClassName="form-control-sm"
-            noun={noun}
-            pluralNoun={pluralNoun}
-            queryConnection={query}
-            nodeComponent={({ node, onFilterClick }) => {
-                return (
+        <>
+            <ul className={styles.sidebarSectionList}>
+                {connection?.nodes.map(node => (
                     <FilterLink
+                        key={node.name}
                         label={node.displayName}
                         value={node.name}
-                        labelConverter={revLabel}
+                        labelConverter={revisionLabel}
                         onFilterChosen={onFilterClick}
                     />
-                )
-            }}
-            nodeComponentProps={{
-                onFilterClick,
-            }}
-            useURLQuery={false}
-        />
+                ))}
+            </ul>
+            {hasNextPage || (connection.totalCount ?? 0) > 100 || connection.nodes.length > 100 ? (
+                <p className={classNames('text-muted d-flex', styles.sidebarSectionFooter)}>
+                    <small className="flex-1">
+                        <span>
+                            {connection?.nodes.length} of {connection?.totalCount} {pluralNoun}
+                        </span>
+                    </small>
+                    {hasNextPage ? (
+                        <button
+                            type="button"
+                            className={classNames('btn btn-link', styles.sidebarSectionButtonLink)}
+                            onClick={fetchMore}
+                        >
+                            Show more
+                        </button>
+                    ) : null}
+                </p>
+            ) : null}
+        </>
     )
 }
 
@@ -135,11 +149,12 @@ const REVISION_TAB_KEY = 'SearchProduct.Sidebar.Revisions.Tab'
 interface RevisionsProps {
     repoName: string
     onFilterClick: (filter: string, value: string) => void
+    query: string
 }
 
-export const Revisions: React.FunctionComponent<RevisionsProps> = ({ repoName, onFilterClick }) => {
+export const Revisions: React.FunctionComponent<RevisionsProps> = ({ repoName, onFilterClick, query }) => {
     const [selectedTab, setSelectedTab] = useLocalStorage(REVISION_TAB_KEY, 0)
-    const onRevFilterClick = (value: string) => onFilterClick('rev', value)
+    const onRevisionFilterClick = (value: string): void => onFilterClick('rev', value)
     return (
         <Tabs index={selectedTab} onChange={setSelectedTab}>
             <TabList className={styles.sidebarSectionTabsHeader}>
@@ -149,23 +164,27 @@ export const Revisions: React.FunctionComponent<RevisionsProps> = ({ repoName, o
             <TabPanels>
                 <TabPanel>
                     <RevisionList
-                        noun="branche"
                         pluralNoun="branches"
                         repoName={repoName}
                         type={GitRefType.GIT_BRANCH}
-                        onFilterClick={onRevFilterClick}
+                        onFilterClick={onRevisionFilterClick}
+                        query={query}
                     />
                 </TabPanel>
                 <TabPanel>
                     <RevisionList
-                        noun="tag"
                         pluralNoun="tags"
                         repoName={repoName}
                         type={GitRefType.GIT_TAG}
-                        onFilterClick={onRevFilterClick}
+                        onFilterClick={onRevisionFilterClick}
+                        query={query}
                     />
                 </TabPanel>
             </TabPanels>
         </Tabs>
     )
 }
+
+export const getRevisions = (props: Omit<RevisionsProps, 'query'>) => (query: string) => (
+    <Revisions {...props} query={query} />
+)

--- a/client/web/src/search/results/sidebar/Revisions.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { GitRefType } from '@sourcegraph/shared/src/graphql/schema'
-import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
 import { useConnection } from '../../../components/FilteredConnection/hooks/useConnection'
 import { SyntaxHighlightedSearchQuery } from '../../../components/SyntaxHighlightedSearchQuery'
@@ -14,6 +13,7 @@ import {
     SearchSidebarGitRefsVariables,
     SearchSidebarGitRefFields,
 } from '../../../graphql-operations'
+import { useTemporarySetting } from '../../../settings/temporary/useTemporarySetting'
 
 import { FilterLink } from './FilterLink'
 import styles from './SearchSidebarSection.module.scss'
@@ -144,8 +144,6 @@ const RevisionList: React.FunctionComponent<RevisionListProps> = ({
     )
 }
 
-const REVISION_TAB_KEY = 'SearchProduct.Sidebar.Revisions.Tab'
-
 interface RevisionsProps {
     repoName: string
     onFilterClick: (filter: string, value: string) => void
@@ -153,10 +151,10 @@ interface RevisionsProps {
 }
 
 export const Revisions: React.FunctionComponent<RevisionsProps> = ({ repoName, onFilterClick, query }) => {
-    const [selectedTab, setSelectedTab] = useLocalStorage(REVISION_TAB_KEY, 0)
+    const [selectedTab, setSelectedTab] = useTemporarySetting('search.sidebar.revisions.tab')
     const onRevisionFilterClick = (value: string): void => onFilterClick('rev', value)
     return (
-        <Tabs index={selectedTab} onChange={setSelectedTab}>
+        <Tabs index={selectedTab ?? 0} onChange={setSelectedTab}>
             <TabList className={styles.sidebarSectionTabsHeader}>
                 <Tab>Branches</Tab>
                 <Tab>Tags</Tab>

--- a/client/web/src/search/results/sidebar/Revisions.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.tsx
@@ -124,18 +124,10 @@ const RevisionList: React.FunctionComponent<RevisionListProps> = ({
                     />
                 ))}
             </ul>
-            {connection.totalCount ?? 0 > DEFAULT_FIRST ? (
+            {(connection.totalCount ?? 0) > DEFAULT_FIRST ? (
                 <p className={classNames('text-muted d-flex', styles.sidebarSectionFooter)}>
-                    <small className="flex-1">
-                        {hasNextPage ? (
-                            <span>
-                                {connection?.nodes.length} of {connection?.totalCount} {pluralNoun}
-                            </span>
-                        ) : (
-                            <span>
-                                {connection?.totalCount} {pluralNoun}
-                            </span>
-                        )}
+                    <small className="flex-1" data-testid="summary">
+                        {connection?.nodes.length} of {connection?.totalCount} {pluralNoun}
                     </small>
                     {hasNextPage ? (
                         <button

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -580,7 +580,7 @@ const SearchReference = (props: SearchReferenceProps): ReactElement => {
                     </TabPanels>
                 </Tabs>
             )}
-            <p className={styles.footer}>
+            <p className={sidebarStyles.sidebarSectionFooter}>
                 <small>
                     <Link target="blank" to="https://docs.sourcegraph.com/code_search/reference/queries">
                         Search syntax <ExternalLinkIcon className="icon-inline" />

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -117,10 +117,14 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         [props.filters]
     )
     const repoName = useLastRepoName(props.query, repoFilters)
-    const repoFilterLinks = useMemo(
-        () => (repoFilters.length > 1 ? getRepoFilterLinks(repoFilters, onDynamicFilterClicked) : null),
-        [repoFilters, onDynamicFilterClicked]
-    )
+    const repoFilterLinks = useMemo(() => getRepoFilterLinks(repoFilters, onDynamicFilterClicked), [
+        repoFilters,
+        onDynamicFilterClicked,
+    ])
+    const showRevisionsSection = props.featureFlags.get('search-sidebar-revisions')
+    // If the revisions section feature is enable we only show the repos
+    // section if there is more than one repo
+    const showReposSection = !showRevisionsSection || repoFilterLinks.length > 1
 
     return (
         <div className={classNames(styles.searchSidebar, props.className)}>
@@ -141,7 +145,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                 >
                     {getDynamicFilterLinks(props.filters, onDynamicFilterClicked)}
                 </SearchSidebarSection>
-                {repoFilterLinks ? (
+                {showReposSection ? (
                     <SearchSidebarSection
                         className={styles.searchSidebarItem}
                         header="Repositories"
@@ -158,7 +162,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                         {repoFilterLinks}
                     </SearchSidebarSection>
                 ) : null}
-                {repoName ? (
+                {showRevisionsSection && repoName ? (
                     <SearchSidebarSection
                         className={styles.searchSidebarItem}
                         header="Revisions"

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -57,7 +57,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     const history = useHistory()
     const [collapsedSections, setCollapsedSections] = useTemporarySetting('search.collapsedSidebarSections')
 
-    const onFilterClicked = useCallback(
+    const toggleFilter = useCallback(
         (value: string) => {
             const newQuery = toggleSearchFilter(props.query, value)
             submitSearch({ ...props, query: newQuery, source: 'filter', history })
@@ -66,7 +66,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     )
 
     // Unlike onFilterClicked, this function will always append or update a filter
-    const updateSearchQuery = useCallback(
+    const updateOrAppendFilter = useCallback(
         (filter: string, value: string) => {
             const newQuery = updateFilter(props.query, filter, value)
             submitSearch({ ...props, query: newQuery, source: 'filter', history })
@@ -80,17 +80,17 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                 search_filter: { value },
             })
 
-            onFilterClicked(value)
+            toggleFilter(value)
         },
-        [onFilterClicked, props.telemetryService]
+        [toggleFilter, props.telemetryService]
     )
 
     const onSnippetClicked = useCallback(
         (value: string) => {
             props.telemetryService.log('SearchSnippetClicked')
-            onFilterClicked(value)
+            toggleFilter(value)
         },
-        [onFilterClicked, props.telemetryService]
+        [toggleFilter, props.telemetryService]
     )
 
     const persistToggleState = useCallback(
@@ -166,7 +166,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                         showSearch={true}
                         clearSearchOnChange={repoName}
                     >
-                        {getRevisions({ repoName, onFilterClick: updateSearchQuery })}
+                        {getRevisions({ repoName, onFilterClick: updateOrAppendFilter })}
                     </SearchSidebarSection>
                 ) : null}
                 <SearchSidebarSection

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { useHistory } from 'react-router'
 import StickyBox from 'react-sticky-box'
 
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
@@ -17,7 +18,7 @@ import { useTemporarySetting } from '../../../settings/temporary/useTemporarySet
 import { QueryState, submitSearch, toggleSearchFilter } from '../../helpers'
 
 import { getDynamicFilterLinks, getRepoFilterLinks, getSearchSnippetLinks } from './FilterLink'
-import { useLastRepoName } from './helpers'
+import { getFiltersOfKind, useLastRepoName } from './helpers'
 import { getQuickLinks } from './QuickLink'
 import { getRevisions } from './Revisions'
 import { getSearchReferenceFactory } from './SearchReference'
@@ -112,19 +113,13 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         [persistToggleState, props.telemetryService]
     )
 
-    const repoFilters = useMemo(
-        () => (props.filters || []).filter(filter => filter.kind === 'repo' && filter.value !== ''),
-        [props.filters]
-    )
+    const repoFilters = useMemo(() => getFiltersOfKind(props.filters, FilterType.repo), [props.filters])
     const repoName = useLastRepoName(props.query, repoFilters)
     const repoFilterLinks = useMemo(() => getRepoFilterLinks(repoFilters, onDynamicFilterClicked), [
         repoFilters,
         onDynamicFilterClicked,
     ])
-    const showRevisionsSection = props.featureFlags.get('search-sidebar-revisions')
-    // If the revisions section feature is enable we only show the repos
-    // section if there is more than one repo
-    const showReposSection = !showRevisionsSection || repoFilterLinks.length > 1
+    const showReposSection = repoFilterLinks.length > 1
 
     return (
         <div className={classNames(styles.searchSidebar, props.className)}>
@@ -162,7 +157,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                         {repoFilterLinks}
                     </SearchSidebarSection>
                 ) : null}
-                {showRevisionsSection && repoName ? (
+                {repoName ? (
                     <SearchSidebarSection
                         className={styles.searchSidebarItem}
                         header="Revisions"

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.module.scss
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.module.scss
@@ -1,6 +1,11 @@
 .sidebar-section {
     isolation: isolate; // Prevent the z-index below from leaking out of this container
 
+    &__tabs-header {
+        margin-top: 1.25rem;
+        margin-bottom: 0.5rem;
+    }
+
     &__button-link {
         // The global font-weight for .btn elements is 500, which also applies to
         // link-like buttons. But in this context we want it to be 400.

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.module.scss
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.module.scss
@@ -10,6 +10,8 @@
         // The global font-weight for .btn elements is 500, which also applies to
         // link-like buttons. But in this context we want it to be 400.
         font-weight: 400;
+        font-size: 0.75rem;
+        padding: 0;
     }
 
     &__collapse-button {
@@ -80,5 +82,12 @@
     &__cta-link {
         font-size: 0.6875rem;
         padding: 0.25rem 0.375rem;
+    }
+
+    // A helper class for sections that render custom content
+    &__footer {
+        border-top: 1px solid var(--border-color);
+        padding-top: 0.75rem;
+        margin: 0;
     }
 }

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
@@ -18,6 +18,12 @@ export const SearchSidebarSection: React.FunctionComponent<{
      * Shown when the built-in search doesn't find any results.
      */
     noResultText?: React.ReactElement | string
+    /**
+     * Clear the search input whenever this value changes. This is supposed to
+     * be used together with function children, which use the search input but
+     * handle search on their own.
+     */
+    clearSearchOnChange?: {}
 }> = ({
     header,
     children = [],
@@ -26,11 +32,13 @@ export const SearchSidebarSection: React.FunctionComponent<{
     onToggle,
     startCollapsed,
     noResultText = 'No results',
+    clearSearchOnChange = children,
 }) => {
     const [filter, setFilter] = useState('')
 
-    // Clear filter when children change
-    useEffect(() => setFilter(''), [children])
+    // Clears the filter whenever clearSearchOnChange changes or the
+    // component's children
+    useEffect(() => setFilter(''), [clearSearchOnChange])
 
     let body
     let searchVisible = showSearch

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
@@ -9,7 +9,7 @@ import styles from './SearchSidebarSection.module.scss'
 
 export const SearchSidebarSection: React.FunctionComponent<{
     header: string
-    children?: React.ReactElement[] | ((filter: string) => React.ReactElement)
+    children?: React.ReactElement | React.ReactElement[] | ((filter: string) => React.ReactElement)
     className?: string
     showSearch?: boolean // Search only works if children are FilterLink
     onToggle?: (open: boolean) => void
@@ -34,11 +34,12 @@ export const SearchSidebarSection: React.FunctionComponent<{
 
     let body
     let searchVisible = showSearch
-    let visible = typeof children === 'function'
+    let visible = false
 
     if (typeof children === 'function') {
+        visible = true
         body = children(filter)
-    } else {
+    } else if (Array.isArray(children)) {
         visible = children.length > 0
         searchVisible = searchVisible && children.length > 1
         const childrenList = children as React.ReactElement[]
@@ -68,6 +69,9 @@ export const SearchSidebarSection: React.FunctionComponent<{
                 </ul>
             </>
         )
+    } else {
+        visible = true
+        body = children
     }
 
     const [collapsed, setCollapsed] = useState(startCollapsed)

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
@@ -22,6 +22,7 @@ export const SearchSidebarSection: React.FunctionComponent<{
      * Clear the search input whenever this value changes. This is supposed to
      * be used together with function children, which use the search input but
      * handle search on their own.
+     * Defaults to the component's children.
      */
     clearSearchOnChange?: {}
 }> = ({
@@ -36,8 +37,8 @@ export const SearchSidebarSection: React.FunctionComponent<{
 }) => {
     const [filter, setFilter] = useState('')
 
-    // Clears the filter whenever clearSearchOnChange changes or the
-    // component's children
+    // Clears the filter whenever clearSearchOnChange changes (defaults to the
+    // component's children)
     useEffect(() => setFilter(''), [clearSearchOnChange])
 
     let body

--- a/client/web/src/search/results/sidebar/helpers.test.ts
+++ b/client/web/src/search/results/sidebar/helpers.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
+import { Filter } from '@sourcegraph/shared/src/search/stream'
+
+import { useLastRepoName } from './helpers'
+
+interface Props {
+    query: string
+    filters: Filter[]
+}
+
+function createRepoFilter(value: string): Filter {
+    return {
+        kind: FilterType.repo,
+        value: `${value}@HEAD`,
+        label: value,
+        count: 1,
+        limitHit: false,
+    }
+}
+
+function setup(props: Props) {
+    return renderHook(({ query, filters }: Props) => useLastRepoName(query, filters), { initialProps: props })
+}
+
+describe('useLastRepoName', () => {
+    const repoName = 'sourcegraph'
+    const repoQuery = 'repo:sourcegraph'
+    const initialProps: Props = { query: repoQuery, filters: [createRepoFilter(repoName)] }
+
+    it('returns no repo name if we have never seen any results', () => {
+        // Empty query and filters
+        const { result, rerender } = setup({ query: '', filters: [] })
+        expect(result.current).toBe('')
+
+        // Single repo query
+        rerender({ query: 'repo:sourcegraph', filters: [] })
+        expect(result.current).toBe('')
+
+        // Multiple repo query
+        rerender({ query: 'repo:sourcegraph/a repo:sourcegraph/b', filters: [] })
+        expect(result.current).toBe('')
+    })
+
+    it('returns the repo name if results contain a single repo', () => {
+        const filters = [createRepoFilter(repoName)]
+
+        const { result, rerender } = setup({ query: '', filters })
+        expect(result.current).toBe(repoName)
+
+        rerender({ query: 'no repo filter', filters: filters.slice() })
+        expect(result.current).toBe(repoName)
+
+        rerender({ query: 'repo:whatever', filters: filters.slice() })
+        expect(result.current).toBe(repoName)
+    })
+
+    it('returns the previous repo name if the query matches but there are no results', () => {
+        const { result, rerender } = setup(initialProps)
+        expect(result.current).toBe(repoName)
+
+        rerender({ query: repoQuery, filters: [] })
+        expect(result.current).toBe(repoName)
+    })
+
+    it('returns an empty repo name if the repo query has changed', () => {
+        let { result, rerender } = setup(initialProps)
+        expect(result.current).toBe(repoName)
+
+        rerender({ query: 'repo:another', filters: [] })
+        expect(result.current).toBe('')
+
+        // reset
+        ;({ result, rerender } = setup(initialProps))
+        expect(result.current).toBe(repoName)
+
+        rerender({ query: repoQuery + ' repo:anotherone', filters: [] })
+        expect(result.current).toBe('')
+    })
+
+    it('returns an empty repo name if the results contain multiple repos', () => {
+        const { result, rerender } = setup(initialProps)
+        expect(result.current).toBe(repoName)
+
+        rerender({ query: repoQuery, filters: [createRepoFilter('sourcegraph/a'), createRepoFilter('sourcegraph/b')] })
+        expect(result.current).toBe('')
+    })
+})

--- a/client/web/src/search/results/sidebar/helpers.ts
+++ b/client/web/src/search/results/sidebar/helpers.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useRef } from 'react'
+
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
+import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
+import { findFilters } from '@sourcegraph/shared/src/search/query/validate'
+import { Filter } from '@sourcegraph/shared/src/search/stream'
+
+/**
+ * Given a search query and filters from query results, this hook will return
+ * a repo name if
+ * - 'filters' is not empty and only contains a single repo filter
+ * - 'filters' is empty, the query contains only a single repo filter and has the
+ * same value as a previous non-empty search
+ *
+ * In all other cases it will return an empty string.
+ */
+export function useLastRepoName(query: string, filters: Filter[] = []): string {
+    const lastRepoQuery = useRef('')
+    const [repoName, setRepoName] = useState('')
+
+    useEffect(() => {
+        // Determine whether query contains a single repo filter and remember it
+        // if it exists
+        let repoQuery = ''
+        const scanResult = scanSearchQuery(query)
+        if (scanResult.type === 'success') {
+            const repoQueryFilters = findFilters(scanResult.term, FilterType.repo)
+            if (repoQueryFilters.length === 1) {
+                repoQuery = repoQueryFilters[0].value?.value ?? ''
+            }
+        }
+        const repoFilters = getFilters(filters, FilterType.repo)
+        switch (repoFilters.length) {
+            case 0:
+                // Reuse last repo name if query contains a repo filter and
+                // it's the same as the previous one, otherwise clear previous
+                // repo name
+                if (!repoQuery || repoQuery !== lastRepoQuery.current) {
+                    lastRepoQuery.current = ''
+                    setRepoName('')
+                }
+                break
+            case 1:
+                // Update last repo name and repo query
+                lastRepoQuery.current = repoQuery
+                setRepoName(repoFilters[0].label)
+                break
+            default:
+                // multiple repos are matched, clear everything
+                lastRepoQuery.current = ''
+                setRepoName('')
+        }
+    }, [query, filters, lastRepoQuery])
+
+    return repoName
+}
+
+export function getFilters(filters: Filter[] = [], kind: FilterType): Filter[] {
+    return filters.filter(filter => filter.kind === kind && filter.value !== '')
+}

--- a/client/web/src/search/results/sidebar/helpers.ts
+++ b/client/web/src/search/results/sidebar/helpers.ts
@@ -29,7 +29,7 @@ export function useLastRepoName(query: string, filters: Filter[] = []): string {
                 repoQuery = repoQueryFilters[0].value?.value ?? ''
             }
         }
-        const repoFilters = getFilters(filters, FilterType.repo)
+        const repoFilters = getFiltersOfKind(filters, FilterType.repo)
         switch (repoFilters.length) {
             case 0:
                 // Reuse last repo name if query contains a repo filter and
@@ -55,6 +55,6 @@ export function useLastRepoName(query: string, filters: Filter[] = []): string {
     return repoName
 }
 
-export function getFilters(filters: Filter[] = [], kind: FilterType): Filter[] {
+export function getFiltersOfKind(filters: Filter[] = [], kind: FilterType): Filter[] {
     return filters.filter(filter => filter.kind === kind && filter.value !== '')
 }

--- a/client/web/src/settings/temporary/TemporarySettings.ts
+++ b/client/web/src/settings/temporary/TemporarySettings.ts
@@ -7,6 +7,7 @@ import { SectionID } from '../../search/results/sidebar/SearchSidebar'
  */
 export interface TemporarySettingsSchema {
     'search.collapsedSidebarSections': { [key in SectionID]?: boolean }
+    'search.sidebar.revisions.tab': number
 }
 
 /**


### PR DESCRIPTION
This is a possible implementation of the new sidebar section for showing a list of available branches and tags if all search result are from a single repository. However, there are a couple of UX issues that might need to be addressed before we can actually ship these (see the video for examples):

- Clicking on a rev will reset the revision filter input because the sidebar rerenders.
  - This *could* possibly be solved by lifting the inputs up into the sidebar component, but I wonder if there is a better solution.
- If a search has no results, the revision section will disappear (because whether or not to show the section is based on search results. no results => no section).
  - This could be solved analyzing the search query to determine whether it contains a `repo:` filter with a "static" value. I'd assume this is a relatively common use case. However, there are still many cases where the section would disappear, for which we probably can't find a solution.


https://user-images.githubusercontent.com/179026/129202173-9be0d55b-ba8a-443e-a605-16a55f6810b0.mp4

---

## Update

I made a couple of changes to address the mentioned issue as good as possible. In particular:

- I'm using `useConnection` instead of `FilteredConnection` and render a custom UI. Now we can use the search input provided by `SidebarSection`. I also made the change to `SidebarSection` that allows us to better control when to clear the search input (that solves the first issue mentioned above)

- Instead of validating the `repo:` filter value to see if it can only match a single repo, I'm using a more flexible heuristic (with its own drawbacks, more about that later): The `useLatestRepoName` observes the current query and search/filter results. If the results only contain a single repo and the query contains a single `repo:` filter it remembers the `repo:` filter value as "good". If later we get an empty result but with the same `repo:` filter, we reuse the remembered repo name.
The drawback is that we must have observed non-empty results for a single repo before the hook can work for empty results.
But on the positive side we don't have to rely on analyzing the structure of a specific value and it will also work when the query does not contain an anchored `repo:` filter (as long queries with that filter have returned results from a single repo).

- Reordered the sidebar sections to "demote" search references (after talking with @rrhyne)

-  I put this feature behind a feature flag. To test this PR, either use commit https://github.com/sourcegraph/sourcegraph/pull/23835/commits/2ece69f4457448cc5057aaaaeb213e5737606271 or add the feature flag locally with an enabled state in https://sourcegraph.test:3443/api/console
```
mutation CreateFeatureFlag {
  createFeatureFlag(name: "search-sidebar-revisions", value:true){
    __typename
  }
}
```
**NOTE:** I already created the feature flag and enabled it for the Sourcegraph org on sourcegraph.com

Finally, here is a video that shows the new behavior, including loading states and empty states. I added some captions but they disappear too quickly so you might have to pause the video (video editing is new to me ;) )


https://user-images.githubusercontent.com/179026/129419448-05688cf1-bb95-4c2c-981a-1d8a8b8e912a.mp4

With feature flag disabled: 
<img width="658" alt="2021-08-13_21-03" src="https://user-images.githubusercontent.com/179026/129421656-d69709a0-5b73-4628-94f5-cae1e27ef570.png">

With feature flag enabled: 
<img width="779" alt="2021-08-13_21-04" src="https://user-images.githubusercontent.com/179026/129421672-b2915d7a-2376-40cd-aced-1ed663640993.png">
