### PR TITLE
doc: Clear up quickstart step order

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 
 To use Sourcegraph OSS:
 
-1. [Initialize the PostgreSQL database](doc/dev/getting-started/quickstart_2_initialize_database.md)
-1. [Ensure Docker is running](doc/dev/getting-started/quickstart_3_start_docker.md)
+1. [Ensure Docker is running](doc/dev/getting-started/quickstart_2_start_docker.md)
+1. [Initialize the PostgreSQL database](doc/dev/getting-started/quickstart_3_initialize_database.md)
 1. [Configure the HTTPS reverse proxy](doc/dev/getting-started/quickstart_5_configure_https_reverse_proxy.md)
 1. [Start the development server](doc/dev/getting-started/quickstart_6_start_server.md)
    ```sh

--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -1,7 +1,7 @@
 # This files provides an easy way to start Redis and PostgreSQL servers for
 # development, via docker-compose.
 #
-# See https://docs.sourcegraph.com/dev/getting-started/quickstart_2_initialize_database#with-docker
+# See https://docs.sourcegraph.com/dev/getting-started/quickstart_3_initialize_database#with-docker
 #
 # You can also use `sg run redis-postgres`.
 services:

--- a/doc/dev/background-information/postgresql.md
+++ b/doc/dev/background-information/postgresql.md
@@ -19,7 +19,7 @@ can make global configuration changes, such as changing the timezone. If you
 need to use other settings for other databases, use a separate PostgreSQL
 instance.
 
-See the [setting up PostgreSQL guide](../getting-started/configure_postgresql.md) or [quickstart step 2: initialize the database](../getting-started/quickstart_2_initialize_database.md)
+See the [setting up PostgreSQL guide](../getting-started/configure_postgresql.md) or [quickstart step 2: initialize the database](../getting-started/quickstart_3_initialize_database.md)
 
 ## Migrations
 

--- a/doc/dev/getting-started/configure_postgresql.md
+++ b/doc/dev/getting-started/configure_postgresql.md
@@ -1,6 +1,6 @@
 # Configure PostgreSQL
 
-TODO: Can this be deprecated and/or combined in favor of [quickstart step 2](quickstart_2_initialize_database.md)?
+TODO: Can this be deprecated and/or combined in favor of [quickstart step 2](quickstart_3_initialize_database.md)?
 
 ## Initialize
 

--- a/doc/dev/getting-started/index.md
+++ b/doc/dev/getting-started/index.md
@@ -5,8 +5,8 @@ Have a look around, our code is on [GitHub](https://sourcegraph.com/github.com/s
 ## Quickstart
 
 - [Step 1: Install dependencies](quickstart_1_install_dependencies.md)
-- [Step 2: Initialize your database](quickstart_2_initialize_database.md)
-- [Step 3: (macOS) Start Docker](quickstart_3_start_docker.md)
+- [Step 2: Start Docker](quickstart_2_start_docker.md)
+- [Step 3: Initialize your database](quickstart_3_initialize_database.md)
 - [Step 4: Get the code](quickstart_4_clone_repository.md)
 - [Step 5: Configure HTTPS reverse proxy](quickstart_5_configure_https_reverse_proxy.md)
 - [Step 6: Start the server](quickstart_6_start_server.md)

--- a/doc/dev/getting-started/quickstart_1_install_dependencies.md
+++ b/doc/dev/getting-started/quickstart_1_install_dependencies.md
@@ -263,4 +263,4 @@ asdf plugin add yarn
 
 You can install the all the versions specified in [.tool-versions](https://github.com/sourcegraph/sourcegraph/blob/main/.tool-versions) by running `asdf install`.
 
-[< Previous](index.md) | [Next >](quickstart_2_initialize_database.md)
+[< Previous](index.md) | [Next >](quickstart_2_start_docker.md)

--- a/doc/dev/getting-started/quickstart_2_start_docker.md
+++ b/doc/dev/getting-started/quickstart_2_start_docker.md
@@ -34,4 +34,4 @@ If you have issues running Docker, try [adding your user to the docker group][do
 [dockerGroup]: https://stackoverflow.com/a/48957722
 [socketPermissions]: https://stackoverflow.com/a/51362528
 
-[< Previous](quickstart_2_initialize_database.md) | [Next >](quickstart_4_clone_repository.md)
+[< Previous](quickstart_1_install_dependencies.md) | [Next >](quickstart_3_initialize_database.md)

--- a/doc/dev/getting-started/quickstart_2_start_docker.md
+++ b/doc/dev/getting-started/quickstart_2_start_docker.md
@@ -1,4 +1,4 @@
-# Quickstart step 3: Start Docker
+# Quickstart step 2: Start Docker
 
 ## macOS
 

--- a/doc/dev/getting-started/quickstart_3_initialize_database.md
+++ b/doc/dev/getting-started/quickstart_3_initialize_database.md
@@ -1,5 +1,27 @@
 # Quickstart step 2: Initialize your database
 
+## With Docker
+
+The Sourcegraph server reads PostgreSQL connection configuration from the [`PG*` environment variables](http://www.postgresql.org/docs/current/static/libpq-envars.html).
+
+The development server startup script as well as the docker compose file provide default settings, so it will work out of the box.
+To initialize your database, you may have to set the appropriate environment variables before running the `createdb` command:
+
+```sh
+export PGUSER=sourcegraph PGPASSWORD=sourcegraph PGDATABASE=sourcegraph
+createdb --user=sourcegraph --owner=sourcegraph --encoding=UTF8 --template=template0 sourcegraph
+```
+
+You can also use the `PGDATA_DIR` environment variable to specify a local folder (instead of a volume) to store the database files. See the `dev/redis-postgres.yml` file for more details.
+
+This can also be spun up using [`sg start redis-postgres`](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md), with the following `sg.config.override.yaml`:
+
+```yaml
+env:
+    PGHOST: localhost
+    PGPASSWORD: sourcegraph
+    PGUSER: sourcegraph
+```
 ## Without Docker
 
 You need a fresh Postgres database and a database user that has full ownership of that database.
@@ -51,33 +73,10 @@ You need a fresh Postgres database and a database user that has full ownership o
     [envdir]: https://cr.yp.to/daemontools/envdir.html
     [dotenv]: https://github.com/joho/godotenv
 
-## With Docker
-
-The Sourcegraph server reads PostgreSQL connection configuration from the [`PG*` environment variables](http://www.postgresql.org/docs/current/static/libpq-envars.html).
-
-The development server startup script as well as the docker compose file provide default settings, so it will work out of the box.
-To initialize your database, you may have to set the appropriate environment variables before running the `createdb` command:
-
-```sh
-export PGUSER=sourcegraph PGPASSWORD=sourcegraph PGDATABASE=sourcegraph
-createdb --user=sourcegraph --owner=sourcegraph --encoding=UTF8 --template=template0 sourcegraph
-```
-
-You can also use the `PGDATA_DIR` environment variable to specify a local folder (instead of a volume) to store the database files. See the `dev/redis-postgres.yml` file for more details.
-
-This can also be spun up using [`sg start redis-postgres`](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md), with the following `sg.config.override.yaml`:
-
-```yaml
-env:
-    PGHOST: localhost
-    PGPASSWORD: sourcegraph
-    PGUSER: sourcegraph
-```
-
 ## More info
 
 For more information about data storage, [read our full PostgreSQL page](../background-information/postgresql.md).
 
 Migrations are applied automatically.
 
-[< Previous](quickstart_1_install_dependencies.md) | [Next >](quickstart_3_start_docker.md)
+[< Previous](quickstart_2_start_docker.md) | [Next >](quickstart_4_clone_repository.md)

--- a/doc/dev/getting-started/quickstart_3_initialize_database.md
+++ b/doc/dev/getting-started/quickstart_3_initialize_database.md
@@ -1,4 +1,4 @@
-# Quickstart step 2: Initialize your database
+# Quickstart step 3: Initialize your database
 
 ## With Docker
 

--- a/doc/dev/getting-started/quickstart_4_clone_repository.md
+++ b/doc/dev/getting-started/quickstart_4_clone_repository.md
@@ -4,4 +4,4 @@
 git clone https://github.com/sourcegraph/sourcegraph.git
 ```
 
-[< Previous](quickstart_3_start_docker.md) | [Next >](quickstart_5_configure_https_reverse_proxy.md)
+[< Previous](quickstart_3_initialize_database.md) | [Next >](quickstart_5_configure_https_reverse_proxy.md)

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -12,8 +12,8 @@ Sourcegraph development is open source at:
 A hands-on introduction for setting up your local development environment.
 
 - [Step 1: Install dependencies](getting-started/quickstart_1_install_dependencies.md)
-- [Step 2: Initialize your database](getting-started/quickstart_2_initialize_database.md)
-- [Step 3: (macOS) Start Docker](getting-started/quickstart_3_start_docker.md)
+- [Step 2: Start Docker](getting-started/quickstart_2_start_docker.md)
+- [Step 3: Initialize your database](getting-started/quickstart_3_initialize_database.md)
 - [Step 4: Get the code](getting-started/quickstart_4_clone_repository.md)
 - [Step 5: Configure HTTPS reverse proxy](getting-started/quickstart_5_configure_https_reverse_proxy.md)
 - [Step 6: Start the server](getting-started/quickstart_6_start_server.md)


### PR DESCRIPTION
Swap step 2 (DB initialization) and step 3 (Run docker) in our quickstart
make `With docker` the first section in the DB initialization

1. We need to install docker anyway, so we might as well do it before initializing the DB
2. It is easier to init the DB with docker, because it’s just 2 commands vs a lot if we do not run docker.
3. We are not following a natural order of things, if we allow using docker in step 2 and then basically require to install it in step 3
