### PR TITLE
compute: return submatches for basic search queries

### DIFF
--- a/internal/compute/match_context_result.go
+++ b/internal/compute/match_context_result.go
@@ -93,7 +93,7 @@ func ofRegexpMatches(matches [][]int, namedGroups []string, lineValue string, li
 	return Match{Value: firstValue, Range: firstRange, Environment: env}
 }
 
-func ofFileMatches(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
+func FromFileMatch(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 	matches := make([]Match, 0, len(fm.LineMatches))
 	for _, l := range fm.LineMatches {
 		regexpMatches := r.FindAllStringSubmatchIndex(l.Preview, -1)

--- a/internal/compute/match_context_result_test.go
+++ b/internal/compute/match_context_result_test.go
@@ -38,7 +38,7 @@ func TestOfLineMatches(t *testing.T) {
 
 	test := func(input string, serialize serializer) string {
 		r, _ := regexp.Compile(input)
-		result := ofFileMatches(data, r)
+		result := FromFileMatch(data, r)
 		v, _ := json.MarshalIndent(serialize(result), "", "  ")
 		return string(v)
 	}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23818.

Hooks up the `compute` GQL endpoint with the logic that computes submatches. Only content in files supported for now (commit search results not supported yet).

Submatches part is tested, I will figure out an integration test in follow up.

---


Example GQL query:


```gql
query Run($query: String!) {
  compute(query: $query) {
    ... on ComputeMatchContext {
      repository {
        name
      }
      commit
      path
      matches {
        value
        range {
          start {
            line
            character
          }
          end {
            line
            character
          }
        }
        environment {
          variable
          value
          range {
            start {
              line
              character
            }
            end {
              line
              character
            }
          }
        }
      }
    }
  }
}
```

```gql
{
  "query": "/func (\\w+)/"
}
```


```json
{
  "data": {
    "compute": [
      {
        "repository": {
          "name": "github.com/rvantonderp/adjust-go-wrk"
        },
        "commit": "63e11dd31fef5ab6cd80670909f422fb3445fadc",
        "path": "client.go",
        "matches": [
          {
            "value": "func buildHeaders",
            "range": {
              "start": {
                "line": 110,
                "character": 0
              },
              "end": {
                "line": 110,
                "character": 17
              }
            },
            "environment": [
              {
                "variable": "$1",
                "value": "buildHeaders",
                "range": {
                  "start": {
                    "line": 110,
                    "character": 5
                  },
                  "end": {
                    "line": 110,
                    "character": 17
                  }
                }
              }
            ]
          },
....
```