### PR TITLE
nix: a shell.nix for running go test

### DIFF
--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This file is called by nix-shell when setting up the shell. It is
+# responsible for setting up the development environment outside of what nix's
+# package management.
+#
+# The main goal of this is to start stateful services which aren't managed by
+# sourcegraph's developer tools. In particular this is our databases, which
+# are used by both our tests and development server.
+
+set -eu
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# TODO build with nix
+if [ ! -e ../../libsqlite3-pcre.so ]; then
+  echo 'Building libsqlite3-pcre...'
+  NIX_ENFORCE_PURITY=0 ../libsqlite3-pcre/build.sh
+fi
+
+. ./start-postgres.sh

--- a/dev/nix/start-postgres.sh
+++ b/dev/nix/start-postgres.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# We start up a postgres tuned for performance vs persistence. This is more
+# likely to lose data, but this seems like a fine trade-off for tests/devenv.
+
+# Use a different data dir depending on PG version. Avoids the need to migrate
+# when we upgrade at the cost of a fresh dev environment.
+PGVER=$(pg_ctl -V | awk '{print $NF}')
+
+export PGHOST="${SG_DATA_DIR:-$HOME/.sourcegraph}/postgres"
+export PGDATA="${PGHOST}/${PGVER}"
+export PGDATABASE=postgres
+export PGDATASOURCE="postgresql:///postgres?host=${PGHOST}"
+
+if [ ! -d "$PGHOST" ]; then
+  mkdir -p "$PGHOST"
+fi
+if [ ! -d "$PGDATA" ]; then
+  echo 'Initializing postgresql database...'
+  initdb "$PGDATA" --nosync -E UNICODE --auth=trust >/dev/null
+  cat <<-EOF >>"$PGDATA"/postgresql.conf
+	    unix_socket_directories = '$PGHOST'
+	    listen_addresses = ''
+	    shared_buffers = 12MB
+	    fsync = off
+	    synchronous_commit = off
+	    full_page_writes = off
+EOF
+fi
+if ! pg_isready --quiet; then
+  echo 'Starting postgresql database...'
+  pg_ctl start -l "$PGHOST/log"
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,82 @@
+# Experimental support for developing in nix. Please reach out to @keegan if
+# you encounter any issues.
+#
+# Things it does differently:
+#
+# - Runs postgres under ~/.sourcegraph with a unix socket. No need to manage a
+#   service. Must remember to run "pg_ctl stop" if you want to stop it.
+#
+# Status: go test ./... and yarn works
+
+{ pkgs ? import <nixpkgs> { }, ... }:
+
+let
+  # pkgs.universal-ctags installs the binary as "ctags", not "universal-ctags"
+  # like zoekt expects.
+  universal-ctags = pkgs.writeScriptBin "universal-ctags" ''
+    #!${pkgs.stdenv.shell}
+    exec ${pkgs.universal-ctags}/bin/ctags "$@"
+  '';
+
+  # The version required of node is ahead of what is available in the
+  # registry, so we build a custom version.
+  node16_7 =
+    pkgs.callPackage "${<nixpkgs>}/pkgs/development/web/nodejs/nodejs.nix" {
+      python = pkgs.python3;
+    } {
+      enableNpm = true;
+      version = "16.7.0";
+      sha256 = "0drd7zyadjrhng9k0mspz456j3pmr7kli5dd0kx8grbqsgxzv1gs";
+    };
+
+  # Build yarn against the node we use.
+  yarn = pkgs.yarn.override { nodejs = node16_7; };
+
+in pkgs.mkShell {
+  name = "sourcegraph-dev";
+
+  # The packages in the `buildInputs` list will be added to the PATH in our shell
+  nativeBuildInputs = with pkgs; [
+    # Our core DB.
+    pkgs.postgresql_13
+
+    # Cache and some store data
+    pkgs.redis
+
+    # Used by symbols and zoekt-git-index to extract symbols from
+    # sourcecode.
+    universal-ctags
+
+    # Build our backend.
+    pkgs.go
+
+    # Lots of our tooling and go tests rely on git.
+    pkgs.git
+
+    # cgo dependency for symbols. TODO build with nix?
+    pkgs.pcre
+    pkgs.sqlite
+    pkgs.pkg-config
+
+    # monitors src files to restart dev services
+    pkgs.watchman
+
+    # CI lint tools you need locally
+    pkgs.shfmt
+    pkgs.shellcheck
+
+    # Web tools
+    node16_7
+    yarn
+    pkgs.nodePackages.typescript
+  ];
+
+  # Startup postgres
+  shellHook = ''
+    . ./dev/nix/shell-hook.sh
+  '';
+
+  # By explicitly setting this environment variable we avoid starting up
+  # universal-ctags via docker.
+  CTAGS_COMMAND = "${universal-ctags}/bin/universal-ctags";
+}


### PR DESCRIPTION
This is a first step towards support nix in our development
environment. It only covers go test and yarn. I am still a nix noob as
well, so could be much better.

Different to our usual environment is that it runs postgres under
~/.sourcegraph with a unix socket. No need to manage service. Must
remember to run pg_ctl shutdown if you want to stop.