### PR TITLE
Fix Chromatic themed variants for CSF stories

### DIFF
--- a/client/storybook/src/chromatic-story/Chromatic.story.tsx
+++ b/client/storybook/src/chromatic-story/Chromatic.story.tsx
@@ -3,20 +3,31 @@ import { raw } from '@storybook/react'
 import isChromatic from 'chromatic/isChromatic'
 
 import { addStory } from './add-story'
+import { storyStore } from './story-store'
 
 // Execute logic below only in the environment where Chromatic snapshots are captured.
 if (isChromatic()) {
-    // Get an array of all stories which are already added to the `StoryStore`.
-    // Use `raw()` because we don't want to apply any filtering and sorting on the array of stories.
-    const storeItems = raw() as PublishedStoreItem[]
+    // CSF stories need to be evaluated before they are added to the `StoryStore` and thus are not immediately available.
+    // We setTimeout to delay this logic until all stories have been added.
+    setTimeout(() => {
+        // Get an array of all stories which are already added to the `StoryStore`.
+        // Use `raw()` because we don't want to apply any filtering and sorting on the array of stories.
+        const storeItems = raw() as PublishedStoreItem[]
 
-    // Add three more versions of each story to test visual regressions with Chromatic snapshots.
-    // In other environments, these themes can be explored by a user via toolbar toggles.
-    for (const storeItem of storeItems) {
-        // Default theme + Dark mode.
-        addStory({
-            storeItem,
-            isDarkModeEnabled: true,
-        })
-    }
+        // `StoryStore` is immutable outside of a configure() call.
+        // As we delay this logic to support CSF stories, we need to set this to ensure changes are still applied.
+        storyStore.startConfiguring()
+
+        // Add three more versions of each story to test visual regressions with Chromatic snapshots.
+        // In other environments, these themes can be explored by a user via toolbar toggles.
+        for (const storeItem of storeItems) {
+            // Default theme + Dark mode.
+            addStory({
+                storeItem,
+                isDarkModeEnabled: true,
+            })
+        }
+
+        storyStore.finishConfiguring()
+    }, 0)
 }

--- a/client/storybook/src/chromatic-story/add-story.ts
+++ b/client/storybook/src/chromatic-story/add-story.ts
@@ -1,19 +1,8 @@
-import { PublishedStoreItem, StoryStore } from '@storybook/client-api'
+import { PublishedStoreItem } from '@storybook/client-api'
 import { toId } from '@storybook/csf'
 
 import { createChromaticStory, CreateChromaticStoryOptions } from './create-chromatic-story'
-
-// This global reference is used internally by Storybook:
-// https://github.com/storybookjs/storybook/blob/3ec358f71c6111838092397d13fbe35b627a9a9d/lib/core-client/src/preview/start.ts#L43
-declare global {
-    interface Window {
-        __STORYBOOK_STORY_STORE__: StoryStore
-    }
-}
-
-// See the discussion about `StoryStore` usage in stories:
-// https://github.com/storybookjs/storybook/discussions/12050#discussioncomment-125658
-const storyStore = window.__STORYBOOK_STORY_STORE__
+import { storyStore } from './story-store'
 
 interface AddStoryOptions extends Pick<CreateChromaticStoryOptions, 'isDarkModeEnabled'> {
     storeItem: PublishedStoreItem

--- a/client/storybook/src/chromatic-story/story-store.ts
+++ b/client/storybook/src/chromatic-story/story-store.ts
@@ -1,0 +1,13 @@
+import { StoryStore } from '@storybook/client-api'
+
+// This global reference is used internally by Storybook:
+// https://github.com/storybookjs/storybook/blob/3ec358f71c6111838092397d13fbe35b627a9a9d/lib/core-client/src/preview/start.ts#L43
+declare global {
+    interface Window {
+        __STORYBOOK_STORY_STORE__: StoryStore
+    }
+}
+
+// See the discussion about `StoryStore` usage in stories:
+// https://github.com/storybookjs/storybook/discussions/12050#discussioncomment-125658
+export const storyStore = window.__STORYBOOK_STORY_STORE__


### PR DESCRIPTION
CSF stories need to be evaluated first before they are injected into the `storyStore`. This logic ensures that can happen, and our Chromatic variants are still generated for CSF stories.

Fix is in the Chromatic diff!