### PR TITLE
cherry-pick: Deploy to dotcom

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2710,7 +2710,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 0+ site level external service sync error rate for 10m0s
+- <span class="badge badge-warning">warning</span> repo-updater: 0.5+ site level external service sync error rate for 10m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 1+ site level external service sync error rate for 10m0s
 
 **Possible solutions**
 
@@ -2725,6 +2726,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 ```json
 "observability.silenceAlerts": [
+  "warning_repo-updater_src_repoupdater_syncer_sync_errors_total",
   "critical_repo-updater_src_repoupdater_syncer_sync_errors_total"
 ]
 ```

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -61,12 +61,25 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 	return baseURL
 }
 
-// CodeHostOf returns the CodeHost of the given repo, if any, as
-// determined by a common prefix between the repo name and the
-// code hosts' URL hostname component.
+// CodeHostOf returns the CodeHost of the given repo, if any. A correct repo name will have three
+// parts separated by a "/":
+// 1. Codehost URL
+// 2. Repo Owner
+// 3. Repo Name
+//
+// For example: github.com/sourcegraph/sourcegraph
+//
+// If "name" does not adhere to this format or the Codehost URL does not match the list of
+// "codehosts" given as the argument to CodeHostOf, it will return nil, otherwise it retuns the
+// matching codehost from the given list.
 func CodeHostOf(name api.RepoName, codehosts ...*CodeHost) *CodeHost {
+	repoNameParts := strings.Split(string(name), "/")
+	if len(repoNameParts) != 3 {
+		return nil
+	}
+
 	for _, c := range codehosts {
-		if strings.HasPrefix(strings.ToLower(string(name)), c.BaseURL.Hostname()) {
+		if strings.EqualFold(repoNameParts[0], c.BaseURL.Hostname()) {
 			return c
 		}
 	}

--- a/internal/extsvc/codehost_test.go
+++ b/internal/extsvc/codehost_test.go
@@ -32,7 +32,13 @@ func TestCodeHostOf(t *testing.T) {
 		repo:      "GITHUB.COM/foo/bar",
 		codehosts: PublicCodeHosts,
 		want:      GitHubDotCom,
-	}} {
+	}, {
+		name:      "invalid",
+		repo:      "github.com.example.com/foo/bar",
+		codehosts: PublicCodeHosts,
+		want:      nil,
+	},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			have := CodeHostOf(tc.repo, tc.codehosts...)
 			if have != tc.want {

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -64,7 +64,8 @@ func RepoUpdater() *monitoring.Container {
 							Name:        "src_repoupdater_syncer_sync_errors_total",
 							Description: "site level external service sync error rate",
 							Query:       `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user"}[5m]))`,
-							Critical:    monitoring.Alert().Greater(0, nil).For(10 * time.Minute),
+							Warning:     monitoring.Alert().Greater(0.5, nil).For(10 * time.Minute),
+							Critical:    monitoring.Alert().Greater(1, nil).For(10 * time.Minute),
 							Panel:       monitoring.Panel().Unit(monitoring.Number).With(monitoring.PanelOptions.ZeroIfNoData()),
 							Owner:       monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: `


### PR DESCRIPTION
# What

A list of cherry picked commits from main that need to be deployed to dotcom.

Here is a list of original PRs that introduced them into main:

#24071: PR that reduces noise of the repo-updater alerts. At the moment the alerts are firing multiple times throughout the day (and night) and have more noise than signal. The alerts stem from errors in repo-updater mostly due to failed repo lookups.

#24137: Fix to handle failed repo-lookups where repo names like `github.com.example.com/foo/bar` are incorrectly identified as the GitHub code host, ultimately leading to the errors which cause the repo-updater alerts to fire. This is an edge case that our previous approach missed.

#24144: Improvement on the fix for the errors to handle edge cases where `/` might be present in the URL args of repo names.

# Why

1. Noisy alerts with little signal -> Disturbed sleep over the weekend -> Unhappy on-call engineer (me) -> Unproductive upcoming week

2. Noisy alerts with little signal -> Ignored because noisy -> Cry Wolf scenario when an alert might be legit but gets ignored because of prior events

# Risks of regression in dotcom

None. 

# Confidence

High.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
