### PR TITLE
insights: fix issue where records were not set as failed if they exceed max retries

### DIFF
--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/cockroachdb/errors"
 	"github.com/derision-test/glock"
 	"github.com/keegancsmith/sqlf"
@@ -650,7 +648,6 @@ func (s *store) MarkErrored(ctx context.Context, id int, failureMessage string, 
 	conds = append(conds, options.ToSQLConds(s.formatQuery)...)
 
 	q := s.formatQuery(markErroredQuery, quote(s.options.TableName), s.options.MaxNumRetries, failureMessage, sqlf.Join(conds, "AND"))
-	log15.Info("markerror", "query", q.Query(sqlf.PostgresBindVar), "args", q.Args())
 	_, ok, err := basestore.ScanFirstInt(s.Query(ctx, q))
 	return ok, err
 }


### PR DESCRIPTION
Closes #24219
Closes #24203

Fixes a bug where records that should be terminally marked `failed` are left in `errored` state because there is a condition requiring the record be `processing` to update the row.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
