### PR TITLE
web: Fix tooltip overlays

### DIFF
--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
@@ -21,7 +21,7 @@
 
     + [data-reach-menu-popover] {
         right: 5px;
-        top: 40px;
+        top: 2.5rem; // base height + y-padding + margin-bottom from InsightCard.module.scss
         z-index: 2;
     }
 }

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.module.scss
@@ -18,6 +18,12 @@
             fill: var(--body-color);
         }
     }
+
+    + [data-reach-menu-popover] {
+        right: 5px;
+        top: 40px;
+        z-index: 2;
+    }
 }
 
 .button-icon {

--- a/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
+++ b/client/web/src/insights/components/insights-view-grid/components/insight-card/components/insight-card-menu/InsightCardMenu.tsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom'
 
 import { isSearchBasedInsightId } from '../../../../../../core/types/insight/search-insight'
 import { DashboardInsightsContext } from '../../../../../../pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsightsContext'
-import { positionRight } from '../../../../../context-menu/utils'
 import { LineChartSettingsContext } from '../../../../../insight-view-content/chart-view-content/charts/line/line-chart-settings-provider'
 
 import styles from './InsightCardMenu.module.scss'
@@ -49,7 +48,7 @@ export const InsightCardMenu: React.FunctionComponent<InsightCardMenuProps> = pr
                             size={16}
                         />
                     </MenuButton>
-                    <MenuPopover portal={true} position={positionRight}>
+                    <MenuPopover portal={false}>
                         <MenuItems
                             data-testid={`context-menu.${insightID}`}
                             className={classnames(styles.panel, 'dropdown-menu')}


### PR DESCRIPTION
This PR addresses one of the two bugs mentioned in the issue. The drop-down menu on an insight card overlays on top of things it should not.

To recreate this problem go to the Insights Dashboard `/insights/dashboards/all` open the card many for any insight by clicking the three dots. then scroll the page down such that the card scrolls offscreen above the navbar. You should see the menu overlaying the navbar.

| before | after|
| --- | --- |
| <img width="389" alt="overlay-before" src="https://user-images.githubusercontent.com/1855233/131719286-f2cbcb49-c8ad-4497-b013-965ce1be6114.png"> | <img width="389" alt="overlay-after" src="https://user-images.githubusercontent.com/1855233/131719312-98ceadfe-1114-43e5-81d3-41a01d06c64b.png"> |

Related to https://github.com/sourcegraph/sourcegraph/issues/24340