### PR TITLE
search: support global search for symbols

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -548,14 +548,14 @@ func withMode(args search.TextParameters, st query.SearchType, versionContext *s
 		return len(args.Query.Values(query.FieldRepo)) == 0 && len(args.Query.Values(query.FieldRepoGroup)) == 0 && len(args.Query.Values(query.FieldRepoHasFile)) == 0
 	}
 
-	isFileOrPath := args.ResultTypes.Has(result.TypeFile) || args.ResultTypes.Has(result.TypePath)
+	hasGlobalSearchResultType := args.ResultTypes.Has(result.TypeFile | result.TypePath | result.TypeSymbol)
 	isIndexedSearch := args.PatternInfo.Index != query.No
 	isEmpty := args.PatternInfo.Pattern == "" && args.PatternInfo.ExcludePattern == "" && len(args.PatternInfo.IncludePatterns) == 0
-	if isGlobalSearch() && isIndexedSearch && isFileOrPath && !isEmpty {
+	if isGlobalSearch() && isIndexedSearch && hasGlobalSearchResultType && !isEmpty {
 		args.Mode = search.ZoektGlobalSearch
 	}
 	if isEmpty {
-		args.Mode = search.SkipContentAndPathSearch
+		args.Mode = search.SkipUnindexed
 	}
 	return args
 }
@@ -1467,16 +1467,27 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		}
 
 		wg := waitGroup(true)
-		wg.Add(1)
-		goroutine.Go(func() {
-			defer wg.Done()
-			_ = agg.DoFilePathSearch(ctx, &argsIndexed)
-		})
+		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
+			wg.Add(1)
+			goroutine.Go(func() {
+				defer wg.Done()
+				_ = agg.DoFilePathSearch(ctx, &argsIndexed)
+			})
+		}
+
+		if args.ResultTypes.Has(result.TypeSymbol) {
+			wg.Add(1)
+			goroutine.Go(func() {
+				defer wg.Done()
+				_ = agg.DoSymbolSearch(ctx, &argsIndexed, limit)
+			})
+		}
+
 		// On sourcegraph.com and for unscoped queries, determineRepos returns the subset
 		// of indexed default searchrepos. No need to call searcher, because
 		// len(searcherRepos) will always be 0.
 		if envvar.SourcegraphDotComMode() {
-			args.Mode = search.SkipContentAndPathSearch
+			args.Mode = search.SkipUnindexed
 		} else {
 			args.Mode = search.SearcherOnly
 		}
@@ -1534,16 +1545,18 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	}
 
 	if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" {
-		wg := waitGroup(args.ResultTypes.Without(result.TypeSymbol) == 0)
-		wg.Add(1)
-		goroutine.Go(func() {
-			defer wg.Done()
-			_ = agg.DoSymbolSearch(ctx, args, limit)
-		})
+		if args.Mode != search.SkipUnindexed {
+			wg := waitGroup(args.ResultTypes.Without(result.TypeSymbol) == 0)
+			wg.Add(1)
+			goroutine.Go(func() {
+				defer wg.Done()
+				_ = agg.DoSymbolSearch(ctx, args, limit)
+			})
+		}
 	}
 
 	if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
-		if args.Mode != search.SkipContentAndPathSearch {
+		if args.Mode != search.SkipUnindexed {
 			wg := waitGroup(true)
 			wg.Add(1)
 			goroutine.Go(func() {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -110,16 +110,16 @@ const (
 	// optimised code path.
 	SearcherOnly
 
-	// Disables content and file path search. Used:
+	// SkipUnindexed disables content, path, and symbol search. Used:
 	// (1) in conjunction with ZoektGlobalSearch on Sourcegraph.com.
-	// (2) when a query does not specify any patterns for a content or file path search.
-	SkipContentAndPathSearch
+	// (2) when a query does not specify any patterns, include patterns, or exclude pattern.
+	SkipUnindexed
 )
 
 var globalSearchModeStrings = map[GlobalSearchMode]string{
-	ZoektGlobalSearch:        "ZoektGlobalSearch",
-	SearcherOnly:             "SearcherOnly",
-	SkipContentAndPathSearch: "SkipContentAndPathSearch",
+	ZoektGlobalSearch: "ZoektGlobalSearch",
+	SearcherOnly:      "SearcherOnly",
+	SkipUnindexed:     "SkipUnindexed",
 }
 
 func (m GlobalSearchMode) String() string {

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -39,7 +39,7 @@ func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissi
 	if args.Mode == search.ZoektGlobalSearch {
 		// performance: optimize global searches where Zoekt searches
 		// all shards anyway.
-		return zoektutil.NewIndexedUniverseSearchRequest(ctx, args, args.RepoOptions, args.UserPrivateRepos)
+		return zoektutil.NewIndexedUniverseSearchRequest(ctx, args, search.TextRequest, args.RepoOptions, args.UserPrivateRepos)
 	}
 	return zoektutil.NewIndexedSubsetSearchRequest(ctx, args, search.TextRequest, onMissing)
 }

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -175,14 +175,14 @@ func (s *IndexedUniverseSearchRequest) UnindexedRepos() []*search.RepositoryRevi
 	return nil
 }
 
-func NewIndexedUniverseSearchRequest(ctx context.Context, args *search.TextParameters, repoOptions search.RepoOptions, userPrivateRepos []types.RepoName) (_ *IndexedUniverseSearchRequest, err error) {
+func NewIndexedUniverseSearchRequest(ctx context.Context, args *search.TextParameters, typ search.IndexedRequestType, repoOptions search.RepoOptions, userPrivateRepos []types.RepoName) (_ *IndexedUniverseSearchRequest, err error) {
 	tr, _ := trace.New(ctx, "NewIndexedUniverseSearchRequest", "text")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	q, err := search.QueryToZoektQuery(args.PatternInfo, false)
+	q, err := search.QueryToZoektQuery(args.PatternInfo, typ == search.SymbolRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func NewIndexedUniverseSearchRequest(ctx context.Context, args *search.TextParam
 		Args: &search.ZoektParameters{
 			Repos:          args.Repos,
 			Query:          q,
-			Typ:            search.TextRequest,
+			Typ:            typ,
 			FileMatchLimit: args.PatternInfo.FileMatchLimit,
 			Enabled:        args.Zoekt.Enabled(),
 			Index:          args.PatternInfo.Index,


### PR DESCRIPTION
We have neglected symbol search in our optimizations for global search
so far. With this change we skip repo resolution for symbol search just like
we do for path and content queries.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
