### PR TITLE
worker: enable distributed tracing for dbworker handler jobs

### DIFF
--- a/internal/workerutil/observability.go
+++ b/internal/workerutil/observability.go
@@ -21,7 +21,9 @@ type Gauge interface {
 }
 
 type operations struct {
-	handle *observation.Operation
+	handle     *observation.Operation
+	postHandle *observation.Operation
+	preHandle  *observation.Operation
 }
 
 type metricOptions struct {
@@ -102,7 +104,9 @@ func newOperations(observationContext *observation.Context, prefix string, keys,
 	}
 
 	return &operations{
-		handle: op("Handle"),
+		handle:     op("Handle"),
+		postHandle: op("PostHandle"),
+		preHandle:  op("PreHandle"),
 	}
 }
 


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/18282288/129632249-abffc51a-154d-4f67-8e07-a8ff6bb6e104.png" height="200px" />

## What it do

This PR enables `worker`/`dbworker`s to emit traces to Jaeger. A span context is created whenever a job is successfully read from the database, and then it's context propagation as normal.

## Sampling of traces

In its initial stage, at least, this PR does not have an answer on how to handle sampling of the vast increase of traces that would be generated. Currently, its effectively got a sampling strategy of `"all"`, which would probably be unwise in production. Initial discussions with @efritz considered [Jaeger 2.20's "delayed sampling"](https://pkg.go.dev/github.com/uber/jaeger-client-go#readme-delayed-sampling) capabilities, but its unclear to us whether our setup/customer setups are setup for this, as well as concerns with its inter-process capabilities.

If these turn out to be non-issues or solvable issues, workers would/should create a custom non-global tracer that uses this delayed sampling instead of [tracer.GlobalTracer()](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40352f5d6+Tracer:+%26trace.Tracer%7BTracer:+opentracing.GlobalTracer%28%29%7D%2C&patternType=regexp) that the rest of the service (aka non-worker codepaths) would be using. This non-global tracer would be passed to [workerutil.NewMetrics()](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@nsc/worker-tracing-inject/-/blob/internal/workerutil/observability.go?L31:6), as ultimately consumed by either [dbworker.NewWorker()](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@352f5d653aa304f86f8e3062cacde7e316c3d50b/-/blob/internal/workerutil/dbworker/worker.go?L10:6) or [workerutil.NewWorker()](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@nsc/worker-tracing-inject/-/blob/internal/workerutil/worker.go?L78:6). Some parts of the tracing code (probably [internal/trace/ot](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@nsc/worker-tracing-inject/-/blob/internal/trace/ot/ot.go), have not done a proper analysis of what areas) may need to be revamped to allow the tracer used to create a new child span come from any existing spans, using [opentracing.Span.Tracer()](https://pkg.go.dev/github.com/uber/jaeger-client-go#Span.Tracer).  
