### PR TITLE
authz/github: do not recommend groupsCacheTTL, document allowGroupsPermissionsSync

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -37,7 +37,7 @@ The GitHub service requires a `token` in order to access their API. There are tw
 No token scopes are required if you only want to sync public repositories and don't want to use any of the following features. Otherwise, the following token scopes are required:
 
 - `repo` to sync private repositories from GitHub to Sourcegraph.
-- `read:org` to use the `"allowOrgs"` setting [with a GitHub authentication provider](../auth/index.md#github) and `groupsCacheTTL` for [permissions caching](../repo/permissions.md#permissions-caching).
+- `read:org` to use the `"allowOrgs"` setting [with a GitHub authentication provider](../auth/index.md#github) and external service `"authorization.groupsCacheTTL"` (which also requires `"allowGroupsPermissionsSync"`) for [permissions caching](../repo/permissions.md#permissions-caching).
 - `repo`, `read:org`, `user:email`, and `read:discussion` to use [batch changes](../../batch_changes/index.md) with GitHub repositories. See "[Code host interactions in batch changes](../../batch_changes/explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes)" for details.
 
 > NOTE: If you plan to use repository permissions with [background permissions syncing](../repo/permissions.md#background-permissions-syncing), an access token that has admin access to all private repositories is required. It is because only admin can list all collaborators of a repository.

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -57,11 +57,26 @@ This caching behaviour can be enabled via the `authorization.groupsCacheTTL` fie
 
 ```json
 {
-   "url": "https://github.com",
+   "url": "https://github.example.com",
    "token": "$PERSONAL_ACCESS_TOKEN",
    "authorization": {
      "groupsCacheTTL": 72, // hours
    }
+}
+```
+
+In the corresponding [authorization provider](../auth/index.md#github), the `allowGroupsPermissionsSync` field must be set as well for the correct auth scopes to be requested from users:
+
+```json
+{
+  // ...
+  "auth.providers": [
+    {
+      "type": "github",
+      "url": "https://github.example.com",
+      "allowGroupsPermissionsSync": true,
+    }
+  ]
 }
 ```
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -53,7 +53,7 @@ The events we consume are:
 
 For GitHub providers, Sourcegraph can leverage caching of GitHub [team](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/managing-team-access-to-an-organization-repository) and [organization](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization) permissions - [learn more about permissions caching](#permissions-caching).
 
-Caching behaviour can be enabld via the `authorization.groupsCacheTTL` field:
+This caching behaviour can be enabled via the `authorization.groupsCacheTTL` field:
 
 ```json
 {
@@ -65,7 +65,10 @@ Caching behaviour can be enabld via the `authorization.groupsCacheTTL` field:
 }
 ```
 
-We currently recommend a default of `72` (hours, or 3 days) for the `groupsCacheTTL`. A lower value can be set if your teams and organizations change frequently, though the chosen value must be at least several hours for the cache to be leveraged in the event of being rate-limited (which takes [an hour to recover from](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)).
+> NOTE: You should only try this if your GitHub setup makes extensive use of GitHub teams and organizations to distribute access to repositories and your number of `users * repos` is greater than 500,000 (which roughly corresponds to the scale at which [GitHub rate limits might become an issue](#permissions-sync-times)).
+<!-- 5,000 requests an hour * 100 items per page = approx. 500,000 items before hitting a limit -->
+
+When enabling this feature, we currently recommend a default of `72` (hours, or 3 days) for `groupsCacheTTL`. A lower value can be set if your teams and organizations change frequently, though the chosen value must be at least several hours for the cache to be leveraged in the event of being rate-limited (which takes [an hour to recover from](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)).
 
 Caches can also be [manually invalidated](#permissions-caching) if necessary.
 

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -165,7 +165,7 @@
       "type": "object",
       "properties": {
         "groupsCacheTTL": {
-          "description": "Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](http://localhost:5080/admin/repo/permissions#teams-and-organizations-permissions-caching).",
+          "description": "Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/repo/permissions#teams-and-organizations-permissions-caching).",
           "type": "number",
           "default": 72
         }

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -165,12 +165,11 @@
       "type": "object",
       "properties": {
         "groupsCacheTTL": {
-          "description": "Hours cached permissions from teams and organizations should be kept for. A negative value disables syncing from teams and organizations, and syncs all permisisons directly from user repository affiliations instead (note that this requires more API requests). In both cases, the same permissions are the synchronized. Ensure the token used for the external service has `read:org` scope. ",
+          "description": "Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](http://localhost:5080/admin/repo/permissions#teams-and-organizations-permissions-caching).",
           "type": "number",
           "default": 72
         }
-      },
-      "examples": [{ "groupsCacheTTL": 72 }]
+      }
     },
     "cloudGlobal": {
       "title": "CloudGlobal",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -631,7 +631,7 @@ type GitHubAuthProvider struct {
 
 // GitHubAuthorization description: If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type "github" with the same `url` field as specified in this `GitHubConnection`.
 type GitHubAuthorization struct {
-	// GroupsCacheTTL description: Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](http://localhost:5080/admin/repo/permissions#teams-and-organizations-permissions-caching).
+	// GroupsCacheTTL description: Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/repo/permissions#teams-and-organizations-permissions-caching).
 	GroupsCacheTTL float64 `json:"groupsCacheTTL,omitempty"`
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -631,7 +631,7 @@ type GitHubAuthProvider struct {
 
 // GitHubAuthorization description: If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type "github" with the same `url` field as specified in this `GitHubConnection`.
 type GitHubAuthorization struct {
-	// GroupsCacheTTL description: Hours cached permissions from teams and organizations should be kept for. A negative value disables syncing from teams and organizations, and syncs all permisisons directly from user repository affiliations instead (note that this requires more API requests). In both cases, the same permissions are the synchronized. Ensure the token used for the external service has `read:org` scope.
+	// GroupsCacheTTL description: Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](http://localhost:5080/admin/repo/permissions#teams-and-organizations-permissions-caching).
 	GroupsCacheTTL float64 `json:"groupsCacheTTL,omitempty"`
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -613,7 +613,7 @@ type GitCommitDescription struct {
 
 // GitHubAuthProvider description: Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.
 type GitHubAuthProvider struct {
-	// AllowGroupsPermissionsSync description: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/repo/permissions#permissions-caching).
+	// AllowGroupsPermissionsSync description: Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/repo/permissions#permissions-caching).
 	AllowGroupsPermissionsSync bool `json:"allowGroupsPermissionsSync,omitempty"`
 	// AllowOrgs description: Restricts new logins to members of these GitHub organizations. Existing sessions won't be invalidated. Leave empty or unset for no org restrictions.
 	AllowOrgs []string `json:"allowOrgs,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1318,7 +1318,7 @@
           }
         },
         "allowGroupsPermissionsSync": {
-          "description": "Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/repo/permissions#permissions-caching).",
+          "description": "Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/repo/permissions#permissions-caching).",
           "default": false,
           "type": "boolean"
         }


### PR DESCRIPTION
Adding example value makes `groupsCacheTTL` a recommended default, which we no longer want to push for. This PR makes the experimental status and niche use case more apparent, and removes the example.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
![Kapture 2021-09-01 at 17 26 20](https://user-images.githubusercontent.com/23356519/131747649-fe3fbef3-159a-41b3-acfe-b62bde400c90.gif)
