### PR TITLE
search: limit search suggestion work for complex queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -74,6 +74,18 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 	})
 
+	t.Run("no suggestions for predicate syntax", func(t *testing.T) {
+		for _, v := range searchVersions {
+			testSuggestions(t, "repo:contains(file:foo)", v, []string{})
+		}
+	})
+
+	t.Run("no suggestions for search expressions", func(t *testing.T) {
+		for _, v := range searchVersions {
+			testSuggestions(t, "file:foo or file:bar", v, []string{})
+		}
+	})
+
 	t.Run("single term", func(t *testing.T) {
 		mockDecodedViewerFinalSettings = &schema.Settings{}
 		defer func() { mockDecodedViewerFinalSettings = nil }()

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -89,6 +89,16 @@ func forAll(nodes []Node, fn func(node Node) bool) bool {
 	return sat
 }
 
+// returns true if the query contains a predicate value.
+func ContainsPredicate(nodes []Node) bool {
+	return exists(nodes, func(node Node) bool {
+		if v, ok := node.(Parameter); ok && v.Annotation.Labels.IsSet(IsPredicate) {
+			return true
+		}
+		return false
+	})
+}
+
 // isPatternExpression returns true if every leaf node in nodes is a search
 // pattern expression.
 func isPatternExpression(nodes []Node) bool {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24472.

After the reorg in https://github.com/sourcegraph/sourcegraph/pull/24442 and while fixing https://github.com/sourcegraph/sourcegraph/pull/24472 I realized that search suggestions tries to do work to process complex queries (with predicates or expressions) that we can't guarantee behaves well in general. This because when we added expressivity to our core search features, we didn't also tackle compatibility with search suggestions. The search suggestions code is generally not great, and not a priority to bring up to scratch right now. This PR gates doing search suggestion work for any complex queries (with predicates or expressions).