### PR TITLE
search is dotcom: update repogroups section

### DIFF
--- a/client/web/src/search/home/LoggedOutHomepage.module.scss
+++ b/client/web/src/search/home/LoggedOutHomepage.module.scss
@@ -14,15 +14,34 @@
 
     &__repogroup-list {
         &-cards {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
-            grid-auto-rows: minmax(4rem, auto);
-            gap: $spacer * 0.75;
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+
+            @media (--md-breakpoint-down) {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+                grid-auto-rows: minmax(4rem, auto);
+                gap: $spacer * 0.75;
+            }
+
+            @media (--sm-breakpoint-down) {
+                display: flex;
+                flex-wrap: wrap;
+            }
+        }
+
+        &-card {
+            max-width: 13.5rem;
+
+            @media (--sm-breakpoint-down) {
+                margin-right: 0.75rem;
+            }
         }
 
         &-icon {
-            width: 3rem;
-            height: 3rem;
+            width: 2rem;
+            height: 2rem;
             object-fit: contain;
         }
     }

--- a/client/web/src/search/home/LoggedOutHomepage.tsx
+++ b/client/web/src/search/home/LoggedOutHomepage.tsx
@@ -144,13 +144,18 @@ export const LoggedOutHomepage: React.FunctionComponent<LoggedOutHomepageProps> 
         </div>
 
         <div className="mt-5">
-            <div className="d-flex align-items-baseline mt-5 mb-3">
-                <div className={classNames(styles.title, 'mr-2')}>Repository groups</div>
-                <div className="font-weight-normal text-muted">Search sets of repositories</div>
+            <div className="d-block d-md-flex align-items-baseline mt-5 mb-3">
+                <div className={classNames(styles.title, 'mr-2')}>Search open source communities</div>
+                <div className="font-weight-normal text-muted">
+                    Customized search portals for our open source partners
+                </div>
             </div>
             <div className={styles.loggedOutHomepageRepogroupListCards}>
                 {repogroupList.map(repogroup => (
-                    <div className="d-flex align-items-center" key={repogroup.name}>
+                    <div
+                        className={classNames(styles.loggedOutHomepageRepogroupListCard, 'd-flex align-items-center')}
+                        key={repogroup.name}
+                    >
                         <img
                             className={classNames(styles.loggedOutHomepageRepogroupListIcon, 'mr-2')}
                             src={repogroup.homepageIcon}

--- a/client/web/src/search/home/homepage.scss
+++ b/client/web/src/search/home/homepage.scss
@@ -1,1 +1,1 @@
-$max-homepage-container-width: 61rem;
+$max-homepage-container-width: 62rem;


### PR DESCRIPTION
Part of #23723

- Update copy of repogroups section title and subtitle, for all screen sizes
- Update sizing and layout for repogroups, for all screen sizes

Desktop:

![image](https://user-images.githubusercontent.com/206864/129421814-8a686ea6-56cd-417b-bc30-cc0c6d9cadd8.png)

Tablet:

![image](https://user-images.githubusercontent.com/206864/129421840-1628d868-43d5-4ce1-8038-c2ae51e44447.png)

Mobile:

![image](https://user-images.githubusercontent.com/206864/129421857-9978555b-dfa7-4b47-a0da-f964a8a2286f.png)
