### PR TITLE
search: 

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -21,6 +21,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
@@ -41,7 +42,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -618,14 +618,14 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 
 // evaluateLeaf performs a single search operation and corresponds to the
 // evaluation of leaf expression in a query.
-func (r *searchResolver) evaluateLeaf(ctx context.Context, args *search.TextParameters) (_ *SearchResults, err error) {
+func (r *searchResolver) evaluateLeaf(ctx context.Context, args *search.TextParameters, jobs []run.Job) (_ *SearchResults, err error) {
 	tr, ctx := trace.New(ctx, "evaluateLeaf", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	return r.resultsWithTimeoutSuggestion(ctx, args)
+	return r.resultsWithTimeoutSuggestion(ctx, args, jobs)
 }
 
 // union returns the union of two sets of search results and merges common search data.
@@ -820,19 +820,19 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, q query.
 			return r.evaluateOr(ctx, q)
 		case query.Concat:
 			r.invalidateCache()
-			args, _, err := r.toSearchInputs(q.ToParseTree())
+			args, jobs, err := r.toSearchInputs(q.ToParseTree())
 			if err != nil {
 				return &SearchResults{}, err
 			}
-			return r.evaluateLeaf(ctx, args)
+			return r.evaluateLeaf(ctx, args, jobs)
 		}
 	case query.Pattern:
 		r.invalidateCache()
-		args, _, err := r.toSearchInputs(q.ToParseTree())
+		args, jobs, err := r.toSearchInputs(q.ToParseTree())
 		if err != nil {
 			return &SearchResults{}, err
 		}
-		return r.evaluateLeaf(ctx, args)
+		return r.evaluateLeaf(ctx, args, jobs)
 	case query.Parameter:
 		// evaluatePatternExpression does not process Parameter nodes.
 		return &SearchResults{}, nil
@@ -845,11 +845,11 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, q query.
 func (r *searchResolver) evaluate(ctx context.Context, q query.Basic) (*SearchResults, error) {
 	if q.Pattern == nil {
 		r.invalidateCache()
-		args, _, err := r.toSearchInputs(query.ToNodes(q.Parameters))
+		args, jobs, err := r.toSearchInputs(query.ToNodes(q.Parameters))
 		if err != nil {
 			return &SearchResults{}, err
 		}
-		return r.evaluateLeaf(ctx, args)
+		return r.evaluateLeaf(ctx, args, jobs)
 	}
 	return r.evaluatePatternExpression(ctx, q)
 }
@@ -1132,9 +1132,9 @@ func searchResultsToFileNodes(matches []result.Match) ([]query.Node, error) {
 // resultsWithTimeoutSuggestion calls doResults, and in case of deadline
 // exceeded returns a search alert with a did-you-mean link for the same
 // query with a longer timeout.
-func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context, args *search.TextParameters) (*SearchResults, error) {
+func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context, args *search.TextParameters, jobs []run.Job) (*SearchResults, error) {
 	start := time.Now()
-	rr, err := r.doResults(ctx, args)
+	rr, err := r.doResults(ctx, args, jobs)
 
 	// If we encountered a context timeout, it indicates one of the many result
 	// type searchers (file, diff, symbol, etc) completely timed out and could not
@@ -1315,11 +1315,11 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		args, _, err := r.toSearchInputs(r.Query)
+		args, jobs, err := r.toSearchInputs(r.Query)
 		if err != nil {
 			return nil, err
 		}
-		results, err := r.doResults(ctx, args)
+		results, err := r.doResults(ctx, args, jobs)
 		if err != nil {
 			return nil, err // do not cache errors.
 		}
@@ -1403,7 +1403,7 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 // regardless of what `type:` is specified in the query string.
 //
 // Partial results AND an error may be returned.
-func (r *searchResolver) doResults(ctx context.Context, args *search.TextParameters) (res *SearchResults, err error) {
+func (r *searchResolver) doResults(ctx context.Context, args *search.TextParameters, jobs []run.Job) (res *SearchResults, err error) {
 	tr, ctx := trace.New(ctx, "doResults", r.rawQuery())
 	defer func() {
 		tr.SetError(err)
@@ -1614,6 +1614,16 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			_ = agg.DoCommitSearch(ctx, args)
 		})
 
+	}
+
+	// Start all specific search jobs, if any.
+	for _, job := range jobs {
+		wg := waitGroup(true)
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+			_ = agg.DoSearch(ctx, job, args.Mode)
+		})
 	}
 
 	hasStartedAllBackends = true

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -37,12 +37,12 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		args, _, err := srs.sr.toSearchInputs(srs.sr.Query)
+		args, jobs, err := srs.sr.toSearchInputs(srs.sr.Query)
 		if err != nil {
 			srs.srsErr = err
 			return
 		}
-		results, err := srs.sr.doResults(ctx, args)
+		results, err := srs.sr.doResults(ctx, args, jobs)
 		if err != nil {
 			srs.srsErr = err
 			return

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -482,12 +482,12 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
 		if len(r.Query.Values(query.FieldDefault)) > 0 {
-			searchArgs, _, err := r.toSearchInputs(r.Query)
+			searchArgs, jobs, err := r.toSearchInputs(r.Query)
 			if err != nil {
 				return nil, err
 			}
 			searchArgs.ResultTypes = result.TypeFile // only "file" result type
-			results, err := r.doResults(ctx, searchArgs)
+			results, err := r.doResults(ctx, searchArgs, jobs)
 			if err == context.DeadlineExceeded {
 				err = nil // don't log as error below
 			}

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -79,6 +79,28 @@ func (a *Aggregator) DoRepoSearch(ctx context.Context, args *search.TextParamete
 	return errors.Wrap(err, "repository search failed")
 }
 
+func jobName(job Job) string {
+	switch job.(type) {
+	default:
+		return "Unknown"
+	}
+}
+
+func (a *Aggregator) DoSearch(ctx context.Context, job Job, mode search.GlobalSearchMode) (err error) {
+	name := jobName(job)
+	tr, ctx := trace.New(ctx, "DoSearch", name)
+	tr.LogFields(trace.Stringer("global_search_mode", mode))
+	defer func() {
+		a.Error(err)
+		tr.SetErrorIfNotContext(err)
+		tr.Finish()
+	}()
+
+	err = job.Run(ctx, a)
+	return errors.Wrap(err, jobName(job)+" search failed")
+
+}
+
 func (a *Aggregator) DoSymbolSearch(ctx context.Context, args *search.TextParameters, limit int) (err error) {
 	tr, ctx := trace.New(ctx, "doSymbolSearch", "")
 	defer func() {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24254.

Broken down by commit for simplicity:

- First: propagate jobs from query conversion to runner in aggregator. The code in this commit is a noop. It's just scaffolding that propagates the argument, and the basic loop / function that calls run on jobs.

- Then: use all of the scaffolding before with structural search: Add logic that creates structural search job in `toSearchInputs`, and remove all references in `doResults`/structural search aggregator code.  🥳 

Observe:

- All job construction and input is done in `toSearchInputs`, there is no reference to stuff in `doResults` any more. This is what I meant with "trickle up" the logic before. 

- Once all job creation is trickled up, `doResults` will be very small. 

- Once we've disentangled the resolver and different kinds of search job state, it can all leave graphqlbackend. That (especially) includes the `toSearchInputs` processing logic.

- Structural search only cares about a handful of inputs, which are all constructed up front in `toSearchInputs`. We want the same state-narrowing for all our searches (commit, diff, etc. for the parameters defined in `internal/search/types.go`).

- Next, I'm prioritizing to do exactly the same lift for our indexed/unindexed text search--convert them to jobs and get the logic out of `doResults`. Once they are jobs, I can _super easily_ create a job for native Zoekt queries that optimizes `and`/`or` expressions for indexed search. This is the whole point.

- Later, our search eval function will simplify too--we will construct the whole tree of jobs to evaluate first, and then run the whole thing in our eval function. Not what we currently do, which is break down the query parse tree and convert individual expressions, run search, and then merge results. The benefit is separation of concerns--we can't run an `EXPLAIN` operation on the job plan if we inline both conversion and evaluation.


