### PR TITLE
Code Insights: Disable backend insight edit operation over some insight fields

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -13,7 +13,6 @@ import { useDebounce } from '@sourcegraph/wildcard'
 import { Settings } from '../../../../../schema/settings.schema'
 import { InsightsApiContext } from '../../../../core/backend/api-provider'
 import { InsightStillProcessingError } from '../../../../core/backend/api/get-backend-insight-by-id'
-import { BackendInsightFilters } from '../../../../core/backend/types'
 import { addInsightToSettings } from '../../../../core/settings-action/insights'
 import { SearchBackendBasedInsight, SearchBasedBackendFilters } from '../../../../core/types/insight/search-insight'
 import { useDeleteInsight } from '../../../../hooks/use-delete-insight/use-delete-insight'
@@ -67,18 +66,17 @@ export const BackendInsight: React.FunctionComponent<BackendInsightProps> = prop
     const [filters, setFilters] = useState<SearchBasedBackendFilters>(originalInsightFilters)
 
     const [isFiltersOpen, setIsFiltersOpen] = useState(false)
-    const debouncedFilters = useDebounce(useDistinctValue<BackendInsightFilters>(filters), 500)
+    const debouncedFilters = useDebounce(useDistinctValue<SearchBasedBackendFilters>(filters), 500)
 
     // Loading the insight backend data
     const { data, loading, error } = useParallelRequests(
         useCallback(
             () =>
                 getBackendInsightById({
-                    id: cachedInsight.id,
-                    series: cachedInsight.series,
+                    ...cachedInsight,
                     filters: debouncedFilters,
                 }),
-            [cachedInsight.id, cachedInsight.series, debouncedFilters, getBackendInsightById]
+            [cachedInsight, debouncedFilters, getBackendInsightById]
         )
     )
 

--- a/client/web/src/insights/core/backend/api/get-backend-insight-by-id.ts
+++ b/client/web/src/insights/core/backend/api/get-backend-insight-by-id.ts
@@ -27,7 +27,7 @@ export function getBackendInsightById(insight: SearchBackendBasedInsight): Obser
         map(backendInsight => ({
             id: backendInsight.id,
             view: {
-                title: insight.title,
+                title: insight.title ?? backendInsight.title,
                 subtitle: backendInsight.description,
                 content: [createViewContent(backendInsight, series)],
                 isFetchingHistoricalData: backendInsight.series.some(line => line.status.pendingJobs > 0),

--- a/client/web/src/insights/core/backend/api/get-backend-insight-by-id.ts
+++ b/client/web/src/insights/core/backend/api/get-backend-insight-by-id.ts
@@ -1,8 +1,9 @@
 import { Observable, of, throwError } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 
+import { SearchBackendBasedInsight } from '../../types/insight/search-insight'
 import { fetchBackendInsights } from '../requests/fetch-backend-insights'
-import { BackendInsightData, BackendInsightInputs } from '../types'
+import { BackendInsightData } from '../types'
 import { createViewContent } from '../utils/create-view-content'
 
 export class InsightStillProcessingError extends Error {
@@ -12,8 +13,8 @@ export class InsightStillProcessingError extends Error {
     }
 }
 
-export function getBackendInsightById(props: BackendInsightInputs): Observable<BackendInsightData> {
-    const { id, filters, series } = props
+export function getBackendInsightById(insight: SearchBackendBasedInsight): Observable<BackendInsightData> {
+    const { id, filters, series } = insight
 
     return fetchBackendInsights([id], filters).pipe(
         switchMap(backendInsights => {
@@ -23,13 +24,13 @@ export function getBackendInsightById(props: BackendInsightInputs): Observable<B
 
             return of(backendInsights[0])
         }),
-        map(insight => ({
-            id: insight.id,
+        map(backendInsight => ({
+            id: backendInsight.id,
             view: {
                 title: insight.title,
-                subtitle: insight.description,
-                content: [createViewContent(insight, series)],
-                isFetchingHistoricalData: insight.series.some(line => line.status.pendingJobs > 0),
+                subtitle: backendInsight.description,
+                content: [createViewContent(backendInsight, series)],
+                isFetchingHistoricalData: backendInsight.series.some(line => line.status.pendingJobs > 0),
             },
         }))
     )

--- a/client/web/src/insights/core/backend/requests/fetch-backend-insights.ts
+++ b/client/web/src/insights/core/backend/requests/fetch-backend-insights.ts
@@ -11,7 +11,7 @@ import {
     SubjectSettingsResult,
     SubjectSettingsVariables,
 } from '../../../../graphql-operations'
-import { BackendInsightFilters } from '../types'
+import { SearchBasedBackendFilters } from '../../types/insight/search-insight'
 
 const insightFieldsFragment = gql`
     fragment InsightFields on Insight {
@@ -35,7 +35,7 @@ const insightFieldsFragment = gql`
 
 export function fetchBackendInsights(
     insightsIds: string[],
-    filters?: BackendInsightFilters
+    filters?: SearchBasedBackendFilters
 ): Observable<InsightFields[]> {
     return requestGraphQL<InsightsResult>(
         gql`

--- a/client/web/src/insights/core/backend/types.ts
+++ b/client/web/src/insights/core/backend/types.ts
@@ -7,7 +7,7 @@ import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { ViewProviderResult } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 
-import { SearchBasedInsightSeries } from '../types/insight/search-insight'
+import { SearchBackendBasedInsight, SearchBasedInsightSeries } from '../types/insight/search-insight'
 
 import { RepositorySuggestion } from './requests/fetch-repository-suggestions'
 
@@ -51,22 +51,6 @@ export interface SearchInsightSettings {
     repositories: string[]
 }
 
-/**
- * Backend insight filters is subset of search based backend filters.
- * We don't have repo list filter support yet. Only regexp filters are
- * supported.
- */
-export interface BackendInsightFilters {
-    excludeRepoRegexp: string | null
-    includeRepoRegexp: string | null
-}
-
-export interface BackendInsightInputs {
-    id: string
-    filters?: BackendInsightFilters
-    series?: SearchBasedInsightSeries[]
-}
-
 export interface LangStatsInsightsSettings {
     /**
      * URL of git repository from which statistics will be collected
@@ -96,7 +80,7 @@ export interface ApiService {
     /**
      * Returns backend insight (via gql API handler) by insight id.
      */
-    getBackendInsightById: (inputs: BackendInsightInputs) => Observable<BackendInsightData>
+    getBackendInsightById: (insight: SearchBackendBasedInsight) => Observable<BackendInsightData>
 
     /**
      * Returns resolved extension provider result by extension view id via extension API.

--- a/client/web/src/insights/core/backend/utils/create-view-content.ts
+++ b/client/web/src/insights/core/backend/utils/create-view-content.ts
@@ -28,7 +28,7 @@ export function createViewContent(
         chart: 'line',
         data: [...dataByXValue.values()],
         series: insight.series.map((series, index) => ({
-            name: series.label,
+            name: seriesSettings[index]?.name ?? series.label,
             dataKey: `series${index}`,
             stroke: seriesSettings[index]?.stroke,
         })),

--- a/client/web/src/insights/core/types/insight/search-insight.ts
+++ b/client/web/src/insights/core/types/insight/search-insight.ts
@@ -66,3 +66,6 @@ export type { SearchBasedInsightSeries, SearchBasedBackendFilters }
  * Example id for the search based insight: "searchInsights.insight.myFirstSearchBasedInsight"
  */
 export const isSearchBasedInsightId = (id: string): boolean => id.startsWith(InsightTypePrefix.search)
+
+export const isSearchBackendBasedInsight = (insight: SearchBasedInsight): insight is SearchBackendBasedInsight =>
+    insight.type === InsightType.Backend

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -132,14 +132,29 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
                 placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"
                 description={
                     <span>
-                        Do not include the <code>repo:</code> filter as it will be added automatically for the
-                        repositories you included above.
+                        {!isSearchQueryDisabled ? (
+                            <>
+                                Do not include the <code>repo:</code> filter as it will be added automatically for the
+                                repositories you included above.
+                            </>
+                        ) : (
+                            <>
+                                We don't yet allow editing queries for insights over all repos. To change the query,
+                                make a new insight. This is a known{' '}
+                                <a
+                                    href="https://docs.sourcegraph.com/code_insights/explanations/current_limitations_of_code_insights"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    beta limitation
+                                </a>
+                            </>
+                        )}
                     </span>
                 }
                 valid={(hasQueryControlledValue || queryField.meta.touched) && queryField.meta.validState === 'VALID'}
                 error={queryField.meta.touched && queryField.meta.error}
                 className="mt-4"
-                data-tooltip={isSearchQueryDisabled ? "You can't edit this field for all repositories insight" : null}
                 {...queryField.input}
             />
 

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -15,9 +15,18 @@ const validQuery = createRequiredValidator('Query is a required field for data s
 interface FormSeriesInputProps {
     /** Series index. */
     index: number
+
+    /**
+     * This prop represents the case whenever the edit insight UI page
+     * deals with backend insight. We need to disable our search insight
+     * query field since our backend insight can't update BE data according
+     * to the latest insight configuration.
+     */
+    isSearchQueryDisabled: boolean
+
     /**
      * Show all validation error of all fields within the form.
-     * */
+     */
     showValidationErrorsOnMount?: boolean
     /** Name of series. */
     name?: string
@@ -43,6 +52,7 @@ interface FormSeriesInputProps {
 export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = props => {
     const {
         index,
+        isSearchQueryDisabled,
         showValidationErrorsOnMount = false,
         name,
         query,
@@ -95,6 +105,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
         name: 'seriesQuery',
         formApi: formAPI,
         validators: { sync: validQuery },
+        disabled: isSearchQueryDisabled,
     })
 
     const colorField = useField({
@@ -128,6 +139,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
                 valid={(hasQueryControlledValue || queryField.meta.touched) && queryField.meta.validState === 'VALID'}
                 error={queryField.meta.touched && queryField.meta.error}
                 className="mt-4"
+                data-tooltip={isSearchQueryDisabled ? "You can't edit this field for all repositories insight" : null}
                 {...queryField.input}
             />
 

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
@@ -9,52 +9,62 @@ import styles from './FormSeries.module.scss'
 
 export interface FormSeriesProps {
     /**
+     * This prop represents the case whenever the edit insight UI page
+     * deals with backend insight. We need to disable our search insight
+     * query field since our backend insight can't update BE data according
+     * to the latest insight configuration.
+     */
+    isSearchQueryDisabled: boolean
+
+    /**
      * Show all validation error for all forms and fields within the series forms.
-     * */
+     */
     showValidationErrorsOnMount: boolean
+
     /**
      * Controlled value (series - chart lines) for series input component.
-     * */
+     */
     series?: EditableDataSeries[]
 
     /**
      * Live change series handler while user typing in active series form.
      * Used by consumers to get latest values from series inputs and pass
      * them tp live preview chart.
-     * */
+     */
     onLiveChange: (liveSeries: EditableDataSeries, isValid: boolean, index: number) => void
 
     /**
      * Handler that runs every time user clicked edit on particular
      * series card.
-     * */
+     */
     onEditSeriesRequest: (editSeriesIndex: number) => void
 
     /**
      * Handler that runs every time use clicked commit (done) in
      * series edit form.
-     * */
+     */
     onEditSeriesCommit: (seriesIndex: number, editedSeries: EditableDataSeries) => void
 
     /**
      * Handler that runs every time use canceled (click cancel) in
      * series edit form.
-     * */
+     */
     onEditSeriesCancel: (closedCardIndex: number) => void
 
     /**
      * Handler that runs every time use removed (click remove) in
      * series card.
-     * */
+     */
     onSeriesRemove: (removedSeriesIndex: number) => void
 }
 
 /**
  * Renders form series (sub-form) for series (chart lines) creation code insight form.
- * */
+ */
 export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
     const {
         series = [],
+        isSearchQueryDisabled,
         showValidationErrorsOnMount,
         onEditSeriesRequest,
         onEditSeriesCommit,
@@ -69,6 +79,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                 line.edit ? (
                     <FormSeriesInput
                         key={line.id}
+                        isSearchQueryDisabled={isSearchQueryDisabled}
                         showValidationErrorsOnMount={showValidationErrorsOnMount}
                         index={index + 1}
                         cancel={series.length > 1}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
@@ -14,7 +14,7 @@ export interface FormSeriesProps {
      * query field since our backend insight can't update BE data according
      * to the latest insight configuration.
      */
-    isSearchQueryDisabled: boolean
+    isBackendInsightEdit: boolean
 
     /**
      * Show all validation error for all forms and fields within the series forms.
@@ -64,7 +64,7 @@ export interface FormSeriesProps {
 export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
     const {
         series = [],
-        isSearchQueryDisabled,
+        isBackendInsightEdit,
         showValidationErrorsOnMount,
         onEditSeriesRequest,
         onEditSeriesCommit,
@@ -79,7 +79,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                 line.edit ? (
                     <FormSeriesInput
                         key={line.id}
-                        isSearchQueryDisabled={isSearchQueryDisabled}
+                        isSearchQueryDisabled={isBackendInsightEdit}
                         showValidationErrorsOnMount={showValidationErrorsOnMount}
                         index={index + 1}
                         cancel={series.length > 1}
@@ -94,6 +94,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                     line && (
                         <SeriesCard
                             key={`${line.id}-card`}
+                            isRemoveSeriesAvailable={!isBackendInsightEdit}
                             onEdit={() => onEditSeriesRequest(index)}
                             onRemove={() => onSeriesRemove(index)}
                             className={styles.formSeriesItem}
@@ -106,6 +107,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
             <button
                 data-testid="add-series-button"
                 type="button"
+                disabled={isBackendInsightEdit}
                 onClick={() => onEditSeriesRequest(series.length)}
                 className={classnames(styles.formSeriesItem, styles.formSeriesAddButton, 'btn btn-link p-3')}
             >

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
@@ -6,6 +6,8 @@ import { DEFAULT_ACTIVE_COLOR } from '../../../form-color-input/FormColorInput'
 import styles from './SeriesCard.module.scss'
 
 interface SeriesCardProps {
+    isRemoveSeriesAvailable: boolean
+
     /** Name of series. */
     name: string
     /** Query value of series. */
@@ -24,7 +26,15 @@ interface SeriesCardProps {
  * Renders series card component, visual list item of series (name, color, query)
  * */
 export function SeriesCard(props: SeriesCardProps): ReactElement {
-    const { name, query, stroke: color = DEFAULT_ACTIVE_COLOR, className, onEdit, onRemove } = props
+    const {
+        isRemoveSeriesAvailable,
+        name,
+        query,
+        stroke: color = DEFAULT_ACTIVE_COLOR,
+        className,
+        onEdit,
+        onRemove,
+    } = props
 
     return (
         <li
@@ -64,6 +74,7 @@ export function SeriesCard(props: SeriesCardProps): ReactElement {
                     data-testid="series-delete-button"
                     type="button"
                     onClick={onRemove}
+                    disabled={!isRemoveSeriesAvailable}
                     className="border-0 btn btn-outline-danger ml-1"
                 >
                     Remove

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -74,9 +74,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         onSubmit,
     })
 
-    const { editSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({
-        series,
-    })
+    const { editSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({ series })
 
     const handleFormReset = (): void => {
         // TODO [VK] Change useForm API in order to implement form.reset method.

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -167,7 +167,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
             >
                 <FormSeries
                     series={series.input.value}
-                    isSearchQueryDisabled={isEditMode && allReposMode.input.value}
+                    isBackendInsightEdit={isEditMode && allReposMode.input.value}
                     showValidationErrorsOnMount={submitted}
                     onLiveChange={onSeriesLiveChange}
                     onEditSeriesRequest={onEditSeriesRequest}

--- a/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -167,6 +167,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
             >
                 <FormSeries
                     series={series.input.value}
+                    isSearchQueryDisabled={isEditMode && allReposMode.input.value}
                     showValidationErrorsOnMount={submitted}
                     onLiveChange={onSeriesLiveChange}
                     onEditSeriesRequest={onEditSeriesRequest}

--- a/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
+++ b/client/web/src/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
@@ -4,6 +4,7 @@ import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { SubmissionErrors } from '../../../../components/form/hooks/useForm'
 import { InsightType, SearchBasedInsight } from '../../../../core/types'
+import { isSearchBackendBasedInsight } from '../../../../core/types/insight/search-insight'
 import { SupportedInsightSubject } from '../../../../core/types/subjects'
 import { createDefaultEditSeries } from '../../creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series'
 import { SearchInsightCreationContent } from '../../creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent'
@@ -48,6 +49,15 @@ export const EditSearchBasedInsight: React.FunctionComponent<EditSearchBasedInsi
     // Handlers
     const handleSubmit = (values: CreateInsightFormFields): SubmissionErrors | Promise<SubmissionErrors> | void => {
         const sanitizedInsight = getSanitizedSearchInsight(values)
+
+        // Preserve backend insight filters since these filters don't represent in form fields
+        // in case if editing hasn't change type of search insight.
+        if (isSearchBackendBasedInsight(sanitizedInsight) && isSearchBackendBasedInsight(insight)) {
+            return onSubmit({
+                ...sanitizedInsight,
+                filters: insight.filters,
+            })
+        }
 
         return onSubmit(sanitizedInsight)
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/24072

### Context

Code Insight Backend uses a sync process to get insight configuration from the setting cascade subject and starts collecting historical data process. However, at the moment this mechanism doesn't work really well with insight configuration updates. We have to disable some data-sensitive fields at the edit page in case if we are updating backend insight. (query search value and number of data series)

<img width="613" alt="Screenshot 2021-08-18 at 21 25 35" src="https://user-images.githubusercontent.com/18492575/129952047-9046f4c6-252f-4d39-b0ef-3f5206ee80dc.png">

Other insight configuration fields we are able to resolve via setting cascade and not by backend insight response. So you're still able to edit some fields (like series name or series color)