### PR TITLE
search: add RepoFetcher for structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -1570,7 +1571,8 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		wg.Add(1)
 		goroutine.Go(func() {
 			defer wg.Done()
-			_ = agg.DoStructuralSearch(ctx, args)
+			repoFetcher := unindexed.NewRepoFetcher(agg, args)
+			_ = agg.DoStructuralSearch(ctx, args, repoFetcher)
 		})
 	}
 

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -91,7 +91,7 @@ func (a *Aggregator) DoSymbolSearch(ctx context.Context, args *search.TextParame
 	return errors.Wrap(err, "symbol search failed")
 }
 
-func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextParameters) (err error) {
+func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *unindexed.RepoFetcher) (err error) {
 	tr, ctx := trace.New(ctx, "doStructuralSearch", "")
 	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {
@@ -100,7 +100,7 @@ func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextPa
 		tr.Finish()
 	}()
 
-	err = unindexed.StructuralSearch(ctx, args, a)
+	err = unindexed.StructuralSearch(ctx, args, repoFetcher, a)
 	return errors.Wrap(err, "structural search failed")
 }
 

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -49,6 +49,38 @@ type searchRepos struct {
 	stream  streaming.Sender
 }
 
+// RepoFetcher is an object that exposes an interface to retrieve repos to
+// search from Zoekt. The interface exposes a Get(ctx) method that allows
+// parameterizing repo fetches by context.
+type RepoFetcher struct {
+	args              *search.TextParameters
+	mode              search.GlobalSearchMode
+	onMissingRepoRevs zoektutil.OnMissingRepoRevs
+}
+
+func NewRepoFetcher(stream streaming.Sender, args *search.TextParameters) *RepoFetcher {
+	return &RepoFetcher{
+		mode:              args.Mode,
+		args:              args,
+		onMissingRepoRevs: zoektutil.MissingRepoRevStatus(stream),
+	}
+}
+
+// Get returns the repository data to run structural search on. Importantly, it
+// allows parameterizing the request to specify a context, for when multiple
+// Get() calls are required with different limits or timeouts.
+func (r *RepoFetcher) Get(ctx context.Context) ([]repoData, error) {
+	request, err := zoektutil.NewIndexedSearchRequest(ctx, r.args, search.TextRequest, r.onMissingRepoRevs)
+	if err != nil {
+		return nil, err
+	}
+	repoSets := []repoData{UnindexedList(request.UnindexedRepos())} // unindexed included by default
+	if r.mode != search.SearcherOnly {
+		repoSets = append(repoSets, IndexedMap(request.IndexedRepos()))
+	}
+	return repoSets, nil
+}
+
 // getJob returns a function parameterized by ctx to search over repos.
 func (s *searchRepos) getJob(ctx context.Context) func() error {
 	return func() error {
@@ -64,27 +96,18 @@ func runJobs(ctx context.Context, jobs []*searchRepos) error {
 	return g.Wait()
 }
 
-// repoSets returns the set of repositories to search (whether indexed or unindexed) based on search mode.
-func repoSets(request zoektutil.IndexedSearchRequest, mode search.GlobalSearchMode) []repoData {
-	repoSets := []repoData{UnindexedList(request.UnindexedRepos())} // unindexed included by default
-	if mode != search.SearcherOnly {
-		repoSets = append(repoSets, IndexedMap(request.IndexedRepos()))
-	}
-	return repoSets
-}
-
 // streamStructuralSearch runs structural search jobs and streams the results.
-func streamStructuralSearch(ctx context.Context, args *search.TextParameters, stream streaming.Sender) (err error) {
+func streamStructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *RepoFetcher, stream streaming.Sender) (err error) {
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
 	defer cleanup()
 
-	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, search.TextRequest, zoektutil.MissingRepoRevStatus(stream))
+	repos, err := repoFetcher.Get(ctx)
 	if err != nil {
 		return err
 	}
 
 	jobs := []*searchRepos{}
-	for _, repoSet := range repoSets(request, args.Mode) {
+	for _, repoSet := range repos {
 		searcherArgs := &search.SearcherParameters{
 			SearcherURLs:    args.SearcherURLs,
 			PatternInfo:     args.PatternInfo,
@@ -98,32 +121,32 @@ func streamStructuralSearch(ctx context.Context, args *search.TextParameters, st
 
 // retryStructuralSearch runs a structural search with a higher limit file match
 // limit so that Zoekt resolves more potential file matches.
-func retryStructuralSearch(ctx context.Context, args *search.TextParameters, stream streaming.Sender) error {
+func retryStructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *RepoFetcher, stream streaming.Sender) error {
 	patternCopy := *(args.PatternInfo)
 	patternCopy.FileMatchLimit = 1000
 	argsCopy := *args
 	argsCopy.PatternInfo = &patternCopy
 	args = &argsCopy
-	return streamStructuralSearch(ctx, args, stream)
+	return streamStructuralSearch(ctx, args, repoFetcher, stream)
 }
 
-func StructuralSearch(ctx context.Context, args *search.TextParameters, stream streaming.Sender) error {
+func StructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *RepoFetcher, stream streaming.Sender) error {
 	if args.PatternInfo.FileMatchLimit != search.DefaultMaxSearchResults {
 		// streamStructuralSearch performs a streaming search when the user sets a value
 		// for `count`. The first return parameter indicates whether the request was
 		// serviced with streaming.
-		return streamStructuralSearch(ctx, args, stream)
+		return streamStructuralSearch(ctx, args, repoFetcher, stream)
 	}
 
 	// For structural search with default limits we retry if we get no results.
 	fileMatches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
-		return streamStructuralSearch(ctx, args, stream)
+		return streamStructuralSearch(ctx, args, repoFetcher, stream)
 	})
 
 	if len(fileMatches) == 0 && err == nil {
 		// retry structural search with a higher limit.
 		fileMatches, stats, err = streaming.CollectStream(func(stream streaming.Sender) error {
-			return retryStructuralSearch(ctx, args, stream)
+			return retryStructuralSearch(ctx, args, repoFetcher, stream)
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24213.

This is a step towards breaking the the dependency that `structural search` needs `TextParameters`. This is the same flavor of change I will make to `literal/regexp search` in a bit. The principle is:

- Expose a `RepoFetcher` object to retrieve repos to search from indexed search, which is what structural search needs. It needs this value to be parameterizable by `ctx` because of retry logic, so it needs to be an object that takes a parameterizable method, I can't just construct it.

- `RepoFetcher` is the thing that depends on a subset of state in `TextParameters`. I don't want structural search logic to depend on `TextParameters`, so the creation of `RepoFetcher` establishes a higher boundary where only _that_ part now depends on `TextParameters`. Soon, it will depend on only the subset of `TextParameters` needed.

- Because of above changes, `RepoFetcher` construction can happen well before calling structural search. And since that's the only thing that depends on `TextParameters`, structural search no longers need to depend on it. It's great that the structural search logic can now abstract over a repofetcher and not care at all about zoekt params or text parameters.

- `RepoFetcher` is specific to structural search, because of retry logic. It's not intended to be a general "get repos for search" it's a "get repos for structural search via indexed search, but abstract away the details about talking to zoekt".

I spent a lot of time thinking through and trying other things, so you can give me the benefit of the doubt :P More inline comments.