### PR TITLE
Change "Global's Insights" to "Global Insights" 

### DIFF
--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
@@ -7,12 +7,11 @@ export const getDashboardTitle = (dashboard: RealInsightDashboard): string => {
     const { builtIn } = dashboard
 
     if (builtIn) {
-        if (dashboard.type == InsightsDashboardType.Global) {
+        if (dashboard.type === InsightsDashboardType.Global) {
             return 'Global Insights'
         }
-        else {
-            return `${dashboard.owner.name}'s Insights`
-        }
+
+        return `${dashboard.owner.name}'s Insights`
     }
 
     return dashboard.title

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
@@ -7,7 +7,12 @@ export const getDashboardTitle = (dashboard: RealInsightDashboard): string => {
     const { builtIn } = dashboard
 
     if (builtIn) {
-        return `${dashboard.owner.name}'s Insights`
+        if (dashboard.type == InsightsDashboardType.Global) {
+            return 'Global Insights'
+        }
+        else {
+            return `${dashboard.owner.name}'s Insights`
+        }
     }
 
     return dashboard.title

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -15,12 +15,12 @@ enum DashboardReasonDenied {
 
 type DashboardPermissions =
     | {
-          isConfigurable: false
-          reason: DashboardReasonDenied
-      }
+        isConfigurable: false
+        reason: DashboardReasonDenied
+    }
     | {
-          isConfigurable: true
-      }
+        isConfigurable: true
+    }
 
 const DEFAULT_DASHBOARD_PERMISSIONS: DashboardPermissions = {
     isConfigurable: false,
@@ -101,8 +101,9 @@ export function getTooltipMessage(
                 case InsightsDashboardType.Personal:
                     return "This is an automatically created dashboard that lists all your private insights. You can't edit this dashboard."
                 case InsightsDashboardType.Organization:
-                case InsightsDashboardType.Global:
                     return `This is an automatically created dashboard that lists all the ${dashboard.owner.name}'s insights. You can't edit this dashboard.`
+                case InsightsDashboardType.Global:
+                    return `This is an automatically created dashboard that lists all the global insights. You can't edit this dashboard.`
             }
         case DashboardReasonDenied.AllVirtualDashboard:
             return "This is an automatically created dashboard that lists all the insights you have access to. You can't edit this dashboard."

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -19,8 +19,8 @@ type DashboardPermissions =
           reason: DashboardReasonDenied
       }
     | {
-        isConfigurable: true
-    }
+          isConfigurable: true
+      }
 
 const DEFAULT_DASHBOARD_PERMISSIONS: DashboardPermissions = {
     isConfigurable: false,

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -15,9 +15,9 @@ enum DashboardReasonDenied {
 
 type DashboardPermissions =
     | {
-        isConfigurable: false
-        reason: DashboardReasonDenied
-    }
+          isConfigurable: false
+          reason: DashboardReasonDenied
+      }
     | {
         isConfigurable: true
     }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -15,12 +15,12 @@ enum DashboardReasonDenied {
 
 type DashboardPermissions =
     | {
-          isConfigurable: false
-          reason: DashboardReasonDenied
-      }
+        isConfigurable: false
+        reason: DashboardReasonDenied
+    }
     | {
-          isConfigurable: true
-      }
+        isConfigurable: true
+    }
 
 const DEFAULT_DASHBOARD_PERMISSIONS: DashboardPermissions = {
     isConfigurable: false,
@@ -101,9 +101,8 @@ export function getTooltipMessage(
                 case InsightsDashboardType.Personal:
                     return "This is an automatically created dashboard that lists all your private insights. You can't edit this dashboard."
                 case InsightsDashboardType.Organization:
-                    return `This is an automatically created dashboard that lists all the ${dashboard.owner.name}'s insights. You can't edit this dashboard.`
                 case InsightsDashboardType.Global:
-                    return `This is an automatically created dashboard that lists all the global insights. You can't edit this dashboard.`
+                    return `This is an automatically created dashboard that lists all ${dashboard.owner.name} insights. You can't edit this dashboard.`
             }
         case DashboardReasonDenied.AllVirtualDashboard:
             return "This is an automatically created dashboard that lists all the insights you have access to. You can't edit this dashboard."


### PR DESCRIPTION
`'s` makes sense for organization and human names but not for "Global" so changing it. 
![image](https://user-images.githubusercontent.com/11967660/129438703-769bb7d5-8268-4412-9b3a-e9eaca5ff025.png)
![image](https://user-images.githubusercontent.com/11967660/129438706-b03edc79-b39c-4456-a403-aa4195932649.png)

I ran this locally and it seemed to make the proper UI change but I'm not yet onboarded to linting/prettifying/etc everything so apologies if there are some style errors here/feel free to toss this out and start from scratch if easier. 