### PR TITLE
search: validate regexp for explicit fields in repo:contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Code Insights the dashboard page no longer triggers insights re-fetching when insight adding/removing actions happen. [#24375](https://github.com/sourcegraph/sourcegraph/pull/24375)
+- Fixed an issue where particular values for subfields in search query predicates triggers a nil dereference. [#24472](https://github.com/sourcegraph/sourcegraph/pull/24472)
 
 ### Removed
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -110,10 +110,16 @@ func (f *RepoContainsPredicate) parseNode(n Node) error {
 			if f.File != "" {
 				return errors.New("cannot specify file multiple times")
 			}
+			if _, err := regexp.Compile(v.Value); err != nil {
+				return errors.Errorf("`contains` predicate has invalid `file` argument: %w", err)
+			}
 			f.File = v.Value
 		case "content":
 			if f.Content != "" {
 				return errors.New("cannot specify content multiple times")
+			}
+			if _, err := regexp.Compile(v.Value); err != nil {
+				return errors.Errorf("`contains` predicate has invalid `content` argument: %w", err)
 			}
 			f.Content = v.Value
 		default:

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -41,6 +41,7 @@ func TestRepoContainsPredicate(t *testing.T) {
 			{`negated content`, `-content:test`, nil},
 			{`unsupported syntax`, `abc:test`, nil},
 			{`unnamed content`, `test`, nil},
+			{`catch invalid content regexp`, `file:foo content:([)`, nil},
 		}
 
 		for _, tc := range invalid {


### PR DESCRIPTION
This fixes a potential nil panic for some predicate syntax. The problem is that validation is underspecified. We correctly checked for valid regular expressions for predicates like `repo:contains.file(<valid regexp>)` but never actually checked for valid regular expressions of the form:

`repo:contains(file:foo content:bar)`

For either `file` or `content` values. When certain parts of our search rely on these being valid values, it would (rightly) cause a panic. Unfortunately this isn't the type of bug we could easily catch with fuzzing the parser, because detection happens at time-of-use. To catch this, we'd have to fuzz the entire app (slow/unreasonable to instrument), or, a more reasonable solution, write a separate test harness that checks "use" properties after parsing.

See [slack thread](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1630334153013300) for more context, or [error log](https://console.cloud.google.com/errors/CP7VwtX6zYXIqAE?time=P30D&project=sourcegraph-dev). 