### PR TITLE
insights: fix off by one error when compressing insight queries

### DIFF
--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -109,6 +109,7 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 	// horizon of the indexer
 	addToPlan(frames[0], "")
 	for i := 1; i < len(frames); i++ {
+		previous := frames[i-1]
 		frame := frames[i]
 		if metadata.LastIndexedAt.Before(frame.To) {
 			// The commit indexer is not up to date enough to understand if this frame can be dropped
@@ -116,7 +117,8 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 			continue
 		}
 
-		commits, err := c.store.Get(ctx, id, frame.From, frame.To)
+		// We have to diff the commits in the previous frame to determine if we should query at the start of this frame
+		commits, err := c.store.Get(ctx, id, previous.From, previous.To)
 		if err != nil {
 			log15.Error("insights: compression.go/FilterFrames unable to retrieve commits\n", "repo_id", id, "from", frame.From, "to", frame.To)
 			addToPlan(frame, "")

--- a/enterprise/internal/insights/compression/testdata/TestFilterFrames/test_multiple_frames_ensure_previous_frame_is_used_for_compression.golden
+++ b/enterprise/internal/insights/compression/testdata/TestFilterFrames/test_multiple_frames_ensure_previous_frame_is_used_for_compression.golden
@@ -1,0 +1,23 @@
+compression.BackfillPlan{
+	Executions: []*compression.QueryExecution{
+		&compression.QueryExecution{RecordingTime: time.Time{
+			ext: 63745056000,
+		}},
+		&compression.QueryExecution{
+			Revision:      "stamp1",
+			RecordingTime: time.Time{ext: 63747734400},
+			SharedRecordings: []time.Time{
+				time.Time{ext: 63750153600},
+				time.Time{ext: 63752832000},
+				time.Time{ext: 63755424000},
+				time.Time{ext: 63758102400},
+			},
+		},
+		&compression.QueryExecution{
+			Revision:         "stamp2",
+			RecordingTime:    time.Time{ext: 63760694400},
+			SharedRecordings: []time.Time{time.Time{ext: 63763372800}},
+		},
+	},
+	RecordCount: 8,
+}


### PR DESCRIPTION
The code insights compression mechanism had an off-by-one error because it was using the wrong time frame to get a selection of commits. This fixes the issue and introduces a test that replicates the real scenario that discovered this issue.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
