### PR TITLE
Insights: Select appropriate commit for search when using commit index

### DIFF
--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -129,12 +129,13 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 			// 1. the commit index is sufficiently up to date
 			// 2. this time range [from, to) doesn't have any commits
 			// so we can skip this frame for this repo
+			log15.Info("insights: skipping query based on no commits", "for_time", frame.From, "repo_id", id)
 			prev.SharedRecordings = append(prev.SharedRecordings, frame.From)
 			count++
 			continue
 		} else {
 			rev := commits[0]
-			log15.Info("caching revision", "rev", rev, "for_time", frame.From, "repo_id", id)
+			log15.Info("insights: generating query with commit index revision", "rev", rev, "for_time", frame.From, "repo_id", id)
 			// as a small optimization we are collecting this revhash here since we already know this is
 			// the revision for which we need to query against
 			addToPlan(frame, string(rev.Commit))

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -133,7 +133,8 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 			count++
 			continue
 		} else {
-			rev := commits[len(commits)-1]
+			rev := commits[0]
+			log15.Info("caching revision", "rev", rev, "for_time", frame.From, "repo_id", id)
 			// as a small optimization we are collecting this revhash here since we already know this is
 			// the revision for which we need to query against
 			addToPlan(frame, string(rev.Commit))

--- a/enterprise/internal/insights/compression/compression_test.go
+++ b/enterprise/internal/insights/compression/compression_test.go
@@ -136,6 +136,11 @@ func TestFilterFrames(t *testing.T) {
 			{
 				RepoID:      2,
 				Commit:      "stamp1",
+				CommittedAt: toTime("2021-01-16"),
+			},
+			{
+				RepoID:      2,
+				Commit:      "donotuse",
 				CommittedAt: toTime("2021-01-15"),
 			},
 		}, nil)


### PR DESCRIPTION
When selecting a commit from the commit index to query against, the oldest commit was accidentally being selected (the last in the list) rather than the youngest.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
