### PR TITLE
Add beta tags for Repos list + Manage repos UIs

### DIFF
--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -9,6 +9,7 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+import { Badge } from '@sourcegraph/web/src/components/Badge'
 import { Container, PageSelector } from '@sourcegraph/wildcard'
 
 import { ALLOW_NAVIGATION, AwayPrompt } from '../../../components/AwayPrompt'
@@ -739,7 +740,9 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
     return (
         <div className="user-settings-repos">
             <PageTitle title="Manage Repositories" />
-            <h2 className="mb-2">Manage Repositories</h2>
+            <h2 className="d-flex mb-2">
+                Manage Repositories <Badge status="beta" className="ml-2" />
+            </h2>
             <p className="text-muted">
                 Choose repositories to sync with Sourcegraph to search code you care about all in one place
             </p>

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -13,6 +13,7 @@ import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/er
 import { repeatUntil } from '@sourcegraph/shared/src/util/rxjs/repeatUntil'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+import { Badge } from '@sourcegraph/web/src/components/Badge'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
@@ -395,7 +396,15 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
             <PageTitle title="Repositories" />
             <PageHeader
                 headingElement="h2"
-                path={[{ text: 'Repositories' }]}
+                path={[
+                    {
+                        text: (
+                            <div className="d-flex">
+                                Repositories <Badge status="beta" className="ml-2" />
+                            </div>
+                        ),
+                    },
+                ]}
                 description={
                     <>
                         All repositories synced with Sourcegraph from{' '}

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -406,10 +406,10 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                     },
                 ]}
                 description={
-                    <>
+                    <div className="text-muted">
                         All repositories synced with Sourcegraph from{' '}
                         <Link to={`${routingPrefix}/code-hosts`}>connected code hosts</Link>
-                    </>
+                    </div>
                 }
                 actions={
                     <Link


### PR DESCRIPTION
### Description

Adds `Beta` tags for "Repositories" and "Manage repositories" views in User → Settings.

### Screenshots

![Screen Shot 2021-08-16 at 3 43 03 PM](https://user-images.githubusercontent.com/1319181/129620529-4c2f5ce6-2395-4a20-a296-0c24e2fbfcda.png)
![Screen Shot 2021-08-16 at 3 42 56 PM](https://user-images.githubusercontent.com/1319181/129620542-47754b6b-6e7a-4efb-a873-999d1dbcc0ba.png)

@quinnkeast, do we need to add tooltips?

p.s. I changed the sub-heading color to `muted` for the Repositories list page too