### PR TITLE
disallow updating monitor namespace to one uneditable by caller

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -157,6 +157,11 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		return nil, errors.Errorf("UpdateCodeMonitor: %w", err)
 	}
 
+	err = r.isAllowedToCreate(ctx, args.Monitor.Update.Namespace)
+	if err != nil {
+		return nil, errors.Errorf("update namespace: %w", err)
+	}
+
 	var monitorID int64
 	err = relay.UnmarshalSpec(args.Monitor.Id, &monitorID)
 	if err != nil {


### PR DESCRIPTION
Any sensitive PR comments should be discussed in https://github.com/sourcegraph/security-issues/issues/170

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
