### PR TITLE
search: factor out FileLimitMatch on structural search

### DIFF
--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -100,7 +100,7 @@ func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextPa
 		tr.Finish()
 	}()
 
-	err = unindexed.StructuralSearch(ctx, args, a)
+	err = unindexed.StructuralSearch(ctx, args, args.PatternInfo.FileMatchLimit, a)
 	return errors.Wrap(err, "structural search failed")
 }
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -138,7 +138,6 @@ const (
 
 // ZoektParameters contains all the inputs to run a Zoekt indexed search.
 type ZoektParameters struct {
-	Repos            []*RepositoryRevisions
 	RepoOptions      RepoOptions
 	Query            zoektquery.Q
 	Typ              IndexedRequestType

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -151,6 +151,23 @@ type ZoektParameters struct {
 	Zoekt *backend.Zoekt
 }
 
+// SearcherParameters the inputs for a search fulfilled by the Searcher service
+// (cmd/searcher). Searcher fulfills (1) unindexed literal and regexp searches
+// and (2) structural search requests.
+type SearcherParameters struct {
+	SearcherURLs *endpoint.Map
+	PatternInfo  *TextPatternInfo
+
+	// UseFullDeadline indicates that the search should try do as much work as
+	// it can within context.Deadline. If false the search should try and be
+	// as fast as possible, even if a "slow" deadline is set.
+	//
+	// For example searcher will wait to full its archive cache for a
+	// repository if this field is true. Another example is we set this field
+	// to true if the user requests a specific timeout or maximum result size.
+	UseFullDeadline bool
+}
+
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
 // to search for, as well as the hydrated list of repository revisions to
 // search. It defines behavior for text search on repository names, file names, and file content.

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -44,7 +44,7 @@ func (UnindexedList) IsIndexed() bool {
 
 // searchRepos represent the arguments to a search called over repositories.
 type searchRepos struct {
-	args    *search.TextParameters
+	args    *search.SearcherParameters
 	repoSet repoData
 	stream  streaming.Sender
 }
@@ -85,7 +85,13 @@ func streamStructuralSearch(ctx context.Context, args *search.TextParameters, st
 
 	jobs := []*searchRepos{}
 	for _, repoSet := range repoSets(request, args.Mode) {
-		jobs = append(jobs, &searchRepos{args: args, stream: stream, repoSet: repoSet})
+		searcherArgs := &search.SearcherParameters{
+			SearcherURLs:    args.SearcherURLs,
+			PatternInfo:     args.PatternInfo,
+			UseFullDeadline: args.UseFullDeadline,
+		}
+
+		jobs = append(jobs, &searchRepos{args: searcherArgs, stream: stream, repoSet: repoSet})
 	}
 	return runJobs(ctx, jobs)
 }

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -85,7 +85,12 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return callSearcherOverRepos(ctx, args, stream, request.UnindexedRepos(), false)
+		searcherArgs := &search.SearcherParameters{
+			SearcherURLs:    args.SearcherURLs,
+			PatternInfo:     args.PatternInfo,
+			UseFullDeadline: args.UseFullDeadline,
+		}
+		return callSearcherOverRepos(ctx, searcherArgs, stream, request.UnindexedRepos(), false)
 	})
 
 	return g.Wait()
@@ -244,7 +249,7 @@ func matchesToFileMatches(matches []result.Match) ([]*result.FileMatch, error) {
 // callSearcherOverRepos calls searcher on searcherRepos.
 func callSearcherOverRepos(
 	ctx context.Context,
-	args *search.TextParameters,
+	args *search.SearcherParameters,
 	stream streaming.Sender,
 	searcherRepos []*search.RepositoryRevisions,
 	index bool,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -191,7 +191,6 @@ func NewIndexedUniverseSearchRequest(ctx context.Context, args *search.TextParam
 		RepoOptions:      repoOptions,
 		UserPrivateRepos: userPrivateRepos,
 		Args: &search.ZoektParameters{
-			Repos:          args.Repos,
 			Query:          q,
 			Typ:            search.TextRequest,
 			FileMatchLimit: args.PatternInfo.FileMatchLimit,
@@ -374,7 +373,6 @@ func NewIndexedSubsetSearchRequest(ctx context.Context, args *search.TextParamet
 
 	return &IndexedSubsetSearchRequest{
 		Args: &search.ZoektParameters{
-			Repos:            args.Repos,
 			Query:            q,
 			Typ:              typ,
 			FileMatchLimit:   args.PatternInfo.FileMatchLimit,


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24170.

This is prep to trickle up structural search dependency so that it only needs `SearcherParameters` and not `TextParameters`. This is representative of a similar change that will happen with `literal/regexp`, it's just a bit easier to pull off in structural search with previous changes.