### PR TITLE
search: move NewIndexedSearchRequest

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -78,7 +78,7 @@ func streamStructuralSearch(ctx context.Context, args *search.TextParameters, st
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
 	defer cleanup()
 
-	request, err := textSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -148,6 +148,15 @@ type IndexedSearchRequest interface {
 	UnindexedRepos() []*search.RepositoryRevisions
 }
 
+func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, onMissing OnMissingRepoRevs) (IndexedSearchRequest, error) {
+	if args.Mode == search.ZoektGlobalSearch {
+		// performance: optimize global searches where Zoekt searches
+		// all shards anyway.
+		return NewIndexedUniverseSearchRequest(ctx, args, search.TextRequest, args.RepoOptions, args.UserPrivateRepos)
+	}
+	return NewIndexedSubsetSearchRequest(ctx, args, search.TextRequest, onMissing)
+}
+
 // IndexedUniverseSearchRequest represents a request to run a search over the universe of indexed repositories.
 type IndexedUniverseSearchRequest struct {
 	RepoOptions      search.RepoOptions


### PR DESCRIPTION
- `renames textSearchRequest` to `NewIndexedSearchRequest`
- moves `NewIndexedSearchRequest` to `indexed_search.go`

This just makes more sense. Also needed for upcoming changes.

