### PR TITLE
web: Fix `LoaderButton` spinner icon position

### DIFF
--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`SignUpPage renders sign up page (cloud) 1`] = `
           className="form-group mb-0"
         >
           <button
-            className="btn btn-primary btn-block"
+            className="btn btn-primary btn-block d-flex justify-content-center align-items-center"
             disabled={true}
             type="submit"
           >
@@ -354,7 +354,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
           className="form-group mb-0"
         >
           <button
-            className="btn btn-primary btn-block"
+            className="btn btn-primary btn-block d-flex justify-content-center align-items-center"
             disabled={true}
             type="submit"
           >

--- a/client/web/src/components/LoaderButton.story.tsx
+++ b/client/web/src/components/LoaderButton.story.tsx
@@ -25,3 +25,16 @@ add('Block', () => (
         {() => <LoaderButton loading={true} label="loader button" className="btn btn-block btn-primary" />}
     </WebStory>
 ))
+
+add('With label', () => (
+    <WebStory>
+        {() => (
+            <LoaderButton
+                alwaysShowLabel={true}
+                loading={true}
+                label="loader button"
+                className="btn btn-block btn-primary"
+            />
+        )}
+    </WebStory>
+))

--- a/client/web/src/components/LoaderButton.tsx
+++ b/client/web/src/components/LoaderButton.tsx
@@ -17,16 +17,16 @@ export const LoaderButton: React.FunctionComponent<Partial<Props>> = ({
     spinnerClassName,
     ...props
 }) => (
-
-    <button {...props}
-            className={classnames(props.className, 'd-flex justify-content-center align-items-center')}
-            // eslint-disable-next-line react/button-has-type
-            type={props.type ?? 'button'}>
+    <button
+        {...props}
+        className={classnames(props.className, 'd-flex justify-content-center align-items-center')}
+        // eslint-disable-next-line react/button-has-type
+        type={props.type ?? 'button'}
+    >
         {loading ? (
             <>
-                <LoadingSpinner
-                    className={classnames(spinnerClassName, 'icon-inline')} />
-                {alwaysShowLabel && <span className='ml-1'>{label}</span>}
+                <LoadingSpinner className={classnames(spinnerClassName, 'icon-inline')} />
+                {alwaysShowLabel && <span className="ml-1">{label}</span>}
             </>
         ) : (
             label

--- a/client/web/src/components/LoaderButton.tsx
+++ b/client/web/src/components/LoaderButton.tsx
@@ -7,14 +7,12 @@ interface Props extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLB
     loading: boolean
     label: string
     alwaysShowLabel: boolean
-    spinnerClassName?: string
 }
 
 export const LoaderButton: React.FunctionComponent<Partial<Props>> = ({
     loading,
     label,
     alwaysShowLabel,
-    spinnerClassName,
     ...props
 }) => (
     <button
@@ -25,7 +23,7 @@ export const LoaderButton: React.FunctionComponent<Partial<Props>> = ({
     >
         {loading ? (
             <>
-                <LoadingSpinner className={classnames(spinnerClassName, 'icon-inline')} />
+                <LoadingSpinner className="icon-inline" />
                 {alwaysShowLabel && <span className="ml-1">{label}</span>}
             </>
         ) : (

--- a/client/web/src/components/LoaderButton.tsx
+++ b/client/web/src/components/LoaderButton.tsx
@@ -17,11 +17,16 @@ export const LoaderButton: React.FunctionComponent<Partial<Props>> = ({
     spinnerClassName,
     ...props
 }) => (
-    // eslint-disable-next-line react/button-has-type
-    <button {...props} type={props.type ?? 'button'}>
+
+    <button {...props}
+            className={classnames(props.className, 'd-flex justify-content-center align-items-center')}
+            // eslint-disable-next-line react/button-has-type
+            type={props.type ?? 'button'}>
         {loading ? (
             <>
-                <LoadingSpinner className={classnames(spinnerClassName, 'icon-inline')} /> {alwaysShowLabel && label}
+                <LoadingSpinner
+                    className={classnames(spinnerClassName, 'icon-inline')} />
+                {alwaysShowLabel && <span className='ml-1'>{label}</span>}
             </>
         ) : (
             label

--- a/client/web/src/components/__snapshots__/LoaderButton.test.tsx.snap
+++ b/client/web/src/components/__snapshots__/LoaderButton.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`LoaderButton should not render a loading spinner when loading prop is false 1`] = `
 <button
+  className="d-flex justify-content-center align-items-center"
   type="button"
 >
   Test
@@ -10,11 +11,11 @@ exports[`LoaderButton should not render a loading spinner when loading prop is f
 
 exports[`LoaderButton should render a loading spinner when loading prop is true 1`] = `
 <button
+  className="d-flex justify-content-center align-items-center"
   type="button"
 >
   <LoadingSpinner
     className="icon-inline"
   />
-   
 </button>
 `;

--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/DrillDownFiltersForm.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/DrillDownFiltersForm.tsx
@@ -153,10 +153,9 @@ export const DrillDownFiltersForm: React.FunctionComponent<DrillDownFiltersFormP
                             ? 'Update default filters'
                             : 'Save default filters'
                     }
-                    spinnerClassName="mr-2"
                     type="submit"
                     disabled={formAPI.submitting || !hasFiltersChanged}
-                    className="d-flex btn btn-outline-secondary ml-auto"
+                    className="btn btn-outline-secondary ml-auto"
                 />
             </footer>
         </form>

--- a/client/web/src/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -101,10 +101,9 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
                                 data-testid="insight-save-button"
                                 loading={formAPI.submitting}
                                 label={formAPI.submitting ? 'Creating' : 'Create dashboard'}
-                                spinnerClassName="mr-2"
                                 type="submit"
                                 disabled={formAPI.submitting}
-                                className="d-flex btn btn-primary ml-2 mb-2"
+                                className="btn btn-primary ml-2 mb-2"
                             />
                         </>
                     )}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
@@ -99,7 +99,6 @@ export const AddInsightModalContent: React.FunctionComponent<AddInsightModalCont
                     label={formAPI.submitting ? 'Saving' : 'Save'}
                     type="submit"
                     disabled={formAPI.submitting}
-                    spinnerClassName="mr-2"
                     className="btn btn-primary"
                 />
             </div>

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/delete-dashboard-modal/DeleteDashboardModal.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/delete-dashboard-modal/DeleteDashboardModal.tsx
@@ -63,7 +63,6 @@ export const DeleteDashboardModal: React.FunctionComponent<DeleteDashboardModalP
                     loading={isDeleting}
                     label={isDeleting ? 'Deleting' : 'Delete forever'}
                     disabled={isDeleting}
-                    spinnerClassName="mr-2"
                     className="btn btn-danger"
                     onClick={handler}
                 />

--- a/client/web/src/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -132,10 +132,9 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
                                 data-testid="insight-save-button"
                                 loading={formAPI.submitting}
                                 label={formAPI.submitting ? 'Saving' : 'Save changes'}
-                                spinnerClassName="mr-2"
                                 type="submit"
                                 disabled={formAPI.submitting}
-                                className="d-flex btn btn-primary ml-2 mb-2"
+                                className="btn btn-primary ml-2 mb-2"
                             />
                         </>
                     )}

--- a/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -105,8 +105,8 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
 
             <hr className={styles.formSeparator} />
 
-            <div className="d-flex flex-wrap align-items-baseline">
-                {submitErrors?.[FORM_ERROR] && <ErrorAlert error={submitErrors[FORM_ERROR]} />}
+            <div className="d-flex flex-wrap align-items-center">
+                {submitErrors?.[FORM_ERROR] && <ErrorAlert className="w-100" error={submitErrors[FORM_ERROR]} />}
 
                 <LoaderButton
                     alwaysShowLabel={true}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -253,8 +253,8 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
 
             <hr className={styles.creationInsightFormSeparator} />
 
-            <div className="d-flex flex-wrap align-items-baseline">
-                {submitErrors?.[FORM_ERROR] && <ErrorAlert error={submitErrors[FORM_ERROR]} />}
+            <div className="d-flex flex-wrap align-items-center">
+                {submitErrors?.[FORM_ERROR] && <ErrorAlert className="w-100" error={submitErrors[FORM_ERROR]} />}
 
                 <LoaderButton
                     alwaysShowLabel={true}

--- a/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
+++ b/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`SiteInitPage normal 1`] = `
           className="form-group mb-0"
         >
           <button
-            className="btn btn-primary btn-block"
+            className="btn btn-primary btn-block d-flex justify-content-center align-items-center"
             disabled={true}
             type="submit"
           >


### PR DESCRIPTION

This PR fixes the loader button spinner icon. Before as you can see on the screenshot below icon position was slightly up compared to the button label. This PR centralizes loader and removes local fixes for the spinner loader which had been solving this problem before this PR in code insights pages.

<table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
    <td>
<img width="222" alt="image" src="https://user-images.githubusercontent.com/18492575/129413175-af8f5aad-612c-404f-8d27-4e7c858312e0.png">
    </td>
    <td>
      
<img width="204" alt="image" src="https://user-images.githubusercontent.com/18492575/129413092-45d2eebc-9707-452b-815f-f957de00169a.png">
    </td>
 </tr>
</table>