### PR TITLE
search: rename  to  for request type

### DIFF
--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -88,7 +88,7 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		trace.Stringer("global_search_mode", args.Mode),
 	)
 
-	indexed, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	request, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}
@@ -98,13 +98,13 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 	if args.Mode != search.SearcherOnly {
 		// Run literal and regexp searches on indexed repositories.
 		g.Go(func() error {
-			return indexed.Search(ctx, stream)
+			return request.Search(ctx, stream)
 		})
 	}
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return callSearcherOverRepos(ctx, args, stream, indexed.Unindexed, false)
+		return callSearcherOverRepos(ctx, args, stream, request.Unindexed, false)
 	})
 
 	return g.Wait()


### PR DESCRIPTION
Just a rename. We have a `zoektutil.IndexedSearchRequest` type and values of this type are called `indexed`. This is a bit of a misnomer with things like `indexed.Unindexed`. This change is in the interest of a better interface for Zoekt searches over a repo (sub)set vs global queries in upcoming changes.