### PR TITLE
authz: slow down primary key grow pace of "user_pending_permissions" table

### DIFF
--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -567,20 +567,19 @@ func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *ex
 
 	// Insert rows for AccountIDs without one in the "user_pending_permissions"
 	// table. The insert does not store any permission data but uses auto-increment
-	// key to generate unique ID. This help guarantees rows of all AccountIDs exist
-	// when getting user IDs in next load query.
+	// key to generate unique ID. This guarantees that rows of all AccountIDs exist
+	// when getting user IDs in the next load query.
 	updatedAt := txs.clock()
 	p.UpdatedAt = updatedAt
 	if len(accounts.AccountIDs) > 0 {
 		// NOTE: The primary key of "user_pending_permissions" table is
 		//  auto-incremented, and it is monotonically growing even with upsert in
 		//  Postgres (i.e. the primary key is increased internally by one even if the row
-		//  exists). This means with large number of existing rows in the table, the
-		//  primary key will grow very quickly every time we do an upsert, and soon
-		//  reaching the largest number an int4 (32-bit integer) can hold
-		//  (2,147,483,647). Therefore, load existing rows would help us only upsert rows
-		//  that are newly discovered. See reasons dozen lines below for why we do upsert
-		//  not insert.
+		//  exists). This means with large number of AccountIDs, the primary key will
+		//  grow very quickly every time we do an upsert, and soon reaching the largest
+		//  number an int4 (32-bit integer) can hold (2,147,483,647). Therefore, load
+		//  existing rows would help us only upsert rows that are newly discovered. See
+		//  NOTE in dozen lines below for why we do upsert not insert.
 		q = loadExistingUserPendingPermissionsBatchQuery(accounts, p)
 		bindIDsToIDs, err := txs.loadExistingUserPendingPermissionsBatch(ctx, q)
 		if err != nil {

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -565,25 +565,62 @@ func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *ex
 
 	p.UserIDs = roaring.NewBitmap()
 
-	// Insert rows for AccountIDs without one in the "user_pending_permissions" table.
-	// The insert does not store any permissions data but uses auto-increment key to generate unique ID.
-	// This help guarantees rows of all AccountIDs exist when getting user IDs in next load query.
+	// Insert rows for AccountIDs without one in the "user_pending_permissions"
+	// table. The insert does not store any permission data but uses auto-increment
+	// key to generate unique ID. This help guarantees rows of all AccountIDs exist
+	// when getting user IDs in next load query.
 	updatedAt := txs.clock()
 	p.UpdatedAt = updatedAt
 	if len(accounts.AccountIDs) > 0 {
-		// NOTE: Row-level locking is not needed here because we're creating stub rows and not modifying permissions.
-		q, err = insertUserPendingPermissionsBatchQuery(accounts, p)
+		// NOTE: The primary key of "user_pending_permissions" table is
+		//  auto-incremented, and it is monotonically growing even with upsert in
+		//  Postgres (i.e. the primary key is increased internally by one even if the row
+		//  exists). This means with large number of existing rows in the table, the
+		//  primary key will grow very quickly every time we do an upsert, and soon
+		//  reaching the largest number an int4 (32-bit integer) can hold
+		//  (2,147,483,647). Therefore, load existing rows would help us only upsert rows
+		//  that are newly discovered. See reasons dozen lines below for why we do upsert
+		//  not insert.
+		q = loadExistingUserPendingPermissionsBatchQuery(accounts, p)
+		bindIDsToIDs, err := txs.loadExistingUserPendingPermissionsBatch(ctx, q)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "load existing user pending permissions")
 		}
 
-		ids, err := txs.loadUserPendingPermissionsIDs(ctx, q)
-		if err != nil {
-			return errors.Wrap(err, "load user pending permissions IDs")
+		missingAccounts := &extsvc.Accounts{
+			ServiceType: accounts.ServiceType,
+			ServiceID:   accounts.ServiceID,
+			AccountIDs:  make([]string, 0, len(accounts.AccountIDs)-len(bindIDsToIDs)),
 		}
 
-		// Make up p.UserIDs from the result set.
-		p.UserIDs.AddMany(ids)
+		for _, bindID := range accounts.AccountIDs {
+			id, ok := bindIDsToIDs[bindID]
+			if ok {
+				p.UserIDs.Add(id)
+			} else {
+				missingAccounts.AccountIDs = append(missingAccounts.AccountIDs, bindID)
+			}
+		}
+
+		// Only do upsert when there are missing accounts
+		if len(missingAccounts.AccountIDs) > 0 {
+			// NOTE: Row-level locking is not needed here because we're creating stub rows
+			//  and not modifying permissions, which is also why it is best to use upsert not
+			//  insert to avoid unique violation in case other transactions are trying to
+			//  create overlapping stub rows.
+			q, err = upsertUserPendingPermissionsBatchQuery(missingAccounts, p)
+			if err != nil {
+				return err
+			}
+
+			ids, err := txs.loadUserPendingPermissionsIDs(ctx, q)
+			if err != nil {
+				return errors.Wrap(err, "load user pending permissions IDs")
+			}
+
+			// Make up p.UserIDs from the result set.
+			p.UserIDs.AddMany(ids)
+		}
 	}
 
 	// Retrieve currently stored user IDs of this repository.
@@ -630,32 +667,42 @@ func (s *PermsStore) loadUserPendingPermissionsIDs(ctx context.Context, q *sqlf.
 	}()
 
 	rows, err := s.Query(ctx, q)
+	return basestore.ScanUint32s(rows, err)
+}
+
+func (s *PermsStore) loadExistingUserPendingPermissionsBatch(ctx context.Context, q *sqlf.Query) (bindIDsToIDs map[string]uint32, err error) {
+	ctx, save := s.observe(ctx, "loadExistingUserPendingPermissionsBatch", "")
+	defer func() {
+		save(&err,
+			otlog.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
+			otlog.Object("Query.Args", q.Args()),
+		)
+	}()
+
+	rows, err := s.Query(ctx, q)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
+	defer func() { err = basestore.CloseRows(rows, err) }()
 
+	bindIDsToIDs = make(map[string]uint32)
 	for rows.Next() {
+		var bindID string
 		var id uint32
-		if err = rows.Scan(&id); err != nil {
+		if err = rows.Scan(&bindID, &id); err != nil {
 			return nil, err
 		}
-
-		ids = append(ids, id)
+		bindIDsToIDs[bindID] = id
 	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return ids, nil
+	return bindIDsToIDs, nil
 }
 
-func insertUserPendingPermissionsBatchQuery(
+func upsertUserPendingPermissionsBatchQuery(
 	accounts *extsvc.Accounts,
 	p *authz.RepoPermissions,
 ) (*sqlf.Query, error) {
 	const format = `
--- source: enterprise/internal/database/perms_store.go:insertUserPendingPermissionsBatchQuery
+-- source: enterprise/internal/database/perms_store.go:upsertUserPendingPermissionsBatchQuery
 INSERT INTO user_pending_permissions
   (service_type, service_id, bind_id, permission, object_type, updated_at)
 VALUES
@@ -687,6 +734,33 @@ RETURNING id
 		format,
 		sqlf.Join(items, ","),
 	), nil
+}
+
+func loadExistingUserPendingPermissionsBatchQuery(accounts *extsvc.Accounts, p *authz.RepoPermissions) *sqlf.Query {
+	const format = `
+-- source: enterprise/internal/database/perms_store.go:loadExistingUserPendingPermissionsBatchQuery
+SELECT bind_id, id FROM user_pending_permissions
+WHERE
+	service_type = %s
+AND service_id = %s
+AND permission = %s
+AND object_type = %s
+AND bind_id IN (%s)
+`
+
+	bindIDs := make([]*sqlf.Query, len(accounts.AccountIDs))
+	for i := range accounts.AccountIDs {
+		bindIDs[i] = sqlf.Sprintf("%s", accounts.AccountIDs[i])
+	}
+
+	return sqlf.Sprintf(
+		format,
+		accounts.ServiceType,
+		accounts.ServiceID,
+		p.Perm.String(),
+		authz.PermRepos,
+		sqlf.Join(bindIDs, ","),
+	)
 }
 
 func loadRepoPendingPermissionsQuery(p *authz.RepoPermissions, lock string) *sqlf.Query {

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -579,11 +579,11 @@ func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *ex
 		//  grow very quickly every time we do an upsert, and soon reaching the largest
 		//  number an int4 (32-bit integer) can hold (2,147,483,647). Therefore, load
 		//  existing rows would help us only upsert rows that are newly discovered. See
-		//  NOTE in dozen lines below for why we do upsert not insert.
+		//  NOTE in below for why we do upsert not insert.
 		q = loadExistingUserPendingPermissionsBatchQuery(accounts, p)
 		bindIDsToIDs, err := txs.loadExistingUserPendingPermissionsBatch(ctx, q)
 		if err != nil {
-			return errors.Wrap(err, "load existing user pending permissions")
+			return errors.Wrap(err, "loading existing user pending permissions")
 		}
 
 		missingAccounts := &extsvc.Accounts{

--- a/internal/database/basestore/rows.go
+++ b/internal/database/basestore/rows.go
@@ -129,6 +129,26 @@ func ScanInt32s(rows *sql.Rows, queryErr error) (_ []int32, err error) {
 	return values, nil
 }
 
+// ScanUint32s reads unsigned integer values from the given row object.
+func ScanUint32s(rows *sql.Rows, queryErr error) (_ []uint32, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = CloseRows(rows, err) }()
+
+	var values []uint32
+	for rows.Next() {
+		var value uint32
+		if err := rows.Scan(&value); err != nil {
+			return nil, err
+		}
+
+		values = append(values, value)
+	}
+
+	return values, nil
+}
+
 // ScanFirstInt reads integer values from the given row object and returns the first one.
 // If no rows match the query, a false-valued flag is returned.
 func ScanFirstInt(rows *sql.Rows, queryErr error) (_ int, _ bool, err error) {


### PR DESCRIPTION
### Context

We're using 32-bit integer (`int32` in Go / `int4` in Postgres) to store a user ID, and we are using [roaring bitmap](https://roaringbitmap.org/) as the efficient in-memory representation for a collection of user IDs, which only supports `uint32`. Therefore it was a natural choice to use `int4` as the column type for `user_pending_permissions` table (same as `users` table).

### What is the problem with existing approach?

Just like we use a primary key with auto-increment property for `users` table, we have the same use case for `user_pending_permissions`. The problem comes from that [Postgres still monotonically increases the primary key with failed inserts](https://dba.stackexchange.com/a/83351) (which based on our query, it becomes an upsert).

In our case, if there are lots of users with pending permissions, we're making lots of failed inserts with every call of `SetRepoPendingPermissions`. The grow pace of the primary key can be simply calculated as follows:

If a repository has 10k users (that are not yet having an account in the Sourcegraph instance, but have access to on the code host), 2,147,483,647 (the largest number a signed 32-bit integer can hold) would only support 214,748 calls of `SetRepoPendingPermissions`. It may seem a lot at a first glance, but imagine our background syncing process picks 10 repositories every minute, that gives us `214748 / 10 / 60 / 24 ~= 15` days, not to mention the initial syncing round would have a call to `SetRepoPendingPermissions` for every single repository.

### Why no customers have ran into this problem?

My hypothesis:

Most of users on the code host have onboarded to the Sourcegraph instance, which makes the primary key grow pace very slow, e.g. < 100 for every call of `SetRepoPendingPermissions`, that is about `21474800 / 10 / 60 / 24 ~= 1500` days to reach the largest number (background permissions was introduced about 18 months / 540 days ago, that leaves customers ~900 days).

### How the approach in this PR helps?

Instead of naively relying on upsert for massive existing rows (that causes fail inserts), we first load existing rows and only do inserts for newly discovered rows. This means if there are 20k users on the code host, the primary key should also only grow to around 20k.