### PR TITLE
compute: fix resolver not copying the data

### DIFF
--- a/cmd/frontend/graphqlbackend/compute_test.go
+++ b/cmd/frontend/graphqlbackend/compute_test.go
@@ -1,0 +1,35 @@
+package graphqlbackend
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+)
+
+func TestToResultResolverList(t *testing.T) {
+	matches := []result.Match{
+		&result.FileMatch{
+			LineMatches: []*result.LineMatch{
+				{Preview: "a"},
+				{Preview: "b"},
+			},
+		},
+	}
+	test := func(input string) string {
+		resolvers := toResultResolverList(regexp.MustCompile(input), matches, new(dbtesting.MockDB))
+		var results []string
+		for _, r := range resolvers {
+			for _, m := range r.result.(*computeMatchContextResolver).matches {
+				results = append(results, m.Value())
+			}
+		}
+		v, _ := json.Marshal(results)
+		return string(v)
+	}
+
+	autogold.Want("resolver copies all match reseults", `["a","b"]`).Equal(t, test("a|b"))
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/23875.

Did you catch the bug in https://github.com/sourcegraph/sourcegraph/pull/23871? Neither did I! 

The code needs to copy the result when creating the resolver. Previously it was just passing a pointer, so would show the same result multiple times.

I _think_ there is no way around this right @camdencheek?