### PR TITLE
search: export TextSearchRequest

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -78,7 +78,7 @@ func streamStructuralSearch(ctx context.Context, args *search.TextParameters, fi
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(fileMatchLimit))
 	defer cleanup()
 
-	request, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	request, err := TextSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -35,7 +35,7 @@ var textSearchLimiter = mutablelimiter.New(32)
 
 var MockSearchFilesInRepos func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error)
 
-func textSearchRequest(ctx context.Context, args *search.TextParameters, onMissing zoektutil.OnMissingRepoRevs) (zoektutil.IndexedSearchRequest, error) {
+func TextSearchRequest(ctx context.Context, args *search.TextParameters, onMissing zoektutil.OnMissingRepoRevs) (zoektutil.IndexedSearchRequest, error) {
 	if args.Mode == search.ZoektGlobalSearch {
 		// performance: optimize global searches where Zoekt searches
 		// all shards anyway.
@@ -69,7 +69,7 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		trace.Stringer("global_search_mode", args.Mode),
 	)
 
-	request, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	request, err := TextSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24179. Prep for next PR which will call this outside of the `unindexed` package for structural search.