### PR TITLE
web: remove `.theme-redesign` selector from settings

### DIFF
--- a/client/web/src/settings/tokens/AccessTokenNode.module.scss
+++ b/client/web/src/settings/tokens/AccessTokenNode.module.scss
@@ -1,15 +1,13 @@
 .access-token-node {
-    :global(.theme-redesign) & {
-        &__container {
-            border: 0;
-            padding: 0;
-            &:not(:last-child) {
-                margin-bottom: 0.5rem;
-            }
-            + .access-token-node__container {
-                border-top: 1px solid var(--border-color);
-                padding-top: 0.5rem;
-            }
+    &__container {
+        border: 0;
+        padding: 0;
+        &:not(:last-child) {
+            margin-bottom: 0.5rem;
+        }
+        + .access-token-node__container {
+            border-top: 1px solid var(--border-color);
+            padding-top: 0.5rem;
         }
     }
 }

--- a/client/web/src/user/UserAvatar.scss
+++ b/client/web/src/user/UserAvatar.scss
@@ -1,25 +1,11 @@
 .user-avatar {
+    display: inline-flex;
     border-radius: 50%;
-}
-
-.theme-redesign {
-    .user-avatar {
-        display: inline-flex;
-        border-radius: 50%;
-        text-transform: capitalize;
-        background: linear-gradient(
-            90deg,
-            #b200f8 0%,
-            #a537f8 20%,
-            #974ff9 40%,
-            #8760f9 60%,
-            #746ffa 80%,
-            #5c7cfa 100%
-        );
-        color: var(--color-bg-1);
-        align-items: center;
-        justify-content: center;
-        min-width: 1.5rem;
-        min-height: 1.5rem;
-    }
+    text-transform: capitalize;
+    background: linear-gradient(90deg, #b200f8 0%, #a537f8 20%, #974ff9 40%, #8760f9 60%, #746ffa 80%, #5c7cfa 100%);
+    color: var(--color-bg-1);
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    min-height: 1.5rem;
 }

--- a/client/web/src/user/settings/UserSettingsSidebar.scss
+++ b/client/web/src/user/settings/UserSettingsSidebar.scss
@@ -2,8 +2,6 @@
     width: 12.5rem;
 
     &__new-org-btn-wrapper {
-        .theme-redesign & {
-            margin-top: 0.25rem;
-        }
+        margin-top: 0.25rem;
     }
 }

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.module.scss
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.module.scss
@@ -1,13 +1,11 @@
 .external-account {
-    :global(.theme-redesign) & {
-        border: 0;
-        padding: 0;
-        &:not(:last-child) {
-            margin-bottom: 1rem;
-        }
-        + .external-account {
-            border-top: 1px solid var(--border-color);
-            padding-top: 1rem;
-        }
+    border: 0;
+    padding: 0;
+    &:not(:last-child) {
+        margin-bottom: 1rem;
+    }
+    + .external-account {
+        border-top: 1px solid var(--border-color);
+        padding-top: 1rem;
     }
 }

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.scss
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.scss
@@ -16,16 +16,14 @@
     }
 
     &__code-host-item {
-        .theme-redesign & {
-            border: 0;
-            padding: 0;
-            &:not(:last-child) {
-                margin-bottom: 1rem;
-            }
-            + .user-code-hosts-page__code-host-item {
-                border-top: 1px solid var(--border-color);
-                padding-top: 1rem;
-            }
+        border: 0;
+        padding: 0;
+        &:not(:last-child) {
+            margin-bottom: 1rem;
+        }
+        + .user-code-hosts-page__code-host-item {
+            border-top: 1px solid var(--border-color);
+            padding-top: 1rem;
         }
     }
 }

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.scss
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.scss
@@ -7,19 +7,13 @@
         color: var(--border-color);
     }
     &__list-item {
-        padding: 1rem;
-        .theme-redesign & {
-            border: 0;
-            padding: 1rem 0;
-            + .user-settings-emails-page__list-item {
-                border-top: 1px solid var(--border-color);
-            }
+        border: 0;
+        padding: 1rem 0;
+        + .user-settings-emails-page__list-item {
+            border-top: 1px solid var(--border-color);
         }
     }
     &__email-form {
-        padding-top: 1.5rem;
-        .theme-redesign & {
-            padding-top: 0.5rem;
-        }
+        padding-top: 0.5rem;
     }
 }

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
@@ -39,16 +39,14 @@
 
     &__container {
         border-color: var(--border-color-2) !important;
-        .theme-redesign & {
-            border: 0;
-            padding: 0;
-            &:not(:last-child) {
-                margin-bottom: 1.5rem;
-            }
-            + .user-settings-repos__container {
-                border-top: 1px solid var(--border-color);
-                padding-top: 1.5rem;
-            }
+        border: 0;
+        padding: 0;
+        &:not(:last-child) {
+            margin-bottom: 1.5rem;
+        }
+        + .user-settings-repos__container {
+            border-top: 1px solid var(--border-color);
+            padding-top: 1.5rem;
         }
     }
 


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from settings.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.