### PR TITLE
search: decorate event stream result

### DIFF
--- a/cmd/frontend/internal/highlight/decorate.go
+++ b/cmd/frontend/internal/highlight/decorate.go
@@ -1,0 +1,51 @@
+package highlight
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+func fetchContent(ctx context.Context, fm *result.FileMatch) (content []byte, err error) {
+	var contentOnce sync.Once
+	contentOnce.Do(func() {
+		content, err = git.ReadFile(ctx, fm.Repo.Name, fm.CommitID, fm.Path, 0)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
+// Decorate file content given FileMatch.
+func Decorate(ctx context.Context, fm *result.FileMatch) (string, error) {
+	content, err := fetchContent(ctx, fm)
+	if err != nil {
+		return "", err
+	}
+	result, aborted, err := Code(ctx, Params{
+		Content:            content,
+		Filepath:           fm.Path,
+		DisableTimeout:     false, // TODO: when false, sets 3 second timeout
+		IsLightTheme:       false, // unused
+		HighlightLongLines: false, // TODO: limits to 2000 by default
+		SimulateTimeout:    false, // for test
+		Metadata: Metadata{ // for logging
+			RepoName: string(fm.Repo.Name),
+			Revision: string(fm.CommitID),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if aborted {
+		// TODO: make Decorate return a value that indicates whether it plaintext HTML,
+		// or decide whether to return nothing.
+
+		// code decoration aborted, returns plaintext HTML.
+		return string(result), nil
+	}
+	return string(result), nil
+}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -19,18 +19,28 @@ type EventContentMatch struct {
 	// Type is always FileMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
-	Path            string     `json:"name"`
-	RepositoryID    int32      `json:"repositoryID"`
-	Repository      string     `json:"repository"`
-	RepoStars       int        `json:"repoStars,omitempty"`
-	RepoLastFetched *time.Time `json:"repoLastFetched,omitempty"`
-	Branches        []string   `json:"branches,omitempty"`
-	Version         string     `json:"version,omitempty"`
+	Path            string          `json:"name"`
+	RepositoryID    int32           `json:"repositoryID"`
+	Repository      string          `json:"repository"`
+	RepoStars       int             `json:"repoStars,omitempty"`
+	RepoLastFetched *time.Time      `json:"repoLastFetched,omitempty"`
+	Branches        []string        `json:"branches,omitempty"`
+	Version         string          `json:"version,omitempty"`
+	Hunks           []DecoratedHunk `json:"hunks,omitempty"` // TODO: blocked on merge for wiring.
 
 	LineMatches []EventLineMatch `json:"lineMatches"`
 }
 
 func (e *EventContentMatch) eventMatch() {}
+
+type DecoratedHunk struct {
+	Content DecoratedContent
+}
+
+type DecoratedContent struct {
+	Plaintext string
+	HTML      string
+}
 
 // EventPathMatch is a subset of zoekt.FileMatch for our Event API.
 // It is used for result.FileMatch results with no line matches and


### PR DESCRIPTION
Should be good for this part, just an open question around timeout values/`ctx` and delineating ("successfully marked up HTML", "plaintext HTML" fallback, and "no highlighting")

- I'm at the junction where I need converted line matches to extract subparts of the highlighted content, so will tackle that in a separate PR: https://github.com/sourcegraph/sourcegraph/pull/24537

- Once that's done, can hook up the URL arguments, parsed in https://github.com/sourcegraph/sourcegraph/pull/24536.

<details>
  <summary>old notes </summary>

- Started off implementing a `Decorate()` method on file match. We can't have that though, because we can't call highlight code from `internal/search` (OK, reasonable). I thought, "should highlight code be in `internal/search` and I think the answer here is "no", it is suited to live in `cmd/frontend/internal`, since we should think of this decoration service happening in frontend. Conclusion: I'm exposing `Decorate()` as a function that takes an `FileMatch` result in highlight code in `frontend/internal`
- 
- Added a `FetchContent` method to `fm` result type. Don't know if we should expand `fm` result type with this method, or just have the `Decorate` function do all of the `git`/`fetch` instead once it gets an `fm`. In the context of `compute` method, it would be handier to have a `FetchContent` method (for rewriting results and data output) than inlining that content fetching into the highlight code. But, a small duplication of content fetching in both of highlight code and `compute` code is not that big of a deal either.

- Just calls highlight on the entire file contents, no range splitting based on line matches yet.

- Inline comments about TODOs and stubbed values.

---

Example invocation:

`https://sourcegraph.test:3443/search/stream?t=literal&display=500&q=test`

you'll see:

```
"repository":"github.com/Andoryuuta/NotSourcegraph","repoStars":6,"repoLastFetched":"2021-09-01T18:55:36.296464Z","branches":[""],"version":"df369f92e49de04cfbbf639e564a4e929d1a9f65","Content":[{"Value":{"Plaintext":"","HTML":"\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd class=\"line\" data-line=\"1\"/\u003e\u003ctd class=\"code\"\u003e\u003cdiv\u003e\u003cspan class=\"hl-source hl-python\"\u003e\u003cspan class=\"hl-meta hl-statement hl-import hl-python\"\u003e\u003cspan class=\"hl-keyword hl-control hl-import hl-python\"\u003eimport\u003c/span\u003e \u003cspan class=\"hl-meta hl-qualified-name hl-python\"\u003e\u003cspan class=\"hl-meta hl-generic-name hl-python\"\u003ecv2\u003c/span\u003e\u003c/span\u003e\u003c/span\u003e\n\u003c/span\u003e\u003c/div\u003e\u003c/td\u003e\u003c/tr blha blah blabh
```

</details>