### PR TITLE
search: fix global search visibility regression (#24115)

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -413,6 +413,31 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query:      "asdfalksd+jflaksjdfklas patterntype:literal -repo:sourcegraph",
 				zeroResult: true,
 			},
+			// Global search visibility
+			{
+				name: "visibility:all for global search includes private repo",
+				// match content in a private repo sgtest/private and a public repo sgtest/go-diff.
+				query:         `(#\ private|#\ go-diff) visibility:all patterntype:regexp`,
+				minMatchCount: 2,
+			},
+			{
+				name: "visibility:public for global search excludes private repo",
+				// expect no matches because pattern '# private' is only in a private repo.
+				query:      "# private visibility:public",
+				zeroResult: true,
+			},
+			{
+				name: "visibility:private for global includes only private repo",
+				// expect no matches because #go-diff doesn't exist in private repo.
+				query:      "# go-diff visibility:private",
+				zeroResult: true,
+			},
+			{
+				name: "visibility:private for global includes only private",
+				// expect a match because # private is only in a private repo.
+				query:      "# private visibility:private",
+				zeroResult: false,
+			},
 			// Repo search
 			{
 				name:  "repo search by name, case yes, nonzero result",

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -356,7 +356,7 @@ func zoektGlobalQuery(query zoektquery.Q, repoOptions search.RepoOptions, userPr
 	}
 
 	// Private
-	if repoOptions.OnlyPublic && len(userPrivateRepos) > 0 {
+	if !repoOptions.OnlyPublic && len(userPrivateRepos) > 0 {
 		privateRepoSet := make(map[string][]string, len(userPrivateRepos))
 		head := []string{"HEAD"}
 		for _, r := range userPrivateRepos {


### PR DESCRIPTION
Cherry-pick of 0e91d3e102e19002662bb3141bb0a4c418d368ca. This regression is live in the release branch `release/2021-08-19`: https://github.com/sourcegraph/sourcegraph/issues/24114 and needs this fix.