### PR TITLE
ping: Fix code intelligence usage data

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -795,28 +795,46 @@ func (l *EventLogStore) CodeIntelligenceRepositoryCountsByLanguage(ctx context.C
 	}
 	defer rows.Close()
 
+	var (
+		language string
+		numRepositoriesWithUploadRecords,
+		numRepositoriesWithFreshUploadRecords,
+		numRepositoriesWithIndexRecords,
+		numRepositoriesWithFreshIndexRecords *int
+	)
+
 	byLangauge := map[string]CodeIntelligenceRepositoryCountsForLanguage{}
 	for rows.Next() {
-		var language string
-
-		var counts CodeIntelligenceRepositoryCountsForLanguage
 		if err := rows.Scan(
 			&language,
-			&counts.NumRepositoriesWithUploadRecords,
-			&counts.NumRepositoriesWithFreshUploadRecords,
-			&counts.NumRepositoriesWithIndexRecords,
-			&counts.NumRepositoriesWithFreshIndexRecords,
+			&numRepositoriesWithUploadRecords,
+			&numRepositoriesWithFreshUploadRecords,
+			&numRepositoriesWithIndexRecords,
+			&numRepositoriesWithFreshIndexRecords,
 		); err != nil {
 			return nil, err
 		}
 
-		byLangauge[language] = counts
+		byLangauge[language] = CodeIntelligenceRepositoryCountsForLanguage{
+			NumRepositoriesWithUploadRecords:      safeDerefIntPtr(numRepositoriesWithUploadRecords),
+			NumRepositoriesWithFreshUploadRecords: safeDerefIntPtr(numRepositoriesWithFreshUploadRecords),
+			NumRepositoriesWithIndexRecords:       safeDerefIntPtr(numRepositoriesWithIndexRecords),
+			NumRepositoriesWithFreshIndexRecords:  safeDerefIntPtr(numRepositoriesWithFreshIndexRecords),
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
 	return byLangauge, nil
+}
+
+func safeDerefIntPtr(v *int) int {
+	if v != nil {
+		return *v
+	}
+
+	return 0
 }
 
 var codeIntelligenceRepositoryCountsByLanguageQuery = `

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -815,7 +815,7 @@ func (l *EventLogStore) CodeIntelligenceRepositoryCountsByLanguage(ctx context.C
 			return nil, err
 		}
 
-		byLangauge[language] = CodeIntelligenceRepositoryCountsForLanguage{
+		byLanguage[language] = CodeIntelligenceRepositoryCountsForLanguage{
 			NumRepositoriesWithUploadRecords:      safeDerefIntPtr(numRepositoriesWithUploadRecords),
 			NumRepositoriesWithFreshUploadRecords: safeDerefIntPtr(numRepositoriesWithFreshUploadRecords),
 			NumRepositoriesWithIndexRecords:       safeDerefIntPtr(numRepositoriesWithIndexRecords),

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -826,7 +826,7 @@ func (l *EventLogStore) CodeIntelligenceRepositoryCountsByLanguage(ctx context.C
 		return nil, err
 	}
 
-	return byLangauge, nil
+	return byLanguage, nil
 }
 
 func safeDerefIntPtr(v *int) int {

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -803,7 +803,7 @@ func (l *EventLogStore) CodeIntelligenceRepositoryCountsByLanguage(ctx context.C
 		numRepositoriesWithFreshIndexRecords *int
 	)
 
-	byLangauge := map[string]CodeIntelligenceRepositoryCountsForLanguage{}
+	byLanguage := map[string]CodeIntelligenceRepositoryCountsForLanguage{}
 	for rows.Next() {
 		if err := rows.Scan(
 			&language,


### PR DESCRIPTION
This is what is stopping code intelligence data from being sent to private instances. This was throwing an error on some local data that I didn't catch during development. Since the change that introduced it, code intelligence stats have not been generated (but all other ping data is fine).