### PR TITLE
internal/extsvc: Use stricter check for equality in CodeHostOf

### DIFF
--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -62,7 +62,10 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 }
 
 // CodeHostOf returns the CodeHost of the given repo, if any. A correct repo name will have three
-// parts separated by a "/": 1. Codehost URL 2. Repo Owner 3. Repo Name
+// parts separated by a "/":
+// 1. Codehost URL
+// 2. Repo Owner
+// 3. Repo Name
 //
 // For example:
 // github.com/sourcegraph/sourcegraph

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -67,8 +67,7 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 // 2. Repo Owner
 // 3. Repo Name
 //
-// For example:
-// github.com/sourcegraph/sourcegraph
+// For example: github.com/sourcegraph/sourcegraph
 //
 // If "name" does not adhere to this format or the Codehost URL does not match the list of
 // "codehosts" given as the argument to CodeHostOf, it will return nil, otherwise it retuns the

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -61,12 +61,23 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 	return baseURL
 }
 
-// CodeHostOf returns the CodeHost of the given repo, if any, as
-// determined by a common prefix between the repo name and the
-// code hosts' URL hostname component.
+// CodeHostOf returns the CodeHost of the given repo, if any. A correct repo name will have three
+// parts separated by a "/": 1. Codehost URL 2. Repo Owner 3. Repo Name
+//
+// For example:
+// github.com/sourcegraph/sourcegraph
+//
+// If "name" does not adhere to this format or the Codehost URL does not match the list of
+// "codehosts" given as the argument to CodeHostOf, it will return nil, otherwise it retuns the
+// matching codehost from the given list.
 func CodeHostOf(name api.RepoName, codehosts ...*CodeHost) *CodeHost {
+	repoNameParts := strings.Split(string(name), "/")
+	if len(repoNameParts) != 3 {
+		return nil
+	}
+
 	for _, c := range codehosts {
-		if strings.HasPrefix(strings.ToLower(string(name)), c.BaseURL.Hostname()) {
+		if strings.EqualFold(repoNameParts[0], c.BaseURL.Hostname()) {
 			return c
 		}
 	}

--- a/internal/extsvc/codehost_test.go
+++ b/internal/extsvc/codehost_test.go
@@ -32,7 +32,13 @@ func TestCodeHostOf(t *testing.T) {
 		repo:      "GITHUB.COM/foo/bar",
 		codehosts: PublicCodeHosts,
 		want:      GitHubDotCom,
-	}} {
+	}, {
+		name:      "trick",
+		repo:      "github.com.example.com/foo/bar",
+		codehosts: PublicCodeHosts,
+		want:      nil,
+	},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			have := CodeHostOf(tc.repo, tc.codehosts...)
 			if have != tc.want {

--- a/internal/extsvc/codehost_test.go
+++ b/internal/extsvc/codehost_test.go
@@ -33,7 +33,7 @@ func TestCodeHostOf(t *testing.T) {
 		codehosts: PublicCodeHosts,
 		want:      GitHubDotCom,
 	}, {
-		name:      "trick",
+		name:      "invalid",
 		repo:      "github.com.example.com/foo/bar",
 		codehosts: PublicCodeHosts,
 		want:      nil,


### PR DESCRIPTION
In this commit we extract the codehost URL from the given repo name
and apply an exact case-insensitive match instead of only checking for
the prefix. The previous approach does not handle corner cases like:
github.com.example.com/foo/bar and falsely identifies it as a repo
belonging to the codehost with URL github.com.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
