### PR TITLE
endpoint: add rendezvous hashing support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
 	github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 // indirect
 	github.com/cespare/xxhash v1.1.0
-	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/cockroachdb/errors v1.8.4
 	github.com/cockroachdb/redact v1.0.9 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	github.com/beevik/etree v1.1.0
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
 	github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 // indirect
+	github.com/cespare/xxhash v1.1.0
+	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/cockroachdb/errors v1.8.4
 	github.com/cockroachdb/redact v1.0.9 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2
@@ -112,6 +114,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/microcosm-cc/bluemonday v1.0.4
+	github.com/montanaflynn/stats v0.6.6
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c
@@ -145,6 +148,7 @@ require (
 	github.com/sourcegraph/go-jsonschema v0.0.0-20200907102109-d14e9f2f3a28
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
+	github.com/sourcegraph/go-rendezvous v0.0.0-20210817141400-b50ebb50dc8a
 	github.com/sourcegraph/gosyntect v0.0.0-20210422223331-645353f16ddc
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -1123,6 +1123,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -1366,6 +1368,8 @@ github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incomp
 github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible/go.mod h1:bBMjfpzEHd6ijPRoQ7f+knFfw+e8R+W158/MsqAy77c=
 github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d h1:afLbh+ltiygTOB37ymZVwKlJwWZn+86syPTbrrOAydY=
 github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=
+github.com/sourcegraph/go-rendezvous v0.0.0-20210817141400-b50ebb50dc8a h1:7aQSpVGMHqodrTJDfC6P3xI97h4FCp9OUEwQPjr/xZ8=
+github.com/sourcegraph/go-rendezvous v0.0.0-20210817141400-b50ebb50dc8a/go.mod h1:IhIP+gIbf0TKVMjcEEwUBjomZRjrPnlZbzT2Wac7XA0=
 github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 h1:K7hzuWsJGoU8ILHJzrXxsuvXvLHpP/g4iUk7VFj2lY8=
 github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8/go.mod h1:0VfoEApmSPgPhnePllwhrB4vwCUkI0K0w8aueOgoJQI=
 github.com/sourcegraph/gosaml2 v0.6.1-0.20210128133756-84151d087b10 h1:lLSG41QZ5I81jSOakWLB1qEXZhJ65spo81f4SEd8Z20=

--- a/internal/endpoint/consistenthash_test.go
+++ b/internal/endpoint/consistenthash_test.go
@@ -1,0 +1,252 @@
+package endpoint
+
+import (
+	"fmt"
+	"hash/crc32"
+	"os"
+	"strings"
+	"testing"
+	"text/tabwriter"
+
+	"github.com/montanaflynn/stats"
+	"github.com/segmentio/fasthash/fnv1"
+	"github.com/segmentio/fasthash/fnv1a"
+	"github.com/sourcegraph/go-rendezvous"
+
+	"github.com/cespare/xxhash"
+)
+
+func TestConsistentHashing(t *testing.T) {
+	keys := readKeys(t, "keys.csv")
+
+	type (
+		hasher   func(string) string
+		hashFunc struct {
+			name string
+			hash func(nodes []string) hasher
+		}
+	)
+
+	fns := []*hashFunc{
+		{
+			name: "consistent(crc32ieee)",
+			hash: func(nodes []string) hasher {
+				m := hashMapNew(50, crc32.ChecksumIEEE)
+				m.add(nodes...)
+				return m.Lookup
+			},
+		},
+		{
+			name: "rendezvous(xxhash64)",
+			hash: func(nodes []string) hasher {
+				return rendezvous.New(nodes, xxhash.Sum64String).Lookup
+			},
+		},
+		{
+			name: "rendezvous(fnv)",
+			hash: func(nodes []string) hasher {
+				return rendezvous.New(nodes, fnv1.HashString64).Lookup
+			},
+		},
+		{
+			name: "rendezvous(fnva)",
+			hash: func(nodes []string) hasher {
+				return rendezvous.New(nodes, fnv1a.HashString64).Lookup
+			},
+		},
+	}
+
+	t.Run("Distribution", func(t *testing.T) {
+		nodes := makeNodes(24)
+		counts := map[string]map[string]int{}
+
+		for _, f := range fns {
+			hash := f.hash(nodes)
+			for _, k := range keys {
+				if counts[f.name] == nil {
+					counts[f.name] = make(map[string]int, len(keys))
+				}
+				counts[f.name][hash(k)]++
+			}
+		}
+
+		var b strings.Builder
+		w := tabwriter.NewWriter(&b, 2, 2, 2, ' ', tabwriter.AlignRight)
+		fmt.Fprintln(w)
+
+		for i, node := range nodes {
+			fmt.Fprintf(w, "node %2d", i)
+			for _, f := range fns {
+				fmt.Fprintf(w, "\t%s\t=>\t%d\t\t%.2f%%",
+					f.name,
+					counts[f.name][node],
+					(float64(counts[f.name][node])/float64(len(keys)))*100.0,
+				)
+			}
+			fmt.Fprintln(w)
+		}
+
+		fmt.Fprintf(w, "\nStats:\n")
+		for _, f := range fns {
+			data := make(stats.Float64Data, 0, len(counts[f.name]))
+			for _, count := range counts[f.name] {
+				data = append(data, float64(count))
+			}
+
+			min, _ := data.Min()
+			max, _ := data.Max()
+			mean, _ := data.Mean()
+			median, _ := data.Median()
+			stdev, _ := data.StandardDeviation()
+
+			fmt.Fprintf(w, "%s\tmin: %d\tmax: %d\tmean: %.3f\tmedian: %d\t\tstdev: %.3f\n",
+				f.name,
+				int(min),
+				int(max),
+				mean,
+				int(median),
+				stdev,
+			)
+
+		}
+
+		w.Flush()
+		t.Log(b.String())
+	})
+
+	t.Run("ClusterDelta", func(t *testing.T) {
+		for _, tc := range [][2]int{
+			{24, 25},
+			{24, 48},
+		} {
+			tc := tc
+			t.Run(fmt.Sprintf("%d->%d", tc[0], tc[1]), func(t *testing.T) {
+				beforeNodes := makeNodes(tc[0])
+				afterNodes := makeNodes(tc[1])
+
+				type nodeStats struct {
+					before int
+					after  int
+					in     int
+					out    int
+					same   int
+				}
+
+				stats := map[string]map[string]*nodeStats{}
+
+				for _, f := range fns {
+					beforeHash := f.hash(beforeNodes)
+					afterHash := f.hash(afterNodes)
+
+					stats[f.name] = map[string]*nodeStats{}
+
+					for _, k := range keys {
+						beforeNode := beforeHash(k)
+						afterNode := afterHash(k)
+
+						if stats[f.name][beforeNode] == nil {
+							stats[f.name][beforeNode] = &nodeStats{}
+						}
+
+						if stats[f.name][afterNode] == nil {
+							stats[f.name][afterNode] = &nodeStats{}
+						}
+
+						stats[f.name][beforeNode].before++
+						stats[f.name][afterNode].after++
+
+						if beforeNode != afterNode {
+							stats[f.name][beforeNode].out++
+							stats[f.name][afterNode].in++
+						} else {
+							stats[f.name][beforeNode].same++
+						}
+					}
+				}
+
+				var b strings.Builder
+				w := tabwriter.NewWriter(&b, 0, 2, 1, ' ', tabwriter.AlignRight)
+				fmt.Fprintln(w)
+
+				for i, node := range afterNodes {
+					fmt.Fprintf(w, "node %2d", i)
+					for _, f := range fns {
+						fmt.Fprintf(w, "\t\t%s\t=>\tout: \t%d \t%.2f%%\t in: %d",
+							f.name,
+							stats[f.name][node].out,
+							(float64(stats[f.name][node].out)/float64(stats[f.name][node].before))*100,
+							stats[f.name][node].in,
+						)
+					}
+					fmt.Fprintln(w)
+				}
+
+				w.Flush()
+				t.Log(b.String())
+			})
+		}
+	})
+
+	t.Run("HashFnChange", func(t *testing.T) {
+		nodes := makeNodes(24)
+
+		in := map[string]int{}
+		out := map[string]int{}
+		same := map[string]int{}
+
+		before := fns[0]
+		after := fns[1]
+		beforeHash := before.hash(nodes)
+		afterHash := after.hash(nodes)
+
+		for _, k := range keys {
+			beforeNode := beforeHash(k)
+			afterNode := afterHash(k)
+
+			if beforeNode != afterNode {
+				out[beforeNode]++
+				in[afterNode]++
+			} else {
+				same[beforeNode]++
+			}
+		}
+
+		var b strings.Builder
+		w := tabwriter.NewWriter(&b, 0, 2, 1, ' ', tabwriter.AlignRight)
+		fmt.Fprintln(w)
+
+		for i, node := range nodes {
+			fmt.Fprintf(w, "node %2d\t%s -> %s\t=>\t-%d\t+%d\t=\t%d\n",
+				i,
+				before.name,
+				after.name,
+				out[node],
+				in[node],
+				same[node],
+			)
+		}
+
+		w.Flush()
+		t.Log(b.String())
+	})
+}
+
+func makeNodes(n int) []string {
+	nodes := make([]string, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = fmt.Sprintf("indexed-search-%d.indexed-search:6070", i)
+	}
+	return nodes
+}
+
+func readKeys(t testing.TB, name string) (keys []string) {
+	t.Helper()
+
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Skipf("failed to read %s, skipping test: %s", name, err)
+		return
+	}
+
+	return strings.Split(string(data), "\n")
+}

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -8,34 +8,42 @@ import (
 
 func TestNew(t *testing.T) {
 	m := New("http://test")
-	expectEndpoints(t, m, nil, "http://test")
+	expectEndpoints(t, m, "http://test")
 
 	m = New("http://test-1 http://test-2")
-	expectEndpoints(t, m, nil, "http://test-1", "http://test-2")
+	expectEndpoints(t, m, "http://test-1", "http://test-2")
 }
 
 func TestStatic(t *testing.T) {
 	m := Static("http://test")
-	expectEndpoints(t, m, nil, "http://test")
+	expectEndpoints(t, m, "http://test")
 
 	m = Static("http://test-1", "http://test-2")
-	expectEndpoints(t, m, nil, "http://test-1", "http://test-2")
+	expectEndpoints(t, m, "http://test-1", "http://test-2")
 }
 
-func TestExclude(t *testing.T) {
+func TestGetN(t *testing.T) {
 	endpoints := []string{"http://test-1", "http://test-2", "http://test-3", "http://test-4"}
 	m := Static(endpoints...)
 
-	exclude := map[string]bool{}
-	for len(endpoints) > 0 {
-		expectEndpoints(t, m, exclude, endpoints...)
+	node, _ := m.Get("foo")
+	have, _ := m.GetN("foo", 3)
 
-		exclude[endpoints[len(endpoints)-1]] = true
-		endpoints = endpoints[:len(endpoints)-1]
+	if len(have) != 3 {
+		t.Fatalf("GetN(3) didn't return 3 nodes")
+	}
+
+	if have[0] != node {
+		t.Fatalf("GetN(foo, 3)[0] != Get(foo): %s != %s", have[0], node)
+	}
+
+	want := []string{"http://test-4", "http://test-2", "http://test-1"}
+	if !reflect.DeepEqual(have, want) {
+		t.Fatalf("GetN(\"foo\", 3):\nhave: %v\nwant: %v", have, want)
 	}
 }
 
-func expectEndpoints(t *testing.T, m *Map, exclude map[string]bool, endpoints ...string) {
+func expectEndpoints(t *testing.T, m *Map, endpoints ...string) {
 	t.Helper()
 
 	// We ask for the URL of a large number of keys, we expect to see every
@@ -45,7 +53,7 @@ func expectEndpoints(t *testing.T, m *Map, exclude map[string]bool, endpoints ..
 		count[e] = 0
 	}
 	for i := 0; i < len(endpoints)*10; i++ {
-		v, err := m.Get(fmt.Sprintf("test-%d", i), exclude)
+		v, err := m.Get(fmt.Sprintf("test-%d", i))
 		if err != nil {
 			t.Fatalf("Get failed: %v", err)
 		}
@@ -65,7 +73,7 @@ func expectEndpoints(t *testing.T, m *Map, exclude map[string]bool, endpoints ..
 	var keys, vals []string
 	for i := 0; i < len(endpoints)*10; i++ {
 		keys = append(keys, fmt.Sprintf("test-%d", i))
-		v, err := m.Get(keys[i], nil)
+		v, err := m.Get(keys[i])
 		if err != nil {
 			t.Fatalf("Get for GetMany failed: %v", err)
 		}

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -70,7 +70,7 @@ func (c *Client) url(key key) (string, error) {
 			c.endpoint = endpoint.New(c.URL)
 		}
 	})
-	return c.endpoint.Get(string(key.repo)+":"+string(key.commitID), nil)
+	return c.endpoint.Get(string(key.repo) + ":" + string(key.commitID))
 }
 
 // Search performs a symbol search on the symbols service.


### PR DESCRIPTION
This commit adds rendezvous hashing support to the endpoint package with
the aim to make it the default in a follow up PR. It's currently
protected by an environment variable which I plan to set on dogfood for
testing.

Additionally, it paves the way for increasing the replication factor by
adding a `GetN` method to map, which I used to replace the previous
`exclude` paramater to `Get` (used only by searcher). Actually raising
replication factor for Zoekt will come later.

[Here](
https://gist.github.com/tsenart/bff23f32d7195d162b712befac6c1f27) is the output of the tests, which shows much better distribution,
and illustrates the data movement needed when changing hash function and
cluster sizes.

I think it's OK for us to shepherd this to prod next week and treat it like
and index version bump, and to write some release notes for customers to expect
some downtime in the next upgrade.