### PR TITLE
search page: revert footer for self-host users

### DIFF
--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -118,7 +118,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                 {props.showEnterpriseHomePanels && props.authenticatedUser && <HomePanels {...props} />}
             </div>
 
-            <SearchPageFooter telemetryService={props.telemetryService} isLightTheme={props.isLightTheme} />
+            <SearchPageFooter {...props} />
         </div>
     )
 }

--- a/client/web/src/search/home/SearchPageFooter.module.scss
+++ b/client/web/src/search/home/SearchPageFooter.module.scss
@@ -69,3 +69,7 @@
     width: 11.5rem;
     font-size: 0.75rem;
 }
+
+.server-footer {
+    margin: 2rem 0;
+}

--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -59,10 +59,9 @@ const footerLinkSections: { name: string; links: { name: string; to: string; eve
     },
 ]
 
-export const SearchPageFooter: React.FunctionComponent<ThemeProps & TelemetryProps> = ({
-    isLightTheme,
-    telemetryService,
-}) => {
+export const SearchPageFooter: React.FunctionComponent<
+    ThemeProps & TelemetryProps & { isSourcegraphDotCom: boolean }
+> = ({ isLightTheme, telemetryService, isSourcegraphDotCom }) => {
     const assetsRoot = window.context?.assetsRoot || ''
 
     const logLinkClicked = (name: string): void => {
@@ -73,7 +72,7 @@ export const SearchPageFooter: React.FunctionComponent<ThemeProps & TelemetryPro
         telemetryService.log('HomepageDevToolTimeClicked')
     }
 
-    return (
+    return isSourcegraphDotCom ? (
         <footer className={styles.footer}>
             <Link to="/search" aria-label="Home" className="flex-shrink-0">
                 <BrandLogo isLightTheme={isLightTheme} variant="symbol" className={styles.logo} />
@@ -116,6 +115,54 @@ export const SearchPageFooter: React.FunctionComponent<ThemeProps & TelemetryPro
                     </a>
                 </li>
             </ul>
+        </footer>
+    ) : (
+        <footer className={classNames(styles.serverFooter, 'd-flex flex-column flex-lg-row align-items-center')}>
+            <h4 className="mb-2 mb-lg-0">Explore and extend</h4>
+            <span className="d-flex flex-column flex-md-row align-items-center">
+                <span className="d-flex flex-row mb-2 mb-md-0">
+                    <Link
+                        className="px-3"
+                        to="https://docs.sourcegraph.com/integration/browser_extension"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        onClick={() => logLinkClicked('BrowserExtensions')}
+                    >
+                        Browser extensions
+                    </Link>
+                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                    <Link
+                        className="px-3"
+                        to="/extensions"
+                        target="_blank"
+                        onClick={() => logLinkClicked('SourcegraphExtensions')}
+                    >
+                        Sourcegraph extensions
+                    </Link>
+                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                </span>
+                <span className="d-flex flex-row">
+                    <Link
+                        className="px-3"
+                        to="https://docs.sourcegraph.com/integration/editor"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        onClick={() => logLinkClicked('EditorPlugins')}
+                    >
+                        Editor plugins
+                    </Link>
+                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                    <Link
+                        className="pl-3"
+                        to="https://docs.sourcegraph.com/admin/external_service"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        onClick={() => logLinkClicked('CodeHostIntegrations')}
+                    >
+                        Code host integrations
+                    </Link>
+                </span>
+            </span>
         </footer>
     )
 }


### PR DESCRIPTION
We shouldn't use the new sourcegraph.com footer for self-host users. This reverts it back to the old footer which only has the extensibility links.

### Server:

![image](https://user-images.githubusercontent.com/206864/129949807-721a04bc-b638-4f7a-a057-5ab687ae1c4f.png)

### Cloud:

![image](https://user-images.githubusercontent.com/206864/129949940-bb8454b5-6072-47bc-8337-f8ec6623b884.png)

