### PR TITLE
Set a lighter font-weight for the 'Sync all' note

### DIFF
--- a/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
+++ b/client/web/src/user/settings/repositories/SelectAffiliatedRepos.tsx
@@ -298,7 +298,6 @@ export const SelectAffiliatedRepos: FunctionComponent<Props> = ({
                 <div className="d-flex flex-column ml-2">
                     <p
                         className={classNames('mb-0', {
-                            'user-settings-repos__text': ALLOW_SYNC_ALL,
                             'user-settings-repos__text-disabled': !ALLOW_SYNC_ALL,
                         })}
                     >
@@ -306,7 +305,7 @@ export const SelectAffiliatedRepos: FunctionComponent<Props> = ({
                     </p>
                     <p
                         className={classNames({
-                            'user-settings-repos__text': ALLOW_SYNC_ALL,
+                            'user-settings-repos__text-light': true,
                             'user-settings-repos__text-disabled': !ALLOW_SYNC_ALL,
                         })}
                     >

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -547,7 +547,6 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                 <div className="d-flex flex-column ml-2">
                     <p
                         className={classNames('mb-0', {
-                            'user-settings-repos__text': ALLOW_SYNC_ALL,
                             'user-settings-repos__text-disabled': !ALLOW_SYNC_ALL,
                         })}
                     >
@@ -555,7 +554,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                     </p>
                     <p
                         className={classNames({
-                            'user-settings-repos__text': ALLOW_SYNC_ALL,
+                            'user-settings-repos__text-light': true,
                             'user-settings-repos__text-disabled': !ALLOW_SYNC_ALL,
                         })}
                     >

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
@@ -60,6 +60,10 @@
         max-width: 30% !important;
     }
 
+    &__text-light {
+        font-weight: 400;
+    }
+
     &__text-disabled {
         color: var(--text-disabled);
     }


### PR DESCRIPTION
###  Description

Set a lighter font-weight for the 'Sync all' note.

### Screenshot

<img width="1543" alt="Screen Shot 2021-08-17 at 3 17 03 AM" src="https://user-images.githubusercontent.com/1319181/129681177-96a00322-f2cd-4e1f-8cc9-a99059e34319.png">

