### PR TITLE
web: remove `.theme-redesign` selector from search

### DIFF
--- a/client/web/src/search/input/SearchButton.scss
+++ b/client/web/src/search/input/SearchButton.scss
@@ -4,14 +4,11 @@
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         display: flex;
+        padding: 0.5rem 1rem;
+        border: none;
 
-        .theme-redesign & {
-            padding: 0.5rem 1rem;
-            border: none;
-
-            @media (--xs-breakpoint-down) {
-                border-radius: var(--border-radius);
-            }
+        @media (--xs-breakpoint-down) {
+            border-radius: var(--border-radius);
         }
     }
 }

--- a/client/web/src/search/input/SearchContextDropdown.scss
+++ b/client/web/src/search/input/SearchContextDropdown.scss
@@ -11,11 +11,9 @@
         box-sizing: border-box;
         transition: none;
 
-        .theme-redesign & {
-            @media (--xs-breakpoint-down) {
-                border: 1px solid var(--input-border-color);
-                margin-left: 0;
-            }
+        @media (--xs-breakpoint-down) {
+            border: 1px solid var(--input-border-color);
+            margin-left: 0;
         }
 
         &:hover,
@@ -76,11 +74,9 @@
     }
 
     &__menu {
-        .theme-redesign & {
-            @media (--xs-breakpoint-down) {
-                max-width: 85%;
-                transform: none;
-            }
+        @media (--xs-breakpoint-down) {
+            max-width: 85%;
+            transform: none;
         }
     }
 }

--- a/client/web/src/search/input/SearchOnboardingTour.scss
+++ b/client/web/src/search/input/SearchOnboardingTour.scss
@@ -110,11 +110,11 @@
         cursor: pointer;
         color: var(--text-muted);
 
-        .theme-redesign.theme-light & {
+        .theme-light & {
             color: var(--gray-07);
         }
 
-        .theme-redesign.theme-dark & {
+        .theme-dark & {
             color: var(--gray-05);
         }
     }

--- a/client/web/src/search/input/toggles/Toggles.scss
+++ b/client/web/src/search/input/toggles/Toggles.scss
@@ -40,11 +40,7 @@
 
         &:active {
             // stylelint-disable-next-line declaration-property-unit-whitelist
-            border: 2px solid var(--border-active-color);
-
-            .theme-redesign & {
-                border-color: var(--primary);
-            }
+            border: 2px solid var(--primary);
         }
 
         &.disabled,
@@ -64,19 +60,11 @@
         }
 
         &--active {
-            background-color: var(--border-active-color);
+            background-color: var(--primary);
             color: #ffffff !important;
 
-            .theme-redesign & {
-                background-color: var(--primary);
-            }
-
             &:hover {
-                background-color: var(--border-active-color);
-
-                .theme-redesign & {
-                    background-color: var(--primary);
-                }
+                background-color: var(--primary);
             }
         }
     }

--- a/client/web/src/search/results/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/progress/StreamingProgress.scss
@@ -8,10 +8,10 @@
 }
 
 .streaming-progress {
+    flex-grow: 1;
     &__count {
         color: var(--body-color);
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
+        padding: 0.375rem 0.5rem;
         border-radius: var(--border-radius);
 
         &--in-progress {
@@ -26,16 +26,7 @@
         }
     }
 
-    &__count-icon {
-        display: none;
-    }
-
     &__skipped {
-        flex-grow: 1;
-        &--warning {
-            color: var(--infobar-warning-color);
-        }
-
         &-popover {
             width: 20rem;
             padding: 0;

--- a/client/web/src/search/results/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/progress/StreamingProgress.scss
@@ -9,23 +9,14 @@
 
 .streaming-progress {
     &__count {
-        padding: 0.375rem 0.75rem; // Match padding for .btn (but this is not a button)
-        color: var(--link-color);
-
-        .theme-redesign & {
-            color: var(--body-color);
-            padding-left: 0.5rem;
-            padding-right: 0.5rem;
-            border-radius: var(--border-radius);
-
-            &--in-progress {
-                color: var(--link-color);
-            }
-        }
+        color: var(--body-color);
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+        border-radius: var(--border-radius);
 
         &--in-progress {
             background-color: var(--color-bg-2);
-            color: $oc-blue-6;
+            color: var(--link-color);
             background-image: linear-gradient(90deg, transparent 25%, $oc-blue-6 25%, $oc-blue-6 40%, transparent 40%);
             background-size: 200% 1px;
             background-repeat: no-repeat;
@@ -36,20 +27,19 @@
     }
 
     &__count-icon {
-        .theme-redesign & {
-            display: none;
-        }
+        display: none;
     }
 
     &__skipped {
+        flex-grow: 1;
+        &--warning {
+            color: var(--infobar-warning-color);
+        }
+
         &-popover {
             width: 20rem;
             padding: 0;
         }
-    }
-
-    .theme-redesign & {
-        flex-grow: 1;
     }
 }
 
@@ -57,16 +47,8 @@
     &__button {
         &:disabled {
             opacity: 1;
-
-            .theme-redesign & {
-                color: var(--body-color);
-            }
+            color: var(--body-color);
         }
-    }
-
-    // Not needed once .theme-redesign is removed
-    &__icon {
-        color: var(--primary);
     }
 
     &__message {
@@ -106,11 +88,6 @@
     }
 
     &--warn {
-        // Not needed once .theme-redesign is removed
-        .streaming-skipped-item__icon {
-            color: var(--danger);
-        }
-
         .streaming-skipped-item__message {
             border-left-color: var(--danger);
         }

--- a/client/web/src/search/results/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/progress/StreamingProgressCount.tsx
@@ -32,7 +32,6 @@ export const StreamingProgressCount: React.FunctionComponent<
                 'streaming-progress__count--in-progress': state === 'loading',
             })}
         >
-            <CalculatorIcon className="mr-2 icon-inline streaming-progress__count-icon" />
             {abbreviateNumber(progress.matchCount)}
             {limitHit(progress) ? '+' : ''} {pluralize('result', progress.matchCount)} in{' '}
             {(progress.durationMs / 1000).toFixed(2)}s

--- a/client/web/src/search/results/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/progress/StreamingProgressCount.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import CalculatorIcon from 'mdi-react/CalculatorIcon'
 import ClipboardPulseOutlineIcon from 'mdi-react/ClipboardPulseOutlineIcon'
 import * as React from 'react'
 

--- a/client/web/src/search/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -15,9 +15,6 @@ exports[`StreamingProgressCount should not render a trace link when not opted in
   <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     0
      
     results
@@ -43,9 +40,6 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
   <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     0
      
     results
@@ -72,9 +66,6 @@ exports[`StreamingProgressCount should render correctly for 0 repositories 1`] =
   <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     0
      
     results
@@ -106,9 +97,6 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
   <small
     className="streaming-progress__count d-flex align-items-center"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     1
      
     result
@@ -140,9 +128,6 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
   <small
     className="streaming-progress__count d-flex align-items-center"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     123
      
     results
@@ -174,9 +159,6 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
   <small
     className="streaming-progress__count d-flex align-items-center"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     1.2m
      
     results
@@ -215,9 +197,6 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
   <small
     className="streaming-progress__count d-flex align-items-center"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     123
     +
      
@@ -251,9 +230,6 @@ exports[`StreamingProgressCount should render correctly when a trace url is prov
   <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
-    <Memo(CalculatorIcon)
-      className="mr-2 icon-inline streaming-progress__count-icon"
-    />
     0
      
     results


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from search.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.