### PR TITLE
search: only show timed out alert if we don't show timedout progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Deprecated site configuration field `email.smtp.disableTLS` has been removed. [#23639](https://github.com/sourcegraph/sourcegraph/pull/23639)
 - Deprecated language servers have been removed from `deploy-sourcegraph`. [deploy-sourcegraph#3605](https://github.com/sourcegraph/deploy-sourcegraph/pull/3605)
 - The experimental `codeInsightsAllRepos` feature flag has been removed. [#23850](https://github.com/sourcegraph/sourcegraph/pull/23850)
-- The "no results found in timeout" search alert has been removed in most circumstances. This alert caused confusion since it was large, would show even if results where returned and duplicated information from the "some results excluded" drop down. [#20319](https://github.com/sourcegraph/sourcegraph/issues/20319)
+- The "no results found in timeout" search alert is not shown if we indicate timeouts in the progress notifications. This alert caused confusion since it was large, would show even if results where returned and duplicated information from the "some results excluded" drop down. [#20319](https://github.com/sourcegraph/sourcegraph/issues/20319)
 
 ## 3.30.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Deprecated site configuration field `email.smtp.disableTLS` has been removed. [#23639](https://github.com/sourcegraph/sourcegraph/pull/23639)
 - Deprecated language servers have been removed from `deploy-sourcegraph`. [deploy-sourcegraph#3605](https://github.com/sourcegraph/deploy-sourcegraph/pull/3605)
 - The experimental `codeInsightsAllRepos` feature flag has been removed. [#23850](https://github.com/sourcegraph/sourcegraph/pull/23850)
+- The "no results found in timeout" search alert has been removed in most circumstances. This alert caused confusion since it was large, would show even if results where returned and duplicated information from the "some results excluded" drop down. [#20319](https://github.com/sourcegraph/sourcegraph/issues/20319)
 
 ## 3.30.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
--
+- The "no results found in timeout" search alert is not shown if we indicate timeouts in the progress notifications. This alert caused confusion since it was large, would show even if results where returned and duplicated information from the "some results excluded" drop down. [#24376](https://github.com/sourcegraph/sourcegraph/issues/24376)
 
 ## 3.31.0
 
@@ -104,7 +104,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Deprecated site configuration field `email.smtp.disableTLS` has been removed. [#23639](https://github.com/sourcegraph/sourcegraph/pull/23639)
 - Deprecated language servers have been removed from `deploy-sourcegraph`. [deploy-sourcegraph#3605](https://github.com/sourcegraph/deploy-sourcegraph/pull/3605)
 - The experimental `codeInsightsAllRepos` feature flag has been removed. [#23850](https://github.com/sourcegraph/sourcegraph/pull/23850)
-- The "no results found in timeout" search alert is not shown if we indicate timeouts in the progress notifications. This alert caused confusion since it was large, would show even if results where returned and duplicated information from the "some results excluded" drop down. [#20319](https://github.com/sourcegraph/sourcegraph/issues/20319)
 
 ## 3.30.4
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1024,7 +1024,7 @@ func DetermineStatusForLogs(srr *SearchResultsResolver, err error) string {
 		return "timeout"
 	case err != nil:
 		return "error"
-	case srr.Stats.AllReposTimedOut():
+	case srr.Stats.Status.All(search.RepoStatusTimedout) && srr.Stats.Status.Len() == len(srr.Stats.Repos):
 		return "timeout"
 	case srr.Stats.Status.Any(search.RepoStatusTimedout):
 		return "partial_timeout"

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -566,17 +566,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("timeout search options", func(t *testing.T) {
-		results, err := client.SearchFiles(`router index:no timeout:1ns`)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if results.Alert == nil {
-			t.Fatal("Want search alert but got nil")
-		}
-	})
-
 	t.Run("structural search", func(t *testing.T) {
 		tests := []struct {
 			name       string

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -109,10 +109,6 @@ func (c *Stats) Equal(other *Stats) bool {
 	return reflect.DeepEqual(c, other)
 }
 
-func (c *Stats) AllReposTimedOut() bool {
-	return c.Status.All(search.RepoStatusTimedout) && c.Status.Len() == len(c.Repos)
-}
-
 // Deref returns the zero-valued stats if its receiver is nil
 func (c *Stats) Deref() Stats {
 	if c != nil {


### PR DESCRIPTION
Attempt yesterday didn't work. Easy to reproduce with very low timeouts like `1ns`. In that case repo resolution would fail, and we would return the deadline as an error.

We now give a somewhat suboptimal solution since it is coupled to the logic of how we decide if to show the timedout notification. However, I wanna fix this and its my third attempt at trying to avoid that sort of solution.

Fixes https://github.com/sourcegraph/sourcegraph/issues/20319