### PR TITLE
insights: report metrics for insights queue store

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -3447,6 +3447,72 @@ This panel indicates insights_search_queue operation errors every 5m.
 
 <br />
 
+### Worker: Codeinsights: dbstore stats
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_total
+
+This panel indicates aggregate store operations every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_99th_percentile_duration
+
+This panel indicates 99th percentile successful aggregate store operation duration over 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total
+
+This panel indicates aggregate store operation errors every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_error_rate
+
+This panel indicates aggregate store operation error rate over 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_total
+
+This panel indicates store operations every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_99th_percentile_duration
+
+This panel indicates 99th percentile successful store operation duration over 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total
+
+This panel indicates store operation errors every 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
+#### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_error_rate
+
+This panel indicates store operation error rate over 5m.
+
+<sub>*Managed by the [Sourcegraph Code-insights team](https://about.sourcegraph.com/handbook/engineering/code-insights).*</sub>
+
+<br />
+
 ### Worker: Internal service requests
 
 #### worker: frontend_internal_api_error_responses

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -44,6 +44,8 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 
 	insightsMetadataStore := store.NewInsightStore(insightsDB)
 
+	workerStore := queryrunner.CreateDBWorkerStore(workerBaseStore, observationContext)
+
 	// Start background goroutines for all of our workers.
 	routines := []goroutine.BackgroundRoutine{
 		// Register the background goroutine which discovers and enqueues insights work.
@@ -51,8 +53,8 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 
 		// Register the query-runner worker and resetter, which executes search queries and records
 		// results to TimescaleDB.
-		queryrunner.NewWorker(ctx, workerBaseStore, insightsStore, queryRunnerWorkerMetrics),
-		queryrunner.NewResetter(ctx, workerBaseStore, queryRunnerResetterMetrics),
+		queryrunner.NewWorker(ctx, workerStore, insightsStore, queryRunnerWorkerMetrics),
+		queryrunner.NewResetter(ctx, workerStore, queryRunnerResetterMetrics),
 		// disabling the cleaner job while we debug mismatched results from historical insights
 		queryrunner.NewCleaner(ctx, workerBaseStore, observationContext),
 

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
@@ -37,9 +39,7 @@ import (
 
 // NewWorker returns a worker that will execute search queries and insert information about the
 // results into the code insights database.
-func NewWorker(ctx context.Context, workerBaseStore *basestore.Store, insightsStore *store.Store, metrics workerutil.WorkerMetrics) *workerutil.Worker {
-	workerStore := createDBWorkerStore(workerBaseStore)
-
+func NewWorker(ctx context.Context, workerStore dbworkerstore.Store, insightsStore *store.Store, metrics workerutil.WorkerMetrics) *workerutil.Worker {
 	numHandlers := conf.Get().InsightsQueryWorkerConcurrency
 	if numHandlers <= 0 {
 		numHandlers = 1
@@ -79,7 +79,6 @@ func NewWorker(ctx context.Context, workerBaseStore *basestore.Store, insightsSt
 	}))
 
 	return dbworker.NewWorker(ctx, workerStore, &workHandler{
-		workerBaseStore: workerBaseStore,
 		insightsStore:   insightsStore,
 		limiter:         limiter,
 		metadadataStore: store.NewInsightStore(insightsStore.Handle().DB()),
@@ -104,8 +103,7 @@ func getRateLimit(defaultValue rate.Limit) func() rate.Limit {
 
 // NewResetter returns a resetter that will reset pending query runner jobs if they take too long
 // to complete.
-func NewResetter(ctx context.Context, workerBaseStore *basestore.Store, metrics dbworker.ResetterMetrics) *dbworker.Resetter {
-	workerStore := createDBWorkerStore(workerBaseStore)
+func NewResetter(ctx context.Context, workerStore dbworkerstore.Store, metrics dbworker.ResetterMetrics) *dbworker.Resetter {
 	options := dbworker.ResetterOptions{
 		Name:     "insights_query_runner_worker_resetter",
 		Interval: 1 * time.Minute,
@@ -114,11 +112,11 @@ func NewResetter(ctx context.Context, workerBaseStore *basestore.Store, metrics 
 	return dbworker.NewResetter(workerStore, options)
 }
 
-// createDBWorkerStore creates the dbworker store for the query runner worker.
+// CreateDBWorkerStore creates the dbworker store for the query runner worker.
 //
 // See internal/workerutil/dbworker for more information about dbworkers.
-func createDBWorkerStore(s *basestore.Store) dbworkerstore.Store {
-	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+func CreateDBWorkerStore(s *basestore.Store, observationContext *observation.Context) dbworkerstore.Store {
+	return dbworkerstore.NewWithMetrics(s.Handle(), dbworkerstore.Options{
 		Name:              "insights_query_runner_jobs_store",
 		TableName:         "insights_query_runner_jobs",
 		ColumnExpressions: jobsColumns,
@@ -133,7 +131,7 @@ func createDBWorkerStore(s *basestore.Store) dbworkerstore.Store {
 		RetryAfter:        10 * time.Second,
 		MaxNumRetries:     3,
 		OrderByExpression: sqlf.Sprintf("priority, id"),
-	})
+	}, observationContext)
 }
 
 func getDependencies(ctx context.Context, workerBaseStore *basestore.Store, jobID int) (_ []time.Time, err error) {

--- a/monitoring/definitions/shared/codeinsights.go
+++ b/monitoring/definitions/shared/codeinsights.go
@@ -84,3 +84,32 @@ func (codeInsights) NewInsightsQueryRunnerResetterGroup(containerName string) mo
 		Errors:              NoAlertsOption("none"),
 	})
 }
+
+func (codeInsights) NewInsightsQueryRunnerStoreGroup(containerName string) monitoring.Group {
+	return Observation.NewGroup(containerName, monitoring.ObservableOwnerCodeInsights, ObservationGroupOptions{
+		GroupConstructorOptions: GroupConstructorOptions{
+			Namespace:       namespace,
+			DescriptionRoot: "dbstore stats",
+			Hidden:          true,
+
+			ObservableConstructorOptions: ObservableConstructorOptions{
+				MetricNameRoot:        "workerutil_dbworker_store_insights_query_runner_jobs_store",
+				MetricDescriptionRoot: "store",
+				By:                    []string{"op"},
+			},
+		},
+
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+	})
+}

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -163,6 +163,7 @@ func Worker() *monitoring.Container {
 			shared.CodeInsights.NewInsightsQueryRunnerQueueGroup(containerName),
 			shared.CodeInsights.NewInsightsQueryRunnerWorkerGroup(containerName),
 			shared.CodeInsights.NewInsightsQueryRunnerResetterGroup(containerName),
+			shared.CodeInsights.NewInsightsQueryRunnerStoreGroup(containerName),
 
 			// Resource monitoring
 			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCodeIntel, nil),


### PR DESCRIPTION
The insights queue store was not reporting metrics, so this enables metrics. To do so, I had to refactor all of the consumers of the store so that it only gets initialized once to prevent re-registration to the metrics registry.

As part of this refactor I also removed an unnecessary query operation from the worker dequeue and instead simply type convert to the appropriate job.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
