### PR TITLE
Add missing `SearchBasedInsightSeries` type

### DIFF
--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -60,6 +60,12 @@ export interface BackendInsightFilters {
     includeRepoRegexp: string | null
 }
 
+export interface DataSeries {
+    name: string
+    stroke: string
+    query: string
+}
+
 export interface BackendInsightInputs {
     id: string
     filters?: BackendInsightFilters

--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -60,16 +60,10 @@ export interface BackendInsightFilters {
     includeRepoRegexp: string | null
 }
 
-export interface DataSeries {
-    name: string
-    stroke: string
-    query: string
-}
-
 export interface BackendInsightInputs {
     id: string
     filters?: BackendInsightFilters
-    series?: DataSeries[]
+    series?: SearchBasedInsightSeries[]
 }
 
 export interface LangStatsInsightsSettings {

--- a/client/web/src/insights/core/backend/utils/create-view-content.ts
+++ b/client/web/src/insights/core/backend/utils/create-view-content.ts
@@ -1,11 +1,11 @@
 import { LineChartContent } from 'sourcegraph'
 
 import { InsightFields } from '../../../../graphql-operations'
-import { DataSeries } from '../types'
+import { SearchBasedInsightSeries } from '../../types/insight/search-insight'
 
 export function createViewContent(
     insight: InsightFields,
-    seriesSettings: DataSeries[] = []
+    seriesSettings: SearchBasedInsightSeries[] = []
 ): LineChartContent<{ dateTime: number; [seriesKey: string]: number }, 'dateTime'> {
     const dataByXValue = new Map<string, { dateTime: number; [seriesKey: string]: number }>()
 


### PR DESCRIPTION
This PR replace the missing `DataSeries` type that has been missed in https://github.com/sourcegraph/sourcegraph/pull/23777 with new one `SearchBasedInsightSeries` shared type