### PR TITLE
batches: omit already-published changesets from selectable

### DIFF
--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -372,6 +372,9 @@ const publishableChangesetSpecIDsFieldsFragment = gql`
                 changesetSpec {
                     ...PublishableChangesetSpecIDsVisibleChangesetSpecFields
                 }
+                changeset {
+                    state
+                }
             }
         }
     }

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -1,4 +1,5 @@
 import {
+    ChangesetState,
     PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields,
     PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields,
     Scalars,
@@ -7,10 +8,16 @@ import {
 /**
  * For a given preview of a changeset to be applied, this method checks if the type of
  * changeset allows for the user to modify its publication state from the UI: namely, that
- * the applied changeset is visible to the user applying, will be attaching or updating
- * the changeset, is not an existing reference, and has not had its publication state set
- * from the batch spec file. Returns the id of the changeset spec if it is publishable
- * from the UI, or null if for any reason it is not.
+ * all of the following conditions are true:
+ * - the changeset is visible to the user applying
+ * - the operation will be attaching or updating a changeset
+ * - the changeset is not an existing reference
+ * - the changeset does not have its publication state specified in the batch spec file
+ * - if the operation is updating a changeset, the changeset is in a state we can
+ * transition to published or draft from
+ *
+ * Returns the id of the changeset spec if it is publishable from the UI, or null if for
+ * any reason it is not.
  *
  * @param node the `ChangesetApplyPreviewFields` node to check
  */
@@ -19,16 +26,26 @@ export const getPublishableChangesetSpecID = (
         | PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields
         | PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields
 ): Scalars['ID'] | null => {
+    // The changeset is either hidden, or the operation is detaching a changeset
     if (
         node.targets.__typename !== 'VisibleApplyPreviewTargetsAttach' &&
         node.targets.__typename !== 'VisibleApplyPreviewTargetsUpdate'
     ) {
         return null
     }
+    // The changeset is an existing reference
     if (node.targets.changesetSpec.description.__typename !== 'GitBranchChangesetDescription') {
         return null
     }
+    // The changeset has its publication state specified in the batch spec file, which takes priority
     if (node.targets.changesetSpec.description.published !== null) {
+        return null
+    }
+    // The changeset is already published or in a state we can't transition to published/draft from
+    if (
+        node.targets.__typename === 'VisibleApplyPreviewTargetsUpdate' &&
+        !(node.targets.changeset.state in [ChangesetState.DRAFT, ChangesetState.UNPUBLISHED])
+    ) {
         return null
     }
     return node.targets.changesetSpec.id


### PR DESCRIPTION
Erik's [comment on #23966](https://github.com/sourcegraph/sourcegraph/pull/23966#discussion_r689446710) got me thinking... since we can't take any action on already-published changesets anyway (we can't convert them to draft nor unpublish them), we might as well just exclude them from what's selectable (and then explain what's up in that FAQ entry).

Of course, we actually have a [lot of potential changeset states](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@kr/publish-from-preview-docs/-/blob/cmd/frontend/graphqlbackend/batches.graphql?L790-835#L790:835). Do correct me if this feels like it's going too far, but it seemed to me like maybe we shouldn't allow modifying the publication state of a changeset unless it's **unpublished** or a **draft**: every other state is either some form of "already published" (open, closed, merged, deleted) or "potentially about to be published" (failed, retrying, scheduled, processing). 