### PR TITLE
authz: perms syncing use `external_service_repos` for user code host connections

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -603,7 +603,6 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		// Remove existing user from the set of pending users
 		delete(pendingAccountIDsSet, aid)
 	}
-
 	for i := range userIDs {
 		p.UserIDs.Add(uint32(userIDs[i]))
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -222,9 +222,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 
 	// NOTE: If a <repo_id, user_id> pair is present in the external_service_repos
 	//  table, the user has proven that they have read access to the repository.
-	//
-	// TODO: Ideally, we only want to get back list of private repo IDs.
-	repoIDs, err := s.reposStore.ListExternalServiceRepoIDsByUserID(ctx, userID)
+	repoIDs, err := s.reposStore.ListExternalServicePrivateRepoIDsByUserID(ctx, userID)
 	if err != nil {
 		return errors.Wrap(err, "list external service repo IDs by user ID")
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -220,9 +220,8 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	ctx, save := s.observe(ctx, "PermsSyncer.syncUserPerms", "")
 	defer save(requestTypeUser, userID, &err)
 
-	// NOTE: We take the assumption that if a pair of repo_id and user_id ends up in
-	//  the external_service_repos table, the user must have proved that they have
-	//  read-access to the repository.
+	// NOTE: If a <repo_id, user_id> pair is present in the external_service_repos
+	//  table, the user has proven that they have read access to the repository.
 	repoIDs, err := s.reposStore.ListExternalServiceRepoIDsByUserID(ctx, userID)
 	if err != nil {
 		return errors.Wrap(err, "list external service repo IDs by user ID")
@@ -491,9 +490,8 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	ctx, save := s.observe(ctx, "PermsSyncer.syncRepoPerms", "")
 	defer save(requestTypeRepo, int32(repoID), &err)
 
-	// NOTE: We take the assumption that if a pair of repo_id and user_id ends up in
-	//  the external_service_repos table, the user must have proved that they have
-	//  read-access to the repository.
+	// NOTE: If a <repo_id, user_id> pair is present in the external_service_repos
+	//  table, the user has proven that they have read access to the repository.
 	userIDs, err := s.reposStore.ListExternalServiceUserIDsByRepoID(ctx, repoID)
 	if err != nil {
 		return errors.Wrap(err, "list external service user IDs by repo ID")

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -171,12 +171,12 @@ func TestPermsSyncer_syncUserPerms_unionExternalServiceRepos(t *testing.T) {
 
 	p.fetchUserPerms = func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 		return &authz.ExternalUserPermissions{
-			Exacts: []extsvc.RepoID{"1,2,3,4"},
+			Exacts: []extsvc.RepoID{"1"},
 		}, nil
 	}
 	p.fetchUserPermsByToken = func(ctx context.Context, s string) (*authz.ExternalUserPermissions, error) {
 		return &authz.ExternalUserPermissions{
-			Exacts: []extsvc.RepoID{"1,2,3,4"},
+			Exacts: []extsvc.RepoID{"1"},
 		}, nil
 	}
 
@@ -240,9 +240,6 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return []*types.ExternalService{extService}, nil
-	}
-	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
-		return []int32{}, nil
 	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{}, nil
@@ -326,9 +323,6 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 	}
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return []*types.ExternalService{}, nil
-	}
-	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
-		return []int32{}, nil
 	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{}, nil
@@ -452,9 +446,6 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return []*types.ExternalService{}, nil
 	}
-	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
-		return []int32{}, nil
-	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{}, nil
 	}
@@ -506,9 +497,6 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		}
 		database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
 			return []int32{}, nil
-		}
-		database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
-			return []api.RepoID{}, nil
 		}
 		defer func() {
 			edb.Mocks.Perms = edb.MockPerms{}
@@ -587,9 +575,6 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
 			return []int32{}, nil
 		}
-		database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
-			return []api.RepoID{}, nil
-		}
 		defer func() {
 			edb.Mocks.Perms = edb.MockPerms{}
 			database.Mocks.Repos = database.MockRepos{}
@@ -654,9 +639,6 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 	}
 	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
 		return []int32{}, nil
-	}
-	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
-		return []api.RepoID{}, nil
 	}
 	defer func() {
 		edb.Mocks.Perms = edb.MockPerms{}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -148,6 +148,12 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return []*types.ExternalService{extService}, nil
 	}
+	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+		return []int32{}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
+		return []api.RepoID{}, nil
+	}
 	defer func() {
 		database.Mocks = database.MockStores{}
 		edb.Mocks.Perms = edb.MockPerms{}
@@ -227,6 +233,12 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 	}
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return []*types.ExternalService{}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+		return []int32{}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
+		return []api.RepoID{}, nil
 	}
 	defer func() {
 		database.Mocks = database.MockStores{}
@@ -347,6 +359,12 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return []*types.ExternalService{}, nil
 	}
+	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+		return []int32{}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
+		return []api.RepoID{}, nil
+	}
 	defer func() {
 		database.Mocks = database.MockStores{}
 		edb.Mocks.Perms = edb.MockPerms{}
@@ -392,6 +410,12 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 					},
 				},
 			}, nil
+		}
+		database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+			return []int32{}, nil
+		}
+		database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
+			return []api.RepoID{}, nil
 		}
 		defer func() {
 			edb.Mocks.Perms = edb.MockPerms{}
@@ -467,6 +491,12 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 				},
 			}, nil
 		}
+		database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+			return []int32{}, nil
+		}
+		database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
+			return []api.RepoID{}, nil
+		}
 		defer func() {
 			edb.Mocks.Perms = edb.MockPerms{}
 			database.Mocks.Repos = database.MockRepos{}
@@ -528,6 +558,12 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 				},
 			},
 		}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+		return []int32{}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
+		return []api.RepoID{}, nil
 	}
 	defer func() {
 		edb.Mocks.Perms = edb.MockPerms{}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -93,6 +93,99 @@ func (p *mockProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Reposito
 	return p.fetchRepoPerms(ctx, repo)
 }
 
+// NOTE: With the latest set of changes, we will be relying on the external_service_repos
+//  table to satisfy repo permissions. That means we don't need to make the external
+//  service calls we currently do, because the data is already present.
+//
+//  We are choosing to _leave_ the current code and tests alone, since the new data
+//  is additive. All existing tests should pass, and this new test captures the new
+//  behavior. We will revisit the issue shortly and excise the old code.
+//
+//  In the test below, the external service has one repo that's visible due to a limited
+//  sign-in connection scope, but additional repositories in the external_service_repos
+//  table. At the end we expect a union of both sets of data.
+func TestPermsSyncer_syncUserPerms_unionExternalServiceRepos(t *testing.T) {
+	p := &mockProvider{
+		id:          1,
+		serviceType: extsvc.TypeGitLab,
+		serviceID:   "https://gitlab.com/",
+	}
+	authz.SetProviders(false, []authz.Provider{p})
+	defer authz.SetProviders(true, nil)
+
+	extAccount := extsvc.Account{
+		AccountSpec: extsvc.AccountSpec{
+			ServiceType: p.ServiceType(),
+			ServiceID:   p.ServiceID(),
+		},
+	}
+	extService := &types.ExternalService{
+		ID:              1,
+		Kind:            extsvc.KindGitLab,
+		DisplayName:     "GITLAB1",
+		Config:          `{"token": "limited"}`,
+		NamespaceUserID: 1,
+	}
+
+	database.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+		return &types.User{ID: id}, nil
+	}
+	database.Mocks.ExternalAccounts.TouchLastValid = func(ctx context.Context, id int32) error {
+		return nil
+	}
+	edb.Mocks.Perms.ListExternalAccounts = func(context.Context, int32) ([]*extsvc.Account, error) {
+		return []*extsvc.Account{&extAccount}, nil
+	}
+	edb.Mocks.Perms.SetUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
+		wantIDs := []uint32{1, 2, 3, 4}
+		if diff := cmp.Diff(wantIDs, p.IDs.ToArray()); diff != "" {
+			return errors.Errorf("IDs mismatch (-want +got):\n%s", diff)
+		}
+		return nil
+	}
+	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
+		if !args.OnlyPrivate {
+			return nil, errors.New("OnlyPrivate want true but got false")
+		}
+		return []types.RepoName{{ID: 1}}, nil
+	}
+	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
+		return nil, nil
+	}
+	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+		return []*types.ExternalService{extService}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+		return []int32{1}, nil
+	}
+	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
+		return []api.RepoID{2, 3, 4}, nil
+	}
+	defer func() {
+		database.Mocks = database.MockStores{}
+		edb.Mocks.Perms = edb.MockPerms{}
+	}()
+
+	permsStore := edb.Perms(nil, timeutil.Now)
+	s := NewPermsSyncer(repos.NewStore(&dbtesting.MockDB{}, sql.TxOptions{}), permsStore, timeutil.Now, nil)
+
+	p.fetchUserPerms = func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error) {
+		return &authz.ExternalUserPermissions{
+			Exacts: []extsvc.RepoID{"1,2,3,4"},
+		}, nil
+	}
+	p.fetchUserPermsByToken = func(ctx context.Context, s string) (*authz.ExternalUserPermissions, error) {
+		return &authz.ExternalUserPermissions{
+			Exacts: []extsvc.RepoID{"1,2,3,4"},
+		}, nil
+	}
+
+	err := s.syncUserPerms(context.Background(), 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	p := &mockProvider{
 		id:          1,

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -18,6 +18,10 @@ type MockRepos struct {
 	Metadata      func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
 	Create        func(ctx context.Context, repos ...*types.Repo) (err error)
 	Count         func(ctx context.Context, opt ReposListOptions) (int, error)
+
+	// TODO: these two methods do not belong here
+	ListExternalServiceUserIDsByRepoID func(ctx context.Context, repoID api.RepoID) ([]int32, error)
+	ListExternalServiceRepoIDsByUserID func(ctx context.Context, userID int32) ([]api.RepoID, error)
 }
 
 func (s *MockRepos) MockGet(t *testing.T, wantRepo api.RepoID) (called *bool) {

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -19,7 +19,7 @@ type MockRepos struct {
 	Create        func(ctx context.Context, repos ...*types.Repo) (err error)
 	Count         func(ctx context.Context, opt ReposListOptions) (int, error)
 
-	// TODO: these two methods do not belong here
+	// TODO: we're knowingly taking on a little tech debt by placing these here for now.
 	ListExternalServiceUserIDsByRepoID func(ctx context.Context, repoID api.RepoID) ([]int32, error)
 	ListExternalServiceRepoIDsByUserID func(ctx context.Context, userID int32) ([]api.RepoID, error)
 }

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -36,6 +36,8 @@ func TestIntegration(t *testing.T) {
 		{"SyncRateLimiters", testSyncRateLimiters},
 		{"EnqueueSyncJobs", testStoreEnqueueSyncJobs},
 		{"EnqueueSingleSyncJob", testStoreEnqueueSingleSyncJob},
+		{"ListExternalServiceUserIDsByRepoID", testStoreListExternalServiceUserIDsByRepoID},
+		{"ListExternalServiceRepoIDsByUserID", testStoreListExternalServiceRepoIDsByUserID},
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
 		{"Syncer/SyncRepo", testSyncRepo},

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -37,7 +37,7 @@ func TestIntegration(t *testing.T) {
 		{"EnqueueSyncJobs", testStoreEnqueueSyncJobs},
 		{"EnqueueSingleSyncJob", testStoreEnqueueSingleSyncJob},
 		{"ListExternalServiceUserIDsByRepoID", testStoreListExternalServiceUserIDsByRepoID},
-		{"ListExternalServiceRepoIDsByUserID", testStoreListExternalServiceRepoIDsByUserID},
+		{"ListExternalServicePrivateRepoIDsByUserID", testStoreListExternalServicePrivateRepoIDsByUserID},
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
 		{"Syncer/SyncRepo", testSyncRepo},

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/types"
 
 	"github.com/sourcegraph/sourcegraph/internal/logging"
@@ -137,20 +138,21 @@ func (o *observedSource) GetRepo(ctx context.Context, path string) (sourced *typ
 
 // StoreMetrics encapsulates the Prometheus metrics of a Store.
 type StoreMetrics struct {
-	Transact                        *metrics.OperationMetrics
-	Done                            *metrics.OperationMetrics
-	CreateExternalServiceRepo       *metrics.OperationMetrics
-	UpdateExternalServiceRepo       *metrics.OperationMetrics
-	DeleteExternalServiceRepo       *metrics.OperationMetrics
-	DeleteExternalServiceReposNotIn *metrics.OperationMetrics
-	UpsertRepos                     *metrics.OperationMetrics
-	UpsertSources                   *metrics.OperationMetrics
-	ListExternalRepoSpecs           *metrics.OperationMetrics
-	GetExternalService              *metrics.OperationMetrics
-	SetClonedRepos                  *metrics.OperationMetrics
-	CountNotClonedRepos             *metrics.OperationMetrics
-	CountUserAddedRepos             *metrics.OperationMetrics
-	EnqueueSyncJobs                 *metrics.OperationMetrics
+	Transact                           *metrics.OperationMetrics
+	Done                               *metrics.OperationMetrics
+	CreateExternalServiceRepo          *metrics.OperationMetrics
+	UpdateExternalServiceRepo          *metrics.OperationMetrics
+	DeleteExternalServiceRepo          *metrics.OperationMetrics
+	DeleteExternalServiceReposNotIn    *metrics.OperationMetrics
+	UpsertRepos                        *metrics.OperationMetrics
+	UpsertSources                      *metrics.OperationMetrics
+	ListExternalRepoSpecs              *metrics.OperationMetrics
+	ListExternalServiceUserIDsByRepoID *metrics.OperationMetrics
+	GetExternalService                 *metrics.OperationMetrics
+	SetClonedRepos                     *metrics.OperationMetrics
+	CountNotClonedRepos                *metrics.OperationMetrics
+	CountUserAddedRepos                *metrics.OperationMetrics
+	EnqueueSyncJobs                    *metrics.OperationMetrics
 }
 
 // MustRegister registers all metrics in StoreMetrics in the given

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -163,6 +163,8 @@ func (sm StoreMetrics) MustRegister(r prometheus.Registerer) {
 		sm.Transact,
 		sm.Done,
 		sm.ListExternalRepoSpecs,
+		sm.ListExternalServiceUserIDsByRepoID,
+		sm.ListExternalServiceRepoIDsByUserID,
 		sm.CreateExternalServiceRepo,
 		sm.UpdateExternalServiceRepo,
 		sm.DeleteExternalServiceRepo,
@@ -306,6 +308,34 @@ func NewStoreMetrics() StoreMetrics {
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_list_external_repo_specs_errors_total",
 				Help: "Total number of errors when listing external repo specs",
+			}, []string{}),
+		},
+		ListExternalServiceUserIDsByRepoID: &metrics.OperationMetrics{
+			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Name: "src_repoupdater_store_list_external_service_user_ids_by_repo_id",
+				Help: "Time spent listing external service users",
+			}, []string{}),
+			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_store_list_external_service_user_ids_by_repo_id_total",
+				Help: "Total number of listed external service users",
+			}, []string{}),
+			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_store_list_external_service_user_ids_by_repo_id_errors_total",
+				Help: "Total number of errors when listing external service users",
+			}, []string{}),
+		},
+		ListExternalServiceRepoIDsByUserID: &metrics.OperationMetrics{
+			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Name: "src_repoupdater_store_list_external_service_repo_ids_by_user_id",
+				Help: "Time spent listing external service repos",
+			}, []string{}),
+			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_store_list_external_service_repo_ids_by_user_id_total",
+				Help: "Total number of listed external service repos",
+			}, []string{}),
+			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_store_list_external_service_repo_ids_by_user_id_errors_total",
+				Help: "Total number of errors when listing external service repos",
 			}, []string{}),
 		},
 		GetExternalService: &metrics.OperationMetrics{

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -148,6 +148,7 @@ type StoreMetrics struct {
 	UpsertSources                      *metrics.OperationMetrics
 	ListExternalRepoSpecs              *metrics.OperationMetrics
 	ListExternalServiceUserIDsByRepoID *metrics.OperationMetrics
+	ListExternalServiceRepoIDsByUserID *metrics.OperationMetrics
 	GetExternalService                 *metrics.OperationMetrics
 	SetClonedRepos                     *metrics.OperationMetrics
 	CountNotClonedRepos                *metrics.OperationMetrics

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -328,7 +328,7 @@ INSERT INTO external_service_repos (external_service_id, repo_id, clone_url, use
 		}
 	}
 }
-func testStoreListExternalServiceRepoIDsByUserID(store *repos.Store) func(*testing.T) {
+func testStoreListExternalServicePrivateRepoIDsByUserID(store *repos.Store) func(*testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 		t.Cleanup(func() {
@@ -368,15 +368,17 @@ DELETE FROM users;
 INSERT INTO repo (id, name, private)
 VALUES
 	(1, 'repo-1', TRUE),
-	(2, 'repo-2', TRUE)
+	(2, 'repo-2', TRUE),
+	(3, 'repo-3', FALSE)
 `),
 			sqlf.Sprintf(`INSERT INTO users (id, username) VALUES (1, 'alice')`),
 			sqlf.Sprintf(`
 INSERT INTO external_service_repos (external_service_id, repo_id, clone_url, user_id)
-		VALUES
-			(%s, 1, '', NULL),
-			(%s, 2, '', 1);
-		`, svc.ID, svc.ID),
+VALUES
+	(%s, 1, '', NULL),
+	(%s, 2, '', 1),
+	(%s, 3, '', 1)
+		`, svc.ID, svc.ID, svc.ID),
 		}
 		for _, q := range qs {
 			if err := store.Exec(ctx, q); err != nil {
@@ -384,7 +386,7 @@ INSERT INTO external_service_repos (external_service_id, repo_id, clone_url, use
 			}
 		}
 
-		got, err := store.ListExternalServiceRepoIDsByUserID(ctx, 1)
+		got, err := store.ListExternalServicePrivateRepoIDsByUserID(ctx, 1)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -261,6 +261,141 @@ func testStoreEnqueueSingleSyncJob(store *repos.Store) func(*testing.T) {
 	}
 }
 
+func testStoreListExternalServiceUserIDsByRepoID(store *repos.Store) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		t.Cleanup(func() {
+			q := sqlf.Sprintf(`
+DELETE FROM external_service_repos;
+DELETE FROM external_services;
+DELETE FROM repo;
+DELETE FROM users;
+`)
+			if err := store.Exec(ctx, q); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		clock := timeutil.NewFakeClock(time.Now(), 0)
+		now := clock.Now()
+
+		svc := types.ExternalService{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "Github - Test",
+			Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+
+		// Create a new external service
+		confGet := func() *conf.Unified {
+			return &conf.Unified{}
+		}
+		err := database.ExternalServicesWith(store).Create(ctx, confGet, &svc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		qs := []*sqlf.Query{
+			sqlf.Sprintf(`
+INSERT INTO repo (id, name, private)
+VALUES
+	(1, 'repo-1', TRUE),
+	(2, 'repo-2', TRUE)
+`),
+			sqlf.Sprintf(`INSERT INTO users (id, username) VALUES (1, 'alice')`),
+			sqlf.Sprintf(`
+INSERT INTO external_service_repos (external_service_id, repo_id, clone_url, user_id)
+		VALUES
+			(%s, 1, '', NULL),
+			(%s, 2, '', 1);
+		`, svc.ID, svc.ID),
+		}
+		for _, q := range qs {
+			if err := store.Exec(ctx, q); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		got, err := store.ListExternalServiceUserIDsByRepoID(ctx, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := []int32{1}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	}
+}
+func testStoreListExternalServiceRepoIDsByUserID(store *repos.Store) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		t.Cleanup(func() {
+			q := sqlf.Sprintf(`
+DELETE FROM external_service_repos;
+DELETE FROM external_services;
+DELETE FROM repo;
+DELETE FROM users;
+`)
+			if err := store.Exec(ctx, q); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		clock := timeutil.NewFakeClock(time.Now(), 0)
+		now := clock.Now()
+
+		svc := types.ExternalService{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "Github - Test",
+			Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+
+		// Create a new external service
+		confGet := func() *conf.Unified {
+			return &conf.Unified{}
+		}
+		err := database.ExternalServicesWith(store).Create(ctx, confGet, &svc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		qs := []*sqlf.Query{
+			sqlf.Sprintf(`
+INSERT INTO repo (id, name, private)
+VALUES
+	(1, 'repo-1', TRUE),
+	(2, 'repo-2', TRUE)
+`),
+			sqlf.Sprintf(`INSERT INTO users (id, username) VALUES (1, 'alice')`),
+			sqlf.Sprintf(`
+INSERT INTO external_service_repos (external_service_id, repo_id, clone_url, user_id)
+		VALUES
+			(%s, 1, '', NULL),
+			(%s, 2, '', 1);
+		`, svc.ID, svc.ID),
+		}
+		for _, q := range qs {
+			if err := store.Exec(ctx, q); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		got, err := store.ListExternalServiceRepoIDsByUserID(ctx, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := []api.RepoID{2}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	}
+}
+
 func mkRepos(n int, base ...*types.Repo) types.Repos {
 	if len(base) == 0 {
 		return nil


### PR DESCRIPTION
Cloud customers should only see private repositories that they have added themselves through a customer-added code host connection, even if another customer added a repository via another code host connection that would normally permit visibility. This helps ensure that customers have confidence in the security of their repositories.

This change shifts toward using the `external_service_repos` table as a source of truth for repo permissions for user-added code host connections. For a `<repo_id, user_id>` pair to be present in the table, the customer by definition has proven that they have sufficient rights to read the repository. Relying on this table avoids a flip-flop situation where a repo would be visible but then be hidden when user permissions are synced from the code host using tokens of lower privilege (e.g. ones that can't see private repos).

fixes https://sourcegraph.atlassian.net/browse/COREAPP-142

Co-authored-by: flying-robot <71571391+flying-robot@users.noreply.github.com>
Co-authored-by: Indradhanush Gupta <indradhanush.gupta@gmail.com>