### PR TITLE
Bump reactstrap to 8.9.0

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
@@ -163,7 +163,61 @@ exports[`FormTriggerArea Correct checkboxes shown when query does not fulfill re
                       }
                       toggle={[Function]}
                       trigger="hover focus"
-                    />
+                    >
+                      <PopperContent
+                        boundariesElement="scrollParent"
+                        container="body"
+                        fade={true}
+                        fallbackPlacement="flip"
+                        flip={true}
+                        hideArrow={false}
+                        isOpen={false}
+                        modifiers={Object {}}
+                        offset={0}
+                        onClosed={[Function]}
+                        placement="bottom"
+                        placementPrefix="bs-tooltip"
+                        popperClassName="tooltip show"
+                        target={
+                          <span
+                            class="d-flex"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="mdi-icon trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                              fill="currentColor"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                              />
+                            </svg>
+                          </span>
+                        }
+                        transition={
+                          Object {
+                            "appear": true,
+                            "baseClass": "fade",
+                            "baseClassActive": "show",
+                            "enter": true,
+                            "exit": true,
+                            "in": true,
+                            "mountOnEnter": false,
+                            "onEnter": [Function],
+                            "onEntered": [Function],
+                            "onEntering": [Function],
+                            "onExit": [Function],
+                            "onExited": [Function],
+                            "onExiting": [Function],
+                            "tag": "div",
+                            "timeout": 150,
+                            "unmountOnExit": false,
+                          }
+                        }
+                      />
+                    </TooltipPopoverWrapper>
                   </Tooltip>
                 </label>
               </ValidQueryChecklistItem>
@@ -284,7 +338,61 @@ exports[`FormTriggerArea Correct checkboxes shown when query does not fulfill re
                       }
                       toggle={[Function]}
                       trigger="hover focus"
-                    />
+                    >
+                      <PopperContent
+                        boundariesElement="scrollParent"
+                        container="body"
+                        fade={true}
+                        fallbackPlacement="flip"
+                        flip={true}
+                        hideArrow={false}
+                        isOpen={false}
+                        modifiers={Object {}}
+                        offset={0}
+                        onClosed={[Function]}
+                        placement="bottom"
+                        placementPrefix="bs-tooltip"
+                        popperClassName="tooltip show"
+                        target={
+                          <span
+                            class="d-flex"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="mdi-icon trigger-area__checklist-hint icon-inline"
+                              fill="currentColor"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                              />
+                            </svg>
+                          </span>
+                        }
+                        transition={
+                          Object {
+                            "appear": true,
+                            "baseClass": "fade",
+                            "baseClassActive": "show",
+                            "enter": true,
+                            "exit": true,
+                            "in": true,
+                            "mountOnEnter": false,
+                            "onEnter": [Function],
+                            "onEntered": [Function],
+                            "onEntering": [Function],
+                            "onExit": [Function],
+                            "onExited": [Function],
+                            "onExiting": [Function],
+                            "tag": "div",
+                            "timeout": 150,
+                            "unmountOnExit": false,
+                          }
+                        }
+                      />
+                    </TooltipPopoverWrapper>
                   </Tooltip>
                 </label>
               </ValidQueryChecklistItem>
@@ -401,7 +509,61 @@ exports[`FormTriggerArea Correct checkboxes shown when query does not fulfill re
                       }
                       toggle={[Function]}
                       trigger="hover focus"
-                    />
+                    >
+                      <PopperContent
+                        boundariesElement="scrollParent"
+                        container="body"
+                        fade={true}
+                        fallbackPlacement="flip"
+                        flip={true}
+                        hideArrow={false}
+                        isOpen={false}
+                        modifiers={Object {}}
+                        offset={0}
+                        onClosed={[Function]}
+                        placement="bottom"
+                        placementPrefix="bs-tooltip"
+                        popperClassName="tooltip show"
+                        target={
+                          <span
+                            class="d-flex"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="mdi-icon trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                              fill="currentColor"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                              />
+                            </svg>
+                          </span>
+                        }
+                        transition={
+                          Object {
+                            "appear": true,
+                            "baseClass": "fade",
+                            "baseClassActive": "show",
+                            "enter": true,
+                            "exit": true,
+                            "in": true,
+                            "mountOnEnter": false,
+                            "onEnter": [Function],
+                            "onEntered": [Function],
+                            "onEntering": [Function],
+                            "onExit": [Function],
+                            "onExited": [Function],
+                            "onExiting": [Function],
+                            "tag": "div",
+                            "timeout": 150,
+                            "unmountOnExit": false,
+                          }
+                        }
+                      />
+                    </TooltipPopoverWrapper>
                   </Tooltip>
                 </label>
               </ValidQueryChecklistItem>

--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "react-stripe-elements": "^6.1.2",
     "react-textarea-autosize": "^8.3.0",
     "react-visibility-sensor": "^5.1.1",
-    "reactstrap": "^8.4.1",
+    "reactstrap": "^8.9.0",
     "recharts": "^1.8.5",
     "regexpp": "^3.1.0",
     "rxjs": "^6.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,7 +1374,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.14.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
@@ -19462,15 +19462,14 @@ react@^16.14.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-reactstrap@^8.4.1:
-  version "8.4.1"
-  resolved "https://registry.npmjs.org/reactstrap/-/reactstrap-8.4.1.tgz#c7f63b9057f58b52833061711ebe235b9ec4e3e5"
-  integrity sha512-oAjp9PYYUGKl7SLXwrQ1oRIrYw0MqfO2mUqYgGapFKHG2uwjEtLip5rYxtMujkGx3COjH5FX1WtcfNU4oqpH0Q==
+reactstrap@^8.9.0:
+  version "8.9.0"
+  resolved "https://registry.npmjs.org/reactstrap/-/reactstrap-8.9.0.tgz#bca4afa3f5cd18899ef9b33d877a141886d5abae"
+  integrity sha512-pmf33YjpNZk1IfrjqpWCUMq9hk6GzSnMWBAofTBNIRJQB1zQ0Au2kzv3lPUAFsBYgWEuI9iYa/xKXHaboSiMkQ==
   dependencies:
-    "@babel/runtime" "^7.2.0"
+    "@babel/runtime" "^7.12.5"
     classnames "^2.2.3"
     prop-types "^15.5.8"
-    react-lifecycles-compat "^3.0.4"
     react-popper "^1.3.6"
     react-transition-group "^2.3.1"
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21807

As far as I can tell from looking at the [changelog](https://github.com/reactstrap/reactstrap/releases), there's nothing that should break from these changes.