### PR TITLE
search: calculate hunks and match ranges for highlight decoration

### DIFF
--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -1,0 +1,77 @@
+package search
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	stream "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+)
+
+// segmentToRangs converts line match ranges into absolute ranges.
+func segmentToRanges(lineNumber int, segments [][2]int32) []stream.Range {
+	ranges := make([]stream.Range, 0, len(segments))
+	for _, segment := range segments {
+		ranges = append(ranges, stream.Range{
+			Start: stream.Location{
+				Offset: -1,
+				Line:   lineNumber,
+				Column: int(segment[0]),
+			},
+			End: stream.Location{
+				Offset: -1,
+				Line:   lineNumber,
+				Column: int(segment[0]) + int(segment[1]),
+			},
+		})
+	}
+	return ranges
+}
+
+// group is a list of contiguous line matches by line number.
+type group []*result.LineMatch
+
+// toHunk converts a group of line matches to a hunk. A hunk comprises:
+// (1) file `Content` (decorated for rendering depending on the request) that
+// spans `LineStart + LineCount`, and
+// (2) a list `Matches` which specify ranges of values to emphasize specially
+// (e.g., with overlay-highlights) within the hunk range.
+func toHunk(group group) stream.DecoratedHunk {
+	matches := make([]stream.Range, 0, len(group))
+	for _, line := range group {
+		matches = append(matches, segmentToRanges(int(line.LineNumber), line.OffsetAndLengths)...)
+	}
+	return stream.DecoratedHunk{
+		Content:   stream.DecoratedContent{Plaintext: "Placeholder"}, // TODO(rvantonder): populate this with decorated content
+		LineStart: int(group[0].LineNumber),
+		LineCount: len(group),
+		Matches:   matches,
+	}
+}
+
+// groupLineMatches converts a flat slice of line matches to groups of
+// contiguous line matches based on line numbers.
+func groupLineMatches(lineMatches []*result.LineMatch) []group {
+	var groups []group
+	var previousLine *result.LineMatch
+	var currentGroup group
+	for _, line := range lineMatches {
+		if previousLine == nil {
+			previousLine = line
+		}
+		if len(currentGroup) == 0 {
+			currentGroup = append(currentGroup, line)
+			// Invariant: previousLine is set to first line match.
+			continue
+		}
+		if line.LineNumber-1 == previousLine.LineNumber {
+			currentGroup = append(currentGroup, line)
+			previousLine = line
+			continue
+		}
+		groups = append(groups, currentGroup)
+		currentGroup = group{line}
+		previousLine = line
+	}
+	if len(currentGroup) > 0 {
+		groups = append(groups, currentGroup)
+	}
+	return groups
+}

--- a/cmd/frontend/internal/search/decorate_test.go
+++ b/cmd/frontend/internal/search/decorate_test.go
@@ -1,0 +1,131 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	stream "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+)
+
+func TestGroupLineMatches(t *testing.T) {
+	data := []*result.LineMatch{
+		{LineNumber: 1},
+		{LineNumber: 2},
+		{LineNumber: 3},
+		{LineNumber: 5},
+		{LineNumber: 6},
+		{LineNumber: 8},
+	}
+
+	want := []group{
+		{
+			{LineNumber: 1},
+			{LineNumber: 2},
+			{LineNumber: 3},
+		},
+		{
+			{LineNumber: 5},
+			{LineNumber: 6},
+		},
+		{
+			{LineNumber: 8},
+		},
+	}
+
+	got := groupLineMatches(data)
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("line match group partition wrong (-want +got):\n%s", diff)
+	}
+}
+
+func TestToHunk(t *testing.T) {
+	data := []group{
+		{
+			{LineNumber: 1, OffsetAndLengths: [][2]int32{{0, 1}}},
+			{LineNumber: 2, OffsetAndLengths: [][2]int32{{2, 3}, {4, 5}}},
+			{LineNumber: 3, OffsetAndLengths: [][2]int32{{6, 7}, {8, 9}}},
+		},
+		{
+			{LineNumber: 5, OffsetAndLengths: [][2]int32{{0, 1}}},
+			{LineNumber: 6, OffsetAndLengths: [][2]int32{{2, 3}, {4, 5}}},
+		},
+		{
+			{LineNumber: 8, OffsetAndLengths: [][2]int32{{6, 7}, {8, 9}}},
+		},
+	}
+
+	want := []stream.DecoratedHunk{
+		{
+			Content:   stream.DecoratedContent{Plaintext: "Placeholder"},
+			LineStart: 1,
+			LineCount: 3,
+			Matches: []stream.Range{
+				{
+					Start: stream.Location{Offset: -1, Line: 1, Column: 0},
+					End:   stream.Location{Offset: -1, Line: 1, Column: 1},
+				},
+				{
+					Start: stream.Location{Offset: -1, Line: 2, Column: 2},
+					End:   stream.Location{Offset: -1, Line: 2, Column: 5},
+				},
+				{
+					Start: stream.Location{Offset: -1, Line: 2, Column: 4},
+					End:   stream.Location{Offset: -1, Line: 2, Column: 9},
+				},
+				{
+					Start: stream.Location{Offset: -1, Line: 3, Column: 6},
+					End:   stream.Location{Offset: -1, Line: 3, Column: 13},
+				},
+				{
+					Start: stream.Location{Offset: -1, Line: 3, Column: 8},
+					End:   stream.Location{Offset: -1, Line: 3, Column: 17},
+				},
+			},
+		},
+		{
+			Content:   stream.DecoratedContent{Plaintext: "Placeholder"},
+			LineStart: 5,
+			LineCount: 2,
+			Matches: []stream.Range{
+				{
+					Start: stream.Location{Offset: -1, Line: 5, Column: 0},
+					End:   stream.Location{Offset: -1, Line: 5, Column: 1},
+				},
+				{
+					Start: stream.Location{Offset: -1, Line: 6, Column: 2},
+					End:   stream.Location{Offset: -1, Line: 6, Column: 5},
+				},
+				{
+					Start: stream.Location{Offset: -1, Line: 6, Column: 4},
+					End:   stream.Location{Offset: -1, Line: 6, Column: 9},
+				},
+			},
+		},
+		{
+			Content:   stream.DecoratedContent{Plaintext: "Placeholder"},
+			LineStart: 8,
+			LineCount: 1,
+			Matches: []stream.Range{
+				{
+					Start: stream.Location{Offset: -1, Line: 8, Column: 6},
+					End:   stream.Location{Offset: -1, Line: 8, Column: 13},
+				},
+				{
+					Start: stream.Location{Offset: -1, Line: 8, Column: 8},
+					End:   stream.Location{Offset: -1, Line: 8, Column: 17},
+				},
+			}},
+	}
+
+	var got []stream.DecoratedHunk
+	for _, group := range data {
+		got = append(got, toHunk(group))
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("line match group partition wrong (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
As per description. This is unused currently and will be hooked up to highlighting code in subsequent PRs.

This logic seems best to live in `cmd/frontend/internal/search/decorate.go` right now, because we'll need to call the highlight service from inside `frontend/internal`, which is very dependent on the conversion logic in this PR.