### PR TITLE
doc: explicit perms not intended to replace code host perms sync

### DIFF
--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -313,9 +313,7 @@ mutation {
 
 ## Explicit permissions API
 
-Sourcegraph exposes a GraphQL API to explicitly set repository permissions. This will become the primary
-way to specify permissions in the future and will eventually replace the other repository
-permissions mechanisms.
+Sourcegraph exposes a GraphQL API to explicitly set repository permissions as an alternative to the code-host-specific repository permissions sync mechanisms.
 
 To enable the permissions API, add the following to the [site configuration](../config/site_config.md):
 


### PR DESCRIPTION
@ggilmore and I were investigating alternatives for a customer and came across this note that explicit permissions API ([RFC 40](https://docs.google.com/document/d/167WV_rhBg3oj0yw9fHwUMlB-8BR3ktk2FSsKiUQo55Y/edit)) is intended to replace the individual code host permissions sync.

However a subsequent RFC ([RFC 114](https://docs.google.com/document/d/1x3Y9jZzjJlJqmJ2czJ4A1NXKbY4hMa9K9pn1501r5IY/edit#heading=h.g5w2zjqikt9h)) notes that:

> One of the initial motivations of RFC 40 was to push all future customers to use the new explicit permissions API. Unfortunately, we soon realized (after finished implementation) that if the customer was going to build a permissions syncing service between the code host and the Sourcegraph instance, they would face the exact same problems we had (i.e. rate-limiting, scaling, etc.), not to say it takes extra engineering effort for either them or us to maintain the syncing service.

It looks like the direction is that explicit permissions API is either complementary or just an alternative to the code hosts sync. This updates the doc to be a bit less alarming to folks setting up permissions syncing. Let me know if I've misunderstood here!



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
