### PR TITLE
batches: Don't error if unknown event received

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -54,7 +54,6 @@ func (h *GitHubWebhook) Register(router *webhooks.GitHubWebhook) {
 // handleGithubWebhook is the entry point for webhooks from the webhook router, see the events
 // it's registered to handle in GitHubWebhook.Register
 func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
-	m := new(multierror.Error)
 	externalServiceID, err := extractExternalServiceID(extSvc)
 	if err != nil {
 		return err
@@ -62,6 +61,11 @@ func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, extSvc *types.E
 
 	prs, ev := h.convertEvent(ctx, externalServiceID, payload)
 
+	if ev == nil {
+		return nil
+	}
+
+	m := new(multierror.Error)
 	for _, pr := range prs {
 		if pr == (PR{}) {
 			continue

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -230,8 +230,8 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					NodeID: &githubRepo.ExternalRepo.ID,
 				},
 				Action: &action,
-			}); err == nil {
-				t.Error("unexpected nil error")
+			}); err != nil {
+				t.Error("unexpected non-nil error")
 			}
 		})
 	}


### PR DESCRIPTION
As GitHub evolves, they are adding more events. Also, we don't care about all possible ones, so it might well be that we don't know of some of the kinds of events we receive. Before, we'd return an error, which causes GitHub to retry the webhook eventually. That caused a lot of additional failures and incoming requests, additional load on the GitHub instance, and a lot of logspam. This fixes it by accepting that we can't know about _all_ events.
