### PR TITLE
web: remove `.theme-redesign` selector from different components

### DIFF
--- a/client/web/src/nav/VersionContextDropdown.scss
+++ b/client/web/src/nav/VersionContextDropdown.scss
@@ -57,7 +57,6 @@
         min-height: fit-content;
         max-height: 20rem;
         overflow-y: auto;
-        background-color: var(--dropdown-bg) !important;
 
         &:focus-within {
             outline: none;

--- a/client/web/src/nav/VersionContextDropdown.scss
+++ b/client/web/src/nav/VersionContextDropdown.scss
@@ -4,13 +4,8 @@
     width: max-content;
 
     &:first-child &__button {
-        border-top-left-radius: 2px;
-        border-bottom-left-radius: 2px;
-
-        .theme-redesign & {
-            border-top-left-radius: var(--border-radius);
-            border-bottom-left-radius: var(--border-radius);
-        }
+        border-top-left-radius: var(--border-radius);
+        border-bottom-left-radius: var(--border-radius);
     }
 
     &:not(:first-child) .version-context-dropdown__button {
@@ -62,6 +57,7 @@
         min-height: fit-content;
         max-height: 20rem;
         overflow-y: auto;
+        background-color: var(--dropdown-bg) !important;
 
         &:focus-within {
             outline: none;

--- a/client/web/src/tree/FileDecorator.scss
+++ b/client/web/src/tree/FileDecorator.scss
@@ -4,10 +4,7 @@
         color: var(--text-muted);
 
         &--active {
-            color: var(--white);
-        }
-
-        .theme-redesign &--active {
+            color: $white;
             color: var(--text-muted);
         }
     }

--- a/client/web/src/tree/FileDecorator.scss
+++ b/client/web/src/tree/FileDecorator.scss
@@ -4,7 +4,6 @@
         color: var(--text-muted);
 
         &--active {
-            color: $white;
             color: var(--text-muted);
         }
     }

--- a/client/wildcard/src/components/Container/Container.module.scss
+++ b/client/wildcard/src/components/Container/Container.module.scss
@@ -1,8 +1,6 @@
 .container {
-    :global(.theme-redesign) & {
-        padding: 1.5rem;
-        background-color: var(--color-bg-1);
-        border: 1px solid var(--border-color);
-        border-radius: var(--border-radius);
-    }
+    padding: 1.5rem;
+    background-color: var(--color-bg-1);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
 }


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.