### PR TITLE
batches: set publication states when applying preview

### DIFF
--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewContext.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewContext.tsx
@@ -1,0 +1,73 @@
+import { noop } from 'lodash'
+import React, { useState } from 'react'
+
+import { ChangesetSpecOperation, ChangesetSpecPublicationStateInput, ChangesetState } from '../../../graphql-operations'
+import { isValidChangesetSpecOperation, isValidChangesetState } from '../utils'
+
+export interface BatchChangePreviewFilters {
+    search: string | null
+    currentState: ChangesetState | null
+    action: ChangesetSpecOperation | null
+}
+
+const defaultFilters = (): BatchChangePreviewFilters => ({
+    search: null,
+    currentState: null,
+    action: null,
+})
+
+export interface BatchChangePreviewContextState {
+    // Filters are required to fetch all the changeset specs if all are selected
+    // when publishing.
+    readonly filters: BatchChangePreviewFilters
+    setFilters: (filters: BatchChangePreviewFilters) => void
+    // Maps any changesets to modified publish statuses set from the UI, to be included in
+    // the mutation to apply the preview.
+    readonly publicationStates: ChangesetSpecPublicationStateInput[]
+    setPublicationStates: (publicationStates: ChangesetSpecPublicationStateInput[]) => void
+}
+
+export const defaultState = (): BatchChangePreviewContextState => ({
+    filters: defaultFilters(),
+    setFilters: noop,
+    publicationStates: [],
+    setPublicationStates: noop,
+})
+
+/**
+ * A context tracking the filters for the Batch Changes preview page.
+ *
+ * @see BatchChangePreviewContextProvider
+ */
+export const BatchChangePreviewContext = React.createContext<BatchChangePreviewContextState>(defaultState())
+
+export const BatchChangePreviewContextProvider: React.FunctionComponent<{}> = ({ children }) => {
+    const urlParameters = new URLSearchParams(location.search)
+
+    const [filters, setFilters] = useState<BatchChangePreviewFilters>(() => {
+        const action = urlParameters.get('action')
+        const currentState = urlParameters.get('current_state')
+        const search = urlParameters.get('search')
+
+        return {
+            action: action && isValidChangesetSpecOperation(action) ? action : null,
+            currentState: currentState && isValidChangesetState(currentState) ? currentState : null,
+            search: search ?? null,
+        }
+    })
+
+    const [publicationStates, setPublicationStates] = useState<ChangesetSpecPublicationStateInput[]>([])
+
+    return (
+        <BatchChangePreviewContext.Provider
+            value={{
+                filters,
+                setFilters,
+                publicationStates,
+                setPublicationStates,
+            }}
+        >
+            {children}
+        </BatchChangePreviewContext.Provider>
+    )
+}

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
@@ -14,7 +14,9 @@ import { PageTitle } from '../../../components/PageTitle'
 import { Description } from '../Description'
 import { SupersedingBatchSpecAlert } from '../detail/SupersedingBatchSpecAlert'
 
+import { MultiSelectContextProvider } from '../MultiSelectContext'
 import { fetchBatchSpecById as _fetchBatchSpecById } from './backend'
+import { BatchChangePreviewContextProvider } from './BatchChangePreviewContext'
 import { BatchChangePreviewStatsBar } from './BatchChangePreviewStatsBar'
 import { BatchChangePreviewProps, BatchChangePreviewTabs } from './BatchChangePreviewTabs'
 import { BatchSpecInfoByline } from './BatchSpecInfoByline'
@@ -64,37 +66,41 @@ export const BatchChangePreviewPage: React.FunctionComponent<BatchChangePreviewP
     }
 
     return (
-        <div className="pb-5">
-            <PageTitle title="Apply batch spec" />
-            <PageHeader
-                path={[
-                    {
-                        icon: BatchChangesIcon,
-                        to: '/batch-changes',
-                    },
-                    { to: `${spec.namespace.url}/batch-changes`, text: spec.namespace.namespaceName },
-                    { text: spec.description.name },
-                ]}
-                byline={<BatchSpecInfoByline createdAt={spec.createdAt} creator={spec.creator} />}
-                headingElement="h2"
-                className="test-batch-change-apply-page mb-3"
-            />
-            <MissingCredentialsAlert
-                authenticatedUser={authenticatedUser}
-                viewerBatchChangesCodeHosts={spec.viewerBatchChangesCodeHosts}
-            />
-            <SupersedingBatchSpecAlert spec={spec.supersedingBatchSpec} />
-            <BatchChangePreviewStatsBar batchSpec={spec} />
-            <CreateUpdateBatchChangeAlert
-                history={history}
-                specID={spec.id}
-                toBeArchived={spec.applyPreview.stats.archive}
-                batchChange={spec.appliesToBatchChange}
-                viewerCanAdminister={spec.viewerCanAdminister}
-                telemetryService={telemetryService}
-            />
-            <Description description={spec.description.description} />
-            <BatchChangePreviewTabs spec={spec} {...props} />
-        </div>
+        <MultiSelectContextProvider>
+            <BatchChangePreviewContextProvider>
+                <div className="pb-5">
+                    <PageTitle title="Apply batch spec" />
+                    <PageHeader
+                        path={[
+                            {
+                                icon: BatchChangesIcon,
+                                to: '/batch-changes',
+                            },
+                            { to: `${spec.namespace.url}/batch-changes`, text: spec.namespace.namespaceName },
+                            { text: spec.description.name },
+                        ]}
+                        byline={<BatchSpecInfoByline createdAt={spec.createdAt} creator={spec.creator} />}
+                        headingElement="h2"
+                        className="test-batch-change-apply-page mb-3"
+                    />
+                    <MissingCredentialsAlert
+                        authenticatedUser={authenticatedUser}
+                        viewerBatchChangesCodeHosts={spec.viewerBatchChangesCodeHosts}
+                    />
+                    <SupersedingBatchSpecAlert spec={spec.supersedingBatchSpec} />
+                    <BatchChangePreviewStatsBar batchSpec={spec} />
+                    <CreateUpdateBatchChangeAlert
+                        history={history}
+                        specID={spec.id}
+                        toBeArchived={spec.applyPreview.stats.archive}
+                        batchChange={spec.appliesToBatchChange}
+                        viewerCanAdminister={spec.viewerCanAdminister}
+                        telemetryService={telemetryService}
+                    />
+                    <Description description={spec.description.description} />
+                    <BatchChangePreviewTabs spec={spec} {...props} />
+                </div>
+            </BatchChangePreviewContextProvider>
+        </MultiSelectContextProvider>
     )
 }

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
@@ -13,8 +13,8 @@ import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
 import { Description } from '../Description'
 import { SupersedingBatchSpecAlert } from '../detail/SupersedingBatchSpecAlert'
-
 import { MultiSelectContextProvider } from '../MultiSelectContext'
+
 import { fetchBatchSpecById as _fetchBatchSpecById } from './backend'
 import { BatchChangePreviewContextProvider } from './BatchChangePreviewContext'
 import { BatchChangePreviewStatsBar } from './BatchChangePreviewStatsBar'

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -70,8 +70,8 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
                     )}{' '}
                     Click 'Apply' or run <code>src batch apply</code> against your batch spec to{' '}
                     {batchChange ? 'update' : 'create'} the batch change and perform the indicated action on each
-                    changeset. Select a changeset and modify the action to customize the publish status of each or all
-                    changesets.
+                    changeset. Select a changeset and modify the action to customize the publication state of each or
+                    all changesets.
                 </div>
                 <div className={styles.createUpdateBatchChangeAlertBtn}>
                     <button

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -60,14 +60,7 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
         <>
             <div className="alert alert-info mb-3 d-block d-md-flex align-items-center body-lead">
                 <div className={classNames(styles.createUpdateBatchChangeAlertCopy, 'flex-grow-1 mr-3')}>
-                    {!batchChange && (
-                        <>
-                            Review the proposed changesets below. Click 'Apply spec' or run <code>src batch apply</code>{' '}
-                            against your batch spec to create the batch change and perform the indicated action on each
-                            changeset.
-                        </>
-                    )}
-                    {batchChange && (
+                    {batchChange ? (
                         <>
                             This operation will update the existing batch change{' '}
                             <Link to={batchChange.url}>{batchChange.name}</Link>

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import * as H from 'history'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -10,6 +10,7 @@ import { ErrorAlert } from '../../../components/alerts'
 import { BatchSpecFields } from '../../../graphql-operations'
 
 import { createBatchChange, applyBatchChange } from './backend'
+import { BatchChangePreviewContext } from './BatchChangePreviewContext'
 import styles from './CreateUpdateBatchChangeAlert.module.scss'
 
 export interface CreateUpdateBatchChangeAlertProps extends TelemetryProps {
@@ -29,6 +30,9 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
     telemetryService,
 }) => {
     const batchChangeID = batchChange?.id
+
+    const { publicationStates } = useContext(BatchChangePreviewContext)
+
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
 
     const onApply = useCallback(async () => {
@@ -38,8 +42,8 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
         setIsLoading(true)
         try {
             const batchChange = batchChangeID
-                ? await applyBatchChange({ batchSpec: specID, batchChange: batchChangeID })
-                : await createBatchChange({ batchSpec: specID })
+                ? await applyBatchChange({ batchSpec: specID, batchChange: batchChangeID, publicationStates })
+                : await createBatchChange({ batchSpec: specID, publicationStates })
 
             if (toBeArchived > 0) {
                 history.push(`${batchChange.url}?archivedCount=${toBeArchived}&archivedBy=${specID}`)
@@ -50,7 +54,7 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
         } catch (error) {
             setIsLoading(error)
         }
-    }, [specID, setIsLoading, history, batchChangeID, telemetryService, toBeArchived])
+    }, [specID, setIsLoading, history, batchChangeID, telemetryService, toBeArchived, publicationStates])
 
     return (
         <>
@@ -66,11 +70,15 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
                     {batchChange && (
                         <>
                             This operation will update the existing batch change{' '}
-                            <Link to={batchChange.url}>{batchChange.name}</Link>. Click 'Apply spec' or run{' '}
-                            <code>src batch apply</code> against your batch spec to update the batch change and perform
-                            the indicated action on each changeset.
+                            <Link to={batchChange.url}>{batchChange.name}</Link>
                         </>
-                    )}
+                    ) : (
+                        'Review the proposed changesets below.'
+                    )}{' '}
+                    Click 'Apply' or run <code>src batch apply</code> against your batch spec to{' '}
+                    {batchChange ? 'update' : 'create'} the batch change and perform the indicated action on each
+                    changeset. Select a changeset and modify the action to customize the publish status of each or all
+                    changesets.
                 </div>
                 <div className={styles.createUpdateBatchChangeAlertBtn}>
                     <button
@@ -85,7 +93,7 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
                             !viewerCanAdminister ? 'You have no permission to apply this batch change.' : undefined
                         }
                     >
-                        Apply spec
+                        Apply
                     </button>
                 </div>
             </div>

--- a/client/web/src/enterprise/batches/preview/backend.ts
+++ b/client/web/src/enterprise/batches/preview/backend.ts
@@ -123,17 +123,18 @@ export const fetchBatchSpecById = (batchSpec: Scalars['ID']): Observable<BatchSp
 
 export const createBatchChange = ({
     batchSpec,
+    publicationStates,
 }: CreateBatchChangeVariables): Promise<CreateBatchChangeResult['createBatchChange']> =>
     requestGraphQL<CreateBatchChangeResult, CreateBatchChangeVariables>(
         gql`
-            mutation CreateBatchChange($batchSpec: ID!) {
-                createBatchChange(batchSpec: $batchSpec) {
+            mutation CreateBatchChange($batchSpec: ID!, $publicationStates: [ChangesetSpecPublicationStateInput!]) {
+                createBatchChange(batchSpec: $batchSpec, publicationStates: $publicationStates) {
                     id
                     url
                 }
             }
         `,
-        { batchSpec }
+        { batchSpec, publicationStates }
     )
         .pipe(
             map(dataOrThrowErrors),
@@ -144,17 +145,26 @@ export const createBatchChange = ({
 export const applyBatchChange = ({
     batchSpec,
     batchChange,
+    publicationStates,
 }: ApplyBatchChangeVariables): Promise<ApplyBatchChangeResult['applyBatchChange']> =>
     requestGraphQL<ApplyBatchChangeResult, ApplyBatchChangeVariables>(
         gql`
-            mutation ApplyBatchChange($batchSpec: ID!, $batchChange: ID!) {
-                applyBatchChange(batchSpec: $batchSpec, ensureBatchChange: $batchChange) {
+            mutation ApplyBatchChange(
+                $batchSpec: ID!
+                $batchChange: ID!
+                $publicationStates: [ChangesetSpecPublicationStateInput!]
+            ) {
+                applyBatchChange(
+                    batchSpec: $batchSpec
+                    ensureBatchChange: $batchChange
+                    publicationStates: $publicationStates
+                ) {
                     id
                     url
                 }
             }
         `,
-        { batchSpec, batchChange }
+        { batchSpec, batchChange, publicationStates }
     )
         .pipe(
             map(dataOrThrowErrors),

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -8,7 +8,8 @@ import { Container } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
 import { BatchSpecApplyPreviewVariables, ChangesetApplyPreviewFields, Scalars } from '../../../../graphql-operations'
-import { MultiSelectContext, MultiSelectContextProvider } from '../../MultiSelectContext'
+import { MultiSelectContext } from '../../MultiSelectContext'
+import { BatchChangePreviewContext } from '../BatchChangePreviewContext'
 import { PreviewPageAuthenticatedUser } from '../BatchChangePreviewPage'
 import { getPublishableChangesetSpecID } from '../utils'
 
@@ -19,7 +20,7 @@ import {
 } from './backend'
 import { ChangesetApplyPreviewNode, ChangesetApplyPreviewNodeProps } from './ChangesetApplyPreviewNode'
 import { EmptyPreviewListElement } from './EmptyPreviewListElement'
-import { PreviewFilterRow, PreviewFilters } from './PreviewFilterRow'
+import { PreviewFilterRow } from './PreviewFilterRow'
 import styles from './PreviewList.module.scss'
 import { PreviewListHeader, PreviewListHeaderProps } from './PreviewListHeader'
 import { PreviewSelectRow } from './PreviewSelectRow'
@@ -43,13 +44,7 @@ interface Props extends ThemeProps {
 /**
  * A list of a batch spec's preview nodes.
  */
-export const PreviewList: React.FunctionComponent<Props> = props => (
-    <MultiSelectContextProvider>
-        <PreviewListImpl {...props} />
-    </MultiSelectContextProvider>
-)
-
-const PreviewListImpl: React.FunctionComponent<Props> = ({
+export const PreviewList: React.FunctionComponent<Props> = ({
     batchSpecID,
     history,
     location,
@@ -61,29 +56,10 @@ const PreviewListImpl: React.FunctionComponent<Props> = ({
     expandChangesetDescriptions,
     queryPublishableChangesetSpecIDs,
 }) => {
-    const {
-        selected,
-        deselectAll,
-        areAllVisibleSelected,
-        isSelected,
-        toggleSingle,
-        toggleVisible,
-        setVisible,
-    } = useContext(MultiSelectContext)
-
-    const [filters, setFilters] = useState<PreviewFilters>({
-        search: null,
-        currentState: null,
-        action: null,
-    })
-
-    const setChangesetFiltersAndDeselectAll = useCallback(
-        (filters: PreviewFilters) => {
-            deselectAll()
-            setFilters(filters)
-        },
-        [deselectAll]
+    const { selected, areAllVisibleSelected, isSelected, toggleSingle, toggleVisible, setVisible } = useContext(
+        MultiSelectContext
     )
+    const { filters } = useContext(BatchChangePreviewContext)
 
     const [queryArguments, setQueryArguments] = useState<BatchSpecApplyPreviewVariables>()
 
@@ -124,11 +100,7 @@ const PreviewListImpl: React.FunctionComponent<Props> = ({
                     queryArguments={queryArguments}
                 />
             ) : (
-                <PreviewFilterRow
-                    history={history}
-                    location={location}
-                    onFiltersChange={setChangesetFiltersAndDeselectAll}
-                />
+                <PreviewFilterRow history={history} location={location} />
             )}
             <FilteredConnection<
                 ChangesetApplyPreviewFields,

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -5,7 +5,7 @@ import React, { useMemo, useContext } from 'react'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
-import { BatchSpecApplyPreviewVariables, Maybe, Scalars } from '../../../../graphql-operations'
+import { BatchSpecApplyPreviewVariables, Scalars } from '../../../../graphql-operations'
 import { Action, DropdownButton } from '../../DropdownButton'
 import { MultiSelectContext } from '../../MultiSelectContext'
 import { BatchChangePreviewContext } from '../BatchChangePreviewContext'
@@ -38,16 +38,15 @@ const ACTIONS: Action[] = [
 ]
 
 // Returns the desired `PublishedValue` for the given action.
-const getPublicationStateFromAction = (action: Action): Maybe<Scalars['PublishedValue']> => {
+const getPublicationStateFromAction = (action: Action): Scalars['PublishedValue'] => {
     switch (action.type) {
-        case 'unpublish':
-            return false
         case 'publish':
             return true
         case 'publish-draft':
             return 'draft'
+        case 'unpublish':
         default:
-            return null
+            return false
     }
 }
 


### PR DESCRIPTION
Part 2 of #23383. Portions of this lifted from or inspired by #22658.

**Note:** This PR is based on #23966 since it builds upon the changes there.

This PR includes:

- applying the new publish statuses when you click "Apply" from the banner on the top of the preview page

This PR does not include:

- recalculating the actions on the backend when a publish status modification is selected
- disabling the "Apply" button until a publish status modification is selected

(Those will each be a follow-up PR)

The majority of this PR is setting up a new `React.Context` for sharing information about the UI controls across preview page components that are very distant relatives. Some of the logic around lifting filters/search from the URL is also moved to the context layer as a result.


