### PR TITLE
Revert "Revert "use alpine postgres image (#22655)" (#23324)"

### DIFF
--- a/docker-images/codeintel-db/build.sh
+++ b/docker-images/codeintel-db/build.sh
@@ -3,5 +3,5 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# This image is identical to our "sourcegraph/postgres-12.6" image.
-IMAGE="${IMAGE:-sourcegraph/codeintel-db}" ../postgres-12.6/build.sh
+# This image is identical to our "sourcegraph/postgres-12.6-alpine" image.
+IMAGE="${IMAGE:-sourcegraph/codeintel-db}" ../postgres-12.6-alpine/build.sh


### PR DESCRIPTION
This reverts commit 791d5df2288c6d328d77000e7d11db68eba5c090 and uses alpine as a base

