### PR TITLE
Fix header layout on mobile

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -248,7 +248,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         <>
                             <NavAction>
                                 <Link className="global-navbar__link" to="https://about.sourcegraph.com">
-                                    About Sourcegraph
+                                    About <span className="d-none d-sm-inline">Sourcegraph</span>
                                 </Link>
                             </NavAction>
 

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -125,7 +125,12 @@ exports[`GlobalNavbar default 1`] = `
           class="global-navbar__link"
           to="https://about.sourcegraph.com"
         >
-          About Sourcegraph
+          About 
+          <span
+            class="d-none d-sm-inline"
+          >
+            Sourcegraph
+          </span>
         </a>
       </li>
       <li
@@ -302,7 +307,12 @@ exports[`GlobalNavbar low-profile 1`] = `
           class="global-navbar__link"
           to="https://about.sourcegraph.com"
         >
-          About Sourcegraph
+          About 
+          <span
+            class="d-none d-sm-inline"
+          >
+            Sourcegraph
+          </span>
         </a>
       </li>
       <li
@@ -479,7 +489,12 @@ exports[`GlobalNavbar no-search-input 1`] = `
           class="global-navbar__link"
           to="https://about.sourcegraph.com"
         >
-          About Sourcegraph
+          About 
+          <span
+            class="d-none d-sm-inline"
+          >
+            Sourcegraph
+          </span>
         </a>
       </li>
       <li


### PR DESCRIPTION
320px before:
![image](https://user-images.githubusercontent.com/9516420/129894410-c712cbd7-9a41-4b84-a58d-f01363a42749.png)

320 after:
![image](https://user-images.githubusercontent.com/9516420/129894450-67ab9308-827b-4c98-9499-46934bd9e86a.png)

Context: https://sourcegraph.slack.com/archives/CHEKCRWKV/p1629279670123500