### PR TITLE
batches: recalculate actions on modifying publication states

### DIFF
--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -86,7 +86,7 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
                     {batchChange ? (
                         <>
                             This operation will update the existing batch change{' '}
-                            <Link to={batchChange.url}>{batchChange.name}</Link>
+                            <Link to={batchChange.url}>{batchChange.name}</Link>.
                         </>
                     ) : (
                         'Review the proposed changesets below.'

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -59,7 +59,7 @@ export const PreviewList: React.FunctionComponent<Props> = ({
     const { selected, areAllVisibleSelected, isSelected, toggleSingle, toggleVisible, setVisible } = useContext(
         MultiSelectContext
     )
-    const { filters } = useContext(BatchChangePreviewContext)
+    const { filters, publicationStates } = useContext(BatchChangePreviewContext)
 
     const [queryArguments, setQueryArguments] = useState<BatchSpecApplyPreviewVariables>()
 
@@ -72,6 +72,7 @@ export const PreviewList: React.FunctionComponent<Props> = ({
                 search: filters.search,
                 currentState: filters.currentState,
                 action: filters.action,
+                publicationStates,
             }
             return queryChangesetApplyPreview(passedArguments).pipe(
                 tap(data => {
@@ -87,7 +88,15 @@ export const PreviewList: React.FunctionComponent<Props> = ({
                 })
             )
         },
-        [batchSpecID, filters.search, filters.currentState, filters.action, queryChangesetApplyPreview, setVisible]
+        [
+            batchSpecID,
+            filters.search,
+            filters.currentState,
+            filters.action,
+            queryChangesetApplyPreview,
+            setVisible,
+            publicationStates,
+        ]
     )
 
     const showSelectRow = selected === 'all' || selected.size > 0

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -67,7 +67,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
     queryPublishableChangesetSpecIDs = _queryPublishableChangesetSpecIDs,
     queryArguments,
 }) => {
-    const { setPublicationStates } = useContext(BatchChangePreviewContext)
+    const { updatePublicationStates } = useContext(BatchChangePreviewContext)
     const { areAllVisibleSelected, deselectAll, selected, selectAll } = useContext(MultiSelectContext)
 
     const allChangesetSpecIDs: string[] | undefined = useObservable(
@@ -83,8 +83,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
                 const dropdownAction: Action = {
                     ...action,
                     onTrigger: onDone => {
-                        // TODO: Recalculate actions with applyPreview
-                        setPublicationStates(
+                        updatePublicationStates(
                             [...selected].map(changeSpecID => ({
                                 changesetSpec: changeSpecID,
                                 publicationState: getPublicationStateFromAction(action),
@@ -97,7 +96,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
 
                 return dropdownAction
             }),
-        [deselectAll, selected, setPublicationStates]
+        [deselectAll, selected, updatePublicationStates]
     )
 
     return (

--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -226,6 +226,7 @@ export const queryChangesetApplyPreview = ({
     search,
     currentState,
     action,
+    publicationStates,
 }: BatchSpecApplyPreviewVariables): Observable<BatchSpecApplyPreviewConnectionFields> =>
     requestGraphQL<BatchSpecApplyPreviewResult, BatchSpecApplyPreviewVariables>(
         gql`
@@ -236,6 +237,7 @@ export const queryChangesetApplyPreview = ({
                 $search: String
                 $currentState: ChangesetState
                 $action: ChangesetSpecOperation
+                $publicationStates: [ChangesetSpecPublicationStateInput!]
             ) {
                 node(id: $batchSpec) {
                     __typename
@@ -246,6 +248,7 @@ export const queryChangesetApplyPreview = ({
                             search: $search
                             currentState: $currentState
                             action: $action
+                            publicationStates: $publicationStates
                         ) {
                             ...BatchSpecApplyPreviewConnectionFields
                         }
@@ -255,7 +258,7 @@ export const queryChangesetApplyPreview = ({
 
             ${batchSpecApplyPreviewConnectionFieldsFragment}
         `,
-        { batchSpec, first, after, search, currentState, action }
+        { batchSpec, first, after, search, currentState, action, publicationStates }
     ).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {


### PR DESCRIPTION
Closes #23383.

This PR includes:

- recalculating the actions on the backend when a publish status modification is selected
- a small fix to #24020

Changelog entry will be included in the docs tickets.

Unfortunately, the UX for this recalculation is less-than-ideal, as it reloads the entire connection when a new publication state is applied because observables are hard. ☹️ But after spending most of the afternoon on it, I think this is best-effort for a first pass and something we certainly will have the resources to come back and improve later.

https://user-images.githubusercontent.com/8942601/129820446-97d5fe99-2ac2-4c6c-8770-020e34858c50.mov

We don't really have a pattern for changing the query parameters on the connection from *outside* of the `FilteredConnection` itself. By placing `publicationStates` in the dependencies array for the query callback, I'm effectively unsubscribing and resubscribing to a new observable whenever they change, which causes the loading fallback screen with the "list reloading" effect as opposed to keeping the observable and re-emitting with the new connection data.

Ideally, we just switch this component over to `useConnection` that allows us to tap into Apollo's cache, because background refetching is exactly what Apollo caching is good at. However, I started going down this path and found that the effort needed to migrate was pretty heavily snowballing, so I decided to abandon that effort for now.

I tried a couple other things to mitigate this and restore the background-refetching behavior, including a hacky suggestion from Erik to "poll" with `repeatWhen` by notifying when there's a change to `publicationStates`, but nothing quite worked out.

In any case, this approach is at least functional, if not pretty, and migrating to `useConnection` + the new way of building a `FilteredConnection` will almost certainly resolve this issue for us. I've filed #24059 to remember this.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
