### PR TITLE
compute: require strict regular expression patterns

### DIFF
--- a/internal/compute/match_context_result.go
+++ b/internal/compute/match_context_result.go
@@ -60,7 +60,7 @@ func newRange(startLine, endLine, startColumn, endColumn int) Range {
 	}
 }
 
-func ofRegexpMatches(matches [][]int, namedGroups []string, lineValue string, lineNumber int) Match {
+func fromRegexpMatches(matches [][]int, namedGroups []string, lineValue string, lineNumber int) Match {
 	env := make(Environment)
 	var firstValue string
 	var firstRange Range
@@ -98,7 +98,7 @@ func FromFileMatch(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 	for _, l := range fm.LineMatches {
 		regexpMatches := r.FindAllStringSubmatchIndex(l.Preview, -1)
 		if len(regexpMatches) > 0 {
-			matches = append(matches, ofRegexpMatches(regexpMatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
+			matches = append(matches, fromRegexpMatches(regexpMatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
 		}
 	}
 	return &MatchContext{Matches: matches, Path: fm.Path}

--- a/internal/compute/match_context_result_test.go
+++ b/internal/compute/match_context_result_test.go
@@ -25,7 +25,7 @@ func environment(r *MatchContext) interface{} {
 	return env
 }
 
-func TestOfLineMatches(t *testing.T) {
+func TestFromLineMatches(t *testing.T) {
 	data := &result.FileMatch{
 		File: result.File{Path: "bedge"},
 		LineMatches: []*result.LineMatch{


### PR DESCRIPTION
`compute` regex capture group results will diverge depending on `case`. When we get the capture groups, it's always case sensitive. When we search, by default we are case-insensitive (ok?). This treats the search case sensitive by default. But it also needs to make the capture group regex _insensitive_ when `case:no` is set.

Somewhere in our code, we are defaulting to non-case-sensitive regular expressions (zoekt?) and it's outside of the parser/planning phase, which is why keeping the above in sync is difficult right now without doing a lot of extra legwork. 