### PR TITLE
move theme props from <SourcegraphWebApp> to useTheme hook

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -347,7 +347,7 @@ export const githubCodeHost: CodeHost = {
     isLightTheme: defer(() => {
         const mode = document.documentElement.dataset.colorMode as 'auto' | 'light' | 'dark' | undefined
         if (mode === 'auto') {
-            return observeSystemIsLightTheme()
+            return observeSystemIsLightTheme().observable
         }
         return of(mode !== 'dark')
     }),

--- a/client/shared/src/theme.ts
+++ b/client/shared/src/theme.ts
@@ -13,13 +13,21 @@ export interface ThemeProps {
 }
 
 /**
- * Returns an Observable that emits the system color scheme using a `prefers-color-scheme` media query.
- * The Observable will emit with the initial value immediately.
+ * Returns an Observable that emits the system color scheme using a `prefers-color-scheme` media
+ * query. The Observable will emit with the initial value immediately. Callers that need the initial
+ * value synchronously can use initialValue.
+ *
+ * @param window_ The global window object (or a mock in tests).
  */
-export const observeSystemIsLightTheme = (): Observable<boolean> => {
-    const mediaList = window.matchMedia('(prefers-color-scheme: dark)')
-    return concat(
-        of(!mediaList.matches),
-        fromEvent<MediaQueryListEvent>(mediaList, 'change').pipe(map(event => !event.matches))
-    )
+export const observeSystemIsLightTheme = (
+    window_: Pick<Window, 'matchMedia'> = window
+): { observable: Observable<boolean>; initialValue: boolean } => {
+    const mediaList = window_.matchMedia('(prefers-color-scheme: dark)')
+    return {
+        observable: concat(
+            of(!mediaList.matches),
+            fromEvent<MediaQueryListEvent>(mediaList, 'change').pipe(map(event => !event.matches))
+        ),
+        initialValue: !mediaList.matches,
+    }
 }

--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -10,6 +10,14 @@ import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHel
 import { SearchPatternType } from './graphql-operations'
 import { Layout, LayoutProps } from './Layout'
 
+jest.mock('./theme', () => ({
+    useTheme: () => ({
+        isLightTheme: true,
+        themePreference: 'system',
+        onThemePreferenceChange: () => {},
+    }),
+}))
+
 describe('Layout', () => {
     const defaultProps: LayoutProps = ({
         // Parsed query components
@@ -34,16 +42,6 @@ describe('Layout', () => {
         extensionsController,
         platformContext: { forceUpdateTooltip: () => {}, settings: NEVER },
     } as unknown) as LayoutProps
-
-    beforeAll(() => {
-        Object.defineProperty(window, 'matchMedia', {
-            writable: true,
-            value: () => ({
-                matches: false,
-                addEventListener: () => {},
-            }),
-        })
-    })
 
     beforeEach(() => {
         const root = document.createElement('div')

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -11,7 +11,6 @@ import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
@@ -62,7 +61,7 @@ import {
 import { QueryState } from './search/helpers'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
-import { ThemePreferenceProps } from './theme'
+import { useTheme } from './theme'
 import { UserAreaRoute } from './user/area/UserArea'
 import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
@@ -76,9 +75,7 @@ export interface LayoutProps
         PlatformContextProps,
         ExtensionsControllerProps,
         KeyboardShortcutsProps,
-        ThemeProps,
         TelemetryProps,
-        ThemePreferenceProps,
         ActivationProps,
         ParsedSearchQueryProps,
         PatternTypeProps,
@@ -231,6 +228,9 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const isSearchAutoFocusRequired = routeMatch === '/survey/:score?' || routeMatch === '/insights'
 
     const authRequired = useObservable(authRequiredObservable)
+
+    const themeProps = useTheme()
+
     const breadcrumbProps = useBreadcrumbs()
 
     // Control browser extension discoverability animation here.
@@ -248,6 +248,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
 
     const context: LayoutRouteComponentProps<any> = {
         ...props,
+        ...themeProps,
         ...breadcrumbProps,
         onExtensionAlertDismissed,
         isMacPlatform,
@@ -264,6 +265,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
             {!isSiteInit && !isSignInOrUp && (
                 <GlobalNavbar
                     {...props}
+                    {...themeProps}
                     authRequired={!!authRequired}
                     showSearchBox={
                         isSearchRelatedPage &&
@@ -311,6 +313,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                 props.location.pathname !== '/sign-in' && (
                     <ResizablePanel
                         {...props}
+                        {...themeProps}
                         repoName={`git://${parseBrowserRepoURL(props.location.pathname).repoName}`}
                         fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                     />

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
 
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { BatchChangesProps } from './batches'
@@ -8,6 +9,7 @@ import { CodeIntelligenceProps } from './codeintel'
 import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
 import type { ExtensionAlertProps } from './repo/RepoContainer'
+import { ThemePreferenceProps } from './theme'
 import { UserExternalServicesOrRepositoriesUpdateProps } from './util'
 import { lazyComponent } from './util/lazyComponent'
 
@@ -35,6 +37,8 @@ const CncfRepogroupPage = lazyComponent(() => import('./repogroups/cncf'), 'Cncf
 export interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof RouteParameters]?: string }>
     extends RouteComponentProps<RouteParameters>,
         Omit<LayoutProps, 'match'>,
+        ThemeProps,
+        ThemePreferenceProps,
         BreadcrumbsProps,
         BreadcrumbSetters,
         ExtensionAlertProps,

--- a/client/web/src/theme.test.ts
+++ b/client/web/src/theme.test.ts
@@ -8,7 +8,7 @@ import { ThemePreference, useTheme } from './theme'
 // Don't test reacting to system-wide theme changes, for simplicity. This means that
 // observeSystemIsLightTheme's initial value will be used, but it will not monitor for subsequent
 // changes.
-jest.mock('../../shared/src/util/useObservable', () => ({
+jest.mock('@sourcegraph/shared/src/util/useObservable', () => ({
     useObservable: () => undefined,
 }))
 

--- a/client/web/src/theme.test.ts
+++ b/client/web/src/theme.test.ts
@@ -1,0 +1,131 @@
+// causes false positive on act()
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+import { renderHook, act } from '@testing-library/react-hooks'
+
+import { ThemePreference, useTheme } from './theme'
+
+// Don't test reacting to system-wide theme changes, for simplicity. This means that
+// observeSystemIsLightTheme's initial value will be used, but it will not monitor for subsequent
+// changes.
+jest.mock('../../shared/src/util/useObservable', () => ({
+    useObservable: () => undefined,
+}))
+
+const mockWindow = (systemTheme: 'light' | 'dark'): Pick<Window, 'matchMedia'> => ({
+    matchMedia: query => {
+        if (query === '(prefers-color-scheme: dark)') {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            return { matches: systemTheme === 'dark' } as MediaQueryList
+        }
+        throw new Error('unexpected matchMedia query')
+    },
+})
+
+const mockDocumentElement = (): Pick<HTMLElement, 'classList'> => document.createElement('html')
+
+const mockLocalStorage = (): Pick<Storage, 'getItem' | 'setItem'> => {
+    const data = new Map<string, string>()
+    return {
+        getItem: key => data.get(key) ?? null,
+        setItem: (key, value) => {
+            data.set(key, String(value))
+        },
+    }
+}
+
+const createUseThemeMocks = (
+    systemTheme: 'light' | 'dark',
+    storedThemePreference: ThemePreference | null
+): Required<Parameters<typeof useTheme>> => {
+    const window = mockWindow(systemTheme)
+    const documentElement = mockDocumentElement()
+    const storage = mockLocalStorage()
+    if (storedThemePreference !== null) {
+        storage.setItem('light-theme', storedThemePreference)
+    }
+    return [window, documentElement, storage]
+}
+
+describe('useTheme()', () => {
+    describe('defaults to system', () => {
+        it('light', () => {
+            const [window, documentElement, localStorage] = createUseThemeMocks('light', null)
+            const { result } = renderHook(() => useTheme(window, documentElement, localStorage))
+            expect(result.current.isLightTheme).toBe(true)
+            expect(result.current.themePreference).toBe(ThemePreference.System)
+            expect(documentElement.classList).toContain('theme-light')
+            expect(documentElement.classList).not.toContain('theme-dark')
+            expect(localStorage.getItem('light-theme')).toBe(null)
+        })
+
+        it('dark', () => {
+            const [window, documentElement, localStorage] = createUseThemeMocks('dark', null)
+            const { result } = renderHook(() => useTheme(window, documentElement, localStorage))
+            expect(result.current.isLightTheme).toBe(false)
+            expect(result.current.themePreference).toBe(ThemePreference.System)
+            expect(documentElement.classList).toContain('theme-dark')
+            expect(documentElement.classList).not.toContain('theme-light')
+            expect(localStorage.getItem('light-theme')).toBe(null)
+        })
+    })
+
+    describe('respects theme preference', () => {
+        it('light', () => {
+            const [window, documentElement, localStorage] = createUseThemeMocks('dark', ThemePreference.Light)
+            const { result } = renderHook(() => useTheme(window, documentElement, localStorage))
+            expect(result.current.isLightTheme).toBe(true)
+            expect(result.current.themePreference).toBe(ThemePreference.Light)
+            expect(documentElement.classList).toContain('theme-light')
+            expect(documentElement.classList).not.toContain('theme-dark')
+            expect(localStorage.getItem('light-theme')).toBe(ThemePreference.Light)
+        })
+
+        it('dark', () => {
+            const [window, documentElement, localStorage] = createUseThemeMocks('light', ThemePreference.Dark)
+            const { result } = renderHook(() => useTheme(window, documentElement, localStorage))
+            expect(result.current.isLightTheme).toBe(false)
+            expect(result.current.themePreference).toBe(ThemePreference.Dark)
+            expect(documentElement.classList).toContain('theme-dark')
+            expect(documentElement.classList).not.toContain('theme-light')
+            expect(localStorage.getItem('light-theme')).toBe(ThemePreference.Dark)
+        })
+
+        it('system', () => {
+            const [window, documentElement, localStorage] = createUseThemeMocks('dark', ThemePreference.System)
+            const { result } = renderHook(() => useTheme(window, documentElement, localStorage))
+            expect(result.current.isLightTheme).toBe(false)
+            expect(result.current.themePreference).toBe(ThemePreference.System)
+            expect(documentElement.classList).toContain('theme-dark')
+            expect(documentElement.classList).not.toContain('theme-light')
+            expect(localStorage.getItem('light-theme')).toBe(ThemePreference.System)
+        })
+    })
+
+    it('changes theme preference', () => {
+        const [window, documentElement, localStorage] = createUseThemeMocks('light', null)
+        const { result } = renderHook(() => useTheme(window, documentElement, localStorage))
+        expect(result.current.isLightTheme).toBe(true)
+        expect(result.current.themePreference).toBe(ThemePreference.System)
+
+        // Change to dark theme.
+        act(() => {
+            result.current.onThemePreferenceChange(ThemePreference.Dark)
+        })
+        expect(result.current.isLightTheme).toBe(false)
+        expect(result.current.themePreference).toBe(ThemePreference.Dark)
+        expect(documentElement.classList).toContain('theme-dark')
+        expect(documentElement.classList).not.toContain('theme-light')
+        expect(localStorage.getItem('light-theme')).toBe(ThemePreference.Dark)
+
+        // Change to system.
+        act(() => {
+            result.current.onThemePreferenceChange(ThemePreference.System)
+        })
+        expect(result.current.isLightTheme).toBe(true)
+        expect(result.current.themePreference).toBe(ThemePreference.System)
+        expect(documentElement.classList).toContain('theme-light')
+        expect(documentElement.classList).not.toContain('theme-dark')
+        expect(localStorage.getItem('light-theme')).toBe(ThemePreference.System)
+    })
+})

--- a/client/web/src/theme.ts
+++ b/client/web/src/theme.ts
@@ -1,3 +1,8 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { observeSystemIsLightTheme, ThemeProps } from '@sourcegraph/shared/src/theme'
+import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+
 /**
  * The user preference for the theme.
  * These values are stored in local storage.
@@ -14,4 +19,63 @@ export enum ThemePreference {
 export interface ThemePreferenceProps {
     themePreference: ThemePreference
     onThemePreferenceChange: (theme: ThemePreference) => void
+}
+
+const LIGHT_THEME_LOCAL_STORAGE_KEY = 'light-theme'
+
+/** Reads the stored theme preference from localStorage */
+const readStoredThemePreference = (localStorage: Pick<Storage, 'getItem' | 'setItem'>): ThemePreference => {
+    const value = localStorage.getItem(LIGHT_THEME_LOCAL_STORAGE_KEY)
+    // Handle both old and new preference values
+    switch (value) {
+        case 'true':
+        case 'light':
+            return ThemePreference.Light
+        case 'false':
+        case 'dark':
+            return ThemePreference.Dark
+        default:
+            return ThemePreference.System
+    }
+}
+
+/**
+ * A React hook for getting and setting the theme.
+ *
+ * @param window_ The global window object (or a mock in tests).
+ * @param documentElement The root HTML document node (or a mock in tests).
+ * @param localStorage The global localStorage object (or a mock in tests).
+ */
+export const useTheme = (
+    window_: Pick<Window, 'matchMedia'> = window,
+    documentElement: Pick<HTMLElement, 'classList'> = document.documentElement,
+    localStorage: Pick<Storage, 'getItem' | 'setItem'> = window.localStorage
+): ThemeProps & ThemePreferenceProps => {
+    // React to system-wide theme change.
+    const { observable: systemIsLightThemeObservable, initialValue: systemIsLightThemeInitialValue } = useMemo(
+        () => observeSystemIsLightTheme(window_),
+        [window_]
+    )
+    const systemIsLightTheme = useObservable(systemIsLightThemeObservable) ?? systemIsLightThemeInitialValue
+
+    const [themePreference, setThemePreference] = useState(readStoredThemePreference(localStorage))
+    const onThemePreferenceChange = useCallback(
+        (themePreference: ThemePreference) => {
+            localStorage.setItem(LIGHT_THEME_LOCAL_STORAGE_KEY, themePreference)
+            setThemePreference(themePreference)
+        },
+        [localStorage]
+    )
+
+    const isLightTheme = themePreference === 'system' ? systemIsLightTheme : themePreference === 'light'
+    useEffect(() => {
+        documentElement.classList.toggle('theme-light', isLightTheme)
+        documentElement.classList.toggle('theme-dark', !isLightTheme)
+    }, [documentElement.classList, isLightTheme])
+
+    return {
+        isLightTheme,
+        themePreference,
+        onThemePreferenceChange,
+    }
 }


### PR DESCRIPTION
Previously, the theme code was scattered in the SourcegraphWebApp class component. Now, it's in a single React hook `useTheme`. Also, there are tests.

This is just a code refactor; there is no (intended) user-visible change.