### PR TITLE
ratelimit: Set fallback burst to 1 from 100

### DIFF
--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -37,7 +37,8 @@ func (r *Registry) Get(baseURL string) *rate.Limiter {
 func (r *Registry) GetOrSet(baseURL string, fallback *rate.Limiter) *rate.Limiter {
 	baseURL = normaliseURL(baseURL)
 	if fallback == nil {
-		fallback = rate.NewLimiter(rate.Inf, 100)
+		// Burst is ignored when rate.Inf is used
+		fallback = rate.NewLimiter(rate.Inf, 1)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
The fallback already uses an infinite limit so it doesn't really matter
what the burst is, but 1 seems less magical than 100.

Changed in response to a comment from another PR:
https://github.com/sourcegraph/sourcegraph/pull/24313#issuecomment-906184681
