### PR TITLE
monitoring: remove hard_timeout_search_api_responses alert

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -397,30 +397,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: hard_timeout_search_api_responses
-
-<p class="subtitle">hard timeout search API responses every 5m</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> frontend: 2%+ hard timeout search API responses every 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 5%+ hard timeout search API responses every 5m for 15m0s
-
-**Possible solutions**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_frontend_hard_timeout_search_api_responses",
-  "critical_frontend_hard_timeout_search_api_responses"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
 ## frontend: hard_error_search_api_responses
 
 <p class="subtitle">hard error search API responses every 5m</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -176,16 +176,6 @@ This panel indicates 90th percentile successful search API request duration over
 
 <br />
 
-#### frontend: hard_timeout_search_api_responses
-
-This panel indicates hard timeout search API responses every 5m.
-
-> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-api-responses).
-
-<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
-
-<br />
-
 #### frontend: hard_error_search_api_responses
 
 This panel indicates hard error search API responses every 5m.

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -248,17 +248,6 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "hard_timeout_search_api_responses",
-							Description: "hard timeout search API responses every 5m",
-							Query:       `(sum(increase(src_graphql_search_response{status="timeout",source="other"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="other"}[5m]))) / sum(increase(src_graphql_search_response{source="other"}[5m])) * 100`,
-
-							Warning:           monitoring.Alert().GreaterOrEqual(2, nil).For(15 * time.Minute),
-							Critical:          monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
-							Panel:             monitoring.Panel().LegendFormat("hard timeout").Unit(monitoring.Percentage),
-							Owner:             monitoring.ObservableOwnerSearch,
-							PossibleSolutions: "none",
-						},
-						{
 							Name:        "hard_error_search_api_responses",
 							Description: "hard error search API responses every 5m",
 							Query:       `sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="other"}[5m]))`,


### PR DESCRIPTION
I am just removing for now. I tried to silence the alert, but our
workflow is insane for sourcegraph.com and I just want to stop opsgenie.