### PR TITLE
monitoring: use label_replace to fill empty fallback series with provided 'by' labels

### DIFF
--- a/monitoring/definitions/shared/standard.go
+++ b/monitoring/definitions/shared/standard.go
@@ -87,7 +87,7 @@ func (standardConstructor) Errors(legend string) observableConstructor {
 				Name:        fmt.Sprintf("%s_errors_total", options.MetricNameRoot),
 				Description: fmt.Sprintf("%s%s errors every 5m", options.MetricDescriptionRoot, legend),
 				Query:       fmt.Sprintf(`sum%s(increase(src_%s_errors_total{%s}[5m]))`, by, options.MetricNameRoot, filters),
-				Panel:       monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s errors", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData()),
+				Panel:       monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s errors", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData(options.By...)),
 				Owner:       owner,
 			}
 		}
@@ -116,7 +116,7 @@ func (standardConstructor) ErrorRate(legend string) observableConstructor {
 				Name:        fmt.Sprintf("%s_error_rate", options.MetricNameRoot),
 				Description: fmt.Sprintf("%s%s error rate over 5m", options.MetricDescriptionRoot, legend),
 				Query:       fmt.Sprintf(`sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m])) / (sum%[1]s(increase(src_%[2]s_total{%[3]s}[5m])) + sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m]))) * 100`, by, options.MetricNameRoot, filters),
-				Panel:       monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s error rate", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData()).Unit(monitoring.Percentage),
+				Panel:       monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s error rate", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData(options.By...)).Unit(monitoring.Percentage),
 				Owner:       owner,
 			}
 		}

--- a/monitoring/monitoring/panel_options.go
+++ b/monitoring/monitoring/panel_options.go
@@ -1,6 +1,8 @@
 package monitoring
 
 import (
+	"fmt"
+
 	"github.com/grafana-tools/sdk"
 )
 
@@ -249,8 +251,8 @@ func (panelOptionsLibrary) NoLegend() ObservablePanelOption {
 // all is well and there are no errors.
 //
 // This is different from Grafana's "null as zero", since "no data" is not "null".
-func (panelOptionsLibrary) ZeroIfNoData() ObservablePanelOption {
-	orZero := " OR on() vector(0)"
+func (panelOptionsLibrary) ZeroIfNoData(labels ...string) ObservablePanelOption {
+	orZero := " OR on() " + labelReplaceZero(labels)
 	return func(o Observable, p *sdk.Panel) {
 		switch o.Panel.panelType {
 		case PanelTypeGraph:
@@ -259,4 +261,14 @@ func (panelOptionsLibrary) ZeroIfNoData() ObservablePanelOption {
 			p.HeatmapPanel.Targets[0].Expr += orZero
 		}
 	}
+}
+
+func labelReplaceZero(labels []string) string {
+	if len(labels) == 0 {
+		return "vector(0)"
+	}
+
+	result := labelReplaceZero(labels[1:])
+
+	return fmt.Sprintf(`label_replace(%s, "%s", "<None>", "", "")`, result, labels[0])
 }


### PR DESCRIPTION
Previously, we had queries in the form of `sum by (op)(increase(src_team_series_total{...}[5m])) OR on() vector(0)`. If there were gaps in the graph, this fills a zero'd series with no labels. This caused dashboard panels to add a spurious label as follows:
![image](https://user-images.githubusercontent.com/18282288/129237188-4fbd9a99-df17-46e8-a2da-0cbc4b151ea2.png)

This PR changes the zero'ing generator to add labels to the zero'd series based on the `by` grouping with the value of `None` for each. 

Before:

<details>
<summary>Image</summary>


![image](https://user-images.githubusercontent.com/18282288/129235251-4e1f7975-7c56-44d3-9f42-b03643412405.png)

</details>

After:

<details>
<summary>Image</summary>

![image](https://user-images.githubusercontent.com/18282288/129236630-02cb9b9c-082f-41c4-8528-8b7f426038b6.png)

</details>

