### PR TITLE
remove needless ~ from CSS/SASS @imports

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -1,5 +1,8 @@
-@import 'open-color/open-color.scss'; // Sass variables
-@import '~open-color/open-color.css'; // CSS variables
+// We need to import *both* SCSS variables (e.g., $oc-red-9) *and* CSS variables (e.g.,
+// var(--oc-red-9). The SCSS variables are used for SCSS color math at build time, and the CSS
+// variables are used at runtime.
+@import 'open-color/open-color.scss';
+@import 'open-color/open-color.css';
 
 // Tell Bootstrap to use our colors.
 $blue: #0b70db;

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -152,7 +152,7 @@ $badge-transition: none; // Avoids setting transitions on badges that aren't lin
 @import './highlight';
 @import './tabs';
 @import './tooltips';
-@import '~@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
+@import '@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
 
 * {
     box-sizing: border-box;

--- a/client/shared/src/hover/HoverOverlay.scss
+++ b/client/shared/src/hover/HoverOverlay.scss
@@ -1,4 +1,4 @@
-@import '~@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
+@import '@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
 
 .hover-overlay {
     --hover-overlay-vertical-padding: 0.25rem;

--- a/client/web/src/api/graphiql-theme.scss
+++ b/client/web/src/api/graphiql-theme.scss
@@ -11,7 +11,7 @@
  * extensibility.
  **/
 
-@import '~graphiql/graphiql.css';
+@import 'graphiql/graphiql.css';
 
 /* stylelint-disable selector-class-pattern */
 /* stylelint-disable declaration-property-unit-whitelist */


### PR DESCRIPTION
Previously, Webpack's sass-loader (incorrectly) required a `~` before a CSS/SASS `@import` for the path to be resolved (i.e., to refer to a path in `node_modules`). This was incorrect because SASS's specification says that *all* non-relative `@import` paths should be resolved.

Now Webpack's sass-loader no longer needs `~`, and in fact it recommends against using it (see https://webpack.js.org/loaders/sass-loader/#resolving-import-at-rules). This removal has no effect on the bundle.