### PR TITLE
all: instrument version in trace and prometheus

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go"
@@ -147,6 +148,7 @@ func newTracer(opts *jaegerOpts) (opentracing.Tracer, io.Closer, error) {
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "jaegercfg.FromEnv failed")
 	}
+	cfg.Tags = append(cfg.Tags, opentracing.Tag{Key: "service.version", Value: version.Version()})
 	if reflect.DeepEqual(cfg.Sampler, &jaegercfg.SamplerConfig{}) {
 		// Default sampler configuration for when it is not specified via
 		// JAEGER_SAMPLER_* env vars. In most cases, this is sufficient

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/google/zoekt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const devVersion = "0.0.0+dev"                              // version string for unreleased development builds
@@ -22,6 +25,9 @@ var version = devVersion
 func init() {
 	exportedVersion := expvar.NewString("sourcegraph.version")
 	exportedVersion.Set(version)
+	promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "src_version",
+	}, []string{"version"}).WithLabelValues(zoekt.Version).Set(1)
 }
 
 // Version returns the version string configured at build time.


### PR DESCRIPTION
We embed a version identifier in our binaries. This adds it to both
tracing and metrics. For tracing we add the tracer tag
"service.version". For metrics we add the gauge "src_version" which has
a label version. For metrics this can then be joined against[1].

This is useful for observing the impact of a version change on
metrics. Additionally when receiving debug information from customers
this helps us understand exactly which versions are being run.

[1]: https://www.robustperception.io/exposing-the-software-version-to-prometheus