### PR TITLE
search: break TextParameter dependency in structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1572,7 +1572,12 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		goroutine.Go(func() {
 			defer wg.Done()
 			repoFetcher := unindexed.NewRepoFetcher(agg, args)
-			_ = agg.DoStructuralSearch(ctx, args, repoFetcher)
+			searcherArgs := &search.SearcherParameters{
+				SearcherURLs:    args.SearcherURLs,
+				PatternInfo:     args.PatternInfo,
+				UseFullDeadline: args.UseFullDeadline,
+			}
+			_ = agg.DoStructuralSearch(ctx, searcherArgs, args.Mode, repoFetcher)
 		})
 	}
 

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -91,9 +91,9 @@ func (a *Aggregator) DoSymbolSearch(ctx context.Context, args *search.TextParame
 	return errors.Wrap(err, "symbol search failed")
 }
 
-func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *unindexed.RepoFetcher) (err error) {
+func (a *Aggregator) DoStructuralSearch(ctx context.Context, args *search.SearcherParameters, mode search.GlobalSearchMode, repoFetcher *unindexed.RepoFetcher) (err error) {
 	tr, ctx := trace.New(ctx, "doStructuralSearch", "")
-	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
+	tr.LogFields(trace.Stringer("global_search_mode", mode))
 	defer func() {
 		a.Error(err)
 		tr.SetErrorIfNotContext(err)

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -97,7 +97,7 @@ func runJobs(ctx context.Context, jobs []*searchRepos) error {
 }
 
 // streamStructuralSearch runs structural search jobs and streams the results.
-func streamStructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *RepoFetcher, stream streaming.Sender) (err error) {
+func streamStructuralSearch(ctx context.Context, args *search.SearcherParameters, repoFetcher *RepoFetcher, stream streaming.Sender) (err error) {
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
 	defer cleanup()
 
@@ -121,7 +121,7 @@ func streamStructuralSearch(ctx context.Context, args *search.TextParameters, re
 
 // retryStructuralSearch runs a structural search with a higher limit file match
 // limit so that Zoekt resolves more potential file matches.
-func retryStructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *RepoFetcher, stream streaming.Sender) error {
+func retryStructuralSearch(ctx context.Context, args *search.SearcherParameters, repoFetcher *RepoFetcher, stream streaming.Sender) error {
 	patternCopy := *(args.PatternInfo)
 	patternCopy.FileMatchLimit = 1000
 	argsCopy := *args
@@ -130,7 +130,7 @@ func retryStructuralSearch(ctx context.Context, args *search.TextParameters, rep
 	return streamStructuralSearch(ctx, args, repoFetcher, stream)
 }
 
-func StructuralSearch(ctx context.Context, args *search.TextParameters, repoFetcher *RepoFetcher, stream streaming.Sender) error {
+func StructuralSearch(ctx context.Context, args *search.SearcherParameters, repoFetcher *RepoFetcher, stream streaming.Sender) error {
 	if args.PatternInfo.FileMatchLimit != search.DefaultMaxSearchResults {
 		// streamStructuralSearch performs a streaming search when the user sets a value
 		// for `count`. The first return parameter indicates whether the request was


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24217. 

See inline comments.