### PR TITLE
search: mint SearcherParameters type

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -151,6 +151,23 @@ type ZoektParameters struct {
 	Zoekt *backend.Zoekt
 }
 
+// SearcherParameters the inputs for a search fulfilled by the Searcher service
+// (cmd/searcher). Searcher fulfills (1) unindexed literal and regexp searches
+// and (2) structural search requests.
+type SearcherParameters struct {
+	SearcherURLs *endpoint.Map
+	PatternInfo  *TextPatternInfo
+
+	// UseFullDeadline indicates that the search should try do as much work as
+	// it can within context.Deadline. If false the search should try and be
+	// as fast as possible, even if a "slow" deadline is set.
+	//
+	// For example searcher will wait to full its archive cache for a
+	// repository if this field is true. Another example is we set this field
+	// to true if the user requests a specific timeout or maximum result size.
+	UseFullDeadline bool
+}
+
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
 // to search for, as well as the hydrated list of repository revisions to
 // search. It defines behavior for text search on repository names, file names, and file content.

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -44,7 +44,7 @@ func (UnindexedList) IsIndexed() bool {
 
 // searchRepos represent the arguments to a search called over repositories.
 type searchRepos struct {
-	args    *search.TextParameters
+	args    *search.SearcherParameters
 	repoSet repoData
 	stream  streaming.Sender
 }
@@ -85,7 +85,13 @@ func streamStructuralSearch(ctx context.Context, args *search.TextParameters, st
 
 	jobs := []*searchRepos{}
 	for _, repoSet := range repoSets(request, args.Mode) {
-		jobs = append(jobs, &searchRepos{args: args, stream: stream, repoSet: repoSet})
+		searcherArgs := &search.SearcherParameters{
+			SearcherURLs:    args.SearcherURLs,
+			PatternInfo:     args.PatternInfo,
+			UseFullDeadline: args.UseFullDeadline,
+		}
+
+		jobs = append(jobs, &searchRepos{args: searcherArgs, stream: stream, repoSet: repoSet})
 	}
 	return runJobs(ctx, jobs)
 }

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -85,7 +85,12 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return callSearcherOverRepos(ctx, args, stream, request.UnindexedRepos(), false)
+		searcherArgs := &search.SearcherParameters{
+			SearcherURLs:    args.SearcherURLs,
+			PatternInfo:     args.PatternInfo,
+			UseFullDeadline: args.UseFullDeadline,
+		}
+		return callSearcherOverRepos(ctx, searcherArgs, stream, request.UnindexedRepos(), false)
 	})
 
 	return g.Wait()
@@ -244,7 +249,7 @@ func matchesToFileMatches(matches []result.Match) ([]*result.FileMatch, error) {
 // callSearcherOverRepos calls searcher on searcherRepos.
 func callSearcherOverRepos(
 	ctx context.Context,
-	args *search.TextParameters,
+	args *search.SearcherParameters,
 	stream streaming.Sender,
 	searcherRepos []*search.RepositoryRevisions,
 	index bool,


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24168.

This mints a new `SearcherParameters` type for inputs that go to searcher. Why does this matter?

When we optimize queries for a particular backend, like the one planned for `Zoekt`, that query representation doesn't make sense to propagate to other backends, like searcher. We want to logically separate these query inputs, and any other inputs that are not specific to a particular backend.

Using this type, this PR establishes a boundary at which point `TextParameters` is not propagated further to any Zoekt or Searcher logic. 

Very cool things are about to happen now. Like, I'm unreasonably excited. Because as-of this PR creating this boundary, it now becomes possible to trickle up the construction of queries/inputs for separate backends. Once fully trickled up, we won't need `TextParameters` any more.


