### PR TITLE
Fix header layout on mobile (on release branch)

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -248,7 +248,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         <>
                             <NavAction>
                                 <Link className="global-navbar__link" to="https://about.sourcegraph.com">
-                                    About Sourcegraph
+                                    About <span className="d-none d-sm-inline">Sourcegraph</span>
                                 </Link>
                             </NavAction>
 

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -125,7 +125,12 @@ exports[`GlobalNavbar default 1`] = `
           class="global-navbar__link"
           to="https://about.sourcegraph.com"
         >
-          About Sourcegraph
+          About 
+          <span
+            class="d-none d-sm-inline"
+          >
+            Sourcegraph
+          </span>
         </a>
       </li>
       <li
@@ -302,7 +307,12 @@ exports[`GlobalNavbar low-profile 1`] = `
           class="global-navbar__link"
           to="https://about.sourcegraph.com"
         >
-          About Sourcegraph
+          About 
+          <span
+            class="d-none d-sm-inline"
+          >
+            Sourcegraph
+          </span>
         </a>
       </li>
       <li
@@ -479,7 +489,12 @@ exports[`GlobalNavbar no-search-input 1`] = `
           class="global-navbar__link"
           to="https://about.sourcegraph.com"
         >
-          About Sourcegraph
+          About 
+          <span
+            class="d-none d-sm-inline"
+          >
+            Sourcegraph
+          </span>
         </a>
       </li>
       <li


### PR DESCRIPTION
This is a cherry-pick of #24084 for the release branch `release/2021-08-19` and fixes a bug introduced in the header on very narrow screens with the homepage updates.
