### PR TITLE
workerutil: experimenting with batch dequeue to reduce queue overhead

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler.go
@@ -49,10 +49,12 @@ func (h *handler) dequeue(ctx context.Context, executorName, executorHostname st
 		return apiclient.Job{}, false, nil
 	}
 
-	job, err := h.RecordTransformer(ctx, record)
+	rec := record[0] // todo: fix lol
+
+	job, err := h.RecordTransformer(ctx, rec)
 	if err != nil {
-		if _, err := h.Store.MarkFailed(ctx, record.RecordID(), fmt.Sprintf("failed to transform record: %s", err), store.MarkFinalOptions{}); err != nil {
-			log15.Error("Failed to mark record as failed", "recordID", record.RecordID(), "error", err)
+		if _, err := h.Store.MarkFailed(ctx, rec.RecordID(), fmt.Sprintf("failed to transform record: %s", err), store.MarkFinalOptions{}); err != nil {
+			log15.Error("Failed to mark record as failed", "recordID", rec.RecordID(), "error", err)
 		}
 
 		return apiclient.Job{}, false, err

--- a/internal/workerutil/dbworker/store_shim.go
+++ b/internal/workerutil/dbworker/store_shim.go
@@ -37,7 +37,7 @@ func (s *storeShim) QueuedCount(ctx context.Context, extraArguments interface{})
 }
 
 // Dequeue calls into the inner store.
-func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (workerutil.Record, bool, error) {
+func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) ([]workerutil.Record, bool, error) {
 	conditions, err := convertArguments(extraArguments)
 	if err != nil {
 		return nil, false, err

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -20,7 +20,7 @@ type Store interface {
 	// Dequeue selects a record for processing. Any extra arguments supplied will be used in accordance with the
 	// concrete persistence layer (e.g. additional SQL conditions for a database layer). This method returns a boolean
 	// flag indicating the existence of a processable record.
-	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (Record, bool, error)
+	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) ([]Record, bool, error)
 
 	// Heartbeat updates last_heartbeat_at of all the given jobs, when they're processing. All IDs of records that were
 	// touched are returned.


### PR DESCRIPTION
### This PR is not meant to be merged, just looking for feedback here

So, what is this?

While debugging some slowness in the code insights worker, I noticed a few things:
1. The dequeue mechanism can be a bottleneck for short-lived, high concurrency `handlers` (dequeue operations can have non-trivial overhead)
2. Other queuing systems (kafka, sqs, etc) allow consumers to poll a batch of records with the semantics that records not successfully marked as completed in some time interval may be deqeueued again.

Now, I'm not interested in rebuilding Kafka here but it would be useful for code insights to have some batching. We are currently spending roughly 400ms on each dequeue operation (this could probably be a bit better, but regardless) and only 100-200ms average on the actual handler invocation. We have millions of invocations to process, so if we could batch something like 20-50 records we would nearly eliminate the queue overhead and save a *lot* of time.

Here are some of the implementation problems I'm looking for feedback on:
1. The [`RecordScanFn`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@workerutil/batch-dequeue/-/blob/internal/workerutil/dbworker/store/store.go?utm_product_name=GoLand&utm_product_version=GoLand&utm_source=JetBrains-v1.2.1#L211:18) can just brick the entire set of records currently because it eats the entire `rows` and gives back just one `Record`. I could update this to return a `[]workerutil.Record`, or I could add a `BatchRecordScanFn` with different semantics. Ideally, the operations on a single `Record` would be in a different store than operations to fetch a `Record` but I think that would be much more work.
2. Should the [`Store`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@workerutil/batch-dequeue/-/blob/internal/workerutil/dbworker/store/store.go?utm_product_name=GoLand&utm_product_version=GoLand&utm_source=JetBrains-v1.2.1#L87:11) interface have both a `Dequeue` and `BatchDequeue` operation? I'm leaning towards yes, to reduce the random impact of changing the `Dequeue` semantics. For example, in this PR there is an executor that uses the same `Store` interface that would have to be updated.
3. What to attach to the trace? Currently, it associates the single record `id` on dequeue. Is this even relevant?
4. Should batching respect the [`NumTotalJobs`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@workerutil/batch-dequeue/-/blob/internal/workerutil/dbworker/store/store.go?utm_product_name=GoLand&utm_product_version=GoLand&utm_source=JetBrains-v1.2.1#L87:11) exactly, or execute within a single `BatchSize`?

So basically this PR is a rough sketch implementation of what this could look like. It doesn't work right because the mapping function eats all of the records, but it should serve to illustrate the idea.

Looking for feedback, thanks!

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
