### PR TITLE
internal/repos: Better name for argument to EnqueueSingleSyncJob

### DIFF
--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -550,7 +550,7 @@ RETURNING updated_at
 
 // EnqueueSingleSyncJob enqueues a single sync job for the given external
 // service if it is not already queued or processing.
-func (s *Store) EnqueueSingleSyncJob(ctx context.Context, id int64) (err error) {
+func (s *Store) EnqueueSingleSyncJob(ctx context.Context, extSvcID int64) (err error) {
 	q := sqlf.Sprintf(`
 INSERT INTO external_service_sync_jobs (external_service_id)
 SELECT %s
@@ -564,7 +564,7 @@ WHERE NOT EXISTS (
 		OR es.cloud_default
 	)
 )
-`, id, id)
+`, extSvcID, extSvcID)
 	return s.Exec(ctx, q)
 }
 


### PR DESCRIPTION
This commit renames the arg `id` to `extSvcID` in `EnqueueSingleSyncJob`.

I was reading this section of the code today and it wasn't immediately
obvious to me what the id referred to. This method is invoked from
`repos.Syncer.TriggerExternalServiceSync` and it is obvious if one looks
at the call site but not when looking independently at the method
definition.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
