### PR TITLE
all: remove Go parameter names for func defs

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -33,7 +33,7 @@ type Services struct {
 
 // NewCodeIntelUploadHandler creates a new handler for the LSIF upload endpoint. The
 // resulting handler skips auth checks when the internal flag is true.
-type NewCodeIntelUploadHandler func(internal bool) http.Handler
+type NewCodeIntelUploadHandler func(bool) http.Handler
 
 // NewExecutorProxyHandler creates a new proxy handler for routes accessible to the
 // executor services deployed separately from the k8s cluster. This handler is protected
@@ -59,7 +59,7 @@ func makeNotFoundHandler(handlerName string) http.Handler {
 	})
 }
 
-type registerFunc func(webhook *webhooks.GitHubWebhook)
+type registerFunc func(*webhooks.GitHubWebhook)
 
 func (fn registerFunc) Register(w *webhooks.GitHubWebhook) {
 	fn(w)

--- a/cmd/frontend/graphqlbackend/virtual_file.go
+++ b/cmd/frontend/graphqlbackend/virtual_file.go
@@ -14,7 +14,7 @@ import (
 )
 
 // FileContentFunc is a closure that returns the contents of a file and is used by the VirtualFileResolver.
-type FileContentFunc func(ctx context.Context) (string, error)
+type FileContentFunc func(context.Context) (string, error)
 
 func NewVirtualFileResolver(stat fs.FileInfo, fileContent FileContentFunc) *virtualFileResolver {
 	return &virtualFileResolver{

--- a/dev/depgraph/internal/lints/lint.go
+++ b/dev/depgraph/internal/lints/lint.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 )
 
-type Lint func(graph *graph.DependencyGraph) []lintError
+type Lint func(*graph.DependencyGraph) []lintError
 
 type lintError struct {
 	pkg     string

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -99,7 +99,7 @@ func (p *Pipeline) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-type StepOpt func(step *Step)
+type StepOpt func(*Step)
 
 func Cmd(command string) StepOpt {
 	return func(step *Step) {

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
@@ -98,7 +98,7 @@ type migrationDriver interface {
 }
 
 // driverFunc is the type of MigrateRowUp and MigrateRowDown.
-type driverFunc func(scanner scanner) ([]interface{}, error)
+type driverFunc func(scanner) ([]interface{}, error)
 
 type scanner interface {
 	Scan(dest ...interface{}) error

--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -27,7 +27,7 @@ type Inserter struct {
 	returningScanner ReturningScanner
 }
 
-type ReturningScanner func(rows *sql.Rows) error
+type ReturningScanner func(*sql.Rows) error
 
 // InsertValues creates a new batch inserter using the given database handle, table name, and
 // column names, then reads from the given channel as if they specify values for a single row.

--- a/internal/endpoint/consistenthash.go
+++ b/internal/endpoint/consistenthash.go
@@ -45,7 +45,7 @@ func newConsistentHash(nodes []string) consistentHash {
 	return m
 }
 
-type hashFn func(data []byte) uint32
+type hashFn func([]byte) uint32
 
 type hashMap struct {
 	hash     hashFn

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -50,7 +50,7 @@ type Finalizer interface {
 }
 
 // HandlerFunc wraps a function so it can be used as a Handler.
-type HandlerFunc func(ctx context.Context) error
+type HandlerFunc func(context.Context) error
 
 func (f HandlerFunc) Handle(ctx context.Context) error {
 	return f(ctx)

--- a/internal/metrics/operation.go
+++ b/internal/metrics/operation.go
@@ -37,7 +37,7 @@ type operationMetricOptions struct {
 }
 
 // OperationMetricsOption alter the default behavior of NewOperationMetrics.
-type OperationMetricsOption func(o *operationMetricOptions)
+type OperationMetricsOption func(*operationMetricOptions)
 
 // WithSubsystem overrides the default subsystem for all metrics.
 func WithSubsystem(subsystem string) OperationMetricsOption {

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -135,7 +135,7 @@ type Operation struct {
 
 // TraceLogger is returned from WithAndLogger and can be used to add timestamped key and
 // value pairs into a related opentracing span.
-type TraceLogger func(fields ...log.Field)
+type TraceLogger func(...log.Field)
 
 // FinishFunc is the shape of the function returned by With and should be invoked within
 // a defer directly before the observed function returns.

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -310,7 +310,7 @@ func (s *GithubSource) excludes(r *github.Repository) bool {
 // - `hasNext` bool: if there is a next page
 // - `cost` int: rate limit cost used to determine recommended wait before next call
 // - `err` error: if something goes wrong
-type repositoryPager func(page int) (repos []*github.Repository, hasNext bool, cost int, err error)
+type repositoryPager func(int) (repos []*github.Repository, hasNext bool, cost int, err error)
 
 // paginate returns all the repositories from the given repositoryPager.
 // It repeatedly calls `pager` with incrementing page count until it

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -9,10 +9,10 @@ processing logic driven by external options.
 */
 
 // A step performs a transformation on nodes, which may fail.
-type step func(nodes []Node) ([]Node, error)
+type step func([]Node) ([]Node, error)
 
 // A pass is a step that never fails.
-type pass func(nodes []Node) []Node
+type pass func([]Node) []Node
 
 // sequence sequences zero or more steps to create a single step.
 func sequence(steps ...step) step {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -516,7 +516,7 @@ func findPatternRevs(includePatterns []string) (includePatternRevs []patternRevs
 	return
 }
 
-type searchableReposFunc func(ctx context.Context) ([]types.RepoName, error)
+type searchableReposFunc func(context.Context) ([]types.RepoName, error)
 
 // searchableRepositories returns the intersection of calling gettRawSearchableRepos
 // (db) and indexed repos (zoekt), minus repos matching excludePatterns.

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -123,4 +123,4 @@ func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k
 
 // repoRevFunc is a function which maps repository names returned from Zoekt
 // into the Sourcegraph's resolved repository revisions for the search.
-type repoRevFunc func(file *zoekt.FileMatch) (repo types.RepoName, revs []string)
+type repoRevFunc func(*zoekt.FileMatch) (repo types.RepoName, revs []string)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -86,7 +86,7 @@ type Store struct {
 // FilterFunc filters tar files based on their header.
 // Tar files for which FilterFunc evaluates to true
 // are not stored in the target zip.
-type FilterFunc func(hdr *tar.Header) bool
+type FilterFunc func(*tar.Header) bool
 
 // Start initializes state and starts background goroutines. It can be called
 // more than once. It is optional to call, but starting it earlier avoids a

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -174,7 +174,7 @@ func gitserverCmdFunc(repo api.RepoName) cmdFunc {
 }
 
 // cmdFunc is a func that creates a new executable Git command.
-type cmdFunc func(args []string) cmd
+type cmdFunc func([]string) cmd
 
 // cmd is an executable Git command.
 type cmd interface {

--- a/lib/codeintel/lsif/reader/reader.go
+++ b/lib/codeintel/lsif/reader/reader.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ElementMapper is the type of function that is invoked for each parsed element.
-type ElementMapper func(lineContext LineContext)
+type ElementMapper func(LineContext)
 
 // Read consumes the given reader as newline-delimited JSON-encoded LSIF. Each parsed vertex and each
 // parsed edge element is registered to the given Stasher. If vertex or edge mappers are supplied, they

--- a/lib/codeintel/lsif/validation/validators.go
+++ b/lib/codeintel/lsif/validation/validators.go
@@ -27,7 +27,7 @@ var edgeValidators = map[string]ElementValidator{
 
 // RelationshipValidator validates a specific property across all vertex and edges
 // registered to the given context's stasher.
-type RelationshipValidator func(ctx *ValidationContext) bool
+type RelationshipValidator func(*ValidationContext) bool
 
 // relationshipValidators is the set of validators that operate across the entire LSIF graph.
 var relationshipValidators = []RelationshipValidator{

--- a/lib/codeintel/pathexistence/git.go
+++ b/lib/codeintel/pathexistence/git.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-type GitFunc func(args ...string) (string, error)
+type GitFunc func(...string) (string, error)
 
 func GitGetChildren(gitFunc GitFunc, commit string, dirnames []string) (map[string][]string, error) {
 	out, err := gitFunc(

--- a/monitoring/definitions/shared/constructor.go
+++ b/monitoring/definitions/shared/constructor.go
@@ -45,7 +45,7 @@ type ObservableConstructorOptions struct {
 
 // observableConstructor is a type of constructor function used in this package that creates
 // a shared observable given a set of common observable options.
-type observableConstructor func(options ObservableConstructorOptions) sharedObservable
+type observableConstructor func(ObservableConstructorOptions) sharedObservable
 
 type GroupConstructorOptions struct {
 	// ObservableConstructorOptions are shared between child observables of the group.

--- a/monitoring/definitions/shared/shared.go
+++ b/monitoring/definitions/shared/shared.go
@@ -68,7 +68,7 @@ func (o Observable) WithNoAlerts(interpretation string) Observable {
 }
 
 // ObservableOption is a function that transforms an observable.
-type ObservableOption func(observable Observable) Observable
+type ObservableOption func(Observable) Observable
 
 func (f ObservableOption) safeApply(observable Observable) Observable {
 	if f == nil {


### PR DESCRIPTION
This PR is just a proposal for discussion:

How do people feel about function definition style like:

`type foo func(name type)` versus just 
`type foo func(type)` ? 

I think I prefer the latter, but out of habit tend to write the former. The name usually doesn't add much to the signature (like ctx context.Context ok lol), and when I go back to my code and see what I did I tend to "fix it" and delete name.

More examples in our code base where the name can go away: https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+type+:%5B%5Bw%5D%5D+func%28:%5B%5Bx%5D%5D+:%5By:e%5D%29+lang:go&patternType=structural

This PR removes all unneeded param names in function type signatures.

```
comby \
'type :[[w]] func(:[[x]] :[y:e])' \
'type :[w] func(:[y:e])' \
'' \
-rg "-g '*.go'" -stats -i
```

