### PR TITLE
compute: don't prepend '$' to env variables

### DIFF
--- a/internal/compute/match_context_result.go
+++ b/internal/compute/match_context_result.go
@@ -1,8 +1,8 @@
 package compute
 
 import (
-	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -83,7 +83,7 @@ func ofRegexpMatches(matches [][]int, namedGroups []string, lineValue string, li
 
 			var v string
 			if namedGroups[j/2] == "" {
-				v = fmt.Sprintf("$%d", j/2)
+				v = strconv.Itoa(j / 2)
 			} else {
 				v = namedGroups[j/2]
 			}

--- a/internal/compute/match_context_result_test.go
+++ b/internal/compute/match_context_result_test.go
@@ -49,7 +49,7 @@ func TestOfLineMatches(t *testing.T) {
 }`).Equal(t, test("nothing", match))
 
 	autogold.Want("compute named regexp submatch", `{
-  "$1": "a",
+  "1": "a",
   "ThisIsNamed": "b"
 }`).Equal(t, test("(a)(?P<ThisIsNamed>b)", environment))
 
@@ -70,7 +70,7 @@ func TestOfLineMatches(t *testing.T) {
         }
       },
       "environment": {
-        "$1": {
+        "1": {
           "value": "bc",
           "range": {
             "start": {
@@ -85,7 +85,7 @@ func TestOfLineMatches(t *testing.T) {
             }
           }
         },
-        "$2": {
+        "2": {
           "value": "c",
           "range": {
             "start": {
@@ -100,7 +100,7 @@ func TestOfLineMatches(t *testing.T) {
             }
           }
         },
-        "$3": {
+        "3": {
           "value": "de",
           "range": {
             "start": {
@@ -115,7 +115,7 @@ func TestOfLineMatches(t *testing.T) {
             }
           }
         },
-        "$4": {
+        "4": {
           "value": "g",
           "range": {
             "start": {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23871.

The environment variables shouldn't have the `$` prepended actually, since we may want to use `$` as metasyntax for substitution and keep it agnostic from the variable (not part of it).