### PR TITLE
github/authz: validate corresponding auth provider exists

### DIFF
--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -122,7 +122,7 @@ func ProvidersFromConfig(
 	}
 
 	if len(gitHubConns) > 0 {
-		ghProviders, ghProblems, ghWarnings := github.NewAuthzProviders(gitHubConns)
+		ghProviders, ghProblems, ghWarnings := github.NewAuthzProviders(gitHubConns, cfg.AuthProviders)
 		providers = append(providers, ghProviders...)
 		seriousProblems = append(seriousProblems, ghProblems...)
 		warnings = append(warnings, ghWarnings...)

--- a/internal/authz/github/authz.go
+++ b/internal/authz/github/authz.go
@@ -50,14 +50,14 @@ func NewAuthzProviders(
 	}
 
 	for _, p := range ps {
-		// Permissions require a corresponding GitHub oauth provider. Without one, repos
+		// Permissions require a corresponding GitHub OAuth provider. Without one, repos
 		// with restricted permissions will not be visible to non-admins.
 		if _, exists := githubAuthProviders[p.ServiceID()]; !exists {
 			warnings = append(warnings,
-				fmt.Sprintf("Did not find authentication provider matching %q. "+
+				fmt.Sprintf("Did not find authentication provider matching %[1]q. "+
 					"Check the [**site configuration**](/site-admin/configuration) to "+
-					"verify an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) exists for %s.",
-					p.ServiceID(), p.ServiceID()))
+					"verify an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) exists for %[1]s.",
+					p.ServiceID()))
 		}
 
 		// Check for other validation issues.

--- a/internal/authz/github/authz.go
+++ b/internal/authz/github/authz.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -18,8 +19,9 @@ import (
 // to false. "Warnings" are all other validation problems.
 func NewAuthzProviders(
 	conns []*types.GitHubConnection,
+	authProviders []schema.AuthProviders,
 ) (ps []authz.Provider, problems []string, warnings []string) {
-	// Authorization (i.e., permissions) providers
+	// Permissions providers
 	for _, c := range conns {
 		p, err := newAuthzProvider(c.URN, c.Authorization, c.Url, c.Token)
 		if err != nil {
@@ -29,7 +31,36 @@ func NewAuthzProviders(
 		}
 	}
 
+	// Auth providers (i.e. login mechanisms)
+	githubAuthProviders := make(map[string]struct{})
+	for _, p := range authProviders {
+		if p.Github != nil {
+			var id string
+			ghURL, err := url.Parse(p.Github.Url)
+			if err != nil {
+				// error reporting for this should happen elsewhere, for now just use what is given
+				id = p.Github.Url
+			} else {
+				// use codehost normalized URL as ID
+				ch := extsvc.NewCodeHost(ghURL, p.Github.Type)
+				id = ch.ServiceID
+			}
+			githubAuthProviders[id] = struct{}{}
+		}
+	}
+
 	for _, p := range ps {
+		// Permissions require a corresponding GitHub oauth provider. Without one, repos
+		// with restricted permissions will not be visible to non-admins.
+		if _, exists := githubAuthProviders[p.ServiceID()]; !exists {
+			warnings = append(warnings,
+				fmt.Sprintf("Did not find authentication provider matching %q. "+
+					"Check the [**site configuration**](/site-admin/configuration) to "+
+					"verify an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) exists for %s.",
+					p.ServiceID(), p.ServiceID()))
+		}
+
+		// Check for other validation issues.
 		for _, problem := range p.Validate() {
 			warnings = append(warnings, fmt.Sprintf("GitHub config for %s was invalid: %s", p.ServiceID(), problem))
 		}
@@ -38,6 +69,8 @@ func NewAuthzProviders(
 	return ps, problems, warnings
 }
 
+// newAuthzProvider instantiates a provider, or returns nil if authorization is disabled.
+// Errors returned are "serious problems".
 func newAuthzProvider(urn string, a *schema.GitHubAuthorization, instanceURL, token string) (authz.Provider, error) {
 	if a == nil {
 		return nil, nil

--- a/internal/authz/github/authz_test.go
+++ b/internal/authz/github/authz_test.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestNewAuthzProviders(t *testing.T) {
+	t.Run("no authorization", func(t *testing.T) {
+		providers, problems, warnings := NewAuthzProviders(
+			[]*types.GitHubConnection{{
+				GitHubConnection: &schema.GitHubConnection{
+					Url:           "https://github.com",
+					Authorization: nil,
+				},
+			}},
+			[]schema.AuthProviders{})
+		if len(providers) != 0 {
+			t.Fatalf("unexpected providers: %+v", providers)
+		}
+		if len(problems) != 0 {
+			t.Fatalf("unexpected problems: %+v", problems)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("unexpected warnings: %+v", warnings)
+		}
+	})
+
+	t.Run("no matching auth provider", func(t *testing.T) {
+		providers, problems, warnings := NewAuthzProviders(
+			[]*types.GitHubConnection{{
+				GitHubConnection: &schema.GitHubConnection{
+					Url:           "https://github.com/my-org",
+					Authorization: &schema.GitHubAuthorization{},
+				},
+			}},
+			[]schema.AuthProviders{{
+				Github: &schema.GitHubAuthProvider{
+					Url: "https://github.com",
+				},
+			}})
+		if len(providers) != 1 || providers[0] == nil {
+			t.Fatal("expected a provider")
+		}
+		if len(problems) != 0 {
+			t.Fatalf("unexpected problems: %+v", problems)
+		}
+		if len(warnings) != 1 || !strings.Contains(warnings[0], "not find authentication provider") {
+			t.Fatalf("unexpected warnings: %+v", warnings)
+		}
+	})
+
+	t.Run("auth enabled, matching auth provider", func(t *testing.T) {
+		providers, problems, warnings := NewAuthzProviders(
+			[]*types.GitHubConnection{{
+				GitHubConnection: &schema.GitHubConnection{
+					Url:           "https://github.com/",
+					Authorization: &schema.GitHubAuthorization{},
+				},
+			}},
+			[]schema.AuthProviders{{
+				Github: &schema.GitHubAuthProvider{
+					Url: "https://github.com",
+				},
+			}})
+		t.Log(providers[0].ServiceID())
+		if len(providers) != 1 || providers[0] == nil {
+			t.Fatal("expected a provider")
+		}
+		if len(problems) != 0 {
+			t.Fatalf("unexpected problems: %+v", problems)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("unexpected warnings: %+v", warnings)
+		}
+	})
+}


### PR DESCRIPTION
This looked complicated to generalize, so just went ahead with a check directly. This is not implemented as a "serious problem" because in https://github.com/sourcegraph/customer/issues/456#issuecomment-905738522 where a misconfiguration occurred, access was not unexpectedly granted to users that should not have access.

Closes https://github.com/sourcegraph/sourcegraph/issues/24419

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
