### PR TITLE
codeintel: Expose dependencies and dependents of uploads

### DIFF
--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
@@ -23,17 +23,17 @@ import { ErrorAlert } from '../../../components/alerts'
 import { PageTitle } from '../../../components/PageTitle'
 import { LsifUploadFields } from '../../../graphql-operations'
 import { fetchLsifUploads as defaultFetchLsifUploads } from '../list/backend'
+import { CodeIntelState } from '../shared/CodeIntelState'
 import { CodeIntelStateBanner } from '../shared/CodeIntelStateBanner'
+import { CodeIntelUploadOrIndexCommit } from '../shared/CodeIntelUploadOrIndexCommit'
+import { CodeIntelUploadOrIndexRepository } from '../shared/CodeIntelUploadOrIndexerRepository'
+import { CodeIntelUploadOrIndexIndexer } from '../shared/CodeIntelUploadOrIndexIndexer'
+import { CodeIntelUploadOrIndexRoot } from '../shared/CodeIntelUploadOrIndexRoot'
 
 import { deleteLsifUpload, fetchLsifUpload as defaultFetchUpload } from './backend'
 import { CodeIntelAssociatedIndex } from './CodeIntelAssociatedIndex'
 import { CodeIntelUploadMeta } from './CodeIntelUploadMeta'
 import { CodeIntelUploadTimeline } from './CodeIntelUploadTimeline'
-import { CodeIntelState } from '../shared/CodeIntelState'
-import { CodeIntelUploadOrIndexCommit } from '../shared/CodeIntelUploadOrIndexCommit'
-import { CodeIntelUploadOrIndexRoot } from '../shared/CodeIntelUploadOrIndexRoot'
-import { CodeIntelUploadOrIndexIndexer } from '../shared/CodeIntelUploadOrIndexIndexer'
-import { CodeIntelUploadOrIndexRepository } from '../shared/CodeIntelUploadOrIndexerRepository'
 
 export interface CodeIntelUploadPageProps extends RouteComponentProps<{ id: string }>, TelemetryProps {
     fetchLsifUpload?: typeof defaultFetchUpload

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
@@ -1,7 +1,10 @@
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import DeleteIcon from 'mdi-react/DeleteIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
+import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
+import { Link } from 'react-router-dom'
 import { timer } from 'rxjs'
 import { catchError, concatMap, delay, repeatWhen, takeWhile } from 'rxjs/operators'
 
@@ -10,20 +13,31 @@ import { LSIFUploadState } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import {
+    FilteredConnection,
+    FilteredConnectionQueryArguments,
+} from '@sourcegraph/web/src/components/FilteredConnection'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../../components/alerts'
 import { PageTitle } from '../../../components/PageTitle'
 import { LsifUploadFields } from '../../../graphql-operations'
+import { fetchLsifUploads as defaultFetchLsifUploads } from '../list/backend'
 import { CodeIntelStateBanner } from '../shared/CodeIntelStateBanner'
 
 import { deleteLsifUpload, fetchLsifUpload as defaultFetchUpload } from './backend'
 import { CodeIntelAssociatedIndex } from './CodeIntelAssociatedIndex'
 import { CodeIntelUploadMeta } from './CodeIntelUploadMeta'
 import { CodeIntelUploadTimeline } from './CodeIntelUploadTimeline'
+import { CodeIntelState } from '../shared/CodeIntelState'
+import { CodeIntelUploadOrIndexCommit } from '../shared/CodeIntelUploadOrIndexCommit'
+import { CodeIntelUploadOrIndexRoot } from '../shared/CodeIntelUploadOrIndexRoot'
+import { CodeIntelUploadOrIndexIndexer } from '../shared/CodeIntelUploadOrIndexIndexer'
+import { CodeIntelUploadOrIndexRepository } from '../shared/CodeIntelUploadOrIndexerRepository'
 
 export interface CodeIntelUploadPageProps extends RouteComponentProps<{ id: string }>, TelemetryProps {
     fetchLsifUpload?: typeof defaultFetchUpload
+    fetchLsifUploads?: typeof defaultFetchLsifUploads
     now?: () => Date
 }
 
@@ -34,17 +48,25 @@ const classNamesByState = new Map([
     [LSIFUploadState.ERRORED, 'alert-danger'],
 ])
 
+enum DependencyGraphState {
+    ShowDependencies,
+    ShowDependents,
+}
+
 export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = ({
     match: {
         params: { id },
     },
     fetchLsifUpload = defaultFetchUpload,
+    fetchLsifUploads = defaultFetchLsifUploads,
     telemetryService,
     now,
+    ...props
 }) => {
     useEffect(() => telemetryService.logViewEvent('CodeIntelUpload'), [telemetryService])
 
     const [deletionOrError, setDeletionOrError] = useState<'loading' | 'deleted' | ErrorLike>()
+    const [dependencyGraphState, setDependencyGraphState] = useState(DependencyGraphState.ShowDependencies)
 
     const uploadOrError = useObservable(
         useMemo(
@@ -86,6 +108,33 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
         }
     }, [id, uploadOrError])
 
+    const queryDependencies = useCallback(
+        (args: FilteredConnectionQueryArguments) => {
+            if (uploadOrError && !isErrorLike(uploadOrError)) {
+                return fetchLsifUploads({ dependencyOf: uploadOrError.id, ...args })
+            }
+
+            throw new Error('unreachable: queryDependencies referenced with invalid upload')
+        },
+        [uploadOrError, fetchLsifUploads]
+    )
+
+    const queryDependents = useCallback(
+        (args: FilteredConnectionQueryArguments) => {
+            if (uploadOrError && !isErrorLike(uploadOrError)) {
+                return fetchLsifUploads({ dependentOf: uploadOrError.id, ...args })
+            }
+
+            throw new Error('unreachable: queryDependents referenced with invalid upload')
+        },
+        [uploadOrError, fetchLsifUploads]
+    )
+
+    const showDependencyGraphState = useCallback(
+        (state: DependencyGraphState) => () => setDependencyGraphState(state),
+        [setDependencyGraphState]
+    )
+
     return deletionOrError === 'deleted' ? (
         <Redirect to="." />
     ) : isErrorLike(deletionOrError) ? (
@@ -103,7 +152,7 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                         headingElement="h2"
                         path={[
                             {
-                                text: `Upload for commit${
+                                text: `Upload for commit ${
                                     uploadOrError.projectRoot
                                         ? uploadOrError.projectRoot.commit.abbreviatedOID
                                         : uploadOrError.inputCommit.slice(0, 7)
@@ -141,6 +190,62 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                     </Container>
 
                     <Container className="mt-2">
+                        <div className="mb-2">
+                            {dependencyGraphState === DependencyGraphState.ShowDependencies ? (
+                                <h2>
+                                    Dependencies
+                                    <button
+                                        type="button"
+                                        className="btn btn-link float-right p-0 mb-2"
+                                        onClick={showDependencyGraphState(DependencyGraphState.ShowDependents)}
+                                    >
+                                        Show dependents
+                                    </button>
+                                </h2>
+                            ) : (
+                                <h2>
+                                    Dependents
+                                    <button
+                                        type="button"
+                                        className="btn btn-link float-right p-0 mb-2"
+                                        onClick={showDependencyGraphState(DependencyGraphState.ShowDependencies)}
+                                    >
+                                        Show dependencies
+                                    </button>
+                                </h2>
+                            )}
+                        </div>
+
+                        {dependencyGraphState === DependencyGraphState.ShowDependencies ? (
+                            <FilteredConnection
+                                listComponent="div"
+                                listClassName="codeintel-uploads__grid mb-3"
+                                noun="dependency"
+                                pluralNoun="dependencies"
+                                nodeComponent={DependencyOrDependentNode}
+                                queryConnection={queryDependencies}
+                                history={props.history}
+                                location={props.location}
+                                cursorPaging={true}
+                                emptyElement={<EmptyDependenciesElement />}
+                            />
+                        ) : (
+                            <FilteredConnection
+                                listComponent="div"
+                                listClassName="codeintel-uploads__grid mb-3"
+                                noun="dependent"
+                                pluralNoun="dependents"
+                                nodeComponent={DependencyOrDependentNode}
+                                queryConnection={queryDependents}
+                                history={props.history}
+                                location={props.location}
+                                cursorPaging={true}
+                                emptyElement={<EmptyDependentsElement />}
+                            />
+                        )}
+                    </Container>
+
+                    <Container className="mt-2">
                         <CodeIntelDeleteUpload
                             state={uploadOrError.state}
                             deleteUpload={deleteUpload}
@@ -158,6 +263,57 @@ const terminalStates = new Set([LSIFUploadState.COMPLETED, LSIFUploadState.ERROR
 function shouldReload(upload: LsifUploadFields | ErrorLike | null | undefined): boolean {
     return !isErrorLike(upload) && !(upload && terminalStates.has(upload.state))
 }
+
+interface DependencyOrDependentNodeProps {
+    node: LsifUploadFields
+    now?: () => Date
+}
+
+const DependencyOrDependentNode: FunctionComponent<DependencyOrDependentNodeProps> = ({ node }) => (
+    <>
+        <span className="codeintel-upload-node__separator" />
+
+        <div className="d-flex flex-column codeintel-upload-node__information">
+            <div className="m-0">
+                <h3 className="m-0 d-block d-md-inline">
+                    <CodeIntelUploadOrIndexRepository node={node} />
+                </h3>
+            </div>
+
+            <div>
+                <span className="mr-2 d-block d-mdinline-block">
+                    Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
+                    <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
+                </span>
+            </div>
+        </div>
+
+        <span className="d-none d-md-inline codeintel-upload-node__state">
+            <CodeIntelState node={node} className="d-flex flex-column align-items-center" />
+        </span>
+        <span>
+            <Link to={`./${node.id}`}>
+                <ChevronRightIcon />
+            </Link>
+        </span>
+    </>
+)
+
+const EmptyDependenciesElement: React.FunctionComponent = () => (
+    <p className="text-muted text-center w-100 mb-0 mt-1">
+        <MapSearchIcon className="mb-2" />
+        <br />
+        This upload has no dependencies.
+    </p>
+)
+
+const EmptyDependentsElement: React.FunctionComponent = () => (
+    <p className="text-muted text-center w-100 mb-0 mt-1">
+        <MapSearchIcon className="mb-2" />
+        <br />
+        This upload has no dependents.
+    </p>
+)
 
 interface CodeIntelDeleteUploadProps {
     state: LSIFUploadState

--- a/client/web/src/enterprise/codeintel/list/backend.ts
+++ b/client/web/src/enterprise/codeintel/list/backend.ts
@@ -39,13 +39,17 @@ export function fetchLsifUploads({
     query,
     state,
     isLatestForRepo,
+    dependencyOf,
+    dependentOf,
     first,
     after,
 }: { repository?: string } & GQL.ILsifUploadsOnRepositoryArguments): Observable<UploadConnection> {
-    const vars = {
+    const vars: GQL.ILsifUploadsOnRepositoryArguments = {
         query: query ?? null,
         state: state ?? null,
         isLatestForRepo: isLatestForRepo ?? null,
+        ...(dependencyOf ? { dependencyOf: dependencyOf as GQL.ID } : {}),
+        ...(dependentOf ? { dependentOf: dependentOf as GQL.ID } : {}),
         first: first ?? null,
         after: after ?? null,
     }
@@ -56,6 +60,8 @@ export function fetchLsifUploads({
                 $repository: ID!
                 $state: LSIFUploadState
                 $isLatestForRepo: Boolean
+                $dependencyOf: ID
+                $dependentOf: ID
                 $first: Int
                 $after: String
                 $query: String
@@ -67,6 +73,8 @@ export function fetchLsifUploads({
                             query: $query
                             state: $state
                             isLatestForRepo: $isLatestForRepo
+                            dependencyOf: $dependencyOf
+                            dependentOf: $dependentOf
                             first: $first
                             after: $after
                         ) {
@@ -112,11 +120,21 @@ export function fetchLsifUploads({
         query LsifUploads(
             $state: LSIFUploadState
             $isLatestForRepo: Boolean
+            $dependencyOf: ID
+            $dependentOf: ID
             $first: Int
             $after: String
             $query: String
         ) {
-            lsifUploads(query: $query, state: $state, isLatestForRepo: $isLatestForRepo, first: $first, after: $after) {
+            lsifUploads(
+                query: $query
+                state: $state
+                isLatestForRepo: $isLatestForRepo
+                dependencyOf: $dependencyOf
+                dependentOf: $dependentOf
+                first: $first
+                after: $after
+            ) {
                 nodes {
                     ...LsifUploadFields
                 }

--- a/client/web/src/enterprise/codeintel/list/backend.ts
+++ b/client/web/src/enterprise/codeintel/list/backend.ts
@@ -44,12 +44,12 @@ export function fetchLsifUploads({
     first,
     after,
 }: { repository?: string } & GQL.ILsifUploadsOnRepositoryArguments): Observable<UploadConnection> {
-    const vars: GQL.ILsifUploadsOnRepositoryArguments = {
+    const vars: LsifUploadsVariables = {
         query: query ?? null,
         state: state ?? null,
         isLatestForRepo: isLatestForRepo ?? null,
-        ...(dependencyOf ? { dependencyOf: dependencyOf as GQL.ID } : {}),
-        ...(dependentOf ? { dependentOf: dependentOf as GQL.ID } : {}),
+        dependencyOf: dependencyOf ?? null,
+        dependentOf: dependentOf ?? null,
         first: first ?? null,
         after: after ?? null,
     }

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -33,6 +33,8 @@ type LSIFUploadsQueryArgs struct {
 	Query           *string
 	State           *string
 	IsLatestForRepo *bool
+	DependencyOf    *graphql.ID
+	DependentOf     *graphql.ID
 	After           *string
 }
 

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -45,6 +45,16 @@ extend type Query {
         state: LSIFUploadState
 
         """
+        When specified, shows only uploads that are a dependency of the specified upload.
+        """
+        dependencyOf: ID
+
+        """
+        When specified, shows only uploads that are a dependent of the specified upload.
+        """
+        dependentOf: ID
+
+        """
         When specified, shows only uploads that are latest for the given repository.
         """
         isLatestForRepo: Boolean
@@ -123,6 +133,16 @@ extend type Repository {
         When specified, shows only uploads that are latest for the given repository.
         """
         isLatestForRepo: Boolean
+
+        """
+        When specified, shows only uploads that are a dependency of the specified upload.
+        """
+        dependencyOf: ID
+
+        """
+        When specified, shows only uploads that are a dependent of the specified upload.
+        """
+        dependentOf: ID
 
         """
         When specified, indicates that this request should be paginated and

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
@@ -9,41 +9,43 @@ import (
 )
 
 type IndexConnectionResolver struct {
-	resolver         *resolvers.IndexesResolver
+	resolver         resolvers.Resolver
+	indexesResolver  *resolvers.IndexesResolver
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
 }
 
-func NewIndexConnectionResolver(resolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver) gql.LSIFIndexConnectionResolver {
+func NewIndexConnectionResolver(resolver resolvers.Resolver, indexesResolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver) gql.LSIFIndexConnectionResolver {
 	return &IndexConnectionResolver{
 		resolver:         resolver,
+		indexesResolver:  indexesResolver,
 		prefetcher:       prefetcher,
 		locationResolver: locationResolver,
 	}
 }
 
 func (r *IndexConnectionResolver) Nodes(ctx context.Context) ([]gql.LSIFIndexResolver, error) {
-	if err := r.resolver.Resolve(ctx); err != nil {
+	if err := r.indexesResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
 
-	resolvers := make([]gql.LSIFIndexResolver, 0, len(r.resolver.Indexes))
-	for i := range r.resolver.Indexes {
-		resolvers = append(resolvers, NewIndexResolver(r.resolver.Indexes[i], r.prefetcher, r.locationResolver))
+	resolvers := make([]gql.LSIFIndexResolver, 0, len(r.indexesResolver.Indexes))
+	for i := range r.indexesResolver.Indexes {
+		resolvers = append(resolvers, NewIndexResolver(r.resolver, r.indexesResolver.Indexes[i], r.prefetcher, r.locationResolver))
 	}
 	return resolvers, nil
 }
 
 func (r *IndexConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
-	if err := r.resolver.Resolve(ctx); err != nil {
+	if err := r.indexesResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
-	return toInt32(&r.resolver.TotalCount), nil
+	return toInt32(&r.indexesResolver.TotalCount), nil
 }
 
 func (r *IndexConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	if err := r.resolver.Resolve(ctx); err != nil {
+	if err := r.indexesResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
-	return encodeIntCursor(toInt32(r.resolver.NextOffset)), nil
+	return encodeIntCursor(toInt32(r.indexesResolver.NextOffset)), nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
@@ -9,41 +9,43 @@ import (
 )
 
 type UploadConnectionResolver struct {
-	resolver         *resolvers.UploadsResolver
+	resolver         resolvers.Resolver
+	uploadsResolver  *resolvers.UploadsResolver
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
 }
 
-func NewUploadConnectionResolver(resolver *resolvers.UploadsResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver) gql.LSIFUploadConnectionResolver {
+func NewUploadConnectionResolver(resolver resolvers.Resolver, uploadsResolver *resolvers.UploadsResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver) gql.LSIFUploadConnectionResolver {
 	return &UploadConnectionResolver{
 		resolver:         resolver,
+		uploadsResolver:  uploadsResolver,
 		prefetcher:       prefetcher,
 		locationResolver: locationResolver,
 	}
 }
 
 func (r *UploadConnectionResolver) Nodes(ctx context.Context) ([]gql.LSIFUploadResolver, error) {
-	if err := r.resolver.Resolve(ctx); err != nil {
+	if err := r.uploadsResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
 
-	resolvers := make([]gql.LSIFUploadResolver, 0, len(r.resolver.Uploads))
-	for i := range r.resolver.Uploads {
-		resolvers = append(resolvers, NewUploadResolver(r.resolver.Uploads[i], r.prefetcher, r.locationResolver))
+	resolvers := make([]gql.LSIFUploadResolver, 0, len(r.uploadsResolver.Uploads))
+	for i := range r.uploadsResolver.Uploads {
+		resolvers = append(resolvers, NewUploadResolver(r.resolver, r.uploadsResolver.Uploads[i], r.prefetcher, r.locationResolver))
 	}
 	return resolvers, nil
 }
 
 func (r *UploadConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
-	if err := r.resolver.Resolve(ctx); err != nil {
+	if err := r.uploadsResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
-	return toInt32(&r.resolver.TotalCount), nil
+	return toInt32(&r.uploadsResolver.TotalCount), nil
 }
 
 func (r *UploadConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	if err := r.resolver.Resolve(ctx); err != nil {
+	if err := r.uploadsResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
-	return encodeIntCursor(toInt32(r.resolver.NextOffset)), nil
+	return encodeIntCursor(toInt32(r.uploadsResolver.NextOffset)), nil
 }

--- a/enterprise/internal/codeintel/stores/dbstore/helpers_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/helpers_test.go
@@ -206,6 +206,21 @@ func deleteRepo(t testing.TB, db *sql.DB, id int, deleted_at time.Time) {
 	}
 }
 
+// insertPackages populates the lsif_packages table with the given packages.
+func insertPackages(t testing.TB, store *Store, packages []lsifstore.Package) {
+	for _, pkg := range packages {
+		if err := store.UpdatePackages(context.Background(), pkg.DumpID, []precise.Package{
+			{
+				Scheme:  pkg.Scheme,
+				Name:    pkg.Name,
+				Version: pkg.Version,
+			},
+		}); err != nil {
+			t.Fatalf("unexpected error updating packages: %s", err)
+		}
+	}
+}
+
 // insertPackageReferences populates the lsif_references table with the given package references.
 func insertPackageReferences(t testing.TB, store *Store, packageReferences []lsifstore.PackageReference) {
 	for _, packageReference := range packageReferences {

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -816,14 +816,6 @@ func intsToString(vs []int) string {
 	return strings.Join(strs, ", ")
 }
 
-func nilStringToString(s *string) string {
-	if s == nil {
-		return ""
-	}
-
-	return *s
-}
-
 func nilTimeToString(t *time.Time) string {
 	if t == nil {
 		return ""

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -282,6 +282,8 @@ type GetUploadsOptions struct {
 	State          string
 	Term           string
 	VisibleAtTip   bool
+	DependencyOf   int
+	DependentOf    int
 	UploadedBefore *time.Time
 	UploadedAfter  *time.Time
 	OldestFirst    bool
@@ -296,6 +298,8 @@ func (s *Store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 		log.String("state", opts.State),
 		log.String("term", opts.Term),
 		log.Bool("visibleAtTip", opts.VisibleAtTip),
+		log.Int("dependencyOf", opts.DependencyOf),
+		log.Int("dependentOf", opts.DependentOf),
 		log.String("uploadedBefore", nilTimeToString(opts.UploadedBefore)),
 		log.String("uploadedAfter", nilTimeToString(opts.UploadedAfter)),
 		log.Bool("oldestFirst", opts.OldestFirst),
@@ -324,6 +328,22 @@ func (s *Store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 	}
 	if opts.VisibleAtTip {
 		conds = append(conds, sqlf.Sprintf("EXISTS ("+visibleAtTipSubselectQuery+")"))
+	}
+	if opts.DependencyOf != 0 {
+		conds = append(conds, sqlf.Sprintf(`
+			u.id IN (
+				SELECT dump_id FROM lsif_packages
+				WHERE (scheme, name, version) IN (SELECT scheme, name, version FROM lsif_references WHERE dump_id = %s)
+			)
+		`, opts.DependencyOf))
+	}
+	if opts.DependentOf != 0 {
+		conds = append(conds, sqlf.Sprintf(`
+			u.id IN (
+				SELECT dump_id FROM lsif_references
+				WHERE (scheme, name, version) IN (SELECT scheme, name, version FROM lsif_packages WHERE dump_id = %s)
+			)
+		`, opts.DependentOf))
 	}
 	if opts.UploadedBefore != nil {
 		conds = append(conds, sqlf.Sprintf("u.uploaded_at < %s", *opts.UploadedBefore))
@@ -794,6 +814,14 @@ func intsToString(vs []int) string {
 	}
 
 	return strings.Join(strs, ", ")
+}
+
+func nilStringToString(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
 }
 
 func nilTimeToString(t *time.Time) string {


### PR DESCRIPTION
This PR exposes package/reference relationship between uploads via GraphQL and adds a filtered connection to the upload UI page.

![Kapture 2021-08-16 at 12 08 28](https://user-images.githubusercontent.com/103087/129602536-0a731a6c-cb9c-4a1c-9e4a-834474adbb76.gif)
