### PR TITLE
oauth: extend state cookie lifetime and fix post-signup-redirection after OAuth flow

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -69,7 +69,12 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
                         // here because this list will not be updated during this component's lifetime.
                         /* eslint-disable react/no-array-index-key */
                         <div className="mb-2" key={index}>
-                            <a href={provider.authenticationURL} className="btn btn-secondary btn-block">
+                            <a
+                                href={`${provider.authenticationURL || ''}${
+                                    props.context.sourcegraphDotComMode ? '&redirect=/welcome' : ''
+                                }`}
+                                className="btn btn-secondary btn-block"
+                            >
                                 {provider.displayName === 'GitHub' && (
                                     <>
                                         <GithubIcon className="icon-inline" />{' '}

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -275,7 +275,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
                             // here because this list will not be updated during this component's lifetime.
                             <div className="mb-2" key={index}>
                                 <a
-                                    href={provider.authenticationURL}
+                                    href={`${provider.authenticationURL || ''}&redirect=/welcome`}
                                     className="btn btn-secondary btn-block"
                                     onClick={onClickExternalAuthSignup(provider.serviceType)}
                                 >

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -143,6 +143,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
         >
           <a
             className="btn btn-secondary btn-block"
+            href="&redirect=/welcome"
           >
             <svg
               className="mdi-icon icon-inline"
@@ -311,6 +312,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
         >
           <a
             className="btn btn-secondary btn-block"
+            href=""
           >
             <svg
               className="mdi-icon icon-inline"

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`SignUpPage renders sign up page (cloud) 1`] = `
         >
           <a
             className="btn btn-secondary btn-block"
+            href="&redirect=/welcome"
             onClick={[Function]}
           >
             <svg

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -58,7 +58,7 @@ func getStateConfig() gologin.CookieConfig {
 	cfg := gologin.CookieConfig{
 		Name:     "github-state-cookie",
 		Path:     "/",
-		MaxAge:   120, // 120 seconds
+		MaxAge:   900, // 15 minutes
 		HTTPOnly: true,
 		Secure:   conf.IsExternalURLSecure(),
 	}

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -69,7 +69,7 @@ func getStateConfig() gologin.CookieConfig {
 	cfg := gologin.CookieConfig{
 		Name:     "gitlab-state-cookie",
 		Path:     "/",
-		MaxAge:   120, // 120 seconds
+		MaxAge:   900, // 15 minutes
 		HTTPOnly: true,
 		Secure:   conf.IsExternalURLSecure(),
 	}


### PR DESCRIPTION
This PR includes two changes:

1. Extend OAuth state cookie lifetime from 2 minutes to 15 minutes, because 2 minutes is not generally enough if the user encounters receive OTP from emails. Fixes https://sourcegraph.atlassian.net/browse/COREAPP-215
2. Fix redirection to welcome page on cloud after OAuth flow by appending `redirect` query parameter to the OAuth authentication URL, which will be consumed by our backend upon user completing the OAuth flow. Fixes https://sourcegraph.atlassian.net/browse/COREAPP-216

Co-authored-by: Milan Freml <kopancek@users.noreply.github.com>