### PR TITLE
insights: change the indexed recorder interval to 1 hour

### DIFF
--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -41,7 +41,7 @@ func newInsightEnqueuer(ctx context.Context, workerBaseStore *basestore.Store, i
 	//
 	// See also https://github.com/sourcegraph/sourcegraph/pull/17227#issuecomment-779515187 for some very rough
 	// data retention / scale concerns.
-	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 12*time.Hour, goroutine.NewHandlerWithErrorMessage(
+	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
 		"insights_enqueuer",
 		func(ctx context.Context) error {
 			queryRunnerEnqueueJob := func(ctx context.Context, job *queryrunner.Job) error {


### PR DESCRIPTION
Since this is now driven by state in the database, we can execute this job much more frequently.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
