### PR TITLE
search: prevent nil panic in symbol suggestions

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -405,7 +405,9 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			if err != nil {
 				return nil, err
 			}
-			fileMatches = results.Matches
+			if results != nil {
+				fileMatches = results.Matches
+			}
 		} else {
 			repoOptions := r.toRepoOptions(r.Query, resolveRepositoriesOpts{})
 			resolved, err := r.resolveRepositories(ctx, repoOptions)


### PR DESCRIPTION
Feature flag is currently disabled, but when it was on this panic would
occur.

We ignore deadline exceeded error but didn't handle results being nil in
that case.