### PR TITLE
Remove username from authz error message

### DIFF
--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -77,7 +77,7 @@ func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID i
 	if isSiteAdminErr == nil {
 		return nil
 	}
-	subjectUser, err := database.Users(db).GetByID(ctx, subjectUserID)
+	_, err := database.Users(db).GetByID(ctx, subjectUserID)
 	if err != nil {
 		return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as an admin (%s)", isSiteAdminErr.Error())}
 	}

--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -67,7 +67,7 @@ func (e *InsufficientAuthorizationError) Unauthorized() bool { return true }
 // It is used when an action on a user can be performed by site admins and the
 // user themselves, but nobody else.
 //
-// Returns an error containing the name of the given user.
+// Returns an error not containing the name of the given user.
 func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID int32) error {
 	a := actor.FromContext(ctx)
 	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {
@@ -77,11 +77,8 @@ func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID i
 	if isSiteAdminErr == nil {
 		return nil
 	}
-	subjectUser, err := database.Users(db).GetByID(ctx, subjectUserID)
-	if err != nil {
-		return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as an admin (%s)", isSiteAdminErr.Error())}
-	}
-	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as %s or as an admin (%s)", subjectUser.Username, isSiteAdminErr.Error())}
+
+	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as an admin (%s)", isSiteAdminErr.Error())}
 }
 
 // CheckSameUser returns an error if the user is not the user specified by

--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -67,7 +67,7 @@ func (e *InsufficientAuthorizationError) Unauthorized() bool { return true }
 // It is used when an action on a user can be performed by site admins and the
 // user themselves, but nobody else.
 //
-// Returns an error not containing the name of the given user.
+// Returns an error containing the name of the given user.
 func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID int32) error {
 	a := actor.FromContext(ctx)
 	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {
@@ -77,8 +77,11 @@ func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID i
 	if isSiteAdminErr == nil {
 		return nil
 	}
-
-	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as an admin (%s)", isSiteAdminErr.Error())}
+	subjectUser, err := database.Users(db).GetByID(ctx, subjectUserID)
+	if err != nil {
+		return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as an admin (%s)", isSiteAdminErr.Error())}
+	}
+	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as the authorized user or as an admin (%s)", isSiteAdminErr.Error())}
 }
 
 // CheckSameUser returns an error if the user is not the user specified by

--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -67,7 +67,7 @@ func (e *InsufficientAuthorizationError) Unauthorized() bool { return true }
 // It is used when an action on a user can be performed by site admins and the
 // user themselves, but nobody else.
 //
-// Returns an error containing the name of the given user.
+// Returns an error without the name of the given user.
 func CheckSiteAdminOrSameUser(ctx context.Context, db dbutil.DB, subjectUserID int32) error {
 	a := actor.FromContext(ctx)
 	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -184,7 +184,7 @@ func TestUpdateUser(t *testing.T) {
 		})
 
 		result, err := (&schemaResolver{db: db}).UpdateUser(context.Background(), &updateUserArgs{User: "VXNlcjox"})
-		wantErr := "must be authenticated as 1 or as an admin (must be site admin)"
+		wantErr := "must be authenticated as the authorized user or as an admin (must be site admin)"
 		gotErr := fmt.Sprintf("%v", err)
 		if wantErr != gotErr {
 			t.Fatalf("err: want %q but got %q", wantErr, gotErr)


### PR DESCRIPTION
The `CheckSiteAdminOrSameUser` function prints an error message containing the username. It can be forced to leak information in corner cases:
![image](https://user-images.githubusercontent.com/11207474/130636461-f6bb04e8-aff6-4d70-b153-0d7e1c173927.png)

This PR just removes the username from the error message.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
