### PR TITLE
allow observability operation error filter to choose error output destination(s)

### DIFF
--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -230,8 +230,11 @@ func newOperations(observationContext *observation.Context) *operations {
 				Name:         fmt.Sprintf("batches.dbstore.%s", name),
 				MetricLabels: []string{name},
 				Metrics:      m,
-				ErrorFilter: func(err error) bool {
-					return errors.Is(err, ErrNoResults)
+				ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+					if errors.Is(err, ErrNoResults) {
+						return observation.EmitForNone
+					}
+					return observation.EmitForAll
 				},
 			})
 		}

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -36,8 +36,11 @@ func newOperations(observationContext *observation.Context) *operations {
 			Name:         fmt.Sprintf("codeintel.gitserver.%s", name),
 			MetricLabels: []string{name},
 			Metrics:      metrics,
-			ErrorFilter: func(err error) bool {
-				return errors.HasType(err, &gitserver.RevisionNotFoundError{})
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				if errors.HasType(err, &gitserver.RevisionNotFoundError{}) {
+					return observation.EmitForNone
+				}
+				return observation.EmitForAll
 			},
 		})
 	}


### PR DESCRIPTION
This PR allows for the observability operation error filter to elect to have certain errors only redirected to certain outputs e.g. only add the error to the trace and metric counter but not to logs.
By returning a bitfield uint8, one can have any combination of output redirection:
- `observation.EmitForTraces | observation.EmitForMetrics` to have an error tracked in metrics and attached to the opentracing span but not printed to logs
- `observation.EmitForAll` to emit to all 3 destinations (akin to `return false` from previous behaviour)
- `observation.EmitForNone` to not emit anywhere (akin to `return true` from previous behaviour)
- etc etc...

Use case arose from https://github.com/sourcegraph/sourcegraph/pull/23720 where I wanted the above behaviour.