### PR TITLE
search contexts: add search box to single page view

### DIFF
--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -22,7 +22,17 @@ export interface SubmitSearchParameters
         Pick<SearchContextProps, 'selectedSearchContextSpec'> {
     history: H.History
     query: string
-    source: 'home' | 'nav' | 'repo' | 'tree' | 'filter' | 'type' | 'scopePage' | 'repogroupPage' | 'excludedResults'
+    source:
+        | 'home'
+        | 'nav'
+        | 'repo'
+        | 'tree'
+        | 'filter'
+        | 'type'
+        | 'scopePage'
+        | 'repogroupPage'
+        | 'excludedResults'
+        | 'searchContextPage'
     searchParameters?: { key: string; value: string }[]
 }
 

--- a/client/web/src/searchContexts/SearchContextPage.tsx
+++ b/client/web/src/searchContexts/SearchContextPage.tsx
@@ -1,32 +1,64 @@
 import classNames from 'classnames'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 import React, { useMemo } from 'react'
-import { RouteComponentProps } from 'react-router'
+import { RouteComponentProps, useHistory, useLocation } from 'react-router'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { PageHeader } from '@sourcegraph/wildcard'
 
+import { AuthenticatedUser } from '../auth'
 import { Page } from '../components/Page'
 import { PageTitle } from '../components/PageTitle'
 import { Timestamp } from '../components/time/Timestamp'
-import { SearchContextProps } from '../search'
+import { KeyboardShortcutsProps } from '../keyboardShortcuts/keyboardShortcuts'
+import { VersionContext } from '../schema/site.schema'
+import {
+    CaseSensitivityProps,
+    ParsedSearchQueryProps,
+    PatternTypeProps,
+    SearchContextInputProps,
+    SearchContextProps,
+} from '../search'
+import { SearchPageInput } from '../search/home/SearchPageInput'
 import { convertMarkdownToBlocks } from '../search/notebook/convertMarkdownToBlocks'
 import { RenderedSearchNotebookMarkdown } from '../search/notebook/RenderedSearchNotebookMarkdown'
 import { SearchNotebookProps } from '../search/notebook/SearchNotebook'
+import { ThemePreferenceProps } from '../theme'
 
 import styles from './SearchContextPage.module.scss'
 
 export interface SearchContextPageProps
     extends Pick<RouteComponentProps<{ spec: Scalars['ID'] }>, 'match'>,
+        ThemeProps,
+        ThemePreferenceProps,
+        ActivationProps,
+        PatternTypeProps,
+        CaseSensitivityProps,
+        KeyboardShortcutsProps,
+        TelemetryProps,
+        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL'>,
+        VersionContextProps,
+        SearchContextInputProps,
         Pick<SearchContextProps, 'fetchSearchContextBySpec'>,
-        Omit<SearchNotebookProps, 'onSerializeBlocks' | 'blocks' | 'collapseMenu'> {}
+        Omit<SearchNotebookProps, 'onSerializeBlocks' | 'blocks' | 'collapseMenu'> {
+    authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
+}
 
 export const SearchContextPage: React.FunctionComponent<SearchContextPageProps> = props => {
     const LOADING = 'loading' as const
@@ -51,6 +83,9 @@ export const SearchContextPage: React.FunctionComponent<SearchContextPageProps> 
         const blocks = convertMarkdownToBlocks(searchContextOrError.description)
         return blocks.length > 1
     }, [searchContextOrError])
+
+    const location = useLocation()
+    const history = useHistory()
 
     return (
         <div className="w-100">
@@ -116,8 +151,20 @@ export const SearchContextPage: React.FunctionComponent<SearchContextPageProps> 
                                     </span>
                                 </div>
                             )}
+                            <div className="my-3">
+                                <SearchPageInput
+                                    {...props}
+                                    location={location}
+                                    history={history}
+                                    hideVersionContexts={true}
+                                    selectedSearchContextSpec={searchContextOrError.spec}
+                                    showOnboardingTour={false}
+                                    showQueryBuilder={false}
+                                    source="searchContextPage"
+                                />
+                            </div>
                             {searchContextOrError.description.length > 0 && (
-                                <div className="my-2">
+                                <div className="my-3">
                                     {useSearchNotebookDescription ? (
                                         <div className="card px-3 pb-3">
                                             <RenderedSearchNotebookMarkdown


### PR DESCRIPTION
Examples:

<img width="920" alt="Screenshot 2021-08-31 at 08 33 10" src="https://user-images.githubusercontent.com/6417322/131453554-9a59233d-0ef8-490b-8635-0cc792ab65c3.png">


<img width="923" alt="Screenshot 2021-08-31 at 08 18 01" src="https://user-images.githubusercontent.com/6417322/131453209-d2f4bdf0-2049-4b77-ae95-e7d75607b246.png">


Fixes #24407