### PR TITLE
batches: update docs for publish from preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights will do a one-time reset of ephemeral insights specific database tables to clean up stale and invalid data. Insight data will regenerate automatically. [23791](https://github.com/sourcegraph/sourcegraph/pull/23791)
 - Perforce: added basic support for Perforce permission table path wildcards. [#23755](https://github.com/sourcegraph/sourcegraph/pull/23755)
 - Added autocompletion and search filtering of branch/tag/commit revisions to the repository compare page. [#23977](https://github.com/sourcegraph/sourcegraph/pull/23977)
-- Batch Changes changesets can now be [published from the Sourcegraph preview UI](https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#within-the-ui). [#22912](https://github.com/sourcegraph/sourcegraph/issues/22912)
+- Batch Changes changesets can now be [set to published when previewing new or updated batch changes](https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#within-the-ui). [#22912](https://github.com/sourcegraph/sourcegraph/issues/22912)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights will do a one-time reset of ephemeral insights specific database tables to clean up stale and invalid data. Insight data will regenerate automatically. [23791](https://github.com/sourcegraph/sourcegraph/pull/23791)
 - Perforce: added basic support for Perforce permission table path wildcards. [#23755](https://github.com/sourcegraph/sourcegraph/pull/23755)
 - Added autocompletion and search filtering of branch/tag/commit revisions to the repository compare page. [#23977](https://github.com/sourcegraph/sourcegraph/pull/23977)
+- Batch Changes changesets can now be [published from the Sourcegraph preview UI](https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#within-the-ui). [#22912](https://github.com/sourcegraph/sourcegraph/issues/22912)
 
 ### Changed
 

--- a/doc/batch_changes/how-tos/creating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/creating_a_batch_change.md
@@ -56,7 +56,7 @@ After writing a batch spec you use the [Sourcegraph CLI (`src`)](https://github.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_link.png" class="screenshot">
 1. Examine the preview. This is the result of executing the batch spec. Confirm that the changes are what you intended. If not, edit the batch spec and then rerun the command above.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_preview.png" class="screenshot">
-1. Click the **Apply spec** button to create the batch change.
+1. Click the **Apply** button to create the batch change.
 
 After you've applied a batch spec, you can [publish changesets](publishing_changesets.md) to the code host when you're ready. This will turn the patches into commits, branches, and changesets (such as GitHub pull requests) for others to review and merge.
 

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -187,6 +187,8 @@ For any changesets that are currently unpublished or only published as drafts, y
 
 <img src="https://sourcegraphstatic.com/docs/images/batch_changes/publish_ui_browser_select_action_on_apply.png" class="screenshot">
 
+> NOTE: Certain types of changeset cannot be published from the UI and will have their checkbox disabled. Not sure why your changeset is disabled? Check the [FAQ](../references/faq.md#why-is-the-checkbox-on-my-changeset-disabled-when-i-m-previewing-a-batch-change).
+
 Once the preview actions look good, you can click **Apply** to publish the changesets. You should see an alert appear indicating that the publication states actions have updated, and the changesets' "Actions" will reflect the new publication states:
 
 <img src="https://sourcegraphstatic.com/docs/images/batch_changes/publish_ui_browser_preview_update.png" class="screenshot">

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -85,7 +85,7 @@ A brief summary of the pros and cons of each workflow is:
             Rapid feedback loop: you can check a specific diff and immediately publish it
           </li>
           <li>
-            Easy to publish random changesets without having to specify rules in the `published` field
+            Easy to publish random changesets without having to specify rules in the <code>published</code> field
           </li>
         </ul>
       </td>
@@ -173,7 +173,19 @@ See [`changesetTemplate.published`](../references/batch_spec_yaml_reference.md#c
 
 > NOTE: This functionality requires Sourcegraph 3.30 or later, and also requires `src` 3.29.2 or later.
 
-To publish from the Sourcegraph UI, you'll need to remove (or omit) the `published` field from your batch spec. When you first apply a batch change without an explicit `published` fields, all changesets are treated as unpublished.
+To publish from the Sourcegraph UI, you'll need to remove (or omit) the `published` field from your batch spec. When you first apply a batch change without an explicit `published` field, all changesets are left unpublished.
+
+#### From the preview
+
+When you run `src batch preview` against your batch spec and open the preview link, you'll see the current states of each of your changesets as well as the actions that will be performed when you apply:
+<!-- TODO: Add image -->
+
+For any changesets that are currently unpublished or only published as drafts, you can select the checkbox and choose an action from the dropdown menu to indicate what publication state you want to set the changesets in on apply:
+<!-- TODO: Add image -->
+
+Once the preview actions look good, you can click "Apply" to publish the changesets.
+
+#### From an open batch change
 
 Once applied, you can select the changesets you want to publish from the batch change page and publish them using the [publish bulk operation](bulk_operations_on_changesets.md), as demonstrated in this video:
 

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -179,13 +179,17 @@ To publish from the Sourcegraph UI, you'll need to remove (or omit) the `publish
 
 > NOTE: This feature requires Sourcegraph 3.31 or later.
 
-When you run `src batch preview` against your batch spec and open the preview link, you'll see the current states of each of your changesets as well as the actions that will be performed when you apply:
-<!-- TODO: Add image -->
+When you run `src batch preview` against your batch spec and open the preview link, you'll see the current states of each of your changesets, as well as a preview of the actions that will be performed when you apply:
 
-For any changesets that are currently unpublished or only published as drafts, you can select the checkbox and choose an action from the dropdown menu to indicate what publication state you want to set the changesets in on apply:
-<!-- TODO: Add image -->
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/publish_ui_browser_preview.png" class="screenshot">
 
-Once the preview actions look good, you can click **Apply** to publish the changesets.
+For any changesets that are currently unpublished or only published as drafts, you can select the checkbox and choose an action from the dropdown menu to indicate what publication state you want to set the changesets to on apply:
+
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/publish_ui_browser_select_action_on_apply.png" class="screenshot">
+
+Once the preview actions look good, you can click **Apply** to publish the changesets. You should see an alert appear indicating that the publication states actions have updated, and the changesets' "Actions" will reflect the new publication states:
+
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/publish_ui_browser_preview_update.png" class="screenshot">
 
 #### From an open batch change
 

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -177,13 +177,15 @@ To publish from the Sourcegraph UI, you'll need to remove (or omit) the `publish
 
 #### From the preview
 
+> NOTE: This feature requires Sourcegraph 3.31 or later.
+
 When you run `src batch preview` against your batch spec and open the preview link, you'll see the current states of each of your changesets as well as the actions that will be performed when you apply:
 <!-- TODO: Add image -->
 
 For any changesets that are currently unpublished or only published as drafts, you can select the checkbox and choose an action from the dropdown menu to indicate what publication state you want to set the changesets in on apply:
 <!-- TODO: Add image -->
 
-Once the preview actions look good, you can click "Apply" to publish the changesets.
+Once the preview actions look good, you can click **Apply** to publish the changesets.
 
 #### From an open batch change
 

--- a/doc/batch_changes/how-tos/updating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/updating_a_batch_change.md
@@ -25,7 +25,7 @@ In order to update a batch change after previewing the changes, do the following
 
     <pre><code>src batch preview -f <em>YOUR_BATCH_SPEC.batch.yaml</em></code></pre>
 1. Open on the URL that's printed to preview the changes that will be made by applying the new batch spec.
-1. Click **Apply spec** to update the batch change.
+1. Click **Apply** to update the batch change.
 
 All of the changesets on your code host will be updated to the desired state that was shown in the preview.
 

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -129,7 +129,7 @@ There are [multiple ways to publish a changeset](how-tos/publishing_changesets.m
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_publish_select_changesets.png" class="screenshot">
 1. Choose the "Publish changesets" action from the dropdown.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_publish_select_action.png" class="screenshot">
-1. Click **Publish changesets**. You'll be prompted to confirm. You may also choose to publish as draft changeset(s), if the code host supports it.
+1. Click **Publish changesets**. You'll be prompted to confirm. You may also choose to publish your changeset(s) as draft(s), if the code host supports it.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_publish_confirm.png" class="screenshot">
 1. Click **Publish**, and wait for an alert to appear (it may take a couple seconds).
 1. Sit tight---once it's done, the page should update, and you should see something like this:

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -4,9 +4,9 @@ Get started and create your first [batch change](index.md) in 10 minutes or less
 
 ## Introduction
 
-In this guide, you'll create a Sourcegraph batch change that appends text to all `README.md` files in all of your repositories.
+In this guide, you'll create a Sourcegraph batch change that appends text to `README.md` files in all of your repositories.
 
-For more information about Batch Changes see the ["Batch Changes"](index.md) documentation and watch the [Batch Changes demo video](https://www.youtube.com/watch?v=EfKwKFzOs3E).
+For more information about Batch Changes, watch the [Batch Changes demo video](https://www.youtube.com/watch?v=EfKwKFzOs3E).
 
 ## Requirements
 
@@ -41,7 +41,7 @@ Once `src login` reports that you're authenticated, we're ready for the next ste
 
 ## Write a batch spec
 
-A **batch spec** is a YAML file that defines a batch change. It specifies which changes should be made in which repositories and how those should be published on the code host.
+A **batch spec** is a YAML file that defines a batch change. It specifies which changes should be made in which repositories.
 
 See the ["batch spec YAML reference"](references/batch_spec_yaml_reference.md) for details.
 
@@ -67,7 +67,6 @@ changesetTemplate:
   branch: hello-world # Push the commit to this branch.
   commit:
     message: Append Hello World to all README.md files
-  published: false
 ```
 
 The commits you create here will use the git config values for `user.name` and `user.email` from your local environment, or "batch-changes@sourcegraph.com" if no user is set. Alternatively, you can also [specify an `author`](./references/batch_spec_yaml_reference.md#changesettemplate-commit-author) in this spec.
@@ -79,19 +78,16 @@ Let's see the changes that will be made. Don't worry---no commits, branches, or 
 1. In your terminal, run this command:
 
     <pre>src batch preview -f hello-world.batch.yaml</pre>
+    <!-- TODO: Update pictures -->
 1. Wait for it to run and compute the changes for each repository.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_waiting.png" class="screenshot">
-1. When it's done, click the displayed link to see all of the changes that will be made.
+1. When it's done, click the displayed link to see the **preview page** of all the changes that will be made.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_link.png" class="screenshot">
 1. Make sure the changes look right.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_preview.png" class="screenshot">
 1. If you want to modify which changes are made, edit the `hello-world.batch.yaml` file, rerun the `src batch preview` command and open the newly generated preview URL.
 
     >NOTE: If you want to run the batch change on fewer repositories, change the `repositoriesMatchingQuery` in `hello-world.batch.yaml` to something like `file:README.md repo:myproject` (to only match repositories whose name contains `myproject`).
-1. Click the **Apply spec** button to create the batch change. You should see something like this:
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_created.png" class="screenshot">
-
-You created your first batch change! The batch change's changesets are still unpublished, which means they exist only on Sourcegraph and haven't been pushed to your code host yet.
 
 ## Publish the changes
 
@@ -109,31 +105,22 @@ This is a one-time operation that you don't need to do for each batch change. Yo
 
 Once you have successfully added a token, Sourcegraph will have everything it needs to publish changesets to that code host!
 
-### Publishing changesets
+### Publish to code hosts
 
-Now that you have credentials set up, you can publish the changesets in the batch change. On a real batch change, you would do the following:
+Back from the **preview page**, for each changest, you can choose whether to leave it as-is unpublished, publish it as a normal pull request/merge request, or publish it as a draft (if the code host supports it). Let's try publishing some changesets normally:
 
-1. Change the `published: false` in `hello-world.batch.yaml` to `published: true`.
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/batch_publish_true.png" class="screenshot">
-
-    > NOTE: Change [`published` to an array](references/batch_spec_yaml_reference.md#publishing-only-specific-changesets) to publish only some of the changesets, or set [`'draft'` to create changesets as drafts on code hosts that support drafts](references/batch_spec_yaml_reference.md#changesettemplate-published).
-1. Run the `src batch preview` command again and open the URL.
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_rerun_preview.png" class="screenshot">
-1. On the preview page you can confirm that changesets will be published when the spec is applied.
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_preview_publish.png" class="screenshot">
-1. Click the **Apply spec** button and those changesets will be published on the code host.
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_async.png" class="screenshot">
-
-    > NOTE: You can also create or update a batch change by running `src batch apply`. This skips the preview stage, and is especially useful when updating an existing batch change.
-
-> NOTE: You can also publish directly from Sourcegraph by omitting the `published` field from your batch spec. This is described in more detail in "[Publishing changesets to the code host](how-tos/publishing_changesets.md#publishing-changesets)".
+<!-- TODO: Add pictures -->
+1. Back from the **preview page**, select the changesets you would like to publish.
+1. Open the actions dropdown, select "Publish", and then click again to update the preview.
+1. You should see the updated actions reflect our intent to publish the changesets.
+1. Click the **Apply** button to create the batch change and publish the changesets. You should see something like this:
 
 ## Congratulations!
 
-You've created your first batch change! 🎉🎉
+You've created your first batch change! 🎉
 
-You can customize your batch spec and experiment with making other types of changes.
+Feel free to customize your batch spec and experiment with making other types of changes.
 
-To update your batch change, edit `hello-world.batch.yaml` and run `src batch preview` again. (As before, you'll see a preview before any changes are applied.)
+To update your batch change, edit `hello-world.batch.yaml` and run `src batch preview` again. As before, you'll see a preview before any changes are applied, but this time, you'll be updating your existing changesets.
 
-To learn what else you can do with Batch Changes, see "[Batch Changes](index.md)" in Sourcegraph documentation.
+[Explore the documentation](index.md) to learn what else you can do with Batch Changes!

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -29,7 +29,7 @@ In order to create batch changes we need to [install the Sourcegraph CLI](../cli
     curl -L https://YOUR-SOURCEGRAPH-INSTANCE/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src
     chmod +x /usr/local/bin/src
     ```
-2. Authenticate `src` with your Sourcegraph instance by running **`src login`** and following the instructions:
+1. Authenticate `src` with your Sourcegraph instance by running **`src login`** and following the instructions:
 
     ```
     src login https://YOUR-SOURCEGRAPH-INSTANCE
@@ -78,49 +78,65 @@ Let's see the changes that will be made. Don't worry---no commits, branches, or 
 1. In your terminal, run this command:
 
     <pre>src batch preview -f hello-world.batch.yaml</pre>
-    <!-- TODO: Update pictures -->
 1. Wait for it to run and compute the changes for each repository.
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_waiting.png" class="screenshot">
-1. When it's done, click the displayed link to see the **preview page** of all the changes that will be made.
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_link.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/src_batch_preview_waiting.png" class="screenshot">
+1. When it's done, follow the link to the *preview page* to see all the changes that will be made.
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/src_batch_preview_link.png" class="screenshot">
 1. Make sure the changes look right.
-    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_preview.png" class="screenshot">
-1. If you want to modify which changes are made, edit the `hello-world.batch.yaml` file, rerun the `src batch preview` command and open the newly generated preview URL.
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_preview.png" class="screenshot">
+1. Click **Apply** to create the batch change. You should see something like this:
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_created.png" class="screenshot">
 
-    >NOTE: If you want to run the batch change on fewer repositories, change the `repositoriesMatchingQuery` in `hello-world.batch.yaml` to something like `file:README.md repo:myproject` (to only match repositories whose name contains `myproject`).
+**You've now created your first batch change!**
 
-## Publish the changes
+The batch change's *changesets* are still unpublished, which means they exist only on Sourcegraph and haven't been pushed to your code host yet. This is good news, as you probably don't want to publish these toy "Hello World" changesets to actively-developed repositories, because that might confuse people ("Why did you add this line to our READMEs?"). In the next steps, we'll prepare to publish a single test changeset.
 
-So far, nothing has been created on the code hosts yet. For that to happen, we need to publish the changesets in our batch change.
+## Publish a changeset
 
-Publishing causes commits, branches, and pull requests/merge requests to be created on your code host.
+So far, nothing has been created on your code hosts. For that to happen, we need to tell Sourcegraph to *publish a changeset*.
 
-_You probably don't want to publish these toy "Hello World" changesets to actively developed repositories, because that might confuse people ("Why did you add this line to our READMEs?")._
+Publishing causes commits, branches, and pull requests/merge requests to be written to your code host.
 
 ### Configure code host credentials
 
-Batch Changes needs permission to open changesets on your behalf. To grant permission, you will need to [add a personal access token](how-tos/configuring_credentials.md#adding-a-token) for each code host you'll be publishing changesets on.
+Batch Changes needs permission to publish changesets on your behalf. To grant permission, you will need to [add a personal access token](how-tos/configuring_credentials.md#adding-a-token) for each code host you'll be publishing changesets on.
 
-This is a one-time operation that you don't need to do for each batch change. You can also ask the administrators of your Sourcegraph instance to [configure global credentials](how-tos/configuring_credentials.md#global-service-account-tokens) instead.
+This is a one-time operation, so don't worry---we won't need to do this for every batch change. You can also ask the administrators of your Sourcegraph instance to [configure global credentials](how-tos/configuring_credentials.md#global-service-account-tokens) instead.
 
-Once you have successfully added a token, Sourcegraph will have everything it needs to publish changesets to that code host!
+### (Optional) Modify the batch spec to only target a specific repository
 
-### Publish to code hosts
+Before publishing, you might want to change the `repositoriesMatchingQuery` in `hello-world.batch.yaml` to target only a single, test repository that you could open a toy pull request/merge request on, such as one that you are the owner of. For example:
 
-Back from the **preview page**, for each changest, you can choose whether to leave it as-is unpublished, publish it as a normal pull request/merge request, or publish it as a draft (if the code host supports it). Let's try publishing some changesets normally:
+```yaml
+# Find all repositories that contain a README.md file and whose name matches our test repo.
+on:
+  - repositoriesMatchingQuery: file:README.md repo:sourcegraph-testing/batch-changes-test-repo
+```
 
-<!-- TODO: Add pictures -->
-1. Back from the **preview page**, select the changesets you would like to publish.
-1. Open the actions dropdown, select "Publish", and then click again to update the preview.
-1. You should see the updated actions reflect our intent to publish the changesets.
-1. Click the **Apply** button to create the batch change and publish the changesets. You should see something like this:
+With your updated batch spec, re-run the preview command, `src batch preview -f hello-world.batch.yaml` (you should notice it's a lot quicker this time thanks to the caching!). Once again, follow the link to the *preview page*. You should now see something like this:
+
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_preview_update.png" class="screenshot">
+
+As before, you get a preview before any changes are applied, but this time, you are *updating your existing changesets*. Now, all of the changesets listed will be *detached* ("Batch Changes speak" for *removed from the batch change*), except for the one you're about to publish.
+
+Once you are ready, click **Apply** again to apply the update to your batch change.
+
+### Publish to code host
+
+There are [multiple ways to publish a changeset](how-tos/publishing_changesets.md#publishing-changesets). Let's look at how to do so from the screen you are currently on.
+
+1. Select the changeset you would like to publish (in our case it's the only one).
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_publish_select_changesets.png" class="screenshot">
+1. Choose the "Publish changesets" action from the dropdown.
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_publish_select_action.png" class="screenshot">
+1. Click **Publish changesets**. You'll be prompted to confirm. You may also choose to publish as draft changeset(s), if the code host supports it.
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_publish_confirm.png" class="screenshot">
+1. Click **Publish**, and wait for an alert to appear (it may take a couple seconds).
+1. Sit tight---once it's done, the page should update, and you should see something like this:
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/quickstart/browser_publish_complete.png" class="screenshot">
 
 ## Congratulations!
 
-You've created your first batch change! 🎉
+**You've published your first Batch Changes changeset!** 🎉
 
-Feel free to customize your batch spec and experiment with making other types of changes.
-
-To update your batch change, edit `hello-world.batch.yaml` and run `src batch preview` again. As before, you'll see a preview before any changes are applied, but this time, you'll be updating your existing changesets.
-
-[Explore the documentation](index.md) to learn what else you can do with Batch Changes!
+Feel free to customize your batch spec and experiment with making other types of changes. You can also [explore the documentation](index.md) to learn what else you can do with Batch Changes!

--- a/doc/batch_changes/references/faq.md
+++ b/doc/batch_changes/references/faq.md
@@ -74,10 +74,10 @@ Commit author is determined at the time of running `src batch [apply|preview]`. 
 
 ### Why is the checkbox on my changeset disabled when I'm previewing a batch change?
 
-Since Sourcegraph 3.31, it is possible to publish many types of changeset when previewing a batch change by modifying the publication state for the changeset directly from the UI (see ["Publishing changesets"](how-tos/publishing_changesets.md#from-the-preview)). However, not every changeset can be published by Sourcegraph. By hovering over your changeset's disabled checkbox, you can see the reason why that specific changeset is not currently publishable. The most common reasons include:
+Since Sourcegraph 3.31, it is possible to publish many types of changeset when previewing a batch change by modifying the publication state for the changeset directly from the UI (see ["Publishing changesets"](../how-tos/publishing_changesets.md#from-the-preview)). However, not every changeset can be published by Sourcegraph. By hovering over your changeset's disabled checkbox, you can see the reason why that specific changeset is not currently publishable. The most common reasons include:
 
 - The changeset is already published (we cannot unpublish a changeset, or convert it back to a draft).
-- The changeset's publication state is being controlled from your batch spec file (i.e. you have the [`published` flag set in your batch spec](references/batch_spec_yaml_reference.md#changesettemplate-published)); the batch spec takes precedence over the UI.
+- The changeset's publication state is being controlled from your batch spec file (i.e. you have the [`published` flag set in your batch spec](batch_spec_yaml_reference.md#changesettemplate-published)); the batch spec takes precedence over the UI.
 - You do not have permission to publish to the repository the changeset would be opened against.
 - The changeset was imported (and therefore, Batch Changes does not own it).
 

--- a/doc/batch_changes/references/faq.md
+++ b/doc/batch_changes/references/faq.md
@@ -16,7 +16,6 @@ Known limitations:
 - Batch Changes creates changesets in parallel locally. You can set up the maximum number of parallel jobs with [`-j`](../../cli/references/batch/apply.md)
 - Manipulating (commenting, notifying users, etc) changesets at that scale can be clumsy. This is a major area of work for future releases.
 
-
 ### How long does it take to create a batch change?
 A rule of thumb:
 
@@ -72,3 +71,14 @@ Keep in mind the context in which the inner `${{ }}` will be evaluated and be su
 ### How is commit author determined for commits produced from Batch Changes?
 
 Commit author is determined at the time of running `src batch [apply|preview]`. If no [author](./batch_spec_yaml_reference.md#changesettemplate-commit-author) key is defined in the batch spec, `src` will try to use the git config values for `user.name` and `user.email` from your local environment, or "batch-changes@sourcegraph.com" if no user is set.
+
+### Why is the checkbox on my changeset disabled when I'm previewing a batch change?
+
+Since Sourcegraph 3.31, it is possible to publish many types of changeset when previewing a batch change by modifying the publication state for the changeset directly from the UI (see ["Publishing changesets"](how-tos/publishing_changesets.md#from-the-preview)). However, not every changeset can be published by Sourcegraph. By hovering over your changeset's disabled checkbox, you can see the reason why that specific changeset is not currently publishable. The most common reasons include:
+
+- The changeset is already published (we cannot unpublish a changeset, or convert it back to a draft).
+- The changeset's publication state is being controlled from your batch spec file (i.e. you have the [`published` flag set in your batch spec](references/batch_spec_yaml_reference.md#changesettemplate-published)); the batch spec takes precedence over the UI.
+- You do not have permission to publish to the repository the changeset would be opened against.
+- The changeset was imported (and therefore, Batch Changes does not own it).
+
+The changeset may also be in a state that we cannot currently publish from, such as if it initially fails to be pushed to the code host, or if you are actively detaching the changeset from your batch change.

--- a/doc/batch_changes/references/faq.md
+++ b/doc/batch_changes/references/faq.md
@@ -79,6 +79,6 @@ Since Sourcegraph 3.31, it is possible to publish many types of changeset when p
 - The changeset is already published (we cannot unpublish a changeset, or convert it back to a draft).
 - The changeset's publication state is being controlled from your batch spec file (i.e. you have the [`published` flag set in your batch spec](batch_spec_yaml_reference.md#changesettemplate-published)); the batch spec takes precedence over the UI.
 - You do not have permission to publish to the repository the changeset would be opened against.
-- The changeset was imported (and therefore, Batch Changes does not own it).
+- The changeset was imported (and was therefore already published by someone or something else).
 
-The changeset may also be in a state that we cannot currently publish from, such as if it initially fails to be pushed to the code host, or if you are actively detaching the changeset from your batch change.
+The changeset may also be in a state that we cannot currently publish from: for example, because a previous push to the code host failed (in which case you should re-apply the batch change), or if you are actively detaching the changeset from your batch change.

--- a/doc/batch_changes/tutorials/refactor_go_comby.md
+++ b/doc/batch_changes/tutorials/refactor_go_comby.md
@@ -67,5 +67,5 @@ changesetTemplate:
 1. Wait for it to run and compute the changes for each repository.
 1. Open the preview URL that the command printed out.
 1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the batch spec and then rerun the command above.
-1. Click the **Apply spec** button to create the batch change.
+1. Click the **Apply** button to create the batch change.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the batch spec](../references/batch_spec_yaml_reference.md#changesettemplate-published) and re-running the `src batch preview` command.

--- a/doc/batch_changes/tutorials/search_and_replace_specific_terms.md
+++ b/doc/batch_changes/tutorials/search_and_replace_specific_terms.md
@@ -68,7 +68,7 @@ changesetTemplate:
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/use_allowlist_denylist_wording_click_url.png" class="screenshot">
 1. Examine the preview. Confirm that the changes are what you intended. If not, edit your batch spec and then rerun the command above.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/use_allowlist_denylist_wording_preview.png" class="screenshot">
-1. Click the **Apply spec** button to create the batch change.
+1. Click the **Apply** button to create the batch change.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the batch spec](../references/batch_spec_yaml_reference.md#changesettemplate-published) and re-running the `src batch preview` command.
 
 ### Using `ruplacer` to replace terms in multiple case styles

--- a/doc/batch_changes/tutorials/update_base_images_in_dockerfiles.md
+++ b/doc/batch_changes/tutorials/update_base_images_in_dockerfiles.md
@@ -83,7 +83,7 @@ changesetTemplate:
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/update_base_images_in_dockerfiles_click_url.png" class="screenshot">
 1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the batch spec and then rerun the command above.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/update_base_images_in_dockerfiles_preview.png" class="screenshot">
-1. Click the **Apply spec** button to create the batch change.
+1. Click the **Apply** button to create the batch change.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the batch spec](../references/batch_spec_yaml_reference.md#changesettemplate-published) and re-running the `src batch preview` command.
 
 ### Updating other base images

--- a/doc/batch_changes/tutorials/updating_go_import_statements.md
+++ b/doc/batch_changes/tutorials/updating_go_import_statements.md
@@ -80,5 +80,5 @@ changesetTemplate:
 1. Wait for it to run and compute the changes for each repository.
 1. Open the preview URL that the command printed out.
 1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the batch spec and then rerun the command above.
-1. Click the **Apply spec** button to create the batch change.
+1. Click the **Apply** button to create the batch change.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the batch spec](../references/batch_spec_yaml_reference.md#changesettemplate-published) and re-running the `src batch preview` command.

--- a/doc/dev/background-information/batch_changes/index.md
+++ b/doc/dev/background-information/batch_changes/index.md
@@ -33,7 +33,7 @@ To give you a rough overview where each part of the code lives, let's take a loo
 
 1. run `src batch preview -f your-batch-spec.yaml`
 1. click on the preview link
-1. click `Apply` to publish changesets on the code hosts
+1. click **Apply** to publish changesets on the code hosts
 
 It starts in [`src-cli`](https://github.com/sourcegraph/src-cli):
 
@@ -46,13 +46,13 @@ It starts in [`src-cli`](https://github.com/sourcegraph/src-cli):
 When you then click the "Preview the batch change" link that `src-cli` printed, you'll land on the preview page in the web frontend:
 
 1. The [`BatchChangePreviewPage` component](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx#L43) then sends a GraphQL request to the backend to [query the `BatchSpecByID`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/backend.ts#L93-L107).
-1. Once you hit the "Apply" button, the component [uses the `applyBatchChange`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/backend.ts#L140-L159) to apply the batch spec and create a batch change.
+1. Once you hit the **Apply** button, the component [uses the `applyBatchChange`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/backend.ts#L140-L159) to apply the batch spec and create a batch change.
 1. You're then redirected to the [`BatchChangeDetailsPage` component](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx#L65) that shows you you're newly-created batch change.
 
 In the backend, all Batch Changes related GraphQL queries and mutations start in the [`Resolver` package](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go):
 
 1. The [`CreateChangesetSpec`](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L545) and [`CreateBatchSpec`](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L489) mutations that `src-cli` called to create the changeset and batch specs are defined here.
-1. When you clicked "Apply" the [`ApplyBatchChange` resolver](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L404) was executed to create the batch change.
+1. When you clicked **Apply** the [`ApplyBatchChange` resolver](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L404) was executed to create the batch change.
 1. Most of that doesn't happen in the resolver layer, but in the service layer: [here is the `(*Service).ApplyBatchChange` method](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/service/service_apply_batch_change.go#L48:19) that talks to the database to create an entry in the `batch_changes` table.
 1. The most important thing that happens in `(*Service).ApplyBatchChange` is that [it calls the `rewirer`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/service/service_apply_batch_change.go#L119-L135) to wire the entries in the `changesets` table to the correct `changeset_specs`.
 1. Once that is done, the `changesets` are created or updated to point to the new `changeset_specs` that you created with `src-cli`.

--- a/doc/dev/background-information/batch_changes/index.md
+++ b/doc/dev/background-information/batch_changes/index.md
@@ -33,7 +33,7 @@ To give you a rough overview where each part of the code lives, let's take a loo
 
 1. run `src batch preview -f your-batch-spec.yaml`
 1. click on the preview link
-1. click `Apply spec` to publish changesets on the code hosts
+1. click `Apply` to publish changesets on the code hosts
 
 It starts in [`src-cli`](https://github.com/sourcegraph/src-cli):
 
@@ -46,13 +46,13 @@ It starts in [`src-cli`](https://github.com/sourcegraph/src-cli):
 When you then click the "Preview the batch change" link that `src-cli` printed, you'll land on the preview page in the web frontend:
 
 1. The [`BatchChangePreviewPage` component](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx#L43) then sends a GraphQL request to the backend to [query the `BatchSpecByID`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/backend.ts#L93-L107).
-1. Once you hit the "Apply spec" button, the component [uses the `applyBatchChange`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/backend.ts#L140-L159) to apply the batch spec and create a batch change.
+1. Once you hit the "Apply" button, the component [uses the `applyBatchChange`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/preview/backend.ts#L140-L159) to apply the batch spec and create a batch change.
 1. You're then redirected to the [`BatchChangeDetailsPage` component](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx#L65) that shows you you're newly-created batch change.
 
 In the backend, all Batch Changes related GraphQL queries and mutations start in the [`Resolver` package](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go):
 
 1. The [`CreateChangesetSpec`](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L545) and [`CreateBatchSpec`](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L489) mutations that `src-cli` called to create the changeset and batch specs are defined here.
-1. When you clicked "Apply Spec" the [`ApplyBatchChange` resolver](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L404) was executed to create the batch change.
+1. When you clicked "Apply" the [`ApplyBatchChange` resolver](https://github.com/sourcegraph/sourcegraph/blob/8b99439e21aaa000443382f03f92e532b0445858/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go#L404) was executed to create the batch change.
 1. Most of that doesn't happen in the resolver layer, but in the service layer: [here is the `(*Service).ApplyBatchChange` method](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/service/service_apply_batch_change.go#L48:19) that talks to the database to create an entry in the `batch_changes` table.
 1. The most important thing that happens in `(*Service).ApplyBatchChange` is that [it calls the `rewirer`](https://github.com/sourcegraph/sourcegraph/blob/e7f26c0d7bc965892669a5fc9835ec65211943aa/enterprise/internal/batches/service/service_apply_batch_change.go#L119-L135) to wire the entries in the `changesets` table to the correct `changeset_specs`.
 1. Once that is done, the `changesets` are created or updated to point to the new `changeset_specs` that you created with `src-cli`.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -731,11 +731,11 @@ type BatchChangesUsageStatistics struct {
 	ViewBatchChangeApplyPageCount int32
 	// ViewBatchChangeDetailsPageAfterCreateCount is the number of page views on
 	// the batch changes details page *after creating* the batch change on the apply
-	// page by clicking "Apply spec".
+	// page by clicking "Apply".
 	ViewBatchChangeDetailsPageAfterCreateCount int32
 	// ViewBatchChangeDetailsPageAfterUpdateCount is the number of page views on
 	// the batch changes details page *after updating* a batch change on the apply page
-	// by clicking "Apply spec".
+	// by clicking "Apply".
 	ViewBatchChangeDetailsPageAfterUpdateCount int32
 
 	// BatchChangesCount is the number of batch changes on the instance. This can go


### PR DESCRIPTION
Closes #23384 and #22179.

This PR:
- Updates the quick start doc to guide users through publishing their changesets from the preview UI, instead of with the batch spec file
- Adds steps to the "publishing changesets" doc to describe the process of publishing from the preview UI
- Adds an FAQ entry for why a changeset may be disabled from being selected in the preview UI
- Updates screenshots across quickstart + "publishing changesets"
- Adds a changelog entry

Since it's hard for you to see what the new docs or screenshots look like without pulling this and running it yourself, I took super long screenshots again to save you the trouble. 🙂

## Quickstart

![screencapture-localhost-5080-batch-changes-quickstart-2021-08-18-22_32_38](https://user-images.githubusercontent.com/8942601/130013706-1f702832-89d9-4a2a-a75d-b51205c8ba86.png)

## Publishing changesets

![screencapture-localhost-5080-batch-changes-how-tos-publishing-changesets-2021-08-18-22_33_29](https://user-images.githubusercontent.com/8942601/130013729-db66342e-0125-48d4-80ab-6950d5fefce3.png)
