### PR TITLE
web: remove `.theme-redesign` selector from batches

### DIFF
--- a/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
@@ -1,4 +1,3 @@
-// unsets the defaults; can probably go away with the redesign
 .batch-change-tabs {
     [data-reach-tab],
     [data-reach-tab]:hover,

--- a/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
@@ -1,41 +1,27 @@
 // unsets the defaults; can probably go away with the redesign
 .batch-change-tabs {
-    :global(.theme-redesign) & {
-        [data-reach-tab] {
-            margin: 0;
-            color: var(--text-muted);
-        }
-        [data-reach-tab][data-selected] {
-            color: var(--body-color);
-            font-weight: 700;
-        }
-    }
-
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {
         padding: 0.5rem 1rem;
         font-size: 0.875rem;
-        :global(.theme-redesign) & {
-            border-top: none;
-            border-left: none;
-            border-right: none;
-            :global(.text-content) {
-                display: inline-flex;
-                align-items: center;
-                flex-direction: column;
-                justify-content: center;
-                // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
-                &::after {
-                    content: attr(data-tab-content);
-                    height: 0;
-                    text-transform: capitalize;
-                    visibility: hidden; // a11y: avoid detection for voice over
-                    overflow: hidden;
-                    user-select: none;
-                    pointer-events: none;
-                    font-weight: 700;
-                }
+
+        :global(.text-content) {
+            display: inline-flex;
+            align-items: center;
+            flex-direction: column;
+            justify-content: center;
+
+            // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
+            &::after {
+                content: attr(data-tab-content);
+                height: 0;
+                text-transform: capitalize;
+                visibility: hidden; // a11y: avoid detection for voice over
+                overflow: hidden;
+                user-select: none;
+                pointer-events: none;
+                font-weight: 700;
             }
         }
     }

--- a/client/web/src/enterprise/batches/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.tsx
@@ -126,7 +126,7 @@ export const BatchChangeTab: React.FunctionComponent<BatchChangeTabProps> = ({ c
         dispatch({ tabName: name, tabIndex: index })
     }, [index, name, dispatch])
 
-    return <Tab className={classNames('nav-link', { active: selectedIndex === index })}>{children}</Tab>
+    return <Tab className={classNames({ active: selectedIndex === index })}>{children}</Tab>
 }
 
 /** Wrapper of ReachUI's `TabPanel`, but that only renders its children if the tab is active */

--- a/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.module.scss
+++ b/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.module.scss
@@ -33,10 +33,7 @@
         }
     }
     &__expanded-section {
-        background-color: var(--oc-blue-0);
-        :global(.theme-redesign) & {
-            background-color: var(--body-bg);
-        }
+        background-color: var(--body-bg);
         // Make it full width in the current row.
         grid-column: 2 / -1;
     }

--- a/client/web/src/enterprise/batches/create/examples/ExampleTabs.module.scss
+++ b/client/web/src/enterprise/batches/create/examples/ExampleTabs.module.scss
@@ -1,19 +1,11 @@
-// unsets the defaults; can probably go away with the redesign
 .example-tabs {
     display: flex;
 
-    :global(.theme-redesign) & {
-        [data-reach-tab-list] {
-            background: none;
-        }
-        [data-reach-tab] {
-            margin: 0;
-            border: none;
-            padding: 0;
-        }
-        [data-reach-tab][data-selected] {
-            border-bottom: none;
-            font-weight: 400;
-        }
+    [data-reach-tab],
+    [data-reach-tab]:hover,
+    [data-reach-tab][data-selected] {
+        margin: 0;
+        border: none;
+        padding: 0;
     }
 }

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.module.scss
@@ -12,10 +12,7 @@
         }
     }
     &__bg-expanded {
-        background-color: var(--oc-blue-0);
-        :global(.theme-redesign) & {
-            background-color: var(--body-bg);
-        }
+        background-color: var(--body-bg);
     }
     &__expanded-section {
         // Make it full width in the current row.

--- a/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.module.scss
@@ -21,10 +21,7 @@
     &__current-state {
         color: var(--icon-color);
         @media (--sm-breakpoint-up) {
-            background-color: var(--oc-blue-0);
-            :global(.theme-redesign) & {
-                background-color: var(--body-bg);
-            }
+            background-color: var(--body-bg);
         }
     }
 }
@@ -34,10 +31,7 @@
         &__current-state {
             color: var(--body-color);
             @media (--sm-breakpoint-up) {
-                background-color: var(--oc-gray-7);
-                :global(.theme-redesign) & {
-                    background-color: var(--body-bg);
-                }
+                background-color: var(--body-bg);
             }
         }
     }

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
@@ -13,10 +13,7 @@ $changeset-backdrop: #f3faff;
         }
     }
     &__bg-expanded {
-        background-color: $changeset-backdrop;
-        :global(.theme-redesign) & {
-            background-color: var(--body-bg);
-        }
+        background-color: var(--body-bg);
         @media (--sm-breakpoint-up) {
             border-top: 1px solid var(--border-color-2);
             padding: 1.5rem;
@@ -25,10 +22,7 @@ $changeset-backdrop: #f3faff;
     &__status-cell {
         color: var(--muted);
         @media (--sm-breakpoint-up) {
-            background-color: $changeset-backdrop;
-            :global(.theme-redesign) & {
-                background-color: var(--body-bg);
-            }
+            background-color: var(--body-bg);
         }
     }
     &__list-cell {
@@ -48,7 +42,7 @@ $changeset-backdrop: #f3faff;
     }
     &__tab-link {
         &--active {
-            background-color: $changeset-backdrop !important;
+            background-color: var(--body-bg) !important;
         }
     }
     &__change-indicator {

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.module.scss
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.module.scss
@@ -1,16 +1,13 @@
 .code-host-connection-node {
     &__container {
-        padding: 1rem;
-        :global(.theme-redesign) & {
-            padding: 0;
-            border: none;
-            &:not(:last-child) {
-                padding-bottom: 1rem;
-            }
-            &:not(:first-child) {
-                padding-top: 1rem;
-                border-top: 1px solid var(--border-color);
-            }
+        padding: 0;
+        border: none;
+        &:not(:last-child) {
+            padding-bottom: 1rem;
+        }
+        &:not(:first-child) {
+            padding-top: 1rem;
+            border-top: 1px solid var(--border-color);
         }
     }
 }


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from batches.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.