### PR TITLE
dotcom: Fix incorrect loader state on 2nd screen of welcome flow

### DIFF
--- a/client/web/src/auth/useRepoCloningStatus.ts
+++ b/client/web/src/auth/useRepoCloningStatus.ts
@@ -179,7 +179,7 @@ export const useRepoCloningStatus = ({
         loading,
         error,
         stopPolling,
-        statusSummary: `${clonedReposCount}/${repoLines.length} done`,
+        statusSummary: `${clonedReposCount}/${repoLines.length} repositories synced`,
     }
 }
 

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -129,15 +129,15 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
 
     return (
         <div className="mt-5">
-            <h3>Start searching...</h3>
+            <h4>Fetching repositories...</h4>
             <p className="text-muted mb-4">
                 We’re cloning your repos to Sourcegraph. In just a few moments, you can make your first search!
             </p>
             <div className="border overflow-hidden rounded">
                 <header>
-                    <div className="py-3 px-4">
-                        <h3 className="d-inline-block m-0">Activity log</h3>
-                        <span className="float-right m-0">{statusSummary}</span>
+                    <div className="py-3 px-4 d-flex justify-content-between align-items-center">
+                        <h3 className="m-0">Activity log</h3>
+                        <small className="m-0 text-muted">{statusSummary}</small>
                     </div>
                 </header>
                 <Terminal>

--- a/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
+++ b/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
@@ -94,11 +94,10 @@ export const SelectAffiliatedRepos: FunctionComponent<Props> = ({
     }, [telemetryService])
 
     const { setComplete, currentIndex } = useSteps()
-    const { externalServices, errorServices, loadingServices } = useExternalServices(authenticatedUser.id)
-    const { affiliatedRepos, errorAffiliatedRepos, loadingAffiliatedRepos } = useAffiliatedRepos(authenticatedUser.id)
-    const { selectedRepos, errorSelectedRepos, loadingSelectedRepos } = useSelectedRepos(authenticatedUser.id)
+    const { externalServices, errorServices } = useExternalServices(authenticatedUser.id)
+    const { affiliatedRepos, errorAffiliatedRepos } = useAffiliatedRepos(authenticatedUser.id)
+    const { selectedRepos, errorSelectedRepos } = useSelectedRepos(authenticatedUser.id)
 
-    const isLoading = loadingServices || loadingAffiliatedRepos || loadingSelectedRepos
     const fetchingError = errorServices || errorAffiliatedRepos || errorSelectedRepos
 
     useEffect(() => {
@@ -507,10 +506,8 @@ export const SelectAffiliatedRepos: FunctionComponent<Props> = ({
                 <ul className="list-group">
                     <li className="list-group-item user-settings-repos__container" key="from-code-hosts">
                         <div className={classNames(!isRedesignEnabled && 'p-4')}>
-                            {(isLoading || fetchingError) && modeSelectShimmer}
-
-                            {/* display type of repo sync radio buttons */}
-                            {hasCodeHosts && selectionState.loaded && modeSelect}
+                            {/* display type of repo sync radio buttons or shimmer when appropriate */}
+                            {hasCodeHosts && selectionState.loaded ? modeSelect : modeSelectShimmer}
 
                             {
                                 // if we're in 'selected' mode, show a list of all the repos on the code hosts to select from


### PR DESCRIPTION
Related:
https://sourcegraph.atlassian.net/browse/COREAPP-208

Loader was showing at the same time as content sometimes.
Changed the code from 2 conditions to a ternary instead.
This assures, that only 1 of the states is shown at a time.

