### PR TITLE
executors: Build AWS AMI in addition to google compute image

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,3 +5,4 @@ shfmt 3.2.0
 shellcheck 0.7.1
 kubectl 1.17.3
 github-cli 1.8.0
+packer 1.6.6

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -36,6 +36,8 @@ steps:
       - 'VERSION=$(git log -n1 --pretty=format:%h)'
       - 'BUILD_TIMESTAMP=$BUILD_TIMESTAMP'
       - 'SRC_CLI_VERSION=$SRC_CLI_VERSION'
+      - 'AWS_EXECUTOR_AMI_ACCESS_KEY=$AWS_EXECUTOR_AMI_ACCESS_KEY'
+      - 'AWS_EXECUTOR_AMI_SECRET_KEY=$AWS_EXECUTOR_AMI_SECRET_KEY'
     args: ['build', 'executor.json']
 EOF
 

--- a/enterprise/cmd/executor/cloudbuild/build.sh
+++ b/enterprise/cmd/executor/cloudbuild/build.sh
@@ -13,6 +13,35 @@ function install_ops_agent() {
   sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 }
 
+## Install CloudWatch agent
+## Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html
+function install_cloudwatch_agent() {
+  wget -q https://s3.us-west-2.amazonaws.com/amazoncloudwatch-agent-us-west-2/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+  dpkg -i -E ./amazon-cloudwatch-agent.deb
+  rm ./amazon-cloudwatch-agent.deb
+
+  CLOUDWATCH_CONFIG_FILE_PATH=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+  cat <<EOF >"${CLOUDWATCH_CONFIG_FILE_PATH}"
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/syslog",
+            "log_group_name": "executors",
+            "timezone": "UTC"
+          }
+        ]
+      }
+    },
+    "log_stream_name": "{instance_id}-syslog"
+  }
+}
+EOF
+  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:"${CLOUDWATCH_CONFIG_FILE_PATH}"
+}
+
 ## Install Docker
 function install_docker() {
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
@@ -126,7 +155,11 @@ function cleanup() {
 }
 
 # Prerequisites
-install_ops_agent
+if [ "${PLATFORM_TYPE}" == "gcp" ]; then
+  install_ops_agent
+else
+  install_cloudwatch_agent
+fi
 install_docker
 install_git
 install_ignite

--- a/enterprise/cmd/executor/cloudbuild/executor.json
+++ b/enterprise/cmd/executor/cloudbuild/executor.json
@@ -6,6 +6,7 @@
   },
   "builders": [
     {
+      "name": "gcp",
       "type": "googlecompute",
       "project_id": "sourcegraph-ci",
       "source_image_project_id": "ubuntu-os-cloud",
@@ -16,16 +17,22 @@
       "image_licenses": ["projects/vm-options/global/licenses/enable-vmx"],
       "disk_type": "pd-ssd",
       "image_name": "executor-{{user `version`}}-{{user `build_timestamp`}}",
-      "tags": ["packer"],
-      "account_file": "/workspace/builder-sa-key.json"
+      "tags": ["packer"]
+    },
+    {
+      "name": "aws",
+      "type": "amazon-ebs",
+      "ami_name": "executor-{{user `version`}}-{{user `build_timestamp`}}",
+      "ssh_username": "ubuntu",
+      "instance_type": "t3.micro",
+      "source_ami": "ami-02868af3c3df4b3aa",
+      "region": "us-west-2",
+      "vpc_id": "vpc-0cdd19a3c7d821029",
+      "subnet_id": "subnet-0d25cdd0f10558e3b",
+      "associate_public_ip_address": true
     }
   ],
   "provisioners": [
-    {
-      "type": "file",
-      "sources": ["/workspace/builder-sa-key.json"],
-      "destination": "/tmp/"
-    },
     {
       "type": "file",
       "sources": ["executor"],
@@ -40,7 +47,14 @@
       "type": "shell",
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}",
       "script": "build.sh",
-      "environment_vars": ["SRC_CLI_VERSION={{user `SRC_CLI_VERSION`}}"]
+      "override": {
+        "gcp": {
+          "environment_vars": ["SRC_CLI_VERSION={{user `SRC_CLI_VERSION`}}", "PLATFORM_TYPE=gcp"]
+        },
+        "aws": {
+          "environment_vars": ["SRC_CLI_VERSION={{user `SRC_CLI_VERSION`}}", "PLATFORM_TYPE=aws"]
+        }
+      }
     }
   ]
 }

--- a/enterprise/cmd/executor/cloudbuild/executor.json
+++ b/enterprise/cmd/executor/cloudbuild/executor.json
@@ -1,6 +1,8 @@
 {
   "variables": {
     "version": "{{env `VERSION`}}",
+    "awsAccessKey": "{{env `AWS_EXECUTOR_AMI_ACCESS_KEY`}}",
+    "awsSecretKey": "{{env `AWS_EXECUTOR_AMI_SECRET_KEY`}}",
     "build_timestamp": "{{env `BUILD_TIMESTAMP`}}",
     "SRC_CLI_VERSION": "{{env `SRC_CLI_VERSION`}}"
   },
@@ -27,9 +29,11 @@
       "instance_type": "t3.micro",
       "source_ami": "ami-02868af3c3df4b3aa",
       "region": "us-west-2",
-      "vpc_id": "vpc-0cdd19a3c7d821029",
-      "subnet_id": "subnet-0d25cdd0f10558e3b",
-      "associate_public_ip_address": true
+      "vpc_id": "vpc-095ba109c7ca96d76",
+      "subnet_id": "subnet-03962956ca2682c50",
+      "associate_public_ip_address": true,
+      "access_key": "{{user `awsAccessKey`}}",
+      "secret_key": "{{user `awsSecretKey`}}"
     }
   ],
   "provisioners": [

--- a/enterprise/cmd/executor/cloudbuild/executor.json
+++ b/enterprise/cmd/executor/cloudbuild/executor.json
@@ -19,7 +19,8 @@
       "image_licenses": ["projects/vm-options/global/licenses/enable-vmx"],
       "disk_type": "pd-ssd",
       "image_name": "executor-{{user `version`}}-{{user `build_timestamp`}}",
-      "tags": ["packer"]
+      "tags": ["packer"],
+      "account_file": "/workspace/builder-sa-key.json"
     },
     {
       "name": "aws",
@@ -37,6 +38,11 @@
     }
   ],
   "provisioners": [
+    {
+      "type": "file",
+      "sources": ["/workspace/builder-sa-key.json"],
+      "destination": "/tmp/"
+    },
     {
       "type": "file",
       "sources": ["executor"],


### PR DESCRIPTION
Luckily importing the weave kernel image doesn't seem to require hitting firecracker, so we can run this on a cheap t3.micro instance.

