### PR TITLE
insights: index columns on insights queue table to speed up dequeue

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -781,6 +781,7 @@ Indexes:
     "insights_query_runner_jobs_pkey" PRIMARY KEY, btree (id)
     "insights_query_runner_jobs_cost_idx" btree (cost)
     "insights_query_runner_jobs_priority_idx" btree (priority)
+    "insights_query_runner_jobs_processable_priority_id" btree (priority, id) WHERE state = 'queued'::text OR state = 'errored'::text
     "insights_query_runner_jobs_state_btree" btree (state)
 Referenced by:
     TABLE "insights_query_runner_jobs_dependencies" CONSTRAINT "insights_query_runner_jobs_dependencies_fk_job_id" FOREIGN KEY (job_id) REFERENCES insights_query_runner_jobs(id) ON DELETE CASCADE

--- a/migrations/frontend/1528395871_insights_queue_state_index.down.sql
+++ b/migrations/frontend/1528395871_insights_queue_state_index.down.sql
@@ -1,0 +1,12 @@
+
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+drop index if exists insights_query_runner_jobs_processable_priority_id;
+COMMIT;

--- a/migrations/frontend/1528395871_insights_queue_state_index.up.sql
+++ b/migrations/frontend/1528395871_insights_queue_state_index.up.sql
@@ -1,0 +1,12 @@
+
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+create index insights_query_runner_jobs_processable_priority_id on insights_query_runner_jobs(priority, id) where state='queued' or state='errored';
+
+COMMIT;

--- a/migrations/frontend/1528395871_insights_queue_state_index.up.sql
+++ b/migrations/frontend/1528395871_insights_queue_state_index.up.sql
@@ -1,4 +1,3 @@
-
 BEGIN;
 
 -- Insert migration here. See README.md. Highlights:
@@ -7,6 +6,6 @@ BEGIN;
 --    need to be able to read/write post migration.
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
-create index insights_query_runner_jobs_processable_priority_id on insights_query_runner_jobs(priority, id) where state='queued' or state='errored';
+CREATE INDEX IF NOT EXISTS insights_query_runner_jobs_processable_priority_id ON insights_query_runner_jobs (priority, id) WHERE state = 'queued' OR state = 'errored';
 
 COMMIT;


### PR DESCRIPTION
The lack of an index on `state` is causing problems when the queue has many records in multiple states.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
