### PR TITLE
Fix totalCount on repo batch changes connection resolver

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection.go
@@ -43,6 +43,7 @@ func (r *batchChangesConnectionResolver) TotalCount(ctx context.Context) (int32,
 		InitialApplierID: r.opts.InitialApplierID,
 		NamespaceUserID:  r.opts.NamespaceUserID,
 		NamespaceOrgID:   r.opts.NamespaceOrgID,
+		RepoID:           r.opts.RepoID,
 	}
 	count, err := r.store.CountBatchChanges(ctx, opts)
 	return int32(count), err


### PR DESCRIPTION
Was missing considering the repoID for the count, too.

Closes https://github.com/sourcegraph/sourcegraph/issues/23906
