### PR TITLE
frontend: merge SITE_CONFIG_FILE

### DIFF
--- a/cmd/frontend/internal/cli/config_test.go
+++ b/cmd/frontend/internal/cli/config_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
@@ -15,5 +20,69 @@ func TestServiceConnections(t *testing.T) {
 	sc := serviceConnections()
 	if reflect.DeepEqual(sc, conftypes.ServiceConnections{}) {
 		t.Fatal("expected non-empty service connections")
+	}
+}
+
+func TestReadSiteConfigFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		Name  string
+		Files []string
+		Want  string
+		Err   string
+	}{{
+		Name:  "one",
+		Files: []string{`{"hello": "world"}`},
+		Want:  `{"hello": "world"}`,
+	}, {
+		Name: "two",
+		Files: []string{
+			`// leading comment
+{
+  // first comment
+  "first": "file",
+} // trailing comment
+`, `{"second": "file"}`},
+		Want: `// merged SITE_CONFIG_FILE
+{
+
+// BEGIN $tmp/0.json
+  "first": "file",
+// END $tmp/0.json
+
+// BEGIN $tmp/1.json
+  "second": "file",
+// END $tmp/1.json
+}
+`,
+	}, {
+		Name: "parse-error",
+		Files: []string{
+			"{}",
+			"{",
+		},
+		Err: "CloseBraceExpected",
+	}}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			var paths []string
+			for i, b := range c.Files {
+				p := filepath.Join(dir, fmt.Sprintf("%d.json", i))
+				paths = append(paths, p)
+				if err := os.WriteFile(p, []byte(b), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := readSiteConfigFile(paths)
+			if c.Err != "" && !strings.Contains(fmt.Sprintf("%s", err), c.Err) {
+				t.Fatalf("%s doesn't contain error substring %s", err, c.Err)
+			}
+			got = bytes.ReplaceAll(got, []byte(dir), []byte("$tmp"))
+			if d := cmp.Diff(c.Want, string(got)); d != "" {
+				t.Fatalf("unexpected merge (-want, +got):\n%s", d)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This commit adds support to expand SITE_CONFIG_FILE into multiple
files. The files are merged by writing out the key values from each file
into a new JSON Object. We include comments so an admin can tell where
the keys come from.

The purpose of this commit is so we can seperate out the secret keys in
the site config from the more general keys. I hope to make the DX around
updating most of the site config much easier. IE most of the config
lives in deploy-sourcegraph-dot-com repo.

Note: there is no validation done at read time. This is left for site
config parsing time.

Part of #21220 