### PR TITLE
repo: fix flaky RevisionsPopover mock

### DIFF
--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.mocks.ts
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.mocks.ts
@@ -1,5 +1,5 @@
 import { MockedResponse } from '@apollo/client/testing'
-import { startOfYesterday } from 'date-fns'
+import { subDays } from 'date-fns'
 
 import { GitRefType } from '@sourcegraph/shared/src/graphql-operations'
 import { getDocumentNode } from '@sourcegraph/shared/src/graphql/graphql'
@@ -24,7 +24,7 @@ export const MOCK_PROPS: RevisionsPopoverProps = {
     showSpeculativeResults: false,
 }
 
-const yesterday = startOfYesterday().toISOString()
+const yesterday = subDays(new Date(), 1).toISOString()
 
 const commitPerson = {
     displayName: 'display-name',


### PR DESCRIPTION
There's evidently some rounding in the date that's displayed here, and Chromatic is occasionally saying "2 days" instead of "1 day". This should reduce the chance of flakiness here by having the date always be exactly one day ago.

Example of the UI review issue in a PR that doesn't go anywhere near this code: https://www.chromatic.com/pullrequest?appId=5f0f381c0e50750022dc6bf7&number=24111&view=changes