### PR TITLE
NO merge 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+-
+
+### Changed
+
+-
+
+### Fixed
+
+-
+
+### Removed
+
+-
+
+## 3.30.0
+
+### Added
+
 - Added support for `select:file.directory` in search queries, which returns unique directory paths for results that satisfy the query. [#22449](https://github.com/sourcegraph/sourcegraph/pull/22449)
 - An `sg_service` Postgres role has been introduced, as well as an `sg_repo_access_policy` policy on the `repo` table that restricts access to that role. The role that owns the `repo` table will continue to get unrestricted access. [#22303](https://github.com/sourcegraph/sourcegraph/pull/22303)
 - Every service that connects to the database (i.e. Postgres) now has a "Database connections" monitoring section in its Grafana dashboard. [#22570](https://github.com/sourcegraph/sourcegraph/pull/22570)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,15 @@ All notable changes to Sourcegraph are documented in this file.
 
 -
 
-## 3.30.2
+## 3.30.3
 
-**⚠️ Users upgrading from 3.29 are advised to upgrade directly to 3.30.2**
+**⚠️ Users upgrading from 3.29 are advised to upgrade directly to 3.30.3**
+
+### Fixed
+
+- Codeintel-db database images have been reverted back to debian due to corruption caused by glibc and alpine. [23324](https://github.com/sourcegraph/sourcegraph/pull/23324)
+
+## 3.30.2
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 -
+- Code Insights backend has moved from the `repo-updater` service to the `worker` service. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
+- Code Insights feature flag `DISABLE_CODE_INSIGHTS` environment variable has moved from the `repo-updater` service to the `worker` service. Any users of this flag will need to update their `worker` service configuration to continue using it. [#23050](https://github.com/sourcegraph/sourcegraph/pull/23050)
 
 ### Fixed
 
@@ -28,6 +30,14 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 -
+
+## 3.30.2
+
+**⚠️ Users upgrading from 3.29 are advised to upgrade directly to 3.30.2**
+
+### Fixed
+
+- Postgres database images have been reverted back to debian due to corruption caused by glibc and alpine. [23302](https://github.com/sourcegraph/sourcegraph/pull/23302)
 
 ## 3.30.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ All notable changes to Sourcegraph are documented in this file.
 - The experimental paginated search feature (the `stable:` keyword) has been removed, to be replaced with streaming search. [#22428](https://github.com/sourcegraph/sourcegraph/pull/22428)
 - The experimental extensions view page has been removed. [#22565](https://github.com/sourcegraph/sourcegraph/pull/22565)
 - A search query diagnostic that previously warned the user when quotes are interpreted literally has been removed. The literal meaning has been Sourcegraph's default search behavior for some time now. [#22892](https://github.com/sourcegraph/sourcegraph/pull/22892)
+- The old batch repository syncer was removed and can no longer be activated by setting `ENABLE_STREAMING_REPOS_SYNCER=false`. [#22949](https://github.com/sourcegraph/sourcegraph/pull/22949)
+- Non-root overlays were removed for `deploy-sourcegraph` in favor of using `non-privileged`. [#3404](https://github.com/sourcegraph/deploy-sourcegraph/pull/3404)
 
 ### API docs (experimental)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 -
 
+## 3.30.1
+
+### Fixed
+
+- An issue where the UI would occassionally display `lsifStore.Ranges: ERROR: relation \"lsif_documentation_mappings\" does not exist (SQLSTATE 42P01)` [#23115](https://github.com/sourcegraph/sourcegraph/pull/23115)
+
 ## 3.30.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - An issue where the UI would occassionally display `lsifStore.Ranges: ERROR: relation \"lsif_documentation_mappings\" does not exist (SQLSTATE 42P01)` [#23115](https://github.com/sourcegraph/sourcegraph/pull/23115)
+- Fixed a vulnerability in our Postgres Alpine image related to libgcrypt [#23174](https://github.com/sourcegraph/sourcegraph/pull/23174)
 
 ## 3.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to Sourcegraph are documented in this file.
 
 - An issue where the UI would occassionally display `lsifStore.Ranges: ERROR: relation \"lsif_documentation_mappings\" does not exist (SQLSTATE 42P01)` [#23115](https://github.com/sourcegraph/sourcegraph/pull/23115)
 - Fixed a vulnerability in our Postgres Alpine image related to libgcrypt [#23174](https://github.com/sourcegraph/sourcegraph/pull/23174)
+- When syncing in streaming mode, repo-updater will now ensure a repo's transaction is committed before notifying gitserver to update that repo. [#23169](https://github.com/sourcegraph/sourcegraph/pull/23169)
+- When encountering spurious errors during streaming syncing (like temporary 500s from codehosts), repo-updater will no longer delete all associated repos that weren't seen. Deletion will happen only if there were no errors or if the error was one of "Unauthorized", "Forbidden" or "Account Suspended". [#23171](https://github.com/sourcegraph/sourcegraph/pull/23171)
+- External HTTP requests are now automatically retried when appropriate. [#23131](https://github.com/sourcegraph/sourcegraph/pull/23131)
 
 ## 3.30.0
 

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -135,6 +135,8 @@ type GitTreeLSIFDataResolver interface {
 	Diagnostics(ctx context.Context, args *LSIFDiagnosticsArgs) (DiagnosticConnectionResolver, error)
 	DocumentationPage(ctx context.Context, args *LSIFDocumentationPageArgs) (DocumentationPageResolver, error)
 	DocumentationPathInfo(ctx context.Context, args *LSIFDocumentationPathInfoArgs) (JSONValue, error)
+	DocumentationDefinitions(ctx context.Context, args *LSIFQueryDocumentationArgs) (LocationConnectionResolver, error)
+	DocumentationReferences(ctx context.Context, args *LSIFPagedQueryDocumentationArgs) (LocationConnectionResolver, error)
 }
 
 type CodeIntelligenceCommitGraphResolver interface {
@@ -152,8 +154,6 @@ type GitBlobLSIFDataResolver interface {
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)
 	Documentation(ctx context.Context, args *LSIFQueryPositionArgs) (DocumentationResolver, error)
-	DocumentationDefinitions(ctx context.Context, args *LSIFQueryDocumentationArgs) (LocationConnectionResolver, error)
-	DocumentationReferences(ctx context.Context, args *LSIFPagedQueryDocumentationArgs) (LocationConnectionResolver, error)
 }
 
 type GitBlobLSIFDataArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -258,6 +258,36 @@ interface TreeEntryLSIFData {
     https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+type+DocumentationPathInfoResult+struct&patternType=literal&case=yes
     """
     documentationPathInfo(pathID: String!, maxDepth: Int, ignoreIndex: Boolean): JSONValue!
+
+    """
+    A list of definitions of the symbol described by the given documentation path ID, if any.
+    """
+    documentationDefinitions(pathID: String!): LocationConnection!
+
+    """
+    A list of references of the symbol under the given document position.
+    """
+    documentationReferences(
+        """
+        The documentation path ID, e.g. from the documentationPage return value.
+        """
+        pathID: String!
+
+        """
+        When specified, indicates that this request should be paginated and
+        to fetch results starting at this cursor.
+        A future request can be made for more results by passing in the
+        'LocationConnection.pageInfo.endCursor' that is returned.
+        """
+        after: String
+
+        """
+        When specified, indicates that this request should be paginated and
+        the first N results (relative to the cursor) should be returned. i.e.
+        how many results to return per page.
+        """
+        first: Int
+    ): LocationConnection!
 }
 
 """

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -33,17 +33,17 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	//version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newBuild("3.29.1")
+	latestReleaseDockerServerImageBuild = newBuild("3.30.0")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newBuild("3.29.1")
+	latestReleaseKubernetesBuild = newBuild("3.30.0")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newBuild("3.29.1")
+	latestReleaseDockerComposeOrPureDocker = newBuild("3.30.0")
 )
 
 func getLatestRelease(deployType string) build {

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -33,17 +33,17 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	//version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newBuild("3.30.0")
+	latestReleaseDockerServerImageBuild = newBuild("3.30.1")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newBuild("3.30.0")
+	latestReleaseKubernetesBuild = newBuild("3.30.1")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newBuild("3.30.0")
+	latestReleaseDockerComposeOrPureDocker = newBuild("3.30.1")
 )
 
 func getLatestRelease(deployType string) build {

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update && apk add --no-cache \
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     'bash=5.0.17-r0' \
-    'redis=5.0.11-r0' \
+    'redis=5.0.13-r0' \
     # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
     'git>=2.18' \
     git-p4 \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -49,6 +49,7 @@ RUN apk update && apk add --no-cache \
     'git>=2.18' \
     git-p4 \
     python2 \
+    python3 \
     'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=14.5.0-r0' \
     postgresql=12.7-r0 \
     postgresql-contrib

--- a/doc/admin/external_services/postgres.md
+++ b/doc/admin/external_services/postgres.md
@@ -32,7 +32,7 @@ Add the following to your `docker run` command:
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 
-<pre class="pre-wrap start-sourcegraph-command"><code>docker run [...]<span class="virtual-br"></span> -e PGHOST=psql1.mycompany.org<span class="virtual-br"></span> -e PGUSER=sourcegraph<span class="virtual-br"></span> -e PGPASSWORD=secret<span class="virtual-br"></span> -e PGDATABASE=sourcegraph<span class="virtual-br"></span> -e PGSSLMODE=require<span class="virtual-br"> -e CODEINTEL_PGHOST=psql2.mycompany.org<span class="virtual-br"></span> -e CODEINTEL_PGUSER=sourcegraph<span class="virtual-br"></span> -e CODEINTEL_PGPASSWORD=secret<span class="virtual-br"></span> -e CODEINTEL_PGDATABASE=sourcegraph-codeintel<span class="virtual-br"></span> -e CODEINTEL_PGSSLMODE=require<span class="virtual-br"></span> sourcegraph/server:3.30.0</code></pre>
+<pre class="pre-wrap start-sourcegraph-command"><code>docker run [...]<span class="virtual-br"></span> -e PGHOST=psql1.mycompany.org<span class="virtual-br"></span> -e PGUSER=sourcegraph<span class="virtual-br"></span> -e PGPASSWORD=secret<span class="virtual-br"></span> -e PGDATABASE=sourcegraph<span class="virtual-br"></span> -e PGSSLMODE=require<span class="virtual-br"> -e CODEINTEL_PGHOST=psql2.mycompany.org<span class="virtual-br"></span> -e CODEINTEL_PGUSER=sourcegraph<span class="virtual-br"></span> -e CODEINTEL_PGPASSWORD=secret<span class="virtual-br"></span> -e CODEINTEL_PGDATABASE=sourcegraph-codeintel<span class="virtual-br"></span> -e CODEINTEL_PGSSLMODE=require<span class="virtual-br"></span> sourcegraph/server:3.30.1</code></pre>
 
 ### Docker Compose
 

--- a/doc/admin/external_services/postgres.md
+++ b/doc/admin/external_services/postgres.md
@@ -32,7 +32,7 @@ Add the following to your `docker run` command:
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 
-<pre class="pre-wrap start-sourcegraph-command"><code>docker run [...]<span class="virtual-br"></span> -e PGHOST=psql1.mycompany.org<span class="virtual-br"></span> -e PGUSER=sourcegraph<span class="virtual-br"></span> -e PGPASSWORD=secret<span class="virtual-br"></span> -e PGDATABASE=sourcegraph<span class="virtual-br"></span> -e PGSSLMODE=require<span class="virtual-br"> -e CODEINTEL_PGHOST=psql2.mycompany.org<span class="virtual-br"></span> -e CODEINTEL_PGUSER=sourcegraph<span class="virtual-br"></span> -e CODEINTEL_PGPASSWORD=secret<span class="virtual-br"></span> -e CODEINTEL_PGDATABASE=sourcegraph-codeintel<span class="virtual-br"></span> -e CODEINTEL_PGSSLMODE=require<span class="virtual-br"></span> sourcegraph/server:3.29.1</code></pre>
+<pre class="pre-wrap start-sourcegraph-command"><code>docker run [...]<span class="virtual-br"></span> -e PGHOST=psql1.mycompany.org<span class="virtual-br"></span> -e PGUSER=sourcegraph<span class="virtual-br"></span> -e PGPASSWORD=secret<span class="virtual-br"></span> -e PGDATABASE=sourcegraph<span class="virtual-br"></span> -e PGSSLMODE=require<span class="virtual-br"> -e CODEINTEL_PGHOST=psql2.mycompany.org<span class="virtual-br"></span> -e CODEINTEL_PGUSER=sourcegraph<span class="virtual-br"></span> -e CODEINTEL_PGPASSWORD=secret<span class="virtual-br"></span> -e CODEINTEL_PGDATABASE=sourcegraph-codeintel<span class="virtual-br"></span> -e CODEINTEL_PGSSLMODE=require<span class="virtual-br"></span> sourcegraph/server:3.30.0</code></pre>
 
 ### Docker Compose
 

--- a/doc/admin/external_services/redis.md
+++ b/doc/admin/external_services/redis.md
@@ -12,7 +12,7 @@ or follow the [IANA specification for Redis URLs](https://www.iana.org/assignmen
   We want line breaks for readability, but backslashes to escape them do not work cross-platform.
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
-<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.29.1</code></pre>
+<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.30.0</code></pre>
 
 > NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
 

--- a/doc/admin/external_services/redis.md
+++ b/doc/admin/external_services/redis.md
@@ -12,7 +12,7 @@ or follow the [IANA specification for Redis URLs](https://www.iana.org/assignmen
   We want line breaks for readability, but backslashes to escape them do not work cross-platform.
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
-<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.30.0</code></pre>
+<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.30.1</code></pre>
 
 > NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
 

--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -37,7 +37,7 @@ docker container run \
   \
   --volume ~/.sourcegraph/config:/etc/sourcegraph  \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph  \
-  sourcegraph/server:3.30.0
+  sourcegraph/server:3.30.1
 ```
 
 ### Sourcegraph Cluster (Kubernetes)

--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -37,7 +37,7 @@ docker container run \
   \
   --volume ~/.sourcegraph/config:/etc/sourcegraph  \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph  \
-  sourcegraph/server:3.29.1
+  sourcegraph/server:3.30.0
 ```
 
 ### Sourcegraph Cluster (Kubernetes)

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -30,7 +30,7 @@ DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.29.1'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.0'
 
 # Install git
 yum update -y

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -30,7 +30,7 @@ DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.0'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.1'
 
 # Install git
 yum update -y

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -34,7 +34,7 @@ DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.29.1'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.0'
 
 # Install git
 sudo apt-get update -y

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -34,7 +34,7 @@ DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.0'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.1'
 
 # Install git
 sudo apt-get update -y

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -34,7 +34,7 @@ DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.29.1'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.0'
 
 # Install git
 sudo apt-get update -y

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -34,7 +34,7 @@ DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.0'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.30.1'
 
 # Install git
 sudo apt-get update -y

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -35,7 +35,7 @@ It takes less than 5 minutes to run and install Sourcegraph using Docker Compose
 
 git clone https://github.com/sourcegraph/deploy-sourcegraph-docker
 cd deploy-sourcegraph-docker/docker-compose
-export SOURCEGRAPH_VERSION="v3.29.1"
+export SOURCEGRAPH_VERSION="v3.30.0"
 git checkout $SOURCEGRAPH_VERSION
 docker-compose up -d
 ```

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -33,7 +33,7 @@ This tutorial shows you how to deploy Sourcegraph to a single EC2 instance on AW
    - usermod -a -G docker ec2-user
 
    # Install and run Sourcegraph. Restart the container upon subsequent reboots
-   - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7080 --publish 127.0.0.1:3370:3370 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.29.1' ]
+   - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7080 --publish 127.0.0.1:3370:3370 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0' ]
    ```
 
 - Select **Next: ...** until you get to the **Configure Security Group** page. Then add the following rules:

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -33,7 +33,7 @@ This tutorial shows you how to deploy Sourcegraph to a single EC2 instance on AW
    - usermod -a -G docker ec2-user
 
    # Install and run Sourcegraph. Restart the container upon subsequent reboots
-   - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7080 --publish 127.0.0.1:3370:3370 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0' ]
+   - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7080 --publish 127.0.0.1:3370:3370 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.1' ]
    ```
 
 - Select **Next: ...** until you get to the **Configure Security Group** page. Then add the following rules:

--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -17,7 +17,7 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Di
 1. Run the Sourcegraph Docker image as a daemon:
 
    ```
-   docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0
+   docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.1
    ```
 1. Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a
    DNS entry for the IP, configure `externalURL` to reflect that.

--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -17,7 +17,7 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Di
 1. Run the Sourcegraph Docker image as a daemon:
 
    ```
-   docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.29.1
+   docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0
    ```
 1. Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a
    DNS entry for the IP, configure `externalURL` to reflect that.

--- a/doc/admin/install/docker/google_cloud.md
+++ b/doc/admin/install/docker/google_cloud.md
@@ -23,7 +23,7 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Go
   sudo apt-get install -y docker-ce
   mkdir -p /root/.sourcegraph/config
   mkdir -p /root/.sourcegraph/data
-  docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0
+  docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.1
   ```
 
 - Create your VM, then navigate to its public IP address.

--- a/doc/admin/install/docker/google_cloud.md
+++ b/doc/admin/install/docker/google_cloud.md
@@ -23,7 +23,7 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Go
   sudo apt-get install -y docker-ce
   mkdir -p /root/.sourcegraph/config
   mkdir -p /root/.sourcegraph/data
-  docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.29.1
+  docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0
   ```
 
 - Create your VM, then navigate to its public IP address.

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -12,7 +12,7 @@ It takes less than a minute to run and install Sourcegraph using Docker:
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 
-<pre class="pre-wrap start-sourcegraph-command"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.30.0</code></pre>
+<pre class="pre-wrap start-sourcegraph-command"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.30.1</code></pre>
 
 Once the server is ready (logo is displayed in the terminal), navigate to the hostname or IP address on port `7080`.  Create the admin account, then you'll be guided through setting up Sourcegraph for code searching and navigation.
 
@@ -67,7 +67,7 @@ Sourcegraph can be **tested** on Windows 10 using roughly the same steps provide
 1. [Install Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
 2. Using a command prompt, follow the same [installation steps provided above](#install-sourcegraph-with-docker) but remove the `--volume` arguments. For example by pasting this:
 
-<pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> sourcegraph/server:3.30.0</code></pre>
+<pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> sourcegraph/server:3.30.1</code></pre>
 
 ## Low resource environments
 

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -12,7 +12,7 @@ It takes less than a minute to run and install Sourcegraph using Docker:
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 
-<pre class="pre-wrap start-sourcegraph-command"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.29.1</code></pre>
+<pre class="pre-wrap start-sourcegraph-command"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.30.0</code></pre>
 
 Once the server is ready (logo is displayed in the terminal), navigate to the hostname or IP address on port `7080`.  Create the admin account, then you'll be guided through setting up Sourcegraph for code searching and navigation.
 
@@ -67,7 +67,7 @@ Sourcegraph can be **tested** on Windows 10 using roughly the same steps provide
 1. [Install Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
 2. Using a command prompt, follow the same [installation steps provided above](#install-sourcegraph-with-docker) but remove the `--volume` arguments. For example by pasting this:
 
-<pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> sourcegraph/server:3.29.1</code></pre>
+<pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> sourcegraph/server:3.30.0</code></pre>
 
 ## Low resource environments
 

--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -36,7 +36,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 # Use the branch of this repository corresponding to the version of Sourcegraph you wish to deploy, e.g. git checkout 3.24
 git clone https://github.com/sourcegraph/deploy-sourcegraph
 cd deploy-sourcegraph
-export SOURCEGRAPH_VERSION="v3.30.0"
+export SOURCEGRAPH_VERSION="v3.30.1"
 git checkout $SOURCEGRAPH_VERSION
 ```
 

--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -36,7 +36,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 # Use the branch of this repository corresponding to the version of Sourcegraph you wish to deploy, e.g. git checkout 3.24
 git clone https://github.com/sourcegraph/deploy-sourcegraph
 cd deploy-sourcegraph
-export SOURCEGRAPH_VERSION="v3.29.1"
+export SOURCEGRAPH_VERSION="v3.30.0"
 git checkout $SOURCEGRAPH_VERSION
 ```
 

--- a/doc/admin/pprof.md
+++ b/doc/admin/pprof.md
@@ -23,7 +23,7 @@ kubectl port-forward sourcegraph-frontend-xxxx 6060:6060
 The docker run command for the single-container server needs an additional publish flag to expose the debug port:
 
 ```bash script
-docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --publish 127.0.0.1:6060:6060 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0
+docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --publish 127.0.0.1:6060:6060 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.1
 ```
 
 If Sourcegraph is deployed to a remote server, then access via an SSH tunnel using a tool

--- a/doc/admin/pprof.md
+++ b/doc/admin/pprof.md
@@ -23,7 +23,7 @@ kubectl port-forward sourcegraph-frontend-xxxx 6060:6060
 The docker run command for the single-container server needs an additional publish flag to expose the debug port:
 
 ```bash script
-docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --publish 127.0.0.1:6060:6060 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.29.1
+docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --publish 127.0.0.1:6060:6060 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.30.0
 ```
 
 If Sourcegraph is deployed to a remote server, then access via an SSH tunnel using a tool

--- a/doc/admin/repo/custom_git_or_ssh_config.md
+++ b/doc/admin/repo/custom_git_or_ssh_config.md
@@ -17,7 +17,7 @@ For example, to mount a `.gitconfig`, create a file `/mnt/sourcegraph/config/git
 Alternatively you can create a new Docker image which inherits from Sourcegraph and then mutates the environment:
 
 ``` dockerfile
-FROM sourcegraph/server:3.29.1
+FROM sourcegraph/server:3.30.0
 
 COPY gitconfig /etc/gitconfig
 COPY ssh /root/.ssh

--- a/doc/admin/repo/custom_git_or_ssh_config.md
+++ b/doc/admin/repo/custom_git_or_ssh_config.md
@@ -17,7 +17,7 @@ For example, to mount a `.gitconfig`, create a file `/mnt/sourcegraph/config/git
 Alternatively you can create a new Docker image which inherits from Sourcegraph and then mutates the environment:
 
 ``` dockerfile
-FROM sourcegraph/server:3.30.0
+FROM sourcegraph/server:3.30.1
 
 COPY gitconfig /etc/gitconfig
 COPY ssh /root/.ssh

--- a/doc/admin/ssl_https_self_signed_cert_nginx.md
+++ b/doc/admin/ssl_https_self_signed_cert_nginx.md
@@ -91,7 +91,7 @@ docker container run \
   \
   --volume ~/.sourcegraph/config:/etc/sourcegraph  \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph  \
-  sourcegraph/server:3.30.0
+  sourcegraph/server:3.30.1
 ```
 
 > NOTE: We recommend removing `--publish 7080:7080` as it's not needed and traffic sent to that port is un-encrypted.

--- a/doc/admin/ssl_https_self_signed_cert_nginx.md
+++ b/doc/admin/ssl_https_self_signed_cert_nginx.md
@@ -91,7 +91,7 @@ docker container run \
   \
   --volume ~/.sourcegraph/config:/etc/sourcegraph  \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph  \
-  sourcegraph/server:3.29.1
+  sourcegraph/server:3.30.0
 ```
 
 > NOTE: We recommend removing `--publish 7080:7080` as it's not needed and traffic sent to that port is un-encrypted.

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -16,6 +16,14 @@ A new version of Sourcegraph is released every month (with patch releases in bet
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## 3.29 -> 3.30
+
+No manual migration required.
+
+Please upgrade to the [`v3.30.0` tag of deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/5d48fde63b2a60f46cd12bbc321a92ccdca79575) by following the [standard upgrade procedure](#standard-upgrade-procedure).
+
+*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.29).*
+
 ## 3.28 -> 3.29
 
 This upgrade adds a new `worker` service that runs a number of background jobs that were previously run in the `frontend` service. See [notes on deploying workers](../workers.md#deploying-workers) for additional details. Good initial values for CPU and memory resources allocated to this new service should match the `frontend` service.

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -24,6 +24,14 @@ Please upgrade to the [`v3.30.0` tag of deploy-sourcegraph-docker](https://githu
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.29).*
 
+## 3.29 -> 3.30.1
+
+**⚠️ Prefer upgrading to the 3.30.1 release over 3.30.0 release, see the CHANGELOG for more info**
+
+No manual migration required.
+
+Please upgrade to the [`v3.30.1` tag of deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.26.0/docker-compose) by following the [standard upgrade procedure](#standard-upgrade-procedure).
+
 ## 3.28 -> 3.29
 
 This upgrade adds a new `worker` service that runs a number of background jobs that were previously run in the `frontend` service. See [notes on deploying workers](../workers.md#deploying-workers) for additional details. Good initial values for CPU and memory resources allocated to this new service should match the `frontend` service.

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -19,10 +19,12 @@ and any manual migration steps you must perform.
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
-## 3.29 -> 3.30
+## 3.29 -> 3.30.1
+
+**⚠️ Prefer upgrading to the 3.30.1 release see CHANGELOG for more info**
 
 This upgrade removes the `non-root` overlay, in favor of using only the `non-privileged` overlay for deploying Sourcegraph in secure environments. If you were
-previously deploying using the `non-root` overlay, you should now generate overlays using the `non-privileged` overlay.  
+previously deploying using the `non-root` overlay, you should now generate overlays using the `non-privileged` overlay.
 
 No other manual migration is required, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your
 deployment.

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -19,6 +19,13 @@ and any manual migration steps you must perform.
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## 3.29 -> 3.30
+
+No manual migration required, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your
+deployment.
+
+*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.29).*
+
 ## 3.28 -> 3.29
 
 This upgrade adds a new `worker` service that runs a number of background jobs that were previously run in the `frontend` service. See [notes on deploying workers](../workers.md#deploying-workers) for additional details. Good initial values for CPU and memory resources allocated to this new service should match the `frontend` service.

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -21,7 +21,10 @@ and any manual migration steps you must perform.
 
 ## 3.29 -> 3.30
 
-No manual migration required, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your
+This upgrade removes the `non-root` overlay, in favor of using only the `non-privileged` overlay for deploying Sourcegraph in secure environments. If you were
+previously deploying using the `non-root` overlay, you should now generate overlays using the `non-privileged` overlay.  
+
+No other manual migration is required, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your
 deployment.
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.29).*

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -16,7 +16,14 @@ A new version of Sourcegraph is released every month (with patch releases in bet
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## 3.30.0 -> 3.30.1
+
+To upgrade, please perform the changes in the following diff:
+[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/ac2b05f403c981568a253e4b2d037e7548726218](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/ac2b05f403c981568a253e4b2d037e7548726218)
+
 ## 3.29 -> 3.30.0
+
+**⚠️ Prefer upgrading to the 3.30.1 release see CHANGELOG for more info**
 
 To upgrade, please perform the changes in the following diff:
 [https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/63802ca5966754162c2b3e077e64e60687138874](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/63802ca5966754162c2b3e077e64e60687138874)

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -16,6 +16,12 @@ A new version of Sourcegraph is released every month (with patch releases in bet
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## 3.29 -> 3.30.0
+
+To upgrade, please perform the changes in the following diff:
+[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/63802ca5966754162c2b3e077e64e60687138874](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/63802ca5966754162c2b3e077e64e60687138874)
+
+*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.29).*
 
 ## 3.28 -> 3.29.1
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -13,7 +13,7 @@ A new version of Sourcegraph is released every month (with patch releases in bet
 
 **Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
-## 3.28 -> 3.29 
+## 3.29 -> 3.30.1
 
 ## Standard upgrade procedure
 
@@ -21,7 +21,15 @@ To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.
 
 You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
 
-## 3.27 -> 3.28 
+## 3.28 -> 3.29
+
+## Standard upgrade procedure
+
+To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
+
+You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
+
+## 3.27 -> 3.28
 
 ## Standard upgrade procedure
 
@@ -76,7 +84,7 @@ In Sourcegraph version 3.20, we would automatically generate a secret key file (
 
 ## 3.16 -> 3.17
 
-- There was [a bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in the `sourcegraph/server:3.30.0` release that caused the version displayed on the `site-admin/update` page to be `0.0.0+dev` instead of `3.17.0`. This issue [was fixed](https://github.com/sourcegraph/sourcegraph/pull/11633) in the `3.17.2` release. We recommend that you avoid this issue by upgrading past `3.17.0` to `3.17.2` using the [Standard upgrade procedure](#Standard-upgrade-procedure) listed below.
+- There was [a bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in release that caused the version displayed on the `site-admin/update` page to be `0.0.0+dev` instead of `3.17.0`. This issue [was fixed](https://github.com/sourcegraph/sourcegraph/pull/11633) in the `3.17.2` release. We recommend that you avoid this issue by upgrading past `3.17.0` to `3.17.2` using the [Standard upgrade procedure](#Standard-upgrade-procedure) listed below.
 
 ## Standard upgrade procedure
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -76,7 +76,7 @@ In Sourcegraph version 3.20, we would automatically generate a secret key file (
 
 ## 3.16 -> 3.17
 
-- There was [a bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in the `sourcegraph/server:3.29.1` release that caused the version displayed on the `site-admin/update` page to be `0.0.0+dev` instead of `3.17.0`. This issue [was fixed](https://github.com/sourcegraph/sourcegraph/pull/11633) in the `3.17.2` release. We recommend that you avoid this issue by upgrading past `3.17.0` to `3.17.2` using the [Standard upgrade procedure](#Standard-upgrade-procedure) listed below.
+- There was [a bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in the `sourcegraph/server:3.30.0` release that caused the version displayed on the `site-admin/update` page to be `0.0.0+dev` instead of `3.17.0`. This issue [was fixed](https://github.com/sourcegraph/sourcegraph/pull/11633) in the `3.17.2` release. We recommend that you avoid this issue by upgrading past `3.17.0` to `3.17.2` using the [Standard upgrade procedure](#Standard-upgrade-procedure) listed below.
 
 ## Standard upgrade procedure
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -331,5 +331,5 @@ To manually test against a Kubernetes cluster, use https://k8s.sgdev.org.
 For testing with a single Docker image, run something like
 
 ```
-IMAGE=sourcegraph/server:3.29.1 ./dev/run-server-image.sh
+IMAGE=sourcegraph/server:3.30.0 ./dev/run-server-image.sh
 ```

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -331,5 +331,5 @@ To manually test against a Kubernetes cluster, use https://k8s.sgdev.org.
 For testing with a single Docker image, run something like
 
 ```
-IMAGE=sourcegraph/server:3.30.0 ./dev/run-server-image.sh
+IMAGE=sourcegraph/server:3.30.1 ./dev/run-server-image.sh
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -66,7 +66,7 @@ You can quickly try out Sourcegraph locally using Docker, which takes only a few
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 
-<pre class="pre-wrap start-sourcegraph-command" id="dockerInstall"><code>docker run -d<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.29.1<span class="iconify copy-text" data-icon="mdi:clipboard-arrow-left-outline" data-inline="false"></span></code>
+<pre class="pre-wrap start-sourcegraph-command" id="dockerInstall"><code>docker run -d<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.30.0<span class="iconify copy-text" data-icon="mdi:clipboard-arrow-left-outline" data-inline="false"></span></code>
 </pre>
 
 For next steps, visit the [Docker installation documentation](admin/install/docker/index.md).

--- a/doc/index.md
+++ b/doc/index.md
@@ -66,7 +66,7 @@ You can quickly try out Sourcegraph locally using Docker, which takes only a few
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 
-<pre class="pre-wrap start-sourcegraph-command" id="dockerInstall"><code>docker run -d<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.30.0<span class="iconify copy-text" data-icon="mdi:clipboard-arrow-left-outline" data-inline="false"></span></code>
+<pre class="pre-wrap start-sourcegraph-command" id="dockerInstall"><code>docker run -d<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.30.1<span class="iconify copy-text" data-icon="mdi:clipboard-arrow-left-outline" data-inline="false"></span></code>
 </pre>
 
 For next steps, visit the [Docker installation documentation](admin/install/docker/index.md).

--- a/docker-images/codeintel-db/build.sh
+++ b/docker-images/codeintel-db/build.sh
@@ -3,5 +3,5 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# This image is identical to our "sourcegraph/postgres-12.6-alpine" image.
-IMAGE="${IMAGE:-sourcegraph/codeintel-db}" ../postgres-12.6-alpine/build.sh
+# This image is identical to our "sourcegraph/postgres-12.6" image.
+IMAGE="${IMAGE:-sourcegraph/codeintel-db}" ../postgres-12.6/build.sh

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql
 
-RUN apk add --upgrade --no-cache libxml2=2.9.10-r7
+RUN apk add --upgrade --no-cache libxml2=2.9.10-r7 libgcrypt=1.8.8-r0
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql
 
-RUN apk add --upgrade --no-cache libxml2=2.9.10-r7 libgcrypt=1.8.8-r0
+RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r0
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
@@ -17,7 +17,6 @@ func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID str
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
-			log.String("path", r.path),
 			log.Int("numUploads", len(r.uploads)),
 			log.String("uploads", uploadIDsToString(r.uploads)),
 			log.String("pathID", pathID),
@@ -30,11 +29,12 @@ func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID str
 	// repository.
 	for _, upload := range r.uploads {
 		traceLog(log.Int("uploadID", upload.ID))
-		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, r.path, pathID, DefinitionsLimit, 0)
+		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, pathID, DefinitionsLimit, 0)
 		if err != nil {
 			return nil, errors.Wrap(err, "lsifStore.DocumentationDefinitions")
 		}
 		if len(locations) > 0 {
+			r.path = locations[0].Path
 			uploadsByID := map[int]dbstore.Dump{upload.ID: upload}
 			return r.adjustLocations(ctx, uploadsByID, locations)
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
@@ -16,7 +16,6 @@ func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID stri
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
-			log.String("path", r.path),
 			log.Int("numUploads", len(r.uploads)),
 			log.String("uploads", uploadIDsToString(r.uploads)),
 			log.String("pathID", pathID),
@@ -33,12 +32,13 @@ func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID stri
 	// request on the first location we find.
 	for _, upload := range r.uploads {
 		traceLog(log.Int("uploadID", upload.ID))
-		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, r.path, pathID, DefinitionsLimit, 0)
+		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, pathID, DefinitionsLimit, 0)
 		if err != nil {
 			return nil, "", errors.Wrap(err, "lsifStore.DocumentationDefinitions")
 		}
 		if len(locations) > 0 {
 			location := locations[0]
+			r.path = location.Path
 			return r.References(ctx, location.Range.Start.Line, location.Range.Start.Character, limit, rawCursor)
 		}
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -54,8 +54,8 @@ type LSIFStore interface {
 	PackageInformation(ctx context.Context, bundleID int, path string, packageInformationID string) (semantic.PackageInformationData, bool, error)
 	DocumentationPage(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPageData, error)
 	DocumentationPathInfo(ctx context.Context, bundleID int, pathID string) (*semantic.DocumentationPathInfoData, error)
-	DocumentationDefinitions(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
-	DocumentationReferences(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
+	DocumentationDefinitions(ctx context.Context, bundleID int, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
+	DocumentationReferences(ctx context.Context, bundleID int, pathID string, limit, offset int) ([]lsifstore.Location, int, error)
 	DocumentationAtPosition(ctx context.Context, bundleID int, path string, line, character int) ([]string, error)
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4784,7 +4784,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		DocumentationDefinitionsFunc: &LSIFStoreDocumentationDefinitionsFunc{
-			defaultHook: func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+			defaultHook: func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 				return nil, 0, nil
 			},
 		},
@@ -4799,7 +4799,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		DocumentationReferencesFunc: &LSIFStoreDocumentationReferencesFunc{
-			defaultHook: func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+			defaultHook: func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 				return nil, 0, nil
 			},
 		},
@@ -5383,24 +5383,24 @@ func (c LSIFStoreDocumentationAtPositionFuncCall) Results() []interface{} {
 // DocumentationDefinitions method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreDocumentationDefinitionsFunc struct {
-	defaultHook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
-	hooks       []func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	defaultHook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
+	hooks       []func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
 	history     []LSIFStoreDocumentationDefinitionsFuncCall
 	mutex       sync.Mutex
 }
 
 // DocumentationDefinitions delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) DocumentationDefinitions(v0 context.Context, v1 int, v2 string, v3 string, v4 int, v5 int) ([]lsifstore.Location, int, error) {
-	r0, r1, r2 := m.DocumentationDefinitionsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.DocumentationDefinitionsFunc.appendCall(LSIFStoreDocumentationDefinitionsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
+func (m *MockLSIFStore) DocumentationDefinitions(v0 context.Context, v1 int, v2 string, v3 int, v4 int) ([]lsifstore.Location, int, error) {
+	r0, r1, r2 := m.DocumentationDefinitionsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DocumentationDefinitionsFunc.appendCall(LSIFStoreDocumentationDefinitionsFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // DocumentationDefinitions method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -5409,7 +5409,7 @@ func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreDocumentationDefinitionsFunc) PushHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationDefinitionsFunc) PushHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5418,7 +5418,7 @@ func (f *LSIFStoreDocumentationDefinitionsFunc) PushHook(hook func(context.Conte
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.SetDefaultHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
@@ -5426,12 +5426,12 @@ func (f *LSIFStoreDocumentationDefinitionsFunc) SetDefaultReturn(r0 []lsifstore.
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *LSIFStoreDocumentationDefinitionsFunc) PushReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.PushHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LSIFStoreDocumentationDefinitionsFunc) nextHook() func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+func (f *LSIFStoreDocumentationDefinitionsFunc) nextHook() func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5476,13 +5476,10 @@ type LSIFStoreDocumentationDefinitionsFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
+	Arg3 int
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 int
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []lsifstore.Location
@@ -5497,7 +5494,7 @@ type LSIFStoreDocumentationDefinitionsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreDocumentationDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
@@ -5736,24 +5733,24 @@ func (c LSIFStoreDocumentationPathInfoFuncCall) Results() []interface{} {
 // DocumentationReferences method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreDocumentationReferencesFunc struct {
-	defaultHook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
-	hooks       []func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)
+	defaultHook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
+	hooks       []func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)
 	history     []LSIFStoreDocumentationReferencesFuncCall
 	mutex       sync.Mutex
 }
 
 // DocumentationReferences delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) DocumentationReferences(v0 context.Context, v1 int, v2 string, v3 string, v4 int, v5 int) ([]lsifstore.Location, int, error) {
-	r0, r1, r2 := m.DocumentationReferencesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.DocumentationReferencesFunc.appendCall(LSIFStoreDocumentationReferencesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
+func (m *MockLSIFStore) DocumentationReferences(v0 context.Context, v1 int, v2 string, v3 int, v4 int) ([]lsifstore.Location, int, error) {
+	r0, r1, r2 := m.DocumentationReferencesFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DocumentationReferencesFunc.appendCall(LSIFStoreDocumentationReferencesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // DocumentationReferences method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -5762,7 +5759,7 @@ func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error)) {
+func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5771,7 +5768,7 @@ func (f *LSIFStoreDocumentationReferencesFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.SetDefaultHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
@@ -5779,12 +5776,12 @@ func (f *LSIFStoreDocumentationReferencesFunc) SetDefaultReturn(r0 []lsifstore.L
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *LSIFStoreDocumentationReferencesFunc) PushReturn(r0 []lsifstore.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+	f.PushHook(func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LSIFStoreDocumentationReferencesFunc) nextHook() func(context.Context, int, string, string, int, int) ([]lsifstore.Location, int, error) {
+func (f *LSIFStoreDocumentationReferencesFunc) nextHook() func(context.Context, int, string, int, int) ([]lsifstore.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5829,13 +5826,10 @@ type LSIFStoreDocumentationReferencesFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
+	Arg3 int
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 int
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []lsifstore.Location
@@ -5850,7 +5844,7 @@ type LSIFStoreDocumentationReferencesFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreDocumentationReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -48,7 +48,6 @@ var SourcegraphDockerImages = []string{
 	"alpine-3.12",
 	"cadvisor",
 	"indexed-searcher",
-	"postgres-11.4",
 	"postgres-12.6",
 	"redis-cache",
 	"redis_exporter",

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -292,7 +292,7 @@ func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["VAGRANT_SERVICE_ACCOUNT"] = "buildkite@sourcegraph-ci.iam.gserviceaccount.com"
 
 	// Test upgrades from mininum upgradeable Sourcegraph version - updated by release tool
-	env["MINIMUM_UPGRADEABLE_VERSION"] = "3.30.0"
+	env["MINIMUM_UPGRADEABLE_VERSION"] = "3.30.1"
 
 	env["DOCKER_CLUSTER_IMAGES_TXT"] = clusterDockerImages(images.SourcegraphDockerImages)
 

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -292,7 +292,7 @@ func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["VAGRANT_SERVICE_ACCOUNT"] = "buildkite@sourcegraph-ci.iam.gserviceaccount.com"
 
 	// Test upgrades from mininum upgradeable Sourcegraph version - updated by release tool
-	env["MINIMUM_UPGRADEABLE_VERSION"] = "3.29.1"
+	env["MINIMUM_UPGRADEABLE_VERSION"] = "3.30.0"
 
 	env["DOCKER_CLUSTER_IMAGES_TXT"] = clusterDockerImages(images.SourcegraphDockerImages)
 

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -191,7 +191,7 @@ SELECT
 	result_id,
 	path_id
 FROM
-	lsif_documentation_mappings
+	lsif_data_documentation_mappings
 WHERE
 	dump_id = %s AND
 	result_id = ANY (%s)
@@ -219,7 +219,7 @@ const documentationPathIDToIDQuery = `
 SELECT
 	result_id
 FROM
-	lsif_documentation_mappings
+	lsif_data_documentation_mappings
 WHERE
 	dump_id = %s AND
 	path_id = %s
@@ -244,26 +244,69 @@ func (s *Store) scanFirstDocumentationResultID(rows *sql.Rows, queryErr error) (
 	return resultID, nil
 }
 
+// documentationPathIDToFilePath queries the file path associated with a documentation path ID,
+// e.g. the file where the documented symbol is located - if the path ID is describing such a
+// symbol, or nil otherwise.
+func (s *Store) documentationPathIDToFilePath(ctx context.Context, bundleID int, pathID string) (_ *string, err error) {
+	ctx, _, endObservation := s.operations.documentationPathIDToFilePath.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("bundleID", bundleID),
+		log.String("pathID", pathID),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	return s.scanFirstDocumentationFilePath(s.Store.Query(ctx, sqlf.Sprintf(documentationPathIDToFilePathQuery, bundleID, pathID)))
+}
+
+const documentationPathIDToFilePathQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/ranges.go:documentationPathIDToFilePath
+SELECT
+	file_path
+FROM
+	lsif_data_documentation_mappings
+WHERE
+	dump_id = %s AND
+	path_id = %s
+LIMIT 1
+`
+
+// scanFirstDocumentationFilePath reads the first file_path row. If no rows match the query, an empty string is returned.
+func (s *Store) scanFirstDocumentationFilePath(rows *sql.Rows, queryErr error) (_ *string, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	if !rows.Next() {
+		return nil, nil
+	}
+
+	var filePath *string
+	if err := rows.Scan(&filePath); err != nil {
+		return nil, err
+	}
+	return filePath, nil
+}
+
 // DocumentationDefinitions returns the set of locations defining the symbol found at the given path ID, if any.
-func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, path, pathID string, limit, offset int) (_ []Location, _ int, err error) {
+func (s *Store) DocumentationDefinitions(ctx context.Context, bundleID int, pathID string, limit, offset int) (_ []Location, _ int, err error) {
 	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
 	if err != nil || resultID == "" {
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.DefinitionResultID }
 	operation := s.operations.documentationDefinitions
-	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
+	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, pathID, resultID, limit, offset)
 }
 
 // DocumentationReferences returns the set of locations referencing the symbol found at the given path ID, if any.
-func (s *Store) DocumentationReferences(ctx context.Context, bundleID int, path string, pathID string, limit, offset int) (_ []Location, _ int, err error) {
+func (s *Store) DocumentationReferences(ctx context.Context, bundleID int, pathID string, limit, offset int) (_ []Location, _ int, err error) {
 	resultID, err := s.documentationPathIDToID(ctx, bundleID, pathID)
 	if resultID == "" || err != nil {
 		return nil, 0, err
 	}
 	extractor := func(r semantic.RangeData) semantic.ID { return r.ReferenceResultID }
 	operation := s.operations.documentationReferences
-	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, path, resultID, limit, offset)
+	return s.documentationDefinitionsReferences(ctx, extractor, operation, bundleID, pathID, resultID, limit, offset)
 }
 
 func (s *Store) documentationDefinitionsReferences(
@@ -271,19 +314,27 @@ func (s *Store) documentationDefinitionsReferences(
 	extractor func(r semantic.RangeData) semantic.ID,
 	operation *observation.Operation,
 	bundleID int,
-	path string,
+	pathID string,
 	resultID semantic.ID,
 	limit,
 	offset int,
 ) (_ []Location, _ int, err error) {
 	ctx, traceLog, endObservation := operation.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
-		log.String("path", path),
 		log.String("resultID", string(resultID)),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	documentData, exists, err := s.scanFirstDocumentData(s.Store.Query(ctx, sqlf.Sprintf(locationsDocumentQuery, bundleID, path)))
+	filePath, err := s.documentationPathIDToFilePath(ctx, bundleID, pathID)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "documentationPathIDToFilePath")
+	}
+	if filePath == nil {
+		// The documentation result is not attached to a file, it cannot have references.
+		return nil, 0, nil
+	}
+
+	documentData, exists, err := s.scanFirstDocumentData(s.Store.Query(ctx, sqlf.Sprintf(locationsDocumentQuery, bundleID, filePath)))
 	if err != nil || !exists {
 		return nil, 0, err
 	}

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -8,32 +8,33 @@ import (
 )
 
 type operations struct {
-	bulkMonikerResults         *observation.Operation
-	clear                      *observation.Operation
-	definitions                *observation.Operation
-	diagnostics                *observation.Operation
-	exists                     *observation.Operation
-	hover                      *observation.Operation
-	monikerResults             *observation.Operation
-	monikersByPosition         *observation.Operation
-	packageInformation         *observation.Operation
-	ranges                     *observation.Operation
-	references                 *observation.Operation
-	documentationPage          *observation.Operation
-	documentationPathInfo      *observation.Operation
-	documentationIDsToPathIDs  *observation.Operation
-	documentationPathIDToID    *observation.Operation
-	documentationDefinitions   *observation.Operation
-	documentationReferences    *observation.Operation
-	documentationAtPosition    *observation.Operation
-	writeDefinitions           *observation.Operation
-	writeDocuments             *observation.Operation
-	writeMeta                  *observation.Operation
-	writeReferences            *observation.Operation
-	writeResultChunks          *observation.Operation
-	writeDocumentationPages    *observation.Operation
-	writeDocumentationPathInfo *observation.Operation
-	writeDocumentationMappings *observation.Operation
+	bulkMonikerResults            *observation.Operation
+	clear                         *observation.Operation
+	definitions                   *observation.Operation
+	diagnostics                   *observation.Operation
+	exists                        *observation.Operation
+	hover                         *observation.Operation
+	monikerResults                *observation.Operation
+	monikersByPosition            *observation.Operation
+	packageInformation            *observation.Operation
+	ranges                        *observation.Operation
+	references                    *observation.Operation
+	documentationPage             *observation.Operation
+	documentationPathInfo         *observation.Operation
+	documentationIDsToPathIDs     *observation.Operation
+	documentationPathIDToID       *observation.Operation
+	documentationPathIDToFilePath *observation.Operation
+	documentationDefinitions      *observation.Operation
+	documentationReferences       *observation.Operation
+	documentationAtPosition       *observation.Operation
+	writeDefinitions              *observation.Operation
+	writeDocuments                *observation.Operation
+	writeMeta                     *observation.Operation
+	writeReferences               *observation.Operation
+	writeResultChunks             *observation.Operation
+	writeDocumentationPages       *observation.Operation
+	writeDocumentationPathInfo    *observation.Operation
+	writeDocumentationMappings    *observation.Operation
 
 	locations           *observation.Operation
 	locationsWithinFile *observation.Operation
@@ -65,32 +66,33 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		bulkMonikerResults:         op("BulkMonikerResults"),
-		clear:                      op("Clear"),
-		definitions:                op("Definitions"),
-		diagnostics:                op("Diagnostics"),
-		exists:                     op("Exists"),
-		hover:                      op("Hover"),
-		monikerResults:             op("MonikerResults"),
-		monikersByPosition:         op("MonikersByPosition"),
-		packageInformation:         op("PackageInformation"),
-		ranges:                     op("Ranges"),
-		references:                 op("References"),
-		documentationPage:          op("DocumentationPage"),
-		documentationPathInfo:      op("DocumentationPathInfo"),
-		documentationIDsToPathIDs:  op("DocumentationIDsToPathIDs"),
-		documentationPathIDToID:    op("DocumentationPathIDToID"),
-		documentationDefinitions:   op("DocumentationDefinitions"),
-		documentationReferences:    op("DocumentationReferences"),
-		documentationAtPosition:    op("DocumentationAtPosition"),
-		writeDefinitions:           op("WriteDefinitions"),
-		writeDocuments:             op("WriteDocuments"),
-		writeMeta:                  op("WriteMeta"),
-		writeReferences:            op("WriteReferences"),
-		writeResultChunks:          op("WriteResultChunks"),
-		writeDocumentationPages:    op("WriteDocumentationPages"),
-		writeDocumentationPathInfo: op("WriteDocumentationPathInfo"),
-		writeDocumentationMappings: op("WriteDocumentationMappings"),
+		bulkMonikerResults:            op("BulkMonikerResults"),
+		clear:                         op("Clear"),
+		definitions:                   op("Definitions"),
+		diagnostics:                   op("Diagnostics"),
+		exists:                        op("Exists"),
+		hover:                         op("Hover"),
+		monikerResults:                op("MonikerResults"),
+		monikersByPosition:            op("MonikersByPosition"),
+		packageInformation:            op("PackageInformation"),
+		ranges:                        op("Ranges"),
+		references:                    op("References"),
+		documentationPage:             op("DocumentationPage"),
+		documentationPathInfo:         op("DocumentationPathInfo"),
+		documentationIDsToPathIDs:     op("DocumentationIDsToPathIDs"),
+		documentationPathIDToID:       op("DocumentationPathIDToID"),
+		documentationPathIDToFilePath: op("DocumentationPathIDToFilePath"),
+		documentationDefinitions:      op("DocumentationDefinitions"),
+		documentationReferences:       op("DocumentationReferences"),
+		documentationAtPosition:       op("DocumentationAtPosition"),
+		writeDefinitions:              op("WriteDefinitions"),
+		writeDocuments:                op("WriteDocuments"),
+		writeMeta:                     op("WriteMeta"),
+		writeReferences:               op("WriteReferences"),
+		writeResultChunks:             op("WriteResultChunks"),
+		writeDocumentationPages:       op("WriteDocumentationPages"),
+		writeDocumentationPathInfo:    op("WriteDocumentationPathInfo"),
+		writeDocumentationMappings:    op("WriteDocumentationMappings"),
 
 		locations:           subOp("locations"),
 		locationsWithinFile: subOp("locationsWithinFile"),

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
+	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/RoaringBitmap/roaring v0.5.1
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect

--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210720153132-eaae5ca7e35b
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210721121719-c54bd1fb8d2e
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/rehttp v1.1.0 h1:JFZ7OeK+hbJpTxhNB0NDZT47AuXqCU0Smxfjtph7/Rs=
+github.com/PuerkitoBio/rehttp v1.1.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -165,11 +167,15 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.2/go.mod h1:zu7rotIY9P4Aoc6ytqLP9j
 github.com/aws/smithy-go v1.2.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.3.1 h1:xJFO4pK0y9J8fCl34uGsSJX5KNnGbdARDlA5BPhXnwE=
 github.com/aws/smithy-go v1.3.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -1620,6 +1626,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20170517211232-f52d1811a629/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -1323,8 +1323,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210720153132-eaae5ca7e35b h1:Fqx7EUOCsIBbaHq3SHxYErwo1bYziQU7PYE1DXDG4pg=
-github.com/sourcegraph/zoekt v0.0.0-20210720153132-eaae5ca7e35b/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
+github.com/sourcegraph/zoekt v0.0.0-20210721121719-c54bd1fb8d2e h1:SsMh/yiUQP5JythaTnsbrYaFygCIncOxQjAQ5b3xwsQ=
+github.com/sourcegraph/zoekt v0.0.0-20210721121719-c54bd1fb8d2e/go.mod h1:duBXIw1lgztMPz/+845Stt0AijBhBUBcTogmiQZP/Gc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -69,6 +69,7 @@ Tracks the range of schema_versions for each upload in the lsif_data_definitions
  dump_id   | integer |           | not null | 
  path_id   | text    |           | not null | 
  result_id | integer |           | not null | 
+ file_path | text    |           |          | 
 Indexes:
     "lsif_data_documentation_mappings_pkey" PRIMARY KEY, btree (dump_id, path_id)
     "lsif_data_documentation_mappings_inverse_unique_idx" UNIQUE, btree (dump_id, result_id)
@@ -78,6 +79,8 @@ Indexes:
 Maps documentation path IDs to their corresponding integral documentationResult vertex IDs, which are unique within a dump.
 
 **dump_id**: The identifier of the associated dump in the lsif_uploads table (state=completed).
+
+**file_path**: The document file path for the documentationResult, if any. e.g. the path to the file where the symbol described by this documentationResult is located, if it is a symbol.
 
 **path_id**: The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -3,6 +3,7 @@ package repos_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"testing"
@@ -248,6 +249,23 @@ func testSyncerSync(s *repos.Store, streaming bool) func(*testing.T) {
 					)}},
 					svcs: []*types.ExternalService{tc.svc},
 					err:  "account suspended",
+				},
+				testCase{
+					// Test that spurious errors don't cause deletions.
+					name: string(tc.repo.Name) + "/spurious-error",
+					sourcer: repos.NewFakeSourcer(nil,
+						repos.NewFakeSource(tc.svc.Clone(), io.EOF),
+					),
+					store: s,
+					stored: types.Repos{tc.repo.With(
+						types.Opt.RepoSources(tc.svc.URN()),
+					)},
+					now: clock.Now,
+					diff: repos.Diff{Unmodified: types.Repos{tc.repo.With(
+						types.Opt.RepoSources(tc.svc.URN()),
+					)}},
+					svcs: []*types.ExternalService{tc.svc},
+					err:  io.EOF.Error(),
 				},
 				testCase{
 					// It's expected that there could be multiple stored sources but only one will ever be returned

--- a/lib/codeintel/semantic/types.go
+++ b/lib/codeintel/semantic/types.go
@@ -180,6 +180,10 @@ type DocumentationMapping struct {
 
 	// PathID is the path ID corresponding to the documentationResult vertex ID.
 	PathID string `json:"pathID"`
+
+	// The file path corresponding to the documentationResult vertex ID, or nil if there is no
+	// associated file.
+	FilePath *string `json:"filePath"`
 }
 
 // Package pairs a package name and the dump that provides it.

--- a/migrations/codeintel/1000000019_documentation_path_mapping.down.sql
+++ b/migrations/codeintel/1000000019_documentation_path_mapping.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE lsif_data_documentation_mappings DROP COLUMN file_path;
+
+COMMIT;

--- a/migrations/codeintel/1000000019_documentation_path_mapping.up.sql
+++ b/migrations/codeintel/1000000019_documentation_path_mapping.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+-- Add nullable file_path column, for mapping documentationResult ID -> file_path
+ALTER TABLE lsif_data_documentation_mappings ADD COLUMN file_path text;
+COMMENT ON COLUMN lsif_data_documentation_mappings.file_path IS 'The document file path for the documentationResult, if any. e.g. the path to the file where the symbol described by this documentationResult is located, if it is a symbol.';
+
+COMMIT;


### PR DESCRIPTION
- changelog: cut sourcegraph@3.30.0 (#23055)
- gomod: update zoekt to remove old meta files (#23075)
- release: sourcegraph@3.30.0 (#23059)
- API docs: LSIF: add references/definitions to tree API, not just blob API (#23115)
- httpcli: add retries to NewExternalHTTPClientFactory (#23131)
- repos: Publish Diff after committing transaction (#23169)
- repos: Make syncer more conservative when deleting repos (#23171)
- fix vuln in libgcrypt (#23174)
- Add CHANGELOG entry for libgcrypt (#23178)
- Update CHANGELOG
- add note about non-root overlays (#23179)
- release: sourcegraph@3.30.1 (#23151)
- revert to debian based pgsql  (#23302)
- CI: bump libxml2 and redis (#23221)
- release sourcegraph@3.30.2
- Revert "use alpine postgres image (#22655)" (#23324)
- 3.30.3 release: Update CHANGELOG.md (#23331)
- Add python3 to image



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
