### PR TITLE
search: use global perf optimizations for suggesting symbols

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -401,8 +401,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		}
 
 		suggestions := make([]SearchSuggestionResolver, 0)
-		fileMatches := results.Matches
-		for _, match := range fileMatches {
+		for _, match := range results.Matches {
 			fileMatch, ok := match.(*result.FileMatch)
 			if !ok {
 				continue

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -392,7 +392,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		}
 		args.ResultTypes = result.TypeSymbol
 
-		res, err := r.doResults(ctx, args)
+		results, err := r.doResults(ctx, args)
 		if errors.Is(err, context.DeadlineExceeded) {
 			err = nil
 		}
@@ -401,7 +401,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		}
 
 		suggestions := make([]SearchSuggestionResolver, 0)
-		fileMatches := res.Matches
+		fileMatches := results.Matches
 		for _, match := range fileMatches {
 			fileMatch, ok := match.(*result.FileMatch)
 			if !ok {


### PR DESCRIPTION
With this change we call `doResults` for symbol suggestions, leveraging
optimizations we have in place for global queries.

Up to now we called `symbol.Search` directly, bypassing `doResults`.
Additionally we have a 3 seconds cutoff for all suggestions. As a consequence,
symbol suggestions for global queries on .COM almost always time out.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->