### PR TITLE
API docs: add ability to view individual symbols

### DIFF
--- a/client/web/src/repo/docs/DocumentationExamples.tsx
+++ b/client/web/src/repo/docs/DocumentationExamples.tsx
@@ -18,6 +18,7 @@ interface Props extends SettingsCascadeProps, VersionContextProps {
     repo: RepositoryFields
     commitID: string
     pathID: string
+    count: number
 }
 
 export const DocumentationExamples: React.FunctionComponent<Props> = props => {

--- a/client/web/src/repo/docs/DocumentationExamplesList.tsx
+++ b/client/web/src/repo/docs/DocumentationExamplesList.tsx
@@ -25,6 +25,7 @@ interface Props extends SettingsCascadeProps, VersionContextProps {
     repo: RepositoryFields
     commitID: string
     pathID: string
+    count: number
 }
 
 const LOADING = 'loading' as const
@@ -34,6 +35,7 @@ export const DocumentationExamplesList: React.FunctionComponent<Props> = ({
     commitID,
     pathID,
     repo,
+    count,
     ...props
 }) => {
     const referencesLocations =
@@ -44,12 +46,12 @@ export const DocumentationExamplesList: React.FunctionComponent<Props> = ({
                         repo: repo.id,
                         revspec: commitID,
                         pathID,
-                        first: 3,
+                        first: count,
                     }).pipe(
                         catchError(error => [asError(error)]),
                         startWith(LOADING)
                     ),
-                [repo.id, commitID, pathID]
+                [repo.id, commitID, pathID, count]
             )
         ) || LOADING
 

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -168,6 +168,7 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = React
         [setVisiblePathID, setVisibilityEvents]
     )
 
+    const onlyPathID = location.search === '' ? undefined : props.pathID + '#' + location.search.slice('?'.length)
     return (
         <div className="repository-docs-page">
             <PageTitle title="API docs" />
@@ -262,6 +263,7 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = React
                                 pagePathID={pagePathID}
                                 depth={0}
                                 isFirstChild={true}
+                                onlyPathID={onlyPathID}
                                 excludingTags={excludingTags}
                                 scrollingRoot={containerReference}
                                 onVisible={onVisible}

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -168,7 +168,16 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = React
         [setVisiblePathID, setVisibilityEvents]
     )
 
+    // If we switch from rendering the entire page to rendering a specific full path ID (section of
+    // the page), then scroll back to the top of the page as our scroll position would no longer be
+    // meaningful.
     const onlyPathID = location.search === '' ? undefined : props.pathID + '#' + location.search.slice('?'.length)
+    useEffect(() => {
+        if (onlyPathID && containerReference.current) {
+            containerReference.current.scrollTop = 0
+        }
+    }, [onlyPathID])
+
     return (
         <div className="repository-docs-page">
             <PageTitle title="API docs" />
@@ -281,7 +290,7 @@ function isElementInView(element: HTMLElement, container: HTMLElement, partial: 
     const containerTop = container.scrollTop
     const containerBottom = containerTop + container.clientHeight
 
-    const elementTop = element.offsetTop as number
+    const elementTop = element.offsetTop
     const elementBottom = elementTop + element.clientHeight
 
     if (elementTop >= containerTop && elementBottom <= containerBottom) {

--- a/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationSidebar.tsx
@@ -215,7 +215,7 @@ export const RepositoryDocumentationSidebar: React.FunctionComponent<Props> = ({
     )
 }
 
-function hasDescendent(node: GQLDocumentationNode, descendentPathID: string): boolean {
+export function hasDescendent(node: GQLDocumentationNode, descendentPathID: string): boolean {
     return !!node.children.find(child => {
         if (child.pathID === descendentPathID || child.node?.pathID === descendentPathID) {
             return true

--- a/client/web/src/util/url.ts
+++ b/client/web/src/util/url.ts
@@ -18,6 +18,13 @@ export function toDocumentationURL(target: RepoDocumentation): string {
     return `/${encodeRepoRevision(target)}/-/docs${target.pathID}`
 }
 
+export function toDocumentationSingleSymbolURL(target: RepoDocumentation): string {
+    const hash = target.pathID.indexOf('#')
+    const path = hash === -1 ? target.PathID : target.pathID.slice(0, hash)
+    const qualifier = hash === -1 ? '' : target.pathID.slice(hash + '#'.length)
+    return `/${encodeRepoRevision(target)}/-/docs${path}?${qualifier}`
+}
+
 /**
  * Returns the given URLSearchParams as a string.
  */

--- a/client/web/src/util/url.ts
+++ b/client/web/src/util/url.ts
@@ -20,7 +20,7 @@ export function toDocumentationURL(target: RepoDocumentation): string {
 
 export function toDocumentationSingleSymbolURL(target: RepoDocumentation): string {
     const hash = target.pathID.indexOf('#')
-    const path = hash === -1 ? target.PathID : target.pathID.slice(0, hash)
+    const path = hash === -1 ? target.pathID : target.pathID.slice(0, hash)
     const qualifier = hash === -1 ? '' : target.pathID.slice(hash + '#'.length)
     return `/${encodeRepoRevision(target)}/-/docs${path}?${qualifier}`
 }


### PR DESCRIPTION
This adds the ability to view individual symbols in isolation, rather than on the entire, full page.

* `/github.com/golang/go/-/docs/archive/tar#ErrHeader` -> full page, scrolled to `ErrHeader`
* `/github.com/golang/go/-/docs/archive/tar?ErrHeader` -> shows just `ErrHeader`
* `/github.com/golang/go/-/docs/archive/tar#Writer` -> full page, scrolled to `Writer`
* `/github.com/golang/go/-/docs/archive/tar#Writer` -> shows just `Writer` on a single page, with the methods etc. below it.

This is primarily useful for:

1. Sharing a link to something specific with others - as the opengraph metadata can (in the future) show exactly the thing you're linking to ("type Writer ..." instead of just "Package tar").
2. Search engines can index these pages individually.
3. We can display more content on such pages, such as more usage examples, more easily.

Fixes #22575

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>