### PR TITLE
github: remove GetAuthenticatedUserOAuthScopes

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -380,7 +380,7 @@ func (c *V3Client) GetAuthenticatedUserOAuthScopes(ctx context.Context) ([]strin
 	return strings.Split(scope, ", "), nil
 }
 
-// GetAuthenticatedUserOAuthScopes gets the list of OAuth scopes granted to the token in use.
+// GetAuthenticatedOAuthScopes gets the list of OAuth scopes granted to the token in use.
 func (c *V3Client) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error) {
 	// We only care about headers
 	var dest struct{}

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -359,29 +359,13 @@ func (c *V3Client) GetAuthenticatedUserTeams(ctx context.Context, page int) (
 	return teams, len(teams) > 0, 1, err
 }
 
-var MockGetAuthenticatedUserOAuthScopes func(ctx context.Context) ([]string, error)
-
-// GetAuthenticatedUserOAuthScopes gets the list of OAuth scopes granted to the
-// currently authenticate user.
-func (c *V3Client) GetAuthenticatedUserOAuthScopes(ctx context.Context) ([]string, error) {
-	if MockGetAuthenticatedUserOAuthScopes != nil {
-		return MockGetAuthenticatedUserOAuthScopes(ctx)
-	}
-	// We only care about headers
-	var dest struct{}
-	header, err := c.requestGetWithHeader(ctx, "/user", &dest)
-	if err != nil {
-		return nil, err
-	}
-	scope := header.Get("x-oauth-scopes")
-	if scope == "" {
-		return []string{}, nil
-	}
-	return strings.Split(scope, ", "), nil
-}
+var MockGetAuthenticatedOAuthScopes func(ctx context.Context) ([]string, error)
 
 // GetAuthenticatedOAuthScopes gets the list of OAuth scopes granted to the token in use.
 func (c *V3Client) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error) {
+	if MockGetAuthenticatedOAuthScopes != nil {
+		return MockGetAuthenticatedOAuthScopes(ctx)
+	}
 	// We only care about headers
 	var dest struct{}
 	header, err := c.requestGetWithHeader(ctx, "/", &dest)

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -165,22 +165,6 @@ func TestListAffiliatedRepositories(t *testing.T) {
 	}
 }
 
-func Test_GetAuthenticatedUserOAuthScopes(t *testing.T) {
-	client, save := newV3TestClient(t, "GetAuthenticatedUserOAuthScopes")
-	defer save()
-
-	scopes, err := client.GetAuthenticatedUserOAuthScopes(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{"admin:enterprise", "admin:gpg_key", "admin:org", "admin:org_hook", "admin:public_key", "admin:repo_hook", "delete:packages", "delete_repo", "gist", "notifications", "repo", "user", "workflow", "write:discussion", "write:packages"}
-	sort.Strings(scopes)
-	if diff := cmp.Diff(want, scopes); diff != "" {
-		t.Fatalf("Scopes mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func Test_GetAuthenticatedOAuthScopes(t *testing.T) {
 	client, save := newV3TestClient(t, "GetAuthenticatedOAuthScopes")
 	defer save()

--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -134,7 +134,7 @@ func GrantedScopes(ctx context.Context, cache ScopeCache, svc *types.ExternalSer
 		if err != nil {
 			return nil, errors.Wrap(err, "creating source")
 		}
-		scopes, err := src.v3Client.GetAuthenticatedUserOAuthScopes(ctx)
+		scopes, err := src.v3Client.GetAuthenticatedOAuthScopes(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting scopes")
 		}

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -251,7 +251,7 @@ func TestGrantedScopes(t *testing.T) {
 	ctx := context.Background()
 
 	want := []string{"repo"}
-	github.MockGetAuthenticatedUserOAuthScopes = func(ctx context.Context) ([]string, error) {
+	github.MockGetAuthenticatedOAuthScopes = func(ctx context.Context) ([]string, error) {
 		return want, nil
 	}
 


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
in favour of GetAuthenticatedOAuthScopes - It looks like [one can provide a token associated with an app and not a user](https://docs.sourcegraph.com/admin/external_service/github#github-api-token-and-access), and the [docs don't note that `/user` can work for a non-user](https://docs.github.com/en/rest/reference/users#get-the-authenticated-user)