### PR TITLE
web: remove `.theme-redesign` selector from nav

### DIFF
--- a/client/web/src/nav/GlobalNavbar.scss
+++ b/client/web/src/nav/GlobalNavbar.scss
@@ -6,51 +6,25 @@
     display: flex;
     align-items: center;
     width: 100%;
-    &--bg {
-        background-color: var(--color-bg-2);
-    }
-
-    &__logo-link {
-        outline: 0;
-        margin: 0.25rem 0.5rem;
-        display: flex;
-        width: fit-content;
-        text-decoration: none;
-    }
 
     &__logo {
         height: 1.5rem;
         width: 1.5rem;
     }
 
-    &__search-box-container {
-        min-width: 12rem;
-        flex: 1 1 auto;
-        margin-right: 0.25rem;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
+    &__link {
+        color: var(--body-color);
+        border-radius: var(--border-radius);
     }
 
-    .theme-redesign & {
-        &__icon {
-            color: var(--header-icon-color);
-        }
+    &__sign-up {
+        border: 1px solid transparent;
+        background-color: var(--brand-secondary);
+        color: var(--white);
 
-        &__link {
-            color: var(--body-color);
-            border-radius: var(--border-radius);
-        }
-
-        &__sign-up {
-            border: 1px solid transparent;
-            background-color: var(--brand-secondary);
+        &:hover {
+            background-color: var(--brand-secondary-3);
             color: var(--white);
-
-            &:hover {
-                background-color: var(--brand-secondary-3);
-                color: var(--white);
-            }
         }
     }
 }

--- a/client/web/src/nav/UserNavItem.scss
+++ b/client/web/src/nav/UserNavItem.scss
@@ -1,29 +1,21 @@
-.theme-redesign {
-    .user-nav-item {
-        &__avatar {
-            height: 1.5rem;
-            width: 1.5rem;
-        }
-        &__dropdown-menu {
-            > .dropdown-item {
-                &:hover {
-                    background-color: var(--link-color);
-                    color: var(--light-text);
-                }
-            }
-            > .dropdown-header {
-                font-size: 0.75rem;
-            }
-            > .dropdown-divider {
-                border-top: 1px solid var(--border-color-2);
-            }
-        }
-    }
-}
-
 .user-nav-item {
     &__dropdown-menu {
         min-width: 12rem;
+
+        > .dropdown-item {
+            &:hover {
+                background-color: var(--link-color);
+                color: var(--light-text);
+            }
+        }
+
+        > .dropdown-header {
+            font-size: 0.75rem;
+        }
+
+        > .dropdown-divider {
+            border-top: 1px solid var(--border-color-2);
+        }
     }
 
     &__tooltip {
@@ -31,18 +23,9 @@
         animation: tooltip-fade-in-out 5s ease-out 100ms;
     }
 
-    &__avatar-background {
-        position: absolute;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
-        border-radius: 50%;
-        opacity: 0;
-        animation: background-fade-in-out 5s ease-out 100ms;
-
-        background: rgba(56, 117, 127, 0.3);
-        filter: blur(1px);
+    &__avatar {
+        height: 1.5rem;
+        width: 1.5rem;
     }
 }
 

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -1,5 +1,4 @@
 import { Shortcut } from '@slimsag/react-shortcuts'
-import classNames from 'classnames'
 import * as H from 'history'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronUpIcon from 'mdi-react/ChevronUpIcon'

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -113,12 +113,7 @@ export const UserNavItem: React.FunctionComponent<UserNavItemProps> = props => {
         <ButtonDropdown isOpen={isOpen} toggle={toggleIsOpen} className="py-0" aria-label="User. Open menu">
             <DropdownToggle className="bg-transparent d-flex align-items-center test-user-nav-item-toggle" nav={true}>
                 <div className="position-relative">
-                    <div
-                        className={classNames('align-items-center d-flex', {
-                            // Temporarily remove user avatar flash animation for redesign
-                            // 'user-nav-item__avatar-background': isExtensionAlertAnimating,
-                        })}
-                    >
+                    <div className="align-items-center d-flex">
                         <UserAvatar
                             user={props.authenticatedUser}
                             targetID={targetID}

--- a/client/web/src/nav/VersionContextDropdown.scss
+++ b/client/web/src/nav/VersionContextDropdown.scss
@@ -4,13 +4,8 @@
     width: max-content;
 
     &:first-child &__button {
-        border-top-left-radius: 2px;
-        border-bottom-left-radius: 2px;
-
-        .theme-redesign & {
-            border-top-left-radius: var(--border-radius);
-            border-bottom-left-radius: var(--border-radius);
-        }
+        border-top-left-radius: var(--border-radius);
+        border-bottom-left-radius: var(--border-radius);
     }
 
     &:not(:first-child) .version-context-dropdown__button {
@@ -20,16 +15,13 @@
     &__button {
         display: flex;
         border-radius: 0;
+        padding: 0.5rem 0.75rem;
+        border: none;
 
-        .theme-redesign & {
-            padding: 0.5rem 0.75rem;
-            border: none;
-
-            @media (--xs-breakpoint-down) {
-                padding: 0.2rem 0.25rem;
-                margin-right: 0.5rem;
-                border-radius: var(--border-radius);
-            }
+        @media (--xs-breakpoint-down) {
+            padding: 0.2rem 0.25rem;
+            margin-right: 0.5rem;
+            border-radius: var(--border-radius);
         }
 
         &-text {


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from extensions.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.