### PR TITLE
insights: fix panic when the query worker initializes with an empty queue

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -349,7 +349,7 @@ func (j *Job) RecordID() int {
 
 func scanJobs(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
 	records, err := doScanJobs(rows, err)
-	if err != nil {
+	if err != nil || len(records) == 0 {
 		return &Job{}, false, err
 	}
 	return records[0], true, nil


### PR DESCRIPTION
Closes #24474

Fix a panic due to dereferencing an out of bounds slice.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
