### PR TITLE
search is dotcom: final polish items

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -250,8 +250,6 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                                 <Link
                                     className="global-navbar__link"
                                     to="https://about.sourcegraph.com"
-                                    rel="noreferrer noopener"
-                                    target="_blank"
                                 >
                                     About Sourcegraph
                                 </Link>

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -247,10 +247,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                     {!props.authenticatedUser && (
                         <>
                             <NavAction>
-                                <Link
-                                    className="global-navbar__link"
-                                    to="https://about.sourcegraph.com"
-                                >
+                                <Link className="global-navbar__link" to="https://about.sourcegraph.com">
                                     About Sourcegraph
                                 </Link>
                             </NavAction>

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -123,8 +123,6 @@ exports[`GlobalNavbar default 1`] = `
       >
         <a
           class="global-navbar__link"
-          rel="noreferrer noopener"
-          target="_blank"
           to="https://about.sourcegraph.com"
         >
           About Sourcegraph
@@ -302,8 +300,6 @@ exports[`GlobalNavbar low-profile 1`] = `
       >
         <a
           class="global-navbar__link"
-          rel="noreferrer noopener"
-          target="_blank"
           to="https://about.sourcegraph.com"
         >
           About Sourcegraph
@@ -481,8 +477,6 @@ exports[`GlobalNavbar no-search-input 1`] = `
       >
         <a
           class="global-navbar__link"
-          rel="noreferrer noopener"
-          target="_blank"
           to="https://about.sourcegraph.com"
         >
           About Sourcegraph

--- a/client/web/src/search/home/CustomersSection.module.scss
+++ b/client/web/src/search/home/CustomersSection.module.scss
@@ -1,3 +1,8 @@
+.text {
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 1rem;
+}
+
 .logos {
     display: flex;
     justify-content: center;

--- a/client/web/src/search/home/CustomersSection.tsx
+++ b/client/web/src/search/home/CustomersSection.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useMemo } from 'react'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -21,7 +22,7 @@ export const CustomersSection: React.FunctionComponent<ThemeProps> = props => {
 
     return (
         <>
-            <div className="text-muted text-center mb-3">
+            <div className={classNames('text-muted text-center mb-3', styles.text)}>
                 Our customers use Sourcegraph every day to build software you rely on.{' '}
             </div>
             <a className={styles.logos} href="https://about.sourcegraph.com/customers">

--- a/client/web/src/search/home/HeroSection.module.scss
+++ b/client/web/src/search/home/HeroSection.module.scss
@@ -6,6 +6,7 @@
     padding: 1.5rem;
     display: flex;
     gap: 3rem;
+    font-family: 'Source Sans Pro', sans-serif;
 
     @media (--sm-breakpoint-down) {
         flex-direction: column;

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -98,9 +98,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
     return (
         <div className="search-page d-flex flex-column align-items-center px-3">
             <BrandLogo className="search-page__logo" isLightTheme={props.isLightTheme} variant="logo" />
-            {props.isSourcegraphDotCom && (
-                <div className="text-muted text-center mt-3">Search your code and 1M+ open source repositories</div>
-            )}
+            {props.isSourcegraphDotCom && <div className="text-muted text-center mt-3">Search public code</div>}
             <div
                 className={classNames('search-page__search-container', {
                     'search-page__search-container--with-content-below':

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -98,7 +98,9 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
     return (
         <div className="search-page d-flex flex-column align-items-center px-3">
             <BrandLogo className="search-page__logo" isLightTheme={props.isLightTheme} variant="logo" />
-            {props.isSourcegraphDotCom && <div className="text-muted text-center mt-3">Search public code</div>}
+            {props.isSourcegraphDotCom && (
+                <div className="text-muted text-center font-italic mt-3">Search public code</div>
+            )}
             <div
                 className={classNames('search-page__search-container', {
                     'search-page__search-container--with-content-below':

--- a/client/web/src/search/home/SelfHostInstructions.tsx
+++ b/client/web/src/search/home/SelfHostInstructions.tsx
@@ -47,7 +47,11 @@ export const SelfHostInstructions: React.FunctionComponent<TelemetryProps> = ({ 
                     <li>Your code never leaves your server</li>
                     <li>Free 30 day trial of enterprise-only features</li>
                 </ul>
-                <a href="https://docs.sourcegraph.com/self-hosted-vs-cloud" target="_blank" rel="noopener noreferrer">
+                <a
+                    href="https://docs.sourcegraph.com/cloud/cloud_ent_on-prem_comparison"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     Learn more about self-hosted vs. cloud features{' '}
                     <OpenInNewIcon aria-label="Open in new window" className="icon-inline" />
                 </a>
@@ -55,10 +59,7 @@ export const SelfHostInstructions: React.FunctionComponent<TelemetryProps> = ({ 
 
             <div className={styles.column}>
                 <div>
-                    <strong>Quickstart:</strong> launch Sourcegraph at{' '}
-                    <a href="http://localhost:3370" target="_blank" rel="noopener noreferrer">
-                        http://localhost:3370
-                    </a>
+                    <strong>Quickstart:</strong> launch Sourcegraph at http://localhost:3370
                 </div>
                 <div className={styles.codeWrapper}>
                     <button


### PR DESCRIPTION
Final fixes for #23723

- [x] Revert subtitle under logo back to “Search public code” (final subtitle will go live [with CTAs](https://github.com/sourcegraph/sourcegraph/pull/24027) instead)
- [x] Make subtitle text style italic
- [x] About link in nav bar should not open a new window
- [x] Remove link to localhost in self-host section (should be plain text)
- [x] Update link to docs in self-host section to final location
- [x] Add Source Sans Pro font to hero and customers sections


![image](https://user-images.githubusercontent.com/206864/129803121-2b460181-1017-4f57-9ecf-f77fa9de691d.png)
