### PR TITLE
executors: Reduce amount of heartbeat requests

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -88,7 +88,7 @@ func (c *Config) WorkerOptions() workerutil.WorkerOptions {
 		Name:              fmt.Sprintf("executor_%s_worker", c.QueueName),
 		NumHandlers:       c.MaximumNumJobs,
 		Interval:          c.QueuePollInterval,
-		HeartbeatInterval: 1 * time.Second,
+		HeartbeatInterval: 5 * time.Second,
 		Metrics:           makeWorkerMetrics(c.QueueName),
 		NumTotalJobs:      c.NumTotalJobs,
 		MaxActiveTime:     c.MaxActiveTime,


### PR DESCRIPTION
Since a reset would only happen after 25 seconds of silence, we can safely tone this down to 5 seconds. This will incur 5 times fewer requests from executors to the frontend servers.