### PR TITLE
centralize (some) CSS colors to the .theme-{light,dark} definitions

### DIFF
--- a/client/branded/src/global-styles/badge.scss
+++ b/client/branded/src/global-styles/badge.scss
@@ -137,28 +137,25 @@ a.badge {
     --badge-border: 1px solid var(--secondary);
 }
 
-.theme-light,
-.theme-dark {
-    // Update secondary text color and focus state for better contrast
-    a.badge-secondary,
-    a.badge-outline-secondary {
-        &:focus,
-        &.focus {
-            box-shadow: var(--focus-box-shadow);
-        }
+// Update secondary text color and focus state for better contrast
+a.badge-secondary,
+a.badge-outline-secondary {
+    &:focus,
+    &.focus {
+        box-shadow: var(--focus-box-shadow);
     }
-    a.badge-secondary {
-        &:hover,
-        &:focus,
-        &.focus {
-            color: var(--body-color);
-        }
+}
+a.badge-secondary {
+    &:hover,
+    &:focus,
+    &.focus {
+        color: var(--body-color);
     }
-    a.badge-outline-secondary {
-        &:hover,
-        &:focus,
-        &.focus {
-            background-color: var(--color-bg-1);
-        }
+}
+a.badge-outline-secondary {
+    &:hover,
+    &:focus,
+    &.focus {
+        background-color: var(--color-bg-1);
     }
 }

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -148,6 +148,16 @@ $theme-colors: (
     --diff-remove-bg: #ffecec;
     --code-selection-bg: var(--gray-03);
     --sourcegraph-logo-text-color: #000000;
+
+    // Forms
+    --input-bg: var(--white);
+    --input-disabled-bg: var(--gray-04);
+    --input-border-color: var(--gray-04);
+    --input-color: var(--gray-09);
+    --input-placeholder-color: var(--gray-07);
+    --input-group-addon-color: var(--gray-08);
+    --input-group-addon-bg: var(--gray-03);
+    --input-group-addon-border-color: var(--gray-03);
 }
 
 .theme-dark {
@@ -200,6 +210,16 @@ $theme-colors: (
     --diff-remove-bg: #3e1d1d;
     --code-selection-bg: var(--gray-08);
     --sourcegraph-logo-text-color: var(--white);
+
+    // Forms
+    --input-bg: var(--gray-10);
+    --input-disabled-bg: var(--gray-08);
+    --input-border-color: var(--gray-08);
+    --input-color: var(--gray-04);
+    --input-placeholder-color: var(--gray-05);
+    --input-group-addon-color: var(--gray-01);
+    --input-group-addon-bg: var(--gray-08);
+    --input-group-addon-border-color: var(--gray-08);
 }
 
 // Additional colors global colors.

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -148,6 +148,7 @@ $theme-colors: (
     --diff-remove-bg: #ffecec;
     --code-selection-bg: var(--gray-03);
     --sourcegraph-logo-text-color: #000000;
+    --dropdown-shadow-color: rgba(36, 41, 54, 0.2);
 
     // Forms
     --input-bg: var(--white);
@@ -210,6 +211,7 @@ $theme-colors: (
     --diff-remove-bg: #3e1d1d;
     --code-selection-bg: var(--gray-08);
     --sourcegraph-logo-text-color: var(--white);
+    --dropdown-shadow-color: rgba(11, 12, 15, 0.8);
 
     // Forms
     --input-bg: var(--gray-10);

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -150,6 +150,7 @@ $theme-colors: (
     --sourcegraph-logo-text-color: #000000;
     --dropdown-shadow-color: rgba(36, 41, 54, 0.2);
     --empty-command-list-color: var(--gray-08);
+    --meter-background: var(--gray-04);
 
     // Forms
     --input-bg: var(--white);
@@ -218,6 +219,7 @@ $theme-colors: (
     --sourcegraph-logo-text-color: var(--white);
     --dropdown-shadow-color: rgba(11, 12, 15, 0.8);
     --empty-command-list-color: var(--gray-05);
+    --meter-background: var(--gray-07);
 
     // Forms
     --input-bg: var(--gray-10);

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -151,6 +151,7 @@ $theme-colors: (
     --dropdown-shadow-color: rgba(36, 41, 54, 0.2);
     --empty-command-list-color: var(--gray-08);
     --meter-background: var(--gray-04);
+    --dialog-overlay-bg: rgba($gray-04, 0.5);
 
     // Forms
     --input-bg: var(--white);
@@ -220,6 +221,7 @@ $theme-colors: (
     --dropdown-shadow-color: rgba(11, 12, 15, 0.8);
     --empty-command-list-color: var(--gray-05);
     --meter-background: var(--gray-07);
+    --dialog-overlay-bg: rgba($gray-08, 0.5);
 
     // Forms
     --input-bg: var(--gray-10);

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -149,6 +149,7 @@ $theme-colors: (
     --code-selection-bg: var(--gray-03);
     --sourcegraph-logo-text-color: #000000;
     --dropdown-shadow-color: rgba(36, 41, 54, 0.2);
+    --empty-command-list-color: var(--gray-08);
 
     // Forms
     --input-bg: var(--white);
@@ -216,6 +217,7 @@ $theme-colors: (
     --code-selection-bg: var(--gray-08);
     --sourcegraph-logo-text-color: var(--white);
     --dropdown-shadow-color: rgba(11, 12, 15, 0.8);
+    --empty-command-list-color: var(--gray-05);
 
     // Forms
     --input-bg: var(--gray-10);

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -159,6 +159,10 @@ $theme-colors: (
     --input-group-addon-color: var(--gray-08);
     --input-group-addon-bg: var(--gray-03);
     --input-group-addon-border-color: var(--gray-03);
+
+    // @sourcegraph/react-loading-spinner coloring
+    --loading-spinner-outer-color: var(--gray-05);
+    --loading-spinner-inner-color: var(--gray-08);
 }
 
 .theme-dark {
@@ -222,6 +226,10 @@ $theme-colors: (
     --input-group-addon-color: var(--gray-01);
     --input-group-addon-bg: var(--gray-08);
     --input-group-addon-border-color: var(--gray-08);
+
+    // @sourcegraph/react-loading-spinner coloring
+    --loading-spinner-outer-color: var(--gray-07);
+    --loading-spinner-inner-color: var(--white);
 }
 
 // Additional colors global colors.

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -1,19 +1,10 @@
 @import 'bootstrap/scss/dropdown';
 
-.theme-light {
+:root {
     --dropdown-bg: var(--input-bg);
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
-    --dropdown-shadow: 0 4px 16px -6px rgba(36, 41, 54, 0.2);
-}
-
-.theme-dark {
-    --dropdown-bg: var(--input-bg);
-    --dropdown-border-color: var(--input-border-color);
-    --dropdown-link-hover-bg: var(--color-bg-2);
-    --dropdown-header-color: var(--text-muted);
-    --dropdown-shadow: 0 4px 16px -6px rgba(11, 12, 15, 0.8);
 }
 
 .dropdown-divider {
@@ -22,5 +13,5 @@
 
 .dropdown-menu {
     border-radius: var(--popover-border-radius);
-    box-shadow: var(--dropdown-shadow);
+    box-shadow: 0 4px 16px -6px var(--dropdown-shadow-color);
 }

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -1,28 +1,4 @@
-.theme-light {
-    --input-bg: var(--white);
-    --input-disabled-bg: var(--gray-04);
-    --input-border-color: var(--gray-04);
-    --input-color: var(--gray-09);
-    --input-placeholder-color: var(--gray-07);
-    --input-group-addon-color: var(--gray-08);
-    --input-group-addon-bg: var(--gray-03);
-    --input-group-addon-border-color: var(--gray-03);
-    --input-focus-border-color: var(--border-active-color);
-    --input-focus-box-shadow: var(--focus-box-shadow);
-
-    // Checkbox margins
-    --form-check-input-margin-y: 0.3rem;
-}
-
-.theme-dark {
-    --input-bg: var(--gray-10);
-    --input-disabled-bg: var(--gray-08);
-    --input-border-color: var(--gray-08);
-    --input-color: var(--gray-04);
-    --input-placeholder-color: var(--gray-05);
-    --input-group-addon-color: var(--gray-01);
-    --input-group-addon-bg: var(--gray-08);
-    --input-group-addon-border-color: var(--gray-08);
+:root {
     --input-focus-border-color: var(--border-active-color);
     --input-focus-box-shadow: var(--focus-box-shadow);
 

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -1,13 +1,4 @@
 meter {
-    --meter-background: var(--border-color-2);
-
-    .theme-dark & {
-        --meter-background: var(--gray-07);
-    }
-    .theme-light & {
-        --meter-background: var(--gray-04);
-    }
-
     /* Reset the default appearence */
     -moz-appearance: none;
     // Don't reset -webkit-appearance: https://bugs.chromium.org/p/chromium/issues/detail?id=632510

--- a/client/branded/src/global-styles/typography.scss
+++ b/client/branded/src/global-styles/typography.scss
@@ -113,14 +113,6 @@ label.text-uppercase small,
     letter-spacing: -(0.25/12) + em;
 }
 
-// Make sure text color utilities are theme-aware
-.theme-light,
-.theme-dark {
-    @each $color, $value in $theme-colors {
-        @include text-emphasis-variant('.text-#{$color}', $value, true);
-    }
-}
-
 .list-dashed {
     list-style: none;
     position: relative;

--- a/client/shared/src/commandPalette/EmptyCommandList.scss
+++ b/client/shared/src/commandPalette/EmptyCommandList.scss
@@ -1,6 +1,6 @@
 .empty-command-list {
     position: relative;
-    color: var(--gray-08);
+    color: var(--empty-command-list-color);
     padding: 1rem;
     background-color: var(--color-bg-1);
 
@@ -18,11 +18,5 @@
         position: absolute;
         bottom: 1rem;
         right: 1rem;
-    }
-}
-
-.theme-dark {
-    .empty-command-list {
-        color: var(--gray-05);
     }
 }

--- a/client/shared/src/global-styles/icons.scss
+++ b/client/shared/src/global-styles/icons.scss
@@ -40,13 +40,3 @@ img.icon-inline,
 .icon-inline > .icon-loader {
     stroke: currentColor;
 }
-
-// @sourcegraph/react-loading-spinner coloring
-.theme-light {
-    --loading-spinner-outer-color: var(--gray-05);
-    --loading-spinner-inner-color: var(--gray-08);
-}
-.theme-dark {
-    --loading-spinner-outer-color: var(--gray-07);
-    --loading-spinner-inner-color: var(--white);
-}

--- a/client/web/src/components/Dialog.scss
+++ b/client/web/src/components/Dialog.scss
@@ -1,13 +1,8 @@
 [data-reach-dialog-overlay] {
-    background-color: rgba($gray-04, 0.5);
+    background-color: var(--dialog-overlay-bg);
 }
 [data-reach-dialog-content] {
     background-color: var(--color-bg-1);
-}
-.theme-dark {
-    [data-reach-dialog-overlay] {
-        background-color: rgba($gray-08, 0.5);
-    }
 }
 
 .modal-body {

--- a/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.scss
+++ b/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.scss
@@ -11,17 +11,11 @@
         &.StripeElement--webkit-autofill {
             background: transparent !important;
         }
-    }
-}
 
-// The default disabled colors on the light theme look disabled, but on the dark theme they are too vivid, so make
-// them less so.
-.theme-dark {
-    .payment-token-form-control {
-        &__card {
-            &--disabled {
-                opacity: 0.65;
-            }
+        // The default disabled colors on the light theme look disabled, but on the dark theme they are too vivid, so make
+        // them less so.
+        &--disabled {
+            opacity: 0.65;
         }
     }
 }


### PR DESCRIPTION
We have 2 color themes: light and dark. To support additional themes, we need a central place for each theme's colors to be defined. This PR is a step in that direction.

Right now, most theme colors are defined in `colors.scss`. But not all. For example, form colors were defined in `forms.scss`. With this PR, they are now defined in `colors.scss` for each color theme.

This PR does not centralize *all* color definitions, but it does reach many of them.

There is no (intended) user-facing change from this PR (i.e., no UI colors will actually change; this is just a code refactor). (I will confirm that on Percy.)