### PR TITLE
PoC: Allow only a single user in OSS version

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -177,7 +177,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 		ExternalServicesUserMode: conf.ExternalServiceUserMode().String(),
 
-		AllowSignup: conf.AuthAllowSignup(),
+		AllowSignup: conf.IsBuiltinSignupAllowed(),
 
 		AuthProviders: authProviders,
 

--- a/cmd/frontend/internal/auth/userpasswd/config.go
+++ b/cmd/frontend/internal/auth/userpasswd/config.go
@@ -53,6 +53,10 @@ func validateConfig(c conf.Unified) (problems conf.Problems) {
 	for _, p := range c.AuthProviders {
 		if p.Builtin != nil {
 			builtinAuthProviders++
+
+			if p.Builtin.AllowSignup && conf.SingleUserMode {
+				problems = append(problems, conf.NewSiteProblem("`allowSignup` for the builtin auth provider is not allowed in OSS version of Sourcegraph"))
+			}
 		}
 	}
 	if builtinAuthProviders >= 2 {

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -46,7 +46,8 @@ func HandleSignUp(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Signup is not enabled (builtin auth provider allowSignup site configuration option)", http.StatusNotFound)
 		return
 	}
-	handleSignUp(w, r, false)
+
+	handleSignUp(w, r, conf.SingleUserMode)
 }
 
 // HandleSiteInit handles submission of the site initialization form, where the initial site admin user is created.

--- a/dev/site-config.json
+++ b/dev/site-config.json
@@ -3,7 +3,7 @@
   "auth.providers": [
     {
       "type": "builtin",
-      "allowSignup": false
+      "allowSignup": true
     }
   ],
   "externalURL": "http://localhost:3080/",

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -24,6 +24,7 @@ import (
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -34,6 +35,7 @@ func main() {
 
 func init() {
 	oobmigration.ReturnEnterpriseMigrations = true
+	conf.SingleUserMode = false
 }
 
 var initFunctions = map[string]func(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services) error{

--- a/internal/conf/auth.go
+++ b/internal/conf/auth.go
@@ -5,6 +5,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+var SingleUserMode = true
+
 // AuthProviderType returns the type string for the auth provider.
 func AuthProviderType(p schema.AuthProviders) string {
 	switch {
@@ -30,16 +32,3 @@ func AuthProviderType(p schema.AuthProviders) string {
 // usage it is preferable for all users to have accounts. But on sourcegraph.com, allowing users to
 // opt-in to accounts remains worthwhile, despite the degraded UX.
 func AuthPublic() bool { return envvar.SourcegraphDotComMode() }
-
-// AuthAllowSignup reports whether the site allows signup. Currently only the builtin auth provider
-// allows signup. AuthAllowSignup returns true if auth.providers' builtin provider has allowSignup
-// true (in site config).
-func AuthAllowSignup() bool { return authAllowSignup(Get()) }
-func authAllowSignup(c *Unified) bool {
-	for _, p := range c.AuthProviders {
-		if p.Builtin != nil && p.Builtin.AllowSignup {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -273,6 +273,10 @@ func IsExternalURLSecure() bool {
 }
 
 func IsBuiltinSignupAllowed() bool {
+	if SingleUserMode {
+		return false
+	}
+
 	provs := Get().AuthProviders
 	for _, prov := range provs {
 		if prov.Builtin != nil {

--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -22,7 +22,7 @@ var DevAndTesting = conftypes.RawUnified{
 	"auth.providers": [
 		{
 			"type": "builtin",
-			"allowSignup": true
+			"allowSignup": false
 		}
 	],
 
@@ -41,7 +41,7 @@ var DockerContainer = conftypes.RawUnified{
 	"auth.providers": [
 		{
 			"type": "builtin",
-			"allowSignup": true
+			"allowSignup": false
 		}
 	],
 


### PR DESCRIPTION
Included:

- Database layer: disables creation of users other than initial site-admin user in open source version through global check
- Auth layer: adds validation to site-config to mark the `allowSignup: true` option of `builtin` auth provider as error
- Conf layer: overwrites "is signup enabled" check to `false` in OSS version to disable sign-up form in UI
- HTTP layer: returns error if create-user request is sent