### PR TITLE
search: methods for indexed/unindexed repos on request

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -71,7 +71,7 @@ func runJobs(ctx context.Context, jobs []withContext) error {
 
 // repoSets returns the set of repositories to search (whether indexed or unindexed) based on search mode.
 func repoSets(request *zoektutil.IndexedSearchRequest, mode search.GlobalSearchMode) []repoData {
-	repoSets := []repoData{UnindexedList(request.Unindexed)} // unindexed included by default
+	repoSets := []repoData{UnindexedList(request.UnindexedRepos())} // unindexed included by default
 	if mode != search.SearcherOnly {
 		repoSets = append(repoSets, IndexedMap(request.IndexedRepos()))
 	}

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -73,7 +73,7 @@ func runJobs(ctx context.Context, jobs []withContext) error {
 func repoSets(request *zoektutil.IndexedSearchRequest, mode search.GlobalSearchMode) []repoData {
 	repoSets := []repoData{UnindexedList(request.Unindexed)} // unindexed included by default
 	if mode != search.SearcherOnly {
-		repoSets = append(repoSets, IndexedMap(request.Repos()))
+		repoSets = append(repoSets, IndexedMap(request.IndexedRepos()))
 	}
 	return repoSets
 }

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -104,7 +104,7 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return callSearcherOverRepos(ctx, args, stream, request.Unindexed, false)
+		return callSearcherOverRepos(ctx, args, stream, request.UnindexedRepos(), false)
 	})
 
 	return g.Wait()

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -169,13 +169,18 @@ type IndexedSearchRequest struct {
 	since func(time.Time) time.Duration
 }
 
-// Repos is a map of repository revisions that are indexed and will be
-// searched by Zoekt. Do not mutate.
-func (s *IndexedSearchRequest) Repos() map[string]*search.RepositoryRevisions {
+// IndxedRepos is a map of indexed repository revisions will be searched by
+// Zoekt. Do not mutate.
+func (s *IndexedSearchRequest) IndexedRepos() map[string]*search.RepositoryRevisions {
 	if s.RepoRevs == nil {
 		return nil
 	}
 	return s.RepoRevs.repoRevs
+}
+
+// UnindexedRepos is a slice of unindexed repositories to search.
+func (s *IndexedSearchRequest) UnindexedRepos() []*search.RepositoryRevisions {
+	return s.Unindexed
 }
 
 // Search streams 0 or more events to c.
@@ -189,7 +194,7 @@ func (s *IndexedSearchRequest) Search(ctx context.Context, c streaming.Sender) e
 		return doZoektSearchGlobal(ctx, q, s.Args.Typ, s.Args.Zoekt.Client, s.Args.FileMatchLimit, s.Args.Select, c)
 	}
 
-	if len(s.Repos()) == 0 {
+	if len(s.IndexedRepos()) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24066.

For the `IndexedSearchRequest` type:

- renames `Repos()` method to `IndexedRepos()`
- mints an `UnindexedRepos()` method to expose the unindexed value. I will need this method to exist so that I can express an interface that works for both global vs non-global searches.
- propagates use of `UnindexedRepos()` instead of `request.Unindexed`