### PR TITLE
web: Fix navbar logo link position

### DIFF
--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`GlobalNavbar default 1`] = `
       class="logo"
     >
       <a
+        class="d-flex align-items-center"
         href="/search"
       >
         <brandlogo
@@ -192,6 +193,7 @@ exports[`GlobalNavbar low-profile 1`] = `
       class="logo"
     >
       <a
+        class="d-flex align-items-center"
         href="/search"
       >
         <brandlogo

--- a/client/wildcard/src/components/NavBar/NavBar.tsx
+++ b/client/wildcard/src/components/NavBar/NavBar.tsx
@@ -55,7 +55,7 @@ const useOutsideClickDetector = (
 export const NavBar = ({ children, logo }: NavBarProps): JSX.Element => (
     <nav aria-label="Main Menu" className={navBarStyles.navbar}>
         <h1 className={navBarStyles.logo}>
-            <RouterLink to="/search">{logo}</RouterLink>
+            <RouterLink className='d-flex align-items-center' to="/search">{logo}</RouterLink>
         </h1>
         <hr className={navBarStyles.divider} />
         {children}

--- a/client/wildcard/src/components/NavBar/NavBar.tsx
+++ b/client/wildcard/src/components/NavBar/NavBar.tsx
@@ -55,7 +55,9 @@ const useOutsideClickDetector = (
 export const NavBar = ({ children, logo }: NavBarProps): JSX.Element => (
     <nav aria-label="Main Menu" className={navBarStyles.navbar}>
         <h1 className={navBarStyles.logo}>
-            <RouterLink className='d-flex align-items-center' to="/search">{logo}</RouterLink>
+            <RouterLink className="d-flex align-items-center" to="/search">
+                {logo}
+            </RouterLink>
         </h1>
         <hr className={navBarStyles.divider} />
         {children}


### PR DESCRIPTION
This PR fixes the logo image position at the navbar component.

<table>
 <tr>
  <th>Before</th>
  <th>After</th>
 </tr>
 
 <tr>
  <td>
<img width="459" alt="Screenshot 2021-08-27 at 13 42 10" src="https://user-images.githubusercontent.com/18492575/131115281-63c6077c-dee0-46ef-b0e5-22dd0194c867.png">
  </td>
  <td>
<img width="451" alt="Screenshot 2021-08-27 at 13 41 46" src="https://user-images.githubusercontent.com/18492575/131115321-3a15b8f4-f0ea-4f6c-99ab-54d4522ef5b0.png">
  </td>
 </tr>
</table>