### PR TITLE
bitbucket server client: add capability to query for project and project repositories

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -321,11 +321,37 @@ func (c *Client) Users(ctx context.Context, pageToken *PageToken, fs ...UserFilt
 	return users, next, err
 }
 
-func (c *Client) Projects(ctx context.Context, pageToken *PageToken) ([]*Project, *PageToken, error) {
+// ProjectFilter defines a sum type of filters to be used when listing projects.
+type ProjectFilter struct {
+	// Name filters the projects' name
+	Name string
+
+	// Permission filters the projects by the specified permission level
+	Permission Perm
+}
+
+func (p *ProjectFilter) EncodeTo(u url.Values) {
+	if p == nil {
+		return
+	}
+
+	if p.Name != "" {
+		u.Set("name", p.Name)
+	}
+
+	if p.Permission != "" {
+		u.Set("permission", string(p.Permission))
+	}
+}
+
+// Projects retrieves a page of projects visible by the current user, optionally filtered via the provided "filter".
+func (c *Client) Projects(ctx context.Context, pageToken *PageToken, filter *ProjectFilter) ([]*Project, *PageToken, error) {
 	var projects []*Project
 
-	// qry := make(url.Values)
-	next, err := c.page(ctx, "/rest/api/1.0/projects", nil, pageToken, &projects)
+	qry := make(url.Values)
+	filter.EncodeTo(qry)
+
+	next, err := c.page(ctx, "/rest/api/1.0/projects", qry, pageToken, &projects)
 	return projects, next, err
 }
 

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -321,6 +321,14 @@ func (c *Client) Users(ctx context.Context, pageToken *PageToken, fs ...UserFilt
 	return users, next, err
 }
 
+func (c *Client) Projects(ctx context.Context, pageToken *PageToken) ([]*Project, *PageToken, error) {
+	var projects []*Project
+
+	qry := make(url.Values)
+	next, err := c.page(ctx, "/rest/api/1.0/projects", qry, pageToken, &projects)
+	return projects, next, err
+}
+
 // UserPermissions retrieves the global permissions assigned to the user with the given
 // username. Used to validate that the client is authenticated as an admin.
 func (c *Client) UserPermissions(ctx context.Context, username string) (perms []Perm, _ error) {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -330,6 +330,7 @@ type ProjectFilter struct {
 	Permission Perm
 }
 
+// EncodeTo encodes the ProjectFilter to the given url.Values.
 func (p *ProjectFilter) EncodeTo(u url.Values) {
 	if p == nil {
 		return
@@ -358,15 +359,22 @@ func (c *Client) Projects(ctx context.Context, pageToken *PageToken, filter *Pro
 // Projects retrieves a page of repositories belonging to the project specified by "projectKey".
 func (c *Client) ProjectRepositories(ctx context.Context, pageToken *PageToken, projectKey string) ([]*Repo, *PageToken, error) {
 	if projectKey == "" {
-		return nil, nil, errors.New("project key is empty")
+		return nil, nil, &argumentError{message: "project key is empty"}
 	}
+	route := fmt.Sprintf("/rest/api/1.0/projects/%s/repos", projectKey)
 
 	var repos []*Repo
 
-	route := fmt.Sprintf("/rest/api/1.0/projects/%s/repos", projectKey)
-
 	next, err := c.page(ctx, route, nil, pageToken, &repos)
 	return repos, next, err
+}
+
+type argumentError struct {
+	message string
+}
+
+func (e argumentError) Error() string {
+	return e.message
 }
 
 // UserPermissions retrieves the global permissions assigned to the user with the given

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -355,6 +355,20 @@ func (c *Client) Projects(ctx context.Context, pageToken *PageToken, filter *Pro
 	return projects, next, err
 }
 
+// Projects retrieves a page of repositories belonging to the project specified by "projectKey".
+func (c *Client) ProjectRepositories(ctx context.Context, pageToken *PageToken, projectKey string) ([]*Repo, *PageToken, error) {
+	if projectKey == "" {
+		return nil, nil, errors.New("project key is empty")
+	}
+
+	var repos []*Repo
+
+	route := fmt.Sprintf("/rest/api/1.0/projects/%s/repos", projectKey)
+
+	next, err := c.page(ctx, route, nil, pageToken, &repos)
+	return repos, next, err
+}
+
 // UserPermissions retrieves the global permissions assigned to the user with the given
 // username. Used to validate that the client is authenticated as an admin.
 func (c *Client) UserPermissions(ctx context.Context, username string) (perms []Perm, _ error) {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -324,8 +324,8 @@ func (c *Client) Users(ctx context.Context, pageToken *PageToken, fs ...UserFilt
 func (c *Client) Projects(ctx context.Context, pageToken *PageToken) ([]*Project, *PageToken, error) {
 	var projects []*Project
 
-	qry := make(url.Values)
-	next, err := c.page(ctx, "/rest/api/1.0/projects", qry, pageToken, &projects)
+	// qry := make(url.Values)
+	next, err := c.page(ctx, "/rest/api/1.0/projects", nil, pageToken, &projects)
 	return projects, next, err
 }
 

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -19,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/inconshreveable/log15"

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -127,6 +128,38 @@ func TestUserFilters(t *testing.T) {
 				t.Error(cmp.Diff(have, want))
 			}
 		})
+	}
+}
+
+func TestClient_Projects(t *testing.T) {
+	cli, save := NewTestClient(t, "Projects", *update)
+	defer save()
+
+	expected := []*Project{{
+		Key:    "Sourcegraph",
+		ID:     1,
+		Name:   "sourcegraph",
+		Public: false, // ?
+		Type:   "bla",
+	}}
+
+	actual, _, err := cli.Projects(context.Background(), &PageToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertProjectsEqual(t, actual, expected)
+}
+
+func assertProjectsEqual(t *testing.T, actual, expected []*Project) {
+	t.Helper()
+
+	for _, s := range [][]*Project{actual, expected} {
+		sort.Slice(s, func(i, j int) bool { return s[i].ID < s[j].ID })
+	}
+
+	if diff := cmp.Diff(actual, expected); diff != "" {
+		t.Errorf("non-zero diff (-got + want):\n%s", diff)
 	}
 }
 

--- a/internal/extsvc/bitbucketserver/testdata/vcr/Projects-Repositories.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/Projects-Repositories.yaml
@@ -1,0 +1,114 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects/PRIVUSER/repos?limit=100
+    method: GET
+  response:
+    body: '{"size":2,"limit":100,"isLastPage":true,"values":[{"slug":"userland","id":6,"name":"userland","hierarchyId":"929e8676f3debd82f27f","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userland.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userland.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userland/browse"}]}},{"slug":"userscript","id":8,"name":"UserScript","hierarchyId":"f60f08eec17849b4e660","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userscript.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userscript.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userscript/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 23:05:22 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1385x1876x0'
+      X-Asessionid:
+      - xbhnxz
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects/PRIVUSER/repos?limit=1
+    method: GET
+  response:
+    body: '{"size":1,"limit":1,"isLastPage":false,"values":[{"slug":"userland","id":6,"name":"userland","hierarchyId":"929e8676f3debd82f27f","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userland.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userland.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userland/browse"}]}}],"start":0,"nextPageStart":1}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 23:05:22 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1385x1877x0'
+      X-Asessionid:
+      - 3t3d8
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects/PRIVUSER/repos?limit=1&start=1
+    method: GET
+  response:
+    body: '{"size":1,"limit":1,"isLastPage":true,"values":[{"slug":"userscript","id":8,"name":"UserScript","hierarchyId":"f60f08eec17849b4e660","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userscript.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userscript.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userscript/browse"}]}}],"start":1}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 23:05:22 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1385x1878x0'
+      X-Asessionid:
+      - ec2or5
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/bitbucketserver/testdata/vcr/Projects-Repositories.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/Projects-Repositories.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bb.sgdev.org/rest/api/1.0/projects/PRIVUSER/repos?limit=100
+    url: https://bb.sgdev.org/rest/api/1.0/projects/PRIVUSER/repos?limit=1000
     method: GET
   response:
-    body: '{"size":2,"limit":100,"isLastPage":true,"values":[{"slug":"userland","id":6,"name":"userland","hierarchyId":"929e8676f3debd82f27f","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userland.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userland.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userland/browse"}]}},{"slug":"userscript","id":8,"name":"UserScript","hierarchyId":"f60f08eec17849b4e660","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userscript.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userscript.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userscript/browse"}]}}],"start":0}'
+    body: '{"size":2,"limit":1000,"isLastPage":true,"values":[{"slug":"userland","id":6,"name":"userland","hierarchyId":"929e8676f3debd82f27f","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userland.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userland.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userland/browse"}]}},{"slug":"userscript","id":8,"name":"UserScript","hierarchyId":"f60f08eec17849b4e660","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},"public":false,"links":{"clone":[{"href":"https://bb.sgdev.org/scm/privuser/userscript.git","name":"http"},{"href":"ssh://git@bb.sgdev.org:7999/privuser/userscript.git","name":"ssh"}],"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER/repos/userscript/browse"}]}}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -18,7 +18,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 01:58:30 GMT
       Pragma:
       - no-cache
       Server:
@@ -26,9 +26,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1876x0'
+      - '@WRQLR1x118x1913x0'
       X-Asessionid:
-      - xbhnxz
+      - 1ib8mc3
       X-Auserid:
       - "104"
       X-Ausername:
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 01:58:30 GMT
       Pragma:
       - no-cache
       Server:
@@ -63,9 +63,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1877x0'
+      - '@WRQLR1x118x1914x0'
       X-Asessionid:
-      - 3t3d8
+      - 15x174z
       X-Auserid:
       - "104"
       X-Ausername:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 01:58:30 GMT
       Pragma:
       - no-cache
       Server:
@@ -100,9 +100,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1878x0'
+      - '@WRQLR1x118x1915x0'
       X-Asessionid:
-      - ec2or5
+      - 1377l1i
       X-Auserid:
       - "104"
       X-Ausername:

--- a/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
@@ -7,14 +7,11 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects
+    url: https://bb.sgdev.org/rest/api/1.0/projects?limit=100
     method: GET
   response:
-    body: '{"size":9,"limit":25,"isLastPage":true,"values":[{"key":"IJ","id":24,"name":"ijt-project-testing-sg-3-6","description":"throwaway","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/IJ"}]}},{"key":"K8S","id":29,"name":"K8S","description":"A
-      lot of test repositories for k8s.sgdev.org.","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/K8S"}]}},{"key":"PRIVATE","id":3,"name":"Private","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PRIVATE"}]}},{"key":"PUBLIC","id":4,"name":"Public","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC"}]}},{"key":"SECRET","id":5,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SECRET"}]}},{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},{"key":"SGDEMO","id":26,"name":"Sourcegraph
-      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},{"key":"SOURCEGRAPH","id":28,"name":"Sourcegraph
-      e2e testing","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}},{"key":"SUPERSECRET","id":6,"name":"Super
-      Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SUPERSECRET"}]}}],"start":0}'
+    body: '{"size":4,"limit":100,"isLastPage":true,"values":[{"key":"PRIV","id":23,"name":"private","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIV"}]}},{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}},{"key":"PUB","id":22,"name":"public","description":"Public
+      project","public":true,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PUB"}]}}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -22,21 +19,58 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 26 Aug 2021 18:35:54 GMT
+      - Fri, 27 Aug 2021 20:55:50 GMT
       Pragma:
       - no-cache
       Server:
       - Caddy
       Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@2EDRUKx1115x17295619x0'
+      - '@WRQLR1x1255x1378x0'
       X-Asessionid:
-      - 15japnt
+      - 1asdhcp
       X-Auserid:
-      - "252"
+      - "104"
       X-Ausername:
-      - buildkite
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects?limit=1
+    method: GET
+  response:
+    body: '{"size":1,"limit":1,"isLastPage":false,"values":[{"key":"PRIV","id":23,"name":"private","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIV"}]}}],"start":0,"nextPageStart":3}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 20:55:50 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1255x1379x0'
+      X-Asessionid:
+      - 1qlq7am
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
       X-Content-Type-Options:
       - nosniff
     status: 200 OK

--- a/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 22:21:24 GMT
+      - Fri, 27 Aug 2021 23:05:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -27,9 +27,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1341x1784x0'
+      - '@WRQLR1x1385x1870x0'
       X-Asessionid:
-      - fg3vv1
+      - 1h8xqvl
       X-Auserid:
       - "104"
       X-Ausername:
@@ -56,7 +56,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 22:21:24 GMT
+      - Fri, 27 Aug 2021 23:05:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -64,9 +64,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1341x1785x0'
+      - '@WRQLR1x1385x1871x0'
       X-Asessionid:
-      - m2ecuf
+      - 18s9pwt
       X-Auserid:
       - "104"
       X-Ausername:
@@ -93,7 +93,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 22:21:24 GMT
+      - Fri, 27 Aug 2021 23:05:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -101,9 +101,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1341x1786x0'
+      - '@WRQLR1x1385x1872x0'
       X-Asessionid:
-      - kznjns
+      - 18jhtub
       X-Auserid:
       - "104"
       X-Ausername:
@@ -130,7 +130,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 22:21:24 GMT
+      - Fri, 27 Aug 2021 23:05:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -138,9 +138,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1341x1787x0'
+      - '@WRQLR1x1385x1873x0'
       X-Asessionid:
-      - zzsvwn
+      - 1cr9z7a
       X-Auserid:
       - "104"
       X-Ausername:
@@ -167,7 +167,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 22:21:24 GMT
+      - Fri, 27 Aug 2021 23:05:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -175,9 +175,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1341x1788x0'
+      - '@WRQLR1x1385x1874x0'
       X-Asessionid:
-      - kk9xyy
+      - 13iap77
       X-Auserid:
       - "104"
       X-Ausername:
@@ -204,7 +204,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 22:21:24 GMT
+      - Fri, 27 Aug 2021 23:05:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -212,9 +212,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1341x1789x0'
+      - '@WRQLR1x1385x1875x0'
       X-Asessionid:
-      - ehokkx
+      - 1ygn5ha
       X-Auserid:
       - "104"
       X-Ausername:

--- a/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 00:45:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -27,9 +27,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1870x0'
+      - '@WRQLR1x45x1885x0'
       X-Asessionid:
-      - 1h8xqvl
+      - 1jkgfjc
       X-Auserid:
       - "104"
       X-Ausername:
@@ -56,7 +56,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 00:45:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -64,9 +64,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1871x0'
+      - '@WRQLR1x45x1886x0'
       X-Asessionid:
-      - 18s9pwt
+      - 1svkzf
       X-Auserid:
       - "104"
       X-Ausername:
@@ -93,7 +93,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 00:45:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -101,9 +101,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1872x0'
+      - '@WRQLR1x45x1887x0'
       X-Asessionid:
-      - 18jhtub
+      - y8shcf
       X-Auserid:
       - "104"
       X-Ausername:
@@ -119,10 +119,10 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bb.sgdev.org/rest/api/1.0/projects?name=private-
+    url: https://bb.sgdev.org/rest/api/1.0/projects?limit=1000&name=private-
     method: GET
   response:
-    body: '{"size":2,"limit":25,"isLastPage":true,"values":[{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}}],"start":0}'
+    body: '{"size":2,"limit":1000,"isLastPage":true,"values":[{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -130,7 +130,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 00:45:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -138,9 +138,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1873x0'
+      - '@WRQLR1x45x1888x0'
       X-Asessionid:
-      - 1cr9z7a
+      - 8wisj4
       X-Auserid:
       - "104"
       X-Ausername:
@@ -156,10 +156,10 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bb.sgdev.org/rest/api/1.0/projects?permission=PROJECT_WRITE
+    url: https://bb.sgdev.org/rest/api/1.0/projects?limit=1000&permission=PROJECT_WRITE
     method: GET
   response:
-    body: '{"size":2,"limit":25,"isLastPage":true,"values":[{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}},{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":0}'
+    body: '{"size":2,"limit":1000,"isLastPage":true,"values":[{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}},{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -167,7 +167,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 00:45:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -175,9 +175,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1874x0'
+      - '@WRQLR1x45x1889x0'
       X-Asessionid:
-      - 13iap77
+      - 1dtdyvl
       X-Auserid:
       - "104"
       X-Ausername:
@@ -193,10 +193,10 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bb.sgdev.org/rest/api/1.0/projects?name=uniq&permission=PROJECT_WRITE
+    url: https://bb.sgdev.org/rest/api/1.0/projects?limit=1000&name=uniq&permission=PROJECT_WRITE
     method: GET
   response:
-    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":0}'
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -204,7 +204,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 23:05:22 GMT
+      - Sat, 28 Aug 2021 00:45:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -212,9 +212,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1385x1875x0'
+      - '@WRQLR1x45x1890x0'
       X-Asessionid:
-      - 1ygn5ha
+      - 1ys1txw
       X-Auserid:
       - "104"
       X-Ausername:

--- a/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
@@ -1,0 +1,44 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects
+    method: GET
+  response:
+    body: '{"size":9,"limit":25,"isLastPage":true,"values":[{"key":"IJ","id":24,"name":"ijt-project-testing-sg-3-6","description":"throwaway","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/IJ"}]}},{"key":"K8S","id":29,"name":"K8S","description":"A
+      lot of test repositories for k8s.sgdev.org.","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/K8S"}]}},{"key":"PRIVATE","id":3,"name":"Private","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PRIVATE"}]}},{"key":"PUBLIC","id":4,"name":"Public","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC"}]}},{"key":"SECRET","id":5,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SECRET"}]}},{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},{"key":"SGDEMO","id":26,"name":"Sourcegraph
+      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},{"key":"SOURCEGRAPH","id":28,"name":"Sourcegraph
+      e2e testing","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}},{"key":"SUPERSECRET","id":6,"name":"Super
+      Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SUPERSECRET"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 26 Aug 2021 18:35:54 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@2EDRUKx1115x17295619x0'
+      X-Asessionid:
+      - 15japnt
+      X-Auserid:
+      - "252"
+      X-Ausername:
+      - buildkite
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/Projects.yaml
@@ -10,8 +10,8 @@ interactions:
     url: https://bb.sgdev.org/rest/api/1.0/projects?limit=100
     method: GET
   response:
-    body: '{"size":4,"limit":100,"isLastPage":true,"values":[{"key":"PRIV","id":23,"name":"private","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIV"}]}},{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}},{"key":"PUB","id":22,"name":"public","description":"Public
-      project","public":true,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PUB"}]}}],"start":0}'
+    body: '{"size":7,"limit":100,"isLastPage":true,"values":[{"key":"PRIVACY","id":28,"name":"privacy","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVACY"}]}},{"key":"PRIV","id":23,"name":"private","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIV"}]}},{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}},{"key":"PUB","id":22,"name":"public","description":"Public
+      project","public":true,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PUB"}]}},{"key":"UNIQ","id":29,"name":"unique","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ"}]}},{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 20:55:50 GMT
+      - Fri, 27 Aug 2021 22:21:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -27,9 +27,9 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1255x1378x0'
+      - '@WRQLR1x1341x1784x0'
       X-Asessionid:
-      - 1asdhcp
+      - fg3vv1
       X-Auserid:
       - "104"
       X-Ausername:
@@ -48,7 +48,7 @@ interactions:
     url: https://bb.sgdev.org/rest/api/1.0/projects?limit=1
     method: GET
   response:
-    body: '{"size":1,"limit":1,"isLastPage":false,"values":[{"key":"PRIV","id":23,"name":"private","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIV"}]}}],"start":0,"nextPageStart":3}'
+    body: '{"size":1,"limit":1,"isLastPage":false,"values":[{"key":"PRIVACY","id":28,"name":"privacy","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVACY"}]}}],"start":0,"nextPageStart":2}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -56,7 +56,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Aug 2021 20:55:50 GMT
+      - Fri, 27 Aug 2021 22:21:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -64,9 +64,157 @@ interactions:
       Vary:
       - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@WRQLR1x1255x1379x0'
+      - '@WRQLR1x1341x1785x0'
       X-Asessionid:
-      - 1qlq7am
+      - m2ecuf
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects?limit=1&start=8
+    method: GET
+  response:
+    body: '{"size":1,"limit":1,"isLastPage":true,"values":[{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":8}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 22:21:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1341x1786x0'
+      X-Asessionid:
+      - kznjns
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects?name=private-
+    method: GET
+  response:
+    body: '{"size":2,"limit":25,"isLastPage":true,"values":[{"key":"PRIVUSER","id":25,"name":"private-only-users","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVUSER"}]}},{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 22:21:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1341x1787x0'
+      X-Asessionid:
+      - zzsvwn
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects?permission=PROJECT_WRITE
+    method: GET
+  response:
+    body: '{"size":2,"limit":25,"isLastPage":true,"values":[{"key":"PRIVWRITE","id":26,"name":"private-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/PRIVWRITE"}]}},{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 22:21:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1341x1788x0'
+      X-Asessionid:
+      - kk9xyy
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - lone-private-user
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bb.sgdev.org/rest/api/1.0/projects?name=uniq&permission=PROJECT_WRITE
+    method: GET
+  response:
+    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"key":"UNIQ2","id":30,"name":"unique-write","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bb.sgdev.org/projects/UNIQ2"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 27 Aug 2021 22:21:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@WRQLR1x1341x1789x0'
+      X-Asessionid:
+      - ehokkx
       X-Auserid:
       - "104"
       X-Ausername:


### PR DESCRIPTION
This PR adds the following capabilities to our bitbucket sever client:

- Querying the list of projects **(visible by the current user):** [`/rest/api/1.0/projects` - bitbucket API docs](https://docs.atlassian.com/bitbucket-server/rest/7.15.1/bitbucket-rest.html#idp147)

- Querying the repositories associated with a project: [`/rest/api/1.0/projects/{projectKey}/repos` - bitbucket API docs](https://docs.atlassian.com/bitbucket-server/rest/7.15.1/bitbucket-rest.html#idp173)

These capabilities are _prerequisites_ for any future caching abilities that may be added. 

Note: For these routes, the visibility of the projects / returned repositories **entirely** depends on the credentials of the caller and **can't** be controlled via filters / query parameters. It's up to other caller to use a mechanism like [`sudo`](https://github.com/sourcegraph/sourcegraph/blob/42d612b9350624c03ca239f10fdc8a31c9922e75/internal/authz/bitbucketserver/provider.go#L204) to enforce that the only responses returned are appropriate for a given `username`.


Note 2: There is a description covering the bitbucket server's setup in a test comment. The visibility of a given project is implicitly tested (using a non-admin user for running the tests). 

---

As an aside, I found the VCR tests to be quite brittle and hard to work with while I was developing them. In the future, I'd appreciate maybe paring with someone who has prior experience with this setup to see if I'm missing something.  
