### PR TITLE
search: remove unused zoekt parameter values

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -138,15 +138,13 @@ const (
 
 // ZoektParameters contains all the inputs to run a Zoekt indexed search.
 type ZoektParameters struct {
-	RepoOptions      RepoOptions
-	Query            zoektquery.Q
-	Typ              IndexedRequestType
-	FileMatchLimit   int32
-	Enabled          bool
-	Index            query.YesNoOnly
-	Mode             GlobalSearchMode
-	UserPrivateRepos []types.RepoName
-	Select           filter.SelectPath
+	Query          zoektquery.Q
+	Typ            IndexedRequestType
+	FileMatchLimit int32
+	Enabled        bool
+	Index          query.YesNoOnly
+	Mode           GlobalSearchMode
+	Select         filter.SelectPath
 
 	Zoekt *backend.Zoekt
 }

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -373,16 +373,14 @@ func NewIndexedSubsetSearchRequest(ctx context.Context, args *search.TextParamet
 
 	return &IndexedSubsetSearchRequest{
 		Args: &search.ZoektParameters{
-			Query:            q,
-			Typ:              typ,
-			FileMatchLimit:   args.PatternInfo.FileMatchLimit,
-			Enabled:          args.Zoekt.Enabled(),
-			Index:            args.PatternInfo.Index,
-			Mode:             args.Mode,
-			RepoOptions:      args.RepoOptions,
-			UserPrivateRepos: args.UserPrivateRepos,
-			Select:           args.PatternInfo.Select,
-			Zoekt:            args.Zoekt,
+			Query:          q,
+			Typ:            typ,
+			FileMatchLimit: args.PatternInfo.FileMatchLimit,
+			Enabled:        args.Zoekt.Enabled(),
+			Index:          args.PatternInfo.Index,
+			Mode:           args.Mode,
+			Select:         args.PatternInfo.Select,
+			Zoekt:          args.Zoekt,
 		},
 
 		Unindexed: limitUnindexedRepos(searcherRepos, maxUnindexedRepoRevSearchesPerQuery, onMissing),


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24170.

Removes `RepoOptions` and `UserPrivateRepos` from the shared `ZoektParameters` type. This since the new `IndexedUniverse` type alone needs these values to run a search, and those values are already part of its type.

