### PR TITLE
add sg doc blurb about overwrites

### DIFF
--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -195,7 +195,7 @@ sg rfc open 420
 
 ## Configuration
 
-`sg` is configured through the `sg.yaml` file in the root of the `sourcegraph/sourcegraph` repository:
+`sg` is configured through the `sg.config.yaml` file in the root of the `sourcegraph/sourcegraph` repository:
 
 ```yaml
 commands:
@@ -290,6 +290,12 @@ tests:
     env:
       TS_NODE_PROJECT: client/web/src/end-to-end/tsconfig.json
 ```
+
+To modify your configuration locally without accidentally committing the changes, you can overwrite
+chunks of configuration with a `sg.config.overwrite.yaml` file in the root of the repository. If it exists,
+the contents of this file will be merged into the contents of the default configuration file, overwriting
+where there are conflicts. This is useful for running custom command sets or adding environment variables
+specific to your work.
 
 ## TODOs
 


### PR DESCRIPTION
There was no mention of the overwrite file in the docs, and I find it very useful in my day-to-day dev work so I don't accidentally commit changes to `sg.config.yaml`. 

Also fixes a reference to the non-existent `sg.yaml`
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
