### PR TITLE
search: ignore dns lookup errors against zoekt

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -5,25 +5,36 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net"
 	"sort"
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/stream"
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
+	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-var reorderQueueSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "src_zoekt_reorder_queue_size",
-	Help:    "Maximum size of result reordering buffer for a request.",
-	Buckets: prometheus.ExponentialBuckets(4, 2, 10),
-}, nil)
+var (
+	metricReorderQueueSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_zoekt_reorder_queue_size",
+		Help:    "Maximum size of result reordering buffer for a request.",
+		Buckets: prometheus.ExponentialBuckets(4, 2, 10),
+	}, nil)
+	metricIgnoredError = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_zoekt_ignored_error_total",
+		Help: "Total number of errors ignored from Zoekt.",
+	})
+)
 
 // HorizontalSearcher is a Streamer which aggregates searches over
 // Map. It manages the connections to Map as the endpoints come and go.
@@ -114,6 +125,10 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 			delete(endpointMaxPendingPriority, endpoint)
 			mu.Unlock()
 
+			if canIgnoreError(ctx, err) {
+				err = nil
+			}
+
 			ch <- err
 		}(endpoint, c)
 	}
@@ -127,7 +142,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 		return err
 	}
 
-	reorderQueueSize.WithLabelValues().Observe(float64(resultQueueMaxLength))
+	metricReorderQueueSize.WithLabelValues().Observe(float64(resultQueueMaxLength))
 	if len(resultQueue) > 0 {
 		log15.Warn("HorizontalSearcher.Streamsearch: results not sent in core loop", len(resultQueue))
 		for len(resultQueue) > 0 {
@@ -238,6 +253,10 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q, opts *zoekt.Li
 	for range clients {
 		r := <-results
 		if r.err != nil {
+			if canIgnoreError(ctx, r.err) {
+				continue
+			}
+
 			return nil, r.err
 		}
 
@@ -397,4 +416,26 @@ func (repoEndpoint dedupper) Dedup(endpoint string, fms []zoekt.FileMatch) []zoe
 	}
 
 	return dedup
+}
+
+// canIgnoreError returns true if the error we received from zoekt can be
+// ignored.
+//
+// Note: ctx is passed in so we can log to the trace when we ignore an
+// error. This is a convenience over logging at the call sites.
+//
+// Currently the only error we ignore is DNS lookup failures. This is since
+// during rollouts of Zoekt, we may still have endpoints of zoekt which are
+// not available in our endpoint map. In particular, this happens when using
+// Kubernetes and the (default) stateful set watcher.
+func canIgnoreError(ctx context.Context, err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		metricIgnoredError.Inc()
+		if span := trace.TraceFromContext(ctx); span != nil {
+			span.LogFields(otlog.String("ignored.error", err.Error()))
+		}
+		return dnsErr.IsNotFound
+	}
+	return false
 }


### PR DESCRIPTION
During rollouts of Zoekt, we may still have endpoints of zoekt which are
not available in our endpoint map. In particular, this happens when
using Kubernetes and the (default) stateful set watcher.

This has the downside of incorrectly configured instances not relying on
service discovery always having an empty set. Right now this trade-off
is worth it because every rollout of Zoekt on sourcegraph.com results in
mostly unavailable search. To help offset this trade-off we instrument
metrics and tracing when we do this.

Co-authored-by: @stefanhengl 