### PR TITLE
extensibility: add query transformers to streaming search

### DIFF
--- a/client/shared/src/api/client/search.ts
+++ b/client/shared/src/api/client/search.ts
@@ -1,7 +1,7 @@
 // For search-related extension API features, such as query transformers
 
 import { Remote } from 'comlink'
-import { from, Observable, of, TimeoutError } from 'rxjs'
+import { from, of, TimeoutError } from 'rxjs'
 import { catchError, filter, first, switchMap, timeout } from 'rxjs/operators'
 
 import { FlatExtensionHostAPI } from '../contract'
@@ -12,43 +12,41 @@ const TRANSFORM_QUERY_TIMEOUT = 3000
 
 /**
  * Executes search query transformers contributed by Sourcegraph extensions.
- *
- * Runs one time before completing/yielding value to streaming search.
- * i.e. extensions that contribute search query transformers that are activated during search
- * will not cause the query to be re-computed.
  */
-export function observeTransformedSearchQuery({
+export function transformSearchQuery({
     query,
     extensionHostAPIPromise,
 }: {
     query: string
     extensionHostAPIPromise: Promise<Remote<FlatExtensionHostAPI>>
-}): Observable<string> {
-    return from(extensionHostAPIPromise).pipe(
-        switchMap(extensionHostAPI =>
-            // Since we won't re-compute on subsequent extension activation, ensure that
-            // at least the initial set of extensions, which should include always-activated
-            // query-transforming extensions, have been loaded to ensure that the initial
-            // search query is transformed
-            wrapRemoteObservable(extensionHostAPI.haveInitialExtensionsLoaded()).pipe(
-                filter(haveLoaded => haveLoaded),
-                first(), // Ensure that it only emits once
-                switchMap(() =>
-                    wrapRemoteObservable(extensionHostAPI.transformSearchQuery(query)).pipe(
-                        first() // Ensure that it only emits once
+}): Promise<string> {
+    return from(extensionHostAPIPromise)
+        .pipe(
+            switchMap(extensionHostAPI =>
+                // Since we won't re-compute on subsequent extension activation, ensure that
+                // at least the initial set of extensions, which should include always-activated
+                // query-transforming extensions, have been loaded to ensure that the initial
+                // search query is transformed
+                wrapRemoteObservable(extensionHostAPI.haveInitialExtensionsLoaded()).pipe(
+                    filter(haveLoaded => haveLoaded),
+                    first(), // Ensure that it only emits once
+                    switchMap(() =>
+                        wrapRemoteObservable(extensionHostAPI.transformSearchQuery(query)).pipe(
+                            first() // Ensure that it only emits once
+                        )
                     )
                 )
-            )
-        ),
-        // Timeout: if this is hanging due to any sort of extension bug, it may not result in a thrown error,
-        // but will degrade search UX.
-        // Wait up to 5 seconds and log to console for users to debug slow query transformer extensions
-        timeout(TRANSFORM_QUERY_TIMEOUT),
-        catchError(error => {
-            if (error instanceof TimeoutError) {
-                console.error(`Extension query transformers took more than ${TRANSFORM_QUERY_TIMEOUT}ms`)
-            }
-            return of(query)
-        })
-    )
+            ),
+            // Timeout: if this is hanging due to any sort of extension bug, it may not result in a thrown error,
+            // but will degrade search UX.
+            // Wait up to 5 seconds and log to console for users to debug slow query transformer extensions
+            timeout(TRANSFORM_QUERY_TIMEOUT),
+            catchError(error => {
+                if (error instanceof TimeoutError) {
+                    console.error(`Extension query transformers took more than ${TRANSFORM_QUERY_TIMEOUT}ms`)
+                }
+                return of(query)
+            })
+        )
+        .toPromise()
 }

--- a/client/shared/src/api/client/search.ts
+++ b/client/shared/src/api/client/search.ts
@@ -1,0 +1,34 @@
+// For search-related extension API features, such as query transformers
+
+import { from, Observable } from 'rxjs'
+import { filter, first, switchMap } from 'rxjs/operators'
+
+import { Controller as ExtensionsController } from '../../extensions/controller'
+
+import { wrapRemoteObservable } from './api/common'
+
+/**
+ * TODO
+ */
+export function observeTransformedSearchQuery({
+    query,
+    extensionsController,
+}: {
+    query: string
+    extensionsController: Pick<ExtensionsController, 'extHostAPI'>
+}): Observable<string> {
+    return from(extensionsController.extHostAPI).pipe(
+        switchMap(extensionHostAPI =>
+            wrapRemoteObservable(extensionHostAPI.haveInitialExtensionsLoaded()).pipe(
+                filter(haveLoaded => haveLoaded),
+                first(),
+                switchMap(() =>
+                    wrapRemoteObservable(extensionHostAPI.transformSearchQuery(query)).pipe(
+                        // TODO: explain why
+                        first()
+                    )
+                )
+            )
+        )
+    )
+}

--- a/client/shared/src/api/client/search.ts
+++ b/client/shared/src/api/client/search.ts
@@ -1,9 +1,10 @@
 // For search-related extension API features, such as query transformers
 
+import { Remote } from 'comlink'
 import { from, Observable, of, TimeoutError } from 'rxjs'
 import { catchError, filter, first, switchMap, timeout } from 'rxjs/operators'
 
-import { Controller as ExtensionsController } from '../../extensions/controller'
+import { FlatExtensionHostAPI } from '../contract'
 
 import { wrapRemoteObservable } from './api/common'
 
@@ -14,12 +15,12 @@ const TRANSFORM_QUERY_TIMEOUT = 3000
  */
 export function observeTransformedSearchQuery({
     query,
-    extensionsController,
+    extensionHostAPIPromise,
 }: {
     query: string
-    extensionsController: Pick<ExtensionsController, 'extHostAPI'>
+    extensionHostAPIPromise: Promise<Remote<FlatExtensionHostAPI>>
 }): Observable<string> {
-    return from(extensionsController.extHostAPI).pipe(
+    return from(extensionHostAPIPromise).pipe(
         switchMap(extensionHostAPI =>
             wrapRemoteObservable(extensionHostAPI.haveInitialExtensionsLoaded()).pipe(
                 filter(haveLoaded => haveLoaded),

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -1,11 +1,13 @@
 /* eslint-disable id-length */
 import { Observable, fromEvent, Subscription, OperatorFunction, pipe, Subscriber, Notification } from 'rxjs'
-import { defaultIfEmpty, map, materialize, scan } from 'rxjs/operators'
+import { defaultIfEmpty, map, materialize, scan, switchMap } from 'rxjs/operators'
 import { AggregableBadge } from 'sourcegraph'
 
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
+import { observeTransformedSearchQuery } from '../api/client/search'
 import { displayRepoName } from '../components/RepoFileLink'
+import { Controller as ExtensionsController } from '../extensions/controller'
 import { SearchPatternType } from '../graphql-operations'
 import { SymbolKind } from '../graphql/schema'
 
@@ -401,6 +403,7 @@ export interface StreamSearchOptions {
     trace: string | undefined
     decorationKinds?: string[]
     decorationContextLines?: number
+    extensionsController: Pick<ExtensionsController, 'extHostAPI'>
 }
 
 /**
@@ -418,37 +421,43 @@ function search({
     trace,
     decorationKinds,
     decorationContextLines,
+    extensionsController,
 }: StreamSearchOptions): Observable<SearchEvent> {
-    return new Observable<SearchEvent>(observer => {
-        const parameters = [
-            ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
-            ['v', version],
-            ['t', patternType as string],
-            ['dl', '0'],
-            ['dk', (decorationKinds || ['html']).join('|')],
-            ['dc', (decorationContextLines || '1').toString()],
-            ['display', '1500'],
-        ]
-        if (versionContext) {
-            parameters.push(['vc', versionContext])
-        }
-        if (trace) {
-            parameters.push(['trace', trace])
-        }
-        const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
+    return observeTransformedSearchQuery({ query, extensionsController }).pipe(
+        switchMap(
+            query =>
+                new Observable<SearchEvent>(observer => {
+                    const parameters = [
+                        ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
+                        ['v', version],
+                        ['t', patternType as string],
+                        ['dl', '15'],
+                        ['dk', (decorationKinds || ['html']).join('|')],
+                        ['dc', (decorationContextLines || '1').toString()],
+                        ['display', '1500'],
+                    ]
+                    if (versionContext) {
+                        parameters.push(['vc', versionContext])
+                    }
+                    if (trace) {
+                        parameters.push(['trace', trace])
+                    }
+                    const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
 
-        const eventSource = new EventSource('/search/stream?' + parameterEncoded)
-        const subscriptions = new Subscription()
-        for (const [eventType, handleMessages] of Object.entries(messageHandlers)) {
-            subscriptions.add(
-                (handleMessages as MessageHandler)(eventType as SearchEvent['type'], eventSource, observer)
-            )
-        }
-        return () => {
-            subscriptions.unsubscribe()
-            eventSource.close()
-        }
-    })
+                    const eventSource = new EventSource('/search/stream?' + parameterEncoded)
+                    const subscriptions = new Subscription()
+                    for (const [eventType, handleMessages] of Object.entries(messageHandlers)) {
+                        subscriptions.add(
+                            (handleMessages as MessageHandler)(eventType as SearchEvent['type'], eventSource, observer)
+                        )
+                    }
+                    return () => {
+                        subscriptions.unsubscribe()
+                        eventSource.close()
+                    }
+                })
+        )
+    )
 }
 
 /** Initiate a streaming search and aggregate the results */

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -429,7 +429,6 @@ function search({
 
         // Call extension-contributed search query transformers
         transformSearchQuery({ query, extensionHostAPIPromise: extensionHostAPI })
-            .then(transformedQuery => transformedQuery)
             .catch(error => {
                 // Fallback: use original query
                 console.error('Extension query transformer error:', error)

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -1,4 +1,5 @@
 /* eslint-disable id-length */
+import { Remote } from 'comlink'
 import { Observable, fromEvent, Subscription, OperatorFunction, pipe, Subscriber, Notification } from 'rxjs'
 import { defaultIfEmpty, map, materialize, scan, switchMap } from 'rxjs/operators'
 import { AggregableBadge } from 'sourcegraph'
@@ -6,8 +7,8 @@ import { AggregableBadge } from 'sourcegraph'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { observeTransformedSearchQuery } from '../api/client/search'
+import { FlatExtensionHostAPI } from '../api/contract'
 import { displayRepoName } from '../components/RepoFileLink'
-import { Controller as ExtensionsController } from '../extensions/controller'
 import { SearchPatternType } from '../graphql-operations'
 import { SymbolKind } from '../graphql/schema'
 
@@ -403,7 +404,7 @@ export interface StreamSearchOptions {
     trace: string | undefined
     decorationKinds?: string[]
     decorationContextLines?: number
-    extensionsController: Pick<ExtensionsController, 'extHostAPI'>
+    extensionHostAPI: Promise<Remote<FlatExtensionHostAPI>>
 }
 
 /**
@@ -421,9 +422,9 @@ function search({
     trace,
     decorationKinds,
     decorationContextLines,
-    extensionsController,
+    extensionHostAPI,
 }: StreamSearchOptions): Observable<SearchEvent> {
-    return observeTransformedSearchQuery({ query, extensionsController }).pipe(
+    return observeTransformedSearchQuery({ query, extensionHostAPIPromise: extensionHostAPI }).pipe(
         switchMap(
             query =>
                 new Observable<SearchEvent>(observer => {

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -439,7 +439,7 @@ function search({
                     ['q', `${transformedQuery} ${caseSensitive ? 'case:yes' : ''}`],
                     ['v', version],
                     ['t', patternType as string],
-                    ['dl', '15'],
+                    ['dl', '0'],
                     ['dk', (decorationKinds || ['html']).join('|')],
                     ['dc', (decorationContextLines || '1').toString()],
                     ['display', '1500'],

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -540,7 +540,7 @@ describe('Search', () => {
                 waitUntil: 'networkidle0',
             })
             await resetCreateCodeMonitorFeatureTour()
-            await driver.page.waitForSelector('.search-result-match', { visible: true })
+            await driver.page.waitForSelector('.test-search-result-label', { visible: true })
             expect(await isCreateCodeMonitorFeatureTourVisible()).toBeFalsy()
         })
 
@@ -550,7 +550,7 @@ describe('Search', () => {
                 waitUntil: 'networkidle0',
             })
             await resetCreateCodeMonitorFeatureTour()
-            await driver.page.waitForSelector('.search-result-match', { visible: true })
+            await driver.page.waitForSelector('.test-search-result-label', { visible: true })
             expect(await isCreateCodeMonitorFeatureTourVisible()).toBeTruthy()
         })
 
@@ -560,7 +560,7 @@ describe('Search', () => {
                 waitUntil: 'networkidle0',
             })
             await resetCreateCodeMonitorFeatureTour(false)
-            await driver.page.waitForSelector('.search-result-match', { visible: true })
+            await driver.page.waitForSelector('.test-search-result-label', { visible: true })
             expect(await isCreateCodeMonitorFeatureTourVisible()).toBeFalsy()
         })
     })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -540,7 +540,7 @@ describe('Search', () => {
                 waitUntil: 'networkidle0',
             })
             await resetCreateCodeMonitorFeatureTour()
-            await driver.page.waitForSelector('.create-code-monitor-button', { visible: true })
+            await driver.page.waitForSelector('.search-result-match', { visible: true })
             expect(await isCreateCodeMonitorFeatureTourVisible()).toBeFalsy()
         })
 
@@ -550,7 +550,7 @@ describe('Search', () => {
                 waitUntil: 'networkidle0',
             })
             await resetCreateCodeMonitorFeatureTour()
-            await driver.page.waitForSelector('.create-code-monitor-button', { visible: true })
+            await driver.page.waitForSelector('.search-result-match', { visible: true })
             expect(await isCreateCodeMonitorFeatureTourVisible()).toBeTruthy()
         })
 
@@ -560,7 +560,7 @@ describe('Search', () => {
                 waitUntil: 'networkidle0',
             })
             await resetCreateCodeMonitorFeatureTour(false)
-            await driver.page.waitForSelector('.create-code-monitor-button', { visible: true })
+            await driver.page.waitForSelector('.search-result-match', { visible: true })
             expect(await isCreateCodeMonitorFeatureTourVisible()).toBeFalsy()
         })
     })

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -52,7 +52,11 @@ const options: Monaco.editor.IStandaloneEditorConstructionOptions = {
 }
 
 export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> = props => {
-    const { globbing, streamSearch } = props
+    const {
+        globbing,
+        streamSearch,
+        extensionsController: { extHostAPI: extensionHostAPI },
+    } = props
 
     const searchQuery = useMemo(() => new BehaviorSubject<string>(parseSearchURLQuery(props.location.search) ?? ''), [
         props.location.search,
@@ -78,8 +82,9 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                 caseSensitive: false,
                 versionContext: undefined,
                 trace: undefined,
+                extensionHostAPI,
             }).pipe(debounceTime(500))
-        }, [patternType, props.location.search, streamSearch])
+        }, [patternType, props.location.search, streamSearch, extensionHostAPI])
     )
 
     const sourcegraphSearchLanguageId = useQueryIntelligence(fetchSuggestions, {

--- a/client/web/src/search/notebook/SearchNotebook.story.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.story.tsx
@@ -4,6 +4,7 @@ import { NEVER } from 'rxjs'
 
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHelpers'
 
 import { WebStory } from '../../components/WebStory'
 
@@ -34,6 +35,7 @@ add('default', () => (
                 onSerializeBlocks={() => {}}
                 blocks={blocks}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
+                extensionsController={extensionsController}
             />
         )}
     </WebStory>
@@ -53,6 +55,7 @@ add('default read-only', () => (
                 onSerializeBlocks={() => {}}
                 blocks={blocks}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
+                extensionsController={extensionsController}
             />
         )}
     </WebStory>

--- a/client/web/src/search/notebook/SearchNotebook.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.tsx
@@ -1,6 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -22,7 +23,8 @@ export interface SearchNotebookProps
     extends SearchStreamingProps,
         ThemeProps,
         TelemetryProps,
-        Omit<StreamingSearchResultsListProps, 'location' | 'allExpanded'> {
+        Omit<StreamingSearchResultsListProps, 'location' | 'allExpanded'>,
+        ExtensionsControllerProps<'extHostAPI'> {
     globbing: boolean
     isMacPlatform: boolean
     isReadOnly?: boolean
@@ -33,9 +35,13 @@ export interface SearchNotebookProps
 export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
     onSerializeBlocks,
     isReadOnly = false,
+    extensionsController,
     ...props
 }) => {
-    const notebook = useMemo(() => new Notebook(props.blocks), [props.blocks])
+    const notebook = useMemo(() => new Notebook(props.blocks, { extensionHostAPI: extensionsController.extHostAPI }), [
+        props.blocks,
+        extensionsController.extHostAPI,
+    ])
 
     const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null)
     const [blocks, setBlocks] = useState<Block[]>(notebook.getBlocks())

--- a/client/web/src/search/notebook/SearchNotebookPage.tsx
+++ b/client/web/src/search/notebook/SearchNotebookPage.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import React, { useCallback, useEffect, useMemo } from 'react'
 import { useHistory, useLocation } from 'react-router'
 
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { FeedbackBadge } from '@sourcegraph/web/src/components/FeedbackBadge'
@@ -21,7 +22,8 @@ interface SearchNotebookPageProps
     extends SearchStreamingProps,
         ThemeProps,
         TelemetryProps,
-        Omit<StreamingSearchResultsListProps, 'allExpanded'> {
+        Omit<StreamingSearchResultsListProps, 'allExpanded'>,
+        ExtensionsControllerProps<'extHostAPI'> {
     globbing: boolean
     isMacPlatform: boolean
 }

--- a/client/web/src/search/notebook/index.ts
+++ b/client/web/src/search/notebook/index.ts
@@ -1,7 +1,9 @@
+import { Remote } from 'comlink'
 import { Observable } from 'rxjs'
 import { startWith } from 'rxjs/operators'
 import * as uuid from 'uuid'
 
+import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import {
     aggregateStreamingSearch,
@@ -48,11 +50,15 @@ export interface BlockProps {
     onDuplicateBlock(id: string): void
 }
 
+export interface BlockDependencies {
+    extensionHostAPI: Promise<Remote<FlatExtensionHostAPI>>
+}
+
 export class Notebook {
     private blocks: Map<string, Block>
     private blockOrder: string[]
 
-    constructor(initializerBlocks: BlockInitializer[]) {
+    constructor(initializerBlocks: BlockInitializer[], private dependencies: BlockDependencies) {
         const blocks = initializerBlocks.map(block => ({ ...block, id: uuid.v4(), output: null }))
 
         this.blocks = new Map(blocks.map(block => [block.id, block]))
@@ -108,6 +114,7 @@ export class Notebook {
                         caseSensitive: false,
                         versionContext: undefined,
                         trace: undefined,
+                        extensionHostAPI: this.dependencies.extensionHostAPI,
                     }).pipe(startWith(emptyAggregateResults)),
                 })
                 break

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -6,6 +6,8 @@ import { BrowserRouter } from 'react-router-dom'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 
+import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
+import { pretendRemote } from '@sourcegraph/shared/src/api/util'
 import { FileMatch } from '@sourcegraph/shared/src/components/FileMatch'
 import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
 import { GitRefType, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
@@ -100,6 +102,7 @@ describe('StreamingSearchResults', () => {
             caseSensitive: true,
             versionContext: 'test',
             trace: undefined,
+            extensionHostAPI: Promise.resolve(pretendRemote<FlatExtensionHostAPI>({})),
         })
 
         element.unmount()
@@ -131,6 +134,7 @@ describe('StreamingSearchResults', () => {
             caseSensitive: false,
             versionContext: undefined,
             trace: undefined,
+            extensionHostAPI: Promise.resolve(pretendRemote<FlatExtensionHostAPI>({})),
         })
 
         element.unmount()

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -90,6 +90,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         authenticatedUser,
         telemetryService,
         codeInsightsEnabled,
+        extensionsController,
     } = props
 
     // Log view event on first load
@@ -130,8 +131,9 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
             caseSensitive,
             versionContext: resolveVersionContext(versionContext, availableVersionContexts),
             trace,
+            extensionsController,
         }),
-        [availableVersionContexts, caseSensitive, patternType, query, trace, versionContext]
+        [availableVersionContexts, caseSensitive, patternType, query, trace, versionContext, extensionsController]
     )
 
     const results = useCachedSearchResults(streamSearch, options, telemetryService)

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -90,7 +90,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         authenticatedUser,
         telemetryService,
         codeInsightsEnabled,
-        extensionsController,
+        extensionsController: { extHostAPI: extensionHostAPI },
     } = props
 
     // Log view event on first load
@@ -131,9 +131,9 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
             caseSensitive,
             versionContext: resolveVersionContext(versionContext, availableVersionContexts),
             trace,
-            extensionsController,
+            extensionHostAPI,
         }),
-        [availableVersionContexts, caseSensitive, patternType, query, trace, versionContext, extensionsController]
+        [availableVersionContexts, caseSensitive, patternType, query, trace, versionContext, extensionHostAPI]
     )
 
     const results = useCachedSearchResults(streamSearch, options, telemetryService)


### PR DESCRIPTION
Closes #19237.

Adds support for [`QueryTransformer`](https://unpkg.com/sourcegraph@25.3.0/dist/docs/interfaces/_sourcegraph_.querytransformer.html)s (API: [`sourcegraph.search.registerQueryTransformer`](https://unpkg.com/sourcegraph@25.3.0/dist/docs/modules/_sourcegraph_.search.html)) to streaming search. They were integrated with "old" search, but not carried over to streaming search. We waited until extension loading performance improved to restore them in order to limit impact on initial search performance.

Notes: 
- Unlike the original implementation, search queries are not re-computed + executed when new query transformers are registered. In practice, this shouldn't matter as long we wait for the initial set of extensions to load (query transformer extensions should [always be active](https://docs.sourcegraph.com/extensions/authoring/activation#sourcegraph-extension-activation), not waiting for files of a language)
- Performance impact: initial search is blocked on extension activation, imperceptible cost for subsequent searches. The `graphql?Extensions` query is the bottleneck right now, but there are multiple PRs aiming to fix that: [caching](https://github.com/sourcegraph/sourcegraph/pull/24639), [speeding up request](https://github.com/sourcegraph/sourcegraph/pull/24632).

TODO 
- I've modernized our query transformer extensions, but they don't work by default with search V2 (?) since it defaults to literal search. Should we try to check `patternType` and add/replace `patternType` in each extension, or just tell users in READMEs that they should be in regexp mode?  I know that without using the query parser from the main repo, determining `patternType` will be tough/naive (e.g. `"patternType:regexp test" patternType:literal`)

Screenshot of go-imports-search working:
![Screenshot from 2021-08-31 18-22-21](https://user-images.githubusercontent.com/37420160/131583588-028b2d2a-70a7-478c-a883-ff50d0c474d7.png)