### PR TITLE
search: fix global search visibility regression

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -413,6 +413,31 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query:      "asdfalksd+jflaksjdfklas patterntype:literal -repo:sourcegraph",
 				zeroResult: true,
 			},
+			// Global search visibility
+			{
+				name: "visibility:all for global search includes private repo",
+				// match content in a private repo sgtest/private and a public repo sgtest/go-diff.
+				query:         `(#\ private|#\ go-diff) visibility:all patterntype:regexp`,
+				minMatchCount: 2,
+			},
+			{
+				name: "visibility:public for global search excludes private repo",
+				// expect no matches because pattern '# private' is only in a private repo.
+				query:      "# private visibility:public",
+				zeroResult: true,
+			},
+			{
+				name: "visibility:private for global includes only private repo",
+				// expect no matches because #go-diff doesn't exist in private repo.
+				query:      "# go-diff visibility:private",
+				zeroResult: true,
+			},
+			{
+				name: "visibility:private for global includes only private",
+				// expect a match because # private is only in a private repo.
+				query:      "# private visibility:private",
+				zeroResult: false,
+			},
 			// Repo search
 			{
 				name:  "repo search by name, case yes, nonzero result",

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -424,7 +424,7 @@ func zoektGlobalQuery(query zoektquery.Q, repoOptions search.RepoOptions, userPr
 	}
 
 	// Private
-	if repoOptions.OnlyPublic && len(userPrivateRepos) > 0 {
+	if !repoOptions.OnlyPublic && len(userPrivateRepos) > 0 {
 		privateRepoSet := make(map[string][]string, len(userPrivateRepos))
 		head := []string{"HEAD"}
 		for _, r := range userPrivateRepos {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/24114. Unfortunately this condition got flipped in my refactor in https://github.com/sourcegraph/sourcegraph/pull/23936/files. No tests mean we didn't catch it. 

Added a test in this PR so the behavior is locked in:

- Added tests pass in this PR: https://buildkite.com/sourcegraph/sourcegraph/builds/105670#7de8e9fe-c069-443c-98df-a1b796dc05be
- Added tests break, as expected, on `main` which has the regression: https://buildkite.com/sourcegraph/sourcegraph/builds/105671#29cf1c6b-1419-4d0e-b7cb-cfcbc1a9626c
> --- FAIL: TestSearch/graphql (4.06s)
--
  | --- FAIL: TestSearch/graphql/global_text_search (0.47s)
  | --- FAIL: TestSearch/graphql/global_text_search/visibility:all_for_global_search_includes_private_repo (0.01s)
  | search_test.go:563: Want at least 2 match count but got 1
  | --- FAIL: TestSearch/graphql/global_text_search/visibility:public_for_global_search_excludes_private_repo (0.01s)
  | search_test.go:554: Want zero result but got 1
  | --- FAIL: TestSearch/graphql/global_text_search/visibility:private_for_global_includes_only_private (0.01s)
  | search_test.go:558: Want non-zero results but got 0
  | --- FAIL: TestSearch/stream (20.35s)
  | --- FAIL: TestSearch/stream/global_text_search (4.40s)
  | --- FAIL: TestSearch/stream/global_text_search/visibility:all_for_global_search_includes_private_repo (0.01s)
  | search_test.go:563: Want at least 2 match count but got 1
  | --- FAIL: TestSearch/stream/global_text_search/visibility:public_for_global_search_excludes_private_repo (0.38s)
  | search_test.go:554: Want zero result but got 1
  | --- FAIL: TestSearch/stream/global_text_search/visibility:private_for_global_includes_only_private (0.01s)
  | search_test.go:558: Want non-zero results but got 0

