### PR TITLE
endpoints: improved k8s statefulset support now with ports

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
@@ -2107,6 +2108,7 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a h1:UcxjrRMyNx/i/y8G7kPvLyy7rfbeuf1PYyBf973pgyU=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -16,12 +16,12 @@ import (
 // the endpoints for a service and update the map when they change. It can
 // also fallback to static URLs if not configured for kubernetes.
 type Map struct {
-	urlspec string
-	mu      sync.RWMutex
-	hm      *hashMap
-	err     error
-	init    sync.Once
-	disco   func(chan endpoints)
+	urlspec   string
+	mu        sync.RWMutex
+	hm        *hashMap
+	err       error
+	init      sync.Once
+	discofunk func(chan endpoints) // I like to know who is in my party!
 }
 
 // endpoints represents a list of a service's endpoints as discovered through
@@ -140,7 +140,7 @@ func (m *Map) Endpoints() (map[string]struct{}, error) {
 
 // discover updates the Map with discovered endpoints
 func (m *Map) discover() {
-	if m.disco == nil {
+	if m.discofunk == nil {
 		return
 	}
 
@@ -148,7 +148,7 @@ func (m *Map) discover() {
 	ready := make(chan struct{})
 
 	go m.sync(ch, ready)
-	go m.disco(ch)
+	go m.discofunk(ch)
 
 	<-ready
 }

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -1,38 +1,35 @@
-// Package endpoint provides a consistent hash map for URLs to kubernetes
-// endpoints.
+// Package endpoint provides a consistent hash map over service endpoints.
 package endpoint
 
 import (
 	"fmt"
 	"hash/crc32"
-	"net/url"
-	"os"
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 )
 
 // Map is a consistent hash map to URLs. It uses the kubernetes API to watch
 // the endpoints for a service and update the map when they change. It can
 // also fallback to static URLs if not configured for kubernetes.
 type Map struct {
-	mu      sync.Mutex
-	init    func() (*hashMap, error)
-	err     error
-	urls    *hashMap
 	urlspec string
+	mu      sync.RWMutex
+	hm      *hashMap
+	err     error
+	init    sync.Once
+	disco   func(chan endpoints)
+}
+
+// endpoints represents a list of a service's endpoints as discovered through
+// the chosen service discovery mechanism.
+type endpoints struct {
+	Service   string
+	Endpoints []string
+	Error     error
 }
 
 // New creates a new Map for the URL specifier.
@@ -50,49 +47,14 @@ type Map struct {
 // Examples URL specifiers:
 //
 // 	"k8s+http://searcher"
-// 	"http://searcher-1 http://searcher-2 http://searcher-3"
+// 	"k8s+rpc://indexed-searcher?kind=sts"
+// 	"http://searcher-0 http://searcher-1 http://searcher-2"
 //
 func New(urlspec string) *Map {
 	if !strings.HasPrefix(urlspec, "k8s+") {
-		return &Map{
-			urlspec: urlspec,
-			urls:    newConsistentHashMap(strings.Fields(urlspec)),
-		}
+		return Static(strings.Fields(urlspec)...)
 	}
-
-	m := &Map{urlspec: urlspec}
-
-	// Kick off setting the initial urls or err on first access. We don't rely
-	// just on inform since it may not communicate updates.
-	m.init = func() (*hashMap, error) {
-		u, err := parseURL(urlspec)
-		if err != nil {
-			return nil, err
-		}
-
-		client, ns, err := loadClient()
-		if err != nil {
-			return nil, err
-		}
-
-		endpoints, err := client.CoreV1().Endpoints(ns).Get(u.Service, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		// Kick off watcher in the background
-		go func() {
-			for {
-				err := inform(client.CoreV1().Endpoints(ns), m, u)
-				log15.Debug("failed to watch kubernetes endpoint", "name", u.Service, "error", err)
-				time.Sleep(time.Second)
-			}
-		}()
-
-		return endpointsToMap(u, *endpoints)
-	}
-
-	return m
+	return K8S(urlspec)
 }
 
 // Static returns an Endpoint map which consistently hashes over endpoints.
@@ -104,7 +66,7 @@ func New(urlspec string) *Map {
 func Static(endpoints ...string) *Map {
 	return &Map{
 		urlspec: fmt.Sprintf("%v", endpoints),
-		urls:    newConsistentHashMap(endpoints),
+		hm:      newConsistentHashMap(endpoints),
 	}
 }
 
@@ -127,12 +89,16 @@ func (m *Map) String() string {
 // endpoint may not actually be available yet / at the moment. So users of the
 // URL should implement a retry strategy.
 func (m *Map) Get(key string, exclude map[string]bool) (string, error) {
-	urls, err := m.getUrls()
-	if err != nil {
-		return "", err
+	m.init.Do(m.discover)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.err != nil {
+		return "", m.err
 	}
 
-	return urls.get(key, exclude), nil
+	return m.hm.get(key, exclude), nil
 }
 
 // GetMany is the same as calling Get on each item of keys. It will only
@@ -141,152 +107,85 @@ func (m *Map) Get(key string, exclude map[string]bool) (string, error) {
 // is it is faster (O(1) mutex acquires vs O(n)) and consistent (endpoint map
 // is immutable vs may change between Get calls).
 func (m *Map) GetMany(keys ...string) ([]string, error) {
-	urls, err := m.getUrls()
-	if err != nil {
-		return nil, err
+	m.init.Do(m.discover)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.err != nil {
+		return nil, m.err
 	}
 
 	vals := make([]string, len(keys))
 	for i := range keys {
-		vals[i] = urls.get(keys[i], nil)
+		vals[i] = m.hm.get(keys[i], nil)
 	}
+
 	return vals, nil
 }
 
 // Endpoints returns a set of all addresses. Do not modify the returned value.
 func (m *Map) Endpoints() (map[string]struct{}, error) {
-	urls, err := m.getUrls()
-	if err != nil {
-		return nil, err
+	m.init.Do(m.discover)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.err != nil {
+		return nil, m.err
 	}
 
-	return urls.values, nil
+	return m.hm.values, nil
 }
 
-func (m *Map) getUrls() (*hashMap, error) {
-	m.mu.Lock()
-	if m.init != nil {
-		m.urls, m.err = m.init()
-		m.init = nil // prevent running again
+// discover updates the Map with discovered endpoints
+func (m *Map) discover() {
+	if m.disco == nil {
+		return
 	}
-	urls, err := m.urls, m.err
-	m.mu.Unlock()
-	return urls, err
+
+	ch := make(chan endpoints)
+	ready := make(chan struct{})
+
+	go m.sync(ch, ready)
+	go m.disco(ch)
+
+	<-ready
 }
 
-func inform(client v1.EndpointsInterface, m *Map, u *k8sURL) error {
+func (m *Map) sync(ch chan endpoints, ready chan struct{}) {
+	for eps := range ch {
+		switch {
+		case eps.Error != nil:
+			m.mu.Lock()
+			m.err = eps.Error
+			m.mu.Unlock()
+		case len(eps.Endpoints) > 0:
+			sort.Strings(eps.Endpoints)
 
-	// TODO(Dax): We shouldn't use watch directly, use an informer here
-	watcher, err := client.Watch(metav1.ListOptions{
-		FieldSelector: "metadata.name=" + u.Service,
-	})
-	if err != nil {
-		return errors.Wrap(err, "could not create watcher")
-	}
+			log15.Debug("endpoints", "service", eps.Service, "endpoints", eps.Endpoints)
+			metricEndpointSize.WithLabelValues(eps.Service).Set(float64(len(eps.Endpoints)))
 
-	defer watcher.Stop()
-
-	for {
-		event := <-watcher.ResultChan()
-		e := event.Object
-		endpoints, ok := e.(*corev1.Endpoints)
-		if !ok {
-			return errors.Wrap(err, "object from watcher is not an endpoint")
+			hm := newConsistentHashMap(eps.Endpoints)
+			m.mu.Lock()
+			m.hm = hm
+			m.mu.Unlock()
+		default:
+			m.mu.Lock()
+			m.err = errors.Errorf(
+				"no %s endpoints could be found (this may indicate more %s replicas are needed, contact support@sourcegraph.com for assistance)",
+				eps.Service,
+				eps.Service,
+			)
+			m.mu.Unlock()
 		}
 
-		if event.Type == watch.Error {
-			return errors.Wrap(err, "watcher error")
-		}
-
-		if event.Type != watch.Added && event.Type != watch.Modified {
-			// Either we are error or the endpoint has been removed.
-			log15.Warn(`eventType is not "added" or "modified"`, "eventType", event.Type, "subsets", endpoints.Subsets)
-			endpoints.Subsets = nil
-		}
-		urls, err := endpointsToMap(u, *endpoints)
-		m.mu.Lock()
-		m.urls, m.err = urls, err
-		m.mu.Unlock()
-	}
-}
-
-func endpointsToMap(u *k8sURL, eps corev1.Endpoints) (*hashMap, error) {
-	var urls []string
-	add := func(addr *corev1.EndpointAddress) {
-		if addr.Hostname != "" {
-			urls = append(urls, u.endpointURL(addr.Hostname+"."+u.Service))
-		} else if addr.IP != "" {
-			urls = append(urls, u.endpointURL(addr.IP))
+		select {
+		case <-ready:
+		default:
+			close(ready)
 		}
 	}
-
-	for _, subset := range eps.Subsets {
-		for _, addr := range subset.Addresses {
-			add(&addr)
-		}
-
-		if u.IncludeNotReady {
-			for _, addr := range subset.NotReadyAddresses {
-				add(&addr)
-			}
-		}
-	}
-
-	sort.Strings(urls)
-	log15.Debug("kubernetes endpoints", "service", u.Service, "urls", urls)
-	metricEndpointSize.WithLabelValues(u.Service).Set(float64(len(urls)))
-	if len(urls) == 0 {
-		return nil, errors.Errorf("no %s endpoints could be found (this may indicate more %s replicas are needed, contact support@sourcegraph.com for assistance)", u.Service, u.Service)
-	}
-	return newConsistentHashMap(urls), nil
-}
-
-type k8sURL struct {
-	url.URL
-
-	Service   string
-	Namespace string
-
-	// IncludeNotReady, if true, will make us include not ready endpoints. Defaults to false.
-	// This is desirable for sharded services like gitserver and indexed-search so that we
-	// don't shuffle things around during unavailability events.
-	IncludeNotReady bool
-}
-
-func (u *k8sURL) endpointURL(endpoint string) string {
-	uCopy := u.URL
-	if port := u.Port(); port != "" {
-		uCopy.Host = endpoint + ":" + port
-	} else {
-		uCopy.Host = endpoint
-	}
-	if uCopy.Scheme == "rpc" {
-		return uCopy.Host
-	}
-	return uCopy.String()
-}
-
-func parseURL(rawurl string) (*k8sURL, error) {
-	u, err := url.Parse(strings.TrimPrefix(rawurl, "k8s+"))
-	if err != nil {
-		return nil, err
-	}
-	parts := strings.Split(u.Hostname(), ".")
-	var svc, ns string
-	switch len(parts) {
-	case 1:
-		svc = parts[0]
-	case 2:
-		svc, ns = parts[0], parts[1]
-	default:
-		return nil, errors.Errorf("invalid k8s url. expected k8s+http://service.namespace:port/path, got %s", rawurl)
-	}
-	return &k8sURL{
-		URL:             *u,
-		Service:         svc,
-		Namespace:       ns,
-		IncludeNotReady: u.Query().Get("include_not_ready") == "true",
-	}, nil
 }
 
 func newConsistentHashMap(keys []string) *hashMap {
@@ -296,59 +195,3 @@ func newConsistentHashMap(keys []string) *hashMap {
 	m.add(keys...)
 	return m
 }
-
-// namespace returns the namespace the pod is currently running in
-// this is done because the k8s client we previously used set the namespace
-// when the client was created, the official k8s client does not
-func namespace() string {
-	const filename = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		log15.Warn("endpoint: falling back to kubernetes default namespace", "error", filename+" is empty")
-		return "default"
-	}
-
-	ns := strings.TrimSpace(string(data))
-	if ns == "" {
-		log15.Warn("file: ", filename, " empty using \"default\" ns")
-		return "default"
-	}
-	return ns
-}
-
-func loadClient() (client *kubernetes.Clientset, ns string, err error) {
-	// Uncomment below to test against a real cluster. This is only important
-	// when you are changing how we interact with the k8s API and you want to
-	// test against the real thing.
-	// Ensure you set your KUBECONFIG env var or your current kubeconfig will be used
-
-	// InClusterConfig only works when running inside of a pod in a k8s
-	// cluster.
-	// From https://github.com/kubernetes/client-go/tree/master/examples/out-of-cluster-client-configuration
-	/*
-		c, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
-		if err != nil {
-			log15.Error("couldn't load kubeconfig")
-			os.Exit(1)
-		}
-		clientConfig := clientcmd.NewDefaultClientConfig(*c, nil)
-		config, err = clientConfig.ClientConfig()
-		namespace = "prod"
-	*/
-
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, "", err
-	}
-	client, err = kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return client, namespace(), err
-}
-
-var metricEndpointSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
-	Name: "src_endpoint_k8s_size",
-	Help: "The number of urls in a watched kubernetes endpoint",
-}, []string{"service"})

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestNew(t *testing.T) {
@@ -94,25 +92,5 @@ func TestEndpoints(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("m.Endpoints() unexpected return:\ngot:  %v\nwant: %v", got, want)
-	}
-}
-
-func TestK8sURL(t *testing.T) {
-	endpoint := "endpoint.service"
-	cases := map[string]string{
-		"k8s+http://searcher:3181":          "http://endpoint.service:3181",
-		"k8s+http://searcher":               "http://endpoint.service",
-		"k8s+http://searcher.namespace:123": "http://endpoint.service:123",
-		"k8s+rpc://indexed-search:6070":     "endpoint.service:6070",
-	}
-	for rawurl, want := range cases {
-		u, err := parseURL(rawurl)
-		if err != nil {
-			t.Fatal(err)
-		}
-		got := u.endpointURL(endpoint)
-		if got != want {
-			t.Errorf("mismatch on %s (-want +got):\n%s", rawurl, cmp.Diff(want, got))
-		}
 	}
 }

--- a/internal/endpoint/k8s.go
+++ b/internal/endpoint/k8s.go
@@ -23,8 +23,8 @@ import (
 // service discovery in the background.
 func K8S(urlspec string) *Map {
 	return &Map{
-		urlspec: urlspec,
-		disco:   k8sDiscovery(urlspec, namespace(), loadClient),
+		urlspec:   urlspec,
+		discofunk: k8sDiscovery(urlspec, namespace(), loadClient),
 	}
 }
 

--- a/internal/endpoint/k8s.go
+++ b/internal/endpoint/k8s.go
@@ -1,0 +1,202 @@
+package endpoint
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+// K8S returns a Map for the given k8s urlspec (e.g. k8s+http://searcher), starting
+// service discovery in the background.
+func K8S(urlspec string) *Map {
+	return &Map{
+		urlspec: urlspec,
+		disco:   k8sDiscovery(urlspec, namespace(), loadClient),
+	}
+}
+
+// k8sDiscovery does service discovery of the given k8s urlspec (e.g. k8s+http://searcher),
+// publishing endpoint changes to the given disco channel. It's started by endpoint.K8S as a
+// go-routine.
+func k8sDiscovery(urlspec, ns string, clientFactory func() (*kubernetes.Clientset, error)) func(chan endpoints) {
+	return func(disco chan endpoints) {
+		u, err := parseURL(urlspec)
+		if err != nil {
+			disco <- endpoints{Service: urlspec, Error: err}
+			return
+		}
+
+		var cli *kubernetes.Clientset
+		if cli, err = clientFactory(); err != nil {
+			disco <- endpoints{Service: urlspec, Error: err}
+			return
+		}
+
+		factory := informers.NewSharedInformerFactoryWithOptions(cli, 0,
+			informers.WithNamespace(ns),
+			informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+				opts.FieldSelector = "metadata.name=" + u.Service
+			}),
+		)
+
+		var informer cache.SharedIndexInformer
+		switch u.Kind {
+		case "sts", "statefulset":
+			informer = factory.Apps().V1().StatefulSets().Informer()
+		default:
+			informer = factory.Core().V1().Endpoints().Informer()
+		}
+
+		handle := func(obj interface{}) {
+			var eps []string
+
+			switch o := (obj).(type) {
+			case *corev1.Endpoints:
+				for _, s := range o.Subsets {
+					for _, a := range s.Addresses {
+						ep := a.Hostname
+						if ep == "" {
+							ep = a.IP
+						}
+						eps = append(eps, ep)
+					}
+				}
+			case *appsv1.StatefulSet:
+				replicas := int32(1)
+				if o.Spec.Replicas != nil {
+					replicas = *o.Spec.Replicas
+				}
+				for i := int32(0); i < replicas; i++ {
+					eps = append(eps, fmt.Sprintf("%s-%d", o.Name, i))
+				}
+			}
+
+			disco <- endpoints{Service: u.Service, Endpoints: eps}
+		}
+
+		informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    handle,
+			UpdateFunc: func(_, obj interface{}) { handle(obj) },
+		})
+
+		stop := make(chan struct{})
+		defer close(stop)
+
+		informer.Run(stop)
+	}
+}
+
+type k8sURL struct {
+	url.URL
+
+	Service   string
+	Namespace string
+	Kind      string
+}
+
+func (u *k8sURL) endpointURL(endpoint string) string {
+	uCopy := u.URL
+	if port := u.Port(); port != "" {
+		uCopy.Host = endpoint + ":" + port
+	} else {
+		uCopy.Host = endpoint
+	}
+	if uCopy.Scheme == "rpc" {
+		return uCopy.Host
+	}
+	return uCopy.String()
+}
+
+func parseURL(rawurl string) (*k8sURL, error) {
+	u, err := url.Parse(strings.TrimPrefix(rawurl, "k8s+"))
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(u.Hostname(), ".")
+	var svc, ns string
+	switch len(parts) {
+	case 1:
+		svc = parts[0]
+	case 2:
+		svc, ns = parts[0], parts[1]
+	default:
+		return nil, errors.Errorf("invalid k8s url. expected k8s+http://service.namespace:port/path?kind=$kind, got %s", rawurl)
+	}
+
+	return &k8sURL{
+		URL:       *u,
+		Service:   svc,
+		Namespace: ns,
+		Kind:      strings.ToLower(u.Query().Get("kind")),
+	}, nil
+}
+
+// namespace returns the namespace the pod is currently running in
+// this is done because the k8s client we previously used set the namespace
+// when the client was created, the official k8s client does not
+func namespace() string {
+	const filename = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		log15.Warn("endpoint: falling back to kubernetes default namespace", "error", filename+" is empty")
+		return "default"
+	}
+
+	ns := strings.TrimSpace(string(data))
+	if ns == "" {
+		log15.Warn("file: ", filename, " empty using \"default\" ns")
+		return "default"
+	}
+	return ns
+}
+
+func loadClient() (client *kubernetes.Clientset, err error) {
+	// Uncomment below to test against a real cluster. This is only important
+	// when you are changing how we interact with the k8s API and you want to
+	// test against the real thing.
+	// Ensure you set your KUBECONFIG env var or your current kubeconfig will be used
+
+	// InClusterConfig only works when running inside of a pod in a k8s
+	// cluster.
+	// From https://github.com/kubernetes/client-go/tree/master/examples/out-of-cluster-client-configuration
+	/*
+		c, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+		if err != nil {
+			log15.Error("couldn't load kubeconfig")
+			os.Exit(1)
+		}
+		clientConfig := clientcmd.NewDefaultClientConfig(*c, nil)
+		config, err = clientConfig.ClientConfig()
+		namespace = "prod"
+	*/
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, err
+}
+
+var metricEndpointSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "src_endpoints_size",
+	Help: "The number of service endpoints discovered",
+}, []string{"service"})

--- a/internal/endpoint/k8s.go
+++ b/internal/endpoint/k8s.go
@@ -67,9 +67,11 @@ func k8sDiscovery(urlspec, ns string, clientFactory func() (*kubernetes.Clientse
 			case *corev1.Endpoints:
 				for _, s := range o.Subsets {
 					for _, a := range s.Addresses {
-						ep := a.Hostname
-						if ep == "" {
-							ep = a.IP
+						var ep string
+						if a.Hostname != "" {
+							ep = u.endpointURL(a.Hostname + "." + u.Service)
+						} else if a.IP != "" {
+							ep = u.endpointURL(a.IP)
 						}
 						eps = append(eps, ep)
 					}
@@ -80,7 +82,7 @@ func k8sDiscovery(urlspec, ns string, clientFactory func() (*kubernetes.Clientse
 					replicas = *o.Spec.Replicas
 				}
 				for i := int32(0); i < replicas; i++ {
-					eps = append(eps, fmt.Sprintf("%s-%d", o.Name, i))
+					eps = append(eps, u.endpointURL(fmt.Sprintf("%s-%d.%s", o.Name, i, u.Service)))
 				}
 			}
 

--- a/internal/endpoint/k8s_test.go
+++ b/internal/endpoint/k8s_test.go
@@ -1,0 +1,110 @@
+package endpoint
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+// Tests that even with publishNotReadyAddresses: true in the headless services,
+// the endpoints are not always returned during rollouts. Just start a roll-out in
+// dogfood and run this test.
+//
+// k -n dogfood-k8s rollout restart sts/indexed-search
+// go test -integration -run=Integration
+// === RUN   TestIntegrationK8SNotReadyAddressesBug
+// DBUG[08-11|16:49:14] kubernetes endpoints  service=indexed-search urls="[indexed-search-0.indexed-search indexed-search-1.indexed-search]"
+// DBUG[08-11|16:49:14] kubernetes endpoints  service=indexed-search urls="[indexed-search-0.indexed-search indexed-search-1.indexed-search]"
+// DBUG[08-11|16:49:28] kubernetes endpoints  service=indexed-search urls="[indexed-search-0.indexed-search indexed-search-1.indexed-search]"
+// DBUG[08-11|16:49:40] kubernetes endpoints  service=indexed-search urls=[indexed-search-0.indexed-search]
+//     endpoint_test.go:163: endpoint set has shrunk from 2 to 1
+// 	--- FAIL: TestIntegrationK8SNotReadyAddressesBug (26.94s)
+
+var integration = flag.Bool("integration", false, "Run integration tests")
+
+func TestIntegrationK8SNotReadyAddressesBug(t *testing.T) {
+	if !*integration {
+		t.Skip("Not running integration tests")
+	}
+
+	urlspec := "k8s+rpc://indexed-search"
+	m := Map{
+		urlspec: urlspec,
+		disco:   k8sDiscovery(urlspec, "dogfood-k8s", localClient),
+	}
+
+	began := time.Now()
+	count := 0
+	for time.Since(began) <= time.Minute {
+		eps, err := m.Endpoints()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("endpoints: %v", eps)
+
+		if count == 0 {
+			count = len(eps)
+		} else if len(eps) < count {
+			t.Fatalf("endpoint set shrunk from %d to %d", count, len(eps))
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func TestIntegrationK8SStatefulSet(t *testing.T) {
+	if !*integration {
+		t.Skip("Not running integration tests")
+	}
+
+	urlspec := "k8s+rpc://indexed-search?kind=sts"
+	m := Map{
+		urlspec: urlspec,
+		disco:   k8sDiscovery(urlspec, "dogfood-k8s", localClient),
+	}
+
+	t.Log(m.Endpoints())
+}
+
+func TestK8sURL(t *testing.T) {
+	endpoint := "endpoint.service"
+	cases := map[string]string{
+		"k8s+http://searcher:3181":          "http://endpoint.service:3181",
+		"k8s+http://searcher":               "http://endpoint.service",
+		"k8s+http://searcher.namespace:123": "http://endpoint.service:123",
+		"k8s+rpc://indexed-search:6070":     "endpoint.service:6070",
+	}
+	for rawurl, want := range cases {
+		u, err := parseURL(rawurl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := u.endpointURL(endpoint)
+		if got != want {
+			t.Errorf("mismatch on %s (-want +got):\n%s", rawurl, cmp.Diff(want, got))
+		}
+	}
+}
+
+func localClient() (*kubernetes.Clientset, error) {
+	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}

--- a/internal/endpoint/k8s_test.go
+++ b/internal/endpoint/k8s_test.go
@@ -60,18 +60,29 @@ func TestIntegrationK8SNotReadyAddressesBug(t *testing.T) {
 	}
 }
 
-func TestIntegrationK8SStatefulSet(t *testing.T) {
+func TestIntegrationK8SStatefulSetEquivalence(t *testing.T) {
 	if !*integration {
 		t.Skip("Not running integration tests")
 	}
 
-	urlspec := "k8s+rpc://indexed-search?kind=sts"
-	m := Map{
-		urlspec: urlspec,
-		disco:   k8sDiscovery(urlspec, "dogfood-k8s", localClient),
+	u1 := "k8s+rpc://indexed-search:6070?kind=sts"
+	m1 := Map{
+		urlspec: u1,
+		disco:   k8sDiscovery(u1, "prod", localClient),
 	}
 
-	t.Log(m.Endpoints())
+	u2 := "k8s+rpc://indexed-search:6070"
+	m2 := Map{
+		urlspec: u2,
+		disco:   k8sDiscovery(u2, "prod", localClient),
+	}
+
+	have, _ := m1.Endpoints()
+	want, _ := m2.Endpoints()
+
+	if diff := cmp.Diff(have, want); diff != "" {
+		t.Fatalf("mismatch (-have, +want):\n%s", diff)
+	}
 }
 
 func TestK8sURL(t *testing.T) {

--- a/internal/endpoint/k8s_test.go
+++ b/internal/endpoint/k8s_test.go
@@ -36,8 +36,8 @@ func TestIntegrationK8SNotReadyAddressesBug(t *testing.T) {
 
 	urlspec := "k8s+rpc://indexed-search"
 	m := Map{
-		urlspec: urlspec,
-		disco:   k8sDiscovery(urlspec, "dogfood-k8s", localClient),
+		urlspec:   urlspec,
+		discofunk: k8sDiscovery(urlspec, "dogfood-k8s", localClient),
 	}
 
 	began := time.Now()
@@ -67,14 +67,14 @@ func TestIntegrationK8SStatefulSetEquivalence(t *testing.T) {
 
 	u1 := "k8s+rpc://indexed-search:6070?kind=sts"
 	m1 := Map{
-		urlspec: u1,
-		disco:   k8sDiscovery(u1, "prod", localClient),
+		urlspec:   u1,
+		discofunk: k8sDiscovery(u1, "prod", localClient),
 	}
 
 	u2 := "k8s+rpc://indexed-search:6070"
 	m2 := Map{
-		urlspec: u2,
-		disco:   k8sDiscovery(u2, "prod", localClient),
+		urlspec:   u2,
+		discofunk: k8sDiscovery(u2, "prod", localClient),
 	}
 
 	have, _ := m1.Endpoints()

--- a/internal/endpoint/main_test.go
+++ b/internal/endpoint/main_test.go
@@ -1,0 +1,12 @@
+package endpoint
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -92,7 +92,7 @@ func zoektAddr(environ []string) string {
 
 	// Not set, use the default (service discovery on the indexed-search
 	// statefulset)
-	return "k8s+rpc://indexed-search:6070?include_not_ready=true"
+	return "k8s+rpc://indexed-search:6070?kind=sts"
 }
 
 func getEnv(environ []string, key string) (string, bool) {

--- a/internal/search/env_test.go
+++ b/internal/search/env_test.go
@@ -13,7 +13,7 @@ func TestZoektAddr(t *testing.T) {
 		want    string
 	}{{
 		name: "default",
-		want: "k8s+rpc://indexed-search:6070?include_not_ready=true",
+		want: "k8s+rpc://indexed-search:6070?kind=sts",
 	}, {
 		name:    "old",
 		environ: []string{"ZOEKT_HOST=127.0.0.1:3070"},


### PR DESCRIPTION
The last PR introduced a bug by not using u.endpointURL like before. So
we were missing port numbers and the service name in each endpoint.

Facepalm.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
