### PR TITLE
extensibility: preload extension bundles in web app

### DIFF
--- a/client/shared/src/api/client/connection.ts
+++ b/client/shared/src/api/client/connection.ts
@@ -49,6 +49,7 @@ export async function createExtensionHostClientConnection(
         | 'telemetryService'
         | 'sideloadedExtensionURL'
         | 'getScriptURLForExtension'
+        | 'clientApplication'
     >
 ): Promise<{
     subscription: Unsubscribable

--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -1,0 +1,78 @@
+import { once } from 'lodash'
+import { combineLatest, from, Observable, of } from 'rxjs'
+import { fromFetch } from 'rxjs/fetch'
+import { catchError, distinctUntilChanged, map, publishReplay, refCount, switchMap } from 'rxjs/operators'
+
+import { checkOk } from '../../backend/fetch'
+import { ConfiguredExtension, isExtensionEnabled } from '../../extensions/extension'
+import { ExtensionManifest } from '../../extensions/extensionManifest'
+import { areExtensionsSame } from '../../extensions/extensions'
+import { viewerConfiguredExtensions } from '../../extensions/helpers'
+import { PlatformContext } from '../../platform/context'
+import { isErrorLike } from '../../util/errors'
+
+/**
+ * The manifest of an extension sideloaded during local development.
+ *
+ * Doesn't include {@link ExtensionManifest#url}, as this is added when
+ * publishing an extension to the registry.
+ * Instead, the bundle URL is computed from the manifest's `main` field.
+ */
+interface SideloadedExtensionManifest extends Omit<ExtensionManifest, 'url'> {
+    name: string
+    main: string
+}
+
+export const getConfiguredSideloadedExtension = (baseUrl: string): Observable<ConfiguredExtension> =>
+    fromFetch(`${baseUrl}/package.json`, { selector: response => checkOk(response).json() }).pipe(
+        map(
+            (response: SideloadedExtensionManifest): ConfiguredExtension => ({
+                id: response.name,
+                manifest: {
+                    ...response,
+                    url: `${baseUrl}/${response.main.replace('dist/', '')}`,
+                },
+                rawManifest: null,
+            })
+        )
+    )
+
+/**
+ * Returns an Observable of extensions enabled for the user.
+ * Is idempotent.
+ */
+export const getEnabledExtensions = once(
+    (
+        context: Pick<
+            PlatformContext,
+            'settings' | 'requestGraphQL' | 'sideloadedExtensionURL' | 'getScriptURLForExtension'
+        >
+    ): Observable<ConfiguredExtension[]> => {
+        const sideloadedExtension: Observable<ConfiguredExtension | null> = from(context.sideloadedExtensionURL).pipe(
+            switchMap(url => (url ? getConfiguredSideloadedExtension(url) : of(null))),
+            catchError(error => {
+                console.error('Error sideloading extension', error)
+                return of(null)
+            })
+        )
+
+        return combineLatest([viewerConfiguredExtensions(context), sideloadedExtension, context.settings]).pipe(
+            map(([configuredExtensions, sideloadedExtension, settings]) => {
+                let enabled = configuredExtensions.filter(extension => isExtensionEnabled(settings.final, extension.id))
+                if (sideloadedExtension) {
+                    if (!isErrorLike(sideloadedExtension.manifest) && sideloadedExtension.manifest?.publisher) {
+                        // Disable extension with the same ID while this extension is sideloaded
+                        const constructedID = `${sideloadedExtension.manifest.publisher}/${sideloadedExtension.id}`
+                        enabled = enabled.filter(extension => extension.id !== constructedID)
+                    }
+
+                    enabled.push(sideloadedExtension)
+                }
+                return enabled
+            }),
+            distinctUntilChanged((a, b) => areExtensionsSame(a, b)),
+            publishReplay(1),
+            refCount()
+        )
+    }
+)

--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -39,7 +39,7 @@ export const getConfiguredSideloadedExtension = (baseUrl: string): Observable<Co
 
 /**
  * Returns an Observable of extensions enabled for the user.
- * Is idempotent.
+ * Wrapped with the `once` function from lodash.
  */
 export const getEnabledExtensions = once(
     (

--- a/client/shared/src/api/client/mainthread-api.test.ts
+++ b/client/shared/src/api/client/mainthread-api.test.ts
@@ -19,13 +19,19 @@ describe('MainThreadAPI', () => {
 
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'requestGraphQL' | 'getScriptURLForExtension' | 'sideloadedExtensionURL'
+                | 'updateSettings'
+                | 'settings'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'sideloadedExtensionURL'
+                | 'clientApplication'
             > = {
                 settings: EMPTY,
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL,
                 getScriptURLForExtension: () => undefined,
                 sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
+                clientApplication: 'other',
             }
 
             const { api } = initMainThreadAPI(pretendRemote({}), platformContext)
@@ -52,13 +58,19 @@ describe('MainThreadAPI', () => {
 
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'requestGraphQL' | 'getScriptURLForExtension' | 'sideloadedExtensionURL'
+                | 'updateSettings'
+                | 'settings'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'sideloadedExtensionURL'
+                | 'clientApplication'
             > = {
                 settings: EMPTY,
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL,
                 getScriptURLForExtension: () => undefined,
                 sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
+                clientApplication: 'other',
             }
 
             const { api } = initMainThreadAPI(pretendRemote({}), platformContext)
@@ -78,7 +90,12 @@ describe('MainThreadAPI', () => {
             }
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'requestGraphQL' | 'getScriptURLForExtension' | 'sideloadedExtensionURL'
+                | 'updateSettings'
+                | 'settings'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'sideloadedExtensionURL'
+                | 'clientApplication'
             > = {
                 settings: of({
                     subjects: [
@@ -100,6 +117,7 @@ describe('MainThreadAPI', () => {
                 requestGraphQL: () => EMPTY,
                 getScriptURLForExtension: () => undefined,
                 sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
+                clientApplication: 'other',
             }
 
             const { api } = initMainThreadAPI(pretendRemote({}), platformContext)
@@ -128,13 +146,19 @@ describe('MainThreadAPI', () => {
 
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'requestGraphQL' | 'getScriptURLForExtension' | 'sideloadedExtensionURL'
+                | 'updateSettings'
+                | 'settings'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'sideloadedExtensionURL'
+                | 'clientApplication'
             > = {
                 settings: of(...values),
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL: () => EMPTY,
                 getScriptURLForExtension: () => undefined,
                 sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
+                clientApplication: 'other',
             }
 
             const passedToExtensionHost: SettingsCascade<object>[] = []
@@ -154,13 +178,19 @@ describe('MainThreadAPI', () => {
             const values = new Subject<SettingsCascade<{ a: string }>>()
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'requestGraphQL' | 'getScriptURLForExtension' | 'sideloadedExtensionURL'
+                | 'updateSettings'
+                | 'settings'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'sideloadedExtensionURL'
+                | 'clientApplication'
             > = {
                 settings: values.asObservable(),
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL: () => EMPTY,
                 getScriptURLForExtension: () => undefined,
                 sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
+                clientApplication: 'other',
             }
             const passedToExtensionHost: SettingsCascade<object>[] = []
             const { subscription } = initMainThreadAPI(

--- a/client/shared/src/api/client/preload.ts
+++ b/client/shared/src/api/client/preload.ts
@@ -1,8 +1,4 @@
-import { Observable } from 'rxjs'
-import { distinctUntilChanged, map, startWith } from 'rxjs/operators'
-
 import { ConfiguredExtension, getScriptURLFromExtensionManifest } from '../../extensions/extension'
-import { getModeFromPath } from '../../languages'
 import { isDefined } from '../../util/types'
 import { ExecutableExtension, extensionsWithMatchedActivationEvent } from '../extension/activation'
 
@@ -16,10 +12,6 @@ const loadedScriptURLs = new Set<string>()
  * is run in the main thread before the extension host requests extension bundles;
  * that way, the browser will share the request if it's inflight, or respond with the
  * cached bundle if it has been fulfilled.
- *
- * Only run this logic in the web app since the HTTP cache is not shared
- * between the browser extension's content script (which runs in the code host's context)
- * and background page. Don't waste resources by loading extensions twice.
  */
 export function preloadExtensions({
     extensions,
@@ -32,8 +24,6 @@ export function preloadExtensions({
         const executableExtensions = extensions
             .map(extension => {
                 try {
-                    // No need to call PlatformContext#getScriptURL: that's a bext only workaround, and we won't run this code in bext.
-                    // There also will not be inline extensions in the web app. Just look in the manifest for script URL.
                     const scriptURL = getScriptURLFromExtensionManifest(extension)
 
                     const executableExtension: ExecutableExtension = {
@@ -65,35 +55,4 @@ export function preloadExtensions({
     } catch (error) {
         console.error('Error preloading Sourcegraph extensions:', error)
     }
-}
-
-/**
- * Returns an Observable of language ID based on the URL.
- * To be used only to guess which language extension to preload.
- *
- * It's ok if this isn't perfect/results in false negatives, since even in the unlikely case that this fails,
- * the necessary extensions will be loaded in the extension host anyways.
- */
-export function observeLanguage(): Observable<string> {
-    const pathnames = new Observable<string>(function subscribe(observer) {
-        const mutationObserver = new MutationObserver(() => {
-            observer.next(location.pathname)
-        })
-        mutationObserver.observe(document, {
-            childList: true,
-            subtree: true,
-        })
-
-        return function unsubscribe() {
-            mutationObserver.disconnect()
-        }
-    })
-
-    // On each mutation, check if the language extension has changed
-    return pathnames.pipe(
-        startWith(location.pathname),
-        distinctUntilChanged(),
-        map(path => getModeFromPath(path)),
-        distinctUntilChanged()
-    )
 }

--- a/client/shared/src/api/client/preload.ts
+++ b/client/shared/src/api/client/preload.ts
@@ -1,0 +1,99 @@
+import { Observable } from 'rxjs'
+import { distinctUntilChanged, map, startWith } from 'rxjs/operators'
+
+import { ConfiguredExtension, getScriptURLFromExtensionManifest } from '../../extensions/extension'
+import { getModeFromPath } from '../../languages'
+import { isDefined } from '../../util/types'
+import { ExecutableExtension, extensionsWithMatchedActivationEvent } from '../extension/activation'
+
+/** Ensure that we only add <link> tags once for each scriptURL */
+const loadedScriptURLs = new Set<string>()
+
+/**
+ * Attaches <link> tags to preload extension bundles in parallel.
+ * If we were to download extensions with `importScripts` in the extension host Web Worker,
+ * extension bundles would be downloaded sequentially. Ensure that `preloadExtensions`
+ * is run in the main thread before the extension host requests extension bundles;
+ * that way, the browser will share the request if it's inflight, or respond with the
+ * cached bundle if it has been fulfilled.
+ *
+ * Only run this logic in the web app since the HTTP cache is not shared
+ * between the browser extension's content script (which runs in the code host's context)
+ * and background page. Don't waste resources by loading extensions twice.
+ */
+export function preloadExtensions({
+    extensions,
+    languages,
+}: {
+    extensions: ConfiguredExtension[]
+    languages: Set<string>
+}): void {
+    try {
+        const executableExtensions = extensions
+            .map(extension => {
+                try {
+                    // No need to call PlatformContext#getScriptURL: that's a bext only workaround, and we won't run this code in bext.
+                    // There also will not be inline extensions in the web app. Just look in the manifest for script URL.
+                    const scriptURL = getScriptURLFromExtensionManifest(extension)
+
+                    const executableExtension: ExecutableExtension = {
+                        id: extension.id,
+                        manifest: extension.manifest,
+                        scriptURL,
+                    }
+
+                    return executableExtension
+                } catch {
+                    // Couldn't find scriptURL, skip this extension
+                    return null
+                }
+            })
+            .filter(isDefined)
+
+        for (const activeExtension of extensionsWithMatchedActivationEvent(executableExtensions, languages)) {
+            if (loadedScriptURLs.has(activeExtension.scriptURL)) {
+                continue
+            }
+            const preloadLink = document.createElement('link')
+            preloadLink.href = activeExtension.scriptURL
+            preloadLink.rel = 'preload'
+            preloadLink.as = 'script'
+            document.head.append(preloadLink)
+
+            loadedScriptURLs.add(activeExtension.scriptURL)
+        }
+    } catch (error) {
+        console.error('Error preloading Sourcegraph extensions:', error)
+    }
+}
+
+/**
+ * Returns an Observable of language ID based on the URL.
+ * To be used only to guess which language extension to preload.
+ *
+ * It's ok if this isn't perfect/results in false negatives, since even in the unlikely case that this fails,
+ * the necessary extensions will be loaded in the extension host anyways.
+ */
+export function observeLanguage(): Observable<string> {
+    const pathnames = new Observable<string>(function subscribe(observer) {
+        const mutationObserver = new MutationObserver(() => {
+            observer.next(location.pathname)
+        })
+        mutationObserver.observe(document, {
+            childList: true,
+            subtree: true,
+        })
+
+        return function unsubscribe() {
+            mutationObserver.disconnect()
+        }
+    })
+
+    // On each mutation, check if the language extension has changed
+    return pathnames.pipe(
+        startWith(location.pathname),
+        distinctUntilChanged(),
+        map(path => getModeFromPath(path)),
+        distinctUntilChanged()
+    )
+}

--- a/client/shared/src/api/extension/activation.ts
+++ b/client/shared/src/api/extension/activation.ts
@@ -303,10 +303,10 @@ async function deactivateExtension(extensionID: string): Promise<void> {
     }
 }
 
-export function extensionsWithMatchedActivationEvent(
-    enabledExtensions: (ConfiguredExtension | ExecutableExtension)[],
+export function extensionsWithMatchedActivationEvent<Extension extends ConfiguredExtension | ExecutableExtension>(
+    enabledExtensions: Extension[],
     visibleTextDocumentLanguages: ReadonlySet<string>
-): (ConfiguredExtension | ExecutableExtension)[] {
+): Extension[] {
     const languageActivationEvents = new Set(
         [...visibleTextDocumentLanguages].map(language => `onLanguage:${language}`)
     )

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -5,7 +5,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import { combineLatest, from, Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 
-import { getConfiguredSideloadedExtension } from '@sourcegraph/shared/src/api/client/mainthread-api'
+import { getConfiguredSideloadedExtension } from '@sourcegraph/shared/src/api/client/enabledExtensions'
 import { extensionIDsFromSettings } from '@sourcegraph/shared/src/extensions/extension'
 import { queryConfiguredRegistryExtensions } from '@sourcegraph/shared/src/extensions/helpers'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'

--- a/client/web/src/util/location.ts
+++ b/client/web/src/util/location.ts
@@ -1,0 +1,12 @@
+import * as H from 'history'
+import { Observable } from 'rxjs'
+
+export function observeLocation(history: H.History): Observable<H.Location> {
+    return new Observable(function subscribe(subscriber) {
+        const unlisten = history.listen(location => {
+            subscriber.next(location)
+        })
+
+        return unlisten
+    })
+}


### PR DESCRIPTION
Part of [RFC 411: Sourcegraph extensions performance](https://docs.google.com/document/d/1kyx3PIee2EYbAKeKLT92CPqDnOZLU9v7WE9G_zJy7_o/edit). Closes #23367.

Kick off parallel loading of extension bundles in the main thread _before_ requests are made through `importScripts()` in the extension host Web Worker. Consequently, bundles are downloaded in parallel (`importScripts` downloads sequentially). 

### New waterfall

![New waterfall](https://user-images.githubusercontent.com/37420160/130870156-298ecf8c-6800-456b-afd0-3ad2251768a7.png)

The biggest bottleneck remaining is the `Extensions` query, which we plan on persisting to `localStorage`, so soon we should be able to load extensions before even the file loads:

![Screenshot from 2021-08-25 18-03-06](https://user-images.githubusercontent.com/37420160/130870498-cf4e69df-2898-4c49-8d8b-a10394fb0d31.png)


### Old waterfall

![Old waterfall](https://user-images.githubusercontent.com/37420160/130870332-8017643b-e43a-42fc-9108-bcb4a646578e.png)

Good riddance 😩️