### PR TITLE
Code Insights: Fix the dashboard page pings

### DIFF
--- a/client/web/src/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
@@ -41,7 +41,7 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
 
     useEffect(() => {
         telemetryService.logViewEvent('Insights')
-    }, [telemetryService])
+    }, [telemetryService, dashboardID])
 
     const handleAddMoreInsightClick = (): void => {
         telemetryService.log('InsightAddMoreClick')

--- a/client/web/src/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
@@ -40,8 +40,12 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
     const { url } = useRouteMatch()
 
     useEffect(() => {
-        telemetryService.logViewEvent('CodeInsightsDashboardPage')
+        telemetryService.logViewEvent('Insights')
     }, [telemetryService])
+
+    const handleAddMoreInsightClick = (): void => {
+        telemetryService.log('InsightAddMoreClick')
+    }
 
     if (!dashboardID) {
         // In case if url doesn't have a dashboard id we should fallback on
@@ -60,7 +64,11 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
                             <Link to="/insights/add-dashboard" className="btn btn-outline-secondary mr-2">
                                 <PlusIcon className="icon-inline" /> Create new dashboard
                             </Link>
-                            <Link to={`/insights/create?dashboardId=${dashboardID}`} className="btn btn-secondary">
+                            <Link
+                                to={`/insights/create?dashboardId=${dashboardID}`}
+                                className="btn btn-secondary"
+                                onClick={handleAddMoreInsightClick}
+                            >
                                 <PlusIcon className="icon-inline" /> Create new insight
                             </Link>
                         </>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/24117

This PR adds an old name for the Insight page views count and brings back ping about the insight creation button on the dashboard page.