### PR TITLE
perms-syncer: Add test for nil provider but with linked user ids 

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -573,8 +573,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return errors.Wrap(err, "set repository permissions")
 	}
 
-	// If there is no provider, there would be no pending permissions will be generated.
-	// TODO: add a test case where userID is not empty but provider is nil
+	// If there is no provider, there would be no pending permissions that need to be generated.
 	if provider != nil {
 		accounts := &extsvc.Accounts{
 			ServiceType: provider.ServiceType(),

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -567,6 +567,51 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		}
 	})
 
+	t.Run("repo sync with external service userid but no providers", func(t *testing.T) {
+		edb.Mocks.Perms.Transact = func(context.Context) (*edb.PermsStore, error) {
+			return &edb.PermsStore{}, nil
+		}
+		edb.Mocks.Perms.GetUserIDsByExternalAccounts = func(context.Context, *extsvc.Accounts) (map[string]int32, error) {
+			return map[string]int32{"user": 1}, nil
+		}
+		edb.Mocks.Perms.SetRepoPermissions = func(_ context.Context, p *authz.RepoPermissions) error {
+			if p.RepoID != 1 {
+				return errors.Errorf("RepoID: want 1 but got %d", p.RepoID)
+			}
+
+			wantUserIDs := []uint32{1}
+			if diff := cmp.Diff(wantUserIDs, p.UserIDs.ToArray()); diff != "" {
+				return errors.Errorf("UserIDs mismatch (-want +got):\n%s", diff)
+			}
+			return nil
+		}
+		edb.Mocks.Perms.SetRepoPendingPermissions = func(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) error {
+			return nil
+		}
+		database.Mocks.Repos.List = func(context.Context, database.ReposListOptions) ([]*types.Repo, error) {
+			return []*types.Repo{
+				{
+					ID:      1,
+					Private: true,
+				},
+			}, nil
+		}
+		database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
+			return []int32{1}, nil
+		}
+		defer func() {
+			edb.Mocks.Perms = edb.MockPerms{}
+			database.Mocks.Repos = database.MockRepos{}
+		}()
+
+		s := newPermsSyncer(repos.NewStore(&dbtesting.MockDB{}, sql.TxOptions{}))
+
+		err := s.syncRepoPerms(context.Background(), 1, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	p := &mockProvider{
 		serviceType: extsvc.TypeGitLab,
 		serviceID:   "https://gitlab.com/",

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -571,9 +571,11 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		edb.Mocks.Perms.Transact = func(context.Context) (*edb.PermsStore, error) {
 			return &edb.PermsStore{}, nil
 		}
+
 		edb.Mocks.Perms.GetUserIDsByExternalAccounts = func(context.Context, *extsvc.Accounts) (map[string]int32, error) {
 			return map[string]int32{"user": 1}, nil
 		}
+
 		edb.Mocks.Perms.SetRepoPermissions = func(_ context.Context, p *authz.RepoPermissions) error {
 			if p.RepoID != 1 {
 				return errors.Errorf("RepoID: want 1 but got %d", p.RepoID)
@@ -585,9 +587,11 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			}
 			return nil
 		}
+
 		edb.Mocks.Perms.SetRepoPendingPermissions = func(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) error {
-			return nil
+			return errors.Errorf("SetRepoPendingPermissions should not be invoked in this test case")
 		}
+
 		database.Mocks.Repos.List = func(context.Context, database.ReposListOptions) ([]*types.Repo, error) {
 			return []*types.Repo{
 				{
@@ -596,9 +600,11 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 				},
 			}, nil
 		}
+
 		database.Mocks.Repos.ListExternalServiceUserIDsByRepoID = func(ctx context.Context, repoID api.RepoID) ([]int32, error) {
 			return []int32{1}, nil
 		}
+
 		defer func() {
 			edb.Mocks.Perms = edb.MockPerms{}
 			database.Mocks.Repos = database.MockRepos{}


### PR DESCRIPTION
We fixed a panic with nil provider object in f018333. This commit
adds a test to ensure it doesn't happen again.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
