### PR TITLE
gomod: update zoekt to respect ranking again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -212,7 +212,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210831082144-d750179d8da9
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210831121401-8536ea0c9f37
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20210809100802-88b656a8713e

--- a/go.sum
+++ b/go.sum
@@ -1433,8 +1433,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210831082144-d750179d8da9 h1:DPTU1a3G/aSXexsFpBTFe0Hu1UE+kbWUT9aPkCJMT+4=
-github.com/sourcegraph/zoekt v0.0.0-20210831082144-d750179d8da9/go.mod h1:wZNiQEHARcFqF+55PUSeWbUNA9rPbWYkRUszQcjk2CQ=
+github.com/sourcegraph/zoekt v0.0.0-20210831121401-8536ea0c9f37 h1:iyAeXDijBUHhC7vvrQPZals2YPLV2BekBetmyZL5PzY=
+github.com/sourcegraph/zoekt v0.0.0-20210831121401-8536ea0c9f37/go.mod h1:wZNiQEHARcFqF+55PUSeWbUNA9rPbWYkRUszQcjk2CQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
We regressed on ranking. When loading a shard all shards ranks where
calculated as 0. See the one line fix in Zoekt:

- https://github.com/sourcegraph/zoekt/commit/8536ea0 shards: correctly calculate max priority

Co-authored-by: @stefanhengl 