### PR TITLE
batches: disable "Apply" while changesets are selected

### DIFF
--- a/client/web/src/components/ButtonTooltip.tsx
+++ b/client/web/src/components/ButtonTooltip.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import styles from './InputTooltip.module.scss'
+
+type ButtonProps = React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
+
+/**
+ * A wrapper around `button` that restores the hover tooltip capability even if the button is disabled.
+ *
+ * Disabled elements do not trigger mouse events on hover, and `Tooltip` relies on mouse events.
+ *
+ * All other props are passed to the `button` element.
+ */
+export const ButtonTooltip: React.FunctionComponent<
+    ButtonProps & { tooltip?: string } & Required<Pick<ButtonProps, 'type'>>
+> = ({ disabled, tooltip, type, ...props }) => (
+    <div className={styles.container}>
+        {disabled && tooltip ? <div className={styles.containerTooltip} data-tooltip={tooltip} /> : null}
+        {/* eslint-disable-next-line react/button-has-type */}
+        <button type={type} disabled={disabled} data-tooltip={disabled ? undefined : tooltip} {...props} />
+    </div>
+)

--- a/client/web/src/components/ButtonTooltip.tsx
+++ b/client/web/src/components/ButtonTooltip.tsx
@@ -16,6 +16,10 @@ export const ButtonTooltip: React.FunctionComponent<
 > = ({ disabled, tooltip, type, ...props }) => (
     <div className={styles.container}>
         {disabled && tooltip ? <div className={styles.containerTooltip} data-tooltip={tooltip} /> : null}
+        {/* This ESLint rule requires specifying the type with a static string or a trivial ternary expression only.
+            The intent is to avoid undesirable page reloading behavior because the default value of `type` for HTML
+            `button`s is "submit". However, because we're using TS and require `type` on this component's props,
+            we can guarantee a valid type is provided and achieve the same result. Hence the disable comment. */}
         {/* eslint-disable-next-line react/button-has-type */}
         <button type={type} disabled={disabled} data-tooltip={disabled ? undefined : tooltip} {...props} />
     </div>


### PR DESCRIPTION
Part 3 of #23383.

**Note:** This PR is based on #24020 since it builds upon the changes there.

This PR includes:

- disabling the "Apply" button until a publish status modification is selected

This PR does not include:

- recalculating the actions on the backend when a publish status modification is selected

(This will be the final follow-up PR)

In order to get the disabled button tooltip [specified in designs](https://www.figma.com/file/2XzIz5k78FGMYwruMZo1Xt/Publish-from-GUI-corrections?node-id=2%3A18), a similar workaround to the [disabled input tooltip PR](https://github.com/sourcegraph/sourcegraph/pull/23919) was required for buttons. I could not find any other instances of buttons with disabled tooltips across the repo, but ostensibly the `ButtonTooltip` could become our go-to in the same way that `InputTooltip` can.

The button is disabled if **any** changesets are selected. Choosing a publication state from the actions menu records the modification and deselects the changesets.

https://user-images.githubusercontent.com/8942601/129667725-299074bf-b93e-402a-b918-9be6843d75c7.mov

