### PR TITLE
Add beta tag to docs!

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -29,6 +29,7 @@ The document content can set class names and IDs on elements (for example, Markd
     --critical-badge-color: #f03e3e;
     --experimental-color: #b200f8;
     --feature-color: #38757F;
+    --beta-color: #72dbe8;
 
     --table-row-bg-1: var(--body-bg);
 }
@@ -428,13 +429,14 @@ body > #page > main > #content {
 }
 
 .badge {
+    /* Mirrored from product badge styles */
     display: inline-block;
-    padding: 0.3em;
+    padding: 0.125rem 0.375rem;
+    line-height: 1rem;
     border-radius: 4px;
-    font-size: 85%;
-    font-weight: bold;
+    font-size: 0.75rem;
+    font-weight: 500;
     color: inherit;
-    line-height: 1;
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
@@ -443,6 +445,12 @@ body > #page > main > #content {
 .badge-experimental {
     color: #ffffff;
     background-color: var(--experimental-color);
+}
+
+.badge-beta {
+    color: #000000;
+    background-color: var(--beta-color);
+    text-transform: uppercase;
 }
 
 .badge-feature {

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,10 +1,10 @@
-# Code Insights [Beta]
+# Code Insights <a href="../admin/beta_and_prototype_features"><sup><span class="badge badge-beta">Beta</span></sup></a>
 
-Code Insights are currently in Private [Beta](../admin/beta_and_prototype_features.md). 
+Code Insights are currently in Private [Beta](../admin/beta_and_prototype_features.md).
 
 If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).
 
-> NOTE: Code insights docs are actively in progress. 
+> NOTE: Code insights docs are actively in progress.
 
 Table of contents:
 

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,10 +1,12 @@
-# Code Insights
+# Code Insights [Beta]
+
+Code Insights are currently in Private [Beta](../admin/beta_and_prototype_features.md). 
+
+If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).
 
 > NOTE: Code insights docs are actively in progress. 
 
-If you're a customer who needs support or early access, please [send us an email](mailto:feedback@sourcegraph.com). 
-
-Work-in-progress table of contents:
+Table of contents:
 
 - [Quickstart](quickstart.md)
 - [Language Insight Quickstart](language_insight_quickstart.md)


### PR DESCRIPTION

@felixfbecker  if you want to get fancy and it'd take you less than 5 minutes, it would be cool to add the beta tag from the product to the docs as well (screenshot) (both light/dark versions since docs can be light/dark). Otherwise, making a fast lightweight change and will merge. 


![image](https://user-images.githubusercontent.com/11967660/131196122-d730c31e-69ee-4685-84e7-e74a5007c796.png)

(Also @felixfbecker, please see the [note here](https://sourcegraph.slack.com/archives/C02C1F8N5TQ/p1630015100004900?thread_ts=1630012354.002600&cid=C02C1F8N5TQ) about (not) having code insights in the sidebar if you haven't yet – this is an intentional omission.) 