### PR TITLE
Add insights filter docs

### DIFF
--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -37,7 +37,7 @@ You can set filters to be persistent, or default, even after a page reload on a 
 
 ### Filter indicator 
 
-Insights that have any filters applied will have a small dot on their filter icon. The filter can always be reset by opening the filter panel again and clicking "Reset" above each filter or "Reset all filters" – but note that, like any filter edit, you must also then "update default filters" to save that reset state if you want it to persist. 
+Insights that have any filters applied will have a small dot on their filter icon. The filter can always be reset by opening the filter panel again and clicking "Reset" above each filter – but note that, like any filter edit, you must also then "update default filters" to save that reset state if you want it to persist. 
 
 ### Saving a filter as a new view
 

--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -1,28 +1,46 @@
 # Code Insights filters
 
-Code insights filters allow you to filter a chart of search insight to a subset of repositories at the time of viewing it.
-Filters are applied immediately without having to recompute the insight and can be reset at any time.
-The filter panel is available through the filter icon in the top right of every search insight.
+Code insights filters allow you to filter a search insight to a subset of repositories. Each search insight has a filter icon that opens the filtering options. 
+
+Filters take effect immediately, without needing to re-process the data series of the insight.
+
+> Note: filters are not yet available on language statistics insights. 
 
 ## Filter options
 
-Repositories are included or excluded from the insight using regular expressions, similar to the `repo:` filter in [Sourcegraph searches](../../code_search/reference/queries#keywords-all-searches).
+### Repo: filters
 
-## Persistance and sharing
+You can include or exclude repositories from your insight using regular expressions, the same way you can with the `repo:` filter in [Sourcegraph searches](../../code_search/reference/queries.md#keywords-all-searches).
 
-Filters you specify are temporary by default and only seen by you.
-Unless you click "Update default filters" or "Save as new view", the filters will not apply to the chart other viewers of the dashboard see and will disappear after a page reload.
+For inclusion, only repositories that have a repository name matching the regular expression will be counted.
 
-### Default filters
+For exclusion, only repositories that have a repository name **not** matching the regular expression will be counted.
 
-By clicking "Update default filters", the filters you entered will be attached to the insight, persist even after a page reload, and be shown to every viewer of the insight/dashboard.
-Viewers can locally modify filters to their liking without affecting what other viewers see, until they click "Update default filters".
+If you combine both filters, the inclusion pattern will be applied first, then the exclusion pattern.
 
-Insights that have default filters applied will be indicated by a small dot at the filter icon. The filter can be reset by opening the filter panel again and clicking "Reset" above each filter or "Reset all filters".
+### Other filtering options
 
-### Insight views
+We're currently exploring additional filters that would be valuable. If you have feedback about a particular filter you'd like for code insights, we would [love to hear your feedback](mailto:feedback@sourcegraph.com).
 
-By clicking "Save as new view", the insight will be forked into a new insight with the specified filters applied.
-The view appears as a separate chart on the dashboard.
-Filters for the newly created view and the original insight can be edited and persisted through "Update default insights" independently.
-Editing the forked insight (e.g. changing the title) will not change the original insight.
+## Filter persistance and sharing
+
+### Filters are temporary by default
+
+By default, filters are temporary (present until you refresh the page) and local (no one else can see them). You can modify filters without affecting what others see, unless or until you save the filters.
+
+### Saving filters as defaults
+
+You can set filters to be persistent, or default, even after a page reload on a code insights in two ways:
+
+1. Create a filter and click "save/update default filters": this will save the filters so they persist for all viewers of this insight, on any dashboard page the insight appears. 
+1. Create a filter and "save as new view": this will create a new insight chart with your filter applied as the default filter on that insight. It will _not_ also save these filters to the existing insight unless you also select "save/update default filters". 
+
+### Filter indicator 
+
+Insights that have any filters applied will have a small dot on their filter icon. The filter can always be reset by opening the filter panel again and clicking "Reset" above each filter or "Reset all filters" – but note that, like any filter edit, you must also then "update default filters" to save that reset state if you want it to persist. 
+
+### Saving a filter as a new view
+
+When you create a filter and "save as new view," it will create a new insight chart with this filter saved as the default filteres. Except the title and filters, all other configuration options will be cloned from the original insight. 
+
+Filters and all other configuration options for the newly created view and the original insight are indpendent. Editing the forked insight (e.g. changing the data series query) will not change the original insight.

--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -1,0 +1,28 @@
+# Code Insights filters
+
+Code insights filters allow you to filter a chart of search insight to a subset of repositories at the time of viewing it.
+Filters are applied immediately without having to recompute the insight and can be reset at any time.
+The filter panel is available through the filter icon in the top right of every search insight.
+
+## Filter options
+
+Repositories are included or excluded from the insight using regular expressions, similar to the `repo:` filter in [Sourcegraph searches](../../code_search/reference/queries#keywords-all-searches).
+
+## Persistance and sharing
+
+Filters you specify are temporary by default and only seen by you.
+Unless you click "Update default filters" or "Save as new view", the filters will not apply to the chart other viewers of the dashboard see and will disappear after a page reload.
+
+### Default filters
+
+By clicking "Update default filters", the filters you entered will be attached to the insight, persist even after a page reload, and be shown to every viewer of the insight/dashboard.
+Viewers can locally modify filters to their liking without affecting what other viewers see, until they click "Update default filters".
+
+Insights that have default filters applied will be indicated by a small dot at the filter icon. The filter can be reset by opening the filter panel again and clicking "Reset" above each filter or "Reset all filters".
+
+### Insight views
+
+By clicking "Save as new view", the insight will be forked into a new insight with the specified filters applied.
+The view appears as a separate chart on the dashboard.
+Filters for the newly created view and the original insight can be edited and persisted through "Update default insights" independently.
+Editing the forked insight (e.g. changing the title) will not change the original insight.

--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -4,7 +4,7 @@ Code insights filters allow you to filter a search insight to a subset of reposi
 
 Filters take effect immediately, without needing to re-process the data series of the insight.
 
-> Note: filters are not yet available on language statistics insights. 
+> NOTE: filters are not yet available on language statistics insights. 
 
 ## Filter options
 

--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -26,7 +26,7 @@ We're currently exploring additional filters that would be valuable. If you have
 
 ### Filters are temporary by default
 
-By default, filters are temporary (present until you refresh the page) and local (no one else can see them). You can modify filters without affecting what others see, unless or until you save the filters.
+By default, filters are temporary (present until you refresh the page or switch to a different dashboard) and local (no one else can see them). You can modify filters without affecting what others see, unless or until you save the filters.
 
 ### Saving filters as defaults
 

--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -8,7 +8,7 @@ Filters take effect immediately, without needing to re-process the data series o
 
 ## Filter options
 
-### Repo: filters
+### `repo:` filters
 
 You can include or exclude repositories from your insight using regular expressions, the same way you can with the `repo:` filter in [Sourcegraph searches](../../code_search/reference/queries.md#keywords-all-searches).
 

--- a/doc/code_insights/explanations/index.md
+++ b/doc/code_insights/explanations/index.md
@@ -8,4 +8,5 @@ The following articles explain different parts of [Sourcegraph Code Insights](..
 - [Administration and Security of Code Insights](administration_and_security_of_code_insights.md)
 - [Current limitations of Code Insights](current_limitations_of_code_insights.md)
 - [Viewing code insights](viewing_code_insights.md)
+- [Code Insights filters](code_insights_filters.md)
 <!-- - [How Code Insights work](explanations/how_code_insights_work.md) -->

--- a/doc/code_insights/explanations/viewing_code_insights.md
+++ b/doc/code_insights/explanations/viewing_code_insights.md
@@ -8,57 +8,61 @@ Code Insights can display in 3 areas of Sourcegraph:
 
 ## Insights dashboards
 
-The main way to view code insights is on a dashboard page. Dashboards have a unique name and visibility level. 
+The main way to view code insights is on a dashboard page. Dashboards have a unique name and visibility level.
 
-There are three possible visibility levels: 
+There are three possible visibility levels:
 
-- Private: visible only to you 
-- Shared with an organization: visible to everyone in the organization 
-- Global: visible to everyone on the Sourcegraph instance 
+- Private: visible only to you
+- Shared with an organization: visible to everyone in the organization
+- Global: visible to everyone on the Sourcegraph instance
 
-> Global visibility is currently only available if your instance is not [using a separate global settings file](../../../admin/config/advanced_config_file.md#global-settings). Global visibility regardless of settings file setup will arrive by October 2021. 
+> Global visibility is currently only available if your instance is not [using a separate global settings file](../../../admin/config/advanced_config_file.md#global-settings). Global visibility regardless of settings file setup will arrive by October 2021.
 
-> The **quick workaround** is to [make an organization and easily add all users to it](../../../admin/organizations.md). 
+> The **quick workaround** is to [make an organization and easily add all users to it](../../../admin/organizations.md).
 
 ### Built-in dashboards
 
-The following dashboards exist on every instance: 
+The following dashboards exist on every instance:
 
-- "All insights": this dashboard contains all the insights defined on the instance that are visible to this specific user 
+- "All insights": this dashboard contains all the insights defined on the instance that are visible to this specific user
 - "[Username] insights": this dashboard contains all the insights that are created by a user and set to "private" visibility
 - "Global insights": this dashboard contains all the insights that are set to global visibility
 
-If the instance has organizations, there will also be an "[Organization name] insights" dashboard for each organization, visible to members of the organization, that contains all insights set to that organization's visibility level. 
+If the instance has organizations, there will also be an "[Organization name] insights" dashboard for each organization, visible to members of the organization, that contains all insights set to that organization's visibility level.
 
 To add insights to your own custom dashboard, see [Creating a custom dashboard of code insights](../how-tos/creating_a_custom_dashboard_of_code_insights.md).
 
-### Dashboard visibility respects insights' visibility 
+### Dashboard visibility respects insights' visibility
 
-A Dashboard's visibility level respects the visibility levels you [set when you created the insight](../quickstart.md#7-set-the-visibility-of-your-insight). You can't add an insight with "Private" visibility to an organization dashboard, but you can add an insight with organization visibility to your private dashboard (assuming you're in the organization). 
+A Dashboard's visibility level respects the visibility levels you [set when you created the insight](../quickstart.md#7-set-the-visibility-of-your-insight). You can't add an insight with "Private" visibility to an organization dashboard, but you can add an insight with organization visibility to your private dashboard (assuming you're in the organization).
 
 ### Insights still enforce individual permissions regardless of dashboard visibility
 
 The dashboard visibility levels have no impact on the data in the insight itself that is displayed to an individual user: insights [enforce the viewer's permissions](administration_and_security_of_code_insights.md#code-insights-enforce-user-permissions).
 
-This means that two organization users with different repo read permission sets might see different values for the same insights on the same dashboards, if it contains results from a repository only one user can view. 
+This means that two organization users with different repo read permission sets might see different values for the same insights on the same dashboards, if it contains results from a repository only one user can view.
 
-(This also means that if you change a private-visible dashboard with both organization-visible and private-visible insights so that the dashboard is now visible to an organization, then the organization can only see the organization-visible insights on that dashboard. This is non-optimal and a bit awkward to convey, and we are actively improving this UX. If you have strong thoughts, please do [leave them on the issue](https://github.com/sourcegraph/sourcegraph/issues/23003).) 
+(This also means that if you change a private-visible dashboard with both organization-visible and private-visible insights so that the dashboard is now visible to an organization, then the organization can only see the organization-visible insights on that dashboard. This is non-optimal and a bit awkward to convey, and we are actively improving this UX. If you have strong thoughts, please do [leave them on the issue](https://github.com/sourcegraph/sourcegraph/issues/23003).)
 
 ### Insights can be on multiple dashboards
 
-You can attach insights to multiple dashboards. 
+You can attach insights to multiple dashboards.
 
 ## Repository and directory pages
 
-On repository pages, any code insight that runs over that repository will display. On directory pages, code insights defined for that repository will display **and** run only over files that are children of the directory. 
+On repository pages, any code insight that runs over that repository will display. On directory pages, code insights defined for that repository will display **and** run only over files that are children of the directory.
 
 This is enabled by default and can be disabled with a flag in your global, organization, or user settings:
 
-```"insights.displayLocation.directory": false```
+```json
+"insights.displayLocation.directory": false
+```
 
 ## Search home page
 
-Code insights can display below the search bar on the search home page. This is disabled by default because we have not yet built the capability to select which insights display on the search home page (so they all do). This can be enabled with a flag in your global, organization, or user settings: 
+Code insights can display below the search bar on the search home page. This is disabled by default because we have not yet built the capability to select which insights display on the search home page (so they all do). This can be enabled with a flag in your global, organization, or user settings:
 
-```"insights.displayLocation.directory": true```
+```json
+"insights.displayLocation.directory": true
+```
 

--- a/doc/code_insights/how-tos/filtering_an_insight.md
+++ b/doc/code_insights/how-tos/filtering_an_insight.md
@@ -1,47 +1,50 @@
 # Filtering a code insight
 
-This how-to assumes that you already have created some search insights.
-If you have yet to create any code insights, start with the [quickstart](../quickstart.md) guide.
+This how-to assumes that you already have [created some search insights](../quickstart.md).
+
+> Note: filters are not yet available on language statistics insights. 
 
 ### 1. Click the filter icon button for the insight you want to filter
 
-While on a dashboard page with the insight you want to filter in front of you, find the filter icon in the top right and click it.
-It will open the filter popover.
+While viewing the insight you want to filter, click the filter icon in the upper right corner of the insight. This will open the filter popover. 
 
-### 2. Include or exclude repositories using a regular expression
+### 2. Filter to include or exclude repositories using a regular expression
 
-The filter popover gives you two inputs to filter the insight to a subset of repositories either by inclusion or by exclusion.
-If you specify an inclusion pattern, only repositories that have a repository name matching the regular expression will be counted.
-If you specify an exclusion pattern, only repositories that have a repository name **not** matching the regular expression will be counted.
-You can also combine both filters, in which case the inclusion pattern will be applied first, then the exclusion pattern.
+The filter popover gives you two inputs that allow you to to filter the repositories contributing to the insight, either via inclusion or exlcusion. 
 
-The repository name is the part of the URL when navigating to a repository that follows your instance domain.
-The regular expression to filter for a repository works the same as the [`repo:` filter in the search box](../../code_search/reference/queries#keywords-all-searches).
+Enter a regular expression for repository names that you'd like to include or exclude. Inclusion filters limit your insight to show data from only given repository matches. Exclusion filters filter out results from the repository matches. ([More details on how repo filters are applied](../explanations/code_insights_filters.md#repo-filters).)
+
+The regular expression to filter for a repository works the same as the [`repo:` filter in the search box](../../code_search/reference/queries.md#keywords-all-searches).
 
 Examples:
 
 | Pattern | Explanation |
 |---------|-------------|
-| `^github\.com/sourcegraph/sourcegraph$` | Include or exclude the specific repository `github.com/sourcegraph/sourcegraph` |
-| `^github\.com/sourcegraph/(sourcegraph\|about\|docsite)$` | Include or exclude the specific repositories `github.com/sourcegraph/sourcegraph`, `github.com/sourcegraph/about` and `github.com/sourcegraph/docsite` |
-| `^github\.com/sourcegraph/go-` | Include or exclude all repositories with the prefix `github.com/sourcegraph/go-` |
-| `service` | Include or exclude all repositories that contain the word `service` in their name |
-| `\.js$` | Include or exclude all repositories that end in `.js` |
+| `^github\.com/sourcegraph/sourcegraph$` | Filter the specific repository `github.com/sourcegraph/sourcegraph` |
+| `^github\.com/sourcegraph/(sourcegraph\|about\|docsite)$` | Filter the specific repositories `github.com/sourcegraph/sourcegraph`, `github.com/sourcegraph/about` and `github.com/sourcegraph/docsite` |
+| `^github\.com/sourcegraph/go-` | Filter all repositories that start with `github.com/sourcegraph/go-` |
+| `service` | Filter all repositories that contain the word `service` in their name |
+| `\.js$` | Filter all repositories that end in `.js` |
 
-You can savely click outside the panel to close it and your filters will still be applied (until a page reload).
-The little dot next to the filters icon indicates that an insight currently has filters applied for you.
+### 3. Close the filter panel 
 
-### 5. Edit or reset filters
+You can safely click outside the panel to close it and your filters will remain (until a page reload).
 
-Bring up the filters panel at any time for an insight by clicking the filters button again to edit them or resetting them with the "Reset" buttons.
+A dot next to the filter icon indicates that an insight currently has filters applied.
 
-### 3. Update default filters (optional)
+### 4. Edit or reset filters
 
-By default, the filter will only be visible to you and reset after a page reload.
-To persist the filter and apply it for other viewers viewing the insight too, click "Update default filters".
+Click the filter button again to edit or reset filters. 
 
-### 4. Save as new view (optional)
+### 5. Save your filters as defaults on this insight (optional)
 
-If you'd like to not modify the insight you're looking at for everyone, but rather fork the insight into a second one with the filters applied for everyone to see an compare to, you can click the button "Save as new view".
-The view appears as a separate chart on the dashboard, with default filters applied, while the original insight stays as-is.
+By default, the filter will only be visible to you locally and will reset after a page reload.
+
+To persist the filter so that anyone who views the insight will have the filters applied by default, click "Save/update default filters".
+
+### 6. Save as new view (optional)
+
+If you don't want to modify the insight for all future viewers, but still want to preserve your filtered view, you can select "save as new view." 
+
+This will fork the insight and create a separate chart on the dashboard with these filters applied by default. The original insight will be unmodified, and future edits to either insight will be independent. 
 

--- a/doc/code_insights/how-tos/filtering_an_insight.md
+++ b/doc/code_insights/how-tos/filtering_an_insight.md
@@ -23,7 +23,7 @@ Examples:
 | Pattern | Explanation |
 |---------|-------------|
 | `^github\.com/sourcegraph/sourcegraph$` | Include or exclude the specific repository `github.com/sourcegraph/sourcegraph` |
-| `^github\.com/sourcegraph/(sourcegraph|about|docsite)$` | Include or exclude the specific repositories `github.com/sourcegraph/sourcegraph`, `github.com/sourcegraph/about` and `github.com/sourcegraph/docsite` |
+| `^github\.com/sourcegraph/(sourcegraph\|about\|docsite)$` | Include or exclude the specific repositories `github.com/sourcegraph/sourcegraph`, `github.com/sourcegraph/about` and `github.com/sourcegraph/docsite` |
 | `^github\.com/sourcegraph/go-` | Include or exclude all repositories with the prefix `github.com/sourcegraph/go-` |
 | `service` | Include or exclude all repositories that contain the word `service` in their name |
 | `\.js$` | Include or exclude all repositories that end in `.js` |

--- a/doc/code_insights/how-tos/filtering_an_insight.md
+++ b/doc/code_insights/how-tos/filtering_an_insight.md
@@ -1,0 +1,47 @@
+# Filtering a code insight
+
+This how-to assumes that you already have created some search insights.
+If you have yet to create any code insights, start with the [quickstart](../quickstart.md) guide.
+
+### 1. Click the filter icon button for the insight you want to filter
+
+While on a dashboard page with the insight you want to filter in front of you, find the filter icon in the top right and click it.
+It will open the filter popover.
+
+### 2. Include or exclude repositories using a regular expression
+
+The filter popover gives you two inputs to filter the insight to a subset of repositories either by inclusion or by exclusion.
+If you specify an inclusion pattern, only repositories that have a repository name matching the regular expression will be counted.
+If you specify an exclusion pattern, only repositories that have a repository name **not** matching the regular expression will be counted.
+You can also combine both filters, in which case the inclusion pattern will be applied first, then the exclusion pattern.
+
+The repository name is the part of the URL when navigating to a repository that follows your instance domain.
+The regular expression to filter for a repository works the same as the [`repo:` filter in the search box](../../code_search/reference/queries#keywords-all-searches).
+
+Examples:
+
+| Pattern | Explanation |
+|---------|-------------|
+| `^github\.com/sourcegraph/sourcegraph$` | Include or exclude the specific repository `github.com/sourcegraph/sourcegraph` |
+| `^github\.com/sourcegraph/(sourcegraph|about|docsite)$` | Include or exclude the specific repositories `github.com/sourcegraph/sourcegraph`, `github.com/sourcegraph/about` and `github.com/sourcegraph/docsite` |
+| `^github\.com/sourcegraph/go-` | Include or exclude all repositories with the prefix `github.com/sourcegraph/go-` |
+| `service` | Include or exclude all repositories that contain the word `service` in their name |
+| `\.js$` | Include or exclude all repositories that end in `.js` |
+
+You can savely click outside the panel to close it and your filters will still be applied (until a page reload).
+The little dot next to the filters icon indicates that an insight currently has filters applied for you.
+
+### 5. Edit or reset filters
+
+Bring up the filters panel at any time for an insight by clicking the filters button again to edit them or resetting them with the "Reset" buttons.
+
+### 3. Update default filters (optional)
+
+By default, the filter will only be visible to you and reset after a page reload.
+To persist the filter and apply it for other viewers viewing the insight too, click "Update default filters".
+
+### 4. Save as new view (optional)
+
+If you'd like to not modify the insight you're looking at for everyone, but rather fork the insight into a second one with the filters applied for everyone to see an compare to, you can click the button "Save as new view".
+The view appears as a separate chart on the dashboard, with default filters applied, while the original insight stays as-is.
+

--- a/doc/code_insights/how-tos/filtering_an_insight.md
+++ b/doc/code_insights/how-tos/filtering_an_insight.md
@@ -2,7 +2,7 @@
 
 This how-to assumes that you already have [created some search insights](../quickstart.md).
 
-> Note: filters are not yet available on language statistics insights. 
+> NOTE: filters are not yet available on language statistics insights. 
 
 ### 1. Click the filter icon button for the insight you want to filter
 

--- a/doc/code_insights/how-tos/index.md
+++ b/doc/code_insights/how-tos/index.md
@@ -3,3 +3,4 @@
 The following is a list of how-tos that show how to use [Code Insights](../index.md):
 
 - [Creating a dashboard of code insights](creating_a_custom_dashboard_of_code_insights.md)
+- [Filtering an insight](filtering_an_insight.md))

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -12,5 +12,7 @@ Work-in-progress table of contents:
     - [Administration and security of Code Insights](explanations/administration_and_security_of_code_insights.md)
     - [Current limitations of Code Insights](explanations/current_limitations_of_code_insights.md)
     - [Viewing code insights](explanations/viewing_code_insights.md)
+    - [Code Insights filters](explanations/code_insights_filters.md)
 - [How-tos](how-tos/index.md)
     - [Creating a dashboard of code insights](how-tos/creating_a_custom_dashboard_of_code_insights.md)
+    - [Filtering an insight](how-tos/filtering_an_insight.md)

--- a/doc/code_insights/quickstart.md
+++ b/doc/code_insights/quickstart.md
@@ -69,7 +69,7 @@ The code insights prototypes currently show you seven datapoints for each data s
 
 You'll be taken to the sourcegraph.example.com/insights page and can view your insight.
 
-### 10. Filter your insight post-creation (optional)
+### 10. Filter your insight to explore it further 
 
-Click the filter button in the top right of an insight card to open the filters panel that allows you to filter the insight down to a subset of repositories through inclusion or exclusion with regular expressions.
+Click the filter button in the top right of an insight card to open the filters panel. This allows you to filter the insight down to a subset of repositories through inclusion or exclusion using regular expressions.
 For more details, see [How to filter an insight](./how-tos/filtering_an_insight.md).

--- a/doc/code_insights/quickstart.md
+++ b/doc/code_insights/quickstart.md
@@ -4,9 +4,9 @@ Get started and create your first [code insight](index.md) in 5 minutes or less.
 
 ## Introduction
 
-In this guide, you'll create a Sourcegraph code insight that tracks the number of `TODOS` that appear in parts of your codebase. 
+In this guide, you'll create a Sourcegraph code insight that tracks the number of `TODOS` that appear in parts of your codebase.
 
-For more information about Code Insights see the [Code Insights](index.md) documentation. 
+For more information about Code Insights see the [Code Insights](index.md) documentation.
 
 <img src="https://sourcegraphstatic.com/docs/images/code_insights/quickstart_TODOs_insight_dark.png" class="screenshot">
 
@@ -21,35 +21,35 @@ For more information about Code Insights see the [Code Insights](index.md) docum
 
 ### 1. Enable the experimental feature flag
 
-Add the following to either your Sourcegraph user settings `sourcegraph.example.com/users/[username]/settings` or organization settings `sourcegraph.example.com/organizations/[your_org]/settings`: 
+Add the following to either your Sourcegraph user settings `sourcegraph.example.com/users/[username]/settings` or organization settings `sourcegraph.example.com/organizations/[your_org]/settings`:
 
 `"experimentalFeatures": { "codeInsights": true }`
 
-If you put this flag in your organization settings, everyone on your Sourcegraph insights will be able to see the "Insights" navbar menu item and create their own code insights. If you put the flag in your user settings, only you will have those abilities. 
+If you put this flag in your organization settings, everyone on your Sourcegraph insights will be able to see the "Insights" navbar menu item and create their own code insights. If you put the flag in your user settings, only you will have those abilities.
 
 (Enabling code insights organization-wide doesn't mean that other users can automatically see the code insights you create, however – you can control that visibility per individual insight.)
 
-### 2. Visit your sourcegraph.example.com/insights page and select "+ Create new insight" 
+### 2. Visit your sourcegraph.example.com/insights page and select "+ Create new insight"
 
 ### 3. On the insight type selection page, select "Create custom insight"
 
-This creates a code insight tracking an arbitrary input that you could run a Sourcegraph search for. 
+This creates a code insight tracking an arbitrary input that you could run a Sourcegraph search for.
 
-If you are more interested in creating a language-based insight to show you language breakdown in your repositories, [follow this tutorial](language_insight_quickstart.md) instead. 
+If you are more interested in creating a language-based insight to show you language breakdown in your repositories, [follow this tutorial](language_insight_quickstart.md) instead.
 
 ### 4. Once on the "Create New Code Insight" form fields page, enter the repositories you want to search
 
-Enter repositories in the repository URL format, like `github.com/Sourcegraph/Sourcegraph`. Separate multiple repositories with a comma. The form field will validate that you've entered the repository correctly. 
+Enter repositories in the repository URL format, like `github.com/Sourcegraph/Sourcegraph`. Separate multiple repositories with a comma. The form field will validate that you've entered the repository correctly.
 
 ### 5. Define a data series to track the incidence of `TODO`
 
-A data series becomes a line on your graph. 
+A data series becomes a line on your graph.
 
 You can **Name** this data series something like `TODOs count`.
 
-To track the incidence of TODOs, you can set your **Search query** to be simply `TODO`. 
+To track the incidence of TODOs, you can set your **Search query** to be simply `TODO`.
 
-You can also select the color of your data series. 
+You can also select the color of your data series.
 
 ### 6. Add a title to the insight
 
@@ -57,14 +57,19 @@ Enter a descriptive **Title** for the chart, like `Count of TODOs in [repository
 
 ### 7. Set the visibility of your insight
 
-This controls who else can see your insight. 
+This controls who else can see your insight.
 
 Anything set to "Private" won't be visible by anyone else. Otherwise, everyone in the selected organization can see your insight (if they have also enabled [the feature flag](#1-enable-the-experimental-feature-flag)).
 
 ### 8. Set the distance between data points to 1 month
 
-The code insights prototypes currently show you seven datapoints for each data series. Your code insight will therefore show you results for a time horizon that is 6 * [distance between datapoints]. Setting it to one month means you'll see the results over the last six months. 
+The code insights prototypes currently show you seven datapoints for each data series. Your code insight will therefore show you results for a time horizon that is 6 * [distance between datapoints]. Setting it to one month means you'll see the results over the last six months.
 
-### 9. Click "create code insight" and view your insight. 
+### 9. Click "create code insight" and view your insight.
 
 You'll be taken to the sourcegraph.example.com/insights page and can view your insight.
+
+### 10. Filter your insight post-creation (optional)
+
+Click the filter button in the top right of an insight card to open the filters panel that allows you to filter the insight down to a subset of repositories through inclusion or exclusion with regular expressions.
+For more details, see [How to filter an insight](./how-tos/filtering_an_insight.md).


### PR DESCRIPTION
Adds docs for insights filters (drilldown feature), a background explanation, a how-to, and a quickstart guide step.

@coury-clark @vovakulikov could you in particular please check that all statements are correct? 🙌🏻 