### PR TITLE
sg: Fix PATH if it contains whitespace

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -335,7 +335,7 @@ commands:
 
   zoekt-indexserver-template: &zoekt_indexserver_template
     cmd: |
-      env PATH="${PWD}/.bin":$PATH .bin/zoekt-sourcegraph-indexserver \
+      env PATH="${PWD}/.bin:$PATH" .bin/zoekt-sourcegraph-indexserver \
         -sourcegraph_url 'http://localhost:3090' \
         -index "$HOME/.sourcegraph/zoekt/index-$ZOEKT_NUM" \
         -hostname "localhost:$ZOEKT_HOSTNAME_PORT" \
@@ -380,11 +380,11 @@ commands:
 
   zoekt-webserver-0:
     <<: *zoekt_webserver_template
-    cmd: env PATH="${PWD}/.bin":$PATH .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-0" -pprof -rpc -listen ":3070"
+    cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-0" -pprof -rpc -listen ":3070"
 
   zoekt-webserver-1:
     <<: *zoekt_webserver_template
-    cmd: env PATH="${PWD}/.bin":$PATH .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -listen ":3071"
+    cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -listen ":3071"
 
   precise-code-intel-worker:
     cmd: .bin/precise-code-intel-worker


### PR DESCRIPTION
Without this change I ran into problems where `env` would complain about
a missing command because my `$PATH` contained a path with whitespace in
it.

    [zoekt-indexserver-0] env: Fusion.app/Contents/Public:/Library/TeX/texbin:/Library/Apple/usr/bin:/Applications/Postgres.app/Contents/Versions/latest/bin:/Applications/kitty.app/Contents/MacOS: No such file or directory
