### PR TITLE
httpcli: only retry DNS lookup failures 3 times

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -367,9 +368,6 @@ var redirectsErrorRe = lazyregexp.New(`stopped after \d+ redirects\z`)
 // specifically so we resort to matching on the error string.
 var schemeErrorRe = lazyregexp.New(`unsupported protocol scheme`)
 
-// A regular expression to match a DNSError no such host.
-var noSuchHostErrorRe = lazyregexp.New(`no such host`)
-
 // MaxRetries returns the max retries to be attempted, which should be passed
 // to NewRetryPolicy. If we're in tests, it returns 1, otherwise it tries to
 // parse SRC_HTTP_CLI_MAX_RETRIES and return that. If it can't, it defaults to 20.
@@ -414,6 +412,14 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 		case context.DeadlineExceeded, context.Canceled:
 			return false
 		default:
+			// Don't retry more than 3 times for no such host errors.
+			// This affords some resilience to dns unreliability while
+			// preventing 20 attempts with a non existing name.
+			var dnsErr *net.DNSError
+			if a.Index >= 3 && errors.As(a.Error, &dnsErr) && dnsErr.IsNotFound {
+				return false
+			}
+
 			if v, ok := a.Error.(*url.Error); ok {
 				e := v.Error()
 				// Don't retry if the error was due to too many redirects.
@@ -423,13 +429,6 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 
 				// Don't retry if the error was due to an invalid protocol scheme.
 				if schemeErrorRe.MatchString(e) {
-					return false
-				}
-
-				// Don't retry more than 3 times for no such host errors.
-				// This affords some resilience to dns unreliability while
-				// preventing 20 attempts with a non existing name.
-				if noSuchHostErrorRe.MatchString(e) && a.Index >= 3 {
 					return false
 				}
 

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -347,6 +348,46 @@ func TestErrorResilience(t *testing.T) {
 
 		if res.StatusCode != 429 {
 			t.Fatalf("want status code 429, got: %d", res.StatusCode)
+		}
+	})
+
+	t.Run("no such host", func(t *testing.T) {
+		// spy on policy so we see what decisions it makes
+		retries := 0
+		policy := NewRetryPolicy(5) // smaller retries for faster failures
+		wrapped := func(a rehttp.Attempt) bool {
+			if policy(a) {
+				retries++
+				return true
+			}
+			return false
+		}
+
+		cli, _ := NewFactory(
+			NewMiddleware(
+				ContextErrorMiddleware,
+			),
+			NewErrorResilientTransportOpt(
+				wrapped,
+				rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+			),
+		).Doer()
+
+		// requests to .invalid will fail DNS lookup. (RFC 6761 section 6.4)
+		req, err := http.NewRequest("GET", "http://test.invalid", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = cli.Do(req)
+
+		var dnsErr *net.DNSError
+		if !errors.As(err, &dnsErr) || !dnsErr.IsNotFound {
+			t.Fatalf("expected err to be net.DNSError with IsNotFound true: %v", err)
+		}
+
+		// policy is on DNS failure to retry 3 times
+		if want := 3; retries != want {
+			t.Fatalf("expected %d retries, got %d", want, retries)
 		}
 	})
 }


### PR DESCRIPTION
We already had this check, but it expected the error type to be
"*url.Error". In practice the error I see is a "*net.OpError" which
wraps the core "*net.DNSError" in the case of DNS lookup failures. From
following the go stdlib code "no such host" errors always originate via
a "*net.DNSError". So instead we do error unwrapping to check against
that.

In practice without the smaller retries we get elevated search response
times if any zoekt replica is unavailable.