### PR TITLE
patch cves

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -60,11 +60,11 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=docker.io/sourcegraph/syntect_server:32d880d@sha256:899661691c3a6f8d587186bed73c3224b065d1e1c3485aff2ea208c261c010f6 /syntect_server /usr/local/bin/
+COPY --from=docker.io/sourcegraph/21-08-31_6556204@sha256:e1a17d5b9abd7b4b1c3cd6a0c12e2b686598dd679760efb85fdc4148faf4eb75 /syntect_server /usr/local/bin/
 
 
 # install minio (keep this up to date with docker-images/minio/Dockerfile)
-ENV MINIO_VERSION=RELEASE.2021-04-22T15-44-28Z
+ENV MINIO_VERSION=RELEASE.2021-08-31T05-46-54Z
 RUN wget "https://dl.min.io/server/minio/release/linux-amd64/archive/minio.$MINIO_VERSION" && \
     chmod +x "minio.$MINIO_VERSION" && \
     mv "minio.$MINIO_VERSION" /usr/local/bin/minio

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
-RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0
+RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0
 
 # Reflects cAdvisor Dockerfile at https://github.com/google/cadvisor/blob/v0.39.2/deploy/Dockerfile
 # alongside additional Sourcegraph defaults.

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -1,7 +1,7 @@
 # sourcegraph/grafana - learn more about this image in https://docs.sourcegraph.com/dev/background-information/observability/grafana
 
 # Build monitoring definitions
-FROM sourcegraph/alpine-3.12:99212_2021-06-14_51f6e1e@sha256:0b98031f67bda9b088421f137a1d7d959b44ad360175cfac59c4d6ccd19a4e57 AS monitoring_builder
+FROM sourcegraph/alpine-3.12:106643_2021-08-30_7f4b12a@sha256:5176711adb03e08bed6f231255aa408f1e1dc67429346e6d5a6811e352e06b88 AS monitoring_builder
 RUN mkdir -p '/generated/grafana'
 COPY ./.bin/monitoring-generator /bin/monitoring-generator
 RUN GRAFANA_DIR='/generated/grafana' PROMETHEUS_DIR='' DOCS_DIR='' NO_PRUNE=true /bin/monitoring-generator
@@ -37,7 +37,7 @@ ADD entry.sh /
 
 USER root
 
-RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0
+RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0
 
 EXPOSE 3370
 USER grafana

--- a/docker-images/jaeger-all-in-one/Dockerfile
+++ b/docker-images/jaeger-all-in-one/Dockerfile
@@ -5,11 +5,11 @@
 ARG JAEGER_VERSION
 FROM jaegertracing/all-in-one:${JAEGER_VERSION} as base
 
-FROM sourcegraph/alpine-3.12:99212_2021-06-14_51f6e1e@sha256:0b98031f67bda9b088421f137a1d7d959b44ad360175cfac59c4d6ccd19a4e57
+FROM sourcegraph/alpine-3.12:106643_2021-08-30_7f4b12a@sha256:5176711adb03e08bed6f231255aa408f1e1dc67429346e6d5a6811e352e06b88
 USER root
 RUN apk update
 # hadolint ignore=DL3018
-RUN apk --no-cache add bash curl apk-tools=2.10.8-r0
+RUN apk --no-cache add bash curl apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /go/bin/all-in-one-linux /go/bin/all-in-one-linux

--- a/docker-images/minio/build.sh
+++ b/docker-images/minio/build.sh
@@ -3,7 +3,7 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Retag the 2021-04-22 MinIO release
-MINIO_RELEASE="RELEASE.2021-04-22T15-44-28Z"
+# Retag the 2021-08-31 MinIO release
+MINIO_RELEASE="RELEASE.2021-08-31T05-46-54Z"
 docker pull minio/minio:$MINIO_RELEASE
 docker tag minio/minio:$MINIO_RELEASE "$IMAGE"

--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull docker.io/sourcegraph/syntect_server:21-08-13_a2d6b30@sha256:b6f9bd9c1da621b0109855fd9268bf54c8537b5b4521d720d71e3cb244a2e336
-docker tag docker.io/sourcegraph/syntect_server:21-08-13_a2d6b30@sha256:b6f9bd9c1da621b0109855fd9268bf54c8537b5b4521d720d71e3cb244a2e336 "$IMAGE"
+docker pull docker.io/sourcegraph/syntect_server:21-08-31_6556204@sha256:e1a17d5b9abd7b4b1c3cd6a0c12e2b686598dd679760efb85fdc4148faf4eb75
+docker tag docker.io/sourcegraph/syntect_server:21-08-31_6556204@sha256:e1a17d5b9abd7b4b1c3cd6a0c12e2b686598dd679760efb85fdc4148faf4eb75 "$IMAGE"


### PR DESCRIPTION
remediates the following CVE's:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36222 (krb5-libs)
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22922 (curl)
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22924 (curl)

