### PR TITLE
add private icon to private repo search results

### DIFF
--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -1,4 +1,5 @@
 import ArchiveIcon from 'mdi-react/ArchiveIcon'
+import LockIcon from 'mdi-react/LockIcon'
 import SourceForkIcon from 'mdi-react/SourceForkIcon'
 import StarIcon from 'mdi-react/StarIcon'
 import React from 'react'
@@ -76,6 +77,17 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, icon, isL
                                     </div>
                                     <div>
                                         <small>Archived</small>
+                                    </div>
+                                </>
+                            )}
+                            {result.private && (
+                                <>
+                                    <div className="search-result__divider" />
+                                    <div>
+                                        <LockIcon className="search-result__icon icon-inline flex-shrink-0 text-muted" />
+                                    </div>
+                                    <div>
+                                        <small>Private</small>
                                     </div>
                                 </>
                             )}


### PR DESCRIPTION
This PR adds an icon and label to repo results that have `private: true` set. This field was added a little while ago, but I hadn't taken the time to use it in the UI. It's nearly an exact copy/paste of archived and fork.

<img width="311" alt="Screen Shot 2021-08-30 at 07 34 06" src="https://user-images.githubusercontent.com/12631702/131347944-786dacee-62ec-450e-b823-9d823267164e.png">

cc @rrhyne 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
