### PR TITLE
web: remove `.theme-redesign` selector from components

### DIFF
--- a/client/web/src/components/Breadcrumbs.module.scss
+++ b/client/web/src/components/Breadcrumbs.module.scss
@@ -1,5 +1,3 @@
-:global(.theme-redesign) {
-    .divider {
-        color: var(--icon-color);
-    }
+.divider {
+    color: var(--icon-color);
 }

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -6,27 +6,17 @@
     min-width: 25rem;
     max-width: 70vw;
 
-    --popover-item-padding-h: 0.75rem;
-    --popover-item-padding-v: 0.325rem;
-
-    .theme-redesign & {
-        --popover-item-padding-h: 1rem;
-        --popover-item-padding-v: 0.25rem;
-        background-color: var(--color-bg-1);
-    }
+    --popover-item-padding-h: 1rem;
+    --popover-item-padding-v: 0.25rem;
+    background-color: var(--color-bg-1);
 
     &__content {
         flex: 1 1 auto;
         display: flex;
         flex-direction: column;
 
-        min-height: 27rem; // avoid jitter when only loading indicator is shown
-        max-height: 70vh;
-
-        .theme-redesign & {
-            min-height: initial;
-            max-height: calc(min(20rem, 70vh));
-        }
+        min-height: initial;
+        max-height: calc(min(20rem, 70vh));
 
         .alert {
             word-break: break-word;
@@ -34,22 +24,13 @@
     }
 
     &__nodes {
-        &:empty {
-            display: none;
-        }
-        .theme-redesign & {
-            border-top: solid 1px var(--border-color-2);
-            padding-top: 0.25rem;
-            padding-bottom: 0.25rem;
-        }
+        border-top: solid 1px var(--border-color-2);
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
     }
 
     &__node {
-        border-bottom: solid 1px var(--border-color);
-
-        .theme-redesign & {
-            border-bottom: none;
-        }
+        border-bottom: none;
 
         &:last-child {
             border-bottom: none;
@@ -59,34 +40,28 @@
             align-items: center;
             padding: var(--popover-item-padding-v) var(--popover-item-padding-h);
             color: var(--text-muted);
+            text-decoration: none;
+            border: none;
 
-            .theme-redesign & {
-                text-decoration: none;
-                border: none;
-
-                &:hover,
-                &:focus {
-                    background-color: var(--primary);
-                    color: var(--light-text);
-                }
+            &:hover,
+            &:focus {
+                background-color: var(--primary);
+                color: var(--light-text);
             }
 
+            &-icon {
+                display: none;
+            }
             &--active {
-                font-weight: bold;
-
-                .theme-redesign & {
-                    font-weight: inherit;
-                    background-color: var(--color-bg-3);
-                }
+                font-weight: inherit;
+                background-color: var(--color-bg-3);
             }
         }
     }
 
     &__input {
-        .theme-redesign & {
-            margin: 0.5rem;
-            padding-left: 0.5rem;
-            padding-right: 0.5rem;
-        }
+        margin: 0.5rem;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
     }
 }

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -14,8 +14,6 @@
         flex: 1 1 auto;
         display: flex;
         flex-direction: column;
-
-        min-height: initial;
         max-height: calc(min(20rem, 70vh));
 
         .alert {
@@ -24,6 +22,9 @@
     }
 
     &__nodes {
+        &:empty {
+            display: none;
+        }
         border-top: solid 1px var(--border-color-2);
         padding-top: 0.25rem;
         padding-bottom: 0.25rem;
@@ -49,9 +50,6 @@
                 color: var(--light-text);
             }
 
-            &-icon {
-                display: none;
-            }
             &--active {
                 font-weight: inherit;
                 background-color: var(--color-bg-3);

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -21,45 +21,47 @@
         }
     }
 
-    &__nodes {
-        &:empty {
-            display: none;
+    .filtered-connection & {
+        &__nodes {
+            &:empty {
+                display: none;
+            }
+            border-top: solid 1px var(--border-color-2);
+            padding-top: 0.25rem;
+            padding-bottom: 0.25rem;
         }
-        border-top: solid 1px var(--border-color-2);
-        padding-top: 0.25rem;
-        padding-bottom: 0.25rem;
-    }
 
-    &__node {
-        border-bottom: none;
-
-        &:last-child {
+        &__node {
             border-bottom: none;
-        }
-        &-link {
-            display: flex;
-            align-items: center;
-            padding: var(--popover-item-padding-v) var(--popover-item-padding-h);
-            color: var(--text-muted);
-            text-decoration: none;
-            border: none;
 
-            &:hover,
-            &:focus {
-                background-color: var(--primary);
-                color: var(--light-text);
+            &:last-child {
+                border-bottom: none;
             }
+            &-link {
+                display: flex;
+                align-items: center;
+                padding: var(--popover-item-padding-v) var(--popover-item-padding-h);
+                color: var(--text-muted);
+                text-decoration: none;
+                border: none;
 
-            &--active {
-                font-weight: inherit;
-                background-color: var(--color-bg-3);
+                &:hover,
+                &:focus {
+                    background-color: var(--primary);
+                    color: var(--light-text);
+                }
+
+                &--active {
+                    font-weight: inherit;
+                    background-color: var(--color-bg-3);
+                }
             }
         }
-    }
 
-    &__input {
-        margin: 0.5rem;
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
+        &__input {
+            margin: 0.5rem;
+            padding-left: 0.5rem;
+            padding-right: 0.5rem;
+        }
     }
 }

--- a/client/web/src/components/SearchResultMatch.scss
+++ b/client/web/src/components/SearchResultMatch.scss
@@ -2,9 +2,13 @@
     text-decoration: none; // don't use cascading link style
     display: flex;
     align-items: flex-start;
-    padding: 0.5rem 0;
     overflow-x: auto;
     overflow-y: hidden;
+    background-color: var(--code-bg);
+    border: 1px solid var(--border-color-2);
+    border-radius: var(--border-radius);
+    border-top: 1px solid var(--border-color);
+    padding: 0.25rem 0;
 
     &-clickable {
         cursor: pointer;
@@ -17,13 +21,6 @@
 
     &:not(:first-child) {
         border-top: 1px solid var(--border-color);
-    }
-
-    .theme-redesign & {
-        background-color: var(--code-bg);
-        border: 1px solid var(--border-color-2);
-        border-radius: var(--border-radius);
-        padding: 0.25rem 0;
     }
 
     pre,
@@ -82,15 +79,8 @@
     }
 
     &__code-excerpt {
-        padding-top: 0;
-        padding-bottom: 1rem;
-        padding-left: 0.5rem;
-        padding-right: 0;
+        padding: 0 0.5rem;
         color: var(--body-color);
-
-        .theme-redesign & {
-            padding: 0 0.5rem;
-        }
 
         table {
             margin-bottom: 0 !important; // Override docsite Markdown table CSS. A currently open PR removes that CSS and lets us remove this override.
@@ -119,6 +109,4 @@
         transform: translateY(-50%);
         left: 50%;
     }
-
-    border-top: 1px solid var(--border-color);
 }

--- a/client/web/src/components/Sidebar.scss
+++ b/client/web/src/components/Sidebar.scss
@@ -1,21 +1,16 @@
 .sidebar {
     isolation: isolate;
     width: 12rem;
-    .theme-redesign & {
-        display: flex;
-        flex-direction: column;
-    }
-
+    display: flex;
+    flex-direction: column;
     &__chevron {
         color: var(--icon-color);
     }
 
     &__link {
         &--inactive {
-            .theme-redesign & {
-                &:hover {
-                    background-color: var(--color-bg-2);
-                }
+            &:hover {
+                background-color: var(--color-bg-2);
             }
         }
     }

--- a/client/web/src/components/diff/FileDiffHunks.scss
+++ b/client/web/src/components/diff/FileDiffHunks.scss
@@ -6,9 +6,7 @@ $color-deletion: $red;
         background-color: var(--code-bg);
         // In the split mode version this selector adds the divider effect between table data cells.
         &:nth-child(3) {
-            .theme-redesign & {
-                border-left: 1px solid var(--border-color);
-            }
+            border-left: 1px solid var(--border-color);
         }
     }
     &__num,
@@ -34,25 +32,18 @@ $color-deletion: $red;
         font-family: $code-font-family;
         padding: 0 0.5rem;
         &--line {
-            color: var(--text-muted);
+            color: var(--line-number-color);
             display: block;
             &:hover {
                 color: var(--body-color);
                 text-decoration: none;
             }
-            .theme-redesign & {
-                color: var(--line-number-color);
-            }
         }
         &--empty {
-            .theme-redesign & {
-                background-color: var(--body-bg);
-            }
+            background-color: var(--body-bg);
         }
-        .theme-redesign & {
-            &:nth-child(3) {
-                border-left: 1px solid var(--border-color);
-            }
+        &:nth-child(3) {
+            border-left: 1px solid var(--border-color);
         }
     }
     &__content {
@@ -67,10 +58,7 @@ $color-deletion: $red;
             content: attr(data-diff-marker);
         }
         &--empty {
-            background-color: var(--color-bg-2);
-            .theme-redesign & {
-                background-color: var(--body-bg);
-            }
+            background-color: var(--body-bg);
             // This cell is always empty opacity will not affect any content
             opacity: 0.5;
         }
@@ -90,39 +78,21 @@ $color-deletion: $red;
                 }
             }
             &--active {
-                background-color: rgba($oc-yellow-5, 0.17) !important;
-                .theme-redesign & {
-                    background-color: var(--code-line-highlight-color) !important;
-                }
+                background-color: var(--code-line-highlight-color) !important;
                 &-num {
-                    background-color: rgba($oc-yellow-5, 0.25);
-                    .theme-redesign & {
-                        background-color: var(--code-line-highlight-color);
-                    }
+                    background-color: var(--code-line-highlight-color);
                 }
             }
             &--addition {
-                background-color: rgba($color-addition, 0.17);
-                .theme-redesign & {
-                    background-color: var(--diff-add-bg);
-                }
+                background-color: var(--diff-add-bg);
                 &-num {
-                    background-color: rgba($color-addition, 0.25);
-                    .theme-redesign & {
-                        background-color: var(--diff-add-bg);
-                    }
+                    background-color: var(--diff-add-bg);
                 }
             }
             &--deletion {
-                background-color: rgba($color-deletion, 0.17);
-                .theme-redesign & {
-                    background-color: var(--diff-remove-bg);
-                }
+                background-color: var(--diff-remove-bg);
                 &-num {
-                    background-color: rgba($color-deletion, 0.25);
-                    .theme-redesign & {
-                        background-color: var(--diff-remove-bg);
-                    }
+                    background-color: var(--diff-remove-bg);
                 }
             }
         }
@@ -130,41 +100,23 @@ $color-deletion: $red;
 
     &__line--active &__num {
         // important suffix is needed in order to overlap any active line with the addition/deletion colors
-        background-color: rgba($oc-yellow-5, 0.35) !important;
-        .theme-redesign & {
-            background-color: var(--code-line-highlight-color) !important;
-        }
+        background-color: var(--code-line-highlight-color) !important;
     }
     &__line--active &__content {
         // important suffix is needed in order to overlap any active line with the addition/deletion colors
-        background-color: rgba($oc-yellow-5, 0.25) !important;
-        .theme-redesign & {
-            background-color: var(--code-line-highlight-color) !important;
-        }
+        background-color: var(--code-line-highlight-color) !important;
     }
     &__line--addition &__num {
-        background-color: rgba($color-addition, 0.25);
-        .theme-redesign & {
-            background-color: var(--diff-add-bg);
-        }
+        background-color: var(--diff-add-bg);
     }
     &__line--addition &__content {
-        background-color: rgba($color-addition, 0.17);
-        .theme-redesign & {
-            background-color: var(--diff-add-bg);
-        }
+        background-color: var(--diff-add-bg);
     }
     &__line--deletion &__num {
-        background-color: rgba($color-deletion, 0.25);
-        .theme-redesign & {
-            background-color: var(--diff-remove-bg);
-        }
+        background-color: var(--diff-remove-bg);
     }
     &__line--deletion &__content {
-        background-color: rgba($color-deletion, 0.17);
-        .theme-redesign & {
-            background-color: var(--diff-remove-bg);
-        }
+        background-color: var(--diff-remove-bg);
     }
     &__line--both &__num,
     &__num--both {

--- a/client/web/src/components/diff/FileDiffNode.scss
+++ b/client/web/src/components/diff/FileDiffNode.scss
@@ -5,10 +5,8 @@
     margin-bottom: 1rem;
 
     &__body {
-        .theme-redesign & {
-            border: 1px solid var(--border-color);
-            border-radius: var(--border-radius);
-        }
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius);
     }
 
     &__status-bar {
@@ -23,11 +21,7 @@
         overflow-x: hidden;
 
         // decrease from .card-header
-        padding-top: 0.25rem;
-        padding-bottom: 0.25rem;
-        .theme-redesign & {
-            padding: 0.25rem 0.5rem;
-        }
+        padding: 0.25rem 0.5rem;
 
         &-path-stat {
             display: flex;
@@ -39,14 +33,9 @@
             white-space: pre;
             text-overflow: ellipsis;
             overflow: hidden;
-            font-family: $code-font-family;
-            color: var(--body-color);
-            font-size: $code-font-size;
-            .theme-redesign & {
-                color: var(--link-color);
-                font-family: inherit;
-                font-size: 0.875rem;
-            }
+            color: var(--link-color);
+            font-family: inherit;
+            font-size: 0.875rem;
         }
 
         &-actions {

--- a/client/web/src/components/diff/FileDiffNode.scss
+++ b/client/web/src/components/diff/FileDiffNode.scss
@@ -34,7 +34,6 @@
             text-overflow: ellipsis;
             overflow: hidden;
             color: var(--link-color);
-            font-family: inherit;
             font-size: 0.875rem;
         }
 


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from components.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.