### PR TITLE
bump redis cache sha

### DIFF
--- a/docker-images/redis-cache/build.sh
+++ b/docker-images/redis-cache/build.sh
@@ -7,5 +7,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/redis-cache:21-08-13_c096e0d35@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c
-docker tag index.docker.io/sourcegraph/redis-cache:21-08-13_c096e0d35a@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c "$IMAGE"
+docker pull index.docker.io/sourcegraph/redis-cache:21-08-13_c096e0d35@sha256:2e41070dbe579686ce421e556dd648f8d5a489505b9842262ba5a8b8a35fbd6c
+docker tag index.docker.io/sourcegraph/redis-cache:21-08-13_c096e0d35a@sha256:2e41070dbe579686ce421e556dd648f8d5a489505b9842262ba5a8b8a35fbd6c "$IMAGE"


### PR DESCRIPTION
remediates https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159