### PR TITLE
sg: Check if new `sg` version is available if executed in sourcegraph/sourcegraph

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -5,7 +5,12 @@ pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
 echo "Compiling..."
 
-export GIT_COMMIT=$(git rev-list -1 HEAD .)
+if [[ $(git diff --stat .) != '' ]]; then
+  export GIT_COMMIT="dev"
+else
+  export GIT_COMMIT=$(git rev-list -1 HEAD .)
+fi
+
 # -mod=mod: default is -mod=readonly. However, because our lib dependency is
 #           not fixed everytime it changes we need to update go.sum. By making
 #           it rw we prevent failing go install.

--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -5,10 +5,11 @@ pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
 echo "Compiling..."
 
+export GIT_COMMIT=$(git rev-list -1 HEAD .)
 # -mod=mod: default is -mod=readonly. However, because our lib dependency is
 #           not fixed everytime it changes we need to update go.sum. By making
 #           it rw we prevent failing go install.
-go install -mod=mod .
+go install -ldflags "-X main.BuildCommit=$GIT_COMMIT" -mod=mod .
 
 # Let's find the install target. The documentation at
 #   https://golang.org/cmd/go/#hdr-Compile_and_install_packages_and_dependencies

--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -3,18 +3,21 @@
 set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
-echo "Compiling..."
-
+# The BUILD_COMMIT is baked into the binary (see `go install` below) and
+# contains the latest commit in the `dev/sg` folder. If the directory is
+# "dirty", though, we mark the build as a dev build.
 if [[ $(git diff --stat .) != '' ]]; then
-  export GIT_COMMIT="dev"
+  BUILD_COMMIT="dev"
 else
-  export GIT_COMMIT=$(git rev-list -1 HEAD .)
+  BUILD_COMMIT=$(git rev-list -1 HEAD .)
 fi
+export BUILD_COMMIT
 
+echo "Compiling..."
 # -mod=mod: default is -mod=readonly. However, because our lib dependency is
 #           not fixed everytime it changes we need to update go.sum. By making
 #           it rw we prevent failing go install.
-go install -ldflags "-X main.BuildCommit=$GIT_COMMIT" -mod=mod .
+go install -ldflags "-X main.BuildCommit=$BUILD_COMMIT" -mod=mod .
 
 # Let's find the install target. The documentation at
 #   https://golang.org/cmd/go/#hdr-Compile_and_install_packages_and_dependencies

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -260,28 +260,38 @@ func setMaxOpenFiles() error {
 	return nil
 }
 
+func checkSgVersion() {
+	_, err := root.RepositoryRoot()
+	if err != nil {
+		// Ignore the error, because we only want to check the version if we're
+		// in sourcegraph/sourcegraph
+		return
+	}
+
+	if BuildCommit == "dev" {
+		// If `sg` was built with a dirty `./dev/sg` directory it's a dev build
+		// and we don't need to display this message.
+		return
+	}
+
+	out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..HEAD", BuildCommit), "./dev/sg")
+	if err != nil {
+		fmt.Printf("error getting new commits in ./dev/sg: %s\n", err)
+		os.Exit(1)
+	}
+
+	out = strings.TrimSpace(out)
+	if out != "" {
+		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "New version of sg available. Run `./dev/sg/install.sh` to install it.\n"))
+	}
+}
+
 func main() {
 	if err := rootCommand.Parse(os.Args[1:]); err != nil {
 		os.Exit(1)
 	}
 
-	fmt.Printf("version:%s\n", BuildCommit)
-
-	_, err := root.RepositoryRoot()
-	if err == nil && BuildCommit != "dev" {
-		// Ignore the error, because we only want to check the version if we're
-		// in sourcegraph/sourcegraph
-		out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..HEAD", BuildCommit), "./dev/sg")
-		if err != nil {
-			fmt.Printf("error: %s\n", err)
-			os.Exit(1)
-		}
-		out = strings.TrimSpace(out)
-		fmt.Printf("out: %q\n", out)
-		if out != "" {
-			fmt.Printf("WATCH OUT! New `sg` available!!!!!")
-		}
-	}
+	checkSgVersion()
 
 	// We always try to set this, since we often want to watch files, start commands, etc.
 	if err := setMaxOpenFiles(); err != nil {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -970,7 +970,6 @@ func printLogo(out io.Writer) {
 }
 
 func logoExec(ctx context.Context, args []string) error {
-	return nil
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r1 := rand.New(s1)
 	randoColor := func() output.Style { return output.Fg256Color(r1.Intn(256)) }

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -282,9 +282,9 @@ func checkSgVersion() {
 
 	out = strings.TrimSpace(out)
 	if out != "" {
-		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "---------------------------"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "New version of sg available. Run `./dev/sg/install.sh` to install it.\n"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "---------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "---------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "New version of sg available. Run `./dev/sg/install.sh` to install it.\n"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "---------------------------"))
 	}
 }
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -282,9 +282,9 @@ func checkSgVersion() {
 
 	out = strings.TrimSpace(out)
 	if out != "" {
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "New version of sg available. Run `./dev/sg/install.sh` to install it.\n"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------------------------------------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "HOT HOT HOT: New version of sg available. Run `./dev/sg/install.sh` to install it."))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------------------------------------------------------"))
 	}
 }
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -282,9 +282,9 @@ func checkSgVersion() {
 
 	out = strings.TrimSpace(out)
 	if out != "" {
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------------------------------------------------------"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "HOT HOT HOT: New version of sg available. Run `./dev/sg/install.sh` to install it."))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------------------------------------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "--------------------------------------------------------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "HEY! New version of sg available. Run `./dev/sg/install.sh` to install it."))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "--------------------------------------------------------------------------"))
 	}
 }
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -282,9 +282,9 @@ func checkSgVersion() {
 
 	out = strings.TrimSpace(out)
 	if out != "" {
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "---------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------"))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "New version of sg available. Run `./dev/sg/install.sh` to install it.\n"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "---------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "----------------------------------"))
 	}
 }
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -282,7 +282,9 @@ func checkSgVersion() {
 
 	out = strings.TrimSpace(out)
 	if out != "" {
+		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "---------------------------"))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "New version of sg available. Run `./dev/sg/install.sh` to install it.\n"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "---------------------------"))
 	}
 }
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
+var BuildCommit string = "dev"
+
 var out *output.Output = stdout.Out
 
 var (
@@ -261,6 +263,24 @@ func setMaxOpenFiles() error {
 func main() {
 	if err := rootCommand.Parse(os.Args[1:]); err != nil {
 		os.Exit(1)
+	}
+
+	fmt.Printf("version:%s\n", BuildCommit)
+
+	_, err := root.RepositoryRoot()
+	if err == nil && BuildCommit != "dev" {
+		// Ignore the error, because we only want to check the version if we're
+		// in sourcegraph/sourcegraph
+		out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..HEAD", BuildCommit), "./dev/sg")
+		if err != nil {
+			fmt.Printf("error: %s\n", err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		fmt.Printf("out: %q\n", out)
+		if out != "" {
+			fmt.Printf("WATCH OUT! New `sg` available!!!!!")
+		}
 	}
 
 	// We always try to set this, since we often want to watch files, start commands, etc.
@@ -938,6 +958,7 @@ func printLogo(out io.Writer) {
 }
 
 func logoExec(ctx context.Context, args []string) error {
+	return nil
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r1 := rand.New(s1)
 	randoColor := func() output.Style { return output.Fg256Color(r1.Intn(256)) }


### PR DESCRIPTION
In collaboration with @jeanduplessis this is the first version of the version check.

Screenshot:

<img width="1104" alt="screenshot_2021-08-20_17 55 31@2x" src="https://user-images.githubusercontent.com/1185253/130260518-f3f11f0b-7ecd-4581-bc5d-2def26abace2.png">


