### PR TITLE
doc: consistent 'access the database' heading

### DIFF
--- a/doc/admin/install/docker-compose/operations.md
+++ b/doc/admin/install/docker-compose/operations.md
@@ -198,7 +198,7 @@ Guides for managing cloud storage and backups are available in our [cloud-specif
 - [Storage and backups for Google Cloud](./google_cloud.md#storage-and-backups)
 - [Storage and backups for Digital Ocean](./digitalocean.md#storage-and-backups)
 
-## Access a docker-compose database
+## Access the database
 
 The following command allows a user to shell into a Sourcegraph database container and run `psql` to interact with the container's postgres database:
 


### PR DESCRIPTION
To mirror https://docs.sourcegraph.com/admin/install/kubernetes/operations#access-the-database and https://docs.sourcegraph.com/admin/install/docker/operations#access-the-database
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
