### PR TITLE
usagestats/auth: log backend events for sign up success and failure

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -125,7 +125,7 @@ func GetAndSaveUser(ctx context.Context, db dbutil.DB, op GetAndSaveUserOp) (use
 
 		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %q}`, op.ExternalAccount.ServiceType))
 		if logErr := usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupSucceeded", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); logErr != nil {
-			log15.Warn("Failed to log event ExternalAuthSignupSucceded")
+			log15.Warn("Failed to log event ExternalAuthSignupSucceded", "error", logErr)
 		}
 
 		return userID, true, true, "", nil

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -124,7 +124,7 @@ func GetAndSaveUser(ctx context.Context, db dbutil.DB, op GetAndSaveUserOp) (use
 		}
 
 		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %s}`, op.ExternalAccount.ServiceType))
-		if err = usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupSucceeded", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); err != nil {
+		if logErr := usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupSucceeded", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); logErr != nil {
 			log15.Warn("Failed to log event ExternalAuthSignupSucceded")
 		}
 
@@ -132,7 +132,7 @@ func GetAndSaveUser(ctx context.Context, db dbutil.DB, op GetAndSaveUserOp) (use
 	}()
 	if err != nil {
 		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %s}`, op.ExternalAccount.ServiceType))
-		if err = usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupFailed", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); err != nil {
+		if logErr := usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupFailed", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); logErr != nil {
 			log15.Warn("Failed to log event ExternalAuthSignUpFailed")
 		}
 		return 0, safeErrMsg, err

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -133,7 +133,7 @@ func GetAndSaveUser(ctx context.Context, db dbutil.DB, op GetAndSaveUserOp) (use
 	if err != nil {
 		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %s}`, op.ExternalAccount.ServiceType))
 		if logErr := usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupFailed", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); logErr != nil {
-			log15.Warn("Failed to log event ExternalAuthSignUpFailed")
+			log15.Warn("Failed to log event ExternalAuthSignUpFailed", "error", logErr)
 		}
 		return 0, safeErrMsg, err
 	}

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -131,7 +131,7 @@ func GetAndSaveUser(ctx context.Context, db dbutil.DB, op GetAndSaveUserOp) (use
 		return userID, true, true, "", nil
 	}()
 	if err != nil {
-		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %s}`, op.ExternalAccount.ServiceType))
+		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %q}`, op.ExternalAccount.ServiceType))
 		if logErr := usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupFailed", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); logErr != nil {
 			log15.Warn("Failed to log event ExternalAuthSignUpFailed", "error", logErr)
 		}

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -123,7 +123,7 @@ func GetAndSaveUser(ctx context.Context, db dbutil.DB, op GetAndSaveUserOp) (use
 			log15.Error("Failed to grant user pending permissions", "userID", userID, "error", err)
 		}
 
-		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %s}`, op.ExternalAccount.ServiceType))
+		serviceTypeArg := json.RawMessage(fmt.Sprintf(`{"serviceType": %q}`, op.ExternalAccount.ServiceType))
 		if logErr := usagestats.LogBackendEvent(db, actor.FromContext(ctx).UID, "ExternalAuthSignupSucceeded", serviceTypeArg, serviceTypeArg, featureflag.FromContext(ctx), nil); logErr != nil {
 			log15.Warn("Failed to log event ExternalAuthSignupSucceded")
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -21,6 +21,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -448,7 +449,7 @@ func LogSearchLatency(ctx context.Context, db dbutil.DB, si *run.SearchInputs, d
 			eventName := fmt.Sprintf("search.latencies.%s", types[0])
 			featureFlags := featureflag.FromContext(ctx)
 			go func() {
-				err := usagestats.LogBackendEvent(db, a.UID, eventName, json.RawMessage(value), featureFlags, nil)
+				err := usagestats.LogBackendEvent(db, a.UID, eventName, json.RawMessage(value), json.RawMessage(value), featureFlags, nil)
 				if err != nil {
 					log15.Warn("Could not log search latency", "err", err)
 				}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -22,11 +22,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -23,7 +23,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/actor"

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -291,7 +291,7 @@ func logSignInEvent(r *http.Request, db dbutil.DB, usr *types.User, name *databa
 	// Safe to ignore this error
 	event.AnonymousUserID, _ = cookie.AnonymousUID(r)
 
-	usagestats.LogBackendEvent(db, int32(usr.ID), string(*name), nil, nil, featureflag.FromContext(r.Context()), nil)
+	usagestats.LogBackendEvent(db, usr.ID, string(*name), nil, nil, featureflag.FromContext(r.Context()), nil)
 	database.SecurityEventLogs(db).LogEvent(r.Context(), event)
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -168,7 +168,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 		http.Error(w, message, statusCode)
 
 		if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpFailed", nil, nil, featureflag.FromContext(r.Context()), nil); err != nil {
-			log15.Warn("Failed to log event SignUpFailed")
+			log15.Warn("Failed to log event SignUpFailed", "error", err)
 		}
 
 		return

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -24,7 +24,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
 type credentials struct {
@@ -164,6 +166,11 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 		}
 		log15.Error("Error in user signup.", "email", creds.Email, "username", creds.Username, "error", err)
 		http.Error(w, message, statusCode)
+
+		if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpFailed", nil, featureflag.FromContext(r.Context()), nil); err != nil {
+			log15.Warn("Failed to log event SignUpFailed")
+		}
+
 		return
 	}
 
@@ -184,14 +191,18 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 	}
 
 	// Write the session cookie
-	actor := &actor.Actor{UID: usr.ID}
-	if err := session.SetActor(w, r, actor, 0, usr.CreatedAt); err != nil {
+	a := &actor.Actor{UID: usr.ID}
+	if err := session.SetActor(w, r, a, 0, usr.CreatedAt); err != nil {
 		httpLogAndError(w, "Could not create new user session", http.StatusInternalServerError)
 	}
 
 	// Track user data
 	if r.UserAgent() != "Sourcegraph e2etest-bot" {
 		go hubspotutil.SyncUser(creds.Email, hubspotutil.SignupEventID, &hubspot.ContactProperties{AnonymousUserID: creds.AnonymousUserID, FirstSourceURL: creds.FirstSourceURL, DatabaseID: usr.ID})
+	}
+
+	if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpSucceeded", nil, featureflag.FromContext(r.Context()), nil); err != nil {
+		log15.Warn("Failed to log event SignUpSucceeded")
 	}
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -167,7 +167,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 		log15.Error("Error in user signup.", "email", creds.Email, "username", creds.Username, "error", err)
 		http.Error(w, message, statusCode)
 
-		if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpFailed", nil, featureflag.FromContext(r.Context()), nil); err != nil {
+		if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpFailed", nil, nil, featureflag.FromContext(r.Context()), nil); err != nil {
 			log15.Warn("Failed to log event SignUpFailed")
 		}
 
@@ -201,7 +201,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 		go hubspotutil.SyncUser(creds.Email, hubspotutil.SignupEventID, &hubspot.ContactProperties{AnonymousUserID: creds.AnonymousUserID, FirstSourceURL: creds.FirstSourceURL, DatabaseID: usr.ID})
 	}
 
-	if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpSucceeded", nil, featureflag.FromContext(r.Context()), nil); err != nil {
+	if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpSucceeded", nil, nil, featureflag.FromContext(r.Context()), nil); err != nil {
 		log15.Warn("Failed to log event SignUpSucceeded")
 	}
 }

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -202,7 +202,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 	}
 
 	if err = usagestats.LogBackendEvent(database.GlobalUsers.Handle().DB(), actor.FromContext(r.Context()).UID, "SignUpSucceeded", nil, nil, featureflag.FromContext(r.Context()), nil); err != nil {
-		log15.Warn("Failed to log event SignUpSucceeded")
+		log15.Warn("Failed to log event SignUpSucceeded", "error", err)
 	}
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -291,6 +291,7 @@ func logSignInEvent(r *http.Request, db dbutil.DB, usr *types.User, name *databa
 	// Safe to ignore this error
 	event.AnonymousUserID, _ = cookie.AnonymousUID(r)
 
+	usagestats.LogBackendEvent(db, int32(usr.ID), string(*name), nil, nil, featureflag.FromContext(r.Context()), nil)
 	database.SecurityEventLogs(db).LogEvent(r.Context(), event)
 }
 

--- a/cmd/frontend/internal/httpapi/telemetry.go
+++ b/cmd/frontend/internal/httpapi/telemetry.go
@@ -21,7 +21,7 @@ func telemetryHandler(db dbutil.DB) http.Handler {
 			log15.Error("telemetryHandler: Decode", "error", err)
 		}
 		featureFlags := featureflag.FromContext(r.Context())
-		err = usagestats.LogBackendEvent(db, tr.UserID, tr.EventName, tr.Argument, featureFlags, nil)
+		err = usagestats.LogBackendEvent(db, tr.UserID, tr.EventName, tr.Argument, tr.PublicArgument, featureFlags, nil)
 		if err != nil {
 			log15.Error("telemetryHandler: usagestats.LogBackendEvent", "error", err)
 		}

--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -13,9 +13,10 @@ import (
 
 // TelemetryRequest represents a request to log telemetry.
 type TelemetryRequest struct {
-	UserID    int32
-	EventName string
-	Argument  json.RawMessage
+	UserID         int32
+	EventName      string
+	Argument       json.RawMessage
+	PublicArgument json.RawMessage
 }
 
 // LogEvent sends a payload representing an event to the api/telemetry endpoint.

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -38,16 +38,17 @@ type Event struct {
 }
 
 // LogBackendEvent is a convenience function for logging backend events.
-func LogBackendEvent(db dbutil.DB, userID int32, eventName string, argument json.RawMessage, featureFlags featureflag.FlagSet, cohortID *string) error {
+func LogBackendEvent(db dbutil.DB, userID int32, eventName string, argument, publicArgument json.RawMessage, featureFlags featureflag.FlagSet, cohortID *string) error {
 	return LogEvent(context.Background(), db, Event{
-		EventName:    eventName,
-		UserID:       userID,
-		UserCookieID: "backend", // Use a non-empty string here to avoid the event_logs table's user existence constraint causing issues
-		URL:          "",
-		Source:       "BACKEND",
-		Argument:     argument,
-		FeatureFlags: featureFlags,
-		CohortID:     cohortID,
+		EventName:      eventName,
+		UserID:         userID,
+		UserCookieID:   "backend", // Use a non-empty string here to avoid the event_logs table's user existence constraint causing issues
+		URL:            "",
+		Source:         "BACKEND",
+		Argument:       argument,
+		PublicArgument: publicArgument,
+		FeatureFlags:   featureFlags,
+		CohortID:       cohortID,
 	})
 }
 


### PR DESCRIPTION
Three changes: 
* 1st commit: Adds logging for backend events when a user's sign up process succeeds or fails. Both for user/password signup and external auth.
* 2nd commit: Adds publicArguments field for `LogBackendEvent` function, and passes public arguments to the field so we can read public arguments attached to events.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
