### PR TITLE
insights: enable queue cleaner configured to purge completed records

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -54,7 +54,7 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 		queryrunner.NewWorker(ctx, workerBaseStore, insightsStore, queryRunnerWorkerMetrics),
 		queryrunner.NewResetter(ctx, workerBaseStore, queryRunnerResetterMetrics),
 		// disabling the cleaner job while we debug mismatched results from historical insights
-		// queryrunner.NewCleaner(ctx, workerBaseStore, observationContext),
+		queryrunner.NewCleaner(ctx, workerBaseStore, observationContext),
 
 		// TODO(slimsag): future: register another worker here for webhook querying.
 	}

--- a/enterprise/internal/insights/background/queryrunner/cleaner.go
+++ b/enterprise/internal/insights/background/queryrunner/cleaner.go
@@ -44,7 +44,7 @@ func NewCleaner(ctx context.Context, workerBaseStore *basestore.Store, observati
 func cleanJobs(ctx context.Context, workerBaseStore *basestore.Store) (numCleaned int, err error) {
 	numCleaned, _, err = basestore.ScanFirstInt(workerBaseStore.Query(
 		ctx,
-		sqlf.Sprintf(cleanJobsFmtStr, time.Now().Add(-12*time.Hour)),
+		sqlf.Sprintf(cleanJobsFmtStr, time.Now().Add(-168*time.Hour)),
 	))
 	return
 }
@@ -52,6 +52,6 @@ func cleanJobs(ctx context.Context, workerBaseStore *basestore.Store) (numCleane
 const cleanJobsFmtStr = `
 -- source: enterprise/internal/insights/background/queryrunner/cleaner.go:cleanJobs
 WITH deleted AS (
-	DELETE FROM insights_query_runner_jobs WHERE (state='completed' OR state='failed') AND started_at >= %s RETURNING *
+	DELETE FROM insights_query_runner_jobs WHERE state='completed' AND started_at <= %s RETURNING *
 ) SELECT count(*) FROM deleted
 `


### PR DESCRIPTION
This will re-enable the queue cleaner job with a few changes:
1. It will only purge records with state 'completed'
2. It will only purge records that were executed greater than 1 week ago.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
