### PR TITLE
fix apk add errors

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -34,9 +34,10 @@ COPY --from=monitoring_builder /generated/grafana/* /sg_config_grafana/provision
 # hadolint ignore=DL3020
 ADD entry.sh /
 
-RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0
 
 USER root
+
+RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0
 
 EXPOSE 3370
 USER grafana

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql
 
-RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r0 apk-tools=2.10.8-r0
+RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r0 apk-tools=2.12.7-r0
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \


### PR DESCRIPTION
fixes to errors in `apk add `.

1. apk not running as root in grafana
2. apk-tools version was no correct in postgres