### PR TITLE
doc: reorganize docsite homepage

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -76,29 +76,30 @@ For next steps, visit the [Docker installation documentation](admin/install/dock
 
 ## Core documentation
 
-- [Install](#getting-started) or [update](admin/updates/index.md) Sourcegraph
-- [Using Sourcegraph](getting-started/index.md)
-- [Administration](admin/index.md)
-- [Extensions](extensions/index.md)
-- [Cloud](code_search/explanations/sourcegraph_cloud.md)
-
-## Cloud documentation
-
-- [Sourcegraph cloud](code_search/explanations/sourcegraph_cloud.md)
-- [Differences between Sourcegraph cloud and self-hosted ](cloud/cloud_ent_on-prem_comparison.md)
-
 ### Features and tutorials
 
 - [Tour](getting-started/tour.md): A walkthrough of Sourcegraph's features, with real-world example use cases.
+- [Using Sourcegraph](getting-started/index.md)
 - [How to run a Sourcegraph trial](adopt/trial/index.md) at your company
 - [Integrations](integration/index.md) with GitHub, GitLab, Bitbucket, etc.
+- [Extensions](extensions/index.md)
 - [Chrome and Firefox browser extensions](integration/browser_extension.md)
+
+### Sourcegraph cloud
+
+- [Sourcegraph cloud](code_search/explanations/sourcegraph_cloud.md)
+- [Differences between Sourcegraph cloud and self-hosted](cloud/cloud_ent_on-prem_comparison.md)
 
 ### Reference
 
 - [Query syntax reference](code_search/reference/queries.md)
 - [GraphQL API](api/graphql/index.md)
 - [Sourcegraph changelog](./CHANGELOG.md)
+
+### Administration
+
+- [Install](#getting-started) or [update](admin/updates/index.md) Sourcegraph
+- [Administration](admin/index.md)
 
 ## Other links
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -39,7 +39,7 @@ This website is home to Sourcegraph's feature, installation, administration, and
   <a href="admin/install/managed" class="btn" alt="Managed instance">
    <span>Managed instance</span>
    </br>
-    A private Sourcegraph deployment provisioned and managed by the Sourcegraph team.
+    Get a Sourcegraph instance provisioned and managed by the Sourcegraph team.
   </a>
 
   <a href="#quick-install" class="btn" alt="Quick install">
@@ -85,18 +85,18 @@ For next steps, visit the [Docker installation documentation](admin/install/dock
 - [Extensions](extensions/index.md)
 - [Chrome and Firefox browser extensions](integration/browser_extension.md)
 
-### Sourcegraph cloud
-
-- [Sourcegraph cloud](code_search/explanations/sourcegraph_cloud.md)
-- [Differences between Sourcegraph cloud and self-hosted](cloud/cloud_ent_on-prem_comparison.md)
-
 ### Reference
 
 - [Query syntax reference](code_search/reference/queries.md)
 - [GraphQL API](api/graphql/index.md)
 - [Sourcegraph changelog](./CHANGELOG.md)
 
-### Administration
+## Cloud documentation
+
+- [Sourcegraph cloud](code_search/explanations/sourcegraph_cloud.md)
+- [Differences between Sourcegraph cloud and self-hosted](cloud/cloud_ent_on-prem_comparison.md)
+
+## Self-hosted documentation
 
 - [Install](#getting-started) or [update](admin/updates/index.md) Sourcegraph
 - [Administration](admin/index.md)


### PR DESCRIPTION
With the recent addition of the `Cloud documentation` section (https://github.com/sourcegraph/sourcegraph/pull/24074), the nesting on the homepage is a bit incorrect, since features/tutorials are now under cloud documentation only:

![image](https://user-images.githubusercontent.com/23356519/130498147-58b49d7f-8819-41f7-be84-dd3099dab639.png)

This PR gets rid of items in the "core documentation" category in favour of more specific categories, so that the more general-use-case feature docs come first, then cloud, then self-hosted

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
