### PR TITLE
repos: safer external services

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -386,7 +386,7 @@ func (s *Syncer) SyncExternalService(
 	externalServiceID int64,
 	minSyncInterval time.Duration,
 ) (err error) {
-	s.log().Debug("Syncing external service", "serviceID", externalServiceID)
+	s.log().Info("Syncing external service", "serviceID", externalServiceID)
 
 	var svc *types.ExternalService
 	ctx, save := s.observeSync(ctx, "Syncer.SyncExternalService", "")
@@ -472,7 +472,7 @@ func (s *Syncer) SyncExternalService(
 	}
 
 	deleted := 0
-	if err = errs.ErrorOrNil(); err == nil || fatal(err) {
+	if err = errs.ErrorOrNil(); err == nil || (svc.NamespaceUserID != 0 && fatal(err)) {
 		s.log().Warn("syncer: deleting not seen repos",
 			"svc", svc.DisplayName, "id", svc.ID, "seen", len(seen), "error", err)
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -471,6 +471,11 @@ func (s *Syncer) SyncExternalService(
 		modified = modified || len(diff.Modified)+len(diff.Added) > 0
 	}
 
+	// We don't delete any repos of site-level external services if there were any errors during a sync.
+	// Only user external services will delete repos in a sync run with fatal errors.
+	// Site-level external services can own lots of repos and are managed by site admins.
+	// It's preferrable to have them fix any invalidated token manually rather than deleting the repos
+	// automatically.
 	deleted := 0
 	if err = errs.ErrorOrNil(); err == nil || (svc.NamespaceUserID != 0 && fatal(err)) {
 		s.log().Warn("syncer: deleting not seen repos",

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -141,10 +141,40 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 			UpdatedAt:   clock.Now(),
 		}
 
+		err := s.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO users (id, username) VALUES (1, 'u')`))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		userAddedGithubSvc := githubService.With(func(service *types.ExternalService) {
+			service.ID = 0
+			service.NamespaceUserID = 1
+		})
+
+		userAddedGitlabSvc := gitlabService.With(func(service *types.ExternalService) {
+			service.ID = 0
+			service.NamespaceUserID = 1
+		})
+
 		// create a few external services
-		if err := s.ExternalServiceStore.Upsert(context.Background(), &svcdup); err != nil {
+		if err := s.ExternalServiceStore.Upsert(context.Background(), &svcdup, userAddedGithubSvc, userAddedGitlabSvc); err != nil {
 			t.Fatalf("failed to insert external services: %v", err)
 		}
+
+		userAddedGithubRepo := githubRepo.With(func(r *types.Repo) {
+			r.Name += "-2"
+			r.ExternalRepo.ID += "-2"
+		},
+			types.Opt.RepoSources(userAddedGithubSvc.URN()),
+		)
+
+		userAddedGitlabRepo := gitlabRepo.With(func(r *types.Repo) {
+			r.Name += "-2"
+			r.ExternalRepo.ID += "-2"
+		},
+			types.Opt.RepoSources(userAddedGitlabSvc.URN()),
+		)
+
 
 		type testCase struct {
 			name    string
@@ -165,6 +195,8 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 		}{
 			{repo: githubRepo, svc: githubService},
 			{repo: gitlabRepo, svc: gitlabService},
+			{repo: userAddedGithubRepo, svc: userAddedGithubSvc},
+			{repo: userAddedGitlabRepo, svc: userAddedGitlabSvc},
 			{repo: bitbucketServerRepo, svc: bitbucketServerService},
 			{repo: awsCodeCommitRepo, svc: awsCodeCommitService},
 			{repo: otherRepo, svc: otherService},
@@ -187,9 +219,25 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 					svcs: []*types.ExternalService{tc.svc},
 					err:  "<nil>",
 				},
+			)
+
+			var diff repos.Diff
+			if tc.svc.NamespaceUserID > 0 {
+				diff.Deleted = append(diff.Deleted, tc.repo.With(
+					types.Opt.RepoSources(tc.svc.URN()),
+				))
+			} else {
+				diff.Unmodified = append(diff.Unmodified, tc.repo.With(
+					types.Opt.RepoSources(tc.svc.URN()),
+				))
+			}
+
+			testCases = append(testCases,
 				testCase{
 					// If the source is unauthorized we should treat this as if zero repos were
 					// returned as it indicates that the source no longer has access to its repos
+					// This only applies to user added external services, since site level ones will
+					// usually regenerate a token.
 					name: string(tc.repo.Name) + "/unauthorized",
 					sourcer: repos.NewFakeSourcer(nil,
 						repos.NewFakeSource(tc.svc.Clone(), &repos.ErrUnauthorized{}),
@@ -198,16 +246,16 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 					stored: types.Repos{tc.repo.With(
 						types.Opt.RepoSources(tc.svc.URN()),
 					)},
-					now: clock.Now,
-					diff: repos.Diff{Deleted: types.Repos{tc.repo.With(
-						types.Opt.RepoSources(tc.svc.URN(), svcdup.URN()),
-					)}},
+					now:  clock.Now,
+					diff: diff,
 					svcs: []*types.ExternalService{tc.svc},
 					err:  "bad credentials",
 				},
 				testCase{
 					// If the source is forbidden we should treat this as if zero repos were returned
 					// as it indicates that the source no longer has access to its repos
+					// This only applies to user added external services, since site level ones will
+					// usually regenerate a token.
 					name: string(tc.repo.Name) + "/forbidden",
 					sourcer: repos.NewFakeSourcer(nil,
 						repos.NewFakeSource(tc.svc.Clone(), &repos.ErrForbidden{}),
@@ -216,16 +264,16 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 					stored: types.Repos{tc.repo.With(
 						types.Opt.RepoSources(tc.svc.URN()),
 					)},
-					now: clock.Now,
-					diff: repos.Diff{Deleted: types.Repos{tc.repo.With(
-						types.Opt.RepoSources(tc.svc.URN(), svcdup.URN()),
-					)}},
+					now:  clock.Now,
+					diff: diff,
 					svcs: []*types.ExternalService{tc.svc},
 					err:  "forbidden",
 				},
 				testCase{
 					// If the source account has been suspended we should treat this as if zero repos were returned as it indicates
 					// that the source no longer has access to its repos
+					// This only applies to user added external services, since site level ones will
+					// usually regenerate a token.
 					name: string(tc.repo.Name) + "/accountsuspended",
 					sourcer: repos.NewFakeSourcer(nil,
 						repos.NewFakeSource(tc.svc.Clone(), &repos.ErrAccountSuspended{}),
@@ -234,10 +282,8 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 					stored: types.Repos{tc.repo.With(
 						types.Opt.RepoSources(tc.svc.URN()),
 					)},
-					now: clock.Now,
-					diff: repos.Diff{Deleted: types.Repos{tc.repo.With(
-						types.Opt.RepoSources(tc.svc.URN(), svcdup.URN()),
-					)}},
+					now:  clock.Now,
+					diff: diff,
 					svcs: []*types.ExternalService{tc.svc},
 					err:  "account suspended",
 				},

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -175,7 +175,6 @@ func testSyncerSync(s *repos.Store) func(*testing.T) {
 			types.Opt.RepoSources(userAddedGitlabSvc.URN()),
 		)
 
-
 		type testCase struct {
 			name    string
 			sourcer repos.Sourcer


### PR DESCRIPTION
This PR does two things:

1. Prevent cloud default external services from being synced by updating config in the UI. This [caused us to delete 4.5M repos](https://sourcegraph.slack.com/archives/C07KZF47K/p1629977644010300) last week.
2. Prevent site level external services from deleting repos when finding errors during a sync. User added external services will keep deleting repos when faced with a fatal error.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
