### PR TITLE
 Code Insights: another attempt to fix flaky screenshot tests

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -7,3 +7,6 @@ snapshot:
     .monaco-editor .cursor {
       visibility: hidden !important;
     }
+    .percy-inactive-element {
+      pointer-events: none !important;
+    }

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/GlyphContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/GlyphContent.tsx
@@ -23,24 +23,33 @@ interface GlyphContentProps<Datum extends object> extends Omit<GlyphProps<Datum>
      * Just because GlyphProps has a bug with types.
      * GlyphProps key is an index of current datum and
      * GlyphProps index doesn't exist in runtime.
-     * */
+     */
     index: string
+
     /** Hovered point info (datum) to calculate proper styles for particular Glyph */
     hoveredDatum: ActiveDatum<Datum> | null
+
     /** Focused point info (datum) to calculate proper styles for particular Glyph */
     focusedDatum: ActiveDatum<Datum> | null
-    /** Focus handler for glyph (chart point) */
-    setFocusedDatum: (datum: ActiveDatum<Datum> | null) => void
+
     /** Map with getters to have a proper value of by x and y axis value for current point */
     accessors: Accessors<Datum, keyof Datum>
+
     /** Line (series) index of current point */
     lineIndex: number
+
     /** Total number of lines (series) to calculate proper aria-label for glyph content */
     totalNumberOfLines: number
+
     /** Data of particular line of current glyph (chart point) */
     line: LineChartContentProps<Datum>['series'][number]
+
+    /** Focus handler for glyph (chart point) */
+    setFocusedDatum: (datum: ActiveDatum<Datum> | null) => void
+
     /** On click handler for root component of glyph content */
     onClick: MouseEventHandler
+
     /** On pointer up handler for root component of glyph content */
     onPointerUp: PointerEventHandler
 }
@@ -56,11 +65,11 @@ export function GlyphContent<Datum extends object>(props: GlyphContentProps<Datu
         accessors,
         lineIndex,
         totalNumberOfLines,
+        x: xCoordinate,
+        y: yCoordinate,
         onPointerUp,
         onClick,
         setFocusedDatum,
-        x: xCoordinate,
-        y: yCoordinate,
     } = props
 
     const currentDatumIndex = +index

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -30,6 +30,8 @@ import { TooltipContent } from './TooltipContent'
  */
 const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
 
+console.log('IS_PERCY_RUN', IS_PERCY_RUN)
+
 // Chart configuration
 const WIDTH_PER_TICK = 70
 const HEIGHT_PER_TICK = 40

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -176,6 +176,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
     const { onPointerMove = noop, onPointerOut = noop, ...otherHandlers } = usePointerEventEmitters({
         source: XYCHART_EVENT_SOURCE,
         onFocus: true,
+        onBlur: true,
     })
 
     // We only need to catch pointerout event on root element - chart
@@ -218,11 +219,14 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
         [focused, onPointerOut, setHoveredDatum]
     )
 
-    const eventEmitters = {
-        onPointerMove: handleRootPointerMove,
-        onPointerOut: handleRootPointerOut,
-        ...otherHandlers,
-    }
+    // Disable all event listeners explicitly to avoid flaky tooltip appearance
+    const eventEmitters = !IS_PERCY_RUN
+        ? {
+              onPointerMove: handleRootPointerMove,
+              onPointerOut: handleRootPointerOut,
+              ...otherHandlers,
+          }
+        : {}
 
     const hoveredDatumLink = hoveredDatum?.line?.linkURLs?.[hoveredDatum?.index]
     const rootClasses = classnames('line-chart__content', { 'line-chart__content--with-cursor': !!hoveredDatumLink })
@@ -350,7 +354,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                                 line={line}
                                                 lineIndex={index}
                                                 totalNumberOfLines={series.length}
-                                                setFocusedDatum={setFocusedDatum}
+                                                setFocusedDatum={IS_PERCY_RUN ? noop : setFocusedDatum}
                                                 onPointerUp={stopPropagation}
                                                 onClick={onDatumLinkClick}
                                             />
@@ -360,16 +364,18 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                             ))}
                         </Group>
 
-                        <Tooltip
-                            className="line-chart__tooltip"
-                            showHorizontalCrosshair={false}
-                            showVerticalCrosshair={true}
-                            snapTooltipToDatumX={false}
-                            snapTooltipToDatumY={false}
-                            showDatumGlyph={false}
-                            showSeriesGlyphs={false}
-                            renderTooltip={renderTooltip}
-                        />
+                        {!IS_PERCY_RUN && (
+                            <Tooltip
+                                className="line-chart__tooltip"
+                                showHorizontalCrosshair={false}
+                                showVerticalCrosshair={true}
+                                snapTooltipToDatumX={false}
+                                snapTooltipToDatumY={false}
+                                showDatumGlyph={false}
+                                showSeriesGlyphs={false}
+                                renderTooltip={renderTooltip}
+                            />
+                        )}
                     </XYChart>
                 </TooltipProvider>
             </DataProvider>

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -30,7 +30,7 @@ import { TooltipContent } from './TooltipContent'
  */
 const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
 
-console.log('IS_PERCY_RUN', IS_PERCY_RUN)
+console.log({ IS_PERCY_RUN })
 
 // Chart configuration
 const WIDTH_PER_TICK = 70

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -28,9 +28,9 @@ import { TooltipContent } from './TooltipContent'
  * by disabling any point events over line chart container.
  * See https://github.com/sourcegraph/sourcegraph/issues/23669
  */
-const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
+const IS_PERCY_RUN = Boolean(JSON.parse(process.env.PERCY_ON ?? ''))
 
-console.log({ 'this-is-env': process.env.PERCY_ON })
+console.log({ 'this-is-env': IS_PERCY_RUN })
 
 // Chart configuration
 const WIDTH_PER_TICK = 70

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -11,6 +11,8 @@ import React, { ReactElement, useCallback, useMemo, useState, MouseEvent, useRef
 import { noop } from 'rxjs'
 import { LineChartContent as LineChartContentType } from 'sourcegraph'
 
+import { readEnvironmentBoolean } from '@sourcegraph/shared/src/testing/utils'
+
 import { DEFAULT_LINE_STROKE } from '../constants'
 import { generateAccessors } from '../helpers/generate-accessors'
 import { getYAxisWidth } from '../helpers/get-y-axis-width'
@@ -28,7 +30,7 @@ import { TooltipContent } from './TooltipContent'
  * by disabling any point events over line chart container.
  * See https://github.com/sourcegraph/sourcegraph/issues/23669
  */
-const IS_PERCY_RUN = Boolean(JSON.parse(process.env.PERCY_ON ?? ''))
+const IS_PERCY_RUN = readEnvironmentBoolean({ variable: 'PERCY_ON', defaultValue: false })
 
 console.log({ 'this-is-env': IS_PERCY_RUN })
 

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -30,7 +30,7 @@ import { TooltipContent } from './TooltipContent'
  */
 const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
 
-console.log({ THIS_IS_ENV: process.env.PERCY_ON, IS_PERCY_RUN })
+console.log({ 'this-is-env': process.env.PERCY_ON })
 
 // Chart configuration
 const WIDTH_PER_TICK = 70

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -30,7 +30,7 @@ import { TooltipContent } from './TooltipContent'
  */
 const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
 
-console.log({ IS_PERCY_RUN, env: process.env.PERCY_ON })
+console.log({ THIS_IS_ENV: process.env.PERCY_ON, IS_PERCY_RUN })
 
 // Chart configuration
 const WIDTH_PER_TICK = 70

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -30,7 +30,7 @@ import { TooltipContent } from './TooltipContent'
  */
 const IS_PERCY_RUN = process.env.PERCY_ON === 'true'
 
-console.log({ IS_PERCY_RUN })
+console.log({ IS_PERCY_RUN, env: process.env.PERCY_ON })
 
 // Chart configuration
 const WIDTH_PER_TICK = 70

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/sourcegraph/sourcegraph"
   },
   "engines": {
-    "node": "^v14.7.0",
+    "node": "^v16.7.0",
     "yarn": "^1.22.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/sourcegraph/sourcegraph"
   },
   "engines": {
-    "node": "^v16.7.0",
+    "node": "^v14.7.0",
     "yarn": "^1.22.4"
   },
   "scripts": {


### PR DESCRIPTION
## Context
This PR removes prev attempt to fix the flakiness of code insights chart tooltip. It turned out this fix couldn't fix that problem cause there is no way to get information about Percy run via process variables from the main app (Sourcegraph FE build). Only integration tests scripts have that info. But Percy config allows us to add custom styles for the page on the Percy browser. 

This PR introduces a new Percy helper to make elements inactive to any mouse and pointer events via `pointer-events:none`. This may help with chart tooltip appearance problem and could be useful in other cases.