### PR TITLE
gitserver: discover endpoints dynamically in k8s

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"sort"
 	"strings"
 	"sync"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/confdb"
@@ -47,19 +49,17 @@ func printConfigValidation() {
 	}
 }
 
-var (
-	metricConfigOverrideUpdates = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "src_frontend_config_file_watcher_updates",
-		Help: "Incremented each time the config file is updated.",
-	}, []string{"status"})
-)
+var metricConfigOverrideUpdates = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "src_frontend_config_file_watcher_updates",
+	Help: "Incremented each time the config file is updated.",
+}, []string{"status"})
 
 func overrideSiteConfig(ctx context.Context) error {
 	path := os.Getenv("SITE_CONFIG_FILE")
 	if path == "" {
 		return nil
 	}
-	var updateFunc = func(ctx context.Context) error {
+	updateFunc := func(ctx context.Context) error {
 		raw, err := (&configurationSource{}).Read(ctx)
 		if err != nil {
 			return err
@@ -91,7 +91,7 @@ func overrideGlobalSettings(ctx context.Context, db dbutil.DB) error {
 		return nil
 	}
 	settings := database.Settings(db)
-	var update = func(ctx context.Context) error {
+	update := func(ctx context.Context) error {
 		globalSettingsBytes, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrap(err, "reading GLOBAL_SETTINGS_FILE")
@@ -131,7 +131,7 @@ func overrideExtSvcConfig(ctx context.Context, db dbutil.DB) error {
 	}
 	extsvcs := database.ExternalServices(db)
 
-	var update = func(ctx context.Context) error {
+	update := func(ctx context.Context) error {
 		raw, err := (&configurationSource{}).Read(ctx)
 		if err != nil {
 			return err
@@ -349,9 +349,15 @@ func (c configurationSource) Read(ctx context.Context) (conftypes.RawUnified, er
 	if err != nil {
 		return conftypes.RawUnified{}, errors.Wrap(err, "confdb.SiteGetLatest")
 	}
+
+	conns, err := serviceConnections()
+	if err != nil {
+		return conftypes.RawUnified{}, err
+	}
+
 	return conftypes.RawUnified{
 		Site:               site.Contents,
-		ServiceConnections: serviceConnections(),
+		ServiceConnections: conns,
 	}, nil
 }
 
@@ -371,9 +377,22 @@ func (c configurationSource) Write(ctx context.Context, input conftypes.RawUnifi
 var (
 	serviceConnectionsVal  conftypes.ServiceConnections
 	serviceConnectionsOnce sync.Once
+
+	gitservers = endpoint.New(func() string {
+		v := os.Getenv("SRC_GIT_SERVERS")
+		if v == "" {
+			// Detect 'go test' and setup default addresses in that case.
+			p, err := os.Executable()
+			if err == nil && strings.HasSuffix(p, ".test") {
+				return "gitserver:3178"
+			}
+			return "k8s+rpc://gitserver:3178?kind=sts"
+		}
+		return v
+	}())
 )
 
-func serviceConnections() conftypes.ServiceConnections {
+func serviceConnections() (conftypes.ServiceConnections, error) {
 	serviceConnectionsOnce.Do(func() {
 		username := ""
 		if user, err := user.Current(); err == nil {
@@ -381,7 +400,6 @@ func serviceConnections() conftypes.ServiceConnections {
 		}
 
 		serviceConnectionsVal = conftypes.ServiceConnections{
-			GitServers:               gitServers(),
 			PostgresDSN:              dbutil.PostgresDSN("", username, os.Getenv),
 			CodeIntelPostgresDSN:     dbutil.PostgresDSN("codeintel", username, os.Getenv),
 			CodeInsightsTimescaleDSN: dbutil.PostgresDSN("codeinsights", username, os.Getenv),
@@ -398,19 +416,28 @@ func serviceConnections() conftypes.ServiceConnections {
 		}
 	})
 
-	return serviceConnectionsVal
-}
-
-func gitServers() []string {
-	v := os.Getenv("SRC_GIT_SERVERS")
-	if v == "" {
-		// Detect 'go test' and setup default addresses in that case.
-		p, err := os.Executable()
-		if err == nil && strings.HasSuffix(p, ".test") {
-			v = "gitserver:3178"
-		}
+	eps, err := gitservers.Endpoints()
+	if err != nil {
+		return conftypes.ServiceConnections{}, err
 	}
-	return strings.Fields(v)
+
+	if len(eps) == 0 {
+		return conftypes.ServiceConnections{}, errors.New("no endpoints configured for gitserver")
+	}
+
+	addrs := make([]string, 0, len(eps))
+	for ep := range eps {
+		addrs = append(addrs, ep)
+	}
+
+	sort.Strings(addrs)
+
+	return conftypes.ServiceConnections{
+		GitServers:               addrs,
+		PostgresDSN:              serviceConnectionsVal.PostgresDSN,
+		CodeIntelPostgresDSN:     serviceConnectionsVal.CodeIntelPostgresDSN,
+		CodeInsightsTimescaleDSN: serviceConnectionsVal.CodeInsightsTimescaleDSN,
+	}, nil
 }
 
 // comparePostgresDSNs returns an error if one of the given Postgres DSN values are

--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	github.com/sourcegraph/go-jsonschema v0.0.0-20200907102109-d14e9f2f3a28
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
-	github.com/sourcegraph/go-rendezvous v0.0.0-20210817141400-b50ebb50dc8a
+	github.com/sourcegraph/go-rendezvous v0.0.0-20210819140028-cdd914a24376
 	github.com/sourcegraph/gosyntect v0.0.0-20210422223331-645353f16ddc
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -1370,6 +1370,8 @@ github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d h1:afLbh+ltiygT
 github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=
 github.com/sourcegraph/go-rendezvous v0.0.0-20210817141400-b50ebb50dc8a h1:7aQSpVGMHqodrTJDfC6P3xI97h4FCp9OUEwQPjr/xZ8=
 github.com/sourcegraph/go-rendezvous v0.0.0-20210817141400-b50ebb50dc8a/go.mod h1:IhIP+gIbf0TKVMjcEEwUBjomZRjrPnlZbzT2Wac7XA0=
+github.com/sourcegraph/go-rendezvous v0.0.0-20210819140028-cdd914a24376 h1:XYZBi/XEMLcTBsB2xbgk3Qljfs3Xt7jps2ixQh+2V4U=
+github.com/sourcegraph/go-rendezvous v0.0.0-20210819140028-cdd914a24376/go.mod h1:IhIP+gIbf0TKVMjcEEwUBjomZRjrPnlZbzT2Wac7XA0=
 github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 h1:K7hzuWsJGoU8ILHJzrXxsuvXvLHpP/g4iUk7VFj2lY8=
 github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8/go.mod h1:0VfoEApmSPgPhnePllwhrB4vwCUkI0K0w8aueOgoJQI=
 github.com/sourcegraph/gosaml2 v0.6.1-0.20210128133756-84151d087b10 h1:lLSG41QZ5I81jSOakWLB1qEXZhJ65spo81f4SEd8Z20=

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"os"
-	"sort"
 	"strings"
 	"sync"
 
@@ -142,8 +141,8 @@ func (m *Map) GetMany(keys ...string) ([]string, error) {
 	return vals, nil
 }
 
-// Endpoints returns a set of all addresses. Do not modify the returned value.
-func (m *Map) Endpoints() (map[string]struct{}, error) {
+// Endpoints returns a list of all addresses. Do not modify the returned value.
+func (m *Map) Endpoints() ([]string, error) {
 	m.init.Do(m.discover)
 
 	m.mu.RLock()
@@ -188,8 +187,6 @@ func (m *Map) sync(ch chan endpoints, ready chan struct{}) {
 			m.err = eps.Error
 			m.mu.Unlock()
 		case len(eps.Endpoints) > 0:
-			sort.Strings(eps.Endpoints)
-
 			metricEndpointSize.WithLabelValues(eps.Service).Set(float64(len(eps.Endpoints)))
 
 			hm := newConsistentHash(eps.Endpoints)

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -87,13 +87,8 @@ func expectEndpoints(t *testing.T, m *Map, endpoints ...string) {
 }
 
 func TestEndpoints(t *testing.T) {
-	eps := []string{"http://test-1", "http://test-2", "http://test-3", "http://test-4"}
-	want := map[string]struct{}{}
-	for _, addr := range eps {
-		want[addr] = struct{}{}
-	}
-
-	m := Static(eps...)
+	want := []string{"http://test-1", "http://test-2", "http://test-3", "http://test-4"}
+	m := Static(want...)
 	got, err := m.Endpoints()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -382,7 +382,7 @@ type atomicMap struct {
 	atomic.Value
 }
 
-func (m *atomicMap) Endpoints() (map[string]struct{}, error) {
+func (m *atomicMap) Endpoints() ([]string, error) {
 	return m.Value.Load().(EndpointMap).Endpoints()
 }
 

--- a/internal/search/backend/indexers_test.go
+++ b/internal/search/backend/indexers_test.go
@@ -161,12 +161,7 @@ func TestFindEndpoint(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			eps := map[string]struct{}{}
-			for _, ep := range tc.endpoints {
-				eps[ep] = struct{}{}
-			}
-
-			got, err := findEndpoint(eps, tc.hostname)
+			got, err := findEndpoint(tc.endpoints, tc.hostname)
 			if tc.errS != "" {
 				got := fmt.Sprintf("%v", err)
 				if !strings.Contains(got, tc.errS) {
@@ -188,12 +183,8 @@ func TestFindEndpoint(t *testing.T) {
 // prefixMap assigns keys to values if the value is a prefix of key.
 type prefixMap []string
 
-func (m prefixMap) Endpoints() (map[string]struct{}, error) {
-	eps := map[string]struct{}{}
-	for _, v := range m {
-		eps[v] = struct{}{}
-	}
-	return eps, nil
+func (m prefixMap) Endpoints() ([]string, error) {
+	return m, nil
 }
 
 func (m prefixMap) GetMany(keys ...string) ([]string, error) {

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -151,7 +151,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 	var indexerEndpoints []string
 	if info.IsStructuralPat {
 		endpoints, err := search.Indexers().Map.Endpoints()
-		for key := range endpoints {
+		for _, key := range endpoints {
 			indexerEndpoints = append(indexerEndpoints, key)
 		}
 		if err != nil {

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -150,10 +150,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 
 	var indexerEndpoints []string
 	if info.IsStructuralPat {
-		endpoints, err := search.Indexers().Map.Endpoints()
-		for _, key := range endpoints {
-			indexerEndpoints = append(indexerEndpoints, key)
-		}
+		indexerEndpoints, err = search.Indexers().Map.Endpoints()
 		if err != nil {
 			return nil, false, err
 		}


### PR DESCRIPTION
This commit makes it so GitServers in ServiceConnections are discovered dynamically in Kubernetes clusters. We re-use the service discovery code from the endpoint package, without leveraging the consistent hashing part yet, which is for the time being still handled in gitserver client (i.e. AddrForRepo).

This should make unnecessary for customers to manually configure SRC_GIT_SERVERS in Kubernetes clusters.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
