### PR TITLE
insights: add dashboard to worker for insights queue and queue processor

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -3223,6 +3223,72 @@ This panel indicates lsif_dependency_index operation errors every 5m.
 
 <br />
 
+### Worker: Codeinsights: Query Runner Queue
+
+#### worker: insights_search_queue_queue_size
+
+This panel indicates code insights search queue queue size.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: insights_search_queue_queue_growth_rate
+
+This panel indicates code insights search queue queue growth rate over 30m.
+
+This value compares the rate of enqueues against the rate of finished jobs.
+
+	- A value < than 1 indicates that process rate > enqueue rate
+	- A value = than 1 indicates that process rate = enqueue rate
+	- A value > than 1 indicates that process rate < enqueue rate
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+### Worker: Codeinsights: insights queue processor
+
+#### worker: insights_search_queue_handlers
+
+This panel indicates handler active handlers.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: insights_search_queue_processor_total
+
+This panel indicates handler operations every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: insights_search_queue_processor_99th_percentile_duration
+
+This panel indicates 99th percentile successful handler operation duration over 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: insights_search_queue_processor_errors_total
+
+This panel indicates handler operation errors every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: insights_search_queue_processor_error_rate
+
+This panel indicates handler operation error rate over 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
 ### Worker: Internal service requests
 
 #### worker: frontend_internal_api_error_responses

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -40,7 +40,7 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
-	queryRunnerWorkerMetrics, queryRunnerResetterMetrics := newWorkerMetrics(observationContext, "insights_search_queue_processor")
+	queryRunnerWorkerMetrics, queryRunnerResetterMetrics := newWorkerMetrics(observationContext, "search_queue_processor")
 
 	insightsMetadataStore := store.NewInsightStore(insightsDB)
 

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -40,7 +40,7 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
-	queryRunnerWorkerMetrics, queryRunnerResetterMetrics := newWorkerMetrics(observationContext, "query_runner_worker")
+	queryRunnerWorkerMetrics, queryRunnerResetterMetrics := newWorkerMetrics(observationContext, "insights_search_queue_processor")
 
 	insightsMetadataStore := store.NewInsightStore(insightsDB)
 

--- a/monitoring/definitions/shared/codeinsights.go
+++ b/monitoring/definitions/shared/codeinsights.go
@@ -1,0 +1,63 @@
+package shared
+
+import "github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+
+var CodeInsights codeInsights
+
+var namespace string = "codeinsights"
+
+// codeInsights provides `CodeInsights` implementations.
+type codeInsights struct{}
+
+// src_insights_search_queue_total
+// src_insights_search_queue_processor_total
+func (codeInsights) NewInsightsQueryRunnerQueueGroup(containerName string) monitoring.Group {
+	return Queue.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, QueueSizeGroupOptions{
+		GroupConstructorOptions: GroupConstructorOptions{
+			Namespace:       namespace,
+			DescriptionRoot: "Query Runner Queue",
+			Hidden:          true,
+
+			ObservableConstructorOptions: ObservableConstructorOptions{
+				MetricNameRoot:        "insights_search_queue",
+				MetricDescriptionRoot: "Code Insights search queue",
+			},
+		},
+
+		QueueSize: NoAlertsOption("none"),
+		QueueGrowthRate: NoAlertsOption(`
+			This value compares the rate of enqueues against the rate of finished jobs.
+
+				- A value < than 1 indicates that process rate > enqueue rate
+				- A value = than 1 indicates that process rate = enqueue rate
+				- A value > than 1 indicates that process rate < enqueue rate
+		`),
+	})
+}
+
+// src_insights_search_queue_processor_total
+// src_insights_search_queue_processor_duration_seconds_bucket
+// src_insights_search_queue_processor_errors_total
+// src_insights_search_queue_processor_handlers
+func (codeInsights) NewInsightsQueryRunnerWorkerGroup(containerName string) monitoring.Group {
+	return Workerutil.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, WorkerutilGroupOptions{
+		GroupConstructorOptions: GroupConstructorOptions{
+			Namespace:       namespace,
+			DescriptionRoot: "Insights queue processor",
+			Hidden:          true,
+
+			ObservableConstructorOptions: ObservableConstructorOptions{
+				MetricNameRoot:        "insights_search_queue",
+				MetricDescriptionRoot: "handler",
+			},
+		},
+
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Handlers: NoAlertsOption("none"),
+	})
+}

--- a/monitoring/definitions/shared/codeinsights.go
+++ b/monitoring/definitions/shared/codeinsights.go
@@ -12,7 +12,7 @@ type codeInsights struct{}
 // src_insights_search_queue_total
 // src_insights_search_queue_processor_total
 func (codeInsights) NewInsightsQueryRunnerQueueGroup(containerName string) monitoring.Group {
-	return Queue.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, QueueSizeGroupOptions{
+	return Queue.NewGroup(containerName, monitoring.ObservableOwnerCodeInsights, QueueSizeGroupOptions{
 		GroupConstructorOptions: GroupConstructorOptions{
 			Namespace:       namespace,
 			DescriptionRoot: "Query Runner Queue",
@@ -20,7 +20,7 @@ func (codeInsights) NewInsightsQueryRunnerQueueGroup(containerName string) monit
 
 			ObservableConstructorOptions: ObservableConstructorOptions{
 				MetricNameRoot:        "insights_search_queue",
-				MetricDescriptionRoot: "Code Insights search queue",
+				MetricDescriptionRoot: "code insights search queue",
 			},
 		},
 
@@ -40,10 +40,10 @@ func (codeInsights) NewInsightsQueryRunnerQueueGroup(containerName string) monit
 // src_insights_search_queue_processor_errors_total
 // src_insights_search_queue_processor_handlers
 func (codeInsights) NewInsightsQueryRunnerWorkerGroup(containerName string) monitoring.Group {
-	return Workerutil.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, WorkerutilGroupOptions{
+	return Workerutil.NewGroup(containerName, monitoring.ObservableOwnerCodeInsights, WorkerutilGroupOptions{
 		GroupConstructorOptions: GroupConstructorOptions{
 			Namespace:       namespace,
-			DescriptionRoot: "Insights queue processor",
+			DescriptionRoot: "insights queue processor",
 			Hidden:          true,
 
 			ObservableConstructorOptions: ObservableConstructorOptions{

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -159,6 +159,8 @@ func Worker() *monitoring.Container {
 				RecordResetFailures: shared.NoAlertsOption("none"),
 				Errors:              shared.NoAlertsOption("none"),
 			}),
+			shared.CodeInsights.NewInsightsQueryRunnerQueueGroup(containerName),
+			shared.CodeInsights.NewInsightsQueryRunnerWorkerGroup(containerName),
 
 			// Resource monitoring
 			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -417,6 +417,7 @@ const (
 	ObservableOwnerSecurity        ObservableOwner = "security"
 	ObservableOwnerWeb             ObservableOwner = "web"
 	ObservableOwnerCoreApplication ObservableOwner = "core application"
+	ObservableOwnerCodeInsights    ObservableOwner = "code-insights"
 )
 
 // toMarkdown returns a Markdown string that also links to the owner's team page


### PR DESCRIPTION
Adds a `Worker` dashboard for the insights queue processor and queue.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
