### PR TITLE
Insights/setting migration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Add a new environment variable `SRC_HTTP_CLI_EXTERNAL_TIMEOUT` to control the timeout for all external HTTP requests. [#23620](https://github.com/sourcegraph/sourcegraph/pull/23620)
 - Improved usability where filters followed by a space in the search query will warn users that the filter value is empty. [#23646](https://github.com/sourcegraph/sourcegraph/pull/23646)
 - Passthrough of [`git p4`'s `--use-client-spec` option](https://git-scm.com/docs/git-p4#Documentation/git-p4.txt---use-client-spec) is now supported by configuring the `useClientSpec` field. [#23833](https://github.com/sourcegraph/sourcegraph/pull/23833)
+- Code Insights will do a one-time reset of ephemeral insights specific database tables to clean up stale and invalid data. Insight data will regenerate automatically. [23791](https://github.com/sourcegraph/sourcegraph/pull/23791)
 
 ### Changed
 
@@ -39,6 +40,14 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph's Prometheus dependency has been upgraded to v2.28.1. [23663](https://github.com/sourcegraph/sourcegraph/pull/23663)
 - Sourcegraph's Alertmanager dependency has been upgraded to v0.22.2. [23663](https://github.com/sourcegraph/sourcegraph/pull/23714)
 - Code Insights will now schedule sample recordings for the first of the next month after creation or a previous recording. [#23799](https://github.com/sourcegraph/sourcegraph/pull/23799)
+- Code Insights now stores data in a new format. Data points will store complete vectors for all repositories even if the underlying Sourcegraph queries were compressed. [#23768](https://github.com/sourcegraph/sourcegraph/pull/23768)
+- Code Insights rate limit values have been tuned for a more reasonable performance. [#23860](https://github.com/sourcegraph/sourcegraph/pull/23860)
+- Code Insights will now generate historical data once per month on the first of the month, up to the configured `insights.historical.frames` number of frames. [#23768](https://github.com/sourcegraph/sourcegraph/pull/23768)
+- Code Insights will now schedule recordings for the first of the next calendar month after an insight is created or recorded. [#23799](https://github.com/sourcegraph/sourcegraph/pull/23799)
+- Code Insights will attempt to sync insight definitions from settings to the database once every 10 minutes. [23805](https://github.com/sourcegraph/sourcegraph/pull/23805)
+- Code Insights exposes information about queries that are flagged `dirty` through the `insights` GraphQL query. [#23857](https://github.com/sourcegraph/sourcegraph/pull/23857/)
+- Code Insights GraphQL query `insights` will now fetch 12 months of data instead of 6 if a specific time range is not provided. [#23786](https://github.com/sourcegraph/sourcegraph/pull/23786)
+- Code Insights will now generate 12 months of historical data during a backfill instead of 6. [#23860](https://github.com/sourcegraph/sourcegraph/pull/23860)
 
 ### Fixed
 

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -136,7 +136,7 @@ type settingMigrator struct {
 // NewMigrateSettingInsightsJob will migrate insights from settings into the database. This is a job that will be
 // deprecated as soon as this functionality is available over an API.
 func NewMigrateSettingInsightsJob(ctx context.Context, base dbutil.DB, insights dbutil.DB) goroutine.BackgroundRoutine {
-	interval := time.Minute * 1
+	interval := time.Minute * 10
 	m := settingMigrator{
 		base:     base,
 		insights: insights,

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -136,7 +136,7 @@ type settingMigrator struct {
 // NewMigrateSettingInsightsJob will migrate insights from settings into the database. This is a job that will be
 // deprecated as soon as this functionality is available over an API.
 func NewMigrateSettingInsightsJob(ctx context.Context, base dbutil.DB, insights dbutil.DB) goroutine.BackgroundRoutine {
-	interval := time.Minute * 10
+	interval := time.Minute * 1
 	m := settingMigrator{
 		base:     base,
 		insights: insights,
@@ -196,7 +196,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 	defer func() { err = tx.Store.Done(err) }()
 
 	log15.Info("attempting to migrate insight", "unique_id", from.ID)
-	series := make([]types.InsightSeries, len(from.Series))
+	dataSeries := make([]types.InsightSeries, len(from.Series))
 	metadata := make([]types.InsightViewSeriesMetadata, len(from.Series))
 
 	for i, timeSeries := range from.Series {
@@ -206,11 +206,21 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 			RecordingIntervalDays: 1,
 			NextRecordingAfter:    insights.NextRecording(time.Now()),
 		}
-		result, err := tx.CreateSeries(ctx, temp)
+		var series types.InsightSeries
+		// first check if this data series already exists (somebody already created an insight of this query), in which case we just need to attach the view to this data series
+		existing, err := tx.GetDataSeries(ctx, store.GetDataSeriesArgs{SeriesID: Encode(timeSeries)})
 		if err != nil {
 			return errors.Wrapf(err, "unable to migrate insight unique_id: %s series_id: %s", from.ID, temp.SeriesID)
+		} else if len(existing) > 0 {
+			series = existing[0]
+			log15.Info("existing data series identified, attempting to construct and attach new view", "series_id", series.SeriesID, "unique_id", from.ID)
+		} else {
+			series, err = tx.CreateSeries(ctx, temp)
+			if err != nil {
+				return errors.Wrapf(err, "unable to migrate insight unique_id: %s series_id: %s", from.ID, temp.SeriesID)
+			}
 		}
-		series[i] = result
+		dataSeries[i] = series
 
 		metadata[i] = types.InsightViewSeriesMetadata{
 			Label:  timeSeries.Name,
@@ -229,7 +239,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
 	}
 
-	for i, insightSeries := range series {
+	for i, insightSeries := range dataSeries {
 		err := tx.AttachSeriesToView(ctx, insightSeries, view, metadata[i])
 		if err != nil {
 			return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)


### PR DESCRIPTION
Closes #23863

There is a bug in the process that migrations insight definitions from user / org settings to the database where a view will not be attached to the underlying data series if the series already exists.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
