### PR TITLE
search: remove repos value in zoekt params

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -138,7 +138,6 @@ const (
 
 // ZoektParameters contains all the inputs to run a Zoekt indexed search.
 type ZoektParameters struct {
-	Repos            []*RepositoryRevisions
 	RepoOptions      RepoOptions
 	Query            zoektquery.Q
 	Typ              IndexedRequestType

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -191,7 +191,6 @@ func NewIndexedUniverseSearchRequest(ctx context.Context, args *search.TextParam
 		RepoOptions:      repoOptions,
 		UserPrivateRepos: userPrivateRepos,
 		Args: &search.ZoektParameters{
-			Repos:          args.Repos,
 			Query:          q,
 			Typ:            typ,
 			FileMatchLimit: args.PatternInfo.FileMatchLimit,
@@ -374,7 +373,6 @@ func NewIndexedSubsetSearchRequest(ctx context.Context, args *search.TextParamet
 
 	return &IndexedSubsetSearchRequest{
 		Args: &search.ZoektParameters{
-			Repos:            args.Repos,
 			Query:            q,
 			Typ:              typ,
 			FileMatchLimit:   args.PatternInfo.FileMatchLimit,


### PR DESCRIPTION
Continuing from my next steps mentioned in https://github.com/sourcegraph/sourcegraph/pull/24069#issue-714774543.

It turns out that `repos` in `ZoektParameters` is now completely unneeded once we construct an indexed search request.