### PR TITLE
Code Insights: Include backend insights in insights count metric/ping

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -353,7 +353,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                 .pipe(bufferCount(2, 1))
                 .subscribe(([[oldSettings], [newSettings, authUser]]) => {
                     if (authUser) {
-                        logInsightMetrics(oldSettings, newSettings, authUser, eventLogger)
+                        logInsightMetrics(oldSettings, newSettings, eventLogger)
                     }
                 })
         )

--- a/client/web/src/insights/core/analytics.ts
+++ b/client/web/src/insights/core/analytics.ts
@@ -3,24 +3,22 @@ import { isEqual } from 'lodash'
 
 import {
     isSettingsValid,
+    mergeSettings,
     Settings,
     SettingsCascade,
     SettingsCascadeOrError,
 } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
-import { AuthenticatedUser } from '../../auth'
-
-import { InsightTypePrefix } from './types'
+import { INSIGHTS_ALL_REPOS_SETTINGS_KEY, InsightTypePrefix } from './types'
 import { SearchBasedExtensionInsightSettings } from './types/insight/search-insight'
 
 export function logInsightMetrics(
     oldSettingsCascade: SettingsCascadeOrError<Settings>,
     newSettingsCascade: SettingsCascadeOrError<Settings>,
-    authUser: AuthenticatedUser,
     telemetryService: TelemetryService
 ): void {
-    logCodeInsightsCount(oldSettingsCascade, newSettingsCascade, authUser, telemetryService)
+    logCodeInsightsCount(oldSettingsCascade, newSettingsCascade, telemetryService)
     logSearchBasedInsightStepSize(oldSettingsCascade, newSettingsCascade, telemetryService)
     logCodeInsightsChanges(oldSettingsCascade, newSettingsCascade, telemetryService)
 }
@@ -28,7 +26,6 @@ export function logInsightMetrics(
 export function logCodeInsightsCount(
     oldSettingsCascade: SettingsCascadeOrError<Settings>,
     newSettingsCascade: SettingsCascadeOrError<Settings>,
-    authUser: AuthenticatedUser,
     telemetryService: TelemetryService
 ): void {
     const oldSettings = isSettingsValid(oldSettingsCascade) && oldSettingsCascade
@@ -36,8 +33,8 @@ export function logCodeInsightsCount(
 
     try {
         if (oldSettings && newSettings) {
-            const oldGroupedInsights = getInsightsGroupedByType(oldSettings, authUser)
-            const newGroupedInsights = getInsightsGroupedByType(newSettings, authUser)
+            const oldGroupedInsights = getInsightsGroupedByType(oldSettings)
+            const newGroupedInsights = getInsightsGroupedByType(newSettings)
 
             if (!isEqual(oldGroupedInsights, newGroupedInsights)) {
                 telemetryService.log('InsightsGroupedCount', newGroupedInsights, newGroupedInsights)
@@ -72,7 +69,7 @@ export function logSearchBasedInsightStepSize(
 
 /**
  * Collect number current insights that are org-visible by type of insight.
- * */
+ */
 export function getGroupedStepSizes(settings: Settings): number[] {
     return Object.keys(settings)
         .filter(key => key.startsWith(InsightTypePrefix.search))
@@ -113,44 +110,49 @@ export function getDaysFromInsightStep(step: Duration): number {
 interface InsightGroups {
     codeStatsInsights: number
     searchBasedInsights: number
+    searchBasedBackendInsights: number
+    searchBasedExtensionInsights: number
 }
 
 /**
  * Collect insights count statistic from orgs settings according to
  * auth user organization list.
- * */
-export function getInsightsGroupedByType(
-    settingsCascade: SettingsCascade<Settings>,
-    authUser: AuthenticatedUser
-): InsightGroups {
+ */
+export function getInsightsGroupedByType(settingsCascade: SettingsCascade<Settings>): InsightGroups {
     const { subjects } = settingsCascade
-    const {
-        organizations: { nodes: orgs },
-    } = authUser
-    const orgIDs = new Set(orgs.map(org => org.id))
 
-    const orgSubjects = subjects.filter(subject => orgIDs.has(subject.subject.id))
+    const globalSubjects = subjects.filter(configuredSubject => configuredSubject.subject.__typename === 'Site')
+    const orgSubjects = subjects.filter(configuredSubject => configuredSubject.subject.__typename === 'Org')
 
-    const finalSettingsOfAllOrgs = orgSubjects.reduce((finalSettings, orgSubject) => {
+    const finalSettingsOfAllPublicSubjects = [...globalSubjects, ...orgSubjects].reduce((finalSettings, orgSubject) => {
         const orgSettings = orgSubject.settings
 
         if (!orgSettings) {
             return finalSettings
         }
-        return { ...finalSettings, ...orgSettings }
-    }, {})
 
-    const codeStatsInsights = Object.keys(finalSettingsOfAllOrgs).filter(key =>
+        const mergedSettings = mergeSettings([finalSettings, orgSettings])
+
+        return mergedSettings ?? finalSettings
+    }, {} as Settings)
+
+    const codeStatsInsightCount = Object.keys(finalSettingsOfAllPublicSubjects).filter(key =>
         key.startsWith(InsightTypePrefix.langStats)
     ).length
 
-    const searchBasedInsights = Object.keys(finalSettingsOfAllOrgs).filter(key =>
+    const searchBasedExtensionInsightCount = Object.keys(finalSettingsOfAllPublicSubjects).filter(key =>
         key.startsWith(InsightTypePrefix.search)
     ).length
 
+    const searchBasedBackendInsightCount = Object.keys(
+        finalSettingsOfAllPublicSubjects[INSIGHTS_ALL_REPOS_SETTINGS_KEY] ?? {}
+    ).filter(key => key.startsWith(InsightTypePrefix.search)).length
+
     return {
-        codeStatsInsights,
-        searchBasedInsights,
+        codeStatsInsights: codeStatsInsightCount,
+        searchBasedInsights: searchBasedExtensionInsightCount + searchBasedBackendInsightCount,
+        searchBasedExtensionInsights: searchBasedExtensionInsightCount,
+        searchBasedBackendInsights: searchBasedBackendInsightCount,
     }
 }
 
@@ -231,31 +233,15 @@ export function parseInsightSettingsKey(key: string): Omit<InsightData, 'configu
         return undefined
     }
 
-    switch (insightType) {
-        // Exceptional extensions that don't adhere to the standard insight settings key format
-        case 'codeStatsInsights': {
-            if (key.split('.')[1] !== 'query') {
-                return
-            }
+    if (maybeInsight !== 'insight') {
+        return
+    }
 
-            return {
-                insightType,
-                name: insightType,
-            }
-        }
-
-        // Extensions that contribute insights should define settings
-        // keys with the format `$EXTENSION_NAME.insight` or `$EXTENSION_NAME.insight.$INSIGHT_NAME`
-        // example key: "searchInsights.insights.graphQLTypesMigration"
-        default: {
-            if (maybeInsight !== 'insight') {
-                return
-            }
-
-            return {
-                insightType,
-                name: insightName ?? insightType, // fallback to type
-            }
-        }
+    // Extensions that contribute insights should define settings
+    // keys with the format `$EXTENSION_NAME.insight` or `$EXTENSION_NAME.insight.$INSIGHT_NAME`
+    // example key: "searchInsights.insights.graphQLTypesMigration"
+    return {
+        insightType,
+        name: insightName ?? insightType, // fallback to type
     }
 }

--- a/client/web/src/insights/core/types/subjects.ts
+++ b/client/web/src/insights/core/types/subjects.ts
@@ -32,11 +32,11 @@ export const SUPPORTED_TYPES_OF_SUBJECT = new Set<string>(Object.values(Supporte
 export const isSubjectInsightSupported = (subject: SettingsSubject): subject is SupportedInsightSubject =>
     SUPPORTED_TYPES_OF_SUBJECT.has(subject.__typename)
 
-export const isGlobalSubject = (subject: SupportedInsightSubject): subject is SettingsSiteSubject =>
+export const isGlobalSubject = (subject: SettingsSubject): subject is SettingsSiteSubject =>
     subject.__typename === SupportedInsightSubjectType.Global
 
-export const isOrganizationSubject = (subject: SupportedInsightSubject): subject is SettingsOrgSubject =>
+export const isOrganizationSubject = (subject: SettingsSubject): subject is SettingsOrgSubject =>
     subject.__typename === SupportedInsightSubjectType.Organization
 
-export const isUserSubject = (subject: SupportedInsightSubject): subject is SettingsUserSubject =>
+export const isUserSubject = (subject: SettingsSubject): subject is SettingsUserSubject =>
     subject.__typename === SupportedInsightSubjectType.User


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/24177
Closes https://github.com/sourcegraph/sourcegraph/issues/24178

### Context
Historically we had been pinging the only extension-based insights which are stored as top-level properties in the setting cascade subjects. But since we introduced Backend Insights which are stored under the `insights.allrepos` key in subjects settings we should take into account this info too to be able to count insights properly. 

This PR adds logic to count backend insights with extension-based insights and at the same time extend ping counting event with new explicit info about extension and backend-based insights. 

```ts
interface InsightGroups {
    codeStatsInsights: number
    
    // All search insights extension-based + backend-based
    searchBasedInsights: number
    
    // Explicit number of backend based insights
    searchBasedBackendInsights: number
    
    // Explicit number of extension based insights
    searchBasedExtensionInsights: number
}
```
 
Note that all insights are counted only from shared places like org-level settings or global site-wide settings. Personal insights don't count. This logic about this was introduced in [this RFC about Code Insights Pings](https://docs.google.com/document/d/1YFmBiqeAZJccXJi8aFPdtvrP-ysLh46sePKH8RGiT6U/edit#)

> of current insights that are org-visible by week, by type of insight – the # of insights that are org-wide in visibility (note: if there are 4 one week, then one more is created, the next week of data should show 5. This metric is not measuring an org-visible insight just on the week it is created) 
This helps us understand if folks are sharing insights at all or just experimenting on their own
