### PR TITLE
authz: remove provider-based perms sync for user code host connections

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"container/heap"
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -220,16 +219,16 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	ctx, save := s.observe(ctx, "PermsSyncer.syncUserPerms", "")
 	defer save(requestTypeUser, userID, &err)
 
+	user, err := database.UsersWith(s.reposStore).GetByID(ctx, userID)
+	if err != nil {
+		return errors.Wrap(err, "get user")
+	}
+
 	// NOTE: If a <repo_id, user_id> pair is present in the external_service_repos
 	//  table, the user has proven that they have read access to the repository.
 	repoIDs, err := s.reposStore.ListExternalServicePrivateRepoIDsByUserID(ctx, userID)
 	if err != nil {
 		return errors.Wrap(err, "list external service repo IDs by user ID")
-	}
-
-	user, err := database.UsersWith(s.reposStore).GetByID(ctx, userID)
-	if err != nil {
-		return errors.Wrap(err, "get user")
 	}
 
 	accts, err := s.permsStore.ListExternalAccounts(ctx, user.ID)
@@ -273,7 +272,8 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			log15.Error("Could not fetch account from authz provider",
 				"userID", user.ID,
 				"authzProvider", provider.ServiceID(),
-				"error", err)
+				"error", err,
+			)
 			continue
 		}
 
@@ -295,108 +295,55 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		accts = append(accts, acct)
 	}
 
-	// Fetch all the users external services
-	externalServices := database.ExternalServicesWith(s.reposStore)
-	svcs, err := externalServices.List(ctx, database.ExternalServicesListOptions{
-		NamespaceUserID: userID,
-		Kinds:           []string{extsvc.KindGitHub, extsvc.KindGitLab},
-	})
-	if err != nil {
-		return errors.Wrap(err, "fetching external services")
-	}
-
-	byURN := s.providersByURNs()
-
-	var accountsOrServices []interface{}
-	for i := range accts {
-		accountsOrServices = append(accountsOrServices, accts[i])
-	}
-	for i := range svcs {
-		accountsOrServices = append(accountsOrServices, svcs[i])
-	}
-
 	var repoSpecs, includeContainsSpecs, excludeContainsSpecs []api.ExternalRepoSpec
-
-	for _, accountOrService := range accountsOrServices {
-		var extIDs *authz.ExternalUserPermissions
-		var provider authz.Provider
-
-		switch v := accountOrService.(type) {
-		case *extsvc.Account:
-			provider = byServiceID[v.ServiceID]
-			if provider == nil {
-				// We have no authz provider configured for this external account or service
-				continue
-			}
-
-			if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
-				return errors.Wrap(err, "wait for rate limiter")
-			}
-			extIDs, err = provider.FetchUserPerms(ctx, v)
-
-			if err != nil {
-				// The "401 Unauthorized" is returned by code hosts when the token is no longer valid
-				unauthorized := errcode.IsUnauthorized(err)
-
-				forbidden := errcode.IsForbidden(err)
-
-				// Detect GitHub account suspension error
-				accountSuspended := errcode.IsAccountSuspended(err)
-
-				if unauthorized || accountSuspended || forbidden {
-					err = accounts.TouchExpired(ctx, v.ID)
-					if err != nil {
-						return errors.Wrapf(err, "set expired for external account %d", v.ID)
-					}
-					log15.Debug("PermsSyncer.syncUserPerms.setExternalAccountExpired",
-						"userID", user.ID, "id", v.ID,
-						"unauthorized", unauthorized, "accountSuspended", accountSuspended, "forbidden", forbidden)
-
-					// We still want to continue processing other external accounts
-					continue
-				}
-
-				// Process partial results if this is an initial fetch.
-				if !noPerms {
-					return errors.Wrap(err, "fetch user permissions")
-				}
-				log15.Warn("PermsSyncer.syncUserPerms.proceedWithPartialResults", "userID", user.ID, "error", err)
-			} else {
-				err = accounts.TouchLastValid(ctx, v.ID)
-				if err != nil {
-					return errors.Wrapf(err, "set last valid for external account %d", v.ID)
-				}
-			}
-
-		case *types.ExternalService:
-			provider = byURN[v.URN()]
-			if provider == nil {
-				// We have no authz provider configured for this external service or service
-				continue
-			}
-			token, err := extsvc.ExtractToken(v.Config, v.Kind)
-			if err != nil {
-				log15.Warn("Extracting token from external service config", "error", err, "id", v.ID)
-				continue
-			}
-			if token == "" {
-				log15.Warn("Empty token for external service", "id", v.ID)
-				continue
-			}
-
-			if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
-				return errors.Wrap(err, "wait for rate limiter")
-			}
-
-			extIDs, err = provider.FetchUserPermsByToken(ctx, token)
-			if err != nil {
-				log15.Warn("Fetching user permissions by token", "error", err)
-				continue
-			}
-
-		default:
-			log15.Error("Expected account or external service", "got", fmt.Sprintf("%T", accountOrService))
+	for _, acct := range accts {
+		provider := byServiceID[acct.ServiceID]
+		if provider == nil {
+			// We have no authz provider configured for this external account or service
 			continue
+		}
+
+		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
+			return errors.Wrap(err, "wait for rate limiter")
+		}
+
+		extIDs, err := provider.FetchUserPerms(ctx, acct)
+		if err != nil {
+			// The "401 Unauthorized" is returned by code hosts when the token is no longer valid
+			unauthorized := errcode.IsUnauthorized(err)
+
+			forbidden := errcode.IsForbidden(err)
+
+			// Detect GitHub account suspension error
+			accountSuspended := errcode.IsAccountSuspended(err)
+
+			if unauthorized || accountSuspended || forbidden {
+				err = accounts.TouchExpired(ctx, acct.ID)
+				if err != nil {
+					return errors.Wrapf(err, "set expired for external account %d", acct.ID)
+				}
+				log15.Debug("PermsSyncer.syncUserPerms.setExternalAccountExpired",
+					"userID", user.ID,
+					"id", acct.ID,
+					"unauthorized", unauthorized,
+					"accountSuspended", accountSuspended,
+					"forbidden", forbidden,
+				)
+
+				// We still want to continue processing other external accounts
+				continue
+			}
+
+			// Process partial results if this is an initial fetch.
+			if !noPerms {
+				return errors.Wrap(err, "fetch user permissions")
+			}
+			log15.Warn("PermsSyncer.syncUserPerms.proceedWithPartialResults", "userID", user.ID, "error", err)
+		} else {
+			err = accounts.TouchLastValid(ctx, acct.ID)
+			if err != nil {
+				return errors.Wrapf(err, "set last valid for external account %d", acct.ID)
+			}
 		}
 
 		if extIDs == nil {
@@ -467,11 +414,11 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		Type:   authz.PermRepos,
 		IDs:    roaring.NewBitmap(),
 	}
-	for i := range repoNames {
-		p.IDs.Add(uint32(repoNames[i].ID))
-	}
 	for i := range repoIDs {
 		p.IDs.Add(uint32(repoIDs[i]))
+	}
+	for i := range repoNames {
+		p.IDs.Add(uint32(repoNames[i].ID))
 	}
 
 	err = s.permsStore.SetUserPermissions(ctx, p)
@@ -525,8 +472,9 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	}
 
 	// For non-private repositories, we rely on the fact that the `provider` is
-	// always nil here because we don't restrict access to non-private repositories.
-	if provider == nil {
+	// always nil and no user IDs here because we don't restrict access to
+	// non-private repositories.
+	if provider == nil && len(userIDs) == 0 {
 		log15.Debug("PermsSyncer.syncRepoPerms.noProvider",
 			"repoID", repo.ID,
 			"private", repo.Private,
@@ -538,55 +486,57 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
 	}
 
-	if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
-		return errors.Wrap(err, "wait for rate limiter")
-	}
-
-	extAccountIDs, err := provider.FetchRepoPerms(ctx, &extsvc.Repository{
-		URI:              repo.URI,
-		ExternalRepoSpec: repo.ExternalRepo,
-	})
-
-	// Detect 404 error (i.e. not authorized to call given APIs) that often happens with GitHub.com
-	// when the owner of the token only has READ access. However, we don't want to fail
-	// so the scheduler won't keep trying to fetch permissions of this same repository, so we
-	// return a nil error and log a warning message.
-	var e *github.APIError
-	if errors.As(err, &e) && e.Code == http.StatusNotFound {
-		log15.Warn("PermsSyncer.syncRepoPerms.ignoreUnauthorizedAPIError", "repoID", repo.ID, "err", err, "suggestion", "GitHub access token user may only have read access to the repository, but needs write for permissions")
-		return errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
-	}
-
-	if err != nil {
-		// Process partial results if this is an initial fetch.
-		if !noPerms {
-			return errors.Wrap(err, "fetch repository permissions")
-		}
-		log15.Warn("PermsSyncer.syncRepoPerms.proceedWithPartialResults", "repoID", repo.ID, "err", err)
-	}
-
 	pendingAccountIDsSet := make(map[string]struct{})
-	var accountIDToUserID map[string]int32 // Account ID -> User ID
-	if len(extAccountIDs) > 0 {
-		accountIDs := make([]string, len(extAccountIDs))
-		for i := range extAccountIDs {
-			accountIDs[i] = string(extAccountIDs[i])
+	accountIDsToUserIDs := make(map[string]int32) // Account ID -> User ID
+	if provider != nil {
+		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
+			return errors.Wrap(err, "wait for rate limiter")
 		}
 
-		// Get corresponding internal database IDs
-		accountIDToUserID, err = s.permsStore.GetUserIDsByExternalAccounts(ctx, &extsvc.Accounts{
-			ServiceType: provider.ServiceType(),
-			ServiceID:   provider.ServiceID(),
-			AccountIDs:  accountIDs,
+		extAccountIDs, err := provider.FetchRepoPerms(ctx, &extsvc.Repository{
+			URI:              repo.URI,
+			ExternalRepoSpec: repo.ExternalRepo,
 		})
-		if err != nil {
-			return errors.Wrap(err, "get user IDs by external accounts")
+
+		// Detect 404 error (i.e. not authorized to call given APIs) that often happens with GitHub.com
+		// when the owner of the token only has READ access. However, we don't want to fail
+		// so the scheduler won't keep trying to fetch permissions of this same repository, so we
+		// return a nil error and log a warning message.
+		var e *github.APIError
+		if errors.As(err, &e) && e.Code == http.StatusNotFound {
+			log15.Warn("PermsSyncer.syncRepoPerms.ignoreUnauthorizedAPIError", "repoID", repo.ID, "err", err, "suggestion", "GitHub access token user may only have read access to the repository, but needs write for permissions")
+			return errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
 		}
 
-		// Set up the set of all account IDs that need to be bound to permissions
-		pendingAccountIDsSet = make(map[string]struct{}, len(accountIDs))
-		for i := range accountIDs {
-			pendingAccountIDsSet[accountIDs[i]] = struct{}{}
+		if err != nil {
+			// Process partial results if this is an initial fetch.
+			if !noPerms {
+				return errors.Wrap(err, "fetch repository permissions")
+			}
+			log15.Warn("PermsSyncer.syncRepoPerms.proceedWithPartialResults", "repoID", repo.ID, "err", err)
+		}
+
+		if len(extAccountIDs) > 0 {
+			accountIDs := make([]string, len(extAccountIDs))
+			for i := range extAccountIDs {
+				accountIDs[i] = string(extAccountIDs[i])
+			}
+
+			// Get corresponding internal database IDs
+			accountIDsToUserIDs, err = s.permsStore.GetUserIDsByExternalAccounts(ctx, &extsvc.Accounts{
+				ServiceType: provider.ServiceType(),
+				ServiceID:   provider.ServiceID(),
+				AccountIDs:  accountIDs,
+			})
+			if err != nil {
+				return errors.Wrap(err, "get user IDs by external accounts")
+			}
+
+			// Set up the set of all account IDs that need to be bound to permissions
+			pendingAccountIDsSet = make(map[string]struct{}, len(accountIDs))
+			for i := range accountIDs {
+				pendingAccountIDsSet[accountIDs[i]] = struct{}{}
+			}
 		}
 	}
 
@@ -597,15 +547,15 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		UserIDs: roaring.NewBitmap(),
 	}
 
-	for aid, uid := range accountIDToUserID {
+	for i := range userIDs {
+		p.UserIDs.Add(uint32(userIDs[i]))
+	}
+	for aid, uid := range accountIDsToUserIDs {
 		// Add existing user to permissions
 		p.UserIDs.Add(uint32(uid))
 
 		// Remove existing user from the set of pending users
 		delete(pendingAccountIDsSet, aid)
-	}
-	for i := range userIDs {
-		p.UserIDs.Add(uint32(userIDs[i]))
 	}
 
 	pendingAccountIDs := make([]string, 0, len(pendingAccountIDsSet))
@@ -631,7 +581,11 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return errors.Wrap(err, "set repository pending permissions")
 	}
 
-	log15.Debug("PermsSyncer.syncRepoPerms.synced", "repoID", repo.ID, "name", repo.Name, "count", len(extAccountIDs))
+	log15.Debug("PermsSyncer.syncRepoPerms.synced",
+		"repoID", repo.ID,
+		"name", repo.Name,
+		"count", p.UserIDs.GetCardinality(),
+	)
 	return nil
 }
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -201,13 +201,6 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 			ServiceID:   p.ServiceID(),
 		},
 	}
-	extService := &types.ExternalService{
-		ID:              1,
-		Kind:            extsvc.KindGitLab,
-		DisplayName:     "GITHUB1",
-		Config:          `{"token": "deadbeef"}`,
-		NamespaceUserID: 1,
-	}
 
 	database.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
 		return &types.User{ID: id}, nil
@@ -238,9 +231,6 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
 	}
-	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-		return []*types.ExternalService{extService}, nil
-	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{}, nil
 	}
@@ -270,11 +260,6 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p.fetchUserPerms = func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error) {
-				return &authz.ExternalUserPermissions{
-					Exacts: []extsvc.RepoID{"1"},
-				}, test.fetchErr
-			}
-			p.fetchUserPermsByToken = func(ctx context.Context, s string) (*authz.ExternalUserPermissions, error) {
 				return &authz.ExternalUserPermissions{
 					Exacts: []extsvc.RepoID{"1"},
 				}, test.fetchErr
@@ -320,9 +305,6 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
-	}
-	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-		return []*types.ExternalService{}, nil
 	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{}, nil
@@ -442,9 +424,6 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
-	}
-	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-		return []*types.ExternalService{}, nil
 	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{}, nil


### PR DESCRIPTION
Remove provider-based repo permissions syncing for user code host connections is necessary to ensure users would only see private repositories they've explicitly added at 100% of time, that is because sometimes provider-based permissions syncing could succeed when the user itself has write access to the private repositories that are being added, we would be able to get results back from GitHub API (we're using OAuth token from user-added code host connection, which should have the max access-level the user has). 

The unwanted side effect is that, if any of user-accessible private repository happens to be added by others, but the user self hasn't explicitly added, that private repository will show up in search results.

_Please review with hide whitespace changes_