### PR TITLE
doc: replace TODO with quick link to Kubernetes secrets

### DIFF
--- a/doc/admin/install/kubernetes/configure.md
+++ b/doc/admin/install/kubernetes/configure.md
@@ -37,7 +37,7 @@ We **strongly** recommend you fork the [Sourcegraph with Kubernetes reference re
 
     <span class="virtual-br"></span>
 
-    > NOTE: We do not recommend storing secrets in the repository itself. TODO
+    > NOTE: We do not recommend storing secrets in the repository itself - instead, consider leveraging [Kubernetes's Secret objects](https://kubernetes.io/docs/concepts/configuration/secret).
 
 - Clone your fork using the repository's URL.
 


### PR DESCRIPTION
Might want to follow up eventually with something more detailed, but at least remove the TODO for now