### PR TITLE
Code Insights: Use native link for the Edit context menu item

### DIFF
--- a/client/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
+++ b/client/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
@@ -53,485 +53,789 @@ exports[`ActivationDropdown renders the activation dropdown 1`] = `
   history="[History]"
 >
   <Menu>
-    <DescendantProvider
-      context={
-        Object {
-          "$$typeof": Symbol(react.context),
-          "Consumer": Object {
+    <DropdownProvider>
+      <DescendantProvider
+        context={
+          Object {
             "$$typeof": Symbol(react.context),
+            "Consumer": Object {
+              "$$typeof": Symbol(react.context),
+              "_calculateChangedBits": null,
+              "_context": "[Cyclic structure]",
+            },
+            "Provider": Object {
+              "$$typeof": Symbol(react.provider),
+              "_context": "[Cyclic structure]",
+            },
             "_calculateChangedBits": null,
-            "_context": "[Cyclic structure]",
-          },
-          "Provider": Object {
-            "$$typeof": Symbol(react.provider),
-            "_context": "[Cyclic structure]",
-          },
-          "_calculateChangedBits": null,
-          "_currentRenderer": Object {},
-          "_currentRenderer2": null,
-          "_currentValue": Object {
-            "descendants": Array [],
-            "registerDescendant": [Function],
-            "unregisterDescendant": [Function],
-          },
-          "_currentValue2": Object {
-            "descendants": Array [],
-            "registerDescendant": [Function],
-            "unregisterDescendant": [Function],
-          },
-          "_threadCount": 0,
-          "displayName": "MenuDescendantContext",
+            "_currentRenderer": Object {},
+            "_currentRenderer2": null,
+            "_currentValue": Object {
+              "descendants": Array [],
+              "registerDescendant": [Function],
+              "unregisterDescendant": [Function],
+            },
+            "_currentValue2": Object {
+              "descendants": Array [],
+              "registerDescendant": [Function],
+              "unregisterDescendant": [Function],
+            },
+            "_threadCount": 0,
+            "displayName": "DropdownDescendantContext",
+          }
         }
-      }
-      items={Array []}
-      set={[Function]}
-    >
-      <MenuButton
-        className="activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center test-activation-nav-item-toggle"
+        items={Array []}
+        set={[Function]}
       >
-        <button
-          aria-controls="menu--1"
-          aria-haspopup={true}
+        <MenuButton
           className="activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center test-activation-nav-item-toggle"
-          data-reach-menu-button=""
-          id="menu-button--menu--1"
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          type="button"
         >
-          <div
-            className="activation-dropdown-button__confetti"
+          <button
+            aria-controls="menu--1"
+            aria-haspopup={true}
+            className="activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center test-activation-nav-item-toggle"
+            data-reach-menu-button=""
+            id="menu-button--menu"
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            type="button"
           >
-            <Confetti
-              active={false}
-              config={
-                Object {
-                  "angle": 210,
-                  "colors": Array [
-                    "#a864fd",
-                    "#29cdff",
-                    "#78ff44",
-                    "#ff718d",
-                    "#fdff6a",
-                  ],
-                  "delay": 20,
-                  "dragFriction": 0.09,
-                  "duration": 3260,
-                  "elementCount": 81,
-                  "spread": 68,
-                  "startVelocity": 12,
-                }
-              }
+            <div
+              className="activation-dropdown-button__confetti"
             >
-              <div
-                style={
+              <Confetti
+                active={false}
+                config={
                   Object {
-                    "position": "relative",
+                    "angle": 210,
+                    "colors": Array [
+                      "#a864fd",
+                      "#29cdff",
+                      "#78ff44",
+                      "#ff718d",
+                      "#fdff6a",
+                    ],
+                    "delay": 20,
+                    "dragFriction": 0.09,
+                    "duration": 3260,
+                    "elementCount": 81,
+                    "spread": 68,
+                    "startVelocity": 12,
                   }
                 }
-              />
-            </Confetti>
-          </div>
-          Get started
-          <div
-            className="activation-dropdown-button__confetti"
-          >
-            <Confetti
-              active={false}
-              config={
-                Object {
-                  "angle": 330,
-                  "colors": Array [
-                    "#a864fd",
-                    "#29cdff",
-                    "#78ff44",
-                    "#ff718d",
-                    "#fdff6a",
-                  ],
-                  "delay": 20,
-                  "dragFriction": 0.09,
-                  "duration": 3260,
-                  "elementCount": 81,
-                  "spread": 68,
-                  "startVelocity": 12,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "position": "relative",
-                  }
-                }
-              />
-            </Confetti>
-          </div>
-          <span
-            className="activation-dropdown-button__progress-bar-container"
-          >
-            <CircularProgressbar
-              background={false}
-              backgroundPadding={0}
-              circleRatio={1}
-              className="activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
-              classes={
-                Object {
-                  "background": "CircularProgressbar-background",
-                  "path": "CircularProgressbar-path",
-                  "root": "CircularProgressbar",
-                  "text": "CircularProgressbar-text",
-                  "trail": "CircularProgressbar-trail",
-                }
-              }
-              counterClockwise={false}
-              maxValue={100}
-              minValue={0}
-              strokeWidth={12}
-              styles={
-                Object {
-                  "background": Object {},
-                  "path": Object {},
-                  "root": Object {},
-                  "text": Object {},
-                  "trail": Object {},
-                }
-              }
-              text=""
-              value={0}
-            >
-              <svg
-                className="CircularProgressbar activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
-                data-test-id="CircularProgressbar"
-                style={Object {}}
-                viewBox="0 0 100 100"
               >
-                <Path
-                  className="CircularProgressbar-trail"
-                  counterClockwise={false}
-                  dashRatio={1}
-                  pathRadius={44}
-                  strokeWidth={12}
+                <div
+                  style={
+                    Object {
+                      "position": "relative",
+                    }
+                  }
+                />
+              </Confetti>
+            </div>
+            Get started
+            <div
+              className="activation-dropdown-button__confetti"
+            >
+              <Confetti
+                active={false}
+                config={
+                  Object {
+                    "angle": 330,
+                    "colors": Array [
+                      "#a864fd",
+                      "#29cdff",
+                      "#78ff44",
+                      "#ff718d",
+                      "#fdff6a",
+                    ],
+                    "delay": 20,
+                    "dragFriction": 0.09,
+                    "duration": 3260,
+                    "elementCount": 81,
+                    "spread": 68,
+                    "startVelocity": 12,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "position": "relative",
+                    }
+                  }
+                />
+              </Confetti>
+            </div>
+            <span
+              className="activation-dropdown-button__progress-bar-container"
+            >
+              <CircularProgressbar
+                background={false}
+                backgroundPadding={0}
+                circleRatio={1}
+                className="activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
+                classes={
+                  Object {
+                    "background": "CircularProgressbar-background",
+                    "path": "CircularProgressbar-path",
+                    "root": "CircularProgressbar",
+                    "text": "CircularProgressbar-text",
+                    "trail": "CircularProgressbar-trail",
+                  }
+                }
+                counterClockwise={false}
+                maxValue={100}
+                minValue={0}
+                strokeWidth={12}
+                styles={
+                  Object {
+                    "background": Object {},
+                    "path": Object {},
+                    "root": Object {},
+                    "text": Object {},
+                    "trail": Object {},
+                  }
+                }
+                text=""
+                value={0}
+              >
+                <svg
+                  className="CircularProgressbar activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
+                  data-test-id="CircularProgressbar"
                   style={Object {}}
+                  viewBox="0 0 100 100"
                 >
-                  <path
+                  <Path
                     className="CircularProgressbar-trail"
-                    d="
-      M 50,50
-      m 0,-44
-      a 44,44 0 1 1 0,88
-      a 44,44 0 1 1 0,-88
-    "
-                    fillOpacity={0}
+                    counterClockwise={false}
+                    dashRatio={1}
+                    pathRadius={44}
                     strokeWidth={12}
-                    style={
-                      Object {
-                        "strokeDasharray": "276.46015351590177px 276.46015351590177px",
-                        "strokeDashoffset": "0px",
-                      }
-                    }
-                  />
-                </Path>
-                <Path
-                  className="CircularProgressbar-path"
-                  counterClockwise={false}
-                  dashRatio={0}
-                  pathRadius={44}
-                  strokeWidth={12}
-                  style={Object {}}
-                >
-                  <path
-                    className="CircularProgressbar-path"
-                    d="
-      M 50,50
-      m 0,-44
-      a 44,44 0 1 1 0,88
-      a 44,44 0 1 1 0,-88
-    "
-                    fillOpacity={0}
-                    strokeWidth={12}
-                    style={
-                      Object {
-                        "strokeDasharray": "276.46015351590177px 276.46015351590177px",
-                        "strokeDashoffset": "276.46015351590177px",
-                      }
-                    }
-                  />
-                </Path>
-              </svg>
-            </CircularProgressbar>
-          </span>
-        </button>
-      </MenuButton>
-      <MenuPopover
-        className="activation-dropdown dropdown-menu show"
-        hidden={false}
-      >
-        <Popover
-          as="div"
-          className="activation-dropdown dropdown-menu show"
-          data-reach-menu=""
-          data-reach-menu-popover=""
-          hidden={false}
-          onBlur={[Function]}
-          targetRef={
-            Object {
-              "current": <button
-                aria-controls="menu--1"
-                aria-haspopup="true"
-                class="activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center test-activation-nav-item-toggle"
-                data-reach-menu-button=""
-                id="menu-button--menu--1"
-                type="button"
-              >
-                <div
-                  class="activation-dropdown-button__confetti"
-                >
-                  <div
-                    style="position: relative;"
-                  />
-                </div>
-                Get started
-                <div
-                  class="activation-dropdown-button__confetti"
-                >
-                  <div
-                    style="position: relative;"
-                  />
-                </div>
-                <span
-                  class="activation-dropdown-button__progress-bar-container"
-                >
-                  <svg
-                    class="CircularProgressbar activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
-                    data-test-id="CircularProgressbar"
-                    viewBox="0 0 100 100"
+                    style={Object {}}
                   >
                     <path
-                      class="CircularProgressbar-trail"
+                      className="CircularProgressbar-trail"
                       d="
       M 50,50
       m 0,-44
       a 44,44 0 1 1 0,88
       a 44,44 0 1 1 0,-88
     "
-                      fill-opacity="0"
-                      stroke-width="12"
-                      style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 0px;"
+                      fillOpacity={0}
+                      strokeWidth={12}
+                      style={
+                        Object {
+                          "strokeDasharray": "276.46015351590177px 276.46015351590177px",
+                          "strokeDashoffset": "0px",
+                        }
+                      }
                     />
+                  </Path>
+                  <Path
+                    className="CircularProgressbar-path"
+                    counterClockwise={false}
+                    dashRatio={0}
+                    pathRadius={44}
+                    strokeWidth={12}
+                    style={Object {}}
+                  >
                     <path
-                      class="CircularProgressbar-path"
+                      className="CircularProgressbar-path"
                       d="
       M 50,50
       m 0,-44
       a 44,44 0 1 1 0,88
       a 44,44 0 1 1 0,-88
     "
-                      fill-opacity="0"
-                      stroke-width="12"
-                      style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 276.46015351590177px;"
+                      fillOpacity={0}
+                      strokeWidth={12}
+                      style={
+                        Object {
+                          "strokeDasharray": "276.46015351590177px 276.46015351590177px",
+                          "strokeDashoffset": "276.46015351590177px",
+                        }
+                      }
                     />
-                  </svg>
-                </span>
-              </button>,
-            }
-          }
+                  </Path>
+                </svg>
+              </CircularProgressbar>
+            </span>
+          </button>
+        </MenuButton>
+        <MenuPopover
+          className="activation-dropdown dropdown-menu show"
+          hidden={false}
         >
-          <Portal>
-            <Portal
-              containerInfo={
-                <reach-portal>
+          <Popover
+            as="div"
+            className="activation-dropdown dropdown-menu show"
+            data-reach-menu-popover=""
+            hidden={false}
+            onBlur={[Function]}
+            targetRef={
+              Object {
+                "current": <button
+                  aria-controls="menu--1"
+                  aria-haspopup="true"
+                  class="activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center test-activation-nav-item-toggle"
+                  data-reach-menu-button=""
+                  id="menu-button--menu"
+                  type="button"
+                >
                   <div
-                    class="activation-dropdown dropdown-menu show"
-                    data-reach-menu=""
-                    data-reach-menu-popover=""
-                    data-reach-popover=""
-                    style="position: absolute; left: 0px; top: 0px;"
+                    class="activation-dropdown-button__confetti"
                   >
                     <div
-                      class="dropdown-item-text activation-dropdown-header"
+                      style="position: relative;"
+                    />
+                  </div>
+                  Get started
+                  <div
+                    class="activation-dropdown-button__confetti"
+                  >
+                    <div
+                      style="position: relative;"
+                    />
+                  </div>
+                  <span
+                    class="activation-dropdown-button__progress-bar-container"
+                  >
+                    <svg
+                      class="CircularProgressbar activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
+                      data-test-id="CircularProgressbar"
+                      viewBox="0 0 100 100"
+                    >
+                      <path
+                        class="CircularProgressbar-trail"
+                        d="
+      M 50,50
+      m 0,-44
+      a 44,44 0 1 1 0,88
+      a 44,44 0 1 1 0,-88
+    "
+                        fill-opacity="0"
+                        stroke-width="12"
+                        style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 0px;"
+                      />
+                      <path
+                        class="CircularProgressbar-path"
+                        d="
+      M 50,50
+      m 0,-44
+      a 44,44 0 1 1 0,88
+      a 44,44 0 1 1 0,-88
+    "
+                        fill-opacity="0"
+                        stroke-width="12"
+                        style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 276.46015351590177px;"
+                      />
+                    </svg>
+                  </span>
+                </button>,
+              }
+            }
+          >
+            <Portal>
+              <Portal
+                containerInfo={
+                  <reach-portal>
+                    <div
+                      class="activation-dropdown dropdown-menu show"
+                      data-reach-menu-popover=""
+                      data-reach-popover=""
+                      style="position: absolute; left: 0px; top: 0px;"
+                    >
+                      <div
+                        class="dropdown-item-text activation-dropdown-header"
+                      >
+                        <h3
+                          class="mb-0"
+                        >
+                          Welcome to Sourcegraph
+                        </h3>
+                        <p
+                          class="mb-2"
+                        >
+                          Complete the steps below to finish onboarding!
+                        </p>
+                      </div>
+                      <div
+                        class="activation-checklist list-group list-group-flush activation-dropdown__checklist"
+                      >
+                        <div
+                          data-reach-accordion=""
+                        >
+                          <div
+                            class="activation-checklist__container list-group-item"
+                            data-reach-accordion-item=""
+                            data-state="collapsed"
+                          >
+                            <button
+                              aria-controls="panel--1--0"
+                              aria-expanded="false"
+                              class="activation-checklist__button list-group-item list-group-item-action btn-link"
+                              data-reach-accordion-button=""
+                              id="button--1--0"
+                            >
+                              <div
+                                class="activation-checklist-item d-flex justify-content-between"
+                              >
+                                <div
+                                  class="d-flex align-items-center"
+                                >
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-down"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-right"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span>
+                                    Add repositories
+                                  </span>
+                                </div>
+                                <div>
+                                  <svg
+                                    class="mdi-icon icon-inline text-muted"
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </button>
+                            <div
+                              aria-labelledby="button--1--0"
+                              class="px-2"
+                              data-reach-accordion-panel=""
+                              data-state="collapsed"
+                              hidden=""
+                              id="panel--1--0"
+                              role="region"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="activation-checklist__detail pb-1"
+                              >
+                                Configure Sourcegraph to talk to your code host and fetch a list of your repositories.
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="activation-checklist__container list-group-item"
+                            data-reach-accordion-item=""
+                            data-state="collapsed"
+                          >
+                            <button
+                              aria-controls="panel--1--1"
+                              aria-expanded="false"
+                              class="activation-checklist__button list-group-item list-group-item-action btn-link"
+                              data-reach-accordion-button=""
+                              id="button--1--1"
+                            >
+                              <div
+                                class="activation-checklist-item d-flex justify-content-between"
+                              >
+                                <div
+                                  class="d-flex align-items-center"
+                                >
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-down"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-right"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span>
+                                    Search your code
+                                  </span>
+                                </div>
+                                <div>
+                                  <svg
+                                    class="mdi-icon icon-inline text-muted"
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </button>
+                            <div
+                              aria-labelledby="button--1--1"
+                              class="px-2"
+                              data-reach-accordion-panel=""
+                              data-state="collapsed"
+                              hidden=""
+                              id="panel--1--1"
+                              role="region"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="activation-checklist__detail pb-1"
+                              >
+                                <span>
+                                  Head to the 
+                                  <a
+                                    href="/search"
+                                  >
+                                    homepage
+                                  </a>
+                                   and perform a search query on your code.
+                                   
+                                  <strong>
+                                    Example:
+                                  </strong>
+                                   type 'lang:' and select a language
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="activation-checklist__container list-group-item"
+                            data-reach-accordion-item=""
+                            data-state="collapsed"
+                          >
+                            <button
+                              aria-controls="panel--1--2"
+                              aria-expanded="false"
+                              class="activation-checklist__button list-group-item list-group-item-action btn-link"
+                              data-reach-accordion-button=""
+                              id="button--1--2"
+                            >
+                              <div
+                                class="activation-checklist-item d-flex justify-content-between"
+                              >
+                                <div
+                                  class="d-flex align-items-center"
+                                >
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-down"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-right"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span>
+                                    Find some references
+                                  </span>
+                                </div>
+                                <div>
+                                  <svg
+                                    class="mdi-icon icon-inline text-muted"
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </button>
+                            <div
+                              aria-labelledby="button--1--2"
+                              class="px-2"
+                              data-reach-accordion-panel=""
+                              data-state="collapsed"
+                              hidden=""
+                              id="panel--1--2"
+                              role="region"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="activation-checklist__detail pb-1"
+                              >
+                                To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click "Find references".
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="activation-checklist__container list-group-item"
+                            data-reach-accordion-item=""
+                            data-state="collapsed"
+                          >
+                            <button
+                              aria-controls="panel--1--3"
+                              aria-expanded="false"
+                              class="activation-checklist__button list-group-item list-group-item-action btn-link"
+                              data-reach-accordion-button=""
+                              id="button--1--3"
+                            >
+                              <div
+                                class="activation-checklist-item d-flex justify-content-between"
+                              >
+                                <div
+                                  class="d-flex align-items-center"
+                                >
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-down"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="activation-checklist-item__icon-container icon-inline icon-right"
+                                  >
+                                    <svg
+                                      class="mdi-icon activation-checklist-item__icon"
+                                      fill="currentColor"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                    >
+                                      <path
+                                        d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span>
+                                    Configure SSO or share with teammates
+                                  </span>
+                                </div>
+                                <div>
+                                  <svg
+                                    class="mdi-icon icon-inline text-muted"
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </button>
+                            <div
+                              aria-labelledby="button--1--3"
+                              class="px-2"
+                              data-reach-accordion-panel=""
+                              data-state="collapsed"
+                              hidden=""
+                              id="panel--1--3"
+                              role="region"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="activation-checklist__detail pb-1"
+                              >
+                                Configure a single-sign on (SSO) provider or have at least one other teammate sign up.
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </reach-portal>
+                }
+              >
+                <PopoverImpl
+                  as="div"
+                  className="activation-dropdown dropdown-menu show"
+                  data-reach-menu-popover=""
+                  hidden={false}
+                  onBlur={[Function]}
+                  targetRef={
+                    Object {
+                      "current": <button
+                        aria-controls="menu--1"
+                        aria-haspopup="true"
+                        class="activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center test-activation-nav-item-toggle"
+                        data-reach-menu-button=""
+                        id="menu-button--menu"
+                        type="button"
+                      >
+                        <div
+                          class="activation-dropdown-button__confetti"
+                        >
+                          <div
+                            style="position: relative;"
+                          />
+                        </div>
+                        Get started
+                        <div
+                          class="activation-dropdown-button__confetti"
+                        >
+                          <div
+                            style="position: relative;"
+                          />
+                        </div>
+                        <span
+                          class="activation-dropdown-button__progress-bar-container"
+                        >
+                          <svg
+                            class="CircularProgressbar activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
+                            data-test-id="CircularProgressbar"
+                            viewBox="0 0 100 100"
+                          >
+                            <path
+                              class="CircularProgressbar-trail"
+                              d="
+      M 50,50
+      m 0,-44
+      a 44,44 0 1 1 0,88
+      a 44,44 0 1 1 0,-88
+    "
+                              fill-opacity="0"
+                              stroke-width="12"
+                              style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 0px;"
+                            />
+                            <path
+                              class="CircularProgressbar-path"
+                              d="
+      M 50,50
+      m 0,-44
+      a 44,44 0 1 1 0,88
+      a 44,44 0 1 1 0,-88
+    "
+                              fill-opacity="0"
+                              stroke-width="12"
+                              style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 276.46015351590177px;"
+                            />
+                          </svg>
+                        </span>
+                      </button>,
+                    }
+                  }
+                >
+                  <div
+                    className="activation-dropdown dropdown-menu show"
+                    data-reach-menu-popover=""
+                    data-reach-popover=""
+                    hidden={false}
+                    onBlur={[Function]}
+                    style={
+                      Object {
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                      }
+                    }
+                  >
+                    <div
+                      className="dropdown-item-text activation-dropdown-header"
                     >
                       <h3
-                        class="mb-0"
+                        className="mb-0"
                       >
                         Welcome to Sourcegraph
                       </h3>
                       <p
-                        class="mb-2"
+                        className="mb-2"
                       >
                         Complete the steps below to finish onboarding!
                       </p>
                     </div>
-                    <div
-                      class="activation-checklist list-group list-group-flush activation-dropdown__checklist"
-                    >
-                      <div
-                        data-reach-accordion=""
-                      >
-                        <div
-                          class="activation-checklist__container list-group-item"
-                          data-reach-accordion-item=""
-                          data-state="collapsed"
-                        >
-                          <button
-                            aria-controls="panel--1--0"
-                            aria-expanded="false"
-                            class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                            data-reach-accordion-button=""
-                            id="button--1--0"
-                          >
-                            <div
-                              class="activation-checklist-item d-flex justify-content-between"
-                            >
-                              <div
-                                class="d-flex align-items-center"
-                              >
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-down"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-right"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span>
-                                  Add repositories
-                                </span>
-                              </div>
-                              <div>
-                                <svg
-                                  class="mdi-icon icon-inline text-muted"
-                                  fill="currentColor"
-                                  height="24"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                >
-                                  <path
-                                    d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
-                          </button>
-                          <div
-                            aria-labelledby="button--1--0"
-                            class="px-2"
-                            data-reach-accordion-panel=""
-                            data-state="collapsed"
-                            hidden=""
-                            id="panel--1--0"
-                            role="region"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="activation-checklist__detail pb-1"
-                            >
-                              Configure Sourcegraph to talk to your code host and fetch a list of your repositories.
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="activation-checklist__container list-group-item"
-                          data-reach-accordion-item=""
-                          data-state="collapsed"
-                        >
-                          <button
-                            aria-controls="panel--1--1"
-                            aria-expanded="false"
-                            class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                            data-reach-accordion-button=""
-                            id="button--1--1"
-                          >
-                            <div
-                              class="activation-checklist-item d-flex justify-content-between"
-                            >
-                              <div
-                                class="d-flex align-items-center"
-                              >
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-down"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-right"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span>
-                                  Search your code
-                                </span>
-                              </div>
-                              <div>
-                                <svg
-                                  class="mdi-icon icon-inline text-muted"
-                                  fill="currentColor"
-                                  height="24"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                >
-                                  <path
-                                    d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
-                          </button>
-                          <div
-                            aria-labelledby="button--1--1"
-                            class="px-2"
-                            data-reach-accordion-panel=""
-                            data-state="collapsed"
-                            hidden=""
-                            id="panel--1--1"
-                            role="region"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="activation-checklist__detail pb-1"
-                            >
-                              <span>
+                    <ActivationChecklist
+                      activation={
+                        Object {
+                          "completed": Object {
+                            "ConnectedCodeHost": false,
+                            "DidSearch": false,
+                            "EnabledRepository": false,
+                            "FoundReferences": false,
+                          },
+                          "refetch": [Function],
+                          "steps": Array [
+                            Object {
+                              "detail": "Configure Sourcegraph to talk to your code host and fetch a list of your repositories.",
+                              "id": "ConnectedCodeHost",
+                              "title": "Add repositories",
+                            },
+                            Object {
+                              "detail": <span>
                                 Head to the 
                                 <a
                                   href="/search"
@@ -544,294 +848,37 @@ exports[`ActivationDropdown renders the activation dropdown 1`] = `
                                   Example:
                                 </strong>
                                  type 'lang:' and select a language
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="activation-checklist__container list-group-item"
-                          data-reach-accordion-item=""
-                          data-state="collapsed"
-                        >
-                          <button
-                            aria-controls="panel--1--2"
-                            aria-expanded="false"
-                            class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                            data-reach-accordion-button=""
-                            id="button--1--2"
-                          >
-                            <div
-                              class="activation-checklist-item d-flex justify-content-between"
-                            >
-                              <div
-                                class="d-flex align-items-center"
-                              >
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-down"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-right"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span>
-                                  Find some references
-                                </span>
-                              </div>
-                              <div>
-                                <svg
-                                  class="mdi-icon icon-inline text-muted"
-                                  fill="currentColor"
-                                  height="24"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                >
-                                  <path
-                                    d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
-                          </button>
-                          <div
-                            aria-labelledby="button--1--2"
-                            class="px-2"
-                            data-reach-accordion-panel=""
-                            data-state="collapsed"
-                            hidden=""
-                            id="panel--1--2"
-                            role="region"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="activation-checklist__detail pb-1"
-                            >
-                              To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click "Find references".
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="activation-checklist__container list-group-item"
-                          data-reach-accordion-item=""
-                          data-state="collapsed"
-                        >
-                          <button
-                            aria-controls="panel--1--3"
-                            aria-expanded="false"
-                            class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                            data-reach-accordion-button=""
-                            id="button--1--3"
-                          >
-                            <div
-                              class="activation-checklist-item d-flex justify-content-between"
-                            >
-                              <div
-                                class="d-flex align-items-center"
-                              >
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-down"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="activation-checklist-item__icon-container icon-inline icon-right"
-                                >
-                                  <svg
-                                    class="mdi-icon activation-checklist-item__icon"
-                                    fill="currentColor"
-                                    height="24"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                  >
-                                    <path
-                                      d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span>
-                                  Configure SSO or share with teammates
-                                </span>
-                              </div>
-                              <div>
-                                <svg
-                                  class="mdi-icon icon-inline text-muted"
-                                  fill="currentColor"
-                                  height="24"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                >
-                                  <path
-                                    d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
-                          </button>
-                          <div
-                            aria-labelledby="button--1--3"
-                            class="px-2"
-                            data-reach-accordion-panel=""
-                            data-state="collapsed"
-                            hidden=""
-                            id="panel--1--3"
-                            role="region"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="activation-checklist__detail pb-1"
-                            >
-                              Configure a single-sign on (SSO) provider or have at least one other teammate sign up.
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </reach-portal>
-              }
-            >
-              <PopoverImpl
-                as="div"
-                className="activation-dropdown dropdown-menu show"
-                data-reach-menu=""
-                data-reach-menu-popover=""
-                hidden={false}
-                onBlur={[Function]}
-                targetRef={
-                  Object {
-                    "current": <button
-                      aria-controls="menu--1"
-                      aria-haspopup="true"
-                      class="activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center test-activation-nav-item-toggle"
-                      data-reach-menu-button=""
-                      id="menu-button--menu--1"
-                      type="button"
-                    >
-                      <div
-                        class="activation-dropdown-button__confetti"
-                      >
-                        <div
-                          style="position: relative;"
-                        />
-                      </div>
-                      Get started
-                      <div
-                        class="activation-dropdown-button__confetti"
-                      >
-                        <div
-                          style="position: relative;"
-                        />
-                      </div>
-                      <span
-                        class="activation-dropdown-button__progress-bar-container"
-                      >
-                        <svg
-                          class="CircularProgressbar activation-dropdown-button__circular-progress-bar test-activation-progress-bar"
-                          data-test-id="CircularProgressbar"
-                          viewBox="0 0 100 100"
-                        >
-                          <path
-                            class="CircularProgressbar-trail"
-                            d="
-      M 50,50
-      m 0,-44
-      a 44,44 0 1 1 0,88
-      a 44,44 0 1 1 0,-88
-    "
-                            fill-opacity="0"
-                            stroke-width="12"
-                            style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 0px;"
-                          />
-                          <path
-                            class="CircularProgressbar-path"
-                            d="
-      M 50,50
-      m 0,-44
-      a 44,44 0 1 1 0,88
-      a 44,44 0 1 1 0,-88
-    "
-                            fill-opacity="0"
-                            stroke-width="12"
-                            style="stroke-dasharray: 276.46015351590177px 276.46015351590177px; stroke-dashoffset: 276.46015351590177px;"
-                          />
-                        </svg>
-                      </span>
-                    </button>,
-                  }
-                }
-              >
-                <div
-                  className="activation-dropdown dropdown-menu show"
-                  data-reach-menu=""
-                  data-reach-menu-popover=""
-                  data-reach-popover=""
-                  hidden={false}
-                  onBlur={[Function]}
-                  style={
-                    Object {
-                      "left": "0px",
-                      "position": "absolute",
-                      "top": "0px",
-                    }
-                  }
-                >
-                  <div
-                    className="dropdown-item-text activation-dropdown-header"
-                  >
-                    <h3
-                      className="mb-0"
-                    >
-                      Welcome to Sourcegraph
-                    </h3>
-                    <p
-                      className="mb-2"
-                    >
-                      Complete the steps below to finish onboarding!
-                    </p>
-                  </div>
-                  <ActivationChecklist
-                    activation={
-                      Object {
-                        "completed": Object {
+                              </span>,
+                              "id": "DidSearch",
+                              "title": "Search your code",
+                            },
+                            Object {
+                              "detail": "To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click \\"Find references\\".",
+                              "id": "FoundReferences",
+                              "title": "Find some references",
+                            },
+                            Object {
+                              "detail": "Configure a single-sign on (SSO) provider or have at least one other teammate sign up.",
+                              "id": "EnabledSharing",
+                              "title": "Configure SSO or share with teammates",
+                            },
+                          ],
+                          "update": [Function],
+                        }
+                      }
+                      alwaysShow={true}
+                      className="activation-dropdown__checklist"
+                      completed={
+                        Object {
                           "ConnectedCodeHost": false,
                           "DidSearch": false,
                           "EnabledRepository": false,
                           "FoundReferences": false,
-                        },
-                        "refetch": [Function],
-                        "steps": Array [
+                        }
+                      }
+                      history="[History]"
+                      steps={
+                        Array [
                           Object {
                             "detail": "Configure Sourcegraph to talk to your code host and fetch a list of your repositories.",
                             "id": "ConnectedCodeHost",
@@ -865,474 +912,493 @@ exports[`ActivationDropdown renders the activation dropdown 1`] = `
                             "id": "EnabledSharing",
                             "title": "Configure SSO or share with teammates",
                           },
-                        ],
-                        "update": [Function],
+                        ]
                       }
-                    }
-                    alwaysShow={true}
-                    className="activation-dropdown__checklist"
-                    completed={
-                      Object {
-                        "ConnectedCodeHost": false,
-                        "DidSearch": false,
-                        "EnabledRepository": false,
-                        "FoundReferences": false,
-                      }
-                    }
-                    history="[History]"
-                    steps={
-                      Array [
-                        Object {
-                          "detail": "Configure Sourcegraph to talk to your code host and fetch a list of your repositories.",
-                          "id": "ConnectedCodeHost",
-                          "title": "Add repositories",
-                        },
-                        Object {
-                          "detail": <span>
-                            Head to the 
-                            <a
-                              href="/search"
-                            >
-                              homepage
-                            </a>
-                             and perform a search query on your code.
-                             
-                            <strong>
-                              Example:
-                            </strong>
-                             type 'lang:' and select a language
-                          </span>,
-                          "id": "DidSearch",
-                          "title": "Search your code",
-                        },
-                        Object {
-                          "detail": "To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click \\"Find references\\".",
-                          "id": "FoundReferences",
-                          "title": "Find some references",
-                        },
-                        Object {
-                          "detail": "Configure a single-sign on (SSO) provider or have at least one other teammate sign up.",
-                          "id": "EnabledSharing",
-                          "title": "Configure SSO or share with teammates",
-                        },
-                      ]
-                    }
-                  >
-                    <div
-                      className="activation-checklist list-group list-group-flush activation-dropdown__checklist"
                     >
-                      <Accordion
-                        collapsible={true}
+                      <div
+                        className="activation-checklist list-group list-group-flush activation-dropdown__checklist"
                       >
-                        <DescendantProvider
-                          context={
-                            Object {
-                              "$$typeof": Symbol(react.context),
-                              "Consumer": Object {
-                                "$$typeof": Symbol(react.context),
-                                "_calculateChangedBits": null,
-                                "_context": "[Cyclic structure]",
-                              },
-                              "Provider": Object {
-                                "$$typeof": Symbol(react.provider),
-                                "_context": "[Cyclic structure]",
-                              },
-                              "_calculateChangedBits": null,
-                              "_currentRenderer": Object {},
-                              "_currentRenderer2": null,
-                              "_currentValue": Object {
-                                "descendants": Array [],
-                                "registerDescendant": [Function],
-                                "unregisterDescendant": [Function],
-                              },
-                              "_currentValue2": Object {
-                                "descendants": Array [],
-                                "registerDescendant": [Function],
-                                "unregisterDescendant": [Function],
-                              },
-                              "_threadCount": 0,
-                              "displayName": "AccordionDescendantContext",
-                            }
-                          }
-                          items={
-                            Array [
-                              Object {
-                                "disabled": false,
-                                "element": <button
-                                  aria-controls="panel--1--0"
-                                  aria-expanded="false"
-                                  class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                  data-reach-accordion-button=""
-                                  id="button--1--0"
-                                >
-                                  <div
-                                    class="activation-checklist-item d-flex justify-content-between"
-                                  >
-                                    <div
-                                      class="d-flex align-items-center"
-                                    >
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-down"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-right"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span>
-                                        Add repositories
-                                      </span>
-                                    </div>
-                                    <div>
-                                      <svg
-                                        class="mdi-icon icon-inline text-muted"
-                                        fill="currentColor"
-                                        height="24"
-                                        viewBox="0 0 24 24"
-                                        width="24"
-                                      >
-                                        <path
-                                          d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </div>
-                                </button>,
-                                "index": 0,
-                              },
-                              Object {
-                                "disabled": false,
-                                "element": <button
-                                  aria-controls="panel--1--1"
-                                  aria-expanded="false"
-                                  class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                  data-reach-accordion-button=""
-                                  id="button--1--1"
-                                >
-                                  <div
-                                    class="activation-checklist-item d-flex justify-content-between"
-                                  >
-                                    <div
-                                      class="d-flex align-items-center"
-                                    >
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-down"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-right"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span>
-                                        Search your code
-                                      </span>
-                                    </div>
-                                    <div>
-                                      <svg
-                                        class="mdi-icon icon-inline text-muted"
-                                        fill="currentColor"
-                                        height="24"
-                                        viewBox="0 0 24 24"
-                                        width="24"
-                                      >
-                                        <path
-                                          d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </div>
-                                </button>,
-                                "index": 1,
-                              },
-                              Object {
-                                "disabled": false,
-                                "element": <button
-                                  aria-controls="panel--1--2"
-                                  aria-expanded="false"
-                                  class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                  data-reach-accordion-button=""
-                                  id="button--1--2"
-                                >
-                                  <div
-                                    class="activation-checklist-item d-flex justify-content-between"
-                                  >
-                                    <div
-                                      class="d-flex align-items-center"
-                                    >
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-down"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-right"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span>
-                                        Find some references
-                                      </span>
-                                    </div>
-                                    <div>
-                                      <svg
-                                        class="mdi-icon icon-inline text-muted"
-                                        fill="currentColor"
-                                        height="24"
-                                        viewBox="0 0 24 24"
-                                        width="24"
-                                      >
-                                        <path
-                                          d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </div>
-                                </button>,
-                                "index": 2,
-                              },
-                              Object {
-                                "disabled": false,
-                                "element": <button
-                                  aria-controls="panel--1--3"
-                                  aria-expanded="false"
-                                  class="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                  data-reach-accordion-button=""
-                                  id="button--1--3"
-                                >
-                                  <div
-                                    class="activation-checklist-item d-flex justify-content-between"
-                                  >
-                                    <div
-                                      class="d-flex align-items-center"
-                                    >
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-down"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span
-                                        class="activation-checklist-item__icon-container icon-inline icon-right"
-                                      >
-                                        <svg
-                                          class="mdi-icon activation-checklist-item__icon"
-                                          fill="currentColor"
-                                          height="24"
-                                          viewBox="0 0 24 24"
-                                          width="24"
-                                        >
-                                          <path
-                                            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span>
-                                        Configure SSO or share with teammates
-                                      </span>
-                                    </div>
-                                    <div>
-                                      <svg
-                                        class="mdi-icon icon-inline text-muted"
-                                        fill="currentColor"
-                                        height="24"
-                                        viewBox="0 0 24 24"
-                                        width="24"
-                                      >
-                                        <path
-                                          d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </div>
-                                </button>,
-                                "index": 3,
-                              },
-                            ]
-                          }
-                          set={[Function]}
+                        <Accordion
+                          collapsible={true}
                         >
-                          <div
-                            data-reach-accordion=""
-                          >
-                            <AccordionItem
-                              className="activation-checklist__container list-group-item"
-                              key="ConnectedCodeHost"
-                            >
-                              <div
-                                className="activation-checklist__container list-group-item"
-                                data-reach-accordion-item=""
-                                data-state="collapsed"
-                              >
-                                <AccordionButton
-                                  className="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                >
-                                  <button
+                          <DescendantProvider
+                            context={
+                              Object {
+                                "$$typeof": Symbol(react.context),
+                                "Consumer": Object {
+                                  "$$typeof": Symbol(react.context),
+                                  "_calculateChangedBits": null,
+                                  "_context": "[Cyclic structure]",
+                                },
+                                "Provider": Object {
+                                  "$$typeof": Symbol(react.provider),
+                                  "_context": "[Cyclic structure]",
+                                },
+                                "_calculateChangedBits": null,
+                                "_currentRenderer": Object {},
+                                "_currentRenderer2": null,
+                                "_currentValue": Object {
+                                  "descendants": Array [],
+                                  "registerDescendant": [Function],
+                                  "unregisterDescendant": [Function],
+                                },
+                                "_currentValue2": Object {
+                                  "descendants": Array [],
+                                  "registerDescendant": [Function],
+                                  "unregisterDescendant": [Function],
+                                },
+                                "_threadCount": 0,
+                                "displayName": "AccordionDescendantContext",
+                              }
+                            }
+                            items={
+                              Array [
+                                Object {
+                                  "disabled": false,
+                                  "element": <button
                                     aria-controls="panel--1--0"
-                                    aria-expanded={false}
-                                    className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                    aria-expanded="false"
+                                    class="activation-checklist__button list-group-item list-group-item-action btn-link"
                                     data-reach-accordion-button=""
                                     id="button--1--0"
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
-                                  >
-                                    <ActivationChecklistItem
-                                      detail="Configure Sourcegraph to talk to your code host and fetch a list of your repositories."
-                                      done={false}
-                                      id="ConnectedCodeHost"
-                                      key="ConnectedCodeHost"
-                                      title="Add repositories"
-                                    >
-                                      <div
-                                        className="activation-checklist-item d-flex justify-content-between"
-                                      >
-                                        <div
-                                          className="d-flex align-items-center"
-                                        >
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-down"
-                                          >
-                                            <Memo(ChevronDownIcon)
-                                              className="activation-checklist-item__icon"
-                                            />
-                                          </span>
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-right"
-                                          >
-                                            <Memo(ChevronRightIcon)
-                                              className="activation-checklist-item__icon"
-                                            />
-                                          </span>
-                                          <span>
-                                            Add repositories
-                                          </span>
-                                        </div>
-                                        <div>
-                                          <Memo(CheckboxBlankCircleOutlineIcon)
-                                            className="icon-inline text-muted"
-                                          />
-                                        </div>
-                                      </div>
-                                    </ActivationChecklistItem>
-                                  </button>
-                                </AccordionButton>
-                                <AccordionPanel
-                                  className="px-2"
-                                >
-                                  <div
-                                    aria-labelledby="button--1--0"
-                                    className="px-2"
-                                    data-reach-accordion-panel=""
-                                    data-state="collapsed"
-                                    hidden={true}
-                                    id="panel--1--0"
-                                    role="region"
-                                    tabIndex={-1}
                                   >
                                     <div
-                                      className="activation-checklist__detail pb-1"
+                                      class="activation-checklist-item d-flex justify-content-between"
                                     >
-                                      Configure Sourcegraph to talk to your code host and fetch a list of your repositories.
+                                      <div
+                                        class="d-flex align-items-center"
+                                      >
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-down"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-right"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span>
+                                          Add repositories
+                                        </span>
+                                      </div>
+                                      <div>
+                                        <svg
+                                          class="mdi-icon icon-inline text-muted"
+                                          fill="currentColor"
+                                          height="24"
+                                          viewBox="0 0 24 24"
+                                          width="24"
+                                        >
+                                          <path
+                                            d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                          />
+                                        </svg>
+                                      </div>
                                     </div>
-                                  </div>
-                                </AccordionPanel>
-                              </div>
-                            </AccordionItem>
-                            <AccordionItem
-                              className="activation-checklist__container list-group-item"
-                              key="DidSearch"
-                            >
-                              <div
-                                className="activation-checklist__container list-group-item"
-                                data-reach-accordion-item=""
-                                data-state="collapsed"
-                              >
-                                <AccordionButton
-                                  className="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                >
-                                  <button
+                                  </button>,
+                                  "index": 0,
+                                },
+                                Object {
+                                  "disabled": false,
+                                  "element": <button
                                     aria-controls="panel--1--1"
-                                    aria-expanded={false}
-                                    className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                    aria-expanded="false"
+                                    class="activation-checklist__button list-group-item list-group-item-action btn-link"
                                     data-reach-accordion-button=""
                                     id="button--1--1"
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
                                   >
-                                    <ActivationChecklistItem
-                                      detail={
+                                    <div
+                                      class="activation-checklist-item d-flex justify-content-between"
+                                    >
+                                      <div
+                                        class="d-flex align-items-center"
+                                      >
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-down"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-right"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span>
+                                          Search your code
+                                        </span>
+                                      </div>
+                                      <div>
+                                        <svg
+                                          class="mdi-icon icon-inline text-muted"
+                                          fill="currentColor"
+                                          height="24"
+                                          viewBox="0 0 24 24"
+                                          width="24"
+                                        >
+                                          <path
+                                            d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                          />
+                                        </svg>
+                                      </div>
+                                    </div>
+                                  </button>,
+                                  "index": 1,
+                                },
+                                Object {
+                                  "disabled": false,
+                                  "element": <button
+                                    aria-controls="panel--1--2"
+                                    aria-expanded="false"
+                                    class="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                    data-reach-accordion-button=""
+                                    id="button--1--2"
+                                  >
+                                    <div
+                                      class="activation-checklist-item d-flex justify-content-between"
+                                    >
+                                      <div
+                                        class="d-flex align-items-center"
+                                      >
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-down"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-right"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span>
+                                          Find some references
+                                        </span>
+                                      </div>
+                                      <div>
+                                        <svg
+                                          class="mdi-icon icon-inline text-muted"
+                                          fill="currentColor"
+                                          height="24"
+                                          viewBox="0 0 24 24"
+                                          width="24"
+                                        >
+                                          <path
+                                            d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                          />
+                                        </svg>
+                                      </div>
+                                    </div>
+                                  </button>,
+                                  "index": 2,
+                                },
+                                Object {
+                                  "disabled": false,
+                                  "element": <button
+                                    aria-controls="panel--1--3"
+                                    aria-expanded="false"
+                                    class="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                    data-reach-accordion-button=""
+                                    id="button--1--3"
+                                  >
+                                    <div
+                                      class="activation-checklist-item d-flex justify-content-between"
+                                    >
+                                      <div
+                                        class="d-flex align-items-center"
+                                      >
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-down"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="activation-checklist-item__icon-container icon-inline icon-right"
+                                        >
+                                          <svg
+                                            class="mdi-icon activation-checklist-item__icon"
+                                            fill="currentColor"
+                                            height="24"
+                                            viewBox="0 0 24 24"
+                                            width="24"
+                                          >
+                                            <path
+                                              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span>
+                                          Configure SSO or share with teammates
+                                        </span>
+                                      </div>
+                                      <div>
+                                        <svg
+                                          class="mdi-icon icon-inline text-muted"
+                                          fill="currentColor"
+                                          height="24"
+                                          viewBox="0 0 24 24"
+                                          width="24"
+                                        >
+                                          <path
+                                            d="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                                          />
+                                        </svg>
+                                      </div>
+                                    </div>
+                                  </button>,
+                                  "index": 3,
+                                },
+                              ]
+                            }
+                            set={[Function]}
+                          >
+                            <div
+                              data-reach-accordion=""
+                            >
+                              <AccordionItem
+                                className="activation-checklist__container list-group-item"
+                                key="ConnectedCodeHost"
+                              >
+                                <div
+                                  className="activation-checklist__container list-group-item"
+                                  data-reach-accordion-item=""
+                                  data-state="collapsed"
+                                >
+                                  <AccordionButton
+                                    className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                  >
+                                    <button
+                                      aria-controls="panel--1--0"
+                                      aria-expanded={false}
+                                      className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                      data-reach-accordion-button=""
+                                      id="button--1--0"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                    >
+                                      <ActivationChecklistItem
+                                        detail="Configure Sourcegraph to talk to your code host and fetch a list of your repositories."
+                                        done={false}
+                                        id="ConnectedCodeHost"
+                                        key="ConnectedCodeHost"
+                                        title="Add repositories"
+                                      >
+                                        <div
+                                          className="activation-checklist-item d-flex justify-content-between"
+                                        >
+                                          <div
+                                            className="d-flex align-items-center"
+                                          >
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-down"
+                                            >
+                                              <Memo(ChevronDownIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-right"
+                                            >
+                                              <Memo(ChevronRightIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span>
+                                              Add repositories
+                                            </span>
+                                          </div>
+                                          <div>
+                                            <Memo(CheckboxBlankCircleOutlineIcon)
+                                              className="icon-inline text-muted"
+                                            />
+                                          </div>
+                                        </div>
+                                      </ActivationChecklistItem>
+                                    </button>
+                                  </AccordionButton>
+                                  <AccordionPanel
+                                    className="px-2"
+                                  >
+                                    <div
+                                      aria-labelledby="button--1--0"
+                                      className="px-2"
+                                      data-reach-accordion-panel=""
+                                      data-state="collapsed"
+                                      hidden={true}
+                                      id="panel--1--0"
+                                      role="region"
+                                      tabIndex={-1}
+                                    >
+                                      <div
+                                        className="activation-checklist__detail pb-1"
+                                      >
+                                        Configure Sourcegraph to talk to your code host and fetch a list of your repositories.
+                                      </div>
+                                    </div>
+                                  </AccordionPanel>
+                                </div>
+                              </AccordionItem>
+                              <AccordionItem
+                                className="activation-checklist__container list-group-item"
+                                key="DidSearch"
+                              >
+                                <div
+                                  className="activation-checklist__container list-group-item"
+                                  data-reach-accordion-item=""
+                                  data-state="collapsed"
+                                >
+                                  <AccordionButton
+                                    className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                  >
+                                    <button
+                                      aria-controls="panel--1--1"
+                                      aria-expanded={false}
+                                      className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                      data-reach-accordion-button=""
+                                      id="button--1--1"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                    >
+                                      <ActivationChecklistItem
+                                        detail={
+                                          <span>
+                                            Head to the 
+                                            <a
+                                              href="/search"
+                                            >
+                                              homepage
+                                            </a>
+                                             and perform a search query on your code.
+                                             
+                                            <strong>
+                                              Example:
+                                            </strong>
+                                             type 'lang:' and select a language
+                                          </span>
+                                        }
+                                        done={false}
+                                        id="DidSearch"
+                                        key="DidSearch"
+                                        title="Search your code"
+                                      >
+                                        <div
+                                          className="activation-checklist-item d-flex justify-content-between"
+                                        >
+                                          <div
+                                            className="d-flex align-items-center"
+                                          >
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-down"
+                                            >
+                                              <Memo(ChevronDownIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-right"
+                                            >
+                                              <Memo(ChevronRightIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span>
+                                              Search your code
+                                            </span>
+                                          </div>
+                                          <div>
+                                            <Memo(CheckboxBlankCircleOutlineIcon)
+                                              className="icon-inline text-muted"
+                                            />
+                                          </div>
+                                        </div>
+                                      </ActivationChecklistItem>
+                                    </button>
+                                  </AccordionButton>
+                                  <AccordionPanel
+                                    className="px-2"
+                                  >
+                                    <div
+                                      aria-labelledby="button--1--1"
+                                      className="px-2"
+                                      data-reach-accordion-panel=""
+                                      data-state="collapsed"
+                                      hidden={true}
+                                      id="panel--1--1"
+                                      role="region"
+                                      tabIndex={-1}
+                                    >
+                                      <div
+                                        className="activation-checklist__detail pb-1"
+                                      >
                                         <span>
                                           Head to the 
                                           <a
@@ -1347,258 +1413,190 @@ exports[`ActivationDropdown renders the activation dropdown 1`] = `
                                           </strong>
                                            type 'lang:' and select a language
                                         </span>
-                                      }
-                                      done={false}
-                                      id="DidSearch"
-                                      key="DidSearch"
-                                      title="Search your code"
-                                    >
-                                      <div
-                                        className="activation-checklist-item d-flex justify-content-between"
-                                      >
-                                        <div
-                                          className="d-flex align-items-center"
-                                        >
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-down"
-                                          >
-                                            <Memo(ChevronDownIcon)
-                                              className="activation-checklist-item__icon"
-                                            />
-                                          </span>
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-right"
-                                          >
-                                            <Memo(ChevronRightIcon)
-                                              className="activation-checklist-item__icon"
-                                            />
-                                          </span>
-                                          <span>
-                                            Search your code
-                                          </span>
-                                        </div>
-                                        <div>
-                                          <Memo(CheckboxBlankCircleOutlineIcon)
-                                            className="icon-inline text-muted"
-                                          />
-                                        </div>
                                       </div>
-                                    </ActivationChecklistItem>
-                                  </button>
-                                </AccordionButton>
-                                <AccordionPanel
-                                  className="px-2"
-                                >
-                                  <div
-                                    aria-labelledby="button--1--1"
-                                    className="px-2"
-                                    data-reach-accordion-panel=""
-                                    data-state="collapsed"
-                                    hidden={true}
-                                    id="panel--1--1"
-                                    role="region"
-                                    tabIndex={-1}
-                                  >
-                                    <div
-                                      className="activation-checklist__detail pb-1"
-                                    >
-                                      <span>
-                                        Head to the 
-                                        <a
-                                          href="/search"
-                                        >
-                                          homepage
-                                        </a>
-                                         and perform a search query on your code.
-                                         
-                                        <strong>
-                                          Example:
-                                        </strong>
-                                         type 'lang:' and select a language
-                                      </span>
                                     </div>
-                                  </div>
-                                </AccordionPanel>
-                              </div>
-                            </AccordionItem>
-                            <AccordionItem
-                              className="activation-checklist__container list-group-item"
-                              key="FoundReferences"
-                            >
-                              <div
+                                  </AccordionPanel>
+                                </div>
+                              </AccordionItem>
+                              <AccordionItem
                                 className="activation-checklist__container list-group-item"
-                                data-reach-accordion-item=""
-                                data-state="collapsed"
+                                key="FoundReferences"
                               >
-                                <AccordionButton
-                                  className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                <div
+                                  className="activation-checklist__container list-group-item"
+                                  data-reach-accordion-item=""
+                                  data-state="collapsed"
                                 >
-                                  <button
-                                    aria-controls="panel--1--2"
-                                    aria-expanded={false}
+                                  <AccordionButton
                                     className="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                    data-reach-accordion-button=""
-                                    id="button--1--2"
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
                                   >
-                                    <ActivationChecklistItem
-                                      detail="To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click \\"Find references\\"."
-                                      done={false}
-                                      id="FoundReferences"
-                                      key="FoundReferences"
-                                      title="Find some references"
+                                    <button
+                                      aria-controls="panel--1--2"
+                                      aria-expanded={false}
+                                      className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                      data-reach-accordion-button=""
+                                      id="button--1--2"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
                                     >
-                                      <div
-                                        className="activation-checklist-item d-flex justify-content-between"
+                                      <ActivationChecklistItem
+                                        detail="To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click \\"Find references\\"."
+                                        done={false}
+                                        id="FoundReferences"
+                                        key="FoundReferences"
+                                        title="Find some references"
                                       >
                                         <div
-                                          className="d-flex align-items-center"
+                                          className="activation-checklist-item d-flex justify-content-between"
                                         >
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-down"
+                                          <div
+                                            className="d-flex align-items-center"
                                           >
-                                            <Memo(ChevronDownIcon)
-                                              className="activation-checklist-item__icon"
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-down"
+                                            >
+                                              <Memo(ChevronDownIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-right"
+                                            >
+                                              <Memo(ChevronRightIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span>
+                                              Find some references
+                                            </span>
+                                          </div>
+                                          <div>
+                                            <Memo(CheckboxBlankCircleOutlineIcon)
+                                              className="icon-inline text-muted"
                                             />
-                                          </span>
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-right"
-                                          >
-                                            <Memo(ChevronRightIcon)
-                                              className="activation-checklist-item__icon"
-                                            />
-                                          </span>
-                                          <span>
-                                            Find some references
-                                          </span>
+                                          </div>
                                         </div>
-                                        <div>
-                                          <Memo(CheckboxBlankCircleOutlineIcon)
-                                            className="icon-inline text-muted"
-                                          />
-                                        </div>
-                                      </div>
-                                    </ActivationChecklistItem>
-                                  </button>
-                                </AccordionButton>
-                                <AccordionPanel
-                                  className="px-2"
-                                >
-                                  <div
-                                    aria-labelledby="button--1--2"
+                                      </ActivationChecklistItem>
+                                    </button>
+                                  </AccordionButton>
+                                  <AccordionPanel
                                     className="px-2"
-                                    data-reach-accordion-panel=""
-                                    data-state="collapsed"
-                                    hidden={true}
-                                    id="panel--1--2"
-                                    role="region"
-                                    tabIndex={-1}
                                   >
                                     <div
-                                      className="activation-checklist__detail pb-1"
+                                      aria-labelledby="button--1--2"
+                                      className="px-2"
+                                      data-reach-accordion-panel=""
+                                      data-state="collapsed"
+                                      hidden={true}
+                                      id="panel--1--2"
+                                      role="region"
+                                      tabIndex={-1}
                                     >
-                                      To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click "Find references".
+                                      <div
+                                        className="activation-checklist__detail pb-1"
+                                      >
+                                        To find references of a token, navigate to a code file in one of your repositories, hover over a token to activate the tooltip, and then click "Find references".
+                                      </div>
                                     </div>
-                                  </div>
-                                </AccordionPanel>
-                              </div>
-                            </AccordionItem>
-                            <AccordionItem
-                              className="activation-checklist__container list-group-item"
-                              key="EnabledSharing"
-                            >
-                              <div
+                                  </AccordionPanel>
+                                </div>
+                              </AccordionItem>
+                              <AccordionItem
                                 className="activation-checklist__container list-group-item"
-                                data-reach-accordion-item=""
-                                data-state="collapsed"
+                                key="EnabledSharing"
                               >
-                                <AccordionButton
-                                  className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                <div
+                                  className="activation-checklist__container list-group-item"
+                                  data-reach-accordion-item=""
+                                  data-state="collapsed"
                                 >
-                                  <button
-                                    aria-controls="panel--1--3"
-                                    aria-expanded={false}
+                                  <AccordionButton
                                     className="activation-checklist__button list-group-item list-group-item-action btn-link"
-                                    data-reach-accordion-button=""
-                                    id="button--1--3"
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
                                   >
-                                    <ActivationChecklistItem
-                                      detail="Configure a single-sign on (SSO) provider or have at least one other teammate sign up."
-                                      done={false}
-                                      id="EnabledSharing"
-                                      key="EnabledSharing"
-                                      title="Configure SSO or share with teammates"
+                                    <button
+                                      aria-controls="panel--1--3"
+                                      aria-expanded={false}
+                                      className="activation-checklist__button list-group-item list-group-item-action btn-link"
+                                      data-reach-accordion-button=""
+                                      id="button--1--3"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
                                     >
-                                      <div
-                                        className="activation-checklist-item d-flex justify-content-between"
+                                      <ActivationChecklistItem
+                                        detail="Configure a single-sign on (SSO) provider or have at least one other teammate sign up."
+                                        done={false}
+                                        id="EnabledSharing"
+                                        key="EnabledSharing"
+                                        title="Configure SSO or share with teammates"
                                       >
                                         <div
-                                          className="d-flex align-items-center"
+                                          className="activation-checklist-item d-flex justify-content-between"
                                         >
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-down"
+                                          <div
+                                            className="d-flex align-items-center"
                                           >
-                                            <Memo(ChevronDownIcon)
-                                              className="activation-checklist-item__icon"
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-down"
+                                            >
+                                              <Memo(ChevronDownIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span
+                                              className="activation-checklist-item__icon-container icon-inline icon-right"
+                                            >
+                                              <Memo(ChevronRightIcon)
+                                                className="activation-checklist-item__icon"
+                                              />
+                                            </span>
+                                            <span>
+                                              Configure SSO or share with teammates
+                                            </span>
+                                          </div>
+                                          <div>
+                                            <Memo(CheckboxBlankCircleOutlineIcon)
+                                              className="icon-inline text-muted"
                                             />
-                                          </span>
-                                          <span
-                                            className="activation-checklist-item__icon-container icon-inline icon-right"
-                                          >
-                                            <Memo(ChevronRightIcon)
-                                              className="activation-checklist-item__icon"
-                                            />
-                                          </span>
-                                          <span>
-                                            Configure SSO or share with teammates
-                                          </span>
+                                          </div>
                                         </div>
-                                        <div>
-                                          <Memo(CheckboxBlankCircleOutlineIcon)
-                                            className="icon-inline text-muted"
-                                          />
-                                        </div>
-                                      </div>
-                                    </ActivationChecklistItem>
-                                  </button>
-                                </AccordionButton>
-                                <AccordionPanel
-                                  className="px-2"
-                                >
-                                  <div
-                                    aria-labelledby="button--1--3"
+                                      </ActivationChecklistItem>
+                                    </button>
+                                  </AccordionButton>
+                                  <AccordionPanel
                                     className="px-2"
-                                    data-reach-accordion-panel=""
-                                    data-state="collapsed"
-                                    hidden={true}
-                                    id="panel--1--3"
-                                    role="region"
-                                    tabIndex={-1}
                                   >
                                     <div
-                                      className="activation-checklist__detail pb-1"
+                                      aria-labelledby="button--1--3"
+                                      className="px-2"
+                                      data-reach-accordion-panel=""
+                                      data-state="collapsed"
+                                      hidden={true}
+                                      id="panel--1--3"
+                                      role="region"
+                                      tabIndex={-1}
                                     >
-                                      Configure a single-sign on (SSO) provider or have at least one other teammate sign up.
+                                      <div
+                                        className="activation-checklist__detail pb-1"
+                                      >
+                                        Configure a single-sign on (SSO) provider or have at least one other teammate sign up.
+                                      </div>
                                     </div>
-                                  </div>
-                                </AccordionPanel>
-                              </div>
-                            </AccordionItem>
-                          </div>
-                        </DescendantProvider>
-                      </Accordion>
-                    </div>
-                  </ActivationChecklist>
-                </div>
-              </PopoverImpl>
+                                  </AccordionPanel>
+                                </div>
+                              </AccordionItem>
+                            </div>
+                          </DescendantProvider>
+                        </Accordion>
+                      </div>
+                    </ActivationChecklist>
+                  </div>
+                </PopoverImpl>
+              </Portal>
             </Portal>
-          </Portal>
-        </Popover>
-      </MenuPopover>
-    </DescendantProvider>
+          </Popover>
+        </MenuPopover>
+      </DescendantProvider>
+    </DropdownProvider>
   </Menu>
 </ActivationDropdown>
 `;

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
@@ -2,8 +2,8 @@ import { Menu, MenuButton, MenuItem, MenuItems, MenuLink, MenuPopover } from '@r
 import classnames from 'classnames'
 import CheckIcon from 'mdi-react/CheckIcon'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'
-import React, { MouseEvent, useContext } from 'react'
-import { useHistory } from 'react-router'
+import React, { useContext } from 'react'
+import { Link } from 'react-router-dom'
 
 import { isSearchBasedInsightId } from '../../../../../../core/types/insight/search-insight'
 import { DashboardInsightsContext } from '../../../../../../pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsightsContext'
@@ -24,26 +24,15 @@ export interface InsightCardMenuProps {
  */
 export const InsightCardMenu: React.FunctionComponent<InsightCardMenuProps> = props => {
     const { insightID, menuButtonClassName, onDelete, onToggleZeroYAxisMin } = props
-    const history = useHistory()
 
     const { zeroYAxisMin } = useContext(LineChartSettingsContext)
 
     // Get dashboard information in case if insight card component
     // is rendered on the dashboard page, otherwise get null value.
     const { dashboard } = useContext(DashboardInsightsContext)
-
-    const handleEditClick = (event: MouseEvent): void => {
-        event.preventDefault()
-
-        const dashboardID = dashboard?.id
-
-        if (dashboardID) {
-            // Redirect to the edit insight page with dashboard id information
-            history.push(`/insights/edit/${insightID}?dashboardId=${dashboardID}`)
-        } else {
-            history.push(`/insights/edit/${insightID}`)
-        }
-    }
+    const editUrl = dashboard?.id
+        ? `/insights/edit/${insightID}?dashboardId=${dashboard.id}`
+        : `/insights/edit/${insightID}`
 
     const showYAxisToggleMenu = isSearchBasedInsightId(insightID) && onToggleZeroYAxisMin
 
@@ -66,9 +55,10 @@ export const InsightCardMenu: React.FunctionComponent<InsightCardMenuProps> = pr
                             className={classnames(styles.panel, 'dropdown-menu')}
                         >
                             <MenuLink
+                                as={Link}
                                 data-testid="InsightContextMenuEditLink"
                                 className={classnames('btn btn-outline', styles.item)}
-                                onClick={handleEditClick}
+                                to={editUrl}
                             >
                                 Edit
                             </MenuLink>

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "@reach/combobox": "^0.15.2",
     "@reach/dialog": "^0.11.2",
     "@reach/listbox": "^0.10.1",
-    "@reach/menu-button": "^0.15.2",
+    "@reach/menu-button": "^0.16.1",
     "@reach/tabs": "^0.13.0",
     "@reach/visually-hidden": "^0.15.2",
     "@sentry/browser": "^5.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2781,6 +2781,14 @@
     "@reach/utils" "0.15.2"
     tslib "^2.3.0"
 
+"@reach/auto-id@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz#dfabc3227844e8c04f8e6e45203a8e14a8edbaed"
+  integrity sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==
+  dependencies:
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
+
 "@reach/auto-id@^0.10.1", "@reach/auto-id@^0.10.2":
   version "0.10.2"
   resolved "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.10.2.tgz#a447af67241123dcb701ecd61931a2c786ed111e"
@@ -2818,6 +2826,14 @@
     "@reach/utils" "0.15.2"
     tslib "^2.3.0"
 
+"@reach/descendants@0.16.1":
+  version "0.16.1"
+  resolved "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz#fa3d89c0503565369707f32985d87eef61985d9f"
+  integrity sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==
+  dependencies:
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
+
 "@reach/descendants@^0.10.1", "@reach/descendants@^0.10.2":
   version "0.10.2"
   resolved "https://registry.npmjs.org/@reach/descendants/-/descendants-0.10.2.tgz#551c9f767a16bcad6d1abc41449bb46a12cd3ee3"
@@ -2837,6 +2853,17 @@
     react-focus-lock "^2.3.1"
     react-remove-scroll "^2.3.0"
     tslib "^2.0.0"
+
+"@reach/dropdown@0.16.1":
+  version "0.16.1"
+  resolved "https://registry.npmjs.org/@reach/dropdown/-/dropdown-0.16.1.tgz#0af4fd17e590ca852f6bb27f34d525f07510a326"
+  integrity sha512-56ITaEAWYFvEYSJz0RqFndrHIDhSuhmobmgB4Wy1q6Aj/3F20Bns1mGu61/ny5Ld8spgP1mJTJViacHsn7x/Dg==
+  dependencies:
+    "@reach/auto-id" "0.16.0"
+    "@reach/descendants" "0.16.1"
+    "@reach/popover" "0.16.0"
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
 
 "@reach/listbox@^0.10.1":
   version "0.10.1"
@@ -2859,15 +2886,14 @@
     "@xstate/fsm" "^1.4.0"
     tslib "^1.11.1"
 
-"@reach/menu-button@^0.15.2":
-  version "0.15.2"
-  resolved "https://registry.npmjs.org/@reach/menu-button/-/menu-button-0.15.2.tgz#00f91402be3ff23d3b4cfe377529f4f9e82a78fe"
-  integrity sha512-slEji1AnfnH134YDZSTwst4nZHYNrfyg9GF+A8p1+kGc8N3JsPysHc7uIUZ/IsK+PdaOCB+r9kuL1QWBgNO+jw==
+"@reach/menu-button@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.npmjs.org/@reach/menu-button/-/menu-button-0.16.1.tgz#a81ab9d2ee21874bf8d957b29a388b8daa2b7cfd"
+  integrity sha512-0Oh/Oq+GupS48LuBdIu8VyMJFLlWReRAGgT24SrcAAxmlyO/qUP9KJS9D1CEvl2KUoSk2wO0Fu885E4eaBYucA==
   dependencies:
-    "@reach/auto-id" "0.15.2"
-    "@reach/descendants" "0.15.2"
-    "@reach/popover" "0.15.2"
-    "@reach/utils" "0.15.2"
+    "@reach/dropdown" "0.16.1"
+    "@reach/popover" "0.16.0"
+    "@reach/utils" "0.16.0"
     prop-types "^15.7.2"
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -2885,6 +2911,17 @@
     "@reach/portal" "0.15.2"
     "@reach/rect" "0.15.2"
     "@reach/utils" "0.15.2"
+    tabbable "^4.0.0"
+    tslib "^2.3.0"
+
+"@reach/popover@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/@reach/popover/-/popover-0.16.0.tgz#82c5ab96a88c49e2451a9c04b2d4392a9055f623"
+  integrity sha512-xmgiSyQwfshMkMNu6URbGrjjDTD3dnAITojvgEqfEtV1chDYqktKdDbIPrq+UGI54ey/IxbRpVzKcIjXiKoMmA==
+  dependencies:
+    "@reach/portal" "0.16.0"
+    "@reach/rect" "0.16.0"
+    "@reach/utils" "0.16.0"
     tabbable "^4.0.0"
     tslib "^2.3.0"
 
@@ -2915,6 +2952,14 @@
     "@reach/utils" "0.15.2"
     tslib "^2.3.0"
 
+"@reach/portal@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz#1544531d978b770770b718b2872b35652a11e7e3"
+  integrity sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==
+  dependencies:
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
+
 "@reach/portal@^0.10.2":
   version "0.10.2"
   resolved "https://registry.npmjs.org/@reach/portal/-/portal-0.10.2.tgz#a2b4f69eaffad0115320e303d08ea57c8942b398"
@@ -2930,6 +2975,17 @@
   dependencies:
     "@reach/observe-rect" "1.2.0"
     "@reach/utils" "0.15.2"
+    prop-types "^15.7.2"
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/rect@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz#78cf6acefe2e83d3957fa84f938f6e1fc5700f16"
+  integrity sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==
+  dependencies:
+    "@reach/observe-rect" "1.2.0"
+    "@reach/utils" "0.16.0"
     prop-types "^15.7.2"
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -2987,6 +3043,14 @@
   version "0.15.2"
   resolved "https://registry.npmjs.org/@reach/utils/-/utils-0.15.2.tgz#a63a761eb36266bf33d65cb91520dd85a04ae116"
   integrity sha512-Lr1SJ5X4hEjD/M0TAonURM8wytM/JuPSuIP7t+e5cil34pThyLsBvTGeNfmpSgaLJ5vlsv0x9u6g4SRAEr84Og==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/utils@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
+  integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
   dependencies:
     tiny-warning "^1.0.3"
     tslib "^2.3.0"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/24083

We had a solution with a link `onClick` handler cause we couldn't use a Link component cause of this issue of `reach-ui/menu-button https://github.com/reach/reach-ui/issues/815 

Since this issue has been fixed in the new version of the menu-button package this PR updates this dependency and removes custom callback with preventDefault call.

