### PR TITLE
search: fix highlight matches count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Patched a vulnerability in `apk-tools`. [#23917](https://github.com/sourcegraph/sourcegraph/pull/23917)
 - Line content was being duplicated in unindexed search payloads, causing memory instability for some dense search queries. [#23918](https://github.com/sourcegraph/sourcegraph/pull/23918)
 - Updating draft merge requests on GitLab from batch changes no longer removes the draft status. [#23944](https://github.com/sourcegraph/sourcegraph/issues/23944)
+- Report highlight matches instead of line matches in search results. [#21443](https://github.com/sourcegraph/sourcegraph/issues/21443)
 
 ### Removed
 

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -14,6 +14,7 @@ import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
 import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isDefined, property } from '@sourcegraph/shared/src/util/types'
 import { parseRepoURI } from '@sourcegraph/shared/src/util/url'
@@ -36,7 +37,7 @@ export const FileLocationsNoGroupSelected: React.FunctionComponent = () => (
     </div>
 )
 
-interface Props extends SettingsCascadeProps, VersionContextProps {
+interface Props extends SettingsCascadeProps, VersionContextProps, TelemetryProps {
     location: H.Location
     /**
      * The observable that emits the locations.
@@ -179,6 +180,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
     ): JSX.Element => (
         <FileMatch
             location={this.props.location}
+            telemetryService={this.props.telemetryService}
             expanded={true}
             result={referencesToContentMatch(uri, locationsByURI.get(uri)!)}
             icon={this.props.icon}

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.story.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.story.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { of } from 'rxjs'
 
 import { Location } from '@sourcegraph/extension-api-types'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHelpers'
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
@@ -92,6 +93,7 @@ const PROPS: HierarchicalLocationsViewProps = {
     isLightTheme: true,
     fetchHighlightedFileLineRanges: () => of([['line1\n', 'line2\n', 'line3\n', 'line4']]),
     versionContext: undefined,
+    telemetryService: NOOP_TELEMETRY_SERVICE,
 }
 
 add('Single repo', () => (

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.test.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.test.tsx
@@ -16,6 +16,7 @@ import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
 import { Controller } from '@sourcegraph/shared/src/extensions/controller'
 import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { HierarchicalLocationsView, HierarchicalLocationsViewProps } from './HierarchicalLocationsView'
 
@@ -53,6 +54,7 @@ describe('<HierarchicalLocationsView />', () => {
             isLightTheme: true,
             fetchHighlightedFileLineRanges: sinon.spy(),
             versionContext: undefined,
+            telemetryService: NOOP_TELEMETRY_SERVICE,
         }
         return { props, registerContributions }
     }

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -13,6 +13,7 @@ import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { parseRepoURI } from '@sourcegraph/shared/src/util/url'
 
@@ -27,6 +28,7 @@ const MAXIMUM_LOCATION_RESULTS = 500
 export interface HierarchicalLocationsViewProps
     extends SettingsCascadeProps,
         VersionContextProps,
+        TelemetryProps,
         ExtensionsControllerProps<'extHostAPI'> {
     location: H.Location
     /**
@@ -281,6 +283,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                     <FileLocations
                         className={styles.fileLocations}
                         location={this.props.location}
+                        telemetryService={this.props.telemetryService}
                         locations={of(visibleLocations)}
                         onSelect={this.props.onSelectLocation}
                         icon={FileDocumentIcon}

--- a/client/branded/src/components/panel/views/PanelView.tsx
+++ b/client/branded/src/components/panel/views/PanelView.tsx
@@ -7,6 +7,7 @@ import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 
 import { PanelViewWithComponent } from '../Panel'
@@ -15,7 +16,7 @@ import { EmptyPanelView } from './EmptyPanelView'
 import { HierarchicalLocationsView } from './HierarchicalLocationsView'
 import styles from './PanelView.module.scss'
 
-interface Props extends ExtensionsControllerProps, SettingsCascadeProps, VersionContextProps {
+interface Props extends ExtensionsControllerProps, SettingsCascadeProps, VersionContextProps, TelemetryProps {
     panelView: PanelViewWithComponent
     repoName?: string
     location: H.Location
@@ -44,6 +45,7 @@ export const PanelView = React.memo<Props>(props => (
                 extensionsController={props.extensionsController}
                 settingsCascade={props.settingsCascade}
                 versionContext={props.versionContext}
+                telemetryService={props.telemetryService}
             />
         )}
         {!props.panelView.content && !props.panelView.reactElement && !props.panelView.locationProvider && (

--- a/client/shared/src/components/FileMatch.test.tsx
+++ b/client/shared/src/components/FileMatch.test.tsx
@@ -5,6 +5,8 @@ import * as React from 'react'
 import _VisibilitySensor from 'react-visibility-sensor'
 import sinon from 'sinon'
 
+import { ContentMatch } from '../search/stream'
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import { HIGHLIGHTED_FILE_LINES_REQUEST, NOOP_SETTINGS_CASCADE, RESULT } from '../util/searchTestHelpers'
 
 import { MockVisibilitySensor } from './CodeExcerpt.test'
@@ -19,6 +21,7 @@ jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children
 describe('FileMatch', () => {
     afterAll(cleanup)
     const history = createBrowserHistory()
+    history.replace({ pathname: '/search' })
     const defaultProps = {
         location: history.location,
         result: RESULT,
@@ -29,11 +32,48 @@ describe('FileMatch', () => {
         isLightTheme: true,
         fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_REQUEST,
         settingsCascade: NOOP_SETTINGS_CASCADE,
+        telemetryService: NOOP_TELEMETRY_SERVICE,
     }
 
     it('renders one result container', () => {
         const { container } = render(<FileMatch {...defaultProps} />)
         expect(getByTestId(container, 'result-container')).toBeVisible()
         expect(getAllByTestId(container, 'result-container').length).toBe(1)
+    })
+
+    it('correctly shows number of context lines when search.contextLines setting is set', () => {
+        const result: ContentMatch = {
+            type: 'content',
+            name: '.travis.yml',
+            repository: 'github.com/golang/oauth2',
+            lineMatches: [
+                {
+                    line: '  - go test -v golang.org/x/oauth2/...',
+                    lineNumber: 4,
+                    offsetAndLengths: [[7, 4]],
+                },
+            ],
+        }
+        const settingsCascade = {
+            final: { 'search.contextLines': 3 },
+            subjects: [
+                {
+                    lastID: 1,
+                    settings: { 'search.contextLines': '3' },
+                    extensions: null,
+                    subject: {
+                        __typename: 'User' as const,
+                        username: 'f',
+                        id: 'abc',
+                        settingsURL: '/users/f/settings',
+                        viewerCanAdminister: true,
+                        displayName: 'f',
+                    },
+                },
+            ],
+        }
+        const { container } = render(<FileMatch {...defaultProps} result={result} settingsCascade={settingsCascade} />)
+        const tableRows = container.querySelectorAll('.code-excerpt tr')
+        expect(tableRows.length).toBe(7)
     })
 })

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -1,20 +1,22 @@
 import * as H from 'history'
-import React, { useEffect, useState } from 'react'
+import React, { useMemo } from 'react'
 import { Observable } from 'rxjs'
 import { AggregableBadge, Badge } from 'sourcegraph'
 
 import { ContentMatch, SymbolMatch, PathMatch, getFileMatchUrl, getRepositoryUrl, getRevision } from '../search/stream'
-import { SettingsCascadeProps } from '../settings/settings'
+import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
+import { TelemetryProps } from '../telemetry/telemetryService'
 import { pluralize } from '../util/strings'
 
 import { FetchFileParameters } from './CodeExcerpt'
-import { EventLogger, FileMatchChildren } from './FileMatchChildren'
+import { FileMatchChildren } from './FileMatchChildren'
+import { calculateMatchGroups } from './FileMatchContext'
 import { LinkOrSpan } from './LinkOrSpan'
 import { RepoFileLink } from './RepoFileLink'
 import { RepoIcon } from './RepoIcon'
 import { Props as ResultContainerProps, ResultContainer } from './ResultContainer'
 
-const SUBSET_COUNT_KEY = 'fileMatchSubsetCount'
+const SUBSET_MATCHES_COUNT = 10
 
 export interface MatchItem extends Badge {
     highlightRanges: {
@@ -29,9 +31,8 @@ export interface MatchItem extends Badge {
     aggregableBadges?: AggregableBadge[]
 }
 
-interface Props extends SettingsCascadeProps {
+interface Props extends SettingsCascadeProps, TelemetryProps {
     location: H.Location
-    eventLogger?: EventLogger
     /**
      * The file match search result.
      */
@@ -70,28 +71,41 @@ interface Props extends SettingsCascadeProps {
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
+const sumHighlightRanges = (count: number, item: MatchItem): number => count + item.highlightRanges.length
+
 export const FileMatch: React.FunctionComponent<Props> = props => {
-    const [subsetMatches, setSubsetMatches] = useState(10)
-    useEffect(() => {
-        const subsetMatches = parseInt(localStorage.getItem(SUBSET_COUNT_KEY) || '', 10)
-        if (!isNaN(subsetMatches)) {
-            setSubsetMatches(subsetMatches)
+    // The number of lines of context to show before and after each match.
+    const context = useMemo(() => {
+        if (props.location.pathname === '/search') {
+            // Check if search.contextLines is configured in settings.
+            const contextLinesSetting =
+                isSettingsValid(props.settingsCascade) &&
+                props.settingsCascade.final &&
+                props.settingsCascade.final['search.contextLines']
+
+            if (typeof contextLinesSetting === 'number' && contextLinesSetting >= 0) {
+                return contextLinesSetting
+            }
         }
-    }, [])
+        return 1
+    }, [props.location, props.settingsCascade])
 
     const result = props.result
-    const items: MatchItem[] =
-        result.type === 'content'
-            ? result.lineMatches.map(match => ({
-                  highlightRanges: match.offsetAndLengths.map(([start, highlightLength]) => ({
-                      start,
-                      highlightLength,
-                  })),
-                  preview: match.line,
-                  line: match.lineNumber,
-                  aggregableBadges: match.aggregableBadges,
-              }))
-            : []
+    const items: MatchItem[] = useMemo(
+        () =>
+            result.type === 'content'
+                ? result.lineMatches.map(match => ({
+                      highlightRanges: match.offsetAndLengths.map(([start, highlightLength]) => ({
+                          start,
+                          highlightLength,
+                      })),
+                      preview: match.line,
+                      line: match.lineNumber,
+                      aggregableBadges: match.aggregableBadges,
+                  }))
+                : [],
+        [result]
+    )
 
     const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
     const revisionDisplayName = getRevision(result.branches, result.version)
@@ -134,13 +148,19 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
 
     let containerProps: ResultContainerProps
 
-    const expandedChildren = (
-        <FileMatchChildren {...props} items={items} result={result} allMatches={true} subsetMatches={subsetMatches} />
-    )
+    const expandedMatchGroups = useMemo(() => calculateMatchGroups(items, 0, context), [items, context])
+    const collapsedMatchGroups = useMemo(() => calculateMatchGroups(items, SUBSET_MATCHES_COUNT, context), [
+        items,
+        context,
+    ])
 
-    const matchCount = items.length || (result.type === 'symbol' ? result.symbols?.length : 0)
+    const highlightRangesCount = items.reduce(sumHighlightRanges, 0)
+    const collapsedHighlightRangesCount = collapsedMatchGroups.matches.reduce(sumHighlightRanges, 0)
+
+    const matchCount = highlightRangesCount || (result.type === 'symbol' ? result.symbols?.length : 0)
     const matchCountLabel = matchCount ? `${matchCount} ${pluralize('match', matchCount, 'matches')}` : ''
 
+    const expandedChildren = <FileMatchChildren {...props} result={result} {...expandedMatchGroups} />
     if (props.showAllMatches) {
         containerProps = {
             collapsible: false,
@@ -154,22 +174,14 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
             repoStars: result.repoStars,
         }
     } else {
-        const length = items.length - subsetMatches
+        const length = highlightRangesCount - collapsedHighlightRangesCount
         containerProps = {
-            collapsible: items.length > subsetMatches,
+            collapsible: items.length > SUBSET_MATCHES_COUNT,
             defaultExpanded: props.expanded,
             icon: props.icon,
             title: renderTitle(),
             description,
-            collapsedChildren: (
-                <FileMatchChildren
-                    {...props}
-                    items={items}
-                    result={result}
-                    allMatches={false}
-                    subsetMatches={subsetMatches}
-                />
-            ),
+            collapsedChildren: <FileMatchChildren {...props} result={result} {...collapsedMatchGroups} />,
             expandedChildren,
             collapseLabel: `Hide ${length}`,
             expandLabel: `${length} more`,

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -154,8 +154,10 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
         context,
     ])
 
-    const highlightRangesCount = items.reduce(sumHighlightRanges, 0)
-    const collapsedHighlightRangesCount = collapsedMatchGroups.matches.reduce(sumHighlightRanges, 0)
+    const highlightRangesCount = useMemo(() => items.reduce(sumHighlightRanges, 0), [items])
+    const collapsedHighlightRangesCount = useMemo(() => collapsedMatchGroups.matches.reduce(sumHighlightRanges, 0), [
+        collapsedMatchGroups,
+    ])
 
     const matchCount = highlightRangesCount || (result.type === 'symbol' ? result.symbols?.length : 0)
     const matchCountLabel = matchCount ? `${matchCount} ${pluralize('match', matchCount, 'matches')}` : ''

--- a/client/shared/src/components/FileMatchChildren.test.tsx
+++ b/client/shared/src/components/FileMatchChildren.test.tsx
@@ -5,6 +5,7 @@ import _VisibilitySensor from 'react-visibility-sensor'
 import { of } from 'rxjs'
 import sinon from 'sinon'
 
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import {
     RESULT,
     HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
@@ -28,11 +29,19 @@ const onSelect = sinon.spy()
 
 const defaultProps = {
     location: history.location,
-    items: [
+    matches: [
         {
             preview: 'third line of code',
             line: 3,
             highlightRanges: [{ start: 7, highlightLength: 4 }],
+        },
+    ],
+    grouped: [
+        {
+            matches: [{ line: 3, character: 7, highlightLength: 4, isInContext: true }],
+            position: { line: 3, character: 7 },
+            startLine: 3,
+            endLine: 4,
         },
     ],
     result: RESULT,
@@ -43,6 +52,7 @@ const defaultProps = {
     settingsCascade: NOOP_SETTINGS_CASCADE,
     isLightTheme: true,
     versionContext: undefined,
+    telemetryService: NOOP_TELEMETRY_SERVICE,
 }
 
 describe('FileMatchChildren', () => {
@@ -54,30 +64,6 @@ describe('FileMatchChildren', () => {
         expect(item).toBeVisible()
         fireEvent.click(item!)
         expect(onSelect.calledOnce).toBe(true)
-    })
-
-    it('correctly shows number of context lines when search.contextLines setting is set', () => {
-        const settingsCascade = {
-            final: { 'search.contextLines': 3 },
-            subjects: [
-                {
-                    lastID: 1,
-                    settings: { 'search.contextLines': '3' },
-                    extensions: null,
-                    subject: {
-                        __typename: 'User' as const,
-                        username: 'f',
-                        id: 'abc',
-                        settingsURL: '/users/f/settings',
-                        viewerCanAdminister: true,
-                        displayName: 'f',
-                    },
-                },
-            ],
-        }
-        const { container } = render(<FileMatchChildren {...defaultProps} settingsCascade={settingsCascade} />)
-        const tableRows = container.querySelectorAll('.code-excerpt tr')
-        expect(tableRows.length).toBe(7)
     })
 
     it('does not disable the highlighting timeout', () => {

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -5,8 +5,9 @@ import { map } from 'rxjs/operators'
 
 import { IHighlightLineRange } from '../graphql/schema'
 import { ContentMatch, SymbolMatch, PathMatch, getFileMatchUrl } from '../search/stream'
-import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
+import { SettingsCascadeProps } from '../settings/settings'
 import { SymbolIcon } from '../symbols/SymbolIcon'
+import { TelemetryProps } from '../telemetry/telemetryService'
 import { ThemeProps } from '../theme'
 import { isErrorLike } from '../util/errors'
 import {
@@ -18,28 +19,16 @@ import {
 import { CodeExcerpt, FetchFileParameters } from './CodeExcerpt'
 import { CodeExcerptUnhighlighted } from './CodeExcerptUnhighlighted'
 import { MatchItem } from './FileMatch'
-import { MatchGroup, calculateMatchGroups } from './FileMatchContext'
+import { MatchGroup } from './FileMatchContext'
 import { Link } from './Link'
 
-export interface EventLogger {
-    log: (eventLabel: string, eventProperties?: any, publicEventProperties?: any) => void
-}
-
-interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
+interface FileMatchProps extends SettingsCascadeProps, ThemeProps, TelemetryProps {
     location: H.Location
-    eventLogger?: EventLogger
-    items: MatchItem[]
     result: ContentMatch | SymbolMatch | PathMatch
+    matches: MatchItem[]
+    grouped: MatchGroup[]
     /* Called when the first result has fully loaded. */
     onFirstResultLoad?: () => void
-    /**
-     * Whether or not to show all matches for this file, or only a subset.
-     */
-    allMatches: boolean
-    /**
-     * The number of matches to show when the results are collapsed (allMatches===false, user has not clicked "Show N more matches")
-     */
-    subsetMatches: number
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
     /**
      * Called when the file's search result is selected.
@@ -51,28 +40,6 @@ interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
 const NO_SEARCH_HIGHLIGHTING = localStorage.getItem('noSearchHighlighting') !== null
 
 export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props => {
-    // The number of lines of context to show before and after each match.
-    let context = 1
-
-    if (props.location.pathname === '/search') {
-        // Check if search.contextLines is configured in settings.
-        const contextLinesSetting =
-            isSettingsValid(props.settingsCascade) &&
-            props.settingsCascade.final &&
-            props.settingsCascade.final['search.contextLines']
-
-        if (typeof contextLinesSetting === 'number' && contextLinesSetting >= 0) {
-            context = contextLinesSetting
-        }
-    }
-
-    const maxMatches = props.allMatches ? 0 : props.subsetMatches
-    const [matches, grouped] = React.useMemo(() => calculateMatchGroups(props.items, maxMatches, context), [
-        props.items,
-        maxMatches,
-        context,
-    ])
-
     // If optimizeHighlighting is enabled, compile a list of the highlighted file ranges we want to
     // fetch (instead of the entire file.)
     const optimizeHighlighting =
@@ -81,7 +48,15 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         props.settingsCascade.final.experimentalFeatures &&
         props.settingsCascade.final.experimentalFeatures.enableFastResultLoading
 
-    const { result, isLightTheme, fetchHighlightedFileLineRanges, eventLogger, onFirstResultLoad } = props
+    const {
+        result,
+        isLightTheme,
+        matches,
+        grouped,
+        fetchHighlightedFileLineRanges,
+        telemetryService,
+        onFirstResultLoad,
+    } = props
     const fetchHighlightedFileRangeLines = React.useCallback(
         (isFirst, startLine, endLine, isLightTheme) => {
             const startTime = Date.now()
@@ -107,20 +82,18 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                     if (isFirst && onFirstResultLoad) {
                         onFirstResultLoad()
                     }
-                    if (eventLogger) {
-                        eventLogger.log(
-                            'search.latencies.frontend.code-load',
-                            { durationMs: Date.now() - startTime },
-                            { durationMs: Date.now() - startTime }
-                        )
-                    }
+                    telemetryService.log(
+                        'search.latencies.frontend.code-load',
+                        { durationMs: Date.now() - startTime },
+                        { durationMs: Date.now() - startTime }
+                    )
                     return optimizeHighlighting
                         ? lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]
                         : lines[0].slice(startLine, endLine)
                 })
             )
         },
-        [result, fetchHighlightedFileLineRanges, grouped, optimizeHighlighting, eventLogger, onFirstResultLoad]
+        [result, fetchHighlightedFileLineRanges, grouped, optimizeHighlighting, telemetryService, onFirstResultLoad]
     )
 
     const createCodeExcerptLink = (group: MatchGroup): string => {

--- a/client/shared/src/components/FileMatchContext.test.tsx
+++ b/client/shared/src/components/FileMatchContext.test.tsx
@@ -31,7 +31,7 @@ describe('components/FileMatchContext', () => {
         test('simple', () => {
             const maxMatches = 3
             const context = 1
-            const [, grouped] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
+            const { grouped } = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
             expect(grouped).toMatchInlineSnapshot(`
                 [
                   {
@@ -40,25 +40,25 @@ describe('components/FileMatchContext', () => {
                         "line": 0,
                         "character": 0,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 1,
                         "character": 0,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 2,
                         "character": 0,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 3,
                         "character": 0,
                         "highlightLength": 5,
-                        "IsInContext": true
+                        "isInContext": true
                       }
                     ],
                     "position": {
@@ -75,7 +75,7 @@ describe('components/FileMatchContext', () => {
         test('no context', () => {
             const maxMatches = 3
             const context = 0
-            const [, grouped] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
+            const { grouped } = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
             expect(grouped).toMatchInlineSnapshot(`
                 [
                   {
@@ -84,19 +84,19 @@ describe('components/FileMatchContext', () => {
                         "line": 0,
                         "character": 0,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 1,
                         "character": 0,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 2,
                         "character": 0,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       }
                     ],
                     "position": {
@@ -113,7 +113,7 @@ describe('components/FileMatchContext', () => {
         test('complex grouping', () => {
             const maxMatches = 10
             const context = 2
-            const [, grouped] = calculateMatchGroups(testDataRealMatches, maxMatches, context)
+            const { grouped } = calculateMatchGroups(testDataRealMatches, maxMatches, context)
             expect(grouped).toMatchInlineSnapshot(`
                 [
                   {
@@ -122,31 +122,31 @@ describe('components/FileMatchContext', () => {
                         "line": 0,
                         "character": 51,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 2,
                         "character": 48,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 3,
                         "character": 15,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 3,
                         "character": 39,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 8,
                         "character": 2,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       }
                     ],
                     "position": {
@@ -162,7 +162,7 @@ describe('components/FileMatchContext', () => {
                         "line": 14,
                         "character": 19,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       }
                     ],
                     "position": {
@@ -178,37 +178,37 @@ describe('components/FileMatchContext', () => {
                         "line": 20,
                         "character": 11,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 24,
                         "character": 8,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 24,
                         "character": 19,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 27,
                         "character": 53,
                         "highlightLength": 5,
-                        "IsInContext": false
+                        "isInContext": false
                       },
                       {
                         "line": 28,
                         "character": 3,
                         "highlightLength": 5,
-                        "IsInContext": true
+                        "isInContext": true
                       },
                       {
                         "line": 29,
                         "character": 13,
                         "highlightLength": 5,
-                        "IsInContext": true
+                        "isInContext": true
                       }
                     ],
                     "position": {

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -32,7 +32,7 @@ const calculateGroupPositions = (
         line: number
         character: number
         highlightLength: number
-        IsInContext: boolean
+        isInContext: boolean
     }[],
     context: number,
     highestLineNumberWithinSubsetMatches: number
@@ -87,7 +87,7 @@ export interface MatchGroup {
         line: number
         character: number
         highlightLength: number
-        IsInContext: boolean
+        isInContext: boolean
     }[]
 
     // The 1-based position of where the first match in the group.
@@ -121,7 +121,7 @@ export const calculateMatchGroups = (
     matches: MatchItem[],
     maxMatches: number,
     context: number
-): [MatchItem[], MatchGroup[]] => {
+): { matches: MatchItem[]; grouped: MatchGroup[] } => {
     const sortedMatches = matches.sort((a, b) => {
         if (a.line < b.line) {
             return -1
@@ -155,15 +155,15 @@ export const calculateMatchGroups = (
 
     const grouped = mergeContext(
         context,
-        flatMap(showMatches, (match, index) =>
+        flatMap(showMatches, match =>
             match.highlightRanges.map(range => ({
                 line: match.line,
                 character: range.start,
                 highlightLength: range.highlightLength,
-                IsInContext: maxMatches === 0 ? false : match.line > highestLineNumberWithinSubsetMatches,
+                isInContext: maxMatches === 0 ? false : match.line > highestLineNumberWithinSubsetMatches,
             }))
         )
     ).map(group => calculateGroupPositions(group, context, highestLineNumberWithinSubsetMatches))
 
-    return [showMatches, grouped]
+    return { matches: showMatches, grouped }
 }

--- a/client/shared/src/components/ResultContainer.test.tsx
+++ b/client/shared/src/components/ResultContainer.test.tsx
@@ -4,6 +4,7 @@ import FileIcon from 'mdi-react/FileIcon'
 import * as React from 'react'
 import sinon from 'sinon'
 
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import {
     MULTIPLE_MATCH_RESULT,
     HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
@@ -20,9 +21,8 @@ describe('ResultContainer', () => {
     const history = H.createBrowserHistory()
     history.replace({ pathname: '/search' })
     const onSelect = sinon.spy()
-    const fileMatchChildrenProps = {
-        location: history.location,
-        items: [
+    const expandedMatchGroups = {
+        matches: [
             {
                 preview: '\t"net/http/httptest"',
                 line: 11,
@@ -49,13 +49,66 @@ describe('ResultContainer', () => {
                 highlightRanges: [{ start: 8, highlightLength: 4 }],
             },
         ],
+        grouped: [
+            {
+                matches: [{ line: 11, character: 15, highlightLength: 4, isInContext: true }],
+                position: { line: 11, character: 15 },
+                startLine: 11,
+                endLine: 12,
+            },
+            {
+                matches: [{ line: 39, character: 11, highlightLength: 4, isInContext: true }],
+                position: { line: 39, character: 11 },
+                startLine: 39,
+                endLine: 40,
+            },
+            {
+                matches: [{ line: 73, character: 5, highlightLength: 4, isInContext: true }],
+                position: { line: 73, character: 5 },
+                startLine: 73,
+                endLine: 74,
+            },
+            {
+                matches: [{ line: 117, character: 11, highlightLength: 4, isInContext: true }],
+                position: { line: 117, character: 11 },
+                startLine: 117,
+                endLine: 118,
+            },
+            {
+                matches: [{ line: 134, character: 8, highlightLength: 4, isInContext: true }],
+                position: { line: 134, character: 8 },
+                startLine: 134,
+                endLine: 135,
+            },
+        ],
+    }
+
+    const collapsedMatchGroups = {
+        matches: [
+            {
+                preview: '\t"net/http/httptest"',
+                line: 11,
+                highlightRanges: [{ start: 15, highlightLength: 4 }],
+            },
+        ],
+        grouped: [
+            {
+                matches: [{ line: 11, character: 15, highlightLength: 4, isInContext: true }],
+                position: { line: 11, character: 15 },
+                startLine: 11,
+                endLine: 12,
+            },
+        ],
+    }
+
+    const fileMatchChildrenProps = {
+        location: history.location,
         result: MULTIPLE_MATCH_RESULT,
-        allMatches: true,
-        subsetMatches: 1,
         fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
         onSelect,
         settingsCascade: NOOP_SETTINGS_CASCADE,
         isLightTheme: true,
+        telemetryService: NOOP_TELEMETRY_SERVICE,
     }
 
     // Props that represent a FileMatch with multiple results, totaling more than subsetMatch.
@@ -74,8 +127,8 @@ describe('ResultContainer', () => {
                 fileURL="https://example.com/file"
             />
         ),
-        expandedChildren: <FileMatchChildren {...fileMatchChildrenProps} />,
-        collapsedChildren: <FileMatchChildren {...fileMatchChildrenProps} allMatches={false} />,
+        expandedChildren: <FileMatchChildren {...fileMatchChildrenProps} {...expandedMatchGroups} />,
+        collapsedChildren: <FileMatchChildren {...fileMatchChildrenProps} {...collapsedMatchGroups} />,
         collapseLabel: 'Hide matches',
         expandLabel: 'Show matches',
         allExpanded: false,
@@ -94,9 +147,9 @@ describe('ResultContainer', () => {
                 fileURL="https://example.com/file"
             />
         ),
-        expandedChildren: <FileMatchChildren {...fileMatchChildrenProps} />,
-        allExpanded: true,
+        expandedChildren: <FileMatchChildren {...fileMatchChildrenProps} {...expandedMatchGroups} />,
     }
+
     it('displays only one result when collapsed, which is the equivalent of subsetMatches', () => {
         const { container } = render(<ResultContainer {...defaultProps} />)
 

--- a/client/web/src/search/results/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/StreamingSearchResultsList.tsx
@@ -24,7 +24,6 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { SearchResult } from '../../components/SearchResult'
-import { eventLogger } from '../../tracking/eventLogger'
 
 import { StreamingSearchResultFooter } from './StreamingSearchResultsFooter'
 
@@ -79,7 +78,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                     return (
                         <FileMatch
                             location={location}
-                            eventLogger={eventLogger}
+                            telemetryService={telemetryService}
                             icon={getFileMatchIcon(result)}
                             result={result}
                             onSelect={logSearchResultClicked}
@@ -112,7 +111,15 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                     )
             }
         },
-        [isLightTheme, location, logSearchResultClicked, allExpanded, fetchHighlightedFileLineRanges, settingsCascade]
+        [
+            isLightTheme,
+            location,
+            telemetryService,
+            logSearchResultClicked,
+            allExpanded,
+            fetchHighlightedFileLineRanges,
+            settingsCascade,
+        ]
     )
 
     return (


### PR DESCRIPTION
Fixes #21443

Current:

<img width="1047" alt="Screenshot 2021-08-23 at 11 11 51" src="https://user-images.githubusercontent.com/6417322/130422177-b18010ae-e945-4e3f-9ee2-e2eb71c07858.png">

Fixed (588 - 576 = 12, which corresponds to the number of visible highlight ranges):

<img width="1041" alt="Screenshot 2021-08-23 at 11 12 24" src="https://user-images.githubusercontent.com/6417322/130422189-fde062c9-1813-4819-b7ba-ebd6e916d432.png">
