### PR TITLE
Code Insights: Add proper dashboard redirection after insight was created via the creation UI

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/components/drill-down-reg-exp-input/DrillDownRegExpInput.module.scss
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/components/drill-down-reg-exp-input/DrillDownRegExpInput.module.scss
@@ -1,5 +1,4 @@
 .prefix-text {
-    font-family: monospace;
     flex-shrink: 0;
     padding: 0.25rem 0.5rem;
     height: 100%;

--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/components/drill-down-reg-exp-input/DrillDownRegExpInput.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/components/drill-down-reg-exp-input/DrillDownRegExpInput.tsx
@@ -17,7 +17,7 @@ export const DrillDownRegExpInput = forwardRef((props: DrillDownRegExpInputProps
 
     return (
         <span className="d-flex w-100">
-            <span className={styles.prefixText}>{prefix}</span>
+            <span className={classnames(styles.prefixText, 'text-monospace')}>{prefix}</span>
             <FlexTextArea {...inputProps} className={classnames(inputProps.className, styles.input)} ref={reference} />
         </span>
     )

--- a/client/web/src/insights/components/link-with-query/index.tsx
+++ b/client/web/src/insights/components/link-with-query/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Link, LinkProps, useLocation } from 'react-router-dom'
+
+export interface LinkWithQueryProps extends Omit<LinkProps, 'to'> {
+    to: string
+}
+
+/**
+ * Renders react router link component with query params preserving between route transitions.
+ */
+export const LinkWithQuery: React.FunctionComponent<LinkWithQueryProps> = props => {
+    const { children, to, ...otherProps } = props
+    const { search } = useLocation()
+
+    return (
+        <Link to={to + search} {...otherProps}>
+            {children}
+        </Link>
+    )
+}

--- a/client/web/src/insights/core/types/dashboard/index.ts
+++ b/client/web/src/insights/core/types/dashboard/index.ts
@@ -26,8 +26,9 @@ export const isPersonalDashboard = (dashboard: InsightDashboard | undefined): da
 export const isGlobalDashboard = (dashboard: InsightDashboard | undefined): dashboard is RealInsightDashboard =>
     dashboard?.type === InsightsDashboardType.Global
 
-export const isVirtualDashboard = (dashboard: InsightDashboard | undefined): dashboard is VirtualInsightsDashboard =>
-    dashboard?.type === InsightsDashboardType.All
+export const isVirtualDashboard = (
+    dashboard: InsightDashboard | undefined | null
+): dashboard is VirtualInsightsDashboard => dashboard?.type === InsightsDashboardType.All
 
 export const isRealDashboard = (dashboard: InsightDashboard | undefined): dashboard is RealInsightDashboard =>
     isOrganizationDashboard(dashboard) || isPersonalDashboard(dashboard) || isGlobalDashboard(dashboard)

--- a/client/web/src/insights/core/types/dashboard/real-dashboard.ts
+++ b/client/web/src/insights/core/types/dashboard/real-dashboard.ts
@@ -36,7 +36,7 @@ export interface SettingsBasedInsightDashboard extends ExtendedInsightDashboard 
 export type RealInsightDashboard = SettingsBasedInsightDashboard | BuiltInInsightDashboard
 
 export function isSettingsBasedInsightsDashboard(
-    dashboard: RealInsightDashboard | undefined
+    dashboard: RealInsightDashboard | undefined | null
 ): dashboard is SettingsBasedInsightDashboard {
     return !!dashboard?.settingsKey
 }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
@@ -60,7 +60,7 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
                             <Link to="/insights/add-dashboard" className="btn btn-outline-secondary mr-2">
                                 <PlusIcon className="icon-inline" /> Create new dashboard
                             </Link>
-                            <Link to="/insights/create" className="btn btn-secondary">
+                            <Link to={`/insights/create?dashboardId=${dashboardID}`} className="btn btn-secondary">
                                 <PlusIcon className="icon-inline" /> Create new insight
                             </Link>
                         </>

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -62,6 +62,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
         <DashboardInsightsContext.Provider value={{ dashboard }}>
             <div>
                 {insights.length > 0 ? (
+
                     <SmartInsightsViewGrid
                         insights={insights}
                         telemetryService={telemetryService}
@@ -69,6 +70,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
                         platformContext={platformContext}
                         extensionsController={extensionsController}
                     />
+
                 ) : (
                     <EmptyInsightDashboard
                         dashboard={dashboard}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -62,7 +62,6 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
         <DashboardInsightsContext.Provider value={{ dashboard }}>
             <div>
                 {insights.length > 0 ? (
-
                     <SmartInsightsViewGrid
                         insights={insights}
                         telemetryService={telemetryService}
@@ -70,7 +69,6 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
                         platformContext={platformContext}
                         extensionsController={extensionsController}
                     />
-
                 ) : (
                     <EmptyInsightDashboard
                         dashboard={dashboard}

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -27,7 +27,7 @@ export const EmptyInsightDashboard: React.FunctionComponent<EmptyInsightDashboar
             onAddInsight={onAddInsight}
         />
     ) : (
-        <EmptyBuiltInDashboard />
+        <EmptyBuiltInDashboard dashboard={dashboard} />
     )
 }
 
@@ -36,9 +36,9 @@ export const EmptyInsightDashboard: React.FunctionComponent<EmptyInsightDashboar
  * Since all insights within built-in dashboards are calculated there's no ability to add insight to
  * this type of dashboard.
  */
-export const EmptyBuiltInDashboard: React.FunctionComponent = () => (
+export const EmptyBuiltInDashboard: React.FunctionComponent<{ dashboard: InsightDashboard }> = props => (
     <section className={styles.emptySection}>
-        <Link to="/insights/create" className={classnames(styles.itemCard, 'card')}>
+        <Link to={`/insights/create?dashboardId=${props.dashboard.id}`} className={classnames(styles.itemCard, 'card')}>
             <PlusIcon size="2rem" />
             <span>Create new insight</span>
         </Link>
@@ -76,7 +76,7 @@ export const EmptySettingsBasedDashboard: React.FunctionComponent<EmptyInsightDa
                 </div>
             </button>
             <span className="d-flex justify-content-center mt-3">
-                <Link to="/insights/create">or, create new insight</Link>
+                <Link to={`/insights/create?dashboardId=${dashboard.id}`}>or, create new insight</Link>
             </span>
         </section>
     )

--- a/client/web/src/insights/pages/insights/creation/CreationRoutes.tsx
+++ b/client/web/src/insights/pages/insights/creation/CreationRoutes.tsx
@@ -8,22 +8,16 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { AuthenticatedUser } from '../../../../auth'
 import { lazyComponent } from '../../../../util/lazyComponent'
 
-const IntroCreationLazyPage = lazyComponent(() => import('./intro/IntroCreationPage'), 'IntroCreationPage')
-const SearchInsightCreationLazyPage = lazyComponent(
-    () => import('./search-insight/SearchInsightCreationPage'),
-    'SearchInsightCreationPage'
-)
+import { InsightCreationPageType } from './InsightCreationPage'
 
-const LangStatsInsightCreationLazyPage = lazyComponent(
-    () => import('./lang-stats/LangStatsInsightCreationPage'),
-    'LangStatsInsightCreationPage'
-)
+const IntroCreationLazyPage = lazyComponent(() => import('./intro/IntroCreationPage'), 'IntroCreationPage')
+const InsightCreationLazyPage = lazyComponent(() => import('./InsightCreationPage'), 'InsightCreationPage')
 
 interface CreationRoutesProps extends TelemetryProps, PlatformContextProps<'updateSettings'>, SettingsCascadeProps {
     /**
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
-     * */
+     */
     authenticatedUser: AuthenticatedUser
 }
 
@@ -47,7 +41,8 @@ export const CreationRoutes: React.FunctionComponent<CreationRoutesProps> = prop
             <Route
                 path={`${match.url}/search`}
                 render={() => (
-                    <SearchInsightCreationLazyPage
+                    <InsightCreationLazyPage
+                        mode={InsightCreationPageType.Search}
                         telemetryService={telemetryService}
                         platformContext={platformContext}
                         settingsCascade={settingsCascade}
@@ -59,7 +54,8 @@ export const CreationRoutes: React.FunctionComponent<CreationRoutesProps> = prop
                 path={`${match.url}/lang-stats`}
                 exact={true}
                 render={() => (
-                    <LangStatsInsightCreationLazyPage
+                    <InsightCreationLazyPage
+                        mode={InsightCreationPageType.LangStats}
                         telemetryService={telemetryService}
                         platformContext={platformContext}
                         settingsCascade={settingsCascade}

--- a/client/web/src/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -84,7 +84,7 @@ export const InsightCreationPage: React.FunctionComponent<InsightCreationPagePro
 
     const handleInsightSuccessfulCreation = (insight: Insight): void => {
         if (!dashboard || isVirtualDashboard(dashboard)) {
-            // Navigate user to the dashboard page with new created dashboard
+            // Navigate to the dashboard page with new created dashboard
             history.push(`/insights/dashboards/${insight.visibility}`)
 
             return

--- a/client/web/src/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -1,0 +1,127 @@
+import React, { useContext } from 'react'
+import { useHistory } from 'react-router'
+
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { InsightsApiContext } from '../../../core/backend/api-provider'
+import { addInsightToDashboard } from '../../../core/settings-action/dashboards'
+import { addInsightToSettings } from '../../../core/settings-action/insights'
+import { InsightDashboard, isVirtualDashboard, Insight } from '../../../core/types'
+import { isSettingsBasedInsightsDashboard } from '../../../core/types/dashboard/real-dashboard'
+import { isUserSubject } from '../../../core/types/subjects'
+import { useDashboard } from '../../../hooks/use-dashboard'
+import { useInsightSubjects } from '../../../hooks/use-insight-subjects/use-insight-subjects'
+import { useQueryParameters } from '../../../hooks/use-query-parameters'
+
+import { LangStatsInsightCreationPage } from './lang-stats/LangStatsInsightCreationPage'
+import { SearchInsightCreationPage } from './search-insight/SearchInsightCreationPage'
+
+export enum InsightCreationPageType {
+    LangStats = 'lang-stats',
+    Search = 'search-based',
+}
+
+const getVisibilityFromDashboard = (dashboard: InsightDashboard | null): string | undefined => {
+    if (!dashboard || isVirtualDashboard(dashboard)) {
+        return undefined
+    }
+
+    return dashboard.owner.id
+}
+
+const addInsight = (settings: string, insight: Insight, dashboard: InsightDashboard | null): string => {
+    const dashboardSettingKey =
+        !isVirtualDashboard(dashboard) && isSettingsBasedInsightsDashboard(dashboard)
+            ? dashboard.settingsKey
+            : undefined
+
+    const transforms = [
+        (settings: string) => addInsightToSettings(settings, insight),
+        (settings: string) =>
+            dashboardSettingKey ? addInsightToDashboard(settings, dashboardSettingKey, insight.id) : settings,
+    ]
+
+    return transforms.reduce((settings, transformer) => transformer(settings), settings)
+}
+
+interface InsightCreateEvent {
+    subjectId: string
+    insight: Insight
+}
+
+interface InsightCreationPageProps
+    extends PlatformContextProps<'updateSettings'>,
+        SettingsCascadeProps,
+        TelemetryProps {
+    mode: InsightCreationPageType
+}
+
+export const InsightCreationPage: React.FunctionComponent<InsightCreationPageProps> = props => {
+    const { mode, platformContext, settingsCascade, telemetryService } = props
+
+    const history = useHistory()
+    const { getSubjectSettings, updateSubjectSettings } = useContext(InsightsApiContext)
+    const { dashboardId } = useQueryParameters(['dashboardId'])
+    const dashboard = useDashboard({ settingsCascade, dashboardId })
+
+    const subjects = useInsightSubjects({ settingsCascade })
+
+    // Calculate initial value for the visibility setting
+    const personalVisibility = subjects.find(isUserSubject)?.id ?? ''
+    const dashboardBasedVisibility = getVisibilityFromDashboard(dashboard)
+    const insightVisibility = dashboardBasedVisibility ?? personalVisibility
+
+    const handleInsightCreateRequest = async (event: InsightCreateEvent): Promise<void> => {
+        const { insight, subjectId } = event
+
+        const settings = await getSubjectSettings(subjectId).toPromise()
+        const updatedSettings = addInsight(settings.contents, insight, dashboard)
+
+        await updateSubjectSettings(platformContext, subjectId, updatedSettings).toPromise()
+    }
+
+    const handleInsightSuccessfulCreation = (insight: Insight): void => {
+        if (!dashboard || isVirtualDashboard(dashboard)) {
+            // Navigate user to the dashboard page with new created dashboard
+            history.push(`/insights/dashboards/${insight.visibility}`)
+
+            return
+        }
+
+        if (dashboard.owner.id === insight.visibility) {
+            history.push(`/insights/dashboards/${dashboard.id}`)
+        } else {
+            history.push(`/insights/dashboards/${insight.visibility}`)
+        }
+    }
+
+    const handleCancel = (): void => {
+        history.push(`/insights/dashboards/${dashboard?.id ?? 'all'}`)
+    }
+
+    if (mode === InsightCreationPageType.Search) {
+        return (
+            <SearchInsightCreationPage
+                visibility={insightVisibility}
+                settingsCascade={settingsCascade}
+                telemetryService={telemetryService}
+                onInsightCreateRequest={handleInsightCreateRequest}
+                onSuccessfulCreation={handleInsightSuccessfulCreation}
+                onCancel={handleCancel}
+            />
+        )
+    }
+
+    return (
+        <LangStatsInsightCreationPage
+            visibility={insightVisibility}
+            settingsCascade={settingsCascade}
+            telemetryService={telemetryService}
+            onInsightCreateRequest={handleInsightCreateRequest}
+            onSuccessfulCreation={handleInsightSuccessfulCreation}
+            onCancel={handleCancel}
+        />
+    )
+}

--- a/client/web/src/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -9,6 +9,7 @@ import { Page } from '../../../../../components/Page'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { LineChart } from '../../../../components/insight-view-content/chart-view-content/charts/line/LineChart'
 import { PieChart } from '../../../../components/insight-view-content/chart-view-content/charts/pie/PieChart'
+import { LinkWithQuery } from '../../../../components/link-with-query'
 
 import { LINE_CHART_DATA, PIE_CHART_DATA } from './charts-mock'
 import styles from './IntroCreationPage.module.scss'
@@ -59,13 +60,13 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                         custom search query.
                     </p>
 
-                    <Link
+                    <LinkWithQuery
                         to="/insights/create/search"
                         onClick={logCreateSearchBasedInsightClick}
                         className={classnames(styles.createIntroPageInsightButton, 'btn', 'btn-primary')}
                     >
                         Create search insight
-                    </Link>
+                    </LinkWithQuery>
 
                     <hr className="ml-n3 mr-n3 mt-4 mb-3" />
 
@@ -82,13 +83,13 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
 
                     <p>Shows language usage in your repository by lines of code.</p>
 
-                    <Link
+                    <LinkWithQuery
                         to="/insights/create/lang-stats"
                         onClick={logCreateCodeStatsInsightClick}
                         className={classnames(styles.createIntroPageInsightButton, 'btn', 'btn-primary')}
                     >
                         Create language usage insight
-                    </Link>
+                    </LinkWithQuery>
 
                     <hr className="ml-n3 mr-n3 mt-4 mb-3" />
 

--- a/client/web/src/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
@@ -1,4 +1,6 @@
 import { storiesOf } from '@storybook/react'
+import delay from 'delay'
+import { noop } from 'lodash'
 import React from 'react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -9,7 +11,7 @@ import { createMockInsightAPI } from '../../../../core/backend/insights-api'
 import { SETTINGS_CASCADE_MOCK } from '../../../../mocks/settings-cascade'
 
 import { getRandomLangStatsMock } from './components/live-preview-chart/live-preview-mock-data'
-import { LangStatsInsightCreationPage, LangStatsInsightCreationPageProps } from './LangStatsInsightCreationPage'
+import { LangStatsInsightCreationPage } from './LangStatsInsightCreationPage'
 
 const { add } = storiesOf('web/insights/CreateLangStatsInsightPageProps', module)
     .addDecorator(story => <WebStory>{() => story()}</WebStory>)
@@ -19,15 +21,14 @@ const { add } = storiesOf('web/insights/CreateLangStatsInsightPageProps', module
         },
     })
 
-const PLATFORM_CONTEXT: LangStatsInsightCreationPageProps['platformContext'] = {
-    // eslint-disable-next-line @typescript-eslint/require-await
-    updateSettings: async (...args) => {
-        console.log('PLATFORM CONTEXT update settings with', { ...args })
-    },
-}
-
 function sleep(delay: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, delay))
+}
+
+const fakeAPIRequest = async () => {
+    await delay(1000)
+
+    throw new Error('Network error')
 }
 
 const mockAPI = createMockInsightAPI({
@@ -51,9 +52,12 @@ const mockAPI = createMockInsightAPI({
 add('Page', () => (
     <InsightsApiContext.Provider value={mockAPI}>
         <LangStatsInsightCreationPage
+            visibility="user_test_id"
             telemetryService={NOOP_TELEMETRY_SERVICE}
-            platformContext={PLATFORM_CONTEXT}
             settingsCascade={SETTINGS_CASCADE_MOCK}
+            onInsightCreateRequest={fakeAPIRequest}
+            onSuccessfulCreation={noop}
+            onCancel={noop}
         />
     </InsightsApiContext.Provider>
 ))

--- a/client/web/src/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -1,8 +1,6 @@
 import classnames from 'classnames'
-import React, { useCallback, useContext, useEffect, useMemo } from 'react'
-import { useHistory, useParams } from 'react-router-dom'
+import React, { useCallback, useEffect } from 'react'
 
-import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError } from '@sourcegraph/shared/src/util/errors'
@@ -11,10 +9,7 @@ import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 import { Page } from '../../../../../components/Page'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { FORM_ERROR, FormChangeEvent } from '../../../../components/form/hooks/useForm'
-import { InsightsApiContext } from '../../../../core/backend/api-provider'
-import { addInsightToSettings } from '../../../../core/settings-action/insights'
-import { isVirtualDashboard } from '../../../../core/types'
-import { useDashboard } from '../../../../hooks/use-dashboard'
+import { LangStatsInsight } from '../../../../core/types'
 import { useInsightSubjects } from '../../../../hooks/use-insight-subjects/use-insight-subjects'
 
 import {
@@ -27,34 +22,54 @@ import { getSanitizedLangStatsInsight } from './utils/insight-sanitizer'
 
 const DEFAULT_FINAL_SETTINGS = {}
 
-export interface LangStatsInsightCreationPageProps
-    extends PlatformContextProps<'updateSettings'>,
-        SettingsCascadeProps,
-        TelemetryProps {}
+export interface InsightCreateEvent {
+    subjectId: string
+    insight: LangStatsInsight
+}
+
+export interface LangStatsInsightCreationPageProps extends SettingsCascadeProps, TelemetryProps {
+    /**
+     * Set initial value for insight visibility setting.
+     */
+    visibility: string
+
+    /**
+     * Whenever the user submit form and clicks on save/submit button
+     *
+     * @param event - creation event with subject id and updated settings content
+     * info.
+     */
+    onInsightCreateRequest: (event: InsightCreateEvent) => Promise<void>
+
+    /**
+     * Whenever insight was created and all operations after creation were completed.
+     */
+    onSuccessfulCreation: (insight: LangStatsInsight) => void
+
+    /**
+     * Whenever the user click on cancel button
+     */
+    onCancel: () => void
+}
 
 export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsightCreationPageProps> = props => {
-    const { settingsCascade, platformContext, telemetryService } = props
-    const { getSubjectSettings, updateSubjectSettings } = useContext(InsightsApiContext)
-    const history = useHistory()
+    const {
+        visibility,
+        settingsCascade,
+        telemetryService,
+        onInsightCreateRequest,
+        onCancel,
+        onSuccessfulCreation,
+    } = props
 
+    const insightSubjects = useInsightSubjects({ settingsCascade })
     const [initialFormValues, setInitialFormValues] = useLocalStorage<LangStatsCreationFormFields | undefined>(
         'insights.code-stats-creation-ui',
         undefined
     )
 
-    const { dashboardId } = useParams<{ dashboardId?: string }>()
-    const dashboard = useDashboard({ settingsCascade, dashboardId })
-
-    // Set dashboard scope as initial value for the insight visibility
-    const mergedInitialValues = useMemo<Partial<LangStatsCreationFormFields>>(() => {
-        if (!dashboard || isVirtualDashboard(dashboard)) {
-            return initialFormValues ?? {}
-        }
-
-        return { ...(initialFormValues ?? {}), visibility: dashboard.owner.id }
-    }, [dashboard, initialFormValues])
-
-    const insightSubjects = useInsightSubjects({ settingsCascade })
+    // Set the top-level scope value as initial value for the insight visibility
+    const mergedInitialValues = { ...(initialFormValues ?? {}), visibility }
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsCodeStatsCreationPage')
@@ -65,52 +80,34 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
             const subjectID = values.visibility
 
             try {
-                const settings = await getSubjectSettings(subjectID).toPromise()
-
                 const insight = getSanitizedLangStatsInsight(values)
-                const editedSettings = addInsightToSettings(settings.contents, insight)
 
-                await updateSubjectSettings(platformContext, subjectID, editedSettings).toPromise()
+                await onInsightCreateRequest({
+                    subjectId: subjectID,
+                    insight,
+                })
 
                 // Clear initial values if user successfully created search insight
                 setInitialFormValues(undefined)
                 telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')
 
-                if (!dashboard || isVirtualDashboard(dashboard)) {
-                    // Navigate user to the dashboard page with new created dashboard
-                    history.push(`/insights/dashboards/${insight.visibility}`)
-
-                    return
-                }
-
-                if (dashboard.owner.id === insight.visibility) {
-                    history.push(`/insights/dashboards/${dashboard.id}`)
-                } else {
-                    history.push(`/insights/dashboards/${insight.visibility}`)
-                }
+                onSuccessfulCreation(insight)
             } catch (error) {
                 return { [FORM_ERROR]: asError(error) }
             }
 
             return
         },
-        [
-            dashboard,
-            getSubjectSettings,
-            updateSubjectSettings,
-            platformContext,
-            setInitialFormValues,
-            telemetryService,
-            history,
-        ]
+        [onInsightCreateRequest, onSuccessfulCreation, setInitialFormValues, telemetryService]
     )
 
     const handleCancel = useCallback(() => {
         // Clear initial values if user successfully created search insight
         setInitialFormValues(undefined)
         telemetryService.log('CodeInsightsCodeStatsCreationPageCancelClick')
-        history.push(`/insights/dashboards/${dashboard?.id ?? 'all'}`)
-    }, [dashboard, history, setInitialFormValues, telemetryService])
+
+        onCancel()
+    }, [setInitialFormValues, telemetryService, onCancel])
 
     const handleChange = (event: FormChangeEvent<LangStatsCreationFormFields>): void => {
         setInitialFormValues(event.values)

--- a/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -36,7 +36,7 @@ export interface LangStatsInsightCreationContentProps {
     subjects?: SupportedInsightSubject[]
 
     /** Initial value for all form fields. */
-    initialValues?: LangStatsCreationFormFields
+    initialValues?: Partial<LangStatsCreationFormFields>
     /** Custom class name for root form element. */
     className?: string
     /** Submit handler for form element. */
@@ -52,18 +52,20 @@ export const LangStatsInsightCreationContent: React.FunctionComponent<LangStatsI
         mode = 'creation',
         settings,
         subjects = [],
-        initialValues,
+        initialValues = {},
         className,
         onSubmit,
         onCancel = noop,
         onChange = noop,
     } = props
 
-    // Calculate initial value for the visibility settings
-    const userSubjectID = subjects.find(isUserSubject)?.id ?? ''
-
     const { values, handleSubmit, formAPI, ref } = useForm<LangStatsCreationFormFields>({
-        initialValues: initialValues ?? { ...INITIAL_VALUES, visibility: userSubjectID },
+        initialValues: {
+            ...INITIAL_VALUES,
+            // Calculate initial value for the visibility settings
+            visibility: subjects.find(isUserSubject)?.id ?? '',
+            ...initialValues,
+        },
         onSubmit,
         onChange,
         touched: mode === 'edit',

--- a/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -28,7 +28,7 @@ export interface LangStatsInsightCreationContentProps {
      * This component might be used in two different modes for creation and
      * edit mode. In edit mode we change some text keys for form and trigger
      * validation on form fields immediately.
-     * */
+     */
     mode?: 'creation' | 'edit'
     /** Final settings cascade. Used for title field validation. */
     settings?: Settings | null

--- a/client/web/src/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
@@ -1,4 +1,6 @@
 import { storiesOf } from '@storybook/react'
+import delay from 'delay'
+import { noop } from 'lodash'
 import React from 'react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -12,7 +14,7 @@ import {
     DEFAULT_MOCK_CHART_CONTENT,
     getRandomDataForMock,
 } from './components/live-preview-chart/live-preview-mock-data'
-import { SearchInsightCreationPage, SearchInsightCreationPageProps } from './SearchInsightCreationPage'
+import { SearchInsightCreationPage } from './SearchInsightCreationPage'
 
 const { add } = storiesOf('web/insights/SearchInsightCreationPage', module)
     .addDecorator(story => <WebStory>{() => story()}</WebStory>)
@@ -21,13 +23,6 @@ const { add } = storiesOf('web/insights/SearchInsightCreationPage', module)
             viewports: [576, 1440],
         },
     })
-
-const PLATFORM_CONTEXT: SearchInsightCreationPageProps['platformContext'] = {
-    // eslint-disable-next-line @typescript-eslint/require-await
-    updateSettings: async (...args) => {
-        console.log('PLATFORM CONTEXT update settings with', { ...args })
-    },
-}
 
 function sleep(delay: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, delay))
@@ -51,12 +46,21 @@ const mockAPI = createMockInsightAPI({
     ],
 })
 
+const fakeAPIRequest = async () => {
+    await delay(1000)
+
+    throw new Error('Network error')
+}
+
 add('Page', () => (
     <InsightsApiContext.Provider value={mockAPI}>
         <SearchInsightCreationPage
+            visibility="user_test_id"
             telemetryService={NOOP_TELEMETRY_SERVICE}
-            platformContext={PLATFORM_CONTEXT}
             settingsCascade={SETTINGS_CASCADE_MOCK}
+            onInsightCreateRequest={fakeAPIRequest}
+            onSuccessfulCreation={noop}
+            onCancel={noop}
         />
     </InsightsApiContext.Provider>
 ))

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -26,7 +26,7 @@ export interface SearchInsightCreationContentProps {
     subjects?: SupportedInsightSubject[]
 
     /** Initial value for all form fields. */
-    initialValue?: CreateInsightFormFields
+    initialValue?: Partial<CreateInsightFormFields>
     /** Custom class name for root form element. */
     className?: string
     /** Test id for the root content element (form element). */

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-insight-creation-form/use-insight-creation-form.ts
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-insight-creation-form/use-insight-creation-form.ts
@@ -27,7 +27,7 @@ export interface UseInsightCreationFormProps {
     /**
      * Initial value for all form fields
      */
-    initialValue?: CreateInsightFormFields
+    initialValue?: Partial<CreateInsightFormFields>
 
     /**
      * Set initial touched state for all form fields.
@@ -61,13 +61,17 @@ export interface InsightCreationForm {
  * Hooks absorbs all insight creation form logic (field state managements, validations, fields dependencies)
  */
 export function useInsightCreationForm(props: UseInsightCreationFormProps): InsightCreationForm {
-    const { subjects = [], initialValue, touched, settings, onSubmit, onChange } = props
+    const { subjects = [], initialValue = {}, touched, settings, onSubmit, onChange } = props
 
     // Calculate initial value for visibility settings
     const userSubjectID = subjects.find(isUserSubject)?.id ?? ''
 
     const form = useForm<CreateInsightFormFields>({
-        initialValues: initialValue ?? { ...INITIAL_INSIGHT_VALUES, visibility: userSubjectID },
+        initialValues: {
+            ...INITIAL_INSIGHT_VALUES,
+            visibility: userSubjectID,
+            ...initialValue,
+        },
         onSubmit,
         onChange,
         touched,

--- a/client/web/src/insights/pages/insights/creation/search-insight/utils/use-initial-values.ts
+++ b/client/web/src/insights/pages/insights/creation/search-insight/utils/use-initial-values.ts
@@ -8,7 +8,7 @@ import { CreateInsightFormFields } from '../types'
 import { useURLQueryInsight } from './use-url-query-insight/use-url-query-insight'
 
 export interface UseInitialValuesResult {
-    initialValues: CreateInsightFormFields | undefined
+    initialValues: Partial<CreateInsightFormFields>
     loading: boolean
     setLocalStorageFormValues: (values: CreateInsightFormFields | undefined) => void
 }
@@ -29,14 +29,14 @@ export function useSearchInsightInitialValues(): UseInitialValuesResult {
 
     if (hasQueryInsight) {
         return {
-            initialValues: !isErrorLike(urlQueryInsightValues) ? urlQueryInsightValues : undefined,
+            initialValues: !isErrorLike(urlQueryInsightValues) ? urlQueryInsightValues ?? {} : {},
             loading: urlQueryInsightValues === undefined,
             setLocalStorageFormValues,
         }
     }
 
     return {
-        initialValues: localStorageFormValues,
+        initialValues: localStorageFormValues ?? {},
         loading: false,
         setLocalStorageFormValues,
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/23202

## Context
This PR is based on the previous PR about dashboard redirection (you can find this here https://github.com/sourcegraph/sourcegraph/pull/23988). This PR adds some dashboard context info for the creation UI pages to be able to redirect users to the dashboard they came from to these pages. For instance, if I came from my personal dashboard I will see the creation UI with prefilled visibility setting with personal visibility value and then I create this insight I will be redirected to my personal dashboard. Same logic if I came from org-level or global dashboards. 

## Tech notes
We achieve this dashboard info context by passing dashboard id as a query param in URL to navigate users to the creation page and then creation page takes this query `dashboardID` and resolves this id in dashboard object and we operate with this info to calculate the right page for the further redirection on saving insight. The main entry point for this logic you can find in [this component](https://github.com/sourcegraph/sourcegraph/pull/23989/files#diff-633cd06727c684d0aede3bf6f1dc243ada1c94fb74da026b25924bc8aa2aa838)

## What have been done
- [x] Extract common logic of saving insight to the setting cascade to separate creation page component
- [x] Change all links to the creation page (adding dashboard id query param)
- [x] Add logic about proper redirection back to the dashboard page


