### PR TITLE
searcher: remove unused decoder

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -25,7 +25,6 @@ import (
 	nettrace "golang.org/x/net/trace"
 
 	"github.com/cockroachdb/errors"
-	"github.com/gorilla/schema"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -57,12 +56,6 @@ const (
 type Service struct {
 	Store *store.Store
 	Log   log15.Logger
-}
-
-var decoder = schema.NewDecoder()
-
-func init() {
-	decoder.IgnoreUnknownKeys(true)
 }
 
 // ServeHTTP handles HTTP based search requests


### PR DESCRIPTION
Now that we use JSON instead of query params, we no longer need the
decoder. This is cleanup of #23793.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
