### PR TITLE
batches: only count changesets that are actually selectable

### DIFF
--- a/client/web/src/enterprise/batches/MultiSelectContext.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.tsx
@@ -14,7 +14,6 @@ export interface MultiSelectContextState {
     // State fields. These must not be mutated other than through the mutator
     // functions below, but may be read at any time.
     selected: MultiSelectContextSelected
-    totalCount?: number
     visible: Set<string>
 
     // Convenience getters that abstract over the possible values of selected.
@@ -29,9 +28,6 @@ export interface MultiSelectContextState {
     selectVisible: () => void
     selectSingle: (id: string) => void
 
-    // Sets the total number of possible selections, if known.
-    setTotalCount: (count?: number) => void
-
     // Sets the current set of visible IDs. This needs to happen in a single
     // call to avoid unnecessary re-renders: consumers are responsible for
     // aggregating the existing state from visible if required (for example, if
@@ -43,7 +39,6 @@ export interface MultiSelectContextState {
 // eslint-disable @typescript-eslint/no-unused-vars
 const defaultState = (): MultiSelectContextState => ({
     selected: new Set(),
-    totalCount: undefined,
     visible: new Set(),
     areAllVisibleSelected: () => false,
     isSelected: () => false,
@@ -53,7 +48,6 @@ const defaultState = (): MultiSelectContextState => ({
     selectAll: () => {},
     selectVisible: () => {},
     selectSingle: () => {},
-    setTotalCount: () => {},
     setVisible: () => {},
 })
 // eslint-enable @typescript-eslint/no-unused-vars
@@ -76,9 +70,8 @@ export const MultiSelectContext = React.createContext<MultiSelectContextState>(d
 export const MultiSelectContextProvider: React.FunctionComponent<{
     // These props are only for testing purposes.
     initialSelected?: MultiSelectContextSelected | string[]
-    initialTotalCount?: number
     initialVisible?: string[]
-}> = ({ children, initialSelected, initialTotalCount, initialVisible }) => {
+}> = ({ children, initialSelected, initialVisible }) => {
     // Set up state and callbacks for the visible items.
     const [visible, setVisibleInternal] = useState<Set<string>>(new Set(initialVisible ?? []))
     const setVisible = useCallback((ids: string[]) => {
@@ -91,12 +84,6 @@ export const MultiSelectContextProvider: React.FunctionComponent<{
     )
     const selectAll = useCallback(() => setSelected('all'), [setSelected])
     const deselectAll = useCallback(() => setSelected(new Set()), [setSelected])
-
-    // Total count handling.
-    const [totalCount, setTotalCountInternal] = useState<number | undefined>(initialTotalCount)
-    const setTotalCount = useCallback((totalCount?: number) => {
-        setTotalCountInternal(totalCount)
-    }, [])
 
     // Callbacks to select and deselect items.
     const selectVisible = useCallback(() => {
@@ -180,7 +167,6 @@ export const MultiSelectContextProvider: React.FunctionComponent<{
         <MultiSelectContext.Provider
             value={{
                 selected,
-                totalCount,
                 visible,
                 areAllVisibleSelected,
                 isSelected,
@@ -190,7 +176,6 @@ export const MultiSelectContextProvider: React.FunctionComponent<{
                 selectAll,
                 selectVisible,
                 selectSingle,
-                setTotalCount,
                 setVisible,
             }}
         >

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -22,6 +22,7 @@ import {
     queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
     queryBulkOperations as _queryBulkOperations,
+    queryAllChangesetIDs as _queryAllChangesetIDs,
 } from './backend'
 import { BatchChangeDetailsPage } from './BatchChangeDetailsPage'
 
@@ -209,6 +210,8 @@ const queryChangesets: typeof _queryChangesets = () =>
             },
         ],
     })
+
+const queryAllChangesetIDs: typeof _queryAllChangesetIDs = () => of(['somev1', 'somev2'])
 
 const queryEmptyExternalChangesetWithFileDiffs: typeof queryExternalChangesetWithFileDiffs = () =>
     of({
@@ -419,6 +422,7 @@ for (const [name, { url, supersededBatchSpec }] of Object.entries(stories)) {
                         queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
                         deleteBatchChange={deleteBatchChange}
                         queryBulkOperations={queryBulkOperations}
+                        queryAllChangesetIDs={queryAllChangesetIDs}
                         extensionsController={{} as any}
                         platformContext={{} as any}
                     />

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -22,6 +22,7 @@ import {
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
     deleteBatchChange as _deleteBatchChange,
     queryBulkOperations as _queryBulkOperations,
+    queryAllChangesetIDs as _queryAllChangesetIDs,
 } from './backend'
 import { BatchChangeDetailsActionSection } from './BatchChangeDetailsActionSection'
 import { BatchChangeDetailsProps, BatchChangeDetailsTabs } from './BatchChangeDetailsTabs'
@@ -42,6 +43,8 @@ export interface BatchChangeDetailsPageProps extends BatchChangeDetailsProps {
     fetchBatchChangeByNamespace?: typeof _fetchBatchChangeByNamespace
     /** For testing only. */
     deleteBatchChange?: typeof _deleteBatchChange
+    /** For testing only. */
+    queryAllChangesetIDs?: typeof _queryAllChangesetIDs
 }
 
 /**

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -27,6 +27,7 @@ import {
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
     queryBulkOperations as _queryBulkOperations,
+    queryAllChangesetIDs as _queryAllChangesetIDs,
 } from './backend'
 import { BatchChangeBurndownChart } from './BatchChangeBurndownChart'
 import { BulkOperationsTab } from './BulkOperationsTab'
@@ -57,6 +58,8 @@ export interface BatchChangeDetailsProps
     queryChangesetCountsOverTime?: typeof _queryChangesetCountsOverTime
     /** For testing only. */
     queryBulkOperations?: typeof _queryBulkOperations
+    /** For testing only. */
+    queryAllChangesetIDs?: typeof _queryAllChangesetIDs
 }
 
 interface BatchChangeDetailsTabsProps extends BatchChangeDetailsProps {
@@ -74,6 +77,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
     queryChangesetCountsOverTime,
     queryChangesets,
     queryExternalChangesetWithFileDiffs,
+    queryAllChangesetIDs,
     telemetryService,
 }) => (
     <BatchChangeTabs history={history} location={location}>
@@ -141,6 +145,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                     telemetryService={telemetryService}
                     queryChangesets={queryChangesets}
                     queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
+                    queryAllChangesetIDs={queryAllChangesetIDs}
                     onlyArchived={false}
                 />
             </BatchChangeTabPanel>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -25,6 +25,7 @@ import { getLSPTextDocumentPositionParameters } from '../../utils'
 import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
+    queryAllChangesetIDs as _queryAllChangesetIDs,
 } from '../backend'
 
 import styles from './BatchChangeChangesets.module.scss'
@@ -50,6 +51,8 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     /** For testing only. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
     /** For testing only. */
+    queryAllChangesetIDs?: typeof _queryAllChangesetIDs
+    /** For testing only. */
     expandByDefault?: boolean
 }
 
@@ -73,6 +76,7 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
     telemetryService,
     hideFilters = false,
     queryChangesets = _queryChangesets,
+    queryAllChangesetIDs = _queryAllChangesetIDs,
     queryExternalChangesetWithFileDiffs,
     expandByDefault,
     onlyArchived,
@@ -242,6 +246,7 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                 <ChangesetSelectRow
                     batchChangeID={batchChangeID}
                     onSubmit={deselectAll}
+                    queryAllChangesetIDs={queryAllChangesetIDs}
                     queryArguments={queryArguments}
                 />
             )}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -95,7 +95,6 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
         isSelected,
         selectSingle,
         selectVisible,
-        setTotalCount,
         setVisible,
     } = useContext(MultiSelectContext)
 
@@ -158,8 +157,6 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                         setVisible(
                             data.nodes.filter(node => node.__typename === 'ExternalChangeset').map(node => node.id)
                         )
-                        // Remember the totalCount.
-                        setTotalCount(data.totalCount)
                     })
                 )
                 .pipe(repeatWhen(notifier => notifier.pipe(delay(5000))))
@@ -173,7 +170,6 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
             onlyArchived,
             queryChangesets,
             setVisible,
-            setTotalCount,
         ]
     )
 

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -1,8 +1,11 @@
+import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
+import { of } from 'rxjs'
 
 import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
 import { MultiSelectContextProvider } from '../../MultiSelectContext'
+import { queryAllChangesetIDs as _queryAllChangesetIDs } from '../backend'
 
 import { ChangesetSelectRow } from './ChangesetSelectRow'
 
@@ -12,113 +15,242 @@ const { add } = storiesOf('web/batches/ChangesetSelectRow', module).addDecorator
 
 const onSubmit = (): void => {}
 
-add('all states', () => (
-    <EnterpriseWebStory>
-        {props => (
-            <>
-                <MultiSelectContextProvider
-                    initialSelected={[]}
-                    initialVisible={['id-1', 'id-2']}
-                    initialTotalCount={100}
-                >
-                    <ChangesetSelectRow
-                        {...props}
-                        onSubmit={onSubmit}
-                        batchChangeID="test-123"
-                        queryArguments={{
-                            batchChange: 'test-123',
-                            checkState: null,
-                            onlyArchived: null,
-                            onlyPublishedByThisBatchChange: null,
-                            reviewState: null,
-                            search: null,
-                            state: null,
-                        }}
-                    />
-                </MultiSelectContextProvider>
-                <hr />
-                <MultiSelectContextProvider
-                    initialSelected={['id-1', 'id-2']}
-                    initialVisible={['id-1', 'id-2']}
-                    initialTotalCount={100}
-                >
-                    <ChangesetSelectRow
-                        {...props}
-                        onSubmit={onSubmit}
-                        batchChangeID="test-123"
-                        queryArguments={{
-                            batchChange: 'test-123',
-                            checkState: null,
-                            onlyArchived: null,
-                            onlyPublishedByThisBatchChange: null,
-                            reviewState: null,
-                            search: null,
-                            state: null,
-                        }}
-                    />
-                </MultiSelectContextProvider>
-                <hr />
-                {/* No total count, just to make sure that's handled. */}
-                <MultiSelectContextProvider initialSelected={['id-1', 'id-2']} initialVisible={['id-1', 'id-2']}>
-                    <ChangesetSelectRow
-                        {...props}
-                        onSubmit={onSubmit}
-                        batchChangeID="test-123"
-                        queryArguments={{
-                            batchChange: 'test-123',
-                            checkState: null,
-                            onlyArchived: null,
-                            onlyPublishedByThisBatchChange: null,
-                            reviewState: null,
-                            search: null,
-                            state: null,
-                        }}
-                    />
-                </MultiSelectContextProvider>
-                <hr />
-                <MultiSelectContextProvider
-                    initialSelected="all"
-                    initialVisible={['id-1', 'id-2']}
-                    initialTotalCount={100}
-                >
-                    <ChangesetSelectRow
-                        {...props}
-                        onSubmit={onSubmit}
-                        batchChangeID="test-123"
-                        queryArguments={{
-                            batchChange: 'test-123',
-                            checkState: null,
-                            onlyArchived: null,
-                            onlyPublishedByThisBatchChange: null,
-                            reviewState: null,
-                            search: null,
-                            state: null,
-                        }}
-                    />
-                </MultiSelectContextProvider>
-                <hr />
-                <MultiSelectContextProvider
-                    initialSelected={['id-1', 'id-2']}
-                    initialVisible={['id-1', 'id-2']}
-                    initialTotalCount={100}
-                >
-                    <ChangesetSelectRow
-                        {...props}
-                        onSubmit={onSubmit}
-                        batchChangeID="test-123"
-                        queryArguments={{
-                            batchChange: 'test-123',
-                            checkState: null,
-                            onlyArchived: true,
-                            onlyPublishedByThisBatchChange: null,
-                            reviewState: null,
-                            search: null,
-                            state: null,
-                        }}
-                        dropDownInitiallyOpen={true}
-                    />
-                </MultiSelectContextProvider>
-            </>
-        )}
-    </EnterpriseWebStory>
-))
+const CHANGESET_IDS = new Array<string>(100).fill('fake-id').map((id, index) => `${id}-${index}`)
+const HALF_CHANGESET_IDS = CHANGESET_IDS.slice(0, 50)
+const queryAll100ChangesetIDs: typeof _queryAllChangesetIDs = () => of(CHANGESET_IDS)
+const queryAll50ChangesetIDs: typeof _queryAllChangesetIDs = () => of(CHANGESET_IDS.slice(0, 50))
+
+add('all states', () => {
+    const totalChangesets = number('Total changesets', 100)
+    const visibleChangesets = number('Visible changesets', 10, { range: true, min: 0, max: totalChangesets })
+    const selectableChangesets = number('Selectable changesets', 100, { range: true, min: 0, max: totalChangesets })
+    const selectedChangesets = number('Selected changesets', 0, { range: true, min: 0, max: selectableChangesets })
+
+    const queryAllChangesetIDs: typeof _queryAllChangesetIDs = () => of(CHANGESET_IDS.slice(0, selectableChangesets))
+    const initialSelected = CHANGESET_IDS.slice(0, selectedChangesets)
+    const initialVisible = CHANGESET_IDS.slice(0, visibleChangesets)
+
+    return (
+        <EnterpriseWebStory>
+            {props => (
+                <>
+                    <h3>Configurable</h3>
+                    <MultiSelectContextProvider initialSelected={initialSelected} initialVisible={initialVisible}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAllChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">All visible, all selectable, none selected</h3>
+                    <MultiSelectContextProvider initialSelected={[]} initialVisible={CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll100ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">All visible, all selectable, half selected</h3>
+                    <MultiSelectContextProvider initialSelected={HALF_CHANGESET_IDS} initialVisible={CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll100ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">All visible, all selectable, all selected</h3>
+                    <MultiSelectContextProvider initialSelected={CHANGESET_IDS} initialVisible={CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll100ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">All visible, half selectable, none selected</h3>
+                    <MultiSelectContextProvider initialSelected={[]} initialVisible={CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll50ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">All visible, half selectable, half selected</h3>
+                    <MultiSelectContextProvider initialSelected={HALF_CHANGESET_IDS} initialVisible={CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll50ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">Half visible, all selectable, none selected</h3>
+                    <MultiSelectContextProvider initialSelected={[]} initialVisible={HALF_CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll100ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">Half visible, all selectable, half selected</h3>
+                    <MultiSelectContextProvider
+                        initialSelected={HALF_CHANGESET_IDS}
+                        initialVisible={HALF_CHANGESET_IDS}
+                    >
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll100ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">Half visible, all selectable, all selected</h3>
+                    <MultiSelectContextProvider initialSelected={CHANGESET_IDS} initialVisible={HALF_CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll100ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">Half visible, half selectable, none selected</h3>
+                    <MultiSelectContextProvider initialSelected={[]} initialVisible={HALF_CHANGESET_IDS}>
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll50ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                    <h3 className="mt-3">Half visible, half selectable, half selected</h3>
+                    <MultiSelectContextProvider
+                        initialSelected={HALF_CHANGESET_IDS}
+                        initialVisible={HALF_CHANGESET_IDS}
+                    >
+                        <ChangesetSelectRow
+                            {...props}
+                            onSubmit={onSubmit}
+                            batchChangeID="test-123"
+                            queryAllChangesetIDs={queryAll50ChangesetIDs}
+                            queryArguments={{
+                                batchChange: 'test-123',
+                                checkState: null,
+                                onlyArchived: null,
+                                onlyPublishedByThisBatchChange: null,
+                                reviewState: null,
+                                search: null,
+                                state: null,
+                            }}
+                        />
+                    </MultiSelectContextProvider>
+                    <hr />
+                </>
+            )}
+        </EnterpriseWebStory>
+    )
+})

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -204,7 +204,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
             <div className="row align-items-center no-gutters">
                 <div className="ml-2 col d-flex align-items-center">
                     <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
-                    {selected === 'all' ? (
+                    {selected === 'all' || allChangesetIDs?.length === selected.size ? (
                         <AllSelectedLabel count={allChangesetIDs?.length} />
                     ) : (
                         `${selected.size} ${pluralize('changeset', selected.size)}`

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -30,7 +30,7 @@ interface ChangesetListAction extends Omit<Action, 'onTrigger'> {
      */
     onTrigger: (
         batchChangeID: Scalars['ID'],
-        changesetIDs: () => Promise<Scalars['ID'][]>,
+        changesetIDs: Scalars['ID'][],
         onDone: () => void,
         onCancel: () => void
     ) => void | JSX.Element
@@ -171,16 +171,8 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                 const dropdownAction: Action = {
                     ...action,
                     onTrigger: (onDone, onCancel) => {
-                        // Depending on the selection, we need to construct a loader function for
-                        // the changeset IDs.
-                        let ids: () => Promise<Scalars['ID'][]>
-                        if (selected === 'all') {
-                            // If all changesets are selected, we can just use the cached allChangesetIDs.
-                            ids = () => Promise.resolve(allChangesetIDs || [])
-                        } else {
-                            // We can just pass down the IDs.
-                            ids = () => Promise.resolve([...selected])
-                        }
+                        // Depending on the selection, the set of changeset ids to act on is different.
+                        const ids = selected === 'all' ? allChangesetIDs || [] : [...selected]
 
                         return action.onTrigger(
                             batchChangeID,

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
@@ -11,7 +11,6 @@ const { add } = storiesOf('web/batches/details/CloseChangesetsModal', module).ad
     <div className="p-3 container">{story()}</div>
 ))
 
-const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
 const closeChangesets = () => {
     action('CloseChangesets')
     return Promise.resolve()
@@ -24,7 +23,7 @@ add('Confirmation', () => (
                 {...props}
                 afterCreate={noop}
                 batchChangeID="test-123"
-                changesetIDs={changesetIDsFunction}
+                changesetIDs={['test-123', 'test-234']}
                 onCancel={noop}
                 closeChangesets={closeChangesets}
             />

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
@@ -12,7 +12,7 @@ export interface CloseChangesetsModalProps {
     onCancel: () => void
     afterCreate: () => void
     batchChangeID: Scalars['ID']
-    changesetIDs: () => Promise<Scalars['ID'][]>
+    changesetIDs: Scalars['ID'][]
 
     /** For testing only. */
     closeChangesets?: typeof _closeChangesets
@@ -30,8 +30,7 @@ export const CloseChangesetsModal: React.FunctionComponent<CloseChangesetsModalP
     const onSubmit = useCallback<React.FormEventHandler>(async () => {
         setIsLoading(true)
         try {
-            const ids = await changesetIDs()
-            await closeChangesets(batchChangeID, ids)
+            await closeChangesets(batchChangeID, changesetIDs)
             afterCreate()
         } catch (error) {
             setIsLoading(asError(error))

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
@@ -11,7 +11,6 @@ const { add } = storiesOf('web/batches/details/CreateCommentModal', module).addD
     <div className="p-3 container">{story()}</div>
 ))
 
-const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
 const createChangesetCommentsAction = () => {
     action('CreateChangesetComments')
     return Promise.resolve()
@@ -24,7 +23,7 @@ add('Confirmation', () => (
                 {...props}
                 afterCreate={noop}
                 batchChangeID="test-123"
-                changesetIDs={changesetIDsFunction}
+                changesetIDs={['test-123', 'test-234']}
                 onCancel={noop}
                 createChangesetComments={createChangesetCommentsAction}
             />

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
@@ -13,7 +13,7 @@ export interface CreateCommentModalProps {
     onCancel: () => void
     afterCreate: () => void
     batchChangeID: Scalars['ID']
-    changesetIDs: () => Promise<Scalars['ID'][]>
+    changesetIDs: Scalars['ID'][]
 
     /** For testing only. */
     createChangesetComments?: typeof _createChangesetComments
@@ -38,8 +38,7 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
             event.preventDefault()
             setIsLoading(true)
             try {
-                const ids = await changesetIDs()
-                await createChangesetComments(batchChangeID, ids, commentBody)
+                await createChangesetComments(batchChangeID, changesetIDs, commentBody)
                 afterCreate()
             } catch (error) {
                 setIsLoading(asError(error))

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
@@ -13,7 +13,6 @@ const { add } = storiesOf('web/batches/details/DetachChangesetsModal', module).a
     <div className="p-3 container">{story()}</div>
 ))
 
-const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
 const detachAction = () => {
     action('DetachChangesets')
     return Promise.resolve()
@@ -26,7 +25,7 @@ add('Confirmation', () => (
                 {...props}
                 afterCreate={noop}
                 batchChangeID="test-123"
-                changesetIDs={changesetIDsFunction}
+                changesetIDs={['test-123', 'test-234']}
                 onCancel={noop}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 detachChangesets={detachAction}

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
@@ -13,7 +13,7 @@ export interface DetachChangesetsModalProps extends TelemetryProps {
     onCancel: () => void
     afterCreate: () => void
     batchChangeID: Scalars['ID']
-    changesetIDs: () => Promise<Scalars['ID'][]>
+    changesetIDs: Scalars['ID'][]
 
     /** For testing only. */
     detachChangesets?: typeof _detachChangesets
@@ -32,8 +32,7 @@ export const DetachChangesetsModal: React.FunctionComponent<DetachChangesetsModa
     const onSubmit = useCallback<React.FormEventHandler>(async () => {
         setIsLoading(true)
         try {
-            const ids = await changesetIDs()
-            await detachChangesets(batchChangeID, ids)
+            await detachChangesets(batchChangeID, changesetIDs)
             telemetryService.logViewEvent('BatchChangeDetailsPageDetachArchivedChangesets')
             afterCreate()
         } catch (error) {

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
@@ -11,7 +11,6 @@ const { add } = storiesOf('web/batches/details/MergeChangesetsModal', module).ad
     <div className="p-3 container">{story()}</div>
 ))
 
-const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
 const mergeChangesets = () => {
     action('MergeChangesets')
     return Promise.resolve()
@@ -24,7 +23,7 @@ add('Confirmation', () => (
                 {...props}
                 afterCreate={noop}
                 batchChangeID="test-123"
-                changesetIDs={changesetIDsFunction}
+                changesetIDs={['test-123', 'test-234']}
                 onCancel={noop}
                 mergeChangesets={mergeChangesets}
             />

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
@@ -13,7 +13,7 @@ export interface MergeChangesetsModalProps {
     onCancel: () => void
     afterCreate: () => void
     batchChangeID: Scalars['ID']
-    changesetIDs: () => Promise<Scalars['ID'][]>
+    changesetIDs: Scalars['ID'][]
 
     /** For testing only. */
     mergeChangesets?: typeof _mergeChangesets
@@ -32,8 +32,7 @@ export const MergeChangesetsModal: React.FunctionComponent<MergeChangesetsModalP
     const onSubmit = useCallback<React.FormEventHandler>(async () => {
         setIsLoading(true)
         try {
-            const ids = await changesetIDs()
-            await mergeChangesets(batchChangeID, ids, squash)
+            await mergeChangesets(batchChangeID, changesetIDs, squash)
             afterCreate()
         } catch (error) {
             setIsLoading(asError(error))

--- a/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.story.tsx
@@ -11,7 +11,6 @@ const { add } = storiesOf('web/batches/details/PublishChangesetsModal', module).
     <div className="p-3 container">{story()}</div>
 ))
 
-const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
 const publishChangesets = () => {
     action('PublishChangesets')
     return Promise.resolve()
@@ -24,7 +23,7 @@ add('Confirmation', () => (
                 {...props}
                 afterCreate={noop}
                 batchChangeID="test-123"
-                changesetIDs={changesetIDsFunction}
+                changesetIDs={['test-123', 'test-234']}
                 onCancel={noop}
                 publishChangesets={publishChangesets}
             />

--- a/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.tsx
@@ -13,7 +13,7 @@ export interface PublishChangesetsModalProps {
     onCancel: () => void
     afterCreate: () => void
     batchChangeID: Scalars['ID']
-    changesetIDs: () => Promise<Scalars['ID'][]>
+    changesetIDs: Scalars['ID'][]
 
     /** For testing only. */
     publishChangesets?: typeof _publishChangesets
@@ -32,8 +32,7 @@ export const PublishChangesetsModal: React.FunctionComponent<PublishChangesetsMo
     const onSubmit = useCallback<React.FormEventHandler>(async () => {
         setIsLoading(true)
         try {
-            const ids = await changesetIDs()
-            await publishChangesets(batchChangeID, ids, draft)
+            await publishChangesets(batchChangeID, changesetIDs, draft)
             afterCreate()
         } catch (error) {
             setIsLoading(asError(error))

--- a/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
@@ -11,7 +11,6 @@ const { add } = storiesOf('web/batches/details/ReenqueueChangesetsModal', module
     <div className="p-3 container">{story()}</div>
 ))
 
-const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
 const reenqueueChangesets = () => {
     action('ReenqueueChangesets')
     return Promise.resolve()
@@ -24,7 +23,7 @@ add('Confirmation', () => (
                 {...props}
                 afterCreate={noop}
                 batchChangeID="test-123"
-                changesetIDs={changesetIDsFunction}
+                changesetIDs={['test-123', 'test-234']}
                 onCancel={noop}
                 reenqueueChangesets={reenqueueChangesets}
             />

--- a/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.tsx
@@ -12,7 +12,7 @@ export interface ReenqueueChangesetsModalProps {
     onCancel: () => void
     afterCreate: () => void
     batchChangeID: Scalars['ID']
-    changesetIDs: () => Promise<Scalars['ID'][]>
+    changesetIDs: Scalars['ID'][]
 
     /** For testing only. */
     reenqueueChangesets?: typeof _reenqueueChangesets
@@ -30,8 +30,7 @@ export const ReenqueueChangesetsModal: React.FunctionComponent<ReenqueueChangese
     const onSubmit = useCallback<React.FormEventHandler>(async () => {
         setIsLoading(true)
         try {
-            const ids = await changesetIDs()
-            await reenqueueChangesets(batchChangeID, ids)
+            await reenqueueChangesets(batchChangeID, changesetIDs)
             afterCreate()
         } catch (error) {
             setIsLoading(asError(error))


### PR DESCRIPTION
Another small bug encountered when working through publish from preview.

This PR fixes a small bug that would occur when selecting all visible changesets when some changesets were unselectable because they are hidden external ones. Previously, when ticking the box to select all visible, the small text button with "(Select ##)" would still appear, implying there were more changesets to select, even if all of the remaining changesets were unselectable (see screenshot below). This fix uses the size of pre-filtered changeset IDs, rather than the total number of changesets, to determine how many total can *actually* be selected.

Before | After
:-----:|:-----:
![Screen Shot 2021-08-14 at 10 31 28 AM](https://user-images.githubusercontent.com/8942601/129455574-0bf57300-627c-487c-b5f3-8aff3e725931.png) | ![Screen Shot 2021-08-14 at 10 30 33 AM](https://user-images.githubusercontent.com/8942601/129455573-062c9859-a7b8-4ae6-8b36-1321b246f9d1.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
