### PR TITLE
web: remove `.theme-redesign` usage from shared

### DIFF
--- a/client/shared/src/commandPalette/CommandList.scss
+++ b/client/shared/src/commandPalette/CommandList.scss
@@ -1,29 +1,23 @@
 .command-list {
     width: 24rem;
     background-color: var(--body-bg);
-
+    .list-group {
+        max-height: 18.5rem;
+        overflow: auto;
+    }
+    .list-group-item {
+        &.active {
+            &:hover {
+                color: var(--body-color);
+            }
+        }
+    }
+    .list-group-item-action {
+        &:hover {
+            background-color: var(--color-bg-3);
+        }
+    }
     &__popover-button {
         cursor: pointer;
-    }
-}
-
-.theme-redesign {
-    .command-list {
-        .list-group {
-            max-height: 18.5rem;
-            overflow: auto;
-        }
-        .list-group-item {
-            &.active {
-                &:hover {
-                    color: var(--body-color);
-                }
-            }
-        }
-        .list-group-item-action {
-            &:hover {
-                background-color: var(--color-bg-3);
-            }
-        }
     }
 }

--- a/client/shared/src/commandPalette/EmptyCommandList.scss
+++ b/client/shared/src/commandPalette/EmptyCommandList.scss
@@ -2,6 +2,7 @@
     position: relative;
     color: var(--gray-08);
     padding: 1rem;
+    background-color: var(--color-bg-1);
 
     &__title {
         font-weight: 600;
@@ -17,9 +18,6 @@
         position: absolute;
         bottom: 1rem;
         right: 1rem;
-    }
-    .theme-redesign & {
-        background-color: var(--color-bg-1);
     }
 }
 

--- a/client/shared/src/components/FileMatchChildren.scss
+++ b/client/shared/src/components/FileMatchChildren.scss
@@ -1,21 +1,15 @@
 .file-match-children {
-    .theme-redesign & {
-        background-color: var(--code-bg);
-        border: 1px solid var(--border-color);
-        border-radius: var(--border-radius);
-        padding: 0.25rem 0;
-    }
+    background-color: var(--code-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 0.25rem 0;
 
     &__item {
         text-decoration: none; // don't use cascading link style
         display: flex;
         align-items: center;
         padding: 0.25rem 0.5rem;
-        background-color: var(--body-bg);
-
-        .theme-redesign & {
-            background-color: var(--code-bg);
-        }
+        background-color: var(--code-bg);
 
         &-clickable {
             cursor: pointer;
@@ -29,11 +23,7 @@
             position: relative;
             overflow-x: auto;
             &:not(:first-child) {
-                border-top: 1px solid var(--border-color);
-
-                .theme-redesign & {
-                    border-color: var(--border-color-2);
-                }
+                border-top: 1px solid var(--border-color-2);
             }
         }
     }

--- a/client/shared/src/components/ResultContainer.scss
+++ b/client/shared/src/components/ResultContainer.scss
@@ -1,6 +1,4 @@
 .result-container {
-    border: none;
-    border-top-width: 1px;
     margin-right: 1rem;
     &:last-child {
         border-bottom-width: 1px;

--- a/client/shared/src/components/ResultContainer.scss
+++ b/client/shared/src/components/ResultContainer.scss
@@ -1,28 +1,20 @@
 .result-container {
-    border: 0 solid var(--border-color);
+    border: none;
     border-top-width: 1px;
+    margin-right: 1rem;
     &:last-child {
         border-bottom-width: 1px;
     }
-
-    .theme-redesign & {
-        border: none;
-        margin-right: 1rem;
-
-        &:not(:last-of-type) {
-            margin-bottom: 0.5rem;
-        }
+    &:not(:last-of-type) {
+        margin-bottom: 0.5rem;
     }
 
     &__header {
-        padding: 0.5rem 0.5rem;
-
+        padding: 0.5rem 0;
+        background-color: transparent;
         display: flex;
         align-items: center;
         white-space: nowrap;
-        $background-color: $card-cap-bg;
-
-        background-color: $background-color;
 
         &-title {
             flex: 1 1 auto;
@@ -31,11 +23,9 @@
         }
 
         &-divider {
-            .theme-redesign & {
-                border-right: 1px solid var(--border-color-2);
-                height: 1rem;
-                margin: 0 0.25rem;
-            }
+            border-right: 1px solid var(--border-color-2);
+            height: 1rem;
+            margin: 0 0.25rem;
         }
 
         p {
@@ -43,28 +33,16 @@
         }
 
         &:not(:only-of-type) {
-            border-bottom: 1px solid var(--border-color);
+            border-bottom: none;
         }
 
-        .theme-redesign & {
-            background-color: transparent;
-            padding: 0.5rem 0;
-
-            &-description {
-                line-height: (14/11);
-            }
-
-            &:not(:only-of-type) {
-                border-bottom: none;
-            }
+        &-description {
+            line-height: (14/11);
         }
     }
 
     &__toggle-matches-container {
         display: flex;
-
-        .theme-redesign & {
-            flex-shrink: 0;
-        }
+        flex-shrink: 0;
     }
 }

--- a/client/shared/src/global-styles/icons.scss
+++ b/client/shared/src/global-styles/icons.scss
@@ -17,23 +17,23 @@
 
 // TODO find a better way to scale icons that is not proportional to the font size
 // 14px font size -> 20px icon size
-$icon-inline-size: (20em / 14);
-$icon-inline-redesign-size: (16em / 14);
+$icon-inline-md-size: (20em / 14);
+$icon-inline-size: (16em / 14);
 
 svg.icon-inline,
 div.icon-inline,
 img.icon-inline,
 .icon-inline svg {
-    width: $icon-inline-redesign-size;
-    height: $icon-inline-redesign-size;
+    width: $icon-inline-size;
+    height: $icon-inline-size;
     // Match color of the text
     fill: currentColor;
     vertical-align: text-bottom;
 }
 
 .icon-inline-md {
-    width: $icon-inline-size;
-    height: $icon-inline-size;
+    width: $icon-inline-md-size;
+    height: $icon-inline-md-size;
 }
 
 // Special case for the loader

--- a/client/shared/src/global-styles/icons.scss
+++ b/client/shared/src/global-styles/icons.scss
@@ -24,16 +24,11 @@ svg.icon-inline,
 div.icon-inline,
 img.icon-inline,
 .icon-inline svg {
-    width: $icon-inline-size;
-    height: $icon-inline-size;
+    width: $icon-inline-redesign-size;
+    height: $icon-inline-redesign-size;
     // Match color of the text
     fill: currentColor;
-
-    :where(.theme-redesign) & {
-        width: $icon-inline-redesign-size;
-        height: $icon-inline-redesign-size;
-        vertical-align: text-bottom;
-    }
+    vertical-align: text-bottom;
 }
 
 .icon-inline-md {


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from branded.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.