### PR TITLE
codeintel: add inferring semanticdb index jobs from upload

### DIFF
--- a/enterprise/internal/codeintel/autoindex/enqueuer/infer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/infer.go
@@ -10,6 +10,7 @@ import (
 func InferRepositoryAndRevision(pkg precise.Package) (repoName, gitTagOrCommit string, ok bool) {
 	for _, fn := range []func(pkg precise.Package) (string, string, bool){
 		inferGoRepositoryAndRevision,
+		inferJVMRepositoryAndRevision,
 	} {
 		if repoName, gitTagOrCommit, ok := fn(pkg); ok {
 			return repoName, gitTagOrCommit, true
@@ -39,4 +40,11 @@ func inferGoRepositoryAndRevision(pkg precise.Package) (string, string, bool) {
 	}
 
 	return strings.Join(repoParts, "/"), version, true
+}
+
+func inferJVMRepositoryAndRevision(pkg precise.Package) (string, string, bool) {
+	if pkg.Scheme != "semanticdb" {
+		return "", "", false
+	}
+	return pkg.Name, "v" + pkg.Version, true
 }


### PR DESCRIPTION
Previously, LSIF uploads would not create index as a repo+revision was not inferred. This PR adds inference from semanticdb LSIF monikers so that we can get dem uploads :tada: 