### PR TITLE
ci: 10m timeout for go tests

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -24,7 +24,7 @@ find . -name go.mod -exec dirname '{}' \; | while read -r d; do
   go mod download
 
   echo "--- $d go test"
-  go test -timeout 5m -coverprofile=coverage.txt -covermode=atomic -race ./...
+  go test -timeout 10m -coverprofile=coverage.txt -covermode=atomic -race ./...
 
   popd >/dev/null
 done


### PR DESCRIPTION
internal/database package is fairly regularly timing out on CI for
me. So doubling the time for now.