### PR TITLE
Code Insights: Add insight delete confirmation step

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -82,7 +82,7 @@ export const BackendInsight: React.FunctionComponent<BackendInsightProps> = prop
                 />
             }
             telemetryService={telemetryService}
-            onDelete={handleDelete}
+            onDelete={() => handleDelete(insight)}
             innerRef={insightCardReference}
             {...otherProps}
             className={classnames('be-insight-card', otherProps.className, {

--- a/client/web/src/insights/components/insights-view-grid/components/extension-insight/ExtensionInsight.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/extension-insight/ExtensionInsight.tsx
@@ -24,10 +24,19 @@ interface ExtensionInsightProps
         ExtensionsControllerProps,
         React.HTMLAttributes<HTMLElement> {
     viewId: string
+    viewTitle: string
 }
 
 export const ExtensionInsight: React.FunctionComponent<ExtensionInsightProps> = props => {
-    const { viewId, telemetryService, settingsCascade, platformContext, extensionsController, ...otherProps } = props
+    const {
+        viewId,
+        viewTitle,
+        telemetryService,
+        settingsCascade,
+        platformContext,
+        extensionsController,
+        ...otherProps
+    } = props
     const { getExtensionViewById } = useContext(InsightsApiContext)
 
     const { data, loading } = useParallelRequests(
@@ -45,7 +54,7 @@ export const ExtensionInsight: React.FunctionComponent<ExtensionInsightProps> = 
             telemetryService={telemetryService}
             hasContextMenu={true}
             insight={{ id: viewId, view: data?.view }}
-            onDelete={handleDelete}
+            onDelete={() => handleDelete({ id: viewId, title: viewTitle })}
             {...otherProps}
             className={classnames('extension-insight-card', otherProps.className)}
         >

--- a/client/web/src/insights/components/insights-view-grid/components/smart-insight/SmartInsight.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/smart-insight/SmartInsight.tsx
@@ -38,6 +38,7 @@ export const SmartInsight: React.FunctionComponent<InsightProps> = props => {
         ) : (
             <ExtensionInsight
                 viewId={insight.id}
+                viewTitle={insight.title}
                 telemetryService={telemetryService}
                 settingsCascade={settingsCascade}
                 platformContext={platformContext}
@@ -51,6 +52,7 @@ export const SmartInsight: React.FunctionComponent<InsightProps> = props => {
     return (
         <ExtensionInsight
             viewId={insight.id}
+            viewTitle={insight.title}
             telemetryService={telemetryService}
             settingsCascade={settingsCascade}
             platformContext={platformContext}

--- a/client/web/src/insights/hooks/use-delete-insight/use-delete-insight.ts
+++ b/client/web/src/insights/hooks/use-delete-insight/use-delete-insight.ts
@@ -4,7 +4,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { ErrorLike } from '@sourcegraph/shared/src/util/errors'
 
-import { InsightTypePrefix } from '../../core/types'
+import { Insight, InsightTypePrefix } from '../../core/types'
 import { usePersistEditOperations } from '../use-persist-edit-operations'
 
 import { getDeleteInsightEditOperations } from './delete-helpers'
@@ -12,7 +12,7 @@ import { getDeleteInsightEditOperations } from './delete-helpers'
 export interface UseDeleteInsightProps extends SettingsCascadeProps, PlatformContextProps<'updateSettings'> {}
 
 export interface UseDeleteInsightAPI {
-    delete: (insightID: string) => Promise<void>
+    delete: (insight: Pick<Insight, 'id' | 'title'>) => Promise<void>
     loading: boolean
     error: ErrorLike | undefined
 }
@@ -29,9 +29,11 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
     const [error, setError] = useState<ErrorLike | undefined>()
 
     const handleDelete = useCallback(
-        async (insightID: string) => {
+        async (insight: Pick<Insight, 'id' | 'title'>) => {
+            const shouldDelete = window.confirm(`Are you sure you want to delete ${insight.title}?`)
+
             // Prevent double call if we already have ongoing request
-            if (loading) {
+            if (loading || !shouldDelete) {
                 return
             }
 
@@ -41,12 +43,12 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
             // For backward compatibility with old code stats insight api we have to delete
             // this insight in a special way. See link below for more information.
             // https://github.com/sourcegraph/sourcegraph-code-stats-insights/blob/master/src/code-stats-insights.ts#L33
-            const isOldCodeStatsInsight = insightID === `${InsightTypePrefix.langStats}.language`
+            const isOldCodeStatsInsight = insight.id === `${InsightTypePrefix.langStats}.language`
 
             const keyForSearchInSettings = isOldCodeStatsInsight
                 ? // Hardcoded value of id from old version of stats insight extension API
                   'codeStatsInsights.query'
-                : insightID
+                : insight.id
 
             try {
                 const deleteInsightOperations = getDeleteInsightEditOperations({

--- a/client/web/src/insights/hooks/use-delete-insight/use-delete-insight.ts
+++ b/client/web/src/insights/hooks/use-delete-insight/use-delete-insight.ts
@@ -30,7 +30,7 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
 
     const handleDelete = useCallback(
         async (insight: Pick<Insight, 'id' | 'title'>) => {
-            const shouldDelete = window.confirm(`Are you sure you want to delete ${insight.title}?`)
+            const shouldDelete = window.confirm(`Are you sure you want to delete the insight "${insight.title}"?`)
 
             // Prevent double call if we already have ongoing request
             if (loading || !shouldDelete) {

--- a/client/web/src/integration/insights/delete-insights.test.ts
+++ b/client/web/src/integration/insights/delete-insights.test.ts
@@ -96,7 +96,11 @@ describe('Code insights page', () => {
             await driver.page.click(
                 '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="InsightContextMenuButton"]'
             )
-            await driver.page.click('[data-testid="insight-context-menu-delete-button"]')
+
+            await Promise.all([
+                driver.acceptNextDialog(),
+                driver.page.click('[data-testid="insight-context-menu-delete-button"]'),
+            ])
         }, 'OverwriteSettings')
 
         assert.deepStrictEqual(JSON.parse(variables.contents), {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21515

## Context

At the moment in main if you click delete insight we immediately delete your insight without any confirmation step. As @felixfbecker noticed 
>there is no "undo" and it's easy to miss the "edit" button and accidentally delete

So this PR adds a simple confirmation step via `window.confirm` method.