### PR TITLE
Code Insights: Fix flaky tooltip screenshot tests

### DIFF
--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/LineChart.scss
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/LineChart.scss
@@ -2,6 +2,10 @@
     display: flex;
     flex-direction: column;
 
+    &--no-interaction {
+        pointer-events: none;
+    }
+
     &__content-parent-size {
         flex-grow: 1;
         position: relative;

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/LineChart.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/LineChart.tsx
@@ -1,8 +1,16 @@
 import { ParentSize } from '@visx/responsive'
 import { EventEmitterProvider } from '@visx/xychart'
+import classnames from 'classnames'
 import React, { ReactElement } from 'react'
 
 import { getLineStroke, LineChartContent, LineChartContentProps } from './components/LineChartContent'
+
+/**
+ * Check percy test run to be able disable flaky line chart tooltip appearance
+ * by disabling any point events over line chart container.
+ * See https://github.com/sourcegraph/sourcegraph/issues/23669
+ */
+const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
 
 export interface LineChartProps<Datum extends object> extends LineChartContentProps<Datum> {}
 
@@ -26,8 +34,12 @@ export function LineChart<Datum extends object>(props: LineChartProps<Datum>): R
 
     return (
         <EventEmitterProvider>
-            {/* eslint-disable-next-line react/forbid-dom-props */}
-            <div aria-label="Line chart" style={{ width, height }} className="line-chart">
+            <div
+                aria-label="Line chart"
+                /* eslint-disable-next-line react/forbid-dom-props */
+                style={{ width, height }}
+                className={classnames('line-chart', { 'line-chart--no-interaction': IS_PERCY_RUN })}
+            >
                 {/*
                     In case if we have a legend to render we have to have responsive container for chart
                     just to calculate right sizes for chart content = rootContainerSizes - legendSizes

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/LineChart.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/LineChart.tsx
@@ -1,16 +1,8 @@
 import { ParentSize } from '@visx/responsive'
 import { EventEmitterProvider } from '@visx/xychart'
-import classnames from 'classnames'
 import React, { ReactElement } from 'react'
 
 import { getLineStroke, LineChartContent, LineChartContentProps } from './components/LineChartContent'
-
-/**
- * Check percy test run to be able disable flaky line chart tooltip appearance
- * by disabling any point events over line chart container.
- * See https://github.com/sourcegraph/sourcegraph/issues/23669
- */
-const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
 
 export interface LineChartProps<Datum extends object> extends LineChartContentProps<Datum> {}
 
@@ -38,7 +30,7 @@ export function LineChart<Datum extends object>(props: LineChartProps<Datum>): R
                 aria-label="Line chart"
                 /* eslint-disable-next-line react/forbid-dom-props */
                 style={{ width, height }}
-                className={classnames('line-chart', { 'line-chart--no-interaction': IS_PERCY_RUN })}
+                className="line-chart"
             >
                 {/*
                     In case if we have a legend to render we have to have responsive container for chart

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -233,7 +233,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                 yScale={scalesConfiguration.y}
                 initialDimensions={{ width, height, margin: dynamicMargin }}
             >
-                <TooltipProvider>
+                <TooltipProvider hideTooltipDebounceMs={0}>
                     <XYChart
                         height={height}
                         width={width}
@@ -353,11 +353,9 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                         </Group>
 
                         <Tooltip
-                            className="line-chart__tooltip percy-hide"
+                            className="line-chart__tooltip"
                             showHorizontalCrosshair={false}
                             showVerticalCrosshair={true}
-                            // Fix flaky code insights test https://github.com/sourcegraph/sourcegraph/issues/23669
-                            verticalCrosshairStyle={{ className: 'percy-hide' }}
                             snapTooltipToDatumX={false}
                             snapTooltipToDatumY={false}
                             showDatumGlyph={false}

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -23,6 +23,13 @@ import { NonActiveBackground } from './NonActiveBackground'
 import { dateTickFormatter, numberFormatter, Tick, getTickXProps, getTickYProps } from './TickComponent'
 import { TooltipContent } from './TooltipContent'
 
+/**
+ * Check percy test run to be able disable flaky line chart tooltip appearance
+ * by disabling any point events over line chart container.
+ * See https://github.com/sourcegraph/sourcegraph/issues/23669
+ */
+const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
+
 // Chart configuration
 const WIDTH_PER_TICK = 70
 const HEIGHT_PER_TICK = 40
@@ -64,7 +71,7 @@ export interface LineChartContentProps<Datum extends object>
 
 /**
  * Displays line chart content - line chart, tooltip, active point
- * */
+ */
 export function LineChartContent<Datum extends object>(props: LineChartContentProps<Datum>): ReactElement {
     const { width, height, data, series, xAxis, onDatumZoneClick = noop, onDatumLinkClick = noop } = props
 
@@ -289,7 +296,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                             // eslint-disable-next-line jsx-a11y/aria-role
                             role="graphics-datagroup"
                             aria-label="Chart series"
-                            pointerEvents="bounding-box"
+                            pointerEvents={IS_PERCY_RUN ? 'none' : 'bounding-box'}
                             {...eventEmitters}
                         >
                             {/* Spread size of parent group element by transparent rect with width and height */}

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -38,7 +38,7 @@ describe('[VISUAL] Code insights page', () => {
 
     async function takeChartSnapshot(name: string): Promise<void> {
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
-        await delay(500)
+        await delay(1000)
         await percySnapshotWithVariants(driver.page, name)
     }
 
@@ -83,9 +83,7 @@ describe('[VISUAL] Code insights page', () => {
                     repositories: [],
                     series: [],
                 },
-                'insights.allrepos': {
-                    'searchInsights.insight.backend_ID_001': {},
-                },
+                'insights.allrepos': {},
             },
             insightExtensionsMocks: {
                 'searchInsights.insight.teamSize': INSIGHT_VIEW_TEAM_SIZE,
@@ -131,9 +129,7 @@ describe('[VISUAL] Code insights page', () => {
                     repositories: [],
                     series: [],
                 },
-                'insights.allrepos': {
-                    'searchInsights.insight.backend_ID_001': {},
-                },
+                'insights.allrepos': {},
             },
             insightExtensionsMocks: {
                 'searchInsights.insight.teamSize': ({ message: 'Error message', name: 'hello' } as unknown) as View,
@@ -180,9 +176,7 @@ describe('[VISUAL] Code insights page', () => {
                     series: [],
                 },
                 'codeStatsInsights.insight.langUsage': {},
-                'insights.allrepos': {
-                    'searchInsights.insight.backend_ID_001': {},
-                },
+                'insights.allrepos': {}
             },
             insightExtensionsMocks: {
                 'codeStatsInsights.insight.langUsage': CODE_STATS_INSIGHT_LANG_USAGE,

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -15,8 +15,7 @@ import {
 } from './utils/insight-mock-data'
 import { overrideGraphQLExtensions } from './utils/override-graphql-with-extensions'
 
-// eslint-disable-next-line ban/ban
-describe.only('[VISUAL] Code insights page', () => {
+describe('[VISUAL] Code insights page', () => {
     let driver: Driver
     let testContext: WebIntegrationTestContext
 

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -15,7 +15,8 @@ import {
 } from './utils/insight-mock-data'
 import { overrideGraphQLExtensions } from './utils/override-graphql-with-extensions'
 
-describe('[VISUAL] Code insights page', () => {
+// eslint-disable-next-line ban/ban
+describe.only('[VISUAL] Code insights page', () => {
     let driver: Driver
     let testContext: WebIntegrationTestContext
 

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -1,4 +1,3 @@
-import delay from 'delay'
 import { View } from 'sourcegraph'
 
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
@@ -37,14 +36,7 @@ describe('[VISUAL] Code insights page', () => {
     afterEach(() => testContext?.dispose())
 
     async function takeChartSnapshot(name: string): Promise<void> {
-        // Move mouse cursor away from charts and click to avoid chart tooltip appearance
-        await driver.page.mouse.move(0, 0)
-        await driver.page.click('body')
-
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
-        // Due to autosize of chart we have to wait 1s that window-resize be able
-        // render chart with container size.
-        await delay(1000)
         await percySnapshotWithVariants(driver.page, name)
     }
 
@@ -69,9 +61,7 @@ describe('[VISUAL] Code insights page', () => {
         await takeChartSnapshot('Code insights page with back-end insights only')
     })
 
-    // Unmute that test when flaky issue with line chart tooltip will be resolved
-    // see https://github.com/sourcegraph/sourcegraph/issues/23669
-    it.skip('is styled correctly with search-based insights ', async () => {
+    it('is styled correctly with search-based insights ', async () => {
         overrideGraphQLExtensions({
             testContext,
 
@@ -108,6 +98,13 @@ describe('[VISUAL] Code insights page', () => {
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
+
+        await driver.page.waitForSelector(
+            '[data-testid="insight-card.searchInsights.insight.teamSize"] [data-testid="line-chart__content"] svg circle'
+        )
+        await driver.page.hover(
+            '[data-testid="insight-card.searchInsights.insight.teamSize"] [data-testid="line-chart__content"] circle:first-child'
+        )
 
         await takeChartSnapshot('Code insights page with search-based insights only')
     })
@@ -149,6 +146,13 @@ describe('[VISUAL] Code insights page', () => {
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
+
+        await driver.page.waitForSelector(
+            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] svg circle'
+        )
+        await driver.page.hover(
+            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] circle:last-child'
+        )
 
         await takeChartSnapshot('Code insights page with search-based errored insight')
     })
@@ -192,6 +196,13 @@ describe('[VISUAL] Code insights page', () => {
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
+
+        await driver.page.waitForSelector(
+            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] svg circle'
+        )
+        await driver.page.hover(
+            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] circle:last-child'
+        )
 
         await takeChartSnapshot('Code insights page with all types of insight')
     })

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -38,7 +38,7 @@ describe('[VISUAL] Code insights page', () => {
 
     async function takeChartSnapshot(name: string): Promise<void> {
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
-        await delay(1000)
+        await delay(500)
         await percySnapshotWithVariants(driver.page, name)
     }
 
@@ -51,9 +51,7 @@ describe('[VISUAL] Code insights page', () => {
                 },
             },
             overrides: {
-                /**
-                 * Mock back-end insights with standard gql API handler.
-                 * */
+                // Mock back-end insights with standard gql API handler.
                 Insights: () => ({ insights: { nodes: BACKEND_INSIGHTS } }),
             },
         })
@@ -67,11 +65,9 @@ describe('[VISUAL] Code insights page', () => {
         overrideGraphQLExtensions({
             testContext,
 
-            /**
-             * Since search insight and code stats insight are working via user/org
-             * settings. We have to mock them by mocking user settings and provide
-             * mock data - mocking extension work.
-             * */
+            // Since search insight and code stats insight are working via user/org
+            // settings. We have to mock them by mocking user settings and provide
+            // mock data - mocking extension work.
             userSettings: {
                 'searchInsights.insight.graphQLTypesMigration': {
                     title: 'The First search-based insight',
@@ -90,22 +86,12 @@ describe('[VISUAL] Code insights page', () => {
                 'searchInsights.insight.graphQLTypesMigration': INSIGHT_VIEW_TYPES_MIGRATION,
             },
             overrides: {
-                /**
-                 * Mock back-end insights with standard gql API handler.
-                 * */
+                // Mock back-end insights with standard gql API handler.
                 Insights: () => ({ insights: { nodes: [] } }),
             },
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
-
-        await driver.page.waitForSelector(
-            '[data-testid="insight-card.searchInsights.insight.teamSize"] [data-testid="line-chart__content"] svg circle'
-        )
-        await driver.page.hover(
-            '[data-testid="insight-card.searchInsights.insight.teamSize"] [data-testid="line-chart__content"] circle:first-child'
-        )
-
         await takeChartSnapshot('Code insights page with search-based insights only')
     })
 
@@ -113,11 +99,9 @@ describe('[VISUAL] Code insights page', () => {
         overrideGraphQLExtensions({
             testContext,
 
-            /**
-             * Since search insight and code stats insight are working via user/org
-             * settings. We have to mock them by mocking user settings and provide
-             * mock data - mocking extension work.
-             * */
+            // Since search insight and code stats insight are working via user/org
+            // settings. We have to mock them by mocking user settings and provide
+            // mock data - mocking extension work.
             userSettings: {
                 'searchInsights.insight.graphQLTypesMigration': {
                     title: 'The First search-based insight',
@@ -136,22 +120,12 @@ describe('[VISUAL] Code insights page', () => {
                 'searchInsights.insight.graphQLTypesMigration': INSIGHT_VIEW_TYPES_MIGRATION,
             },
             overrides: {
-                /**
-                 * Mock back-end insights with standard gql API handler.
-                 * */
+                // Mock back-end insights with standard gql API handler.
                 Insights: () => ({ insights: { nodes: [] } }),
             },
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
-
-        await driver.page.waitForSelector(
-            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] svg circle'
-        )
-        await driver.page.hover(
-            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] circle:last-child'
-        )
-
         await takeChartSnapshot('Code insights page with search-based errored insight')
     })
 
@@ -159,11 +133,9 @@ describe('[VISUAL] Code insights page', () => {
         overrideGraphQLExtensions({
             testContext,
 
-            /**
-             * Since search insight and code stats insight are working via user/org
-             * settings. We have to mock them by mocking user settings and provide
-             * mock data - mocking extension work.
-             * */
+            // Since search insight and code stats insight are working via user/org
+            // settings. We have to mock them by mocking user settings and provide
+            // mock data - mocking extension work.
             userSettings: {
                 'searchInsights.insight.graphQLTypesMigration': {
                     title: 'The First search-based insight',
@@ -184,22 +156,12 @@ describe('[VISUAL] Code insights page', () => {
                 'searchInsights.insight.graphQLTypesMigration': INSIGHT_VIEW_TYPES_MIGRATION,
             },
             overrides: {
-                /**
-                 * Mock back-end insights with standard gql API handler.
-                 * */
+                // Mock back-end insights with standard gql API handler.
                 Insights: () => ({ insights: { nodes: BACKEND_INSIGHTS } }),
             },
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
-
-        await driver.page.waitForSelector(
-            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] svg circle'
-        )
-        await driver.page.hover(
-            '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="line-chart__content"] circle:last-child'
-        )
-
         await takeChartSnapshot('Code insights page with all types of insight')
     })
 })

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -1,3 +1,4 @@
+import delay from 'delay'
 import { View } from 'sourcegraph'
 
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
@@ -37,6 +38,7 @@ describe('[VISUAL] Code insights page', () => {
 
     async function takeChartSnapshot(name: string): Promise<void> {
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
+        await delay(500)
         await percySnapshotWithVariants(driver.page, name)
     }
 

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -20,7 +20,7 @@ describe('[VISUAL] Code insights page', () => {
     let testContext: WebIntegrationTestContext
 
     before(async () => {
-        driver = await createDriverForTest()
+        driver = await createDriverForTest({ defaultViewport: { width: 1920 } })
     })
 
     after(() => driver?.close())
@@ -176,7 +176,7 @@ describe('[VISUAL] Code insights page', () => {
                     series: [],
                 },
                 'codeStatsInsights.insight.langUsage': {},
-                'insights.allrepos': {}
+                'insights.allrepos': {},
             },
             insightExtensionsMocks: {
                 'codeStatsInsights.insight.langUsage': CODE_STATS_INSIGHT_LANG_USAGE,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook",
-    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=false --retries=1 --jobs=2  \"./client/web/src/integration/**/*.test.ts\"",
+    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=2  \"./client/web/src/integration/**/*.test.ts\"",
     "test-browser-integration": "yarn --cwd client/browser run test-integration",
     "cover-integration": "nyc --hook-require=false yarn test-integration",
     "cover-browser-integration": "nyc --hook-require=false yarn --cwd client/browser test-integration",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook",
-    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=2  \"./client/web/src/integration/**/*.test.ts\"",
+    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=false --retries=1 --jobs=2  \"./client/web/src/integration/**/*.test.ts\"",
     "test-browser-integration": "yarn --cwd client/browser run test-integration",
     "cover-integration": "nyc --hook-require=false yarn test-integration",
     "cover-browser-integration": "nyc --hook-require=false yarn --cwd client/browser test-integration",


### PR DESCRIPTION
### Context
We have some Percy screenshot tests for catching any visual regression over code insight line and pie charts on the dashboard page. However, some of these tests have a flaky logic of chart tooltip appearance. This PR adds some PERCY only logic to disable any user interaction over line chart element (via `pointer-events: none`)

