### PR TITLE
web: remove `.theme-redesign` selector from branded

### DIFF
--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -235,7 +235,7 @@ export const Panel = React.memo<Props>(props => {
 
     return (
         <Tabs className={styles.panel} index={tabIndex} onChange={handleActiveTab}>
-            <div className={classNames('tablist-wrapper d-flex justify-content-between', styles.header)}>
+            <div className={classNames('tablist-wrapper d-flex justify-content-between sticky-top', styles.header)}>
                 <TabList>
                     <div className="d-flex w-100">
                         {items.map(({ label, id }) => (

--- a/client/branded/src/global-styles/badge.scss
+++ b/client/branded/src/global-styles/badge.scss
@@ -11,141 +11,134 @@
 }
 
 :root {
-    --badge-font-size: 0.75em;
-    --badge-font-weight: 600;
-    --badge-padding-y: 0.34em;
-    --badge-padding-x: 0.6em;
-    --badge-border-radius: 3px;
-}
-
-.theme-redesign {
     --badge-font-size: 0.75rem;
     --badge-font-weight: 500;
     --badge-padding-y: 0.125rem;
     --badge-padding-x: 0.375rem;
+    --badge-border-radius: 3px;
+}
 
-    .badge {
-        background-color: var(--subtle-bg);
-        color: var(--link-color);
-        border: none;
-        line-height: 1rem;
+.badge {
+    background-color: var(--subtle-bg);
+    color: var(--link-color);
+    border: none;
+    line-height: 1rem;
+
+    &:focus,
+    &.focus {
+        outline: 0;
+    }
+}
+
+.badge-sm {
+    --badge-font-size: #{(11/16)}rem;
+    --badge-padding-y: 0;
+    --badge-padding-x: 0.25rem;
+    --badge-border-radius: 2px;
+}
+
+a.badge {
+    // Badge acts like btn-link, replicate Bootstrap btn transition
+    transition: $btn-transition;
+}
+
+// Variants
+.badge-primary,
+.badge-secondary,
+.badge-success,
+.badge-danger,
+.badge-info,
+.badge-warning,
+.badge-merged,
+.badge-outline-secondary {
+    background-color: var(--badge-base);
+    color: var(--badge-text);
+    border: var(--badge-border, none);
+
+    @at-root #{selector-unify('a', &)} {
+        background-color: var(--badge-base);
+        color: var(--badge-text);
+
+        &:hover,
+        &:focus,
+        &.focus {
+            color: var(--badge-text);
+            background-color: var(--badge-dark);
+        }
 
         &:focus,
         &.focus {
             outline: 0;
-        }
-    }
 
-    .badge-sm {
-        --badge-font-size: #{(11/16)}rem;
-        --badge-padding-y: 0;
-        --badge-padding-x: 0.25rem;
-        --badge-border-radius: 2px;
-    }
-
-    a.badge {
-        // Badge acts like btn-link, replicate Bootstrap btn transition
-        transition: $btn-transition;
-    }
-
-    // Variants
-    .badge-primary,
-    .badge-secondary,
-    .badge-success,
-    .badge-danger,
-    .badge-info,
-    .badge-warning,
-    .badge-merged,
-    .badge-outline-secondary {
-        background-color: var(--badge-base);
-        color: var(--badge-text);
-        border: var(--badge-border, none);
-
-        @at-root #{selector-unify('a', &)} {
-            background-color: var(--badge-base);
-            color: var(--badge-text);
-
-            &:hover,
-            &:focus,
-            &.focus {
-                color: var(--badge-text);
-                background-color: var(--badge-dark);
+            @at-root #{selector-append('.theme-light', &)} {
+                box-shadow: 0 0 0 0.125rem var(--badge-light);
             }
-
-            &:focus,
-            &.focus {
-                outline: 0;
-
-                @at-root #{selector-append('.theme-light', &)} {
-                    box-shadow: 0 0 0 0.125rem var(--badge-light);
-                }
-                @at-root #{selector-append('.theme-dark', &)} {
-                    box-shadow: 0 0 0 0.125rem var(--badge-dark);
-                }
+            @at-root #{selector-append('.theme-dark', &)} {
+                box-shadow: 0 0 0 0.125rem var(--badge-dark);
             }
         }
-    }
-
-    .badge-primary {
-        --badge-base: var(--primary);
-        --badge-light: var(--primary-2);
-        --badge-dark: var(--primary-3);
-        --badge-text: var(--light-text);
-    }
-
-    .badge-secondary {
-        --badge-base: var(--secondary);
-        --badge-light: var(--secondary-2);
-        --badge-dark: var(--secondary-3);
-        --badge-text: var(--body-color);
-    }
-
-    .badge-success {
-        --badge-base: var(--success);
-        --badge-light: var(--success-2);
-        --badge-dark: var(--success-3);
-        --badge-text: var(--light-text);
-    }
-
-    .badge-danger {
-        --badge-base: var(--danger);
-        --badge-light: var(--danger-2);
-        --badge-dark: var(--danger-3);
-        --badge-text: var(--light-text);
-    }
-
-    .badge-info {
-        --badge-base: var(--info);
-        --badge-light: var(--info-2);
-        --badge-dark: var(--info-3);
-        --badge-text: var(--dark-text);
-    }
-
-    .badge-warning {
-        --badge-base: var(--warning);
-        --badge-light: var(--warning-2);
-        --badge-dark: var(--warning-3);
-        --badge-text: var(--dark-text);
-    }
-
-    .badge-merged {
-        --badge-base: var(--merged);
-        --badge-light: var(--merged-2);
-        --badge-dark: var(--merged-3);
-        --badge-text: var(--light-text);
-    }
-
-    .badge-outline-secondary {
-        --badge-base: transparent;
-        --badge-light: var(--secondary-2);
-        --badge-dark: var(--secondary-3);
-        --badge-text: var(--text-muted);
-        --badge-border: 1px solid var(--secondary);
     }
 }
 
-.theme-light.theme-redesign,
-.theme-dark.theme-redesign {
+.badge-primary {
+    --badge-base: var(--primary);
+    --badge-light: var(--primary-2);
+    --badge-dark: var(--primary-3);
+    --badge-text: var(--light-text);
+}
+
+.badge-secondary {
+    --badge-base: var(--secondary);
+    --badge-light: var(--secondary-2);
+    --badge-dark: var(--secondary-3);
+    --badge-text: var(--body-color);
+}
+
+.badge-success {
+    --badge-base: var(--success);
+    --badge-light: var(--success-2);
+    --badge-dark: var(--success-3);
+    --badge-text: var(--light-text);
+}
+
+.badge-danger {
+    --badge-base: var(--danger);
+    --badge-light: var(--danger-2);
+    --badge-dark: var(--danger-3);
+    --badge-text: var(--light-text);
+}
+
+.badge-info {
+    --badge-base: var(--info);
+    --badge-light: var(--info-2);
+    --badge-dark: var(--info-3);
+    --badge-text: var(--dark-text);
+}
+
+.badge-warning {
+    --badge-base: var(--warning);
+    --badge-light: var(--warning-2);
+    --badge-dark: var(--warning-3);
+    --badge-text: var(--dark-text);
+}
+
+.badge-merged {
+    --badge-base: var(--merged);
+    --badge-light: var(--merged-2);
+    --badge-dark: var(--merged-3);
+    --badge-text: var(--light-text);
+}
+
+.badge-outline-secondary {
+    --badge-base: transparent;
+    --badge-light: var(--secondary-2);
+    --badge-dark: var(--secondary-3);
+    --badge-text: var(--text-muted);
+    --badge-border: 1px solid var(--secondary);
+}
+
+.theme-light,
+.theme-dark {
     // Update secondary text color and focus state for better contrast
     a.badge-secondary,
     a.badge-outline-secondary {

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -5,12 +5,8 @@ code,
 .text-code {
     font-family: $code-font-family;
     font-size: $code-font-size;
-    line-height: (16/12);
+    line-height: 1rem;
     white-space: pre;
-
-    .theme-redesign & {
-        line-height: 1rem;
-    }
 }
 
 .bg-code {

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -1,22 +1,6 @@
 @import 'bootstrap/scss/dropdown';
 
-.theme-dark {
-    --dropdown-bg: #0e121b;
-    --dropdown-border-color: var(--border-color);
-    --dropdown-link-hover-bg: var(--color-bg-2);
-    --dropdown-header-color: var(--text-muted);
-    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
-}
-
 .theme-light {
-    --dropdown-bg: #ffffff;
-    --dropdown-border-color: var(--border-color);
-    --dropdown-link-hover-bg: var(--color-bg-2);
-    --dropdown-header-color: var(--text-muted);
-    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
-}
-
-.theme-light.theme-redesign {
     --dropdown-bg: var(--input-bg);
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
@@ -24,7 +8,7 @@
     --dropdown-shadow: 0 4px 16px -6px rgba(36, 41, 54, 0.2);
 }
 
-.theme-dark.theme-redesign {
+.theme-dark {
     --dropdown-bg: var(--input-bg);
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -1,36 +1,4 @@
-.theme-dark {
-    --input-bg: #0e121b; // even darker than --color-bg-1
-    --input-disabled-bg: var(--color-bg-3);
-    --input-border-color: var(--border-color);
-    --input-color: var(--body-color);
-    --input-placeholder-color: var(--text-muted);
-    --input-group-addon-color: var(--body-color);
-    --input-group-addon-bg: var(--color-bg-2);
-    --input-group-addon-border-color: var(--color-bg-2);
-    --input-focus-border-color: var(--primary);
-    --input-focus-box-shadow: 0 0 0 2px #{rgba($primary, 0.25)};
-
-    // Checkbox margins
-    --form-check-input-margin-y: 0.2rem;
-}
-
 .theme-light {
-    --input-bg: var(--color-bg-1);
-    --input-disabled-bg: var(--color-bg-3);
-    --input-border-color: var(--border-color);
-    --input-color: var(--body-color);
-    --input-placeholder-color: var(--text-muted);
-    --input-group-addon-color: var(--body-color);
-    --input-group-addon-bg: var(--color-bg-2);
-    --input-group-addon-border-color: var(--color-bg-2);
-    --input-focus-border-color: var(--primary);
-    --input-focus-box-shadow: 0 0 0 2px #{rgba($primary, 0.25)};
-
-    // Checkbox margins
-    --form-check-input-margin-y: 0.2rem;
-}
-
-.theme-light.theme-redesign {
     --input-bg: var(--white);
     --input-disabled-bg: var(--gray-04);
     --input-border-color: var(--gray-04);
@@ -46,7 +14,7 @@
     --form-check-input-margin-y: 0.3rem;
 }
 
-.theme-dark.theme-redesign {
+.theme-dark {
     --input-bg: var(--gray-10);
     --input-disabled-bg: var(--gray-08);
     --input-border-color: var(--gray-08);
@@ -90,91 +58,88 @@
     }
 }
 
-// Overrides
-.theme-redesign {
-    // Input feedback messages
-    .valid-feedback {
-        color: var(--text-muted);
+// Input feedback messages
+.valid-feedback {
+    color: var(--text-muted);
+}
+.invalid-feedback {
+    color: var(--danger);
+}
+.form-check-input {
+    ~ .field-message,
+    ~ .valid-feedback,
+    ~ .invalid-feedback {
+        // Adjust spacing for radio/checkboxes
+        margin-top: 0;
     }
-    .invalid-feedback {
+}
+
+// Update text color to better indicate disabled fields
+.form-control,
+.custom-select {
+    &:disabled {
+        color: var(--text-disabled);
+
+        &::placeholder {
+            color: var(--text-disabled);
+        }
+    }
+}
+
+// Valid form inputs and selects
+.was-validated .form-control:valid,
+.was-validated .custom-select:valid,
+.form-control.is-valid,
+.custom-select.is-valid {
+    border-color: var(--success);
+
+    &:focus {
+        @at-root #{selector-append('.theme-light', &)} {
+            box-shadow: 0 0 0 2px var(--success-2);
+        }
+        @at-root #{selector-append('.theme-dark', &)} {
+            box-shadow: 0 0 0 2px var(--success-3);
+        }
+    }
+}
+
+// Invalid form inputs and selects
+.was-validated .form-control:invalid,
+.was-validated .custom-select:invalid,
+.form-control.is-invalid,
+.custom-select.is-invalid {
+    border-color: var(--danger);
+
+    &:focus {
+        @at-root #{selector-append('.theme-light', &)} {
+            box-shadow: 0 0 0 2px var(--danger-2);
+        }
+        @at-root #{selector-append('.theme-dark', &)} {
+            box-shadow: 0 0 0 2px var(--danger-3);
+        }
+    }
+}
+
+// Valid Radio/checkbox labels
+.was-validated .form-check-input:valid,
+.form-check-input.is-valid {
+    ~ .form-check-label {
+        color: var(--success);
+    }
+}
+
+// Invalid Radio/checkbox labels
+.was-validated .form-check-input:invalid,
+.form-check-input.is-invalid {
+    ~ .form-check-label {
         color: var(--danger);
     }
-    .form-check-input {
-        ~ .field-message,
-        ~ .valid-feedback,
-        ~ .invalid-feedback {
-            // Adjust spacing for radio/checkboxes
-            margin-top: 0;
-        }
-    }
+}
 
-    // Update text color to better indicate disabled fields
-    .form-control,
-    .custom-select {
-        &:disabled {
-            color: var(--text-disabled);
-
-            &::placeholder {
-                color: var(--text-disabled);
-            }
-        }
-    }
-
-    // Valid form inputs and selects
-    .was-validated .form-control:valid,
-    .was-validated .custom-select:valid,
-    .form-control.is-valid,
-    .custom-select.is-valid {
-        border-color: var(--success);
-
-        &:focus {
-            @at-root #{selector-append('.theme-light', &)} {
-                box-shadow: 0 0 0 2px var(--success-2);
-            }
-            @at-root #{selector-append('.theme-dark', &)} {
-                box-shadow: 0 0 0 2px var(--success-3);
-            }
-        }
-    }
-
-    // Invalid form inputs and selects
-    .was-validated .form-control:invalid,
-    .was-validated .custom-select:invalid,
-    .form-control.is-invalid,
-    .custom-select.is-invalid {
-        border-color: var(--danger);
-
-        &:focus {
-            @at-root #{selector-append('.theme-light', &)} {
-                box-shadow: 0 0 0 2px var(--danger-2);
-            }
-            @at-root #{selector-append('.theme-dark', &)} {
-                box-shadow: 0 0 0 2px var(--danger-3);
-            }
-        }
-    }
-
-    // Valid Radio/checkbox labels
-    .was-validated .form-check-input:valid,
-    .form-check-input.is-valid {
-        ~ .form-check-label {
-            color: var(--success);
-        }
-    }
-
-    // Invalid Radio/checkbox labels
-    .was-validated .form-check-input:invalid,
-    .form-check-input.is-invalid {
-        ~ .form-check-label {
-            color: var(--danger);
-        }
-    }
-
-    // Remove feedback icon for <select> and <textarea>
-    select.form-control,
-    textarea.form-control:not(.with-invalid-icon) {
-        background-image: none;
-    }
+// Remove feedback icon for <select> and <textarea>
+select.form-control,
+textarea.form-control:not(.with-invalid-icon) {
+    background-image: none;
 }
 
 input:-webkit-autofill,

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -755,23 +755,10 @@
         }
         .hl-markup.hl-deleted {
             color: var(--hl-white);
-            background: var(--hl-bg-dark-red);
+            background: var(--diff-remove-bg);
         }
         .hl-markup.hl-inserted {
             color: var(--hl-white);
-            background: var(--hl-bg-dark-green);
-        }
-    }
-}
-
-// Redesign theme overrides
-.theme-redesign {
-    .hl-source.hl-diff {
-        .hl-markup.hl-deleted {
-            background: var(--diff-remove-bg);
-        }
-
-        .hl-markup.hl-inserted {
             background: var(--diff-add-bg);
         }
     }

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -161,17 +161,12 @@ $badge-transition: none; // Avoids setting transitions on badges that aren't lin
 // Our simple popovers only need these styles. We don't want the caret or special font sizes from
 // Bootstrap's popover CSS.
 .popover-inner {
-    background-color: var(--body-bg);
+    background-color: var(--color-bg-1);
     border: solid 1px var(--border-color);
-    border-radius: $border-radius;
-
-    .theme-redesign & {
-        background-color: var(--color-bg-1);
-        box-shadow: var(--dropdown-shadow);
-        border-radius: var(--popover-border-radius);
-        // Ensure content is clipped by border
-        overflow: hidden;
-    }
+    box-shadow: var(--dropdown-shadow);
+    border-radius: var(--popover-border-radius);
+    // Ensure content is clipped by border
+    overflow: hidden;
 }
 
 // Show a focus ring when performing keyboard navigation. Uses the polyfill at

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -1,10 +1,10 @@
 meter {
     --meter-background: var(--border-color-2);
 
-    .theme-dark.theme-redesign & {
+    .theme-dark & {
         --meter-background: var(--gray-07);
     }
-    .theme-light.theme-redesign & {
+    .theme-light & {
         --meter-background: var(--gray-04);
     }
 

--- a/client/branded/src/global-styles/nav.scss
+++ b/client/branded/src/global-styles/nav.scss
@@ -13,51 +13,48 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
 // to have an undesirable bottom border when active.
 .nav-tabs > .nav-item > .nav-link {
     height: 100%;
-    .theme-redesign & {
+
+    display: inline-flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-muted);
+    &:focus-visible {
+        border-radius: var(--border-radius);
+        // Add this new stacking context in order to show the focus ring without cutting any edge.
+        isolation: isolate;
+        z-index: 1;
+    }
+    &:not(.active):hover {
+        border-bottom: 2px solid var(--border-color-2);
+        margin-top: 0;
+        color: var(--body-color);
+    }
+    // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
+    .text-content {
         display: inline-flex;
         align-items: center;
         flex-direction: column;
         justify-content: center;
-        border: none;
-        border-bottom: 2px solid transparent;
-        color: var(--text-muted);
-        &:focus-visible {
-            border-radius: var(--border-radius);
-            // Add this new stacking context in order to show the focus ring without cutting any edge.
-            isolation: isolate;
-            z-index: 1;
-        }
-        &:not(.active):hover {
-            border-bottom: 2px solid var(--border-color-2);
-            margin-top: 0;
-            color: var(--body-color);
-        }
-        // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
-        .text-content {
-            display: inline-flex;
-            align-items: center;
-            flex-direction: column;
-            justify-content: center;
-            &::after {
-                content: attr(data-tab-content);
-                height: 0;
-                text-transform: capitalize;
-                visibility: hidden; // a11y: avoid detection for voice over
-                overflow: hidden;
-                user-select: none;
-                pointer-events: none;
-                font-weight: 700;
-            }
+        &::after {
+            content: attr(data-tab-content);
+            height: 0;
+            text-transform: capitalize;
+            visibility: hidden; // a11y: avoid detection for voice over
+            overflow: hidden;
+            user-select: none;
+            pointer-events: none;
+            font-weight: 700;
         }
     }
 }
 
 .nav-tabs > .nav-item > .nav-link.active {
-    .theme-redesign & {
-        color: var(--body-color);
-        font-weight: 700;
-        border-bottom: 2px solid var(--brand-secondary);
-    }
+    color: var(--body-color);
+    font-weight: 700;
+    border-bottom: 2px solid var(--brand-secondary);
 }
 
 // Bootstrap's nav base class does not include styles for the active state.

--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -29,7 +29,6 @@
     justify-content: center;
     border-bottom: 2px solid transparent;
     &:hover {
-        // color: var(--body-color);
         border-bottom: 2px solid var(--border-color);
     }
     &[data-selected] {

--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -3,92 +3,68 @@
     background: transparent;
 }
 
+.tablist-wrapper {
+    min-height: 2rem;
+    border-bottom: 1px solid var(--border-color-2);
+    padding-bottom: 0;
+    display: flex;
+    align-items: stretch;
+    justify-content: space-between;
+}
+
+[data-reach-tabs] {
+    background: var(--body-bg);
+}
+
 [data-reach-tab] {
-    text-transform: uppercase;
+    align-items: center;
+    letter-spacing: normal;
     font-size: 0.75rem;
-    letter-spacing: 1px;
-    border-bottom: 3px solid transparent;
-    margin-bottom: -(3/16) + rem;
-    padding: (5/16) + rem;
-    color: var(--text-muted);
+    margin: 0 0.375rem;
+    padding: 0 0.125rem;
+    color: var(--body-color);
+    text-transform: none;
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    border-bottom: 2px solid transparent;
     &:hover {
-        color: var(--body-color);
-        border-bottom: 3px solid var(--link-color);
+        // color: var(--body-color);
+        border-bottom: 2px solid var(--border-color);
     }
     &[data-selected] {
         color: var(--body-color);
-        border-bottom: 3px solid var(--primary);
+        font-weight: 700;
+        border-bottom: 2px solid var(--brand-secondary);
     }
-}
-
-.tablist-wrapper {
-    border-bottom: 3px solid var(--border-color);
-    align-items: center;
-}
-
-.theme-redesign {
-    [data-reach-tabs] {
-        background: var(--body-bg);
+    &:active {
+        background-color: transparent;
     }
-
-    [data-reach-tab] {
-        align-items: center;
-        letter-spacing: normal;
-        font-size: 0.75rem;
-        margin: 0 0.375rem;
-        padding: 0 0.125rem;
-        color: var(--body-color);
-        text-transform: none;
-        display: inline-flex;
-        flex-direction: column;
-        justify-content: center;
-        border-bottom: 2px solid transparent;
-        &:active {
-            background-color: transparent;
-        }
-        &:hover {
-            border-bottom: 2px solid var(--border-color);
-        }
-        &[data-selected] {
-            color: var(--body-color);
-            font-weight: 700;
-            border-bottom: 2px solid var(--brand-secondary);
-        }
-        // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
-        &::after {
-            content: attr(data-tab-content);
-            height: 0;
-            text-transform: capitalize;
-            visibility: hidden; // a11y: avoid detection for voice over
-            overflow: hidden;
-            user-select: none;
-            pointer-events: none;
-            font-weight: 700;
-        }
-
-        &:first-of-type {
-            margin-left: 0;
-        }
-
-        &:focus-visible {
-            outline: none;
-            box-shadow: none;
-            > .tablist-wrapper--tab-label {
-                padding: 0.125rem;
-                margin: 0 -0.125rem;
-                border-radius: var(--border-radius);
-                outline: 1px solid transparent;
-                box-shadow: var(--focus-box-shadow);
-            }
-        }
+    // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
+    &::after {
+        content: attr(data-tab-content);
+        height: 0;
+        text-transform: capitalize;
+        visibility: hidden; // a11y: avoid detection for voice over
+        overflow: hidden;
+        user-select: none;
+        pointer-events: none;
+        font-weight: 700;
     }
 
-    .tablist-wrapper {
-        min-height: 2rem;
-        border-bottom: 1px solid var(--border-color-2);
-        padding-bottom: 0;
-        display: flex;
-        align-items: stretch;
-        justify-content: space-between;
+    &:first-of-type {
+        margin-left: 0;
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: none;
+        > .tablist-wrapper--tab-label {
+            padding: 0.125rem;
+            margin: 0 -0.125rem;
+            border-radius: var(--border-radius);
+            outline: 1px solid transparent;
+            box-shadow: var(--focus-box-shadow);
+        }
     }
 }


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from branded.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.