### PR TITLE
authz: remove FetchRepoPermsByToken, add options to repo sync

### DIFF
--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
@@ -20,21 +21,23 @@ import (
 
 // handleGithubRepoAuthzEvent handles any github event containing a repository field, and enqueues the contained
 // repo for permissions synchronisation.
-func handleGitHubRepoAuthzEvent(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
-	if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
-		return nil
-	}
-	if globals.PermissionsUserMapping().Enabled {
-		return nil
-	}
+func handleGitHubRepoAuthzEvent(opts authz.FetchPermsOptions) func(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
+	return func(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
+		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
+			return nil
+		}
+		if globals.PermissionsUserMapping().Enabled {
+			return nil
+		}
 
-	log15.Debug("handleGitHubRepoAuthzEvent: Got github event", "type", fmt.Sprintf("%T", payload))
+		log15.Debug("handleGitHubRepoAuthzEvent: Got github event", "type", fmt.Sprintf("%T", payload))
 
-	e, ok := payload.(repoGetter)
-	if !ok {
-		return errors.Errorf("incorrect event type sent to github event handler: %T", payload)
+		e, ok := payload.(repoGetter)
+		if !ok {
+			return errors.Errorf("incorrect event type sent to github event handler: %T", payload)
+		}
+		return scheduleRepoUpdate(ctx, e.GetRepo(), opts)
 	}
-	return scheduleRepoUpdate(ctx, e.GetRepo())
 }
 
 type repoGetter interface {
@@ -44,7 +47,7 @@ type repoGetter interface {
 // scheduleRepoUpdate finds an internal repo from a github repo, and posts it to repo-updater to
 // schedule a permissions update
 // 🚨 SECURITY: we want to be able to find any private repo here, so the DB call uses internal actor
-func scheduleRepoUpdate(ctx context.Context, repo *gh.Repository) error {
+func scheduleRepoUpdate(ctx context.Context, repo *gh.Repository, opts authz.FetchPermsOptions) error {
 	if repo == nil {
 		return nil
 	}
@@ -61,5 +64,6 @@ func scheduleRepoUpdate(ctx context.Context, repo *gh.Repository) error {
 	c := repoupdater.DefaultClient
 	return c.SchedulePermsSync(ctx, protocol.PermsSyncRequest{
 		RepoIDs: []api.RepoID{r.ID},
+		Options: opts,
 	})
 }

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
@@ -10,14 +10,17 @@ func Init(db dbutil.DB, w *webhooks.GitHubWebhook) {
 	// Refer to https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
 	// for event types
 
-	w.Register(handleGitHubRepoAuthzEvent, "public")
-	w.Register(handleGitHubRepoAuthzEvent, "repository")
-	w.Register(handleGitHubRepoAuthzEvent, "member") // member has both users and repos
-	w.Register(handleGitHubRepoAuthzEvent, "team_add")
+	// Repository events
+	w.Register(handleGitHubRepoAuthzEvent(authz.FetchPermsOptions{}), "public")
+	w.Register(handleGitHubRepoAuthzEvent(authz.FetchPermsOptions{}), "repository")
 
-	w.Register(handleGitHubUserAuthzEvent(db, authz.FetchPermsOptions{}), "member") // member has both users and repos
+	// Member refers to repository collaborators, and has both users and repos
+	w.Register(handleGitHubRepoAuthzEvent(authz.FetchPermsOptions{}), "member")
+	w.Register(handleGitHubUserAuthzEvent(db, authz.FetchPermsOptions{}), "member")
 
 	// Events that touch cached permissions in authz/github.Provider implementation
+	w.Register(handleGitHubRepoAuthzEvent(authz.FetchPermsOptions{InvalidateCaches: true}), "team_add")
 	w.Register(handleGitHubUserAuthzEvent(db, authz.FetchPermsOptions{InvalidateCaches: true}), "organisation")
 	w.Register(handleGitHubUserAuthzEvent(db, authz.FetchPermsOptions{InvalidateCaches: true}), "membership")
+
 }

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -130,7 +130,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 	permsStore := edb.Perms(testDB, timeutil.Now)
 	syncer := NewPermsSyncer(reposStore, permsStore, timeutil.Now, nil)
 
-	err = syncer.syncRepoPerms(ctx, repo.ID, false)
+	err = syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -438,7 +438,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 // syncRepoPerms processes permissions syncing request in repository-centric way.
 // When `noPerms` is true, the method will use partial results to update permissions
 // tables even when error occurs.
-func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPerms bool) (err error) {
+func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPerms bool, fetchOpts authz.FetchPermsOptions) (err error) {
 	ctx, save := s.observe(ctx, "PermsSyncer.syncRepoPerms", "")
 	defer save(requestTypeRepo, int32(repoID), &err)
 
@@ -501,7 +501,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		extAccountIDs, err := provider.FetchRepoPerms(ctx, &extsvc.Repository{
 			URI:              repo.URI,
 			ExternalRepoSpec: repo.ExternalRepo,
-		}, authz.FetchPermsOptions{})
+		}, fetchOpts)
 
 		// Detect 404 error (i.e. not authorized to call given APIs) that often happens with GitHub.com
 		// when the owner of the token only has READ access. However, we don't want to fail
@@ -594,6 +594,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		"repoID", repo.ID,
 		"name", repo.Name,
 		"count", p.UserIDs.GetCardinality(),
+		"fetchOpts.invalidateCaches", fetchOpts.InvalidateCaches,
 	)
 	return nil
 }
@@ -624,7 +625,7 @@ func (s *PermsSyncer) syncPerms(ctx context.Context, request *syncRequest) error
 	case requestTypeUser:
 		err = s.syncUserPerms(ctx, request.ID, request.NoPerms, request.Options)
 	case requestTypeRepo:
-		err = s.syncRepoPerms(ctx, api.RepoID(request.ID), request.NoPerms)
+		err = s.syncRepoPerms(ctx, api.RepoID(request.ID), request.NoPerms, request.Options)
 	default:
 		err = errors.Errorf("unexpected request type: %v", request.Type)
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -501,7 +501,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		extAccountIDs, err := provider.FetchRepoPerms(ctx, &extsvc.Repository{
 			URI:              repo.URI,
 			ExternalRepoSpec: repo.ExternalRepo,
-		})
+		}, authz.FetchPermsOptions{})
 
 		// Detect 404 error (i.e. not authorized to call given APIs) that often happens with GitHub.com
 		// when the owner of the token only has READ access. However, we don't want to fail

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -67,9 +67,8 @@ type mockProvider struct {
 	serviceType string
 	serviceID   string
 
-	fetchUserPerms        func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error)
-	fetchUserPermsByToken func(context.Context, string) (*authz.ExternalUserPermissions, error)
-	fetchRepoPerms        func(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error)
+	fetchUserPerms func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error)
+	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error)
 }
 
 func (*mockProvider) FetchAccount(context.Context, *types.User, []*extsvc.Account, []string) (*extsvc.Account, error) {
@@ -83,10 +82,6 @@ func (*mockProvider) Validate() []string    { return nil }
 
 func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
 	return p.fetchUserPerms(ctx, acct)
-}
-
-func (p *mockProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return p.fetchUserPermsByToken(ctx, token)
 }
 
 func (p *mockProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
@@ -170,11 +165,6 @@ func TestPermsSyncer_syncUserPerms_unionExternalServiceRepos(t *testing.T) {
 	s := NewPermsSyncer(repos.NewStore(&dbtesting.MockDB{}, sql.TxOptions{}), permsStore, timeutil.Now, nil)
 
 	p.fetchUserPerms = func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error) {
-		return &authz.ExternalUserPermissions{
-			Exacts: []extsvc.RepoID{"1"},
-		}, nil
-	}
-	p.fetchUserPermsByToken = func(ctx context.Context, s string) (*authz.ExternalUserPermissions, error) {
 		return &authz.ExternalUserPermissions{
 			Exacts: []extsvc.RepoID{"1"},
 		}, nil

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -69,7 +69,7 @@ type mockProvider struct {
 
 	fetchUserPerms        func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error)
 	fetchUserPermsByToken func(context.Context, string) (*authz.ExternalUserPermissions, error)
-	fetchRepoPerms        func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error)
+	fetchRepoPerms        func(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error)
 }
 
 func (*mockProvider) FetchAccount(context.Context, *types.User, []*extsvc.Account, []string) (*extsvc.Account, error) {
@@ -89,8 +89,8 @@ func (p *mockProvider) FetchUserPermsByToken(ctx context.Context, token string, 
 	return p.fetchUserPermsByToken(ctx, token)
 }
 
-func (p *mockProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
-	return p.fetchRepoPerms(ctx, repo)
+func (p *mockProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
+	return p.fetchRepoPerms(ctx, repo, opts)
 }
 
 // NOTE: With the latest set of changes, we will be relying on the external_service_repos
@@ -502,7 +502,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			id:          1,
 			serviceType: extsvc.TypeGitLab,
 			serviceID:   "https://gitlab.com/",
-			fetchRepoPerms: func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
+			fetchRepoPerms: func(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 				return []extsvc.AccountID{"user"}, nil
 			},
 		}
@@ -510,7 +510,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			id:          2,
 			serviceType: extsvc.TypeGitLab,
 			serviceID:   "https://gitlab.com/",
-			fetchRepoPerms: func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
+			fetchRepoPerms: func(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 				return nil, errors.New("not supposed to be called")
 			},
 		}
@@ -694,7 +694,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p.fetchRepoPerms = func(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
+			p.fetchRepoPerms = func(context.Context, *extsvc.Repository, authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 				return []extsvc.AccountID{"user", "pending_user"}, test.fetchErr
 			}
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -474,7 +474,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 
 		s := newPermsSyncer(repos.NewStore(&dbtesting.MockDB{}, sql.TxOptions{}))
 
-		err := s.syncRepoPerms(context.Background(), 1, false)
+		err := s.syncRepoPerms(context.Background(), 1, false, authz.FetchPermsOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -551,7 +551,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 
 		s := newPermsSyncer(repos.NewStore(&dbtesting.MockDB{}, sql.TxOptions{}))
 
-		err := s.syncRepoPerms(context.Background(), 1, false)
+		err := s.syncRepoPerms(context.Background(), 1, false, authz.FetchPermsOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -602,7 +602,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 
 		s := newPermsSyncer(repos.NewStore(&dbtesting.MockDB{}, sql.TxOptions{}))
 
-		err := s.syncRepoPerms(context.Background(), 1, false)
+		err := s.syncRepoPerms(context.Background(), 1, false, authz.FetchPermsOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -688,7 +688,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 				return []extsvc.AccountID{"user", "pending_user"}, test.fetchErr
 			}
 
-			err := s.syncRepoPerms(context.Background(), 1, test.noPerms)
+			err := s.syncRepoPerms(context.Background(), 1, test.noPerms, authz.FetchPermsOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -52,10 +52,6 @@ func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Accou
 	panic("should never be called")
 }
 
-func (m gitlabAuthzProviderParams) FetchUserPermsByToken(context.Context, string, authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	panic("should never be called")
-}
-
 func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository, authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	panic("should never be called")
 }

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -56,7 +56,7 @@ func (m gitlabAuthzProviderParams) FetchUserPermsByToken(context.Context, string
 	panic("should never be called")
 }
 
-func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
+func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository, authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	panic("should never be called")
 }
 

--- a/internal/authz/bitbucketserver/provider.go
+++ b/internal/authz/bitbucketserver/provider.go
@@ -155,12 +155,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	}, err
 }
 
-// FetchUserPermsByToken is currently only required for syncing permissions for
-// GitHub and GitLab on sourcegraph.com
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, errors.New("not implemented")
-}
-
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given repo on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/internal/authz/bitbucketserver/provider.go
+++ b/internal/authz/bitbucketserver/provider.go
@@ -170,7 +170,7 @@ func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts
 // callers to decide whether to discard.
 //
 // API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8283203728
-func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
+func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	switch {
 	case repo == nil:
 		return nil, errors.New("no repo provided")

--- a/internal/authz/bitbucketserver/provider_test.go
+++ b/internal/authz/bitbucketserver/provider_test.go
@@ -283,7 +283,7 @@ func testProviderFetchRepoPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 
 				tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", cli.URL.String())
 
-				ids, err := p.FetchRepoPerms(tc.ctx, tc.repo)
+				ids, err := p.FetchRepoPerms(tc.ctx, tc.repo, authz.FetchPermsOptions{})
 
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("error:\nhave: %q\nwant: %q", have, want)

--- a/internal/authz/github/github.go
+++ b/internal/authz/github/github.go
@@ -209,7 +209,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 // callers to decide whether to discard.
 //
 // API docs: https://developer.github.com/v4/object/repositorycollaboratorconnection/
-func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
+func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {

--- a/internal/authz/github/github.go
+++ b/internal/authz/github/github.go
@@ -73,10 +73,10 @@ func (p *Provider) Validate() (problems []string) {
 	return nil
 }
 
-// FetchUserPermsByToken fetches all the private repo ids that the token can access.
+// fetchUserPermsByToken fetches all the private repo ids that the token can access.
 //
 // This may return a partial result if an error is encountered, e.g. via rate limits.
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
+func (p *Provider) fetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
 	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
 	client := p.client.WithToken(token)
 
@@ -197,7 +197,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 		return nil, errors.New("no token found in the external account data")
 	}
 
-	return p.FetchUserPermsByToken(ctx, tok.AccessToken, opts)
+	return p.fetchUserPermsByToken(ctx, tok.AccessToken, opts)
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/internal/authz/github/github_test.go
+++ b/internal/authz/github/github_test.go
@@ -461,7 +461,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 func TestProvider_FetchRepoPerms(t *testing.T) {
 	t.Run("nil repository", func(t *testing.T) {
 		p := NewProvider("", ProviderOptions{GitHubURL: mustURL(t, "https://github.com")})
-		_, err := p.FetchRepoPerms(context.Background(), nil)
+		_, err := p.FetchRepoPerms(context.Background(), nil, authz.FetchPermsOptions{})
 		want := "no repository provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -479,6 +479,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 					ServiceID:   "https://gitlab.com/",
 				},
 			},
+			authz.FetchPermsOptions{},
 		)
 		want := `not a code host of the repository: want "https://gitlab.com/" but have "https://github.com/"`
 		got := fmt.Sprintf("%v", err)
@@ -515,6 +516,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 				ServiceID:   "https://github.com/",
 			},
 		},
+		authz.FetchPermsOptions{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/authz/gitlab/oauth.go
+++ b/internal/authz/gitlab/oauth.go
@@ -102,13 +102,6 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 	return listProjects(ctx, client)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms but it only requires a
-// token.
-func (p *OAuthProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	client := p.clientProvider.GetOAuthClient(token)
-	return listProjects(ctx, client)
-}
-
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given project on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/internal/authz/gitlab/oauth.go
+++ b/internal/authz/gitlab/oauth.go
@@ -118,7 +118,7 @@ func (p *OAuthProvider) FetchUserPermsByToken(ctx context.Context, token string,
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
-func (p *OAuthProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
+func (p *OAuthProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {

--- a/internal/authz/gitlab/oauth_test.go
+++ b/internal/authz/gitlab/oauth_test.go
@@ -121,7 +121,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, err := p.FetchRepoPerms(context.Background(), nil)
+		_, err := p.FetchRepoPerms(context.Background(), nil, authz.FetchPermsOptions{})
 		want := "no repository provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -141,6 +141,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 					ServiceID:   "https://github.com/",
 				},
 			},
+			authz.FetchPermsOptions{},
 		)
 		want := `not a code host of the repository: want "https://github.com/" but have "https://gitlab.com/"`
 		got := fmt.Sprintf("%v", err)
@@ -198,6 +199,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 					ID:          "gitlab_project_id",
 				},
 			},
+			authz.FetchPermsOptions{},
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -254,6 +256,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 					ID:          "gitlab_project_id",
 				},
 			},
+			authz.FetchPermsOptions{},
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/authz/gitlab/sudo.go
+++ b/internal/authz/gitlab/sudo.go
@@ -267,7 +267,7 @@ func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUs
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
-func (p *SudoProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
+func (p *SudoProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {

--- a/internal/authz/gitlab/sudo.go
+++ b/internal/authz/gitlab/sudo.go
@@ -212,13 +212,6 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 	return listProjects(ctx, client)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms but it only requires a
-// token.
-func (p *SudoProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	client := p.clientProvider.GetOAuthClient(token)
-	return listProjects(ctx, client)
-}
-
 // listProjects is a helper function to request for all private projects that are accessible
 // (access level: 20 => Reporter access) by the authenticated or impersonated user in the client.
 // It may return partial but valid results in case of error, and it is up to callers to decide

--- a/internal/authz/gitlab/sudo_test.go
+++ b/internal/authz/gitlab/sudo_test.go
@@ -325,7 +325,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, err := p.FetchRepoPerms(context.Background(), nil)
+		_, err := p.FetchRepoPerms(context.Background(), nil, authz.FetchPermsOptions{})
 		want := "no repository provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -345,6 +345,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 					ServiceID:   "https://github.com/",
 				},
 			},
+			authz.FetchPermsOptions{},
 		)
 		want := `not a code host of the repository: want "https://github.com/" but have "https://gitlab.com/"`
 		got := fmt.Sprintf("%v", err)
@@ -400,6 +401,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 				ID:          "gitlab_project_id",
 			},
 		},
+		authz.FetchPermsOptions{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -66,14 +66,6 @@ type Provider interface {
 	// to decide whether to discard.
 	FetchUserPerms(ctx context.Context, account *extsvc.Account, opts FetchPermsOptions) (*ExternalUserPermissions, error)
 
-	// FetchUserPermsByToken is similar to FetchUserPerms but only requires a token
-	// in order to communicate with the code host.
-	//
-	// Because permissions fetching APIs are often expensive, the implementation should
-	// try to return partial but valid results in case of error, and it is up to callers
-	// to decide whether to discard.
-	FetchUserPermsByToken(ctx context.Context, token string, opts FetchPermsOptions) (*ExternalUserPermissions, error)
-
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 	// the given repository/project on the code host. The user ID should be the same value
 	// as it would be used as extsvc.Account.AccountID. The returned list should

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -68,6 +68,10 @@ type Provider interface {
 
 	// FetchUserPermsByToken is similar to FetchUserPerms but only requires a token
 	// in order to communicate with the code host.
+	//
+	// Because permissions fetching APIs are often expensive, the implementation should
+	// try to return partial but valid results in case of error, and it is up to callers
+	// to decide whether to discard.
 	FetchUserPermsByToken(ctx context.Context, token string, opts FetchPermsOptions) (*ExternalUserPermissions, error)
 
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
@@ -78,7 +82,7 @@ type Provider interface {
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error)
+	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts FetchPermsOptions) ([]extsvc.AccountID, error)
 
 	// ServiceType returns the service type (e.g., "gitlab") of this authz provider.
 	ServiceType() string

--- a/internal/authz/perforce/perforce.go
+++ b/internal/authz/perforce/perforce.go
@@ -303,12 +303,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	}, errors.Wrap(scanner.Err(), "scanner.Err")
 }
 
-// FetchUserPermsByToken is currently only required for syncing permissions for
-// GitHub and GitLab on sourcegraph.com
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, errors.New("not implemented")
-}
-
 // getAllUserEmails returns a set of username <-> email pairs of all users in the Perforce server.
 func (p *Provider) getAllUserEmails(ctx context.Context) (map[string]string, error) {
 	if p.cachedAllUserEmails != nil {

--- a/internal/authz/perforce/perforce.go
+++ b/internal/authz/perforce/perforce.go
@@ -402,7 +402,7 @@ func (p *Provider) getGroupMembers(ctx context.Context, group string) ([]string,
 
 // FetchRepoPerms returns a list of users that have access to the given
 // repository on the Perforce Server.
-func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
+func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {

--- a/internal/authz/perforce/perforce_test.go
+++ b/internal/authz/perforce/perforce_test.go
@@ -257,7 +257,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 
 	t.Run("nil repository", func(t *testing.T) {
 		p := NewProvider("", "ssl:111.222.333.444:1666", "admin", "password")
-		_, err := p.FetchRepoPerms(ctx, nil)
+		_, err := p.FetchRepoPerms(ctx, nil, authz.FetchPermsOptions{})
 		want := "no repository provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -275,6 +275,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 					ServiceID:   "https://gitlab.com/",
 				},
 			},
+			authz.FetchPermsOptions{},
 		)
 		want := `not a code host of the repository: want "https://gitlab.com/" but have "ssl:111.222.333.444:1666"`
 		got := fmt.Sprintf("%v", err)
@@ -338,6 +339,7 @@ Users:
 				ServiceID:   "ssl:111.222.333.444:1666",
 			},
 		},
+		authz.FetchPermsOptions{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -41,10 +41,6 @@ func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account, authz.Fe
 	return nil, nil
 }
 
-func (p *fakeProvider) FetchUserPermsByToken(context.Context, string, authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, nil
-}
-
 func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository, authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	return nil, nil
 }

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -45,7 +45,7 @@ func (p *fakeProvider) FetchUserPermsByToken(context.Context, string, authz.Fetc
 	return nil, nil
 }
 
-func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
+func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository, authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Partial follow-up to https://github.com/sourcegraph/sourcegraph/pull/23978 - no real functionality changes here, mostly interface adjustments:

- Makes the necessary Provider-level changes to add cached repos sync (to come in a follow-up)
- Removes `FetchRepoPermsByToken` (added in https://github.com/sourcegraph/sourcegraph/pull/23018) - somewhere along the lines it seems all external usage of this was removed ([removing it from the Provider interface](https://github.com/sourcegraph/sourcegraph/commit/620396e96f5b278bbdd716977960d8a5c1321516) did not break anything). All implementations have either been privatized or removed entirely. This allows us to add account ID information to the GitHub provider's token sync for caching.