### PR TITLE
repo-updater: Add PermsSyncer to syncer & sync private repo perms

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -380,16 +380,6 @@ func watchSyncer(
 				sched.UpdateFromDiff(diff)
 			}
 
-			if gps == nil {
-				continue
-			}
-
-			go func() {
-				if err := gps.Sync(ctx, diff.Repos()); err != nil {
-					log15.Error("GitolitePhabricatorMetadataSyncer", "error", err)
-				}
-			}()
-
 			// PermsSyncer is only available in enterprise mode.
 			if permsSyncer != nil {
 				// Schedule a repo permissions sync for all private repos that were added or
@@ -410,6 +400,17 @@ func watchSyncer(
 
 				permsSyncer.ScheduleRepos(ctx, repoIDs...)
 			}
+
+			if gps == nil {
+				continue
+			}
+
+			go func() {
+				if err := gps.Sync(ctx, diff.Repos()); err != nil {
+					log15.Error("GitolitePhabricatorMetadataSyncer", "error", err)
+				}
+			}()
+
 		}
 	}
 }

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -41,15 +41,6 @@ type Syncer struct {
 	// Registerer is the interface to register / unregister prometheus metrics.
 	Registerer prometheus.Registerer
 
-	// PermsSyncer is the interface that lets the syncer schedule permissions syncing without
-	// directly having access to the permissions syncer client.
-	PermsSyncer interface {
-		// ScheduleRepos will schedule a repository permissions sync. PermsSyncer can be nil so
-		// callers of syncer.PermsSyncer.ScheduleRepos must ensure to check if the interface is nil
-		// before invoking the method.
-		ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID)
-	}
-
 	// UserReposMaxPerUser can be used to override the value read from config.
 	// If zero, we'll read from config instead.
 	UserReposMaxPerUser int

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -38,7 +38,17 @@ type Syncer struct {
 	// Now is time.Now. Can be set by tests to get deterministic output.
 	Now func() time.Time
 
+	// Registerer is the interface to register / unregister prometheus metrics.
 	Registerer prometheus.Registerer
+
+	// PermsSyncer is the interface that lets the syncer schedule permissions syncing without
+	// directly having access to the permissions syncer client.
+	PermsSyncer interface {
+		// ScheduleRepos will schedule a repository permissions sync. PermsSyncer can be nil so
+		// callers of syncer.PermsSyncer.ScheduleRepos must ensure to check if the interface is nil
+		// before invoking the method.
+		ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID)
+	}
 
 	// UserReposMaxPerUser can be used to override the value read from config.
 	// If zero, we'll read from config instead.


### PR DESCRIPTION
Follow up on #23884.

In this commit we trigger a repo permissions sync for all private repos (both added and modified) in the diff read from the `syncer.Synced` channel. We do not make extra checks for existing private repos that were modified as we do not anticipate a performance based regression based on the number of repos being scheduled for permissions syncing.

# Post merge

When this is out on dotcom, I will keep an eye on the `Permissions` dashboard, specifically:
* `Repo permissions synced per minute`
* `Repo permissions sync duration`
* `Repo permissions sync error rate`

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
