### PR TITLE
use pre-highlighted results if they are sent

### DIFF
--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -186,7 +186,7 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
 
         // TODO(camdencheek) handle unexpanded
         const expandedChildren = <FileMatchChildren {...props} result={result} grouped={grouped} />
-        const matchCount = grouped.reduce((n, group) => n + group.matches.length, 0)
+        const matchCount = grouped.reduce((previous, group) => previous + group.matches.length, 0)
         containerProps = {
             // TODO(camdencheek) make this collapsible
             collapsible: false,

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -95,7 +95,7 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
         </>
     )
 
-	// If we received pre-highlighted results, use them
+    // If we received pre-highlighted results, use them
     if (result.type == 'content' && result.content) {
         const grouped: MatchGroup[] = useMemo(
             () =>

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -163,9 +163,9 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
 
     const expandedChildren = <FileMatchChildren {...props} result={result} {...expandedMatchGroups} />
 
-    if (result.type === 'content' && result.content) {
+    if (result.type === 'content' && result.hunks) {
         const grouped: MatchGroup[] =
-            result.content?.map(
+            result.hunks?.map(
                 hunk =>
                     ({
                         blobLines: hunk.content.html?.split(/\r?\n/),
@@ -175,10 +175,10 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
                             highlightLength: match.end.column - match.start.column,
                             isInContext: false, // TODO(camdencheek) what is this for?
                         })),
-                        startLine: hunk.start,
-                        endLine: hunk.start + hunk.length,
+                        startLine: hunk.lineStart,
+                        endLine: hunk.lineStart + hunk.lineCount,
                         position: {
-                            line: hunk.matches[0].start.line + hunk.start + 1,
+                            line: hunk.matches[0].start.line + hunk.lineStart + 1,
                             character: hunk.matches[0].start.column + 1,
                         },
                     } as MatchGroup)
@@ -186,7 +186,7 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
 
         // TODO(camdencheek) handle unexpanded
         const expandedChildren = <FileMatchChildren {...props} result={result} grouped={grouped} />
-        const matchCount = grouped.reduce((prev, group) => prev + group.matches.length, 0)
+        const matchCount = grouped.reduce((n, group) => n + group.matches.length, 0)
         containerProps = {
             // TODO(camdencheek) make this collapsible
             collapsible: false,

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -142,6 +142,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                                     isLightTheme={isLightTheme}
                                     fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
                                     isFirst={index === 0}
+									blobLines={group.blobLines}
                                 />
                             </Link>
                         </div>

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -142,7 +142,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                                     isLightTheme={isLightTheme}
                                     fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
                                     isFirst={index === 0}
-									blobLines={group.blobLines}
+                                    blobLines={group.blobLines}
                                 />
                             </Link>
                         </div>

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -82,6 +82,8 @@ const calculateGroupPositions = (
  * Describes a single group of matches.
  */
 export interface MatchGroup {
+    blobLines?: string[]
+
     // The matches in this group to display.
     matches: {
         line: number

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -38,6 +38,30 @@ export interface ContentMatch {
     branches?: string[]
     version?: string
     lineMatches: LineMatch[]
+    content?: DecoratedHunk[]
+}
+
+export interface DecoratedHunk {
+    content: DecoratedContent
+    start: number
+    length: number
+    matches: Range[]
+}
+
+export interface DecoratedContent {
+    plaintext?: string
+    html?: string
+}
+
+export interface Range {
+    start: Location
+    end: Location
+}
+
+export interface Location {
+    offset: number
+    line: number
+    column: number
 }
 
 interface LineMatch {
@@ -375,6 +399,8 @@ export interface StreamSearchOptions {
     caseSensitive: boolean
     versionContext: string | undefined
     trace: string | undefined
+    decorationKinds?: string[]
+    decorationContextLines?: number
 }
 
 /**
@@ -390,12 +416,17 @@ function search({
     caseSensitive,
     versionContext,
     trace,
+    decorationKinds,
+    decorationContextLines,
 }: StreamSearchOptions): Observable<SearchEvent> {
     return new Observable<SearchEvent>(observer => {
         const parameters = [
             ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
+            ['decorationLimit', '15'],
+            ['decorationKind', (decorationKinds || ['html']).join('|')],
+            ['decorationContextLines', decorationContextLines || 1],
             ['display', '1500'],
         ]
         if (versionContext) {

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -426,7 +426,7 @@ function search({
             ['t', patternType as string],
             ['decorationLimit', '15'],
             ['decorationKind', (decorationKinds || ['html']).join('|')],
-            ['decorationContextLines', decorationContextLines || 1],
+            ['decorationContextLines', (decorationContextLines || '1').toString()],
             ['display', '1500'],
         ]
         if (versionContext) {

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -38,13 +38,13 @@ export interface ContentMatch {
     branches?: string[]
     version?: string
     lineMatches: LineMatch[]
-    content?: DecoratedHunk[]
+    hunks?: DecoratedHunk[]
 }
 
 export interface DecoratedHunk {
     content: DecoratedContent
-    start: number
-    length: number
+    lineStart: number
+    lineCount: number
     matches: Range[]
 }
 
@@ -424,9 +424,9 @@ function search({
             ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
-            ['decorationLimit', '15'],
-            ['decorationKind', (decorationKinds || ['html']).join('|')],
-            ['decorationContextLines', (decorationContextLines || '1').toString()],
+            ['dL', '15'],
+            ['dK', (decorationKinds || ['html']).join('|')],
+            ['dCL', (decorationContextLines || '1').toString()],
             ['display', '1500'],
         ]
         if (versionContext) {

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -424,9 +424,9 @@ function search({
             ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
-            ['dL', '15'],
-            ['dK', (decorationKinds || ['html']).join('|')],
-            ['dCL', (decorationContextLines || '1').toString()],
+            ['dl', '15'],
+            ['dk', (decorationKinds || ['html']).join('|')],
+            ['dc', (decorationContextLines || '1').toString()],
             ['display', '1500'],
         ]
         if (versionContext) {

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -26,7 +26,7 @@ type EventContentMatch struct {
 	RepoLastFetched *time.Time       `json:"repoLastFetched,omitempty"`
 	Branches        []string         `json:"branches,omitempty"`
 	Version         string           `json:"version,omitempty"`
-	Content         []DecoratedHunk  `json:"content"`
+	Hunks           []DecoratedHunk  `json:"hunks"`
 	LineMatches     []EventLineMatch `json:"lineMatches"`
 }
 
@@ -52,11 +52,10 @@ type EventPathMatch struct {
 func (e *EventPathMatch) eventMatch() {}
 
 type DecoratedHunk struct {
-	// TODO union of plaintext/html/ansi/etc.
-	Content DecoratedContent `json:"content"`
-	Start   int              `json:"start"`
-	Length  int              `json:"length"`
-	Matches []Range          `json:"matches,omitempty"`
+	Content   DecoratedContent `json:"content"`
+	LineStart int              `json:"lineStart"`
+	LineCount int              `json:"lineCount"`
+	Matches   []Range          `json:"matches,omitempty"`
 }
 
 type Range struct {
@@ -73,7 +72,6 @@ type Location struct {
 type DecoratedContent struct {
 	Plaintext string `json:"plaintext,omitempty"`
 	HTML      string `json:"html,omitempty"`
-	// ANSI string
 }
 
 // EventLineMatch is a subset of zoekt.LineMatch for our Event API.

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -19,15 +19,15 @@ type EventContentMatch struct {
 	// Type is always FileMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
-	Path            string     `json:"name"`
-	RepositoryID    int32      `json:"repositoryID"`
-	Repository      string     `json:"repository"`
-	RepoStars       int        `json:"repoStars,omitempty"`
-	RepoLastFetched *time.Time `json:"repoLastFetched,omitempty"`
-	Branches        []string   `json:"branches,omitempty"`
-	Version         string     `json:"version,omitempty"`
-
-	LineMatches []EventLineMatch `json:"lineMatches"`
+	Path            string           `json:"name"`
+	RepositoryID    int32            `json:"repositoryID"`
+	Repository      string           `json:"repository"`
+	RepoStars       int              `json:"repoStars,omitempty"`
+	RepoLastFetched *time.Time       `json:"repoLastFetched,omitempty"`
+	Branches        []string         `json:"branches,omitempty"`
+	Version         string           `json:"version,omitempty"`
+	Content         []DecoratedHunk  `json:"content"`
+	LineMatches     []EventLineMatch `json:"lineMatches"`
 }
 
 func (e *EventContentMatch) eventMatch() {}
@@ -50,6 +50,31 @@ type EventPathMatch struct {
 }
 
 func (e *EventPathMatch) eventMatch() {}
+
+type DecoratedHunk struct {
+	// TODO union of plaintext/html/ansi/etc.
+	Content DecoratedContent `json:"content"`
+	Start   int              `json:"start"`
+	Length  int              `json:"length"`
+	Matches []Range          `json:"matches,omitempty"`
+}
+
+type Range struct {
+	Start Location `json:"start"`
+	End   Location `json:"end"`
+}
+
+type Location struct {
+	Offset int `json:"offset"`
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type DecoratedContent struct {
+	Plaintext string `json:"plaintext,omitempty"`
+	HTML      string `json:"html,omitempty"`
+	// ANSI string
+}
 
 // EventLineMatch is a subset of zoekt.LineMatch for our Event API.
 type EventLineMatch struct {
@@ -112,6 +137,7 @@ type EventCommitMatch struct {
 	Label           string     `json:"label"`
 	URL             string     `json:"url"`
 	Detail          string     `json:"detail"`
+	RepositoryID    int32      `json:"repositoryID"`
 	Repository      string     `json:"repository"`
 	RepoStars       int        `json:"repoStars,omitempty"`
 	RepoLastFetched *time.Time `json:"repoLastFetched,omitempty"`


### PR DESCRIPTION
Now that we've got some interfaces defined for sending pre-highlighted
results, this PR modifies the UI to use those highlights if they exist.
This should not modify any current behavior since there are currently no
highlights being sent. There are still some TODOs around allowing
collapsing results, but those can be handled in followup PRs.

Stacked on #24521 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
