### PR TITLE
Add metrics to batch changes webhooks

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -712,6 +712,72 @@ This panel indicates store operation error rate over 5m.
 
 <br />
 
+### Frontend: Batches: webhooks stats
+
+#### frontend: batches_webhooks_total
+
+This panel indicates aggregate webhook operations every 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
+#### frontend: batches_webhooks_99th_percentile_duration
+
+This panel indicates 99th percentile successful aggregate webhook operation duration over 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
+#### frontend: batches_webhooks_errors_total
+
+This panel indicates aggregate webhook operation errors every 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
+#### frontend: batches_webhooks_error_rate
+
+This panel indicates aggregate webhook operation error rate over 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
+#### frontend: batches_webhooks_total
+
+This panel indicates webhook operations every 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
+#### frontend: batches_webhooks_99th_percentile_duration
+
+This panel indicates 99th percentile successful webhook operation duration over 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
+#### frontend: batches_webhooks_errors_total
+
+This panel indicates webhook operation errors every 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
+#### frontend: batches_webhooks_error_rate
+
+This panel indicates webhook operation error rate over 5m.
+
+<sub>*Managed by the [Sourcegraph Batches team](https://about.sourcegraph.com/handbook/engineering/batches).*</sub>
+
+<br />
+
 ### Frontend: Out-of-band migrations: up migration invocation (one batch processed)
 
 #### frontend: oobmigration_total

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -41,14 +41,14 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 	}
 
 	// Initialize store.
-	cstore := store.New(db, observationContext, keyring.Default().BatchChangesCredentialKey)
+	bstore := store.New(db, observationContext, keyring.Default().BatchChangesCredentialKey)
 
 	// Register enterprise services.
-	enterpriseServices.BatchChangesResolver = resolvers.New(cstore)
-	enterpriseServices.GitHubWebhook = webhooks.NewGitHubWebhook(cstore)
-	enterpriseServices.BitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(cstore)
-	enterpriseServices.GitLabWebhook = webhooks.NewGitLabWebhook(cstore)
+	enterpriseServices.BatchChangesResolver = resolvers.New(bstore)
+	enterpriseServices.GitHubWebhook = webhooks.NewGitHubWebhook(bstore, observationContext)
+	enterpriseServices.BitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(bstore, observationContext)
+	enterpriseServices.GitLabWebhook = webhooks.NewGitLabWebhook(bstore, observationContext)
 
 	// Register Batch Changes OOB migrations.
-	return migrations.Register(cstore, outOfBandMigrationRunner)
+	return migrations.Register(bstore, outOfBandMigrationRunner)
 }

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -480,7 +480,7 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			// We can induce an error with a broken database connection.
 			s := gitLabTestSetup(t, db)
 			h := NewGitLabWebhook(s)
-			h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+			h.store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
 
 			es, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if es != nil {
@@ -540,7 +540,7 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+				h.store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -560,7 +560,7 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+				h.store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
@@ -24,7 +24,7 @@ import (
 type webhook struct {
 	store *store.Store
 
-	// serviceType corresponds to api.ExternalRepoSpec.serviceType
+	// serviceType corresponds to api.ExternalRepoSpec.ServiceType
 	// Example values: extsvc.TypeBitbucketServer, extsvc.TypeGitHub
 	serviceType string
 }

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -304,6 +304,7 @@ func Frontend() *monitoring.Container {
 			shared.CodeIntelligence.NewUploadStoreGroup(containerName),
 
 			shared.Batches.NewDBStoreGroup(containerName),
+			shared.Batches.NewWebhooksGroup(containerName),
 
 			// src_oobmigration_total
 			// src_oobmigration_duration_seconds_bucket

--- a/monitoring/definitions/shared/batches.go
+++ b/monitoring/definitions/shared/batches.go
@@ -42,3 +42,35 @@ func (batches) NewDBStoreGroup(containerName string) monitoring.Group {
 		},
 	})
 }
+
+// src_batches_webhooks_total
+// src_batches_webhooks_duration_seconds_bucket
+// src_batches_webhooks_errors_total
+func (batches) NewWebhooksGroup(containerName string) monitoring.Group {
+	return Observation.NewGroup(containerName, monitoring.ObservableOwnerBatches, ObservationGroupOptions{
+		GroupConstructorOptions: GroupConstructorOptions{
+			Namespace:       "batches",
+			DescriptionRoot: "webhooks stats",
+			Hidden:          true,
+
+			ObservableConstructorOptions: ObservableConstructorOptions{
+				MetricNameRoot:        "batches_webhooks",
+				MetricDescriptionRoot: "webhook",
+				By:                    []string{"op"},
+			},
+		},
+
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+	})
+}


### PR DESCRIPTION
Today I wondered "do we even dogfood webhooks"? Then I realized we have some configured, but there's no insight into whether they're doing something at all. So here we are: We now have a dedicated section for stats in the Grafana dashboards for the frontend service to tell how many requests we get, whether they succeed and how much of a load this poses on our system.
