### PR TITLE
Fix theme-dark dropdown background color

### DIFF
--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -1,7 +1,7 @@
 @import 'bootstrap/scss/dropdown';
 
 .theme-light {
-    --dropdown-bg: var(--input-bg);
+    --dropdown-bg: var(--color-bg-1);
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -9,7 +9,7 @@
 }
 
 .theme-dark {
-    --dropdown-bg: var(--input-bg);
+    --dropdown-bg: var(--color-bg-1);
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);


### PR DESCRIPTION

Updates/fixes `.theme-dark  >  --dropdown-bg` CSS variable/color to match designs. Closes #23182.

### Description
The issue was that the dropdown hover was not working, after some investigation turned out that the problem was because the dropdown background color and hover background color were the same and had no effect on hover.  I found that the hover color was set correctly, but the regular state background color does NOT match [figma designs](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=1955%3A33720).

### Fixes
1. [Extensions page](http://localhost:3080/extensions?category=All)

| before | after |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/131381726-d19dd65f-3694-42f3-ae05-00cf578672fb.png) | ![image](https://user-images.githubusercontent.com/6717049/131381573-bcd7bba8-1aec-4096-a46a-0ff0ea8539bd.png) |

<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

2. `Navbar > Getting Started`

| before | after |
| ---: | :--- |
| ![image](https://user-images.githubusercontent.com/6717049/131382188-0df05af2-e2a1-40b2-b322-00a051fc041c.png) | ![image](https://user-images.githubusercontent.com/6717049/131382360-08c44883-ee9e-4de4-b3b4-23a0e28d2e1f.png) |
