### PR TITLE
web: fix example repo in query

### DIFF
--- a/client/web/src/search/home/LoggedOutHomepage.constants.ts
+++ b/client/web/src/search/home/LoggedOutHomepage.constants.ts
@@ -12,7 +12,7 @@ export const exampleQueries: SearchExample[] = [
         label: 'Search all of your repos, without escaping or regex',
         trackEventName: 'HomepageExampleRepoClicked',
         query: 'repo:sourcegraph/.* Sprintf("%d -file:tests',
-        to: '/search?q=context:global+repo:sourcegraph/*+Sprintf%28%22%25d+-file:tests&patternType=literal&case=yes',
+        to: '/search?q=context:global+repo:sourcegraph/.*+Sprintf%28%22%25d+-file:tests&patternType=literal&case=yes',
     },
     {
         label: 'Search and review commits faster than git log and grep',


### PR DESCRIPTION
The displayed query does not correspond to link. It should also be `.*`, the `/*` means `*` is meaningless. At least, until we can switch to globbing one day.

Corresponding notebook change: https://github.com/sourcegraph/notebooks/pull/9