### PR TITLE
extensibility: cache extension bundles for one year

### DIFF
--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -77,7 +77,7 @@ func handleRegistryExtensionBundle(w http.ResponseWriter, r *http.Request) {
 	// want stale data from pre-reset. So, assume that the presence of a query string means that it
 	// includes some identifier that changes when the database is reset.
 	if r.URL.RawQuery != "" {
-		w.Header().Set("Cache-Control", "max-age=604800, private, immutable")
+		w.Header().Set("Cache-Control", "max-age=31536000, private, immutable")
 	}
 	var data []byte
 	if wantSourceMap {


### PR DESCRIPTION
According to a code comment, we intend to cache extension bundles indefinitely. However, we only specified a week-long `max-age` (604800).

Change that value to 31536000, or one year, which is the maximum valid value.