### PR TITLE
search: introduce IndexedSearchRequest interface

### DIFF
--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -57,7 +57,7 @@ func Search(ctx context.Context, args *search.TextParameters, limit int, stream 
 	ctx, stream, cancel := streaming.WithLimit(ctx, stream, limit)
 	defer cancel()
 
-	indexed, err := zoektutil.NewIndexedSearchRequest(ctx, args, search.SymbolRequest, zoektutil.MissingRepoRevStatus(stream))
+	indexed, err := zoektutil.NewIndexedSubsetSearchRequest(ctx, args, search.SymbolRequest, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -70,7 +70,7 @@ func runJobs(ctx context.Context, jobs []withContext) error {
 }
 
 // repoSets returns the set of repositories to search (whether indexed or unindexed) based on search mode.
-func repoSets(request *zoektutil.IndexedSearchRequest, mode search.GlobalSearchMode) []repoData {
+func repoSets(request *zoektutil.IndexedSubsetSearchRequest, mode search.GlobalSearchMode) []repoData {
 	repoSets := []repoData{UnindexedList(request.UnindexedRepos())} // unindexed included by default
 	if mode != search.SearcherOnly {
 		repoSets = append(repoSets, IndexedMap(request.IndexedRepos()))

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -70,7 +70,7 @@ func runJobs(ctx context.Context, jobs []withContext) error {
 }
 
 // repoSets returns the set of repositories to search (whether indexed or unindexed) based on search mode.
-func repoSets(request *zoektutil.IndexedSubsetSearchRequest, mode search.GlobalSearchMode) []repoData {
+func repoSets(request zoektutil.IndexedSearchRequest, mode search.GlobalSearchMode) []repoData {
 	repoSets := []repoData{UnindexedList(request.UnindexedRepos())} // unindexed included by default
 	if mode != search.SearcherOnly {
 		repoSets = append(repoSets, IndexedMap(request.IndexedRepos()))

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -35,15 +35,15 @@ var textSearchLimiter = mutablelimiter.New(32)
 
 var MockSearchFilesInRepos func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error)
 
-func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissing zoektutil.OnMissingRepoRevs) (*zoektutil.IndexedSearchRequest, error) {
-	// performance: for global searches, we avoid calling NewIndexedSearchRequest
+func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissing zoektutil.OnMissingRepoRevs) (*zoektutil.IndexedSubsetSearchRequest, error) {
+	// performance: for global searches, we avoid calling NewIndexedSubsetSearchRequest
 	// because zoekt will anyway have to search all its shards.
 	if args.Mode == search.ZoektGlobalSearch {
 		q, err := search.QueryToZoektQuery(args.PatternInfo, false)
 		if err != nil {
 			return nil, err
 		}
-		return &zoektutil.IndexedSearchRequest{
+		return &zoektutil.IndexedSubsetSearchRequest{
 			Args: &search.ZoektParameters{
 				Repos:            args.Repos,
 				Query:            q,
@@ -60,7 +60,7 @@ func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissi
 			RepoRevs: &zoektutil.IndexedRepoRevs{},
 		}, nil
 	}
-	return zoektutil.NewIndexedSearchRequest(ctx, args, search.TextRequest, onMissing)
+	return zoektutil.NewIndexedSubsetSearchRequest(ctx, args, search.TextRequest, onMissing)
 }
 
 // SearchFilesInRepos searches a set of repos for a pattern.

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -138,10 +138,12 @@ func (rb *IndexedRepoRevs) getRepoInputRev(file *zoekt.FileMatch) (repo types.Re
 	return repoRev.Repo, inputRevs
 }
 
-// IndexedSearchRequest is responsible for translating a Sourcegraph search
-// query into a Zoekt query and mapping the results from zoekt back to
-// Sourcegraph result types.
-type IndexedSearchRequest struct {
+// IndexedSubsetSearchRequest is responsible for:
+// (1) partitioning repos into indexed and unindexed sets of repos to search.
+//     These sets are a subset of the universe of repos.
+// (2) providing a method Search(...) that runs Zoekt over the indexed set of
+//     repositories.
+type IndexedSubsetSearchRequest struct {
 	// Unindexed is a slice of repository revisions that can't be searched by
 	// Zoekt. The repository revisions should be searched by the searcher
 	// service.
@@ -171,7 +173,7 @@ type IndexedSearchRequest struct {
 
 // IndxedRepos is a map of indexed repository revisions will be searched by
 // Zoekt. Do not mutate.
-func (s *IndexedSearchRequest) IndexedRepos() map[string]*search.RepositoryRevisions {
+func (s *IndexedSubsetSearchRequest) IndexedRepos() map[string]*search.RepositoryRevisions {
 	if s.RepoRevs == nil {
 		return nil
 	}
@@ -179,12 +181,12 @@ func (s *IndexedSearchRequest) IndexedRepos() map[string]*search.RepositoryRevis
 }
 
 // UnindexedRepos is a slice of unindexed repositories to search.
-func (s *IndexedSearchRequest) UnindexedRepos() []*search.RepositoryRevisions {
+func (s *IndexedSubsetSearchRequest) UnindexedRepos() []*search.RepositoryRevisions {
 	return s.Unindexed
 }
 
 // Search streams 0 or more events to c.
-func (s *IndexedSearchRequest) Search(ctx context.Context, c streaming.Sender) error {
+func (s *IndexedSubsetSearchRequest) Search(ctx context.Context, c streaming.Sender) error {
 	if s.Args == nil {
 		return nil
 	}
@@ -224,8 +226,8 @@ func MissingRepoRevStatus(stream streaming.Sender) OnMissingRepoRevs {
 	}
 }
 
-func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ search.IndexedRequestType, onMissing OnMissingRepoRevs) (_ *IndexedSearchRequest, err error) {
-	tr, ctx := trace.New(ctx, "newIndexedSearchRequest", string(typ))
+func NewIndexedSubsetSearchRequest(ctx context.Context, args *search.TextParameters, typ search.IndexedRequestType, onMissing OnMissingRepoRevs) (_ *IndexedSubsetSearchRequest, err error) {
+	tr, ctx := trace.New(ctx, "NewIndexedSubsetSearchRequest", string(typ))
 	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {
 		tr.SetError(err)
@@ -238,7 +240,7 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 			return nil, errors.Errorf("invalid index:%q (indexed search is not enabled)", args.PatternInfo.Index)
 		}
 
-		return &IndexedSearchRequest{
+		return &IndexedSubsetSearchRequest{
 			Unindexed:        limitUnindexedRepos(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
 			IndexUnavailable: true,
 		}, nil
@@ -249,14 +251,14 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		if args.PatternInfo.Index == query.Only {
 			return nil, errors.Errorf("invalid index:%q (revsions with glob pattern cannot be resolved for indexed searches)", args.PatternInfo.Index)
 		}
-		return &IndexedSearchRequest{
+		return &IndexedSubsetSearchRequest{
 			Unindexed: limitUnindexedRepos(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
 		}, nil
 	}
 
 	// Fallback to Unindexed if index:no
 	if args.PatternInfo.Index == query.No {
-		return &IndexedSearchRequest{
+		return &IndexedSubsetSearchRequest{
 			Unindexed: limitUnindexedRepos(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
 		}, nil
 	}
@@ -283,7 +285,7 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 			log15.Warn("zoektIndexedRepos failed", "error", err)
 		}
 
-		return &IndexedSearchRequest{
+		return &IndexedSubsetSearchRequest{
 			Unindexed:        limitUnindexedRepos(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
 			IndexUnavailable: true,
 		}, ctx.Err()
@@ -309,7 +311,7 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		return nil, err
 	}
 
-	return &IndexedSearchRequest{
+	return &IndexedSubsetSearchRequest{
 		Args: &search.ZoektParameters{
 			Repos:            args.Repos,
 			Query:            q,

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -268,7 +268,7 @@ func TestIndexedSearch(t *testing.T) {
 				},
 			}
 
-			indexed, err := NewIndexedSearchRequest(context.Background(), args, search.TextRequest, MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})))
+			indexed, err := NewIndexedSubsetSearchRequest(context.Background(), args, search.TextRequest, MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24068.

Introduces an interface to separate searches over the universe of repos (AKA global search) and a subset of repos.

By commit:
- First just rename `NewIndexedSearchRequest` to `NewIndexedSubsetSearchRequest`. The comment is updated ahead of the second commit to reflect the intent of this type.
  - I'm not too attached to the new name, I also considered `NewIndexedRepoSubsetRequest` and variants of these. I settled on the name that didn't bloat this too much.

- Second commit introduces the interface and adds `NewIndexedUniverseSearchRequest`. See doc and inline comments.

---

Here are notes for what I'm doing next. We are really really close to optimized Zoekt queries that be cleanly propagated through the logic:

- `ZoektParameters` can simplify more, I think `Repos` is unneeded for global searches. 
- Factor out `TextParameters`, so that (finally) zoekt search logic from at the point of `NewIndexedRequest` and forwards doesn't rely on `TextParameters`, but instead relies only on `ZoektParameters`
- Lift `ZoektParameters` construction even higher to a top level search function (`SearchFilesInRepos`)
- Figure out how to break dependence on `TextParameters` for Zoekt search entirely. This likely means passing `ZoektParameters` to `SearchFilesInRepos` for simplicity, but can be expressed more cleanly with another type.
- Construct optimized zoekt query and pass purely via `ZoektParameters` for execution. The zoekt logic at this point can consume the optimized query and only the `ZoektParameters` it cares bout, and it does not care or reference any of `PatternInfo` or `TextParameters` 🥳 
