### PR TITLE
Remove codeInsightsAllRepos feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Email notifications for saved searches are now deprecated in favor of Code Monitoring. Email notifications can no longer be enabled for saved searches. Saved searches that already have notifications enabled will continue to work, but there is now a button users can click to migrate to code monitors. Notifications for saved searches will be removed entirely in the future. [#23275](https://github.com/sourcegraph/sourcegraph/pull/23275)
 - The `sg_service` Postgres role and `sg_repo_access_policy` policy on the `repo` table have been removed due to performance concerns. [#23622](https://github.com/sourcegraph/sourcegraph/pull/23622)
 - Deprecated site configuration field `email.smtp.disableTLS` has been removed. [#23639](https://github.com/sourcegraph/sourcegraph/pull/23639)
+- The experimental `codeInsightsAllRepos` feature flag has been removed.
 
 ## 3.30.3
 

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -6,7 +6,6 @@ import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { FormChangeEvent, SubmissionErrors } from '../../../../../../components/form/hooks/useForm'
 import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
-import { getExperimentalFeatures } from '../../../../../../utils/get-experimental-features'
 import { CreateInsightFormFields } from '../../types'
 import { getSanitizedRepositories } from '../../utils/insight-sanitizer'
 import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLivePreview'
@@ -53,8 +52,6 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     } = props
 
     const isEditMode = mode === 'edit'
-
-    const { codeInsightsAllRepos } = getExperimentalFeatures(settings)
 
     const {
         form: { values, formAPI, ref, handleSubmit },
@@ -127,7 +124,6 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 step={step}
                 stepValue={stepValue}
                 isFormClearActive={hasFilledValue}
-                hasAllReposUI={codeInsightsAllRepos}
                 onSeriesLiveChange={listen}
                 onCancel={onCancel}
                 onEditSeriesRequest={editRequest}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -28,11 +28,6 @@ interface CreationSearchInsightFormProps {
     className?: string
     isFormClearActive?: boolean
 
-    /**
-     * Enables the experimental insight mode (run insight on all repositories in the instance)
-     */
-    hasAllReposUI?: boolean
-
     title: useFieldAPI<CreateInsightFormFields['title']>
     repositories: useFieldAPI<CreateInsightFormFields['repositories']>
     allReposMode: useFieldAPI<CreateInsightFormFields['allRepos']>
@@ -86,7 +81,6 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         step,
         className,
         isFormClearActive,
-        hasAllReposUI,
         onCancel,
         onSeriesLiveChange,
         onEditSeriesRequest,
@@ -125,22 +119,18 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                     className="mb-0 d-flex flex-column"
                 />
 
-                {hasAllReposUI && (
-                    <>
-                        <label className="d-flex align-items-center mb-2 mt-2 font-weight-normal">
-                            <input
-                                type="checkbox"
-                                {...allReposMode.input}
-                                value="all-repos-mode"
-                                checked={allReposMode.input.value}
-                            />
+                <label className="d-flex align-items-center mb-2 mt-2 font-weight-normal">
+                    <input
+                        type="checkbox"
+                        {...allReposMode.input}
+                        value="all-repos-mode"
+                        checked={allReposMode.input.value}
+                    />
 
-                            <span className="pl-2">Run your insight over all your repositories</span>
-                        </label>
+                    <span className="pl-2">Run your insight over all your repositories</span>
+                </label>
 
-                        <hr className={styles.creationInsightFormSeparator} />
-                    </>
-                )}
+                <hr className={styles.creationInsightFormSeparator} />
             </FormGroup>
 
             <FormGroup
@@ -149,7 +139,6 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 subtitle="Add any number of data series to your chart"
                 error={series.meta.touched && series.meta.error}
                 innerRef={series.input.ref}
-                className={!hasAllReposUI ? 'mt-5' : undefined}
             >
                 <FormSeries
                     series={series.input.value}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1366,8 +1366,6 @@ type SettingsExperimentalFeatures struct {
 	BatchChangesExecution *bool `json:"batchChangesExecution,omitempty"`
 	// CodeInsights description: Enables code insights on directory pages.
 	CodeInsights *bool `json:"codeInsights,omitempty"`
-	// CodeInsightsAllRepos description: Enables the experimental ability to run an insight over all repositories on the instance.
-	CodeInsightsAllRepos *bool `json:"codeInsightsAllRepos,omitempty"`
 	// CodeMonitoring description: Enables code monitoring.
 	CodeMonitoring *bool `json:"codeMonitoring,omitempty"`
 	// CopyQueryButton description: DEPRECATED: This feature is now permanently enabled. Enables displaying the copy query button in the search bar when hovering over the global navigation bar.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -20,14 +20,6 @@
             "pointer": true
           }
         },
-        "codeInsightsAllRepos": {
-          "description": "Enables the experimental ability to run an insight over all repositories on the instance.",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
         "codeMonitoring": {
           "description": "Enables code monitoring.",
           "type": "boolean",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/23204

This PR removes an experimental feature flag `codeInsightsAllRepos`. We are going to enable this feature for all users by default.