### PR TITLE
insights: manually fetching job record to fix broken dependency link

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -79,6 +79,7 @@ func NewWorker(ctx context.Context, workerStore dbworkerstore.Store, insightsSto
 	}))
 
 	return dbworker.NewWorker(ctx, workerStore, &workHandler{
+		baseWorkerStore: basestore.NewWithDB(workerStore.Handle().DB(), sql.TxOptions{}),
 		insightsStore:   insightsStore,
 		limiter:         limiter,
 		metadadataStore: store.NewInsightStore(insightsStore.Handle().DB()),


### PR DESCRIPTION
I goofed in https://github.com/sourcegraph/sourcegraph/pull/24290 and forgot that part of the manual dequeue is to grab the dependent records from another table. There may be another way to accomplish that I can look into, but this is is just to fix it for now.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
