### PR TITLE
batches: select changesets, publication state from preview

### DIFF
--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -71,7 +71,7 @@ async function generateGraphQlOperations() {
           JSONValue: 'unknown',
           GitObjectID: 'string',
           JSONCString: 'string',
-          PublishedValue: "boolean | 'draft' | null",
+          PublishedValue: "boolean | 'draft'",
           BigInt: 'string',
         },
       },

--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -71,7 +71,7 @@ async function generateGraphQlOperations() {
           JSONValue: 'unknown',
           GitObjectID: 'string',
           JSONCString: 'string',
-          PublishedValue: "boolean | 'draft'",
+          PublishedValue: "boolean | 'draft' | null",
           BigInt: 'string',
         },
       },

--- a/client/web/src/enterprise/batches/MultiSelectContext.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.tsx
@@ -42,20 +42,20 @@ export interface MultiSelectContextState {
 
 // eslint-disable @typescript-eslint/no-unused-vars
 const defaultState = (): MultiSelectContextState => ({
-    selected: new Set(),
-    visible: new Set(),
     areAllVisibleSelected: () => false,
-    isSelected: () => false,
     deselectAll: noop,
-    deselectVisible: noop,
     deselectSingle: noop,
+    deselectVisible: noop,
+    isSelected: () => false,
     selectAll: noop,
-    selectVisible: noop,
-    toggleAll: noop,
-    toggleVisible: noop,
-    toggleSingle: noop,
+    selected: new Set(),
     selectSingle: noop,
+    selectVisible: noop,
     setVisible: noop,
+    toggleAll: noop,
+    toggleSingle: noop,
+    toggleVisible: noop,
+    visible: new Set(),
 })
 // eslint-enable @typescript-eslint/no-unused-vars
 
@@ -196,20 +196,20 @@ export const MultiSelectContextProvider: React.FunctionComponent<{
     return (
         <MultiSelectContext.Provider
             value={{
-                selected,
-                visible,
                 areAllVisibleSelected,
-                isSelected,
                 deselectAll,
-                deselectVisible,
                 deselectSingle,
+                deselectVisible,
+                isSelected,
                 selectAll,
-                selectVisible,
+                selected,
                 selectSingle,
-                toggleAll,
-                toggleVisible,
-                toggleSingle,
+                selectVisible,
                 setVisible,
+                toggleAll,
+                toggleSingle,
+                toggleVisible,
+                visible,
             }}
         >
             {children}

--- a/client/web/src/enterprise/batches/MultiSelectContext.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.tsx
@@ -185,9 +185,9 @@ export const MultiSelectContextProvider: React.FunctionComponent<{
     const toggleSingle = useCallback(
         (id: string): void => {
             if (isSelected(id)) {
-                selectSingle(id)
-            } else {
                 deselectSingle(id)
+            } else {
+                selectSingle(id)
             }
         },
         [deselectSingle, isSelected, selectSingle]

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -251,7 +251,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                     className="filtered-connection__centered-summary"
                     headComponent={BatchChangeChangesetsHeader}
                     headComponentProps={{
-                        allSelected: areAllVisibleSelected(),
+                        allSelected: showSelectRow && areAllVisibleSelected(),
                         toggleSelectAll: toggleVisible,
                         disabled: !viewerCanAdminister,
                     }}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -56,16 +56,16 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     expandByDefault?: boolean
 }
 
+/**
+ * A list of a batch change's changesets.
+ */
 export const BatchChangeChangesets: React.FunctionComponent<Props> = props => (
     <MultiSelectContextProvider>
         <BatchChangeChangesetsImpl {...props} />
     </MultiSelectContextProvider>
 )
 
-/**
- * A list of a batch change's changesets.
- */
-export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
+const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
     batchChangeID,
     viewerCanAdminister,
     history,
@@ -89,33 +89,12 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
     const {
         selected,
         deselectAll,
-        deselectSingle,
-        deselectVisible,
         areAllVisibleSelected,
         isSelected,
-        selectSingle,
-        selectVisible,
+        toggleSingle,
+        toggleVisible,
         setVisible,
     } = useContext(MultiSelectContext)
-
-    const onSelect = useCallback(
-        (id: string, isSelected: boolean): void => {
-            if (isSelected) {
-                selectSingle(id)
-            } else {
-                deselectSingle(id)
-            }
-        },
-        [deselectSingle, selectSingle]
-    )
-
-    const toggleSelectVisible = useCallback(() => {
-        if (areAllVisibleSelected()) {
-            deselectVisible()
-        } else {
-            selectVisible()
-        }
-    }, [areAllVisibleSelected, deselectVisible, selectVisible])
 
     const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
         checkState: null,
@@ -257,7 +236,7 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                         extensionInfo: { extensionsController, hoverifier },
                         expandByDefault,
                         queryExternalChangesetWithFileDiffs,
-                        selectable: { onSelect, isSelected },
+                        selectable: { onSelect: toggleSingle, isSelected },
                     }}
                     queryConnection={queryChangesetsConnection}
                     hideSearch={true}
@@ -273,7 +252,7 @@ export const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                     headComponent={BatchChangeChangesetsHeader}
                     headComponentProps={{
                         allSelected: areAllVisibleSelected(),
-                        toggleSelectAll: toggleSelectVisible,
+                        toggleSelectAll: toggleVisible,
                         disabled: !viewerCanAdminister,
                     }}
                     // Only show the empty element, if no filters are selected.

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
@@ -21,7 +21,7 @@ export interface ChangesetNodeProps extends ThemeProps {
     history: H.History
     location: H.Location
     selectable?: {
-        onSelect: (id: string, selected: boolean) => void
+        onSelect: (id: string) => void
         isSelected: (id: string) => boolean
     }
     extensionInfo?: {

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -193,7 +193,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
 
     return (
         <>
-            <div className="row align-items-center no-gutters">
+            <div className="row align-items-center no-gutters mb-2">
                 <div className="ml-2 col d-flex align-items-center">
                     <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
                     {selected === 'all' || allChangesetIDs?.length === selected.size ? (
@@ -213,7 +213,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                 <div className="w-100 d-block d-md-none" />
                 <div className="m-0 col col-md-auto">
                     <div className="row no-gutters">
-                        <div className="col my-2 ml-0 ml-sm-2">
+                        <div className="col ml-0 ml-sm-2">
                             <DropdownButton
                                 actions={actions}
                                 dropdownMenuPosition="right"

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -35,7 +35,7 @@ export interface ExternalChangesetNodeProps extends ThemeProps {
     node: ExternalChangesetFields
     viewerCanAdminister: boolean
     selectable?: {
-        onSelect: (id: string, selected: boolean) => void
+        onSelect: (id: string) => void
         isSelected: (id: string) => boolean
     }
     history: H.History
@@ -75,8 +75,8 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
 
     const selected = selectable?.isSelected(node.id)
     const toggleSelected = useCallback((): void => {
-        selectable?.onSelect(node.id, !selected)
-    }, [selectable, selected, node.id])
+        selectable?.onSelect(node.id)
+    }, [selectable, node.id])
 
     return (
         <>

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
@@ -26,7 +26,7 @@ const { add } = storiesOf('web/batches/preview/BatchChangePreviewPage', module)
     })
 
 const nodes: ChangesetApplyPreviewFields[] = [
-    ...Object.values(visibleChangesetApplyPreviewNodeStories),
+    ...Object.values(visibleChangesetApplyPreviewNodeStories(false)),
     ...Object.values(hiddenChangesetApplyPreviewStories),
 ]
 

--- a/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.story.tsx
@@ -18,7 +18,7 @@ const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: nul
 
 add('Overview', () => {
     const nodes = [
-        ...Object.values(visibleChangesetApplyPreviewNodeStories),
+        ...Object.values(visibleChangesetApplyPreviewNodeStories(false)),
         ...Object.values(hiddenChangesetApplyPreviewStories),
     ]
     return (

--- a/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.tsx
@@ -16,6 +16,10 @@ export interface ChangesetApplyPreviewNodeProps extends ThemeProps {
     history: H.History
     location: H.Location
     authenticatedUser: PreviewPageAuthenticatedUser
+    selectable?: {
+        onSelect: (id: string) => void
+        isSelected: (id: string) => boolean
+    }
 
     /** Used for testing. */
     queryChangesetSpecFileDiffs?: typeof queryChangesetSpecFileDiffs
@@ -25,12 +29,9 @@ export interface ChangesetApplyPreviewNodeProps extends ThemeProps {
 
 export const ChangesetApplyPreviewNode: React.FunctionComponent<ChangesetApplyPreviewNodeProps> = ({
     node,
-    history,
-    location,
-    authenticatedUser,
-    isLightTheme,
     queryChangesetSpecFileDiffs,
     expandChangesetDescriptions,
+    ...props
 }) => {
     if (node.__typename === 'HiddenChangesetApplyPreview') {
         return (
@@ -45,10 +46,7 @@ export const ChangesetApplyPreviewNode: React.FunctionComponent<ChangesetApplyPr
             <span className={styles.changesetApplyPreviewNodeSeparator} />
             <VisibleChangesetApplyPreviewNode
                 node={node}
-                history={history}
-                location={location}
-                isLightTheme={isLightTheme}
-                authenticatedUser={authenticatedUser}
+                {...props}
                 queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
                 expandChangesetDescriptions={expandChangesetDescriptions}
             />

--- a/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.tsx
@@ -3,6 +3,7 @@ import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import React from 'react'
 
 import { ChangesetState } from '@sourcegraph/shared/src/graphql-operations'
+import { InputTooltip } from '@sourcegraph/web/src/components/InputTooltip'
 
 import { ChangesetSpecType, HiddenChangesetApplyPreviewFields } from '../../../../graphql-operations'
 import { ChangesetStatusCell } from '../../detail/changesets/ChangesetStatusCell'
@@ -20,6 +21,16 @@ export const HiddenChangesetApplyPreviewNode: React.FunctionComponent<HiddenChan
 }) => (
     <>
         <span className={classNames(styles.hiddenChangesetApplyPreviewNodeListCell, 'd-none d-sm-block')} />
+        <div className="p-2">
+            <InputTooltip
+                id="select-changeset-hidden"
+                type="checkbox"
+                className="btn"
+                checked={false}
+                disabled={true}
+                tooltip="You do not have permission to perform this operation"
+            />
+        </div>
         <HiddenChangesetApplyPreviewNodeStatusCell
             node={node}
             className={classNames(

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
@@ -2,7 +2,10 @@
     &__grid {
         display: grid;
         grid-template-columns:
-            [checkbox] min-content [caret] min-content [current_state] min-content [indicator] min-content [action] min-content [info] minmax(
+            [checkbox] minmax(
+                min-content,
+                auto
+            ) [caret] min-content [current_state] min-content [indicator] min-content [action] min-content [info] minmax(
                 auto,
                 1fr
             )

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
@@ -2,10 +2,8 @@
     &__grid {
         display: grid;
         grid-template-columns:
-            [checkbox] minmax(
-                min-content,
-                auto
-            ) [caret] min-content [current_state] min-content [indicator] min-content [action] min-content [info] minmax(
+            [checkbox] minmax(min-content, auto)
+            [caret] min-content [current_state] min-content [indicator] min-content [action] min-content [info] minmax(
                 auto,
                 1fr
             )

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
@@ -2,7 +2,7 @@
     &__grid {
         display: grid;
         grid-template-columns:
-            [caret] min-content [current_state] min-content [indicator] min-content [action] min-content [info] minmax(
+            [checkbox] min-content [caret] min-content [current_state] min-content [indicator] min-content [action] min-content [info] minmax(
                 auto,
                 1fr
             )

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -5,12 +5,13 @@ import { of, Observable } from 'rxjs'
 
 import { BatchSpecApplyPreviewConnectionFields, ChangesetApplyPreviewFields } from '../../../../graphql-operations'
 import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+import { getPublishableChangesetSpecID } from '../utils'
 
 import { hiddenChangesetApplyPreviewStories } from './HiddenChangesetApplyPreviewNode.story'
 import { PreviewList } from './PreviewList'
 import { visibleChangesetApplyPreviewNodeStories } from './VisibleChangesetApplyPreviewNode.story'
 
-const { add } = storiesOf('web/batches/preview/PreviewList', module)
+const { add } = storiesOf('web/batches/preview', module)
     .addDecorator(story => <div className="p-3 container">{story()}</div>)
     .addParameters({
         chromatic: {
@@ -20,7 +21,7 @@ const { add } = storiesOf('web/batches/preview/PreviewList', module)
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
-add('List view', () => {
+add('PreviewList', () => {
     const publishStatusSet = boolean('publish status set by spec file', false)
 
     const nodes: ChangesetApplyPreviewFields[] = [
@@ -38,6 +39,13 @@ add('List view', () => {
             nodes,
         })
 
+    const queryPublishableChangesetSpecIDs = (): Observable<string[]> =>
+        of(
+            Object.values(visibleChangesetApplyPreviewNodeStories(publishStatusSet))
+                .map(node => getPublishableChangesetSpecID(node))
+                .filter((id): id is string => id !== null)
+        )
+
     return (
         <EnterpriseWebStory>
             {props => (
@@ -52,6 +60,7 @@ add('List view', () => {
                     }}
                     queryChangesetApplyPreview={queryChangesetApplyPreview}
                     queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                    queryPublishableChangesetSpecIDs={queryPublishableChangesetSpecIDs}
                 />
             )}
         </EnterpriseWebStory>

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -22,10 +22,10 @@ const { add } = storiesOf('web/batches/preview', module)
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
 add('PreviewList', () => {
-    const publishStatusSet = boolean('publish status set by spec file', false)
+    const publicationStateSet = boolean('publication state set by spec file', false)
 
     const nodes: ChangesetApplyPreviewFields[] = [
-        ...Object.values(visibleChangesetApplyPreviewNodeStories(publishStatusSet)),
+        ...Object.values(visibleChangesetApplyPreviewNodeStories(publicationStateSet)),
         ...Object.values(hiddenChangesetApplyPreviewStories),
     ]
 
@@ -41,7 +41,7 @@ add('PreviewList', () => {
 
     const queryPublishableChangesetSpecIDs = (): Observable<string[]> =>
         of(
-            Object.values(visibleChangesetApplyPreviewNodeStories(publishStatusSet))
+            Object.values(visibleChangesetApplyPreviewNodeStories(publicationStateSet))
                 .map(node => getPublishableChangesetSpecID(node))
                 .filter((id): id is string => id !== null)
         )

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -1,3 +1,4 @@
+import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { of, Observable } from 'rxjs'
@@ -17,38 +18,42 @@ const { add } = storiesOf('web/batches/preview/PreviewList', module)
         },
     })
 
-const nodes: ChangesetApplyPreviewFields[] = [
-    ...Object.values(visibleChangesetApplyPreviewNodeStories),
-    ...Object.values(hiddenChangesetApplyPreviewStories),
-]
-
-const queryChangesetApplyPreview = (): Observable<BatchSpecApplyPreviewConnectionFields> =>
-    of({
-        pageInfo: {
-            endCursor: null,
-            hasNextPage: false,
-        },
-        totalCount: nodes.length,
-        nodes,
-    })
-
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
-add('List view', () => (
-    <EnterpriseWebStory>
-        {props => (
-            <PreviewList
-                {...props}
-                batchSpecID="123123"
-                authenticatedUser={{
-                    url: '/users/alice',
-                    displayName: 'Alice',
-                    username: 'alice',
-                    email: 'alice@email.test',
-                }}
-                queryChangesetApplyPreview={queryChangesetApplyPreview}
-                queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
-            />
-        )}
-    </EnterpriseWebStory>
-))
+add('List view', () => {
+    const publishStatusSet = boolean('publish status set by spec file', false)
+
+    const nodes: ChangesetApplyPreviewFields[] = [
+        ...Object.values(visibleChangesetApplyPreviewNodeStories(publishStatusSet)),
+        ...Object.values(hiddenChangesetApplyPreviewStories),
+    ]
+
+    const queryChangesetApplyPreview = (): Observable<BatchSpecApplyPreviewConnectionFields> =>
+        of({
+            pageInfo: {
+                endCursor: null,
+                hasNextPage: false,
+            },
+            totalCount: nodes.length,
+            nodes,
+        })
+
+    return (
+        <EnterpriseWebStory>
+            {props => (
+                <PreviewList
+                    {...props}
+                    batchSpecID="123123"
+                    authenticatedUser={{
+                        url: '/users/alice',
+                        displayName: 'Alice',
+                        username: 'alice',
+                        email: 'alice@email.test',
+                    }}
+                    queryChangesetApplyPreview={queryChangesetApplyPreview}
+                    queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                />
+            )}
+        </EnterpriseWebStory>
+    )
+})

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -68,7 +68,6 @@ const PreviewListImpl: React.FunctionComponent<Props> = ({
         isSelected,
         toggleSingle,
         toggleVisible,
-        setTotalCount,
         setVisible,
     } = useContext(MultiSelectContext)
 
@@ -109,20 +108,10 @@ const PreviewListImpl: React.FunctionComponent<Props> = ({
                             .map(node => getPublishableChangesetSpecID(node))
                             .filter((id): id is string => id !== null)
                     )
-                    // Remember the totalCount.
-                    setTotalCount(data.totalCount)
                 })
             )
         },
-        [
-            batchSpecID,
-            filters.search,
-            filters.currentState,
-            filters.action,
-            queryChangesetApplyPreview,
-            setTotalCount,
-            setVisible,
-        ]
+        [batchSpecID, filters.search, filters.currentState, filters.action, queryChangesetApplyPreview, setVisible]
     )
 
     const showSelectRow = selected === 'all' || selected.size > 0

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -1,12 +1,15 @@
 import * as H from 'history'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
+import { tap } from 'rxjs/operators'
 
+import { VisibleApplyPreviewTargetsUpdateFieldPolicy } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Container } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
 import { ChangesetApplyPreviewFields, Scalars } from '../../../../graphql-operations'
+import { MultiSelectContext, MultiSelectContextProvider } from '../../MultiSelectContext'
 import { PreviewPageAuthenticatedUser } from '../BatchChangePreviewPage'
 
 import { queryChangesetApplyPreview as _queryChangesetApplyPreview, queryChangesetSpecFileDiffs } from './backend'
@@ -14,7 +17,7 @@ import { ChangesetApplyPreviewNode, ChangesetApplyPreviewNodeProps } from './Cha
 import { EmptyPreviewListElement } from './EmptyPreviewListElement'
 import { PreviewFilterRow, PreviewFilters } from './PreviewFilterRow'
 import styles from './PreviewList.module.scss'
-import { PreviewListHeader } from './PreviewListHeader'
+import { PreviewListHeader, PreviewListHeaderProps } from './PreviewListHeader'
 
 interface Props extends ThemeProps {
     batchSpecID: Scalars['ID']
@@ -33,7 +36,13 @@ interface Props extends ThemeProps {
 /**
  * A list of a batch spec's preview nodes.
  */
-export const PreviewList: React.FunctionComponent<Props> = ({
+export const PreviewList: React.FunctionComponent<Props> = props => (
+    <MultiSelectContextProvider>
+        <PreviewListImpl {...props} />
+    </MultiSelectContextProvider>
+)
+
+const PreviewListImpl: React.FunctionComponent<Props> = ({
     batchSpecID,
     history,
     location,
@@ -44,6 +53,17 @@ export const PreviewList: React.FunctionComponent<Props> = ({
     queryChangesetSpecFileDiffs,
     expandChangesetDescriptions,
 }) => {
+    const {
+        selected,
+        deselectAll,
+        areAllVisibleSelected,
+        isSelected,
+        toggleSingle,
+        toggleVisible,
+        setTotalCount,
+        setVisible,
+    } = useContext(MultiSelectContext)
+
     const [filters, setFilters] = useState<PreviewFilters>({
         search: null,
         currentState: null,
@@ -59,14 +79,40 @@ export const PreviewList: React.FunctionComponent<Props> = ({
                 search: filters.search,
                 currentState: filters.currentState,
                 action: filters.action,
-            }),
-        [batchSpecID, filters.search, filters.currentState, filters.action, queryChangesetApplyPreview]
+            }).pipe(
+                tap(data => {
+                    setVisible(
+                        data.nodes
+                            .filter(
+                                node =>
+                                    node.targets.__typename === 'VisibleApplyPreviewTargetsAttach' ||
+                                    node.targets.__typename === 'VisibleApplyPreviewTargetsUpdate'
+                            )
+                            .map(node => node.targets.changesetSpec.id)
+                    )
+                    // Remember the totalCount.
+                    setTotalCount(data.totalCount)
+                })
+            ),
+        [
+            batchSpecID,
+            filters.search,
+            filters.currentState,
+            filters.action,
+            queryChangesetApplyPreview,
+            setTotalCount,
+            setVisible,
+        ]
     )
 
     return (
         <Container>
             <PreviewFilterRow history={history} location={location} onFiltersChange={setFilters} />
-            <FilteredConnection<ChangesetApplyPreviewFields, Omit<ChangesetApplyPreviewNodeProps, 'node'>>
+            <FilteredConnection<
+                ChangesetApplyPreviewFields,
+                Omit<ChangesetApplyPreviewNodeProps, 'node'>,
+                PreviewListHeaderProps
+            >
                 className="mt-2"
                 nodeComponent={ChangesetApplyPreviewNode}
                 nodeComponentProps={{
@@ -76,6 +122,7 @@ export const PreviewList: React.FunctionComponent<Props> = ({
                     authenticatedUser,
                     queryChangesetSpecFileDiffs,
                     expandChangesetDescriptions,
+                    selectable: { onSelect: toggleSingle, isSelected },
                 }}
                 queryConnection={queryChangesetApplyPreviewConnection}
                 hideSearch={true}
@@ -88,6 +135,10 @@ export const PreviewList: React.FunctionComponent<Props> = ({
                 listComponent="div"
                 listClassName={styles.previewListGrid}
                 headComponent={PreviewListHeader}
+                headComponentProps={{
+                    allSelected: areAllVisibleSelected(),
+                    toggleSelectAll: toggleVisible,
+                }}
                 cursorPaging={true}
                 noSummaryIfAllNodesVisible={true}
                 emptyElement={

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -102,7 +102,7 @@ const PreviewListImpl: React.FunctionComponent<Props> = ({
                     // Store the query arguments used for the current connection.
                     setQueryArguments(passedArguments)
                     // Available changeset specs are all changesets specs that a user can
-                    // modify the publish status of.
+                    // modify the publication state of from the UI.
                     setVisible(
                         data.nodes
                             .map(node => getPublishableChangesetSpecID(node))

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -3,7 +3,6 @@ import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import React, { useCallback, useContext, useState } from 'react'
 import { tap } from 'rxjs/operators'
 
-import { VisibleApplyPreviewTargetsUpdateFieldPolicy } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Container } from '@sourcegraph/wildcard'
 
@@ -88,7 +87,8 @@ const PreviewListImpl: React.FunctionComponent<Props> = ({
                                     node.targets.__typename === 'VisibleApplyPreviewTargetsAttach' ||
                                     node.targets.__typename === 'VisibleApplyPreviewTargetsUpdate'
                             )
-                            .map(node => node.targets.changesetSpec.id)
+                            // TODO: Lol fix me pls
+                            .map(node => (node.targets as any).changesetSpec.id)
                     )
                     // Remember the totalCount.
                     setTotalCount(data.totalCount)

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { InputTooltip } from '@sourcegraph/web/src/components/InputTooltip'
+
 export interface PreviewListHeaderProps {
     allSelected?: boolean
     toggleSelectAll?: () => void
@@ -13,12 +15,12 @@ export const PreviewListHeader: React.FunctionComponent<PreviewListHeaderProps> 
         <span className="p-2 d-none d-sm-block" />
         {toggleSelectAll && (
             <div className="d-flex p-2 align-items-center">
-                <input
+                <InputTooltip
                     type="checkbox"
                     className="btn"
                     checked={allSelected}
                     onChange={toggleSelectAll}
-                    data-tooltip="Click to select all changesets"
+                    tooltip="Click to select all changesets"
                     aria-label="Click to select all changesets"
                 />
                 <span className="pl-2 d-block d-sm-none">Select all</span>

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -1,12 +1,26 @@
 import React from 'react'
 
 export interface PreviewListHeaderProps {
-    // Nothing for now.
+    allSelected?: boolean
+    toggleSelectAll?: () => void
 }
 
-export const PreviewListHeader: React.FunctionComponent<PreviewListHeaderProps> = () => (
+export const PreviewListHeader: React.FunctionComponent<PreviewListHeaderProps> = ({
+    allSelected,
+    toggleSelectAll,
+}) => (
     <>
         <span className="p-2 d-none d-sm-block" />
+        {toggleSelectAll && (
+            <input
+                type="checkbox"
+                className="btn ml-2"
+                checked={allSelected}
+                onChange={toggleSelectAll}
+                data-tooltip="Click to select all changesets"
+                aria-label="Click to select all changesets"
+            />
+        )}
         <h5 className="p-2 d-none d-sm-block text-uppercase text-center">Current state</h5>
         <h5 className="d-none d-sm-block text-uppercase text-center">
             +<br />-

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -12,14 +12,17 @@ export const PreviewListHeader: React.FunctionComponent<PreviewListHeaderProps> 
     <>
         <span className="p-2 d-none d-sm-block" />
         {toggleSelectAll && (
-            <input
-                type="checkbox"
-                className="btn ml-2"
-                checked={allSelected}
-                onChange={toggleSelectAll}
-                data-tooltip="Click to select all changesets"
-                aria-label="Click to select all changesets"
-            />
+            <div className="d-flex p-2 align-items-center">
+                <input
+                    type="checkbox"
+                    className="btn"
+                    checked={allSelected}
+                    onChange={toggleSelectAll}
+                    data-tooltip="Click to select all changesets"
+                    aria-label="Click to select all changesets"
+                />
+                <span className="pl-2 d-block d-sm-none">Select all</span>
+            </div>
         )}
         <h5 className="p-2 d-none d-sm-block text-uppercase text-center">Current state</h5>
         <h5 className="d-none d-sm-block text-uppercase text-center">

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -17,7 +17,7 @@ const ACTIONS: Action[] = [
         buttonLabel: 'Unpublish',
         dropdownTitle: 'Unpublish',
         dropdownDescription:
-            'Do not publish selected changesets on the codehost. Note, we cannot unpublish a published changeset.',
+            'Do not publish selected changesets on the codehost. Note that a changeset that has already been published cannot be unpublished.',
         onTrigger: noop,
     },
     {

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -1,0 +1,113 @@
+import { noop } from 'lodash'
+import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
+import React, { useMemo, useContext } from 'react'
+
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
+import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+
+import { BatchSpecApplyPreviewVariables } from '../../../../graphql-operations'
+import { Action, DropdownButton } from '../../DropdownButton'
+import { MultiSelectContext } from '../../MultiSelectContext'
+
+import { queryPublishableChangesetSpecIDs as _queryPublishableChangesetSpecIDs } from './backend'
+
+const ACTIONS: Action[] = [
+    {
+        type: 'unpublish',
+        buttonLabel: 'Unpublish',
+        dropdownTitle: 'Unpublish',
+        dropdownDescription:
+            "Remove the selected changesets from this batch change. Unlike archive, this can't be undone.",
+        onTrigger: noop,
+    },
+    {
+        type: 'publish',
+        buttonLabel: 'Publish',
+        dropdownTitle: 'Publish',
+        dropdownDescription: 'Re-enqueues the selected changesets for processing, if they failed.',
+        onTrigger: noop,
+    },
+    {
+        type: 'publish-draft',
+        buttonLabel: 'Publish draft',
+        dropdownTitle: 'Publish draft',
+        dropdownDescription:
+            'Create a comment on all selected changesets. For example, you could ask people for reviews, give an update, or post a cat GIF.',
+        onTrigger: noop,
+    },
+]
+
+export interface PreviewSelectRowProps {
+    queryArguments: BatchSpecApplyPreviewVariables
+    /** For testing only. */
+    dropDownInitiallyOpen?: boolean
+    /** For testing only. */
+    queryPublishableChangesetSpecIDs?: typeof _queryPublishableChangesetSpecIDs
+}
+
+/**
+ * Renders the top bar of the PreviewList with the publish status dropdown selector and
+ * the X selected label. Provides select ALL functionality.
+ */
+export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = ({
+    dropDownInitiallyOpen = false,
+    queryPublishableChangesetSpecIDs = _queryPublishableChangesetSpecIDs,
+    queryArguments,
+}) => {
+    const { areAllVisibleSelected, selected, selectAll, totalCount } = useContext(MultiSelectContext)
+
+    const allChangesetSpecIDs: string[] | undefined = useObservable(
+        useMemo(() => queryPublishableChangesetSpecIDs(queryArguments), [
+            queryArguments,
+            queryPublishableChangesetSpecIDs,
+        ])
+    )
+
+    return (
+        <>
+            <div className="row align-items-center no-gutters mb-3">
+                <div className="ml-2 col d-flex align-items-center">
+                    <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
+                    {selected === 'all' || allChangesetSpecIDs?.length === selected.size ? (
+                        <AllSelectedLabel count={allChangesetSpecIDs?.length} />
+                    ) : (
+                        `${selected.size} ${pluralize('changeset', selected.size)}`
+                    )}
+                    {selected !== 'all' &&
+                        areAllVisibleSelected() &&
+                        allChangesetSpecIDs &&
+                        allChangesetSpecIDs.length > selected.size && (
+                            <button type="button" className="btn btn-link py-0 px-1" onClick={selectAll}>
+                                (Select all{totalCount !== undefined && ` ${totalCount}`})
+                            </button>
+                        )}
+                </div>
+                <div className="w-100 d-block d-md-none" />
+                <div className="m-0 col col-md-auto">
+                    <div className="row no-gutters">
+                        <div className="col ml-0 ml-sm-2">
+                            <DropdownButton
+                                actions={ACTIONS}
+                                dropdownMenuPosition="right"
+                                initiallyOpen={dropDownInitiallyOpen}
+                                placeholder="Select action"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
+}
+
+const AllSelectedLabel: React.FunctionComponent<{ count?: number }> = ({ count }) => {
+    if (count === undefined) {
+        return <>All changesets selected</>
+    }
+
+    return (
+        <>
+            All {count} {pluralize('changeset', count)} selected
+        </>
+    )
+}

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -53,7 +53,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
     queryPublishableChangesetSpecIDs = _queryPublishableChangesetSpecIDs,
     queryArguments,
 }) => {
-    const { areAllVisibleSelected, selected, selectAll, totalCount } = useContext(MultiSelectContext)
+    const { areAllVisibleSelected, selected, selectAll } = useContext(MultiSelectContext)
 
     const allChangesetSpecIDs: string[] | undefined = useObservable(
         useMemo(() => queryPublishableChangesetSpecIDs(queryArguments), [
@@ -77,7 +77,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
                         allChangesetSpecIDs &&
                         allChangesetSpecIDs.length > selected.size && (
                             <button type="button" className="btn btn-link py-0 px-1" onClick={selectAll}>
-                                (Select all{totalCount !== undefined && ` ${totalCount}`})
+                                (Select all{allChangesetSpecIDs !== undefined && ` ${allChangesetSpecIDs.length}`})
                             </button>
                         )}
                 </div>

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -17,7 +17,7 @@ const ACTIONS: Action[] = [
         buttonLabel: 'Unpublish',
         dropdownTitle: 'Unpublish',
         dropdownDescription:
-            'Do not publish selected changesets on the codehost. Note that a changeset that has already been published cannot be unpublished.',
+            'Do not publish selected changesets on the codehost. Note: a changeset that has been published cannot be unpublished.',
         onTrigger: noop,
     },
     {

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -45,7 +45,7 @@ export interface PreviewSelectRowProps {
 }
 
 /**
- * Renders the top bar of the PreviewList with the publish status dropdown selector and
+ * Renders the top bar of the PreviewList with the publication state dropdown selector and
  * the X selected label. Provides select ALL functionality.
  */
 export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = ({

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -17,22 +17,21 @@ const ACTIONS: Action[] = [
         buttonLabel: 'Unpublish',
         dropdownTitle: 'Unpublish',
         dropdownDescription:
-            "Remove the selected changesets from this batch change. Unlike archive, this can't be undone.",
+            'Do not publish selected changesets on the codehost. Note, we cannot unpublish a published changeset.',
         onTrigger: noop,
     },
     {
         type: 'publish',
         buttonLabel: 'Publish',
         dropdownTitle: 'Publish',
-        dropdownDescription: 'Re-enqueues the selected changesets for processing, if they failed.',
+        dropdownDescription: 'Publish selected changesets on the codehost.',
         onTrigger: noop,
     },
     {
         type: 'publish-draft',
         buttonLabel: 'Publish draft',
         dropdownTitle: 'Publish draft',
-        dropdownDescription:
-            'Create a comment on all selected changesets. For example, you could ask people for reviews, give an update, or post a cat GIF.',
+        dropdownDescription: 'Publish selected changesets as drafts on the codehost.',
         onTrigger: noop,
     },
 ]

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -23,12 +23,13 @@ const { add } = storiesOf('web/batches/preview/VisibleChangesetApplyPreviewNode'
 const testRepo = { name: 'github.com/sourcegraph/testrepo', url: 'https://test.test/repo' }
 
 function baseChangesetSpec(
+    id: number,
     published: Scalars['PublishedValue'],
     overrides: Partial<VisibleChangesetSpecFields> = {}
 ): VisibleChangesetSpecFields {
     return {
         __typename: 'VisibleChangesetSpec',
-        id: 'someidv2' + String(published) + JSON.stringify(overrides),
+        id: 'someidv2' + id.toString() + String(published) + JSON.stringify(overrides),
         type: ChangesetSpecType.EXISTING,
         description: {
             __typename: 'GitBranchChangesetDescription',
@@ -105,7 +106,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(1, true),
         },
     },
     'Create changeset draft': {
@@ -122,7 +123,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec('draft'),
+            changesetSpec: baseChangesetSpec(2, 'draft'),
         },
     },
     'Create changeset not published': {
@@ -139,7 +140,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(false),
+            changesetSpec: baseChangesetSpec(3, false),
         },
     },
     'Update changeset title': {
@@ -156,7 +157,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(4, true),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -211,7 +212,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(5, true),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -266,7 +267,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(6, true),
             changeset: {
                 id: '123123',
                 title: 'Le draft changeset',
@@ -321,7 +322,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(7, true),
             changeset: {
                 id: '123123',
                 title: 'Le closed changeset',
@@ -438,7 +439,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(8, true),
             changeset: {
                 id: '123123',
                 title: 'Change base ref',
@@ -493,7 +494,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(9, true),
             changeset: {
                 id: '123123',
                 title: 'Change base ref',
@@ -548,7 +549,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(10, true),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -603,7 +604,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(true),
+            changesetSpec: baseChangesetSpec(11, true),
             changeset: {
                 id: '123123',
                 title: 'the old title',

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -67,7 +67,7 @@ And the more explanatory body. And the more explanatory body. And the more expla
 }
 
 export const visibleChangesetApplyPreviewNodeStories = (
-    publishStatusSet: boolean
+    publicationStateSet: boolean
 ): Record<string, VisibleChangesetApplyPreviewFields> => ({
     'Import changeset': {
         __typename: 'VisibleChangesetApplyPreview',
@@ -109,7 +109,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(1, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(1, publicationStateSet ? true : null),
         },
     },
     'Create changeset draft': {
@@ -126,7 +126,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(2, publishStatusSet ? 'draft' : null),
+            changesetSpec: baseChangesetSpec(2, publicationStateSet ? 'draft' : null),
         },
     },
     'Create changeset not published': {
@@ -143,7 +143,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(3, publishStatusSet ? false : null),
+            changesetSpec: baseChangesetSpec(3, publicationStateSet ? false : null),
         },
     },
     'Update changeset title': {
@@ -160,7 +160,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(4, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(4, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -215,7 +215,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(5, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(5, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -270,7 +270,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(6, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(6, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Le draft changeset',
@@ -325,7 +325,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(7, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(7, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Le closed changeset',
@@ -442,7 +442,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(8, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(8, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Change base ref',
@@ -497,7 +497,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(9, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(9, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Change base ref',
@@ -552,7 +552,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(10, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(10, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -607,7 +607,7 @@ export const visibleChangesetApplyPreviewNodeStories = (
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(11, publishStatusSet ? true : null),
+            changesetSpec: baseChangesetSpec(11, publicationStateSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -65,7 +65,9 @@ And the more explanatory body. And the more explanatory body. And the more expla
     }
 }
 
-export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChangesetApplyPreviewFields> = {
+export const visibleChangesetApplyPreviewNodeStories = (
+    publishStatusSet: boolean
+): Record<string, VisibleChangesetApplyPreviewFields> => ({
     'Import changeset': {
         __typename: 'VisibleChangesetApplyPreview',
         operations: [ChangesetSpecOperation.IMPORT],
@@ -106,7 +108,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(1, true),
+            changesetSpec: baseChangesetSpec(1, publishStatusSet ? true : null),
         },
     },
     'Create changeset draft': {
@@ -123,7 +125,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(2, 'draft'),
+            changesetSpec: baseChangesetSpec(2, publishStatusSet ? 'draft' : null),
         },
     },
     'Create changeset not published': {
@@ -140,7 +142,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
-            changesetSpec: baseChangesetSpec(3, false),
+            changesetSpec: baseChangesetSpec(3, publishStatusSet ? false : null),
         },
     },
     'Update changeset title': {
@@ -157,7 +159,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(4, true),
+            changesetSpec: baseChangesetSpec(4, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -212,7 +214,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(5, true),
+            changesetSpec: baseChangesetSpec(5, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -267,7 +269,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(6, true),
+            changesetSpec: baseChangesetSpec(6, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Le draft changeset',
@@ -322,7 +324,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(7, true),
+            changesetSpec: baseChangesetSpec(7, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Le closed changeset',
@@ -439,7 +441,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(8, true),
+            changesetSpec: baseChangesetSpec(8, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Change base ref',
@@ -494,7 +496,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(9, true),
+            changesetSpec: baseChangesetSpec(9, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'Change base ref',
@@ -549,7 +551,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(10, true),
+            changesetSpec: baseChangesetSpec(10, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -604,7 +606,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
-            changesetSpec: baseChangesetSpec(11, true),
+            changesetSpec: baseChangesetSpec(11, publishStatusSet ? true : null),
             changeset: {
                 id: '123123',
                 title: 'the old title',
@@ -645,17 +647,19 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
             },
         },
     },
-}
+})
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
-for (const storyName of Object.keys(visibleChangesetApplyPreviewNodeStories)) {
+const stories = visibleChangesetApplyPreviewNodeStories(true)
+
+for (const storyName of Object.keys(stories)) {
     add(storyName, () => (
         <EnterpriseWebStory>
             {props => (
                 <VisibleChangesetApplyPreviewNode
                     {...props}
-                    node={visibleChangesetApplyPreviewNodeStories[storyName]}
+                    node={stories[storyName]}
                     authenticatedUser={{
                         url: '/users/alice',
                         displayName: 'Alice',

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -3,9 +3,10 @@ import classNames from 'classnames'
 import React from 'react'
 import { of } from 'rxjs'
 
-import { ChangesetSpecOperation, ChangesetState } from '@sourcegraph/shared/src/graphql-operations'
-
 import {
+    ChangesetSpecOperation,
+    ChangesetState,
+    Maybe,
     VisibleChangesetSpecFields,
     ChangesetSpecType,
     Scalars,
@@ -24,7 +25,7 @@ const testRepo = { name: 'github.com/sourcegraph/testrepo', url: 'https://test.t
 
 function baseChangesetSpec(
     id: number,
-    published: Scalars['PublishedValue'],
+    published: Maybe<Scalars['PublishedValue']>,
     overrides: Partial<VisibleChangesetSpecFields> = {}
 ): VisibleChangesetSpecFields {
     return {

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -229,7 +229,7 @@ const SelectBox: React.FunctionComponent<{
             className="btn"
             checked={false}
             disabled={true}
-            tooltip="You cannot currently modify the publish status for this changeset"
+            tooltip="You cannot currently modify the publication state for this changeset"
         />
     ) : (
         <InputTooltip
@@ -238,14 +238,16 @@ const SelectBox: React.FunctionComponent<{
             className="btn"
             checked={selectable.isSelected(changesetSpecID)}
             onChange={toggleSelected}
-            tooltip="Click to select changeset for bulk-modifying the publish status"
+            tooltip="Click to select changeset for bulk-modifying the publication state"
         />
     )
 
     return (
         <div className="d-flex p-2 align-items-center">
             {input}
-            {changesetSpecID ? <span className="pl-2 d-block d-sm-none text-nowrap">Modify publish status</span> : null}
+            {changesetSpecID ? (
+                <span className="pl-2 d-block d-sm-none text-nowrap">Modify publication state</span>
+            ) : null}
         </div>
     )
 }

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -245,7 +245,7 @@ const SelectBox: React.FunctionComponent<{
     return (
         <div className="d-flex p-2 align-items-center">
             {input}
-            {changesetSpecID ? <span className="pl-2 d-block d-sm-none">Modify publish status</span> : null}
+            {changesetSpecID ? <span className="pl-2 d-block d-sm-none text-nowrap">Modify publish status</span> : null}
         </div>
     )
 }

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -232,13 +232,13 @@ const SelectBox: React.FunctionComponent<{
             tooltip="You cannot currently modify the publish status for this changeset"
         />
     ) : (
-        <input
+        <InputTooltip
             id={`select-changeset-${changesetSpecID}`}
             type="checkbox"
             className="btn"
             checked={selectable.isSelected(changesetSpecID)}
             onChange={toggleSelected}
-            data-tooltip="Click to select changeset for bulk-modifying the publish status"
+            tooltip="Click to select changeset for bulk-modifying the publish status"
         />
     )
 

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -222,31 +222,30 @@ const SelectBox: React.FunctionComponent<{
         }
     }, [selectable, changesetSpecID])
 
-    if (!changesetSpecID) {
-        return (
-            <div className="p-2">
-                <InputTooltip
-                    id="select-changeset-hidden"
-                    type="checkbox"
-                    className="btn"
-                    checked={false}
-                    disabled={true}
-                    tooltip="You cannot currently modify the publish status for this changeset"
-                />
-            </div>
-        )
-    }
+    const input = !changesetSpecID ? (
+        <InputTooltip
+            id="select-changeset-hidden"
+            type="checkbox"
+            className="btn"
+            checked={false}
+            disabled={true}
+            tooltip="You cannot currently modify the publish status for this changeset"
+        />
+    ) : (
+        <input
+            id={`select-changeset-${changesetSpecID}`}
+            type="checkbox"
+            className="btn"
+            checked={selectable.isSelected(changesetSpecID)}
+            onChange={toggleSelected}
+            data-tooltip="Click to select changeset for bulk-modifying the publish status"
+        />
+    )
 
     return (
-        <div className="p-2">
-            <input
-                id={`select-changeset-${changesetSpecID}`}
-                type="checkbox"
-                className="btn"
-                checked={selectable.isSelected(changesetSpecID)}
-                onChange={toggleSelected}
-                data-tooltip="Click to select changeset for bulk-modifying the publish status"
-            />
+        <div className="d-flex p-2 align-items-center">
+            {input}
+            {changesetSpecID ? <span className="pl-2 d-block d-sm-none">Modify publish status</span> : null}
         </div>
     )
 }

--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -13,6 +13,9 @@ import {
     BatchSpecApplyPreviewVariables,
     ChangesetSpecFileDiffConnectionFields,
     Scalars,
+    AllPublishableChangesetSpecIDsVariables,
+    PublishableChangesetSpecIDsConnectionFields,
+    AllPublishableChangesetSpecIDsResult,
 } from '../../../../graphql-operations'
 import { personLinkFieldsFragment } from '../../../../person/PersonLink'
 import { getPublishableChangesetSpecID } from '../utils'
@@ -328,25 +331,115 @@ export const queryChangesetSpecFileDiffs = ({
         })
     )
 
+const publishableChangesetSpecIDsFieldsFragment = gql`
+    fragment PublishableChangesetSpecIDsConnectionFields on ChangesetApplyPreviewConnection {
+        nodes {
+            ...PublishableChangesetSpecIDsChangesetApplyPreviewFields
+        }
+        pageInfo {
+            hasNextPage
+            endCursor
+        }
+    }
+
+    fragment PublishableChangesetSpecIDsChangesetApplyPreviewFields on ChangesetApplyPreview {
+        __typename
+        ... on HiddenChangesetApplyPreview {
+            ...PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields
+        }
+        ... on VisibleChangesetApplyPreview {
+            ...PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields
+        }
+    }
+
+    fragment PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields on HiddenChangesetApplyPreview {
+        __typename
+        targets {
+            __typename
+        }
+    }
+
+    fragment PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields on VisibleChangesetApplyPreview {
+        __typename
+        targets {
+            __typename
+            ... on VisibleApplyPreviewTargetsAttach {
+                changesetSpec {
+                    ...PublishableChangesetSpecIDsVisibleChangesetSpecFields
+                }
+            }
+            ... on VisibleApplyPreviewTargetsUpdate {
+                changesetSpec {
+                    ...PublishableChangesetSpecIDsVisibleChangesetSpecFields
+                }
+            }
+        }
+    }
+
+    fragment PublishableChangesetSpecIDsVisibleChangesetSpecFields on VisibleChangesetSpec {
+        id
+        description {
+            __typename
+            ... on GitBranchChangesetDescription {
+                published
+            }
+        }
+    }
+`
+
 export const queryPublishableChangesetSpecIDs = ({
     batchSpec,
+    first,
     search,
     currentState,
     action,
-}: BatchSpecApplyPreviewVariables): Observable<Scalars['ID'][]> => {
-    const request = (after: string | null): Observable<BatchSpecApplyPreviewConnectionFields> =>
-        queryChangesetApplyPreview({
-            batchSpec,
-            first: 10000,
-            after,
-            search,
-            currentState,
-            action,
-        })
+}: Omit<AllPublishableChangesetSpecIDsVariables, 'after'>): Observable<Scalars['ID'][]> => {
+    const request = (after: string | null): Observable<PublishableChangesetSpecIDsConnectionFields> =>
+        requestGraphQL<AllPublishableChangesetSpecIDsResult, AllPublishableChangesetSpecIDsVariables>(
+            gql`
+                query AllPublishableChangesetSpecIDs(
+                    $batchSpec: ID!
+                    $first: Int
+                    $after: String
+                    $search: String
+                    $currentState: ChangesetState
+                    $action: ChangesetSpecOperation
+                ) {
+                    node(id: $batchSpec) {
+                        __typename
+                        ... on BatchSpec {
+                            applyPreview(
+                                first: $first
+                                after: $after
+                                search: $search
+                                currentState: $currentState
+                                action: $action
+                            ) {
+                                ...PublishableChangesetSpecIDsConnectionFields
+                            }
+                        }
+                    }
+                }
+
+                ${publishableChangesetSpecIDsFieldsFragment}
+            `,
+            { batchSpec, first, after, search, currentState, action }
+        ).pipe(
+            map(dataOrThrowErrors),
+            map(({ node }) => {
+                if (!node) {
+                    throw new Error(`BatchSpec with ID ${batchSpec} does not exist`)
+                }
+                if (node.__typename !== 'BatchSpec') {
+                    throw new Error(`The given ID is a ${node.__typename}, not a BatchSpec`)
+                }
+                return node.applyPreview
+            })
+        )
 
     return request(null).pipe(
         expand(connection => (connection.pageInfo.hasNextPage ? request(connection.pageInfo.endCursor) : EMPTY)),
-        reduce<BatchSpecApplyPreviewConnectionFields, Scalars['ID'][]>(
+        reduce<PublishableChangesetSpecIDsConnectionFields, Scalars['ID'][]>(
             (previous, next) =>
                 previous.concat(
                     next.nodes

--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -346,14 +346,14 @@ export const queryPublishableChangesetSpecIDs = ({
 
     return request(null).pipe(
         expand(connection => (connection.pageInfo.hasNextPage ? request(connection.pageInfo.endCursor) : EMPTY)),
-        reduce(
+        reduce<BatchSpecApplyPreviewConnectionFields, Scalars['ID'][]>(
             (previous, next) =>
                 previous.concat(
                     next.nodes
                         .map(node => getPublishableChangesetSpecID(node))
-                        .filter((maybeID): maybeID is string => maybeID !== null)
+                        .filter((maybeID): maybeID is Scalars['ID'] => maybeID !== null)
                 ),
-            [] as Scalars['ID'][]
+            []
         )
     )
 }

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -1,4 +1,8 @@
-import { HiddenChangesetApplyPreviewFields, VisibleChangesetApplyPreviewFields } from '../../../graphql-operations'
+import {
+    HiddenChangesetApplyPreviewFields,
+    VisibleChangesetApplyPreviewFields,
+    Scalars,
+} from '../../../graphql-operations'
 
 /**
  * For a given preview of a changeset to be applied, this method checks if the type of
@@ -12,7 +16,7 @@ import { HiddenChangesetApplyPreviewFields, VisibleChangesetApplyPreviewFields }
  */
 export const getPublishableChangesetSpecID = (
     node: VisibleChangesetApplyPreviewFields | HiddenChangesetApplyPreviewFields
-): string | null => {
+): Scalars['ID'] | null => {
     if (
         node.targets.__typename !== 'VisibleApplyPreviewTargetsAttach' &&
         node.targets.__typename !== 'VisibleApplyPreviewTargetsUpdate'

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -6,9 +6,9 @@ import {
 
 /**
  * For a given preview of a changeset to be applied, this method checks if the type of
- * changeset allows for the user to modify its publish status from the UI: namely, that
+ * changeset allows for the user to modify its publication state from the UI: namely, that
  * the applied changeset is visible to the user applying, will be attaching or updating
- * the changeset, is not an existing reference, and has not had its publish status set
+ * the changeset, is not an existing reference, and has not had its publication state set
  * from the batch spec file. Returns the id of the changeset spec if it is publishable
  * from the UI, or null if for any reason it is not.
  *

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -1,0 +1,29 @@
+import { HiddenChangesetApplyPreviewFields, VisibleChangesetApplyPreviewFields } from '../../../graphql-operations'
+
+/**
+ * For a given preview of a changeset to be applied, this method checks if the type of
+ * changeset allows for the user to modify its publish status from the UI: namely, that
+ * the applied changeset is visible to the user applying, will be attaching or updating
+ * the changeset, is not an existing reference, and has not had its publish status set
+ * from the batch spec file. Returns the id of the changeset spec if it is publishable
+ * from the UI, or null if for any reason it is not.
+ *
+ * @param node the `ChangesetApplyPreviewFields` node to check
+ */
+export const getPublishableChangesetSpecID = (
+    node: VisibleChangesetApplyPreviewFields | HiddenChangesetApplyPreviewFields
+): string | null => {
+    if (
+        node.targets.__typename !== 'VisibleApplyPreviewTargetsAttach' &&
+        node.targets.__typename !== 'VisibleApplyPreviewTargetsUpdate'
+    ) {
+        return null
+    }
+    if (node.targets.changesetSpec.description.__typename !== 'GitBranchChangesetDescription') {
+        return null
+    }
+    if (node.targets.changesetSpec.description.published !== null) {
+        return null
+    }
+    return node.targets.changesetSpec.id
+}

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -1,6 +1,6 @@
 import {
-    HiddenChangesetApplyPreviewFields,
-    VisibleChangesetApplyPreviewFields,
+    PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields,
+    PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields,
     Scalars,
 } from '../../../graphql-operations'
 
@@ -15,7 +15,9 @@ import {
  * @param node the `ChangesetApplyPreviewFields` node to check
  */
 export const getPublishableChangesetSpecID = (
-    node: VisibleChangesetApplyPreviewFields | HiddenChangesetApplyPreviewFields
+    node:
+        | PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields
+        | PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields
 ): Scalars['ID'] | null => {
     if (
         node.targets.__typename !== 'VisibleApplyPreviewTargetsAttach' &&


### PR DESCRIPTION
Part 1 of #23383. Portions of this lifted from or inspired by #22658.

**Note:** This PR is temporarily based on #23960 since it copies the same pattern fixed there.

This PR includes:
- some light cleanup/followup to #23821
- selecting the preview changesets
- selecting the desired publish status from a dropdown

![image](https://user-images.githubusercontent.com/8942601/129510858-80cbfc71-eb12-4b90-bbd1-f1591dbc1908.png)


This PR does not include:
- recalculating the actions on the backend when a publish status modification is selected
- applying the new publish statuses when you click "Apply"
- disabling the "Apply" button until a publish status modification is selected

(Those will each be a follow-up PR, but this one I think is the chunkiest)

This absolutely duplicates a lot of code between `BatchChangeChangesets` and `PreviewList`, but I was not feeling particularly motivated to refactor it because
1. we're trying to get this out sooner rather than later
2. it's only duplicated across 2 places, not 3 or 4 or 5 or 10
3. we're slowly moving towards getting rid of the preview page anyway

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
