### PR TITLE
API docs: LSIF: correct documentation lookups when bundle root != "/"

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_documentation.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -109,7 +110,10 @@ func (r *queryResolver) Documentation(ctx context.Context, line, character int) 
 		pathIDs, err := r.lsifStore.DocumentationAtPosition(
 			ctx,
 			location.Dump.ID,
-			location.Path,
+			// Note: location.Path here would be relative to the repository root, e.g. "src/encoding/json/stream.go"
+			// instead of relative to the bundle, e.g. "encoding/json/stream.go" - which would
+			// cause a lookup mismatch, so we strip the bundle root first.
+			strings.TrimPrefix(location.Path, location.Dump.Root),
 			target.Start.Line,
 			target.Start.Character,
 		)


### PR DESCRIPTION
This fixes lookups for documentation path IDs (what we use to power "Go to API docs")
when the bundle root is not the same as the root of the repository, e.g. in the golang/go
repository.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
