### PR TITLE
Remove 500 repos warning

### DIFF
--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -67,7 +67,7 @@ interface CreationSearchInsightFormProps {
 /**
  * Displays creation code insight form (title, visibility, series, etc.)
  * UI layer only, all controlled data should be managed by consumer of this component.
- * */
+ */
 export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchInsightFormProps> = props => {
     const {
         mode,
@@ -141,18 +141,13 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                             <span className="pl-2">Run your insight over all your repositories</span>
 
                             <small className="w-100 mt-2 text-muted">
-                                {!allReposMode.input.value ? (
-                                    <>This feature is actively in development. </>
-                                ) : (
-                                    <>This feature is actively in development. </>
-                                )}
-                                Read about the{' '}
+                                This feature is actively in development. Read about the{' '}
                                 <a
                                     href="https://docs.sourcegraph.com/code_insights/explanations/current_limitations_of_code_insights"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >
-                                    beta limitations here. 
+                                    beta limitations here.
                                 </a>
                             </small>
                         </label>

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -142,28 +142,17 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
 
                             <small className="w-100 mt-2 text-muted">
                                 {!allReposMode.input.value ? (
-                                    <>
-                                        We currently recommend not exceeding more than ~500 repositories per insight.
-                                        You can filter down from "all repositories" using a{' '}
-                                        <a
-                                            href="https://docs.sourcegraph.com/code_search/reference/queries#repository-search"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            repo: filter
-                                        </a>{' '}
-                                        in your search queries below.
-                                    </>
+                                    <>This feature is actively in development. </>
                                 ) : (
-                                    <>We strongly recommend not to exceed 500 repositories per insight.</>
+                                    <>This feature is actively in development. </>
                                 )}
-                                Read more about the{' '}
+                                Read about the{' '}
                                 <a
                                     href="https://docs.sourcegraph.com/code_insights/explanations/current_limitations_of_code_insights"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >
-                                    beta limitations
+                                    beta limitations here. 
                                 </a>
                             </small>
                         </label>


### PR DESCRIPTION
We actually don't seem to yet support repo: filters in queries so we shouldn't tell you to do this! I left the conditional logic in just because I wasn't sure why we had it/if there's a good reason to show different messages here. 

(Also, the original was missing a trailing space, in screenshot – do I need to have that explicitly or did the space I added between `. </>` take care of it?) 
![image](https://user-images.githubusercontent.com/11967660/129828577-61cea9bf-9ff4-4c39-a56b-0264d4d15f9c.png)
