### PR TITLE
doc: fix two instances of a misnamed field

### DIFF
--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -903,7 +903,7 @@ and this workspace configuration
 workspaces:
   - rootAtLocationOf: package.json
     in: github.com/our-our/our-large-monorepo
-    fetchOnlyWorkspace: true
+    onlyFetchWorkspace: true
 ```
 
 then
@@ -921,5 +921,5 @@ Only download the workspaces of specific JavaScript projects in a large monorepo
 workspaces:
   - rootAtLocationOf: package.json
     in: github.com/our-our/our-large-monorepo
-    fetchOnlyWorkspace: true
+    onlyFetchWorkspace: true
 ```


### PR DESCRIPTION
Our examples didn't line up with the actual field name. Now they will!