### PR TITLE
Increase minimal label y-axis padding

### DIFF
--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/helpers/get-y-axis-width.ts
@@ -4,6 +4,7 @@ import { AnyD3Scale } from '@visx/scale/lib/types/Scale'
 import { numberFormatter } from '../components/TickComponent'
 
 const APPROXIMATE_SYMBOL_WIDTH = 11
+const MINIMAL_NUMBER_OF_LABEL_SYMBOLS = 2
 
 export function getYAxisWidth<Scale extends AnyD3Scale>(scale: Scale, numberTicks: number): number {
     const ticksValues = getTicks(scale, numberTicks)
@@ -16,7 +17,7 @@ export function getYAxisWidth<Scale extends AnyD3Scale>(scale: Scale, numberTick
                 .filter(symbol => symbol !== '.').length
     )
 
-    const maxNumberSymbolsInTicks = Math.max(...ticksLengths, 0)
+    const maxNumberSymbolsInTicks = Math.max(...ticksLengths, MINIMAL_NUMBER_OF_LABEL_SYMBOLS)
 
     return maxNumberSymbolsInTicks * APPROXIMATE_SYMBOL_WIDTH
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/24174

This PR just increases a minimal number of symbols for the y-axis padding

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
 <td>
 <img width="546" alt="Screenshot 2021-08-20 at 11 39 42" src="https://user-images.githubusercontent.com/18492575/130206165-5cdf69d5-ff71-4b69-9efd-e4a29ab50065.png">
 </td>
 <td>
<img width="550" alt="Screenshot 2021-08-20 at 11 38 36" src="https://user-images.githubusercontent.com/18492575/130206133-61ce471e-2308-48a1-9102-7c5408c7f490.png">
 </td>
</tr>
</table>