### PR TITLE
authz: only derived providers from site-level code host connections

### DIFF
--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -48,6 +48,7 @@ func ProvidersFromConfig(
 	}()
 
 	opt := database.ExternalServicesListOptions{
+		NoNamespace: true,
 		Kinds: []string{
 			extsvc.KindGitHub,
 			extsvc.KindGitLab,


### PR DESCRIPTION
We have started looking at `external_service_repos` table as the source of truth for repo permissions of user-added code host connections since https://github.com/sourcegraph/sourcegraph/pull/23836, thus there is no need to derive authz providers from non-site level (aka. no namespace) code host connections.