### PR TITLE
sg: Do not run gulp with --silent option

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -269,11 +269,11 @@ commands:
       CADDY_VERSION: 2.3.0
 
   web:
-    cmd: ./node_modules/.bin/gulp --silent --color dev
+    cmd: ./node_modules/.bin/gulp --color dev
     install: yarn --no-progress
 
   enterprise-web:
-    cmd: ./node_modules/.bin/gulp --silent --color dev
+    cmd: ./node_modules/.bin/gulp --color dev
     install: yarn --no-progress
     env:
       ENTERPRISE: 1


### PR DESCRIPTION
I suspect that when `--silent` is used, `gulp` also doesn't print errors on
stderr. And since the output has become much less noisy, I think it's
fine to re-enable it.
