### PR TITLE
dotcom: Improve copy & styling of 3rd step in welcome flow

### DIFF
--- a/client/web/src/auth/useRepoCloningStatus.ts
+++ b/client/web/src/auth/useRepoCloningStatus.ts
@@ -179,7 +179,7 @@ export const useRepoCloningStatus = ({
         loading,
         error,
         stopPolling,
-        statusSummary: `${clonedReposCount}/${repoLines.length} done`,
+        statusSummary: `${clonedReposCount}/${repoLines.length} repositories synced`,
     }
 }
 

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -129,14 +129,14 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
 
     return (
         <div className="mt-5">
-            <h4>Fetching repositories...</h4>
+            <h3>Fetching repositories...</h3>
             <p className="text-muted mb-4">
                 We’re cloning your repos to Sourcegraph. In just a few moments, you can make your first search!
             </p>
             <div className="border overflow-hidden rounded">
                 <header>
                     <div className="py-3 px-4 d-flex justify-content-between align-items-center">
-                        <h3 className="m-0">Activity log</h3>
+                        <h4 className="m-0">Activity log</h4>
                         <small className="m-0 text-muted">{statusSummary}</small>
                     </div>
                 </header>

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -129,15 +129,15 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
 
     return (
         <div className="mt-5">
-            <h3>Start searching...</h3>
+            <h4>Fetching repositories...</h4>
             <p className="text-muted mb-4">
                 We’re cloning your repos to Sourcegraph. In just a few moments, you can make your first search!
             </p>
             <div className="border overflow-hidden rounded">
                 <header>
-                    <div className="py-3 px-4">
-                        <h3 className="d-inline-block m-0">Activity log</h3>
-                        <span className="float-right m-0">{statusSummary}</span>
+                    <div className="py-3 px-4 d-flex justify-content-between align-items-center">
+                        <h3 className="m-0">Activity log</h3>
+                        <small className="m-0 text-muted">{statusSummary}</small>
                     </div>
                 </header>
                 <Terminal>


### PR DESCRIPTION
Changes of text copy & styling based on https://sourcegraph.atlassian.net/browse/COREAPP-205

Original:
<img width="627" alt="Screenshot 2021-08-13 at 16 57 58" src="https://user-images.githubusercontent.com/9974711/129376599-6ca9b85c-80c5-400e-be98-38c6953f68ab.png">

New:
<img width="644" alt="Screenshot 2021-08-13 at 16 57 38" src="https://user-images.githubusercontent.com/9974711/129376616-70a92667-9a54-4f67-9fbd-2b81c669325d.png">

