### PR TITLE
externalservice: fix redacting secrets in resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -74,11 +74,11 @@ func (r *externalServiceResolver) DisplayName() string {
 }
 
 func (r *externalServiceResolver) Config() (JSONCString, error) {
-	err := r.externalService.RedactConfigSecrets()
+	redacted, err := r.externalService.RedactConfigSecrets()
 	if err != nil {
 		return "", err
 	}
-	return JSONCString(r.externalService.Config), nil
+	return JSONCString(redacted), nil
 }
 
 func (r *externalServiceResolver) CreatedAt() DateTime {

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -24,9 +24,9 @@ const RedactedSecret = "REDACTED"
 
 // RedactConfigSecrets replaces any secret fields in the Config field with RedactedSecret, be sure to call
 // UnRedactExternalServiceConfig before writing back to the database, otherwise validation will throw errors.
-func (e *ExternalService) RedactConfigSecrets() error {
+func (e *ExternalService) RedactConfigSecrets() (string, error) {
 	if e.Config == "" {
-		return nil
+		return "", nil
 	}
 	var (
 		newCfg string
@@ -34,7 +34,7 @@ func (e *ExternalService) RedactConfigSecrets() error {
 	)
 	cfg, err := e.Configuration()
 	if err != nil {
-		return err
+		return "", err
 	}
 	switch cfg := cfg.(type) {
 	case *schema.GitHubConnection:
@@ -71,10 +71,9 @@ func (e *ExternalService) RedactConfigSecrets() error {
 		err = errors.Errorf("RedactExternalServiceConfig: kind %q not implemented", e.Kind)
 	}
 	if err != nil {
-		return err
+		return "", err
 	}
-	e.Config = newCfg
-	return nil
+	return newCfg, nil
 }
 
 // redactField will unmarshal the passed JSON string into the passed value, and then replace the pointer fields you pass

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -148,7 +148,8 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 				Kind:   c.kind,
 				Config: old,
 			}
-			if err := svc.RedactConfigSecrets(); err != nil {
+			redacted, err := svc.RedactConfigSecrets()
+			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
@@ -156,7 +157,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 			if err := zeroFields(c.config); err != nil {
 				t.Errorf("unexpected error: %s", err)
 			}
-			if err := json.Unmarshal([]byte(svc.Config), &c.config); err != nil {
+			if err := json.Unmarshal([]byte(redacted), &c.config); err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
 			if c.secretField != nil {


### PR DESCRIPTION
This PR stop doing secret redaction in place for external service because it would cause other GraphQL field resolvers to incorrectly use `REDACTED` version, which in turn causes useless failing API calls to code hosts.

This fix may explain why we're seeing a lot 401 errors for calling GitHub APIs on the `/user` endpoint.

Co-authored-by: Tomas Senart <tomas@sourcegraph.com>
Co-authored-by: Indradhanush Gupta <indradhanush.gupta@gmail.com>