### PR TITLE
batches: show alert when publication states are recalculated

### DIFF
--- a/client/web/src/components/DismissibleAlert/DismissibleAlert.tsx
+++ b/client/web/src/components/DismissibleAlert/DismissibleAlert.tsx
@@ -5,22 +5,30 @@ import * as React from 'react'
 import styles from './DismissibleAlert.module.scss'
 
 interface Props {
-    /** used to build the key that represents the alert in local storage */
-    partialStorageKey: string
+    /**
+     * If provided, used to build the key that represents the alert in local storage. An
+     * alert with a storage key will be permanently dismissed once the user dismisses it.
+     */
+    partialStorageKey?: string
 
     /** class name to be applied to the alert */
     className: string
 }
 
 /**
- * A global site alert that can be dismissed. Once dismissed, it is never shown
- * again.
+ * A global site alert that can be dismissed. If a `partialStorageKey` is provided, the
+ * alert will never be shown again after it is dismissed. Otherwise, it will be shown
+ * whenever unmounted and remounted.
  */
 export const DismissibleAlert: React.FunctionComponent<Props> = ({ partialStorageKey, className, children }) => {
-    const [dismissed, setDismissed] = React.useState<boolean>(isAlertDismissed(partialStorageKey))
+    const [dismissed, setDismissed] = React.useState<boolean>(
+        partialStorageKey ? isAlertDismissed(partialStorageKey) : false
+    )
 
     const onDismiss = React.useCallback(() => {
-        dismissAlert(partialStorageKey)
+        if (partialStorageKey) {
+            dismissAlert(partialStorageKey)
+        }
         setDismissed(true)
     }, [partialStorageKey])
 

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewContext.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewContext.tsx
@@ -25,6 +25,12 @@ export interface BatchChangePreviewContextState {
     // the mutation to apply the preview.
     readonly publicationStates: ChangesetSpecPublicationStateInput[]
     updatePublicationStates: (publicationStates: ChangesetSpecPublicationStateInput[]) => void
+    // Timestamps (as numbers) for each time preview publication states are successfully
+    // recalculated. We really only care about knowing the number of times we have
+    // recalculated so far, but the timestamp gives us a stable key to use for creating an
+    // array of React components from the updates.
+    readonly recalculationUpdates: number[]
+    addRecalculationUpdate: (date: Date) => void
 }
 
 export const defaultState = (): BatchChangePreviewContextState => ({
@@ -32,6 +38,8 @@ export const defaultState = (): BatchChangePreviewContextState => ({
     setFilters: noop,
     publicationStates: [],
     updatePublicationStates: noop,
+    recalculationUpdates: [],
+    addRecalculationUpdate: noop,
 })
 
 /**
@@ -70,6 +78,14 @@ export const BatchChangePreviewContextProvider: React.FunctionComponent<{}> = ({
         [publicationStates]
     )
 
+    const [recalculationUpdates, setRecalculationUpdates] = useState<number[]>([])
+    const addRecalculationUpdate = useCallback(
+        (date: Date) => {
+            setRecalculationUpdates([...recalculationUpdates, date.getTime()])
+        },
+        [recalculationUpdates]
+    )
+
     return (
         <BatchChangePreviewContext.Provider
             value={{
@@ -77,6 +93,8 @@ export const BatchChangePreviewContextProvider: React.FunctionComponent<{}> = ({
                 setFilters,
                 publicationStates,
                 updatePublicationStates,
+                recalculationUpdates,
+                addRecalculationUpdate,
             }}
         >
             {children}

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { MultiSelectContextProvider } from '../MultiSelectContext'
 
 import { CreateUpdateBatchChangeAlert } from './CreateUpdateBatchChangeAlert'
 
@@ -37,6 +38,21 @@ add('Update', () => (
                 batchChange={{ id: '123', name: 'awesome-batch-change', url: 'http://test.test/awesome' }}
                 viewerCanAdminister={boolean('viewerCanAdminister', true)}
             />
+        )}
+    </EnterpriseWebStory>
+))
+add('Disabled', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <MultiSelectContextProvider initialSelected={['id1', 'id2']}>
+                <CreateUpdateBatchChangeAlert
+                    {...props}
+                    specID="123"
+                    toBeArchived={199}
+                    batchChange={{ id: '123', name: 'awesome-batch-change', url: 'http://test.test/awesome' }}
+                    viewerCanAdminister={boolean('viewerCanAdminister', true)}
+                />
+            </MultiSelectContextProvider>
         )}
     </EnterpriseWebStory>
 ))

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -122,6 +122,7 @@ export const PreviewList: React.FunctionComponent<Props> = ({
             ) : (
                 <PreviewFilterRow history={history} location={location} />
             )}
+            <PublicationStatesUpdateAlerts />
             <FilteredConnection<
                 ChangesetApplyPreviewFields,
                 Omit<ChangesetApplyPreviewNodeProps, 'node'>,
@@ -176,3 +177,22 @@ const EmptyPreviewSearchElement: React.FunctionComponent<{}> = () => (
         </div>
     </div>
 )
+
+/**
+ * A list of none to many dismissible alerts, one for each time the publication state
+ * actions are recalculated when the user modifies the publication states for preview
+ * changesets.
+ */
+const PublicationStatesUpdateAlerts: React.FunctionComponent<{}> = () => {
+    const { recalculationUpdates } = useContext(BatchChangePreviewContext)
+
+    return (
+        <div className="mt-2">
+            {recalculationUpdates.map(timestamp => (
+                <DismissibleAlert className="alert-success" key={timestamp}>
+                    Publication state actions were recalculated.
+                </DismissibleAlert>
+            ))}
+        </div>
+    )
+}

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useContext, useState } from 'react'
 import { tap } from 'rxjs/operators'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { DismissibleAlert } from '@sourcegraph/web/src/components/DismissibleAlert'
 import { Container } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
@@ -59,7 +60,7 @@ export const PreviewList: React.FunctionComponent<Props> = ({
     const { selected, areAllVisibleSelected, isSelected, toggleSingle, toggleVisible, setVisible } = useContext(
         MultiSelectContext
     )
-    const { filters, publicationStates } = useContext(BatchChangePreviewContext)
+    const { filters, publicationStates, addRecalculationUpdate } = useContext(BatchChangePreviewContext)
 
     const [queryArguments, setQueryArguments] = useState<BatchSpecApplyPreviewVariables>()
 
@@ -98,6 +99,16 @@ export const PreviewList: React.FunctionComponent<Props> = ({
             publicationStates,
         ]
     )
+
+    // Every subsequent query after the first will have its success time recorded
+    const [isInitialQuery, setIsInitialQuery] = useState(true)
+    const onUpdate = useCallback(() => {
+        if (isInitialQuery) {
+            setIsInitialQuery(false)
+        } else {
+            addRecalculationUpdate(new Date())
+        }
+    }, [addRecalculationUpdate, isInitialQuery])
 
     const showSelectRow = selected === 'all' || selected.size > 0
 
@@ -151,6 +162,7 @@ export const PreviewList: React.FunctionComponent<Props> = ({
                         <EmptyPreviewListElement />
                     )
                 }
+                onUpdate={onUpdate}
             />
         </Container>
     )


### PR DESCRIPTION
As another small improvement that came out of the design review this morning, this adds an alert banner whenever the publication states are recalculated:

https://user-images.githubusercontent.com/8942601/129980568-e155818c-fc6d-4dac-bb9b-a4defb64c88e.mov

To support this, `DismissibleAlert` will now only permanently be dismissed if you provide the local storage partial key. If not, you can revive it by unmounting + remounting.

I also added a story for the disabled "Apply" button in the first banner just for fun.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
