### PR TITLE
Insights/resetter metrics

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -3289,6 +3289,32 @@ This panel indicates handler operation error rate over 5m.
 
 <br />
 
+### Worker: Codeinsights: code insights search queue record resetter
+
+#### worker: insights_search_queue_record_resets_total
+
+This panel indicates insights_search_queue records reset to queued state every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+#### worker: insights_search_queue_record_reset_failures_total
+
+This panel indicates insights_search_queue records reset to errored state every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+#### worker: insights_search_queue_record_reset_errors_total
+
+This panel indicates insights_search_queue operation errors every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 ### Worker: Internal service requests
 
 #### worker: frontend_internal_api_error_responses

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -3295,7 +3295,7 @@ This panel indicates handler operation error rate over 5m.
 
 This panel indicates insights_search_queue records reset to queued state every 5m.
 
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
 
 <br />
 
@@ -3303,7 +3303,7 @@ This panel indicates insights_search_queue records reset to queued state every 5
 
 This panel indicates insights_search_queue records reset to errored state every 5m.
 
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
 
 <br />
 
@@ -3311,7 +3311,7 @@ This panel indicates insights_search_queue records reset to errored state every 
 
 This panel indicates insights_search_queue operation errors every 5m.
 
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
 
 <br />
 

--- a/internal/workerutil/dbworker/resetter.go
+++ b/internal/workerutil/dbworker/resetter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+
 	"github.com/cockroachdb/errors"
 	"github.com/derision-test/glock"
 	"github.com/inconshreveable/log15"
@@ -37,6 +39,35 @@ type ResetterMetrics struct {
 	RecordResets        prometheus.Counter
 	RecordResetFailures prometheus.Counter
 	Errors              prometheus.Counter
+}
+
+// NewMetrics returns a metrics object for a resetter that follows standard naming convention. The base metric name should be
+// the same metric name provided to a `worker` ex. my_job_queue. Do not provide prefix "src" or postfix "_record...".
+func NewMetrics(observationContext *observation.Context, metricNameRoot string) *ResetterMetrics {
+	resets := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_" + metricNameRoot + "_record_resets_total",
+		Help: "The number of stalled record resets.",
+	})
+	observationContext.Registerer.MustRegister(resets)
+
+	resetFailures := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_" + metricNameRoot + "_record_reset_failures_total",
+		Help: "The number of stalled record resets marked as failure.",
+	})
+	observationContext.Registerer.MustRegister(resetFailures)
+
+	resetErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_" + metricNameRoot + "_record_reset_errors_total",
+		Help: "The number of errors that occur during stalled " +
+			"record reset.",
+	})
+	observationContext.Registerer.MustRegister(resetErrors)
+
+	return &ResetterMetrics{
+		RecordResets:        resets,
+		RecordResetFailures: resetFailures,
+		Errors:              resetErrors,
+	}
 }
 
 func NewResetter(store store.Store, options ResetterOptions) *Resetter {

--- a/monitoring/definitions/shared/codeinsights.go
+++ b/monitoring/definitions/shared/codeinsights.go
@@ -61,3 +61,26 @@ func (codeInsights) NewInsightsQueryRunnerWorkerGroup(containerName string) moni
 		Handlers: NoAlertsOption("none"),
 	})
 }
+
+// src_insights_search_queue_resets_total
+// src_insights_search_queue_reset_failures_total
+// src_insights_search_queue_reset_errors_total
+func (codeInsights) NewInsightsQueryRunnerResetterGroup(containerName string) monitoring.Group {
+
+	return WorkerutilResetter.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, ResetterGroupOptions{
+		GroupConstructorOptions: GroupConstructorOptions{
+			Namespace:       namespace,
+			DescriptionRoot: "code insights search queue record resetter",
+			Hidden:          true,
+
+			ObservableConstructorOptions: ObservableConstructorOptions{
+				MetricNameRoot:        "insights_search_queue",
+				MetricDescriptionRoot: "insights_search_queue",
+			},
+		},
+
+		RecordResets:        NoAlertsOption("none"),
+		RecordResetFailures: NoAlertsOption("none"),
+		Errors:              NoAlertsOption("none"),
+	})
+}

--- a/monitoring/definitions/shared/codeinsights.go
+++ b/monitoring/definitions/shared/codeinsights.go
@@ -67,7 +67,7 @@ func (codeInsights) NewInsightsQueryRunnerWorkerGroup(containerName string) moni
 // src_insights_search_queue_reset_errors_total
 func (codeInsights) NewInsightsQueryRunnerResetterGroup(containerName string) monitoring.Group {
 
-	return WorkerutilResetter.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, ResetterGroupOptions{
+	return WorkerutilResetter.NewGroup(containerName, monitoring.ObservableOwnerCodeInsights, ResetterGroupOptions{
 		GroupConstructorOptions: GroupConstructorOptions{
 			Namespace:       namespace,
 			DescriptionRoot: "code insights search queue record resetter",

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -161,6 +161,7 @@ func Worker() *monitoring.Container {
 			}),
 			shared.CodeInsights.NewInsightsQueryRunnerQueueGroup(containerName),
 			shared.CodeInsights.NewInsightsQueryRunnerWorkerGroup(containerName),
+			shared.CodeInsights.NewInsightsQueryRunnerResetterGroup(containerName),
 
 			// Resource monitoring
 			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),


### PR DESCRIPTION
Two things in this PR:
1. Code insights queue resetter dashboard
2. It seems like we have a standard naming convention to auto-generate dashboards, but we don't autogenerate the metrics themselves. I added a method to generate resetter metrics using the same naming convention as the dashboard expects.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
