### PR TITLE
insights: sort returned series from gql by query text ascending for deterministic output

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -70,6 +71,15 @@ func (r *insightConnectionResolver) compute(ctx context.Context) ([]types.Insigh
 			r.err = err
 			return
 		}
+		// currently insight metadata is partially stored in user settings. Series will be joined with their appropriate
+		// metadata by sorting based on query text, and joining in the frontend. This is largely a temporary solution
+		// until insights has a full graphql api
+		for _, insight := range mapped {
+			sort.Slice(insight.Series, func(i, j int) bool {
+				return insight.Series[i].Query < insight.Series[j].Query
+			})
+		}
+
 		r.insights = mapped
 	})
 	return r.insights, r.next, r.err


### PR DESCRIPTION
For the time being insight metadata is still stored in user settings. This will sort the insight data to provide deterministic order so that the frontend can match metadata appropriately.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
