### PR TITLE
batches: recalculate preview stats on publication states change

### DIFF
--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
@@ -31,22 +31,6 @@ const nodes: ChangesetApplyPreviewFields[] = [
     ...Object.values(hiddenChangesetApplyPreviewStories),
 ]
 
-const APPLY_PREVIEW_STATS: ApplyPreviewStatsFields['stats'] = {
-    close: 10,
-    detach: 10,
-    import: 10,
-    publish: 10,
-    publishDraft: 10,
-    push: 10,
-    reopen: 10,
-    undraft: 10,
-    update: 10,
-    archive: 18,
-    added: 5,
-    modified: 10,
-    removed: 3,
-}
-
 const batchSpec = (): BatchSpecFields => ({
     appliesToBatchChange: null,
     createdAt: subDays(new Date(), 5).toISOString(),
@@ -82,7 +66,9 @@ const batchSpec = (): BatchSpecFields => ({
     },
     originalInput: 'name: awesome-batch-change\ndescription: somestring',
     applyPreview: {
-        stats: APPLY_PREVIEW_STATS,
+        stats: {
+            archive: 18,
+        },
         totalCount: 18,
     },
 })
@@ -117,7 +103,22 @@ const fetchBatchSpecUpdate: typeof fetchBatchSpecById = () =>
         },
     })
 
-const queryApplyPreviewStats = (): Observable<ApplyPreviewStatsFields['stats']> => of(APPLY_PREVIEW_STATS)
+const queryApplyPreviewStats = (): Observable<ApplyPreviewStatsFields['stats']> =>
+    of({
+        close: 10,
+        detach: 10,
+        import: 10,
+        publish: 10,
+        publishDraft: 10,
+        push: 10,
+        reopen: 10,
+        undraft: 10,
+        update: 10,
+        archive: 18,
+        added: 5,
+        modified: 10,
+        removed: 3,
+    })
 
 const queryChangesetApplyPreview = (): Observable<BatchSpecApplyPreviewConnectionFields> =>
     of({

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { of, Observable } from 'rxjs'
 
 import {
+    ApplyPreviewStatsFields,
     BatchSpecApplyPreviewConnectionFields,
     BatchSpecFields,
     ChangesetApplyPreviewFields,
@@ -29,6 +30,22 @@ const nodes: ChangesetApplyPreviewFields[] = [
     ...Object.values(visibleChangesetApplyPreviewNodeStories(false)),
     ...Object.values(hiddenChangesetApplyPreviewStories),
 ]
+
+const APPLY_PREVIEW_STATS: ApplyPreviewStatsFields['stats'] = {
+    close: 10,
+    detach: 10,
+    import: 10,
+    publish: 10,
+    publishDraft: 10,
+    push: 10,
+    reopen: 10,
+    undraft: 10,
+    update: 10,
+    archive: 18,
+    added: 5,
+    modified: 10,
+    removed: 3,
+}
 
 const batchSpec = (): BatchSpecFields => ({
     appliesToBatchChange: null,
@@ -65,21 +82,7 @@ const batchSpec = (): BatchSpecFields => ({
     },
     originalInput: 'name: awesome-batch-change\ndescription: somestring',
     applyPreview: {
-        stats: {
-            close: 10,
-            detach: 10,
-            import: 10,
-            publish: 10,
-            publishDraft: 10,
-            push: 10,
-            reopen: 10,
-            undraft: 10,
-            update: 10,
-            archive: 18,
-            added: 5,
-            modified: 10,
-            removed: 3,
-        },
+        stats: APPLY_PREVIEW_STATS,
         totalCount: 18,
     },
 })
@@ -114,6 +117,8 @@ const fetchBatchSpecUpdate: typeof fetchBatchSpecById = () =>
         },
     })
 
+const queryApplyPreviewStats = (): Observable<ApplyPreviewStatsFields['stats']> => of(APPLY_PREVIEW_STATS)
+
 const queryChangesetApplyPreview = (): Observable<BatchSpecApplyPreviewConnectionFields> =>
     of({
         pageInfo: {
@@ -146,6 +151,7 @@ add('Create', () => (
                 fetchBatchSpecById={fetchBatchSpecCreate}
                 queryChangesetApplyPreview={queryChangesetApplyPreview}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                queryApplyPreviewStats={queryApplyPreviewStats}
                 authenticatedUser={{
                     url: '/users/alice',
                     displayName: 'Alice',
@@ -167,6 +173,7 @@ add('Update', () => (
                 fetchBatchSpecById={fetchBatchSpecUpdate}
                 queryChangesetApplyPreview={queryChangesetApplyPreview}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                queryApplyPreviewStats={queryApplyPreviewStats}
                 authenticatedUser={{
                     url: '/users/alice',
                     displayName: 'Alice',
@@ -188,6 +195,7 @@ add('Missing credentials', () => (
                 fetchBatchSpecById={fetchBatchSpecMissingCredentials}
                 queryChangesetApplyPreview={queryChangesetApplyPreview}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                queryApplyPreviewStats={queryApplyPreviewStats}
                 authenticatedUser={{
                     url: '/users/alice',
                     displayName: 'Alice',
@@ -209,6 +217,7 @@ add('Spec file', () => (
                 fetchBatchSpecById={fetchBatchSpecCreate}
                 queryChangesetApplyPreview={queryChangesetApplyPreview}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                queryApplyPreviewStats={queryApplyPreviewStats}
                 authenticatedUser={{
                     url: '/users/alice',
                     displayName: 'Alice',
@@ -230,6 +239,7 @@ add('No changesets', () => (
                 fetchBatchSpecById={fetchBatchSpecCreate}
                 queryChangesetApplyPreview={queryEmptyChangesetApplyPreview}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                queryApplyPreviewStats={queryApplyPreviewStats}
                 authenticatedUser={{
                     url: '/users/alice',
                     displayName: 'Alice',

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
@@ -15,7 +15,7 @@ import { Description } from '../Description'
 import { SupersedingBatchSpecAlert } from '../detail/SupersedingBatchSpecAlert'
 import { MultiSelectContextProvider } from '../MultiSelectContext'
 
-import { fetchBatchSpecById as _fetchBatchSpecById } from './backend'
+import { fetchBatchSpecById as _fetchBatchSpecById, queryApplyPreviewStats as _queryApplyPreviewStats } from './backend'
 import { BatchChangePreviewContextProvider } from './BatchChangePreviewContext'
 import { BatchChangePreviewStatsBar } from './BatchChangePreviewStatsBar'
 import { BatchChangePreviewProps, BatchChangePreviewTabs } from './BatchChangePreviewTabs'
@@ -28,6 +28,8 @@ export type PreviewPageAuthenticatedUser = Pick<AuthenticatedUser, 'url' | 'disp
 export interface BatchChangePreviewPageProps extends BatchChangePreviewProps {
     /** Used for testing. */
     fetchBatchSpecById?: typeof _fetchBatchSpecById
+    /** Used for testing. */
+    queryApplyPreviewStats?: typeof _queryApplyPreviewStats
 }
 
 export const BatchChangePreviewPage: React.FunctionComponent<BatchChangePreviewPageProps> = props => {
@@ -37,6 +39,7 @@ export const BatchChangePreviewPage: React.FunctionComponent<BatchChangePreviewP
         authenticatedUser,
         telemetryService,
         fetchBatchSpecById = _fetchBatchSpecById,
+        queryApplyPreviewStats,
     } = props
 
     const spec = useObservable(
@@ -88,7 +91,7 @@ export const BatchChangePreviewPage: React.FunctionComponent<BatchChangePreviewP
                         viewerBatchChangesCodeHosts={spec.viewerBatchChangesCodeHosts}
                     />
                     <SupersedingBatchSpecAlert spec={spec.supersedingBatchSpec} />
-                    <BatchChangePreviewStatsBar batchSpec={spec} />
+                    <BatchChangePreviewStatsBar batchSpec={spec} queryApplyPreviewStats={queryApplyPreviewStats} />
                     <CreateUpdateBatchChangeAlert
                         history={history}
                         specID={spec.id}

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
@@ -91,7 +91,11 @@ export const BatchChangePreviewPage: React.FunctionComponent<BatchChangePreviewP
                         viewerBatchChangesCodeHosts={spec.viewerBatchChangesCodeHosts}
                     />
                     <SupersedingBatchSpecAlert spec={spec.supersedingBatchSpec} />
-                    <BatchChangePreviewStatsBar batchSpec={spec} queryApplyPreviewStats={queryApplyPreviewStats} />
+                    <BatchChangePreviewStatsBar
+                        batchSpec={spec.id}
+                        diffStat={spec.diffStat}
+                        queryApplyPreviewStats={queryApplyPreviewStats}
+                    />
                     <CreateUpdateBatchChangeAlert
                         history={history}
                         specID={spec.id}

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -29,7 +29,7 @@ const actionClassNames = classNames(
 export interface BatchChangePreviewStatsBarProps {
     batchSpec: BatchSpecFields
     /** For testing purposes only. */
-    queryApplyPreviewStats: typeof _queryApplyPreviewStats
+    queryApplyPreviewStats?: typeof _queryApplyPreviewStats
 }
 
 export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePreviewStatsBarProps> = ({

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -1,9 +1,13 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useContext, useMemo } from 'react'
+
+import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { DiffStatStack } from '../../../components/diff/DiffStat'
-import { BatchSpecFields } from '../../../graphql-operations'
+import { ApplyPreviewStatsFields, BatchSpecFields } from '../../../graphql-operations'
 
+import { queryApplyPreviewStats as _queryApplyPreviewStats } from './backend'
+import { BatchChangePreviewContext } from './BatchChangePreviewContext'
 import styles from './BatchChangePreviewStatsBar.module.scss'
 import { ChangesetAddedIcon, ChangesetModifiedIcon, ChangesetRemovedIcon } from './icons'
 import {
@@ -24,44 +28,63 @@ const actionClassNames = classNames(
 
 export interface BatchChangePreviewStatsBarProps {
     batchSpec: BatchSpecFields
+    /** For testing purposes only. */
+    queryApplyPreviewStats: typeof _queryApplyPreviewStats
 }
 
-export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePreviewStatsBarProps> = ({ batchSpec }) => (
-    <div className="d-flex flex-wrap mb-3 align-items-center">
-        <h2 className="m-0 align-self-center">
-            <span className="badge badge-info text-uppercase mb-0">Preview</span>
-        </h2>
-        <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-sm-block mx-3')} />
-        <DiffStatStack className={styles.batchChangePreviewStatsBarDiff} {...batchSpec.diffStat} />
-        <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-sm-none my-3')} />
-        <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'mx-3 d-none d-sm-block d-md-none')} />
-        <div className={classNames(styles.batchChangePreviewStatsBarMetrics, 'flex-grow-1 d-flex justify-content-end')}>
-            <PreviewStatsAdded count={batchSpec.applyPreview.stats.added} />
-            <PreviewStatsRemoved count={batchSpec.applyPreview.stats.removed} />
-            <PreviewStatsModified count={batchSpec.applyPreview.stats.modified} />
+export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePreviewStatsBarProps> = ({
+    batchSpec,
+    queryApplyPreviewStats = _queryApplyPreviewStats,
+}) => {
+    const { publicationStates } = useContext(BatchChangePreviewContext)
+
+    /** We use this to recalculate the stats when the publication states are modified. */
+    const applyPreviewStats = useObservable<ApplyPreviewStatsFields['stats']>(
+        useMemo(() => queryApplyPreviewStats({ batchSpec: batchSpec.id, publicationStates }), [
+            publicationStates,
+            batchSpec.id,
+            queryApplyPreviewStats,
+        ])
+    )
+
+    const stats = applyPreviewStats || batchSpec.applyPreview.stats
+
+    return (
+        <div className="d-flex flex-wrap mb-3 align-items-center">
+            <h2 className="m-0 align-self-center">
+                <span className="badge badge-info text-uppercase mb-0">Preview</span>
+            </h2>
+            <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-sm-block mx-3')} />
+            <DiffStatStack className={styles.batchChangePreviewStatsBarDiff} {...batchSpec.diffStat} />
+            <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-sm-none my-3')} />
+            <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'mx-3 d-none d-sm-block d-md-none')} />
+            <div
+                className={classNames(
+                    styles.batchChangePreviewStatsBarMetrics,
+                    'flex-grow-1 d-flex justify-content-end'
+                )}
+            >
+                <PreviewStatsAdded count={stats.added} />
+                <PreviewStatsRemoved count={stats.removed} />
+                <PreviewStatsModified count={stats.modified} />
+            </div>
+            <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-md-none my-3')} />
+            <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-md-block ml-3 mr-2')} />
+            <div className={classNames(styles.batchChangePreviewStatsBarStates, 'd-flex justify-content-end')}>
+                <PreviewActionReopen className={actionClassNames} label={`${stats.reopen} Reopen`} />
+                <PreviewActionClose className={actionClassNames} label={`${stats.reopen} Close`} />
+                <PreviewActionUpdate className={actionClassNames} label={`${stats.update} Update`} />
+                <PreviewActionUndraft className={actionClassNames} label={`${stats.undraft} Undraft`} />
+                <PreviewActionPublish
+                    className={actionClassNames}
+                    label={`${stats.publish + stats.publishDraft} Publish`}
+                />
+                <PreviewActionImport className={actionClassNames} label={`${stats.import} Import`} />
+                <PreviewActionArchive className={actionClassNames} label={`${stats.archive} Archive`} />
+            </div>
         </div>
-        <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-md-none my-3')} />
-        <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-md-block ml-3 mr-2')} />
-        <div className={classNames(styles.batchChangePreviewStatsBarStates, 'd-flex justify-content-end')}>
-            <PreviewActionReopen className={actionClassNames} label={`${batchSpec.applyPreview.stats.reopen} Reopen`} />
-            <PreviewActionClose className={actionClassNames} label={`${batchSpec.applyPreview.stats.reopen} Close`} />
-            <PreviewActionUpdate className={actionClassNames} label={`${batchSpec.applyPreview.stats.update} Update`} />
-            <PreviewActionUndraft
-                className={actionClassNames}
-                label={`${batchSpec.applyPreview.stats.undraft} Undraft`}
-            />
-            <PreviewActionPublish
-                className={actionClassNames}
-                label={`${batchSpec.applyPreview.stats.publish + batchSpec.applyPreview.stats.publishDraft} Publish`}
-            />
-            <PreviewActionImport className={actionClassNames} label={`${batchSpec.applyPreview.stats.import} Import`} />
-            <PreviewActionArchive
-                className={actionClassNames}
-                label={`${batchSpec.applyPreview.stats.archive} Archive`}
-            />
-        </div>
-    </div>
-)
+    )
+}
 
 export const PreviewStatsAdded: React.FunctionComponent<{ count: number }> = ({ count }) => (
     <div className={classNames(styles.batchChangePreviewStatsBarStat, 'd-flex flex-column mr-2 text-nowrap')}>

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -4,7 +4,7 @@ import React, { useContext, useMemo } from 'react'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { DiffStatStack } from '../../../components/diff/DiffStat'
-import { ApplyPreviewStatsFields, BatchSpecFields } from '../../../graphql-operations'
+import { ApplyPreviewStatsFields, DiffStatFields, Scalars } from '../../../graphql-operations'
 
 import { queryApplyPreviewStats as _queryApplyPreviewStats } from './backend'
 import { BatchChangePreviewContext } from './BatchChangePreviewContext'
@@ -27,27 +27,31 @@ const actionClassNames = classNames(
 )
 
 export interface BatchChangePreviewStatsBarProps {
-    batchSpec: BatchSpecFields
+    batchSpec: Scalars['ID']
+    diffStat: DiffStatFields
     /** For testing purposes only. */
     queryApplyPreviewStats?: typeof _queryApplyPreviewStats
 }
 
 export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePreviewStatsBarProps> = ({
     batchSpec,
+    diffStat,
     queryApplyPreviewStats = _queryApplyPreviewStats,
 }) => {
     const { publicationStates } = useContext(BatchChangePreviewContext)
 
     /** We use this to recalculate the stats when the publication states are modified. */
-    const applyPreviewStats = useObservable<ApplyPreviewStatsFields['stats']>(
-        useMemo(() => queryApplyPreviewStats({ batchSpec: batchSpec.id, publicationStates }), [
+    const stats = useObservable<ApplyPreviewStatsFields['stats']>(
+        useMemo(() => queryApplyPreviewStats({ batchSpec, publicationStates }), [
             publicationStates,
-            batchSpec.id,
+            batchSpec,
             queryApplyPreviewStats,
         ])
     )
 
-    const stats = applyPreviewStats || batchSpec.applyPreview.stats
+    if (!stats) {
+        return null
+    }
 
     return (
         <div className="d-flex flex-wrap mb-3 align-items-center">
@@ -55,7 +59,7 @@ export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePrev
                 <span className="badge badge-info text-uppercase mb-0">Preview</span>
             </h2>
             <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-sm-block mx-3')} />
-            <DiffStatStack className={styles.batchChangePreviewStatsBarDiff} {...batchSpec.diffStat} />
+            <DiffStatStack className={styles.batchChangePreviewStatsBarDiff} {...diffStat} />
             <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-sm-none my-3')} />
             <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'mx-3 d-none d-sm-block d-md-none')} />
             <div

--- a/client/web/src/enterprise/batches/preview/backend.ts
+++ b/client/web/src/enterprise/batches/preview/backend.ts
@@ -65,20 +65,7 @@ export const batchSpecFragment = gql`
         originalInput
         applyPreview {
             stats {
-                close
-                detach
                 archive
-                import
-                publish
-                publishDraft
-                push
-                reopen
-                undraft
-                update
-
-                added
-                modified
-                removed
             }
             totalCount
         }

--- a/client/web/src/enterprise/batches/preview/backend.ts
+++ b/client/web/src/enterprise/batches/preview/backend.ts
@@ -14,6 +14,9 @@ import {
     BatchSpecByIDResult,
     BatchSpecByIDVariables,
     BatchSpecFields,
+    QueryApplyPreviewStatsVariables,
+    QueryApplyPreviewStatsResult,
+    ApplyPreviewStatsFields,
 } from '../../../graphql-operations'
 
 export const viewerBatchChangesCodeHostsFragment = gql`
@@ -118,6 +121,57 @@ export const fetchBatchSpecById = (batchSpec: Scalars['ID']): Observable<BatchSp
                 throw new Error(`The given ID is a ${node.__typename}, not a BatchSpec`)
             }
             return node
+        })
+    )
+
+export const queryApplyPreviewStats = ({
+    batchSpec,
+    publicationStates,
+}: QueryApplyPreviewStatsVariables): Observable<ApplyPreviewStatsFields['stats']> =>
+    requestGraphQL<QueryApplyPreviewStatsResult, QueryApplyPreviewStatsVariables>(
+        gql`
+            query QueryApplyPreviewStats($batchSpec: ID!, $publicationStates: [ChangesetSpecPublicationStateInput!]) {
+                node(id: $batchSpec) {
+                    __typename
+                    ... on BatchSpec {
+                        id
+                        applyPreview(publicationStates: $publicationStates) {
+                            ...ApplyPreviewStatsFields
+                        }
+                    }
+                }
+            }
+
+            fragment ApplyPreviewStatsFields on ChangesetApplyPreviewConnection {
+                stats {
+                    close
+                    detach
+                    archive
+                    import
+                    publish
+                    publishDraft
+                    push
+                    reopen
+                    undraft
+                    update
+
+                    added
+                    modified
+                    removed
+                }
+            }
+        `,
+        { batchSpec, publicationStates }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(({ node }) => {
+            if (!node) {
+                throw new Error(`BatchSpec with ID ${batchSpec} does not exist`)
+            }
+            if (node.__typename !== 'BatchSpec') {
+                throw new Error(`The given ID is a ${node.__typename}, not a BatchSpec`)
+            }
+            return node.applyPreview.stats
         })
     )
 

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -574,19 +574,7 @@ describe('Batches', () => {
                             originalInput: 'name: awesome-batch-change\ndescription: somestring',
                             applyPreview: {
                                 stats: {
-                                    close: 10,
-                                    detach: 10,
-                                    import: 10,
-                                    publish: 10,
-                                    publishDraft: 10,
-                                    push: 10,
-                                    reopen: 10,
-                                    undraft: 10,
-                                    update: 10,
                                     archive: 10,
-                                    added: 5,
-                                    modified: 10,
-                                    removed: 3,
                                 },
                                 totalCount: 10,
                             },
@@ -678,6 +666,30 @@ describe('Batches', () => {
                         createBatchChange: {
                             id: 'change123',
                             url: namespaceURL + '/batch-changes/test-batch-change',
+                        },
+                    }),
+                    QueryApplyPreviewStats: () => ({
+                        node: {
+                            __typename: 'BatchSpec',
+                            id: 'spec123',
+
+                            applyPreview: {
+                                stats: {
+                                    close: 10,
+                                    detach: 10,
+                                    import: 10,
+                                    publish: 10,
+                                    publishDraft: 10,
+                                    push: 10,
+                                    reopen: 10,
+                                    undraft: 10,
+                                    update: 10,
+                                    archive: 18,
+                                    added: 5,
+                                    modified: 10,
+                                    removed: 3,
+                                },
+                            },
                         },
                     }),
                 })


### PR DESCRIPTION
Okay so I know I said #24120 was supposed to be the last UI piece but... 🐛🐛🐛

This PR hooks up the stats at the top of the preview page to also recalculate when the publication states are modified. 👀

https://user-images.githubusercontent.com/8942601/130157727-3471b590-176f-4fcb-9297-9c1dba2c49ed.mov


Closes #22912.