### PR TITLE
web: fix `--tour-bg` dark theme CSS variable

### DIFF
--- a/client/web/src/search/FeatureTour.module.scss
+++ b/client/web/src/search/FeatureTour.module.scss
@@ -1,7 +1,7 @@
 .feature-tour {
     --tour-bg: var(--white);
 
-    :global(.theme-dark) {
+    :global(.theme-dark) & {
         --tour-bg: var(--gray-08);
     }
 


### PR DESCRIPTION
## Changes

- Fixed `--tour-bg` CSS variable for `.theme-dark`.

Closes https://github.com/sourcegraph/sourcegraph/issues/24002