### PR TITLE
docs: add dev page for temporary settings

### DIFF
--- a/doc/dev/background-information/index.md
+++ b/doc/dev/background-information/index.md
@@ -19,6 +19,7 @@
   - [Wildcard Component Library](web/wildcard.md)
   - [Styling UI](web/styling.md)
   - [Accessibility](web/accessibility.md)
+  - [Temporary settings](web/temporary_settings.md)
   - [Build process](web/build.md)
 - [Developing the GraphQL API](graphql_api.md)
 - [Developing batch changes](batch_changes/index.md)

--- a/doc/dev/background-information/web/index.md
+++ b/doc/dev/background-information/web/index.md
@@ -9,5 +9,5 @@ See also our [TypeScript guide](https://about.sourcegraph.com/handbook/engineeri
 - [Wildcard Component Library](wildcard.md)
 - [Styling UI](styling.md)
 - [Accessibility](accessibility.md)
-- [Temporary settings](web/temporary_settings.md)
+- [Temporary settings](temporary_settings.md)
 - [Build process](build.md)

--- a/doc/dev/background-information/web/index.md
+++ b/doc/dev/background-information/web/index.md
@@ -9,4 +9,5 @@ See also our [TypeScript guide](https://about.sourcegraph.com/handbook/engineeri
 - [Wildcard Component Library](wildcard.md)
 - [Styling UI](styling.md)
 - [Accessibility](accessibility.md)
+- [Temporary settings](web/temporary_settings.md)
 - [Build process](build.md)

--- a/doc/dev/background-information/web/temporary_settings.md
+++ b/doc/dev/background-information/web/temporary_settings.md
@@ -1,6 +1,6 @@
 # Temporary settings
 
-Basic user settings that should be retained for users across sessions 
+Basic user settings that should be retained for users across sessions
 can be stored as temporary settings. These should be trivial settings
 that would be fine if they were lost.
 
@@ -35,16 +35,16 @@ Examples of data that is a good candidate for temporary settings include:
 * Basic theme settings like "light" or "dark"
 * "Most recently used" lists
 * Data needed for keeping track of a user's interactions as part of an 
-  A/B test or flight, or similar settings that are not meant to be user-editable
+  A/B test or flight, or similar settings that should not be user-editable
 
 Examples of data that should not be stored as temporary settings include:
 
 * Any data that should not be retained between sessions, such as search results
 * Any data that may need to be shared between users, such as a code insights chart
   or a search context configuration
-* Data that may be not be easily recoverable in a few clicks, such as a search notebook
-* Settings that need to be cascaded from global site settings or org to users (temporary settings
-  don't support cascading)
+* Data that may not be easily recoverable in a few clicks, such as a search notebook
+* Settings that need to cascade from global site settings or org settings to users
+  (temporary settings don't support cascading)
 * Any settings the user would like to edit manually (temporary settings are not user-editable)
 
 ## Using temporary settings
@@ -52,7 +52,7 @@ Examples of data that should not be stored as temporary settings include:
 ### Update schema
 
 Update the interface [`TemporarySettingsSchema` in `TemporarySettings.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/TemporarySettings.ts?L8:18) 
-by adding a key for the setting you want to store. The key should be namespaced based on 
+by adding a key for the setting you want to store. The key should be namespaced based on
 the area of the site that will be using the settings. Example names include `'search.collapsedSidebarSections'` 
 or `'codeInsights.hiddenCharts'`. The value of the setting can be any JSON-serializable type.
 
@@ -60,7 +60,7 @@ or `'codeInsights.hiddenCharts'`. The value of the setting can be any JSON-seria
 
 Use the React hook [`useTemporarySetting`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/useTemporarySetting.ts?L14:33) 
 to get an up-to-date value of the setting and a function that can update the value,
-simlar to other hooks like `useState`. The value will be updated automatically if
+similar to other hooks like `useState`. The value will be updated automatically if
 the user's authentication state changes or the setting is modified elsewhere in the
 application.
 
@@ -80,6 +80,7 @@ return <>
 
 ### 🚨 Data sync warning
 
-Currently, settings are not kept up-to-date if modified in more than one tab/browser at once.
-This can cause settings to be out of sync and lost. **Do not use temporary settings for
-important data.** We will address this in the future.
+Currently, settings are not kept up-to-date if modified in more than one tab/browser at once,
+which can cause settings to be out of sync and lost. **Do not use temporary settings for
+important data that may not be easily recoverable with a few clicks.**
+We will address this in the future.

--- a/doc/dev/background-information/web/temporary_settings.md
+++ b/doc/dev/background-information/web/temporary_settings.md
@@ -9,7 +9,7 @@ in the `temporary_setings` table and are queried and modified via the GraphQL AP
 
 For unauthenticated users, temporary settings are stored in `localStorage`. 
 
-## Different between temporary settings and site settings
+## Difference between temporary settings and site settings
 
 Site settings are the primary way to handle settings in Sourcegraph. They are accessible as
 global site settings, org settings, and user settings. These are the primary differences
@@ -59,9 +59,24 @@ or `'codeInsights.hiddenCharts'`. The value of the setting can be any JSON-seria
 ### Getting and setting settings
 
 Use the React hook [`useTemporarySetting`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/useTemporarySetting.ts?L14:33) 
-to get an up-to-date value of the setting and a function that can update the value. 
-The value will be updated automatically if the user's authentication state changes 
-or the setting is modified elsewhere in the application.
+to get an up-to-date value of the setting and a function that can update the value,
+simlar to other hooks like `useState`. The value will be updated automatically if
+the user's authentication state changes or the setting is modified elsewhere in the
+application.
+
+#### Example usage:
+
+```typescript
+const [modalVisible, setModalVisible] = useTemporarySetting('example.modalVisible')
+
+const toggleModal = () => {
+    setModalVisible(currentVisibility => !currentVisibility)
+}
+
+return <>
+    {modalVisible && <Modal onClose={toggleModal} />}
+</>
+```
 
 ### 🚨 Data sync warning
 

--- a/doc/dev/background-information/web/temporary_settings.md
+++ b/doc/dev/background-information/web/temporary_settings.md
@@ -1,0 +1,70 @@
+# Temporary settings
+
+Basic user settings that should be retained for users across sessions 
+can be stored as temporary settings. These should be trivial settings
+that would be fine if they were lost.
+
+For authenticated users, temporary settings are stored in the database 
+in the `temporary_setings` table and are queried and modified via the GraphQL API.
+
+For unauthenticated users, temporary settings are stored in `localStorage`. 
+
+## Different between temporary settings and site settings
+
+Site settings are the primary way to handle settings in Sourcegraph. They are accessible as
+global site settings, org settings, and user settings. These are the primary differences
+between temporary settings and site settings:
+
+|  | Site settings | Temporary settings |
+|---|---|---|
+| User editable | ✅  | ❌ |
+| Cascades from global to org to users | ✅  | ❌ |
+| Persisted across sessions | ✅  | ✅ |
+| Stored for unauthenticated users | ❌ <br /> (will use global site settings) | ✅ |
+| Typed schema | ✅  <br /> (in [`settings.schema.json`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/settings.schema.json))| ✅  <br /> (in [`TemporarySettings.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/TemporarySettings.ts))|
+| Available in Go code | ✅  | ❌ |
+
+
+## Examples
+
+Examples of data that is a good candidate for temporary settings include:
+
+* Settings that should be available to unauthenticated users
+* The dismiss state of a modal
+* The collapse state of a panel
+* Basic theme settings like "light" or "dark"
+* "Most recently used" lists
+* Data needed for keeping track of a user's interactions as part of an 
+  A/B test or flight, or similar settings that are not meant to be user-editable
+
+Examples of data that should not be stored as temporary settings include:
+
+* Any data that should not be retained between sessions, such as search results
+* Any data that may need to be shared between users, such as a code insights chart
+  or a search context configuration
+* Data that may be not be easily recoverable in a few clicks, such as a search notebook
+* Settings that need to be cascaded from global site settings or org to users (temporary settings
+  don't support cascading)
+* Any settings the user would like to edit manually (temporary settings are not user-editable)
+
+## Using temporary settings
+
+### Update schema
+
+Update the interface [`TemporarySettingsSchema` in `TemporarySettings.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/TemporarySettings.ts?L8:18) 
+by adding a key for the setting you want to store. The key should be namespaced based on 
+the area of the site that will be using the settings. Example names include `'search.collapsedSidebarSections'` 
+or `'codeInsights.hiddenCharts'`. The value of the settingcan be any JSON-serializable type.
+
+### Getting and setting settings
+
+Use the React hook [`useTemporarySetting`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/useTemporarySetting.ts?L14:33) 
+to get an up-to-date value of the setting and a function that can update the value. 
+The value will be updated automatically if the user's authentication state changes 
+or the setting is modified elsewhere in the application.
+
+### Caveats
+
+Currently, settings are not kept up-to-date if modified in more than one tab/browser at once.
+This can cause settings to be out of sync and lost. Do not use temporary settings for
+important data. We will address this in the future.

--- a/doc/dev/background-information/web/temporary_settings.md
+++ b/doc/dev/background-information/web/temporary_settings.md
@@ -54,7 +54,7 @@ Examples of data that should not be stored as temporary settings include:
 Update the interface [`TemporarySettingsSchema` in `TemporarySettings.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/TemporarySettings.ts?L8:18) 
 by adding a key for the setting you want to store. The key should be namespaced based on 
 the area of the site that will be using the settings. Example names include `'search.collapsedSidebarSections'` 
-or `'codeInsights.hiddenCharts'`. The value of the settingcan be any JSON-serializable type.
+or `'codeInsights.hiddenCharts'`. The value of the setting can be any JSON-serializable type.
 
 ### Getting and setting settings
 
@@ -63,8 +63,8 @@ to get an up-to-date value of the setting and a function that can update the val
 The value will be updated automatically if the user's authentication state changes 
 or the setting is modified elsewhere in the application.
 
-### Caveats
+### 🚨 Data sync warning
 
 Currently, settings are not kept up-to-date if modified in more than one tab/browser at once.
-This can cause settings to be out of sync and lost. Do not use temporary settings for
-important data. We will address this in the future.
+This can cause settings to be out of sync and lost. **Do not use temporary settings for
+important data.** We will address this in the future.

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -86,6 +86,7 @@ Clarification and discussion about key concepts, architecture, and development s
   - [Wildcard Component Library](background-information/web/wildcard.md)
   - [Styling UI](background-information/web/styling.md)
   - [Accessibility](background-information/web/accessibility.md)
+  - [Temporary settings](background-information/web/temporary_settings.md)
   - [Build process](background-information/web/build.md)
 - [Developing the GraphQL API](background-information/graphql_api.md)
 - [Developing batch changes](background-information/batch_changes/index.md)


### PR DESCRIPTION
Adds a docs page explaining what temporary settings are, what is the difference between temporary settings and site settings, and how to use temporary settings.