### PR TITLE
Revert "search: mint ZoektParameters type"

### DIFF
--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -11,6 +11,13 @@ import (
 	zoekt "github.com/google/zoekt/query"
 )
 
+type IndexedRequestType string
+
+const (
+	TextRequest   IndexedRequestType = "text"
+	SymbolRequest IndexedRequestType = "symbol"
+)
+
 func TestQueryToZoektQuery(t *testing.T) {
 	cases := []struct {
 		Name    string

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -57,7 +57,7 @@ func Search(ctx context.Context, args *search.TextParameters, limit int, stream 
 	ctx, stream, cancel := streaming.WithLimit(ctx, stream, limit)
 	defer cancel()
 
-	indexed, err := zoektutil.NewIndexedSearchRequest(ctx, args, search.SymbolRequest, zoektutil.MissingRepoRevStatus(stream))
+	indexed, err := zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.SymbolRequest, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	zoektquery "github.com/google/zoekt/query"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
@@ -127,29 +126,6 @@ func (m GlobalSearchMode) String() string {
 		return s
 	}
 	return "None"
-}
-
-type IndexedRequestType string
-
-const (
-	TextRequest   IndexedRequestType = "text"
-	SymbolRequest IndexedRequestType = "symbol"
-)
-
-// ZoektParameters contains all the inputs to run a Zoekt indexed search.
-type ZoektParameters struct {
-	Repos            []*RepositoryRevisions
-	RepoOptions      RepoOptions
-	Query            zoektquery.Q
-	Typ              IndexedRequestType
-	FileMatchLimit   int32
-	Enabled          bool
-	Index            query.YesNoOnly
-	Mode             GlobalSearchMode
-	UserPrivateRepos []types.RepoName
-	Select           filter.SelectPath
-
-	Zoekt *searchbackend.Zoekt
 }
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -44,23 +44,13 @@ func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissi
 			return nil, err
 		}
 		return &zoektutil.IndexedSearchRequest{
-			Args: &search.ZoektParameters{
-				Repos:            args.Repos,
-				Query:            q,
-				Typ:              search.TextRequest,
-				FileMatchLimit:   args.PatternInfo.FileMatchLimit,
-				Enabled:          args.Zoekt.Enabled(),
-				Index:            args.PatternInfo.Index,
-				Mode:             args.Mode,
-				RepoOptions:      args.RepoOptions,
-				UserPrivateRepos: args.UserPrivateRepos,
-				Select:           args.PatternInfo.Select,
-				Zoekt:            args.Zoekt,
-			},
+			Args:     args,
+			Query:    q,
+			Typ:      zoektutil.TextRequest,
 			RepoRevs: &zoektutil.IndexedRepoRevs{},
 		}, nil
 	}
-	return zoektutil.NewIndexedSearchRequest(ctx, args, search.TextRequest, onMissing)
+	return zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.TextRequest, onMissing)
 }
 
 // SearchFilesInRepos searches a set of repos for a pattern.

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -268,7 +268,7 @@ func TestIndexedSearch(t *testing.T) {
 				},
 			}
 
-			indexed, err := NewIndexedSearchRequest(context.Background(), args, search.TextRequest, MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})))
+			indexed, err := NewIndexedSearchRequest(context.Background(), args, TextRequest, MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#23935

Bad merge, should have rebased first, this breaks `main`.