### PR TITLE
internal: Add logging to observe rate limits of external services

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -162,11 +162,11 @@ func (c *V3Client) get(ctx context.Context, requestURI string, result interface{
 		//
 		// This is part of COREAPP-218.
 		remaining, reset, retry, known := c.rateLimitMonitor.Get()
-		return nil, errors.Wrap(errInternalRateLimitExceeded, fmt.Sprintf(
+		return nil, errors.Wrapf(errInternalRateLimitExceeded, 
 			"rate limit: %v, monitor state (remaining: %d, reset: %v, retry: %v, known: %t)",
 			c.rateLimit.Limit(),
 			remaining, reset.Minutes(), retry.Minutes(), known,
-		))
+		)
 	}
 
 	return doRequest(ctx, c.apiURL, c.auth, c.rateLimitMonitor, c.httpClient, req, result)

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -162,7 +162,7 @@ func (c *V3Client) get(ctx context.Context, requestURI string, result interface{
 		//
 		// This is part of COREAPP-218.
 		remaining, reset, retry, known := c.rateLimitMonitor.Get()
-		return nil, errors.Wrapf(errInternalRateLimitExceeded, 
+		return nil, errors.Wrapf(errInternalRateLimitExceeded,
 			"rate limit: %v, monitor state (remaining: %d, reset: %v, retry: %v, known: %t)",
 			c.rateLimit.Limit(),
 			remaining, reset.Minutes(), retry.Minutes(), known,

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -156,11 +156,6 @@ func (c *V3Client) get(ctx context.Context, requestURI string, result interface{
 
 	err = c.rateLimit.Wait(ctx)
 	if err != nil {
-
-		// TEMPORARY: The errors.Wrap is added to observe an ongoing case where we see internal rate
-		// limit exceeded on dotcom, while it should be infinite on dotcom.
-		//
-		// This is part of COREAPP-218.
 		remaining, reset, retry, known := c.rateLimitMonitor.Get()
 		return nil, errors.Wrapf(errInternalRateLimitExceeded,
 			"rate limit: %v, monitor state (remaining: %d, reset: %v, retry: %v, known: %t)",

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -82,7 +82,7 @@ func NewV4Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V4Cli
 	}
 
 	rl := ratelimit.DefaultRegistry.Get(apiURL.String())
-	log15.Info("NewV4Client", "limit", rl.Limit(), "burst", rl.Burst(), "apiURL", apiURL.String())
+	log15.Debug("NewV4Client", "limit", rl.Limit(), "burst", rl.Burst(), "apiURL", apiURL.String())
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, "graphql", &ratelimit.Monitor{HeaderPrefix: "X-"})
 
 	return &V4Client{

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -82,6 +82,7 @@ func NewV4Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V4Cli
 	}
 
 	rl := ratelimit.DefaultRegistry.Get(apiURL.String())
+	log15.Info("NewV4Client", "limit", rl.Limit(), "burst", rl.Burst(), "apiURL", apiURL.String())
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, "graphql", &ratelimit.Monitor{HeaderPrefix: "X-"})
 
 	return &V4Client{

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -155,6 +155,7 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 		}
 	}
 
+	log15.Info("newGithubSource", "service ID", svc.ID, "service display name", svc.DisplayName, "cloud_default", svc.CloudDefault)
 	return &GithubSource{
 		svc:              svc,
 		config:           c,

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -155,7 +155,7 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 		}
 	}
 
-	log15.Info("newGithubSource", "service ID", svc.ID, "service display name", svc.DisplayName, "cloud_default", svc.CloudDefault)
+	log15.Debug("newGithubSource", "service ID", svc.ID, "service display name", svc.DisplayName, "cloud_default", svc.CloudDefault)
 	return &GithubSource{
 		svc:              svc,
 		config:           c,


### PR DESCRIPTION
Recently we've noticed that we see frequent "internal rate limit
exceeded" errors on dotcom. Whereas, based on the investigation of the
current site-config and the external service config of the cloud
default GitHub external service, the rate limit should be
infiinite (math.MaxFloat64) as we don't set the `requestsPerHour`
config at all. These logs will help us to get an insight into the
current state of the rate limiter for these external services.

COREAPP-218


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
