### PR TITLE
insights: add prometheus metric for insights queue size

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 
 	"github.com/cockroachdb/errors"
@@ -63,6 +65,18 @@ func NewWorker(ctx context.Context, workerBaseStore *basestore.Store, insightsSt
 	})
 
 	sharedCache := make(map[string]*types.InsightSeries)
+
+	prometheus.DefaultRegisterer.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "src_insights_query_runner_queued_total",
+		Help: "Total number of jobs in the queued state.",
+	}, func() float64 {
+		count, err := workerStore.QueuedCount(context.Background(), false, nil)
+		if err != nil {
+			log15.Error("Failed to get queued job count", "error", err)
+		}
+
+		return float64(count)
+	}))
 
 	return dbworker.NewWorker(ctx, workerStore, &workHandler{
 		workerBaseStore: workerBaseStore,

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -67,7 +67,7 @@ func NewWorker(ctx context.Context, workerBaseStore *basestore.Store, insightsSt
 	sharedCache := make(map[string]*types.InsightSeries)
 
 	prometheus.DefaultRegisterer.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "src_insights_query_runner_queued_total",
+		Name: "src_insights_search_queue_total",
 		Help: "Total number of jobs in the queued state.",
 	}, func() float64 {
 		count, err := workerStore.QueuedCount(context.Background(), false, nil)


### PR DESCRIPTION
Adds a prometheus metric for the code insights queue size.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
