### PR TITLE
Code Insights: Add dynamic y-axis width calculation

### DIFF
--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
@@ -7,16 +7,15 @@ const APPROXIMATE_SYMBOL_WIDTH = 11
 
 export function getYAxisWidth<Scale extends AnyD3Scale>(scale: Scale, numberTicks: number): number {
     const ticksValues = getTicks(scale, numberTicks)
-    const ticksLengths = ticksValues
-        .map(numberFormatter)
-        .map(value =>
-            value
+    const ticksLengths = ticksValues.map(
+        value =>
+            numberFormatter(value)
                 .split('')
                 // Filter all dots from the label symbols to avoid unnecessary
                 // width increasing (dots take just a few pixels)
-                .filter(symbol => symbol !== '.')
-        )
-        .map(value => value.length)
+                .filter(symbol => symbol !== '.').length
+    )
+
     const maxNumberSymbolsInTicks = Math.max(...ticksLengths)
 
     return maxNumberSymbolsInTicks * APPROXIMATE_SYMBOL_WIDTH

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
@@ -3,11 +3,20 @@ import { AnyD3Scale } from '@visx/scale/lib/types/Scale'
 
 import { numberFormatter } from '../components/TickComponent'
 
-const APPROXIMATE_SYMBOL_WIDTH = 8
+const APPROXIMATE_SYMBOL_WIDTH = 11
 
 export function getYAxisWidth<Scale extends AnyD3Scale>(scale: Scale, numberTicks: number): number {
     const ticksValues = getTicks(scale, numberTicks)
-    const ticksLengths = ticksValues.map(numberFormatter).map(value => value.length)
+    const ticksLengths = ticksValues
+        .map(numberFormatter)
+        .map(value =>
+            value
+                .split('')
+                // Filter all dots from the label symbols to avoid unnecessary
+                // width increasing (dots take just a few pixels)
+                .filter(symbol => symbol !== '.')
+        )
+        .map(value => value.length)
     const maxNumberSymbolsInTicks = Math.max(...ticksLengths)
 
     return maxNumberSymbolsInTicks * APPROXIMATE_SYMBOL_WIDTH

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
@@ -1,0 +1,14 @@
+import { getTicks } from '@visx/scale'
+import { AnyD3Scale } from '@visx/scale/lib/types/Scale'
+
+import { numberFormatter } from '../components/TickComponent'
+
+const APPROXIMATE_SYMBOL_WIDTH = 8
+
+export function getYAxisWidth<Scale extends AnyD3Scale>(scale: Scale, numberTicks: number): number {
+    const ticksValues = getTicks(scale, numberTicks)
+    const ticksLengths = ticksValues.map(numberFormatter).map(value => value.length)
+    const maxNumberSymbolsInTicks = Math.max(...ticksLengths)
+
+    return maxNumberSymbolsInTicks * APPROXIMATE_SYMBOL_WIDTH
+}

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
@@ -16,7 +16,7 @@ export function getYAxisWidth<Scale extends AnyD3Scale>(scale: Scale, numberTick
                 .filter(symbol => symbol !== '.').length
     )
 
-    const maxNumberSymbolsInTicks = Math.max(...ticksLengths)
+    const maxNumberSymbolsInTicks = Math.max(...ticksLengths, 0)
 
     return maxNumberSymbolsInTicks * APPROXIMATE_SYMBOL_WIDTH
 }

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/use-scales.ts
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/use-scales.ts
@@ -1,7 +1,7 @@
-import { AxisScaleOutput } from '@visx/axis'
+import { AxisScale, AxisScaleOutput } from '@visx/axis'
 import { DefaultOutput, ScaleConfig, scaleLinear, scaleTime } from '@visx/scale'
 import { PickScaleConfigWithoutType } from '@visx/scale/lib/types/ScaleConfig'
-import { ScaleLinear, ScaleTime } from 'd3-scale'
+import { ScaleTime } from 'd3-scale'
 import { useMemo, useContext } from 'react'
 
 import { LineChartSettingsContext } from '../line-chart-settings-provider'
@@ -12,48 +12,35 @@ import { getRangeWithPadding } from './get-range-with-padding'
 
 const LINE_VERTICAL_PADDING = 0.15
 
-interface UseScalesProps<Datum> {
+interface ScalesConfiguration {
+    x: ScaleConfig<AxisScaleOutput, any, any>
+    y: ScaleConfig<AxisScaleOutput, any, any>
+}
+
+export interface UseScalesConfiguration<Datum> {
     /**
      * D3 scales configuration
      * See https://github.com/d3/d3-scale#continuous_domain
      */
-    config: {
-        x: ScaleConfig<AxisScaleOutput, any, any>
-        y: ScaleConfig<AxisScaleOutput, any, any>
-    }
-    /** Accessors map to get value from datum object */
-    accessors: Accessors<Datum, keyof Datum>
-    /** Chart width in px */
-    width: number
-    /** Chart height in px */
-    height: number
-    /** Dataset with all series (lines) of chart */
+    config: ScalesConfiguration
+
+    /**
+     * Dataset with all series (lines) of chart
+     */
     data: Datum[]
+
+    /**
+     * Accessors map to get (x, y) value from datum objects
+     */
+    accessors: Accessors<Datum, keyof Datum>
 }
 
-interface UseScalesOutput {
-    /** Extended (with new domain) configuration for XYChart */
-    config: {
-        x: ScaleConfig<AxisScaleOutput, any, any>
-        y: ScaleConfig<AxisScaleOutput, any, any>
-    }
-
-    /** Time d3 scale (used to calculate x position for ticks label) */
-    xScale: ScaleTime<number, number>
-
-    /** Continuous d3 scale (used to calculate y position for ticks label) */
-    yScale: ScaleLinear<number, number>
-}
-
-/**
- * Hook to generate d3 scales according to chart configuration.
- */
-export function useScales<Datum>(props: UseScalesProps<Datum>): UseScalesOutput {
-    const { config, accessors, width, height, data } = props
+export function useScalesConfiguration<Datum>(props: UseScalesConfiguration<Datum>): ScalesConfiguration {
+    const { config, data, accessors } = props
     const { zeroYAxisMin } = useContext(LineChartSettingsContext)
 
     // Extend origin config with calculated domain with vertical padding
-    const scalesConfig = useMemo(() => {
+    return useMemo(() => {
         let [min, max] = getMinAndMax(data, accessors)
         if (zeroYAxisMin) {
             min = 0
@@ -67,25 +54,57 @@ export function useScales<Datum>(props: UseScalesProps<Datum>): UseScalesOutput 
             },
         }
     }, [data, accessors, zeroYAxisMin, config])
+}
 
-    const xScale = useMemo(
+interface UseYScalesProps {
+    /**
+     * D3 scales configuration
+     * See https://github.com/d3/d3-scale#continuous_domain
+     */
+    config: ScaleConfig<AxisScaleOutput, any, any>
+    height: number
+}
+
+export function useYScale(props: UseYScalesProps): AxisScale {
+    const { config, height } = props
+
+    return useMemo(
+        () =>
+            scaleLinear({
+                ...(config as PickScaleConfigWithoutType<'linear', DefaultOutput>),
+                range: [height, 0],
+            }),
+        [config, height]
+    )
+}
+
+interface UseXScalesProps<Datum> {
+    /**
+     * D3 scales configuration
+     * See https://github.com/d3/d3-scale#continuous_domain
+     */
+    config: ScaleConfig<AxisScaleOutput, any, any>
+
+    /** Accessors map to get value from datum object */
+    accessors: Accessors<Datum, keyof Datum>
+
+    /** Chart width in px */
+    width: number
+
+    /** Dataset with all series (lines) of chart */
+    data: Datum[]
+}
+
+export function useXScale<Datum>(props: UseXScalesProps<Datum>): ScaleTime<number, number> {
+    const { config, accessors, data, width } = props
+
+    return useMemo(
         () =>
             scaleTime({
-                ...scalesConfig.x,
+                ...config,
                 range: [0, width],
                 domain: [accessors.x(data[0]), accessors.x(data[data.length - 1])],
             }),
-        [scalesConfig.x, accessors, data, width]
+        [config, accessors, data, width]
     )
-
-    const yScale = useMemo(
-        () =>
-            scaleLinear({
-                ...(scalesConfig.y as PickScaleConfigWithoutType<'linear', DefaultOutput>),
-                range: [height, 0],
-            }),
-        [scalesConfig.y, height]
-    )
-
-    return { config: scalesConfig, xScale, yScale }
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/23950

## Context
This PR adds dynamic Y-axis calculations to be able to change width based on the biggest tick label for the y-axis. Before this PR we had just a static value (40px) this covered almost all cases but still there were some cases when this static padding value doesn't work really well.

<table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
  <td>
  <img width="583" alt="Screenshot 2021-08-18 at 17 35 24" src="https://user-images.githubusercontent.com/18492575/129917870-e44370b2-9feb-46db-b484-22cd7a67b1db.png">
  </td>
  


  <td>
  <img width="545" alt="Screenshot 2021-08-18 at 17 26 38" src="https://user-images.githubusercontent.com/18492575/129917828-31066809-acf3-4ac0-9a7e-b430617ddc23.png">
  </td>
 </tr>
</table>