### PR TITLE
repo-updater: more efficient external service validation

### DIFF
--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -48,6 +48,7 @@ func (r *RateLimitSyncer) SyncRateLimiters(ctx context.Context) error {
 
 	for {
 		services, err := r.serviceLister.List(ctx, database.ExternalServicesListOptions{
+			NoNamespace: true,
 			LimitOffset: &cursor,
 		})
 		if err != nil {


### PR DESCRIPTION
This PR did two improvements to the sync-external-service endpoint:

1. Only list site-level external services for syncing internal code host rate limiting.
2. Return on first result for external service validation

Fixes #24281

COREAPP-234 #done