### PR TITLE
web: import `@reach/ui` global styles once

### DIFF
--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -129,6 +129,9 @@ $badge-transition: none; // Avoids setting transitions on badges that aren't lin
 @import 'bootstrap/scss/custom-forms';
 @import 'bootstrap/scss/input-group';
 
+// Global styles provided by @reach packages. Should be imported once in the global scope.
+@import '@reach/tabs/styles';
+
 @import 'wildcard/src/global-styles/breakpoints';
 @import 'shared/src/global-styles/icons';
 @import './background';

--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -1,7 +1,4 @@
-@import '@reach/tabs/styles';
-
 // Override tabs component styles (see: https://reach.tech/styling/#including-base-styles)
-
 [data-reach-tab-list] {
     background: transparent;
 }

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -71,6 +71,12 @@ body,
     min-width: 0;
 }
 
+// Global styles provided by @reach packages. Should be imported once in the global scope.
+@import '@reach/dialog/styles.css';
+@import '@reach/combobox/styles.css';
+@import '@reach/menu-button/styles.css';
+@import '@reach/listbox/styles.css';
+
 // Pages
 @import './Layout';
 @import './api/ApiConsole';

--- a/client/web/src/components/Dialog.scss
+++ b/client/web/src/components/Dialog.scss
@@ -1,5 +1,3 @@
-@import '~@reach/dialog/styles.css';
-
 [data-reach-dialog-overlay] {
     background-color: rgba($gray-04, 0.5);
 }

--- a/client/web/src/insights/components/form/repositories-field/RepositoriesField.module.scss
+++ b/client/web/src/insights/components/form/repositories-field/RepositoriesField.module.scss
@@ -1,5 +1,3 @@
-@import '@reach/combobox/styles.css';
-
 .combobox {
     width: 100%;
 

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
@@ -1,5 +1,3 @@
-@import '~@reach/menu-button/styles.css';
-
 .panel[data-reach-menu-items] {
     font-size: inherit;
     overflow: hidden;

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
@@ -3,13 +3,11 @@
     overflow: hidden;
     padding: 0.25rem 0;
 
-    // Explicit override @reach ui border styles
-    border: 1px solid var(--dropdown-border-color);
-    background-color: var(--dropdown-bg);
-
     // class .dropdown-menu brings position absolute and breaks
     // Menu positioning in portal because of it we reset position
     position: static;
+    // The .dropdown-menu is hidden by default
+    display: block;
 }
 
 .button {

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
@@ -29,6 +29,7 @@
 }
 
 .item[data-reach-menu-item] {
+    display: block;
     padding: 0.25rem 0.75rem;
     text-align: right;
     width: 100%;

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
@@ -6,18 +6,18 @@
     font-size: inherit;
     overflow: hidden;
     padding: 0.25rem 0;
-    background-color: var(--dropdown-bg);
-
-    // Explicit override @reach ui border styles
-    border: 1px solid var(--dropdown-border-color);
 
     // The .dropdown-menu class adds absolute position to the element
     // that makes parent of this element wrong width/height settled
     // Therefore this breaks popover position of reach-ui popover
     position: static;
+    // The .dropdown-menu is hidden by default
+    display: block;
 }
 
 .menu-item[data-reach-menu-item] {
+    // Override default Bootstrap button style
+    display: block;
     padding: 0.25rem 0.75rem;
     text-align: right;
     width: 100%;

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
@@ -1,5 +1,3 @@
-@import '~@reach/menu-button/styles.css';
-
 .trigger-button {
     padding: 0.25rem;
 }

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.module.scss
@@ -1,5 +1,3 @@
-@import '~@reach/listbox/styles.css';
-
 .list {
     display: block;
     position: static;

--- a/client/web/src/nav/VersionContextDropdown.scss
+++ b/client/web/src/nav/VersionContextDropdown.scss
@@ -1,4 +1,3 @@
-@import '~@reach/listbox/styles.css';
 @import 'wildcard/src/global-styles/breakpoints';
 
 .version-context-dropdown {

--- a/client/wildcard/src/components/Tabs/Tabs.module.scss
+++ b/client/wildcard/src/components/Tabs/Tabs.module.scss
@@ -1,5 +1,3 @@
-@import '@reach/tabs/styles';
-
 .wildcard-tabs {
     --small-size-font: 0.875rem;
     --medium-size-font: 0.75rem;


### PR DESCRIPTION
## Context 

Importing the same set of global styles into different CSS modules results in styles duplication. SCSS loader cannot reuse `@import` statements between files because of the mutable nature of SCSS — order of evaluation matters, so every `@import` statement is evaluated independently. 

### Example 

```scss
// DashboardMenu.module.scss
@import '~@reach/menu-button/styles.css';

// CardMenu.module.scss
@import '~@reach/menu-button/styles.css';
```

`menu-button/styles.css` will be included in the CSS bundle twice. The last occurrence will have a higher priority in applying CSS rules because of the order, which might cause bugs. 

Such an issue was spotted in `VersionContextDropdown` styles. Some `@reach` styles were redefined in `VersionContextDropdown.scss`. Later the same `@reach/ui` styles were imported in the CSS module, which overwrote the changes in `VersionContextDropdown.scss`.

### Solution

Import global third-party styles only in global styles entry points like:

1. `client/branded/src/global-styles/index.scss`
2. `client/web/src/SourcegraphWebApp.scss`

## Screenshots

### Before

<img width="1087" alt="Screenshot 2021-08-17 at 10 25 25" src="https://user-images.githubusercontent.com/3846380/129683523-9dae8449-52c3-4509-9b5a-1b24dae1c3e3.png">

### After 

<img width="1088" alt="Screenshot 2021-08-17 at 10 25 52" src="https://user-images.githubusercontent.com/3846380/129683554-6ef44602-f671-4baf-bfdc-e8d19cc7ad94.png">
