### PR TITLE
web: remove `.theme-redesign` selector from code-monitoring

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
@@ -8,13 +8,11 @@
         padding: 0;
     }
 
-    .theme-redesign & {
-        &:not(:last-of-type) {
-            margin-bottom: 1rem;
-        }
-        + .code-monitoring-node {
-            padding-top: 1rem;
-            border-top: 1px solid var(--border-color);
-        }
+    &:not(:last-of-type) {
+        margin-bottom: 1rem;
+    }
+    + .code-monitoring-node {
+        padding-top: 1rem;
+        border-top: 1px solid var(--border-color);
     }
 }


### PR DESCRIPTION
## Changes

- Removed `.theme-redesign` usage from code-monitoring.

Part of https://github.com/sourcegraph/sourcegraph/issues/20847.