### PR TITLE
extensibility: fix search info bar action styles

### DIFF
--- a/client/web/src/components/shared.tsx
+++ b/client/web/src/components/shared.tsx
@@ -1,7 +1,5 @@
-import classNames from 'classnames'
 import React from 'react'
 
-import { ActionsNavItems, ActionsNavItemsProps } from '@sourcegraph/shared/src/actions/ActionsNavItems'
 import {
     CommandListPopoverButton,
     CommandListPopoverButtonProps,
@@ -26,20 +24,3 @@ export const WebCommandListPopoverButton: React.FunctionComponent<CommandListPop
 )
 
 WebCommandListPopoverButton.displayName = 'WebCommandListPopoverButton'
-
-export const WebActionsNavItems: React.FunctionComponent<ActionsNavItemsProps> = ({
-    listClass,
-    listItemClass,
-    actionItemClass,
-    actionItemIconClass,
-    ...props
-}) => (
-    <ActionsNavItems
-        {...props}
-        listClass={classNames(listClass, 'nav')}
-        listItemClass={classNames(listItemClass, 'nav-item')}
-        actionItemClass={classNames(actionItemClass, 'nav-link')}
-        actionItemIconClass={classNames(actionItemIconClass, 'icon-inline-md')}
-    />
-)
-WebActionsNavItems.displayName = 'WebActionsNavItems'

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -9,6 +9,8 @@ import MenuIcon from 'mdi-react/MenuIcon'
 import MenuUpIcon from 'mdi-react/MenuUpIcon'
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { ActionItem } from '@sourcegraph/shared/src/actions/ActionItem'
+import { ActionsContainer } from '@sourcegraph/shared/src/actions/ActionsContainer'
 import { ContributableMenu } from '@sourcegraph/shared/src/api/protocol'
 import { ButtonLink } from '@sourcegraph/shared/src/components/LinkOrButton'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -21,7 +23,6 @@ import { PatternTypeProps, CaseSensitivityProps } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { CodeMonitoringProps } from '../../code-monitoring'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
-import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { SearchPatternType } from '../../graphql-operations'
 import { BookmarkRadialGradientIcon, CodeMonitorRadialGradientIcon } from '../CtaIcons'
 import styles from '../FeatureTour.module.scss'
@@ -311,14 +312,25 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 <div className="search-results-info-bar__expander" />
 
                 <ul className="nav align-items-center">
-                    <ActionsNavItems
+                    <ActionsContainer
                         {...props}
                         extraContext={extraContext}
                         menu={ContributableMenu.SearchResultsToolbar}
-                        wrapInList={false}
-                        showLoadingSpinnerDuringExecution={true}
-                        actionItemClass="btn btn-outline-secondary mr-2 text-decoration-none btn-sm"
-                    />
+                    >
+                        {actionItems => (
+                            <>
+                                {actionItems.map(actionItem => (
+                                    <ActionItem
+                                        {...props}
+                                        {...actionItem}
+                                        key={actionItem.action.id}
+                                        showLoadingSpinnerDuringExecution={false}
+                                        className="btn btn-outline-secondary mr-2 text-decoration-none btn-sm"
+                                    />
+                                ))}
+                            </>
+                        )}
+                    </ActionsContainer>
 
                     {(codeInsightsButton || createCodeMonitorButton || saveSearchButton) && (
                         <li className="search-results-info-bar__divider" aria-hidden="true" />


### PR DESCRIPTION
Fix #23872.

- Don't use `ActionsNavItems` anymore since search info bar buttons are no longer nav items, which have more padding.
- Remove `WebActionsNavItems` since it's no longer used anywhere.

![Screenshot from 2021-08-18 17-00-33](https://user-images.githubusercontent.com/37420160/129971556-48c47b3e-8aa1-44ce-a75d-4fabc23c5e9d.png)


NOTE: Due to extensibility code freeze, we will merge this PR after branch cut tomorrow (edit: release has been pushed back a week, so we are merging now).