### PR TITLE
Disable flaky TestSyncRegistry test

### DIFF
--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -156,6 +156,7 @@ func TestSyncerRun(t *testing.T) {
 }
 
 func TestSyncRegistry(t *testing.T) {
+	t.Skip("Flaky test")
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
I need to rework this test completely. There's too much going on.
Ticket: https://github.com/sourcegraph/sourcegraph/issues/24508