### PR TITLE
batches: supply tooltip reason if changeset not selectable

### DIFF
--- a/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.tsx
@@ -28,7 +28,7 @@ export const HiddenChangesetApplyPreviewNode: React.FunctionComponent<HiddenChan
                 className="btn"
                 checked={false}
                 disabled={true}
-                tooltip="You do not have permission to perform this operation"
+                tooltip="You do not have permission to publish to this repository."
             />
         </div>
         <HiddenChangesetApplyPreviewNodeStatusCell

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -6,7 +6,7 @@ import { of, Observable } from 'rxjs'
 import { BatchSpecApplyPreviewConnectionFields, ChangesetApplyPreviewFields } from '../../../../graphql-operations'
 import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
 import { MultiSelectContextProvider } from '../../MultiSelectContext'
-import { getPublishableChangesetSpecID } from '../utils'
+import { filterPublishableIDs } from '../utils'
 
 import { hiddenChangesetApplyPreviewStories } from './HiddenChangesetApplyPreviewNode.story'
 import { PreviewList } from './PreviewList'
@@ -41,11 +41,7 @@ add('PreviewList', () => {
         })
 
     const queryPublishableChangesetSpecIDs = (): Observable<string[]> =>
-        of(
-            Object.values(visibleChangesetApplyPreviewNodeStories(publicationStateSet))
-                .map(node => getPublishableChangesetSpecID(node))
-                .filter((id): id is string => id !== null)
-        )
+        of(filterPublishableIDs(Object.values(visibleChangesetApplyPreviewNodeStories(publicationStateSet))))
 
     return (
         <EnterpriseWebStory>

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -12,7 +12,7 @@ import { BatchSpecApplyPreviewVariables, ChangesetApplyPreviewFields, Scalars } 
 import { MultiSelectContext } from '../../MultiSelectContext'
 import { BatchChangePreviewContext } from '../BatchChangePreviewContext'
 import { PreviewPageAuthenticatedUser } from '../BatchChangePreviewPage'
-import { getPublishableChangesetSpecID } from '../utils'
+import { filterPublishableIDs } from '../utils'
 
 import {
     queryChangesetApplyPreview as _queryChangesetApplyPreview,
@@ -81,11 +81,7 @@ export const PreviewList: React.FunctionComponent<Props> = ({
                     setQueryArguments(passedArguments)
                     // Available changeset specs are all changesets specs that a user can
                     // modify the publication state of from the UI.
-                    setVisible(
-                        data.nodes
-                            .map(node => getPublishableChangesetSpecID(node))
-                            .filter((id): id is string => id !== null)
-                    )
+                    setVisible(filterPublishableIDs(data.nodes))
                 })
             )
         },

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -27,7 +27,7 @@ import { Description } from '../../Description'
 import { ChangesetStatusCell } from '../../detail/changesets/ChangesetStatusCell'
 import { ExternalChangesetTitle } from '../../detail/changesets/ExternalChangesetTitle'
 import { PreviewPageAuthenticatedUser } from '../BatchChangePreviewPage'
-import { getPublishableChangesetSpecID } from '../utils'
+import { checkPublishability } from '../utils'
 
 import { queryChangesetSpecFileDiffs as _queryChangesetSpecFileDiffs } from './backend'
 import { GitBranchChangesetDescriptionInfo } from './GitBranchChangesetDescriptionInfo'
@@ -214,38 +214,38 @@ const SelectBox: React.FunctionComponent<{
         isSelected: (id: string) => boolean
     }
 }> = ({ node, selectable }) => {
-    const changesetSpecID = useMemo(() => getPublishableChangesetSpecID(node), [node])
+    const isPublishableResult = useMemo(() => checkPublishability(node), [node])
 
     const toggleSelected = useCallback((): void => {
-        if (changesetSpecID) {
-            selectable.onSelect(changesetSpecID)
+        if (isPublishableResult.publishable) {
+            selectable.onSelect(isPublishableResult.changesetSpecID)
         }
-    }, [selectable, changesetSpecID])
+    }, [selectable, isPublishableResult])
 
-    const input = !changesetSpecID ? (
+    const input = isPublishableResult.publishable ? (
+        <InputTooltip
+            id={`select-changeset-${isPublishableResult.changesetSpecID}`}
+            type="checkbox"
+            className="btn"
+            checked={selectable.isSelected(isPublishableResult.changesetSpecID)}
+            onChange={toggleSelected}
+            tooltip="Click to select changeset for bulk-modifying the publication state"
+        />
+    ) : (
         <InputTooltip
             id="select-changeset-hidden"
             type="checkbox"
             className="btn"
             checked={false}
             disabled={true}
-            tooltip="You cannot currently modify the publication state for this changeset"
-        />
-    ) : (
-        <InputTooltip
-            id={`select-changeset-${changesetSpecID}`}
-            type="checkbox"
-            className="btn"
-            checked={selectable.isSelected(changesetSpecID)}
-            onChange={toggleSelected}
-            tooltip="Click to select changeset for bulk-modifying the publication state"
+            tooltip={isPublishableResult.reason}
         />
     )
 
     return (
         <div className="d-flex p-2 align-items-center">
             {input}
-            {changesetSpecID ? (
+            {isPublishableResult.publishable ? (
                 <span className="pl-2 d-block d-sm-none text-nowrap">Modify publication state</span>
             ) : null}
         </div>

--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -18,7 +18,7 @@ import {
     AllPublishableChangesetSpecIDsResult,
 } from '../../../../graphql-operations'
 import { personLinkFieldsFragment } from '../../../../person/PersonLink'
-import { getPublishableChangesetSpecID } from '../utils'
+import { filterPublishableIDs } from '../utils'
 
 const changesetSpecFieldsFragment = gql`
     fragment CommonChangesetSpecFields on ChangesetSpec {
@@ -446,12 +446,7 @@ export const queryPublishableChangesetSpecIDs = ({
     return request(null).pipe(
         expand(connection => (connection.pageInfo.hasNextPage ? request(connection.pageInfo.endCursor) : EMPTY)),
         reduce<PublishableChangesetSpecIDsConnectionFields, Scalars['ID'][]>(
-            (previous, next) =>
-                previous.concat(
-                    next.nodes
-                        .map(node => getPublishableChangesetSpecID(node))
-                        .filter((maybeID): maybeID is Scalars['ID'] => maybeID !== null)
-                ),
+            (previous, next) => previous.concat(filterPublishableIDs(next.nodes)),
             []
         )
     )

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -28,8 +28,8 @@ export interface Unpublishable {
  * - if the operation is updating a changeset, the changeset is in a state we can
  * transition to published or draft from
  *
- * Returns the id of the changeset spec if it is publishable from the UI, or null if for
- * any reason it is not.
+ * Returns a `Publishable` with the node's changeset spec ID if it is publishable from the
+ * UI, or else an `Unpublishable` with the reason it is not.
  *
  * @param node the `ChangesetApplyPreviewFields` node to check
  */

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -38,7 +38,7 @@ export const checkPublishability = (
         | PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields
         | PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields
 ): Publishable | Unpublishable => {
-    // The operatino is detaching a changeset
+    // The operation is detaching a changeset
     if (node.targets.__typename === 'VisibleApplyPreviewTargetsDetach') {
         return {
             publishable: false,

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -5,6 +5,18 @@ import {
     Scalars,
 } from '../../../graphql-operations'
 
+/* The preview changeset can be published from the UI */
+export interface Publishable {
+    publishable: true
+    changesetSpecID: Scalars['ID']
+}
+
+/* The preview changeset cannot currently be published from the UI */
+export interface Unpublishable {
+    publishable: false
+    reason: string
+}
+
 /**
  * For a given preview of a changeset to be applied, this method checks if the type of
  * changeset allows for the user to modify its publication state from the UI: namely, that
@@ -21,32 +33,60 @@ import {
  *
  * @param node the `ChangesetApplyPreviewFields` node to check
  */
-export const getPublishableChangesetSpecID = (
+export const checkPublishability = (
     node:
         | PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields
         | PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields
-): Scalars['ID'] | null => {
-    // The changeset is either hidden, or the operation is detaching a changeset
+): Publishable | Unpublishable => {
+    // The operatino is detaching a changeset
+    if (node.targets.__typename === 'VisibleApplyPreviewTargetsDetach') {
+        return {
+            publishable: false,
+            reason:
+                'You cannot modify the publication state for a changeset that will be detached from this batch change.',
+        }
+    }
+    // The changeset is hidden to the user applying
     if (
         node.targets.__typename !== 'VisibleApplyPreviewTargetsAttach' &&
         node.targets.__typename !== 'VisibleApplyPreviewTargetsUpdate'
     ) {
-        return null
+        return { publishable: false, reason: 'You do not have permission to publish to this repository.' }
     }
-    // The changeset is an existing reference
+    // The changeset is an existing, imported reference
     if (node.targets.changesetSpec.description.__typename !== 'GitBranchChangesetDescription') {
-        return null
+        return {
+            publishable: false,
+            reason: 'You cannot modify the publication state for an imported changeset.',
+        }
     }
     // The changeset has its publication state specified in the batch spec file, which takes priority
     if (node.targets.changesetSpec.description.published !== null) {
-        return null
+        return {
+            publishable: false,
+            reason:
+                "This changeset's publication state is being controlled by the spec file. To modify it here, omit it from your spec.",
+        }
     }
-    // The changeset is already published or in a state we can't transition to published/draft from
-    if (
-        node.targets.__typename === 'VisibleApplyPreviewTargetsUpdate' &&
-        !(node.targets.changeset.state in [ChangesetState.DRAFT, ChangesetState.UNPUBLISHED])
-    ) {
-        return null
+    if (node.targets.__typename === 'VisibleApplyPreviewTargetsUpdate') {
+        console.log(
+            node.targets.changeset.state,
+            [ChangesetState.CLOSED, ChangesetState.DELETED, ChangesetState.MERGED, ChangesetState.OPEN].includes(
+                node.targets.changeset.state
+            )
+        )
+        // The changeset is already published
+        if (
+            [ChangesetState.CLOSED, ChangesetState.DELETED, ChangesetState.MERGED, ChangesetState.OPEN].includes(
+                node.targets.changeset.state
+            )
+        ) {
+            return { publishable: false, reason: 'This changeset has already been published.' }
+        }
+        // This changeset is not in a state we want to transition to published/draft from
+        if (![ChangesetState.DRAFT, ChangesetState.UNPUBLISHED].includes(node.targets.changeset.state)) {
+            return { publishable: false, reason: 'This changeset is in a state we cannot currently publish from.' }
+        }
     }
-    return node.targets.changesetSpec.id
+    return { publishable: true, changesetSpecID: node.targets.changesetSpec.id }
 }

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -69,12 +69,6 @@ export const checkPublishability = (
         }
     }
     if (node.targets.__typename === 'VisibleApplyPreviewTargetsUpdate') {
-        console.log(
-            node.targets.changeset.state,
-            [ChangesetState.CLOSED, ChangesetState.DELETED, ChangesetState.MERGED, ChangesetState.OPEN].includes(
-                node.targets.changeset.state
-            )
-        )
         // The changeset is already published
         if (
             [ChangesetState.CLOSED, ChangesetState.DELETED, ChangesetState.MERGED, ChangesetState.OPEN].includes(

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -90,3 +90,20 @@ export const checkPublishability = (
     }
     return { publishable: true, changesetSpecID: node.targets.changesetSpec.id }
 }
+
+/**
+ * For a list of `ChangesetApplyPreview` nodes, this method returns a list of the
+ * changeset spec IDs for any of the nodes that are considered publishable.
+ *
+ * @see `checkPublishability`
+ */
+export const filterPublishableIDs = (
+    nodes: (
+        | PublishableChangesetSpecIDsVisibleChangesetApplyPreviewFields
+        | PublishableChangesetSpecIDsHiddenChangesetApplyPreviewFields
+    )[]
+): Scalars['ID'][] =>
+    nodes
+        .map(node => checkPublishability(node))
+        .filter((result): result is Publishable => result.publishable)
+        .map(result => result.changesetSpecID)


### PR DESCRIPTION
I couldn't help myself; since we "have more time" anyway to get this wrapped up, I decided to improve the UX for when a preview changeset isn't selectable. There's a lot of potential reasons we wouldn't be able to modify the publication state for a given preview changeset, but the disabled checkbox doesn't communicate all those reasons. @rrhyne + the rest of the team in attendance of today's design session weren't necessarily in love with the next best idea of just telling users to search the docs for the FAQ entry I'm also adding about this, so for marginally more effort, the utility method we were using to identify publishable changeset specs can now provide the *exact reason* it deemed a preview changeset ~unworthy~ unselectable. 😉

Here's some examples of how it manifests:

![Screen Shot 2021-08-18 at 7 45 24 PM](https://user-images.githubusercontent.com/8942601/129999408-10d5d185-9221-4be9-a5e4-0a69e8087cd0.png)
![Screen Shot 2021-08-18 at 7 45 32 PM](https://user-images.githubusercontent.com/8942601/129999411-6453b26b-e3b9-4494-a6d2-39b09c8cba02.png)
![Screen Shot 2021-08-18 at 7 45 38 PM](https://user-images.githubusercontent.com/8942601/129999418-9a252dfb-09fd-4145-95d7-7cc65a34173c.png)
![Screen Shot 2021-08-18 at 7 46 03 PM](https://user-images.githubusercontent.com/8942601/129999420-0546991e-aa38-4753-876c-8898abe21f82.png)
![Screen Shot 2021-08-18 at 7 48 00 PM](https://user-images.githubusercontent.com/8942601/129999647-d43ea5c0-d298-4b9f-b443-6c8aae4f4ed6.png)

Wording suggestions welcome.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
