### PR TITLE
web: add query parameter to favicon for cache busting

### DIFF
--- a/client/web/src/components/branding/BrandLogo.tsx
+++ b/client/web/src/components/branding/BrandLogo.tsx
@@ -39,7 +39,7 @@ export const BrandLogo: React.FunctionComponent<Props> = ({
 
     const sourcegraphLogoUrl =
         variant === 'symbol'
-            ? `${assetsRoot}/img/sourcegraph-mark.svg`
+            ? `${assetsRoot}/img/sourcegraph-mark.svg?v2` // Add query parameter for cache busting.
             : `${assetsRoot}/img/sourcegraph-logo-${themeProperty}.svg`
 
     const customBrandingLogoUrl = branding?.[themeProperty]?.[variant]

--- a/client/web/src/components/branding/__snapshots__/BrandLogo.test.tsx.snap
+++ b/client/web/src/components/branding/__snapshots__/BrandLogo.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`BrandLogo renders dark sourcegraph symbol 1`] = `
 <img
   alt="Sourcegraph logo"
   className="brand-logo brand-logo--spin"
-  src="/assets/img/sourcegraph-mark.svg"
+  src="/assets/img/sourcegraph-mark.svg?v2"
 />
 `;
 
@@ -60,6 +60,6 @@ exports[`BrandLogo renders light sourcegraph symbol 1`] = `
 <img
   alt="Sourcegraph logo"
   className="brand-logo brand-logo--spin"
-  src="/assets/img/sourcegraph-mark.svg"
+  src="/assets/img/sourcegraph-mark.svg?v2"
 />
 `;

--- a/client/web/src/enterprise/productSubscription/ProductCertificate.tsx
+++ b/client/web/src/enterprise/productSubscription/ProductCertificate.tsx
@@ -34,7 +34,7 @@ export const ProductCertificate: React.FunctionComponent<Props> = ({
         <div className="card-body d-flex align-items-center">
             <img
                 className="product-certificate__logo mr-1 p-2"
-                src="/.assets/img/sourcegraph-mark.svg"
+                src="/.assets/img/sourcegraph-mark.svg?v2"
                 alt="Sourcegraph logo"
             />
             <div>

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserProductSubscriptionStatus.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserProductSubscriptionStatus.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`UserProductSubscriptionStatus toggle: license key hidden 1`] = `
     <img
       alt="Sourcegraph logo"
       className="product-certificate__logo mr-1 p-2"
-      src="/.assets/img/sourcegraph-mark.svg"
+      src="/.assets/img/sourcegraph-mark.svg?v2"
     />
     <div>
       <h2
@@ -74,7 +74,7 @@ exports[`UserProductSubscriptionStatus toggle: license key revealed 1`] = `
     <img
       alt="Sourcegraph logo"
       className="product-certificate__logo mr-1 p-2"
-      src="/.assets/img/sourcegraph-mark.svg"
+      src="/.assets/img/sourcegraph-mark.svg?v2"
     />
     <div>
       <h2

--- a/cmd/frontend/internal/app/misc_handlers.go
+++ b/cmd/frontend/internal/app/misc_handlers.go
@@ -33,7 +33,14 @@ func robotsTxtHelper(w io.Writer, allowRobots bool) {
 }
 
 func favicon(w http.ResponseWriter, r *http.Request) {
-	path := assetsutil.URL("/img/favicon.png").String()
+	url := assetsutil.URL("/img/favicon.png")
+
+	// Add query parameter for cache busting.
+	query := url.Query()
+	query.Set("v", "2")
+	url.RawQuery = query.Encode()
+	path := url.String()
+
 	if branding := globals.Branding(); branding.Favicon != "" {
 		path = branding.Favicon
 	}


### PR DESCRIPTION
## Context

With [updated](https://github.com/sourcegraph/sourcegraph/pull/23751) favicon and sourcegraph-mark.svg we need to force cache busting for users to see the latest version of the assets.

## Changes

- Added query parameter to favicon
- Added query parameter to sourcegraph-mark.svg