### PR TITLE
Code Insights: Add series color setting to the backend insight

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -43,7 +43,7 @@ const insights: Insight[] = [
 ]
 
 const mockInsightAPI = createMockInsightAPI({
-    getBackendInsightById: (id: string) =>
+    getBackendInsightById: ({ id }) =>
         of({
             id,
             view: {

--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -29,7 +29,7 @@ const INSIGHT_CONFIGURATION_MOCK: SearchBackendBasedInsight = {
 }
 
 const mockInsightAPI = createMockInsightAPI({
-    getBackendInsightById: (id: string) =>
+    getBackendInsightById: ({ id }) =>
         of({
             id,
             view: {
@@ -53,7 +53,7 @@ add('Backend Insight Card', () => (
 ))
 
 const mockInsightAPIWithDelay = createMockInsightAPI({
-    getBackendInsightById: (id: string) =>
+    getBackendInsightById: ({ id }) =>
         of({
             id,
             view: {

--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -52,11 +52,15 @@ export const BackendInsight: React.FunctionComponent<BackendInsightProps> = prop
     const debouncedFilters = useDebounce(regexpFilters, 500)
 
     const { data, loading, error } = useParallelRequests(
-        useCallback(() => getBackendInsightById(insight.id, debouncedFilters), [
-            insight.id,
-            debouncedFilters,
-            getBackendInsightById,
-        ])
+        useCallback(
+            () =>
+                getBackendInsightById({
+                    id: insight.id,
+                    filters: debouncedFilters,
+                    series: insight.series,
+                }),
+            [insight.id, insight.series, debouncedFilters, getBackendInsightById]
+        )
     )
 
     const { loading: isDeleting, delete: handleDelete } = useDeleteInsight({

--- a/client/web/src/insights/core/backend/api/get-backend-insight-by-id.ts
+++ b/client/web/src/insights/core/backend/api/get-backend-insight-by-id.ts
@@ -2,10 +2,12 @@ import { Observable, of, throwError } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 
 import { fetchBackendInsights } from '../requests/fetch-backend-insights'
-import { BackendInsightData, BackendInsightFilters } from '../types'
+import { BackendInsightData, BackendInsightInputs } from '../types'
 import { createViewContent } from '../utils/create-view-content'
 
-export function getBackendInsightById(id: string, filters?: BackendInsightFilters): Observable<BackendInsightData> {
+export function getBackendInsightById(props: BackendInsightInputs): Observable<BackendInsightData> {
+    const { id, filters, series } = props
+
     return fetchBackendInsights([id], filters).pipe(
         switchMap(backendInsights => {
             if (backendInsights.length === 0) {
@@ -19,7 +21,7 @@ export function getBackendInsightById(id: string, filters?: BackendInsightFilter
             view: {
                 title: insight.title,
                 subtitle: insight.description,
-                content: [createViewContent(insight)],
+                content: [createViewContent(insight, series)],
             },
         }))
     )

--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -59,6 +59,12 @@ export interface BackendInsightFilters {
     includeRepoRegexp: string
 }
 
+export interface BackendInsightInputs {
+    id: string
+    filters?: BackendInsightFilters
+    series?: DataSeries[]
+}
+
 export interface LangStatsInsightsSettings {
     /**
      * URL of git repository from which statistics will be collected
@@ -87,10 +93,8 @@ export interface ApiService {
 
     /**
      * Returns backend insight (via gql API handler) by insight id.
-     *
-     * @param id - insight id
      */
-    getBackendInsightById: (id: string, filters?: BackendInsightFilters) => Observable<BackendInsightData>
+    getBackendInsightById: (inputs: BackendInsightInputs) => Observable<BackendInsightData>
 
     /**
      * Returns resolved extension provider result by extension view id via extension API.

--- a/client/web/src/insights/core/backend/utils/create-view-content.ts
+++ b/client/web/src/insights/core/backend/utils/create-view-content.ts
@@ -30,7 +30,7 @@ export function createViewContent(
         series: insight.series.map((series, index) => ({
             name: series.label,
             dataKey: `series${index}`,
-            stroke: `${seriesSettings[index]?.stroke ?? undefined}`,
+            stroke: seriesSettings[index]?.stroke,
         })),
         xAxis: {
             dataKey: 'dateTime',

--- a/client/web/src/insights/core/backend/utils/create-view-content.ts
+++ b/client/web/src/insights/core/backend/utils/create-view-content.ts
@@ -1,11 +1,14 @@
 import { LineChartContent } from 'sourcegraph'
 
 import { InsightFields } from '../../../../graphql-operations'
+import { DataSeries } from '../types'
 
 export function createViewContent(
-    insight: InsightFields
+    insight: InsightFields,
+    seriesSettings: DataSeries[] = []
 ): LineChartContent<{ dateTime: number; [seriesKey: string]: number }, 'dateTime'> {
     const dataByXValue = new Map<string, { dateTime: number; [seriesKey: string]: number }>()
+
     for (const [seriesIndex, series] of insight.series.entries()) {
         for (const point of series.points) {
             let dataObject = dataByXValue.get(point.dateTime)
@@ -20,12 +23,14 @@ export function createViewContent(
             dataObject[`series${seriesIndex}`] = point.value
         }
     }
+
     return {
         chart: 'line',
         data: [...dataByXValue.values()],
         series: insight.series.map((series, index) => ({
             name: series.label,
             dataKey: `series${index}`,
+            stroke: `${seriesSettings[index]?.stroke ?? undefined}`,
         })),
         xAxis: {
             dataKey: 'dateTime',


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/23205

## Context

At the moment our insight GQL API handler doesn't return information about data series color (in fact that returns only query label and points). But we already have this information in the settings cascade which is available for the code insights chart. This PR reads information from the settings cascade and passes it to the backend insight handler in order to build chart content with series (lines) colors.