### PR TITLE
batches: update preview action wording to "on apply"

### DIFF
--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -50,7 +50,7 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
             return "You don't have permission to apply this batch change."
         }
         if (selected === 'all' || selected.size > 0) {
-            return 'You have selected changesets. Choose an action or deselect to continue.'
+            return 'You have selected changesets. Choose the action to be performed on apply or deselect to continue.'
         }
         return undefined
     }, [canApply, selected, viewerCanAdminister])

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -5,7 +5,7 @@ import { of, Observable } from 'rxjs'
 
 import { BatchSpecApplyPreviewConnectionFields, ChangesetApplyPreviewFields } from '../../../../graphql-operations'
 import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
-import { MultiSelectContext, MultiSelectContextProvider } from '../../MultiSelectContext'
+import { MultiSelectContextProvider } from '../../MultiSelectContext'
 import { getPublishableChangesetSpecID } from '../utils'
 
 import { hiddenChangesetApplyPreviewStories } from './HiddenChangesetApplyPreviewNode.story'

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -5,6 +5,7 @@ import { of, Observable } from 'rxjs'
 
 import { BatchSpecApplyPreviewConnectionFields, ChangesetApplyPreviewFields } from '../../../../graphql-operations'
 import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+import { MultiSelectContext, MultiSelectContextProvider } from '../../MultiSelectContext'
 import { getPublishableChangesetSpecID } from '../utils'
 
 import { hiddenChangesetApplyPreviewStories } from './HiddenChangesetApplyPreviewNode.story'
@@ -49,19 +50,21 @@ add('PreviewList', () => {
     return (
         <EnterpriseWebStory>
             {props => (
-                <PreviewList
-                    {...props}
-                    batchSpecID="123123"
-                    authenticatedUser={{
-                        url: '/users/alice',
-                        displayName: 'Alice',
-                        username: 'alice',
-                        email: 'alice@email.test',
-                    }}
-                    queryChangesetApplyPreview={queryChangesetApplyPreview}
-                    queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
-                    queryPublishableChangesetSpecIDs={queryPublishableChangesetSpecIDs}
-                />
+                <MultiSelectContextProvider>
+                    <PreviewList
+                        {...props}
+                        batchSpecID="123123"
+                        authenticatedUser={{
+                            url: '/users/alice',
+                            displayName: 'Alice',
+                            username: 'alice',
+                            email: 'alice@email.test',
+                        }}
+                        queryChangesetApplyPreview={queryChangesetApplyPreview}
+                        queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                        queryPublishableChangesetSpecIDs={queryPublishableChangesetSpecIDs}
+                    />
+                </MultiSelectContextProvider>
             )}
         </EnterpriseWebStory>
     )

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -15,24 +15,24 @@ import { queryPublishableChangesetSpecIDs as _queryPublishableChangesetSpecIDs }
 const ACTIONS: Action[] = [
     {
         type: 'unpublish',
-        buttonLabel: 'Unpublish',
-        dropdownTitle: 'Unpublish',
+        buttonLabel: 'Unpublish on apply',
+        dropdownTitle: 'Unpublish on apply',
         dropdownDescription:
-            'Do not publish selected changesets on the codehost. Note: a changeset that has been published cannot be unpublished.',
+            'Do not publish selected changesets on the codehost on apply. Note: a changeset that has been published cannot be unpublished.',
         onTrigger: noop,
     },
     {
         type: 'publish',
-        buttonLabel: 'Publish',
-        dropdownTitle: 'Publish',
-        dropdownDescription: 'Publish selected changesets on the codehost.',
+        buttonLabel: 'Publish on apply',
+        dropdownTitle: 'Publish on apply',
+        dropdownDescription: 'Publish selected changesets on the codehost on apply.',
         onTrigger: noop,
     },
     {
         type: 'publish-draft',
-        buttonLabel: 'Publish draft',
-        dropdownTitle: 'Publish draft',
-        dropdownDescription: 'Publish selected changesets as drafts on the codehost.',
+        buttonLabel: 'Publish draft on apply',
+        dropdownTitle: 'Publish draft on apply',
+        dropdownDescription: 'Publish selected changesets as drafts on the codehost on apply.',
         onTrigger: noop,
     },
 ]

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -126,7 +126,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
                                 actions={actions}
                                 dropdownMenuPosition="right"
                                 initiallyOpen={dropDownInitiallyOpen}
-                                placeholder="Select action"
+                                placeholder="Select action on apply"
                             />
                         </div>
                     </div>


### PR DESCRIPTION
Pulled the wording change + context fix commit out of #24065 and tacked on two other small wording revisions from design review with Rob this morning:

- Dropdown placeholder now matches "on apply" pattern - `Select action on apply`
- Disabled tooltip for "Apply" button in banner is more technically aligned with what's actually happening


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
