### PR TITLE
Code Insights: Add Caution/suggest copy to the all repos creation form mode

### DIFF
--- a/client/web/src/insights/components/live-preview-container/LivePreviewContainer.tsx
+++ b/client/web/src/insights/components/live-preview-container/LivePreviewContainer.tsx
@@ -20,10 +20,11 @@ export interface LivePreviewContainerProps {
     dataOrError: ChartContent | Error | undefined
     defaultMock: ChartContent
     mockMessage: ReactNode
+    description?: ReactNode
 }
 
 export function LivePreviewContainer(props: LivePreviewContainerProps): ReactElement {
-    const { disabled, loading, dataOrError, defaultMock, onUpdateClick, className, mockMessage } = props
+    const { disabled, loading, dataOrError, defaultMock, onUpdateClick, className, mockMessage, description } = props
 
     return (
         <section className={classnames(styles.livePreview, className)}>
@@ -61,6 +62,8 @@ export function LivePreviewContainer(props: LivePreviewContainerProps): ReactEle
                     {!dataOrError && <p className={styles.livePreviewLoadingChartInfo}>{mockMessage}</p>}
                 </div>
             )}
+
+            <span className="mt-2 text-muted">{description}</span>
         </section>
     )
 }

--- a/client/web/src/insights/components/live-preview-container/LivePreviewContainer.tsx
+++ b/client/web/src/insights/components/live-preview-container/LivePreviewContainer.tsx
@@ -63,7 +63,7 @@ export function LivePreviewContainer(props: LivePreviewContainerProps): ReactEle
                 </div>
             )}
 
-            <span className="mt-2 text-muted">{description}</span>
+            {description && <span className="mt-2 text-muted">{description}</span>}
         </section>
     )
 }

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
@@ -22,14 +22,18 @@ export interface SearchInsightLivePreviewProps {
     series: EditableDataSeries[]
     /** Step value for chart. */
     stepValue: string
+
     /**
      * Disable prop to disable live preview.
      * Used in a consumer of this component when some required fields
      * for live preview are invalid.
-     * */
+     */
     disabled?: boolean
+
     /** Step mode for step value prop. */
     step: InsightStep
+
+    isAllReposMode: boolean
 }
 
 /**
@@ -37,7 +41,7 @@ export interface SearchInsightLivePreviewProps {
  * from creation UI form.
  */
 export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLivePreviewProps> = props => {
-    const { series, repositories, step, stepValue, disabled = false, className } = props
+    const { series, repositories, step, stepValue, disabled = false, isAllReposMode, className } = props
 
     const { getSearchInsightContent } = useContext(InsightsApiContext)
 
@@ -94,10 +98,20 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
             disabled={disabled}
             defaultMock={DEFAULT_MOCK_CHART_CONTENT}
             mockMessage={
-                <span>
-                    {' '}
-                    The chart preview will be shown here once you have filled out the repositories and series fields.
-                </span>
+                isAllReposMode ? (
+                    <span> Live previews are currently not available for insights running over all repositories. </span>
+                ) : (
+                    <span>
+                        {' '}
+                        The chart preview will be shown here once you have filled out the repositories and series
+                        fields.
+                    </span>
+                )
+            }
+            description={
+                isAllReposMode
+                    ? 'Previews are only displayed only if you individually list up to 50 repositories.'
+                    : null
             }
             className={className}
             onUpdateClick={() => setLastPreviewVersion(version => version + 1)}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -140,6 +140,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
             <SearchInsightLivePreview
                 disabled={!allFieldsForPreviewAreValid}
                 repositories={repositories.meta.value}
+                isAllReposMode={allReposMode.input.value}
                 series={editSeries}
                 step={step.meta.value}
                 stepValue={stepValue.meta.value}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -109,15 +109,18 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         >
             <FormGroup
                 name="insight repositories"
-                title="Repositories"
+                title="Targeted repositories"
                 subtitle="Create a list of repositories to run your search over"
             >
                 <FormInput
                     as={RepositoriesField}
                     autoFocus={true}
                     required={true}
+                    title="Repositories"
                     description="Separate repositories with commas"
-                    placeholder="Example: github.com/sourcegraph/sourcegraph"
+                    placeholder={
+                        allReposMode.input.value ? 'All repositories' : 'Example: github.com/sourcegraph/sourcegraph'
+                    }
                     loading={repositories.meta.validState === 'CHECKING'}
                     valid={repositories.meta.touched && repositories.meta.validState === 'VALID'}
                     error={repositories.meta.touched && repositories.meta.error}
@@ -127,7 +130,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
 
                 {hasAllReposUI && (
                     <>
-                        <label className="d-flex align-items-center mb-2 mt-2 font-weight-normal">
+                        <label className="d-flex flex-wrap align-items-center mb-2 mt-3 font-weight-normal">
                             <input
                                 type="checkbox"
                                 {...allReposMode.input}
@@ -136,6 +139,33 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                             />
 
                             <span className="pl-2">Run your insight over all your repositories</span>
+
+                            <small className="w-100 mt-2 text-muted">
+                                {!allReposMode.input.value ? (
+                                    <>
+                                        We currently recommend not exceeding more than ~500 repositories per insight.
+                                        You can filter down from "all repositories" using a{' '}
+                                        <a
+                                            href="https://docs.sourcegraph.com/code_search/reference/queries#repository-search"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            repo: filter
+                                        </a>{' '}
+                                        in your search queries below.
+                                    </>
+                                ) : (
+                                    <>We strongly recommend not to exceed 500 repositories per insight.</>
+                                )}
+                                Read more about the{' '}
+                                <a
+                                    href="https://docs.sourcegraph.com/code_insights/explanations/current_limitations_of_code_insights"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    beta limitations
+                                </a>
+                            </small>
                         </label>
 
                         <hr className={styles.creationInsightFormSeparator} />


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/23260
Closes https://github.com/sourcegraph/sourcegraph/issues/23655

## Context
This PR adds 
- Some cautious description to the all-over repositories form control. 
- Special mock and description messages to the live preview chart if all-repos mode has been turned on

You can find Figma designs here https://www.figma.com/file/wXKTspDmgTrPPumahHQTXQ/Caution-suggest-to-keep-insights-500-repos-23655?node-id=0%3A1

## How to test
Since this all-repos mode is still under the feature flag `experimentalFeatures.codeInsightsAllRepos`
You have to turn it on in your personal or org settings. Then you will see all-repos checkbox at the creation insight page `/insights/create/search`

<img width="594" alt="Screenshot 2021-08-16 at 12 58 41" src="https://user-images.githubusercontent.com/18492575/129546337-463db06e-e1bc-40cf-a0b4-dd95655b9a27.png">


