### PR TITLE
doc: minor tidy up of admin homepage

### DIFF
--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -1,30 +1,45 @@
 # Administration
 
-Site administrators are the admins responsible for deploying, managing, and configuring Sourcegraph for regular users. They have [special privileges](privileges.md) on the Sourcegraph instance.
+<p class="lead">
+Adminstration guides and documentationfor <a href="install/index.md">self-hosted Sourcegraph instances</a>.
+</p>
+
+Adminstration is usually handled by site administrators are the admins responsible for deploying, managing, and configuring Sourcegraph for regular users. They have [special privileges](privileges.md) on a Sourcegraph instance.
 
 ## [Install Sourcegraph](install/index.md)
 
-## Management, deployment, and configuration
 - [Best Practices](deployment_best_practices.md)
-- [Configuration](config/index.md)
-- [Adding Git repositories](repo/add.md) (from a code host or clone URL)
-- [HTTP and HTTPS/SSL configuration](http_https_configuration.md)
-  - [Adding SSL (HTTPS) to Sourcegraph with a self-signed certificate](ssl_https_self_signed_cert_nginx.md)
-- [Monorepo](monorepo.md)
-- [Repository webhooks](repo/webhooks.md)
-- [User authentication](auth/index.md)
 - [Deploying workers](workers.md)
-- [Upgrading Sourcegraph](updates/index.md)
-- [Migrations](migration/index.md)
-- [Setting the URL for your instance](url.md)
-- [Observability](observability.md)
-- [Repository permissions](repo/permissions.md)
-  - [Row-level security](repo/row_level_security.md)
 - [PostgreSQL configuration](config/postgres-conf.md)
 - [Upgrading PostgreSQL](postgres.md)
 - [Using external services (PostgreSQL, Redis, S3/GCS)](external_services/index.md)
-- [User data deletion](user_data_deletion.md)
 - <span class="badge badge-experimental">Experimental</span> [Validation](validation.md)
+
+## [Upgrade Sourcegraph](updates/index.md)
+
+- [Migrations](migration/index.md)
+
+## [Configuration](config/index.md)
+
+- [Integrations](../integration/index.md)
+- [Adding Git repositories](repo/add.md) (from a code host or clone URL)
+  - [Monorepo](monorepo.md)
+  - [Repository webhooks](repo/webhooks.md)
+- [HTTP and HTTPS/SSL configuration](http_https_configuration.md)
+  - [Adding SSL (HTTPS) to Sourcegraph with a self-signed certificate](ssl_https_self_signed_cert_nginx.md)
+- [User authentication](auth/index.md)
+  - [User data deletion](user_data_deletion.md)
+- [Setting the URL for your instance](url.md)
+- [Repository permissions](repo/permissions.md)
+  - [Row-level security](repo/row_level_security.md)
+  
+For deployment configuration, please refer to the relevant [installation guide](./install/index.md).
+
+## [Observability](observability.md)
+
+- [Monitoring guide](how-to/monitoring-guide.md)
+- [Metrics and dashboards](./observability/metrics.md)
+- [Alerting](./observability/alerting.md)
 
 ## Features
 
@@ -37,9 +52,3 @@ Site administrators are the admins responsible for deploying, managing, and conf
 - [User feedback surveys](user_surveys.md)
 - [Beta and prototype features](beta_and_prototype_features.md)
 - [Pricing and subscriptions](subscriptions/index.md)
-
-## [Integrations](../integration/index.md)
-
-## [Migration guides](migration/index.md)
-
-## [How-to guides](how-to/index.md)

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -1,7 +1,7 @@
 # Administration
 
 <p class="lead">
-Adminstration guides and documentationfor <a href="install/index.md">self-hosted Sourcegraph instances</a>.
+Adminstration guides and documentationfor <a href="install">self-hosted Sourcegraph instances</a>.
 </p>
 
 Adminstration is usually handled by site administrators are the admins responsible for deploying, managing, and configuring Sourcegraph for regular users. They have [special privileges](privileges.md) on a Sourcegraph instance.

--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -18,6 +18,8 @@ Learn more about metrics, dashboards, and alert labels in our [metrics guide](me
 
 ## Setting up alerting
 
+<span class="badge badge-note">Sourcegraph 3.17+</span>
+
 Visit your site configuration (e.g. `https://sourcegraph.example.com/site-admin/configuration`) to configure alerts using the [`observability.alerts`](../config/site_config.md#observability-alerts) field. As always, you can use `Ctrl+Space` at any time to get hints about allowed fields as well as relevant documentation inside the configuration editor.
 
 Once configured, Sourcegraph alerts will automatically be routed to the appropriate notification channels by severity level.
@@ -133,6 +135,8 @@ Note that to receive email notifications, the [`email.address`](../config/site_c
 
 ### Testing alerts
 
+<span class="badge badge-note">Sourcegraph 3.19+</span>
+
 Configured alerts can be tested using the Sourcegraph GraphQL API. Visit your API Console (e.g. `https://sourcegraph.example.com/api/console`) and use the following mutation to trigger an alert:
 
 ```gql
@@ -147,6 +151,8 @@ The test alert may take up to a minute to fire. The triggered alert will automat
 
 ### Silencing alerts
 
+<span class="badge badge-note">Sourcegraph 3.18+</span>
+
 If there is an alert you are aware of and you wish to silence notifications (from the notification channels you have set up) for it, add an entry to the [`observability.silenceAlerts`](../config/site_config.md#observability-silenceAlerts)field. For example:
 
 ```json
@@ -160,55 +166,3 @@ If there is an alert you are aware of and you wish to silence notifications (fro
 You can find the appropriate identifier for each alert in [alert solutions](./alert_solutions.md).
 
 > NOTE: You can still see the alerts on your [Grafana dashboard](./metrics.md#grafana).
-
-## Setting up alerting: before Sourcegraph 3.17
-
-### Configure alert channels in Grafana
-
-Before configuring specific alerts in Grafana, you must set up alert channels. Each channel
-corresponds to an external service to which Grafana will push alerts.
-
-1. Access Grafana directly as a Grafana admin:
-  1. Follow [these instructions](metrics.md#accessing-grafana-directly) to access Grafana directly (instead of going through the Sourcegraph Site Admin Monitoring page as usual).
-  1. Navigate to the Grafana `/login` URL (e.g., `http://localhost:3070/-/debug/grafana/login` or append `/login` to your Grafana direct access URL if different). If you are doing this for the first time, user the username and password `admin` and `admin`.
-1. In the left sidebar, click the bell icon 🔔 and select `Notification channels`.
-1. Click `New channel` and then specify the settings of your channel. The `Type` field selects the type of external service (e.g., PagerDuty, Slack, Email). Some service types will require additional configuration in the service itself. Here are some examples:
-  1. Slack
-     1. Go to `https://api.slack.com/apps` to create a new Slack App.
-     1. Click `Create an App`, give the app a name, and click `Create App`.
-     1. Click `Incoming Webhooks` and toggle on `Activate Incoming Webhooks`.
-     1. Click `Add New Webhook to Workspace`.
-     1. Pick the channel to which this Slack App will post.
-     1. Back on the Grafana New Notification Channel page, copy the webhook URL to the `Url` field.
-  1. PagerDuty
-     1. Go to `https://app.pagerduty.com/developer/apps`.
-     1. Click `Create New App`. Give the app a name and decription, and set the category to
-        "Application Performance Management". For "Would you like to publish the app for all
-        PagerDuty users?", select "No". Click `Save`.
-     1. On the Configure App page, under Functionality > Events Integration, click `Add`.
-     1. On the Event Integration page, under Events Integration Test > Create a Test Service, enter a name and click `Create`.
-     1. Copy the Integration Key. Click `Save` and then `Save` again on the Configure App page.
-     1. Back in the Grafana New Notification Channel page, paste the Integration Key into the `Integration Key` field.
-1. After you have specified the settings on the Grafana New Notification Channel page, click `Send Test` to send a test notification. You should receive a notification from Grafana via your specified channel. If this worked, click `Save`.
-
-> NOTE: Alerts have a link back to the relevant Grafana panel. In order for these links to work properly Grafana needs
-> to know under which external URL it is running (note: this is usually different from the direct access URL you used
-> earlier). Set the environment variable `GF_SERVER_ROOT_URL` to your Sourcegraph instance external URL followed
-> by the path `/-/debug/grafana`.
-
-### Set up an individual alert
-
-After adding the appropriate notification channels, configure individual alerts to notify those channels.
-
-1. Navigate to the dashboard with the panel and metric for which you'd like to configure an
-   alert.
-   1. Make sure the dashboard is not read-only (the default Sourcegraph-provided dashboards are
-      read-only, because they are provisioned from disk). If the dashboard is read-only, go to the
-      dashboard settings (the gear icon in the upper right) and click `Save As..` to create a
-      writeable copy.
-1. The panel title has a small dropdown next to it. Click the dropdown icon and select `Edit`.
-1. In the left sidebar, choose the bell icon 🔔 for Alert.
-1. Fill out the fields for the alert rule and select a notification channel.
-1. Verify your rule by clicking `Test Rule` or viewing `State History`.
-1. Return to the dashboard page by clicking the left arrow in the upper left. Save the dashboard by
-   clicking the save icon in the upper right.


### PR DESCRIPTION
In case anyone lands on it as part of the upcoming launch :) Long-term still hoping to not have these manual index pages, but this'll do for now

Also removes legacy grafana-based alerting guide

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
