### PR TITLE
searcher: remove batch API

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -53,10 +53,6 @@ type Request struct {
 	// Whether the revision to be searched is indexed or unindexed. This matters for
 	// structural search because it will query Zoekt for indexed structural search.
 	Indexed bool
-
-	// (Experimental) Whether to stream results to the client with server sent events
-	// rather than returning them as a batch
-	Stream bool
 }
 
 // PatternInfo describes a search request on a repo. Most of the fields

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -40,12 +40,6 @@ import (
 )
 
 const (
-	// maxLimit is a hard-coded maximum for total number of matches we return.
-	// This may be increased in the future pending stability evaluation, or may
-	// be removed entirely once streaming is in place and we don't need to buffer
-	// the whole result set in memory.
-	maxLimit = 20000
-
 	// numWorkers is how many concurrent readerGreps run in the case of
 	// regexSearch, and the number of parallel workers in the case of
 	// structuralSearch.
@@ -91,43 +85,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if p.Stream {
-		s.streamSearch(ctx, w, p)
-		return
-	}
-
-	if p.Limit == 0 || p.Limit > maxLimit {
-		p.Limit = maxLimit
-	}
-
-	ctx, cancel, stream := newLimitedStreamCollector(ctx, p.Limit)
-	defer cancel()
-
-	deadlineHit, err := s.search(ctx, &p, stream)
-	if err != nil {
-		code := http.StatusInternalServerError
-		if errcode.IsBadRequest(err) || errors.Is(ctx.Err(), context.Canceled) {
-			code = http.StatusBadRequest
-		} else if errcode.IsTemporary(err) {
-			code = http.StatusServiceUnavailable
-		} else {
-			log.Printf("internal error serving %#+v: %s", p, err)
-		}
-		http.Error(w, err.Error(), code)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	resp := protocol.Response{
-		Matches:     stream.Collected(),
-		LimitHit:    stream.LimitHit(),
-		DeadlineHit: deadlineHit,
-	}
-	// The only reasonable error is the client going away now since we know we
-	// can encode resp. This happens relatively often due to our
-	// graphqlbackend regularly cancelling in-flight requests. We can't send
-	// an error response, so we just ignore.
-	_ = json.NewEncoder(w).Encode(&resp)
+	s.streamSearch(ctx, w, p)
 }
 
 func (s *Service) streamSearch(ctx context.Context, w http.ResponseWriter, p protocol.Request) {

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -19,7 +19,6 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	nettrace "golang.org/x/net/trace"
@@ -101,16 +100,13 @@ func (s *Service) streamSearch(ctx context.Context, w http.ResponseWriter, p pro
 		return
 	}
 
-	var bufMux sync.Mutex
 	matchesBuf := streamhttp.NewJSONArrayBuf(32*1024, func(data []byte) error {
 		return eventWriter.EventBytes("matches", data)
 	})
 	onMatches := func(match protocol.FileMatch) {
-		bufMux.Lock()
 		if err := matchesBuf.Append(match); err != nil {
 			log.Printf("failed appending match to buffer: %s", err)
 		}
-		bufMux.Unlock()
 	}
 
 	ctx, cancel, stream := newLimitedStream(ctx, p.Limit, onMatches)

--- a/cmd/searcher/search/sender.go
+++ b/cmd/searcher/search/sender.go
@@ -112,8 +112,8 @@ func (m *limitedStream) Send(match protocol.FileMatch) {
 	if match.MatchCount <= m.remaining {
 		m.remaining -= match.MatchCount
 		m.sentCount += match.MatchCount
-		m.mux.Unlock()
 		m.cb(match)
+		m.mux.Unlock()
 		return
 	}
 
@@ -137,8 +137,8 @@ func (m *limitedStream) Send(match protocol.FileMatch) {
 	match.MatchCount = m.remaining
 	m.sentCount += m.remaining
 	m.remaining = 0
-	m.mux.Unlock()
 	m.cb(match)
+	m.mux.Unlock()
 }
 
 func (m *limitedStream) SentCount() int {

--- a/cmd/searcher/search/sender.go
+++ b/cmd/searcher/search/sender.go
@@ -97,6 +97,10 @@ type limitedStream struct {
 	cancel    context.CancelFunc
 }
 
+// newLimitedStream creates a stream that will limit the number of matches passed through it,
+// cancelling the context it returns when that happens. For each match sent to the stream,
+// if it hasn't hit the limit, it will call the onMatch callback with that match. The onMatch
+// callback will never be called concurrently.
 func newLimitedStream(ctx context.Context, limit int, cb func(protocol.FileMatch)) (context.Context, context.CancelFunc, *limitedStream) {
 	ctx, cancel := context.WithCancel(ctx)
 	s := &limitedStream{

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -77,7 +77,6 @@ func Search(
 		Indexed:          indexed,
 		FetchTimeout:     fetchTimeout.String(),
 		IndexerEndpoints: indexerEndpoints,
-		Stream:           true,
 	}
 
 	if deadline, ok := ctx.Deadline(); ok {

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	searchDoer, _ = httpcli.NewInternalClientFactory("search").Doer()
-	MockSearch    func(ctx context.Context, repo api.RepoName, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*protocol.FileMatch, limitHit bool, err error)
+	MockSearch    func(ctx context.Context, repo api.RepoName, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration, onMatches func([]*protocol.FileMatch)) (matches []*protocol.FileMatch, limitHit bool, err error)
 )
 
 // Search searches repo@commit with p.
@@ -43,7 +43,7 @@ func Search(
 	onMatches func([]*protocol.FileMatch),
 ) (matches []*protocol.FileMatch, limitHit bool, err error) {
 	if MockSearch != nil {
-		return MockSearch(ctx, repo, commit, p, fetchTimeout)
+		return MockSearch(ctx, repo, commit, p, fetchTimeout, onMatches)
 	}
 
 	tr, ctx := trace.New(ctx, "searcher.client", fmt.Sprintf("%s@%s", repo, commit))

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -124,16 +124,9 @@ func Search(
 		}
 
 		tr.LazyPrintf("attempt %d: %s", attempt, url)
-		if onMatches != nil {
-			limitHit, err = textSearchStream(ctx, url, body, onMatches)
-			if err == nil || errcode.IsTimeout(err) {
-				return nil, limitHit, err
-			}
-		} else {
-			matches, limitHit, err = textSearch(ctx, url, body)
-			if err == nil || errcode.IsTimeout(err) {
-				return matches, limitHit, err
-			}
+		limitHit, err = textSearchStream(ctx, url, body, onMatches)
+		if err == nil || errcode.IsTimeout(err) {
+			return nil, limitHit, err
 		}
 
 		// If we are canceled, return that error.
@@ -205,54 +198,6 @@ func textSearchStream(ctx context.Context, url string, body []byte, cb func([]*p
 		err = context.DeadlineExceeded
 	}
 	return ed.LimitHit, err
-}
-
-func textSearch(ctx context.Context, url string, body []byte) ([]*protocol.FileMatch, bool, error) {
-	req, err := http.NewRequest("GET", url, bytes.NewReader(body))
-	if err != nil {
-		return nil, false, err
-	}
-	req = req.WithContext(ctx)
-
-	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), req,
-		nethttp.OperationName("Searcher Client"),
-		nethttp.ClientTrace(false))
-	defer ht.Finish()
-
-	// Do not lose the context returned by TraceRequest
-	ctx = req.Context()
-
-	resp, err := searchDoer.Do(req)
-	if err != nil {
-		// If we failed due to cancellation or timeout (with no partial results in the response
-		// body), return just that.
-		if ctx.Err() != nil {
-			err = ctx.Err()
-		}
-		return nil, false, errors.Wrap(err, "searcher request failed")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, false, err
-		}
-		return nil, false, errors.WithStack(&searcherError{StatusCode: resp.StatusCode, Message: string(body)})
-	}
-
-	r := struct {
-		Matches     []*protocol.FileMatch
-		LimitHit    bool
-		DeadlineHit bool
-	}{}
-	err = json.NewDecoder(resp.Body).Decode(&r)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "searcher response invalid")
-	}
-	if r.DeadlineHit {
-		err = context.DeadlineExceeded
-	}
-	return r.Matches, r.LimitHit, err
 }
 
 type searcherError struct {

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -77,6 +77,7 @@ func Search(
 		Indexed:          indexed,
 		FetchTimeout:     fetchTimeout.String(),
 		IndexerEndpoints: indexerEndpoints,
+		Stream:           true,
 	}
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -85,9 +86,6 @@ func Search(
 			return nil, false, err
 		}
 		r.Deadline = string(t)
-	}
-	if onMatches != nil {
-		r.Stream = true
 	}
 	body, err := json.Marshal(r)
 	if err != nil {

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -123,11 +123,11 @@ func SearchFilesInReposBatch(ctx context.Context, args *search.TextParameters) (
 	return fms, stats, err
 }
 
-var mockSearchFilesInRepo func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.Match, limitHit bool, err error)
+var mockSearchFilesInRepo func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (matches []result.Match, limitHit bool, err error)
 
 func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo types.RepoName, gitserverRepo api.RepoName, rev string, index bool, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) ([]result.Match, bool, error) {
 	if mockSearchFilesInRepo != nil {
-		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout)
+		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout, stream)
 	}
 
 	// Do not trigger a repo-updater lookup (e.g.,

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
@@ -335,12 +334,7 @@ func callSearcherOverRepos(
 					ctx, done := limitCtx, limitDone
 					defer done()
 
-					var s streaming.Sender
-					if featureflag.FromContext(ctx).GetBoolOr("cc_streaming_searcher", true) {
-						s = stream
-					}
-
-					matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), repoRev.RevSpecs()[0], index, args.PatternInfo, fetchTimeout, s)
+					matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), repoRev.RevSpecs()[0], index, args.PatternInfo, fetchTimeout, stream)
 					if err != nil {
 						tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
 						log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -165,12 +165,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 		})
 	}
 
-	limitHit, err := searcher.Search(ctx, searcherURLs, gitserverRepo, rev, commit, index, info, fetchTimeout, indexerEndpoints, onMatches)
-	if err != nil {
-		return false, err
-	}
-
-	return limitHit, err
+	return searcher.Search(ctx, searcherURLs, gitserverRepo, rev, commit, index, info, fetchTimeout, indexerEndpoints, onMatches)
 }
 
 // newToMatches returns a closure that converts []*protocol.FileMatch to []result.Match.

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -165,12 +165,12 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 		})
 	}
 
-	searcherMatches, limitHit, err := searcher.Search(ctx, searcherURLs, gitserverRepo, rev, commit, index, info, fetchTimeout, indexerEndpoints, onMatches)
+	limitHit, err := searcher.Search(ctx, searcherURLs, gitserverRepo, rev, commit, index, info, fetchTimeout, indexerEndpoints, onMatches)
 	if err != nil {
 		return nil, false, err
 	}
 
-	return toMatches(searcherMatches), limitHit, err
+	return nil, limitHit, err
 }
 
 // newToMatches returns a closure that converts []*protocol.FileMatch to []result.Match.
@@ -238,7 +238,7 @@ func repoHasFilesWithNamesMatching(ctx context.Context, searcherURLs *endpoint.M
 			}
 		}
 		p := search.TextPatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
-		_, _, err := searcher.Search(ctx, searcherURLs, gitserverRepo, "", commit, false, &p, fetchTimeout, []string{}, onMatches)
+		_, err := searcher.Search(ctx, searcherURLs, gitserverRepo, "", commit, false, &p, fetchTimeout, []string{}, onMatches)
 		if err != nil {
 			return false, err
 		}

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -159,14 +159,10 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 	}
 
 	toMatches := newToMatches(repo, commit, &rev)
-
-	var onMatches func([]*protocol.FileMatch)
-	if stream != nil {
-		onMatches = func(searcherMatches []*protocol.FileMatch) {
-			stream.Send(streaming.SearchEvent{
-				Results: toMatches(searcherMatches),
-			})
-		}
+	onMatches := func(searcherMatches []*protocol.FileMatch) {
+		stream.Send(streaming.SearchEvent{
+			Results: toMatches(searcherMatches),
+		})
 	}
 
 	searcherMatches, limitHit, err := searcher.Search(ctx, searcherURLs, gitserverRepo, rev, commit, index, info, fetchTimeout, indexerEndpoints, onMatches)

--- a/internal/search/unindexed/unindexed_test.go
+++ b/internal/search/unindexed/unindexed_test.go
@@ -269,12 +269,14 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 }
 
 func TestRepoShouldBeSearched(t *testing.T) {
-	searcher.MockSearch = func(ctx context.Context, repo api.RepoName, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*protocol.FileMatch, limitHit bool, err error) {
+	searcher.MockSearch = func(ctx context.Context, repo api.RepoName, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration, onMatches func([]*protocol.FileMatch)) (matches []*protocol.FileMatch, limitHit bool, err error) {
 		repoName := repo
 		switch repoName {
 		case "foo/one":
+			onMatches([]*protocol.FileMatch{{Path: "main.go"}})
 			return []*protocol.FileMatch{{Path: "main.go"}}, false, nil
 		case "foo/no-filematch":
+			onMatches([]*protocol.FileMatch{})
 			return []*protocol.FileMatch{}, false, nil
 		default:
 			return nil, false, errors.New("Unexpected repo")

--- a/internal/search/unindexed/unindexed_test.go
+++ b/internal/search/unindexed/unindexed_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestSearchFilesInRepos(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (matches []result.Match, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
@@ -47,7 +47,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 					},
 				}},
 			})
-			return nil, false, nil
+			return false, nil
 		case "foo/two":
 			stream.Send(streaming.SearchEvent{
 				Results: []result.Match{&result.FileMatch{
@@ -58,24 +58,24 @@ func TestSearchFilesInRepos(t *testing.T) {
 					},
 				}},
 			})
-			return nil, false, nil
+			return false, nil
 		case "foo/empty":
-			return nil, false, nil
+			return false, nil
 		case "foo/cloning":
-			return nil, false, &vcs.RepoNotExistError{Repo: repoName, CloneInProgress: true}
+			return false, &vcs.RepoNotExistError{Repo: repoName, CloneInProgress: true}
 		case "foo/missing":
-			return nil, false, &vcs.RepoNotExistError{Repo: repoName}
+			return false, &vcs.RepoNotExistError{Repo: repoName}
 		case "foo/missing-database":
-			return nil, false, &errcode.Mock{Message: "repo not found: foo/missing-database", IsNotFound: true}
+			return false, &errcode.Mock{Message: "repo not found: foo/missing-database", IsNotFound: true}
 		case "foo/timedout":
-			return nil, false, context.DeadlineExceeded
+			return false, context.DeadlineExceeded
 		case "foo/no-rev":
 			// TODO we do not specify a rev when searching "foo/no-rev", so it
 			// is treated as an empty repository. We need to test the fatal
 			// case of trying to search a revision which doesn't exist.
-			return nil, false, &gitserver.RevisionNotFoundError{Repo: repoName, Spec: "missing"}
+			return false, &gitserver.RevisionNotFoundError{Repo: repoName, Spec: "missing"}
 		default:
-			return nil, false, errors.New("Unexpected repo")
+			return false, errors.New("Unexpected repo")
 		}
 	}
 	defer func() { mockSearchFilesInRepo = nil }()
@@ -135,7 +135,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 }
 
 func TestSearchFilesInReposStream(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (matches []result.Match, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
@@ -148,7 +148,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 					},
 				}},
 			})
-			return nil, false, nil
+			return false, nil
 		case "foo/two":
 			stream.Send(streaming.SearchEvent{
 				Results: []result.Match{&result.FileMatch{
@@ -159,7 +159,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 					},
 				}},
 			})
-			return nil, false, nil
+			return false, nil
 		case "foo/three":
 			stream.Send(streaming.SearchEvent{
 				Results: []result.Match{&result.FileMatch{
@@ -170,9 +170,9 @@ func TestSearchFilesInReposStream(t *testing.T) {
 					},
 				}},
 			})
-			return nil, false, nil
+			return false, nil
 		default:
-			return nil, false, errors.New("Unexpected repo")
+			return false, errors.New("Unexpected repo")
 		}
 	}
 	defer func() { mockSearchFilesInRepo = nil }()
@@ -220,7 +220,7 @@ func assertReposStatus(t *testing.T, repoNames map[api.RepoID]string, got search
 }
 
 func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (matches []result.Match, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
@@ -233,7 +233,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 					},
 				}},
 			})
-			return nil, false, nil
+			return false, nil
 		default:
 			panic("unexpected repo")
 		}

--- a/internal/search/unindexed/unindexed_test.go
+++ b/internal/search/unindexed/unindexed_test.go
@@ -269,17 +269,17 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 }
 
 func TestRepoShouldBeSearched(t *testing.T) {
-	searcher.MockSearch = func(ctx context.Context, repo api.RepoName, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration, onMatches func([]*protocol.FileMatch)) (matches []*protocol.FileMatch, limitHit bool, err error) {
+	searcher.MockSearch = func(ctx context.Context, repo api.RepoName, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration, onMatches func([]*protocol.FileMatch)) (limitHit bool, err error) {
 		repoName := repo
 		switch repoName {
 		case "foo/one":
 			onMatches([]*protocol.FileMatch{{Path: "main.go"}})
-			return []*protocol.FileMatch{{Path: "main.go"}}, false, nil
+			return false, nil
 		case "foo/no-filematch":
 			onMatches([]*protocol.FileMatch{})
-			return []*protocol.FileMatch{}, false, nil
+			return false, nil
 		default:
-			return nil, false, errors.New("Unexpected repo")
+			return false, errors.New("Unexpected repo")
 		}
 	}
 	defer func() { searcher.MockSearch = nil }()


### PR DESCRIPTION
Now that the stream API is enabled by default, and appears to be stable, we can remove the unused batch API. 

I'm making this PR a little early since I don't plan to merge it until the 3.31 release is cut on Thursday. This way, if any customer issues come up, there is still a path to disable the streaming API for at least a full release. Just getting the review process kicked off ahead of time. 

Each commit is pretty small and self-contained, so if you'd like to see the progression, review commit-by-commit. Note that all integration tests are now running against the streaming API. 

Closes #23981 