### PR TITLE
nix: support sqlite on mac

### DIFF
--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -11,10 +11,7 @@
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null || exit
 
 # TODO build with nix
-if [ ! -e ../../libsqlite3-pcre.so ]; then
-  echo 'Building libsqlite3-pcre...'
-  NIX_ENFORCE_PURITY=0 ../libsqlite3-pcre/build.sh
-fi
+NIX_ENFORCE_PURITY=0 ../libsqlite3-pcre/build.sh
 
 . ./start-postgres.sh
 . ./start-redis.sh


### PR DESCRIPTION
We can just always shell out to the build script since it is a noop if
the shared library exists. Previously we would always print the
"building" message since the filename is different on mac.