### PR TITLE
search: unify indexed search requests

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -78,7 +78,7 @@ func streamStructuralSearch(ctx context.Context, args *search.TextParameters, st
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
 	defer cleanup()
 
-	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, search.TextRequest, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -60,7 +60,7 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		trace.Stringer("global_search_mode", args.Mode),
 	)
 
-	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, zoektutil.MissingRepoRevStatus(stream))
+	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, search.TextRequest, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
 	}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -148,13 +148,13 @@ type IndexedSearchRequest interface {
 	UnindexedRepos() []*search.RepositoryRevisions
 }
 
-func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, onMissing OnMissingRepoRevs) (IndexedSearchRequest, error) {
+func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ search.IndexedRequestType, onMissing OnMissingRepoRevs) (IndexedSearchRequest, error) {
 	if args.Mode == search.ZoektGlobalSearch {
 		// performance: optimize global searches where Zoekt searches
 		// all shards anyway.
-		return NewIndexedUniverseSearchRequest(ctx, args, search.TextRequest, args.RepoOptions, args.UserPrivateRepos)
+		return NewIndexedUniverseSearchRequest(ctx, args, typ, args.RepoOptions, args.UserPrivateRepos)
 	}
-	return NewIndexedSubsetSearchRequest(ctx, args, search.TextRequest, onMissing)
+	return NewIndexedSubsetSearchRequest(ctx, args, typ, onMissing)
 }
 
 // IndexedUniverseSearchRequest represents a request to run a search over the universe of indexed repositories.


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24212.

Replaces `symbolSearchRequest` with `NewIndexedSearchRequest` so that text and symbol search go through `NewIndexedSearchRequest`, since the `mode` casing is shared. Later, this Indexed Request will be lifted higher in the call chain, so it makes sense to unify.