### PR TITLE
Code Insights: Fix focus management insight card problems

### DIFF
--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -175,6 +175,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
 
     const { onPointerMove = noop, onPointerOut = noop, ...otherHandlers } = usePointerEventEmitters({
         source: XYCHART_EVENT_SOURCE,
+        onFocus: true,
     })
 
     // We only need to catch pointerout event on root element - chart

--- a/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-insight-creation-form/DrillDownInsightCreationForm.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-insight-creation-form/DrillDownInsightCreationForm.tsx
@@ -70,6 +70,7 @@ export const DrillDownInsightCreationForm: React.FunctionComponent<DrillDownInsi
 
             <FormInput
                 title="Name"
+                autoFocus={true}
                 required={true}
                 description="Shown as the title for your insight"
                 placeholder="Example: Migration to React function components"


### PR DESCRIPTION

This PR fixes two small problems with focus management on the dashboard page 
1. Add autofocus for the title field in the drill-down insight creation flow 
2. Add chart tooltip appearance when link chart dot is focused.

## Before
https://user-images.githubusercontent.com/18492575/130803280-539fb9ca-bf3d-493f-bbb4-fc9381d3a5ef.mov

https://user-images.githubusercontent.com/18492575/130804417-f05c7fe0-0fbd-4be7-a644-54d37ad97a8c.mov

## After
https://user-images.githubusercontent.com/18492575/130803129-3d98a307-1656-43ec-a306-da0cd022ada7.mov

https://user-images.githubusercontent.com/18492575/130804379-dacebcba-b221-410c-a6a5-951a7930fc8f.mov

