### PR TITLE
frontend: Extract logic from for loop so it can be traced

### DIFF
--- a/cmd/frontend/internal/cloneurls/clone_urls.go
+++ b/cmd/frontend/internal/cloneurls/clone_urls.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -55,58 +56,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL st
 		opt.AfterID = svcs[len(svcs)-1].ID // Advance the cursor
 
 		for _, svc := range svcs {
-			cfg, err := extsvc.ParseConfig(svc.Kind, svc.Config)
-			if err != nil {
-				return "", errors.Wrap(err, "parse config")
-			}
-
-			var host string
-			var rs reposource.RepoSource
-			switch c := cfg.(type) {
-			case *schema.GitHubConnection:
-				rs = reposource.GitHub{GitHubConnection: c}
-				host = c.Url
-			case *schema.GitLabConnection:
-				rs = reposource.GitLab{GitLabConnection: c}
-				host = c.Url
-			case *schema.BitbucketServerConnection:
-				rs = reposource.BitbucketServer{BitbucketServerConnection: c}
-				host = c.Url
-			case *schema.AWSCodeCommitConnection:
-				rs = reposource.AWS{AWSCodeCommitConnection: c}
-				// AWS type does not have URL
-			case *schema.GitoliteConnection:
-				rs = reposource.Gitolite{GitoliteConnection: c}
-				// Gitolite type does not have URL
-			case *schema.PhabricatorConnection:
-				// If this repository is mirrored by Phabricator, its clone URL should be
-				// handled by a supported code host or an OtherExternalServiceConnection.
-				// If this repository is hosted by Phabricator, it should be handled by
-				// an OtherExternalServiceConnection.
-				continue
-			case *schema.OtherExternalServiceConnection:
-				rs = reposource.Other{OtherExternalServiceConnection: c}
-				host = c.Url
-			default:
-				return "", errors.Errorf("unexpected connection type: %T", cfg)
-			}
-
-			// Submodules are allowed to have relative paths for their .gitmodules URL.
-			// In that case, we default to stripping any relative prefix and crafting
-			// a new URL based on the reposource's host, if available.
-			if strings.HasPrefix(cloneURL, "../") && host != "" {
-				u, err := neturl.Parse(cloneURL)
-				if err != nil {
-					return "", err
-				}
-				base, err := neturl.Parse(host)
-				if err != nil {
-					return "", err
-				}
-				cloneURL = base.ResolveReference(u).String()
-			}
-
-			repoName, err := rs.CloneURLToRepoName(cloneURL)
+			repoName, err := getRepoNameFromService(ctx, cloneURL, svc)
 			if err != nil {
 				return "", err
 			}
@@ -126,5 +76,65 @@ func ReposourceCloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL st
 			Url: "https://github.com",
 		},
 	}
+	return rs.CloneURLToRepoName(cloneURL)
+}
+
+func getRepoNameFromService(ctx context.Context, cloneURL string, svc *types.ExternalService) (api.RepoName, error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "getRepoNameFromService")
+	defer span.Finish()
+	span.SetTag("ExternalService.ID", svc.ID)
+	span.SetTag("ExternalService.Kind", svc.Kind)
+
+	cfg, err := extsvc.ParseConfig(svc.Kind, svc.Config)
+	if err != nil {
+		return "", errors.Wrap(err, "parse config")
+	}
+
+	var host string
+	var rs reposource.RepoSource
+	switch c := cfg.(type) {
+	case *schema.GitHubConnection:
+		rs = reposource.GitHub{GitHubConnection: c}
+		host = c.Url
+	case *schema.GitLabConnection:
+		rs = reposource.GitLab{GitLabConnection: c}
+		host = c.Url
+	case *schema.BitbucketServerConnection:
+		rs = reposource.BitbucketServer{BitbucketServerConnection: c}
+		host = c.Url
+	case *schema.AWSCodeCommitConnection:
+		rs = reposource.AWS{AWSCodeCommitConnection: c}
+		// AWS type does not have URL
+	case *schema.GitoliteConnection:
+		rs = reposource.Gitolite{GitoliteConnection: c}
+		// Gitolite type does not have URL
+	case *schema.PhabricatorConnection:
+		// If this repository is mirrored by Phabricator, its clone URL should be
+		// handled by a supported code host or an OtherExternalServiceConnection.
+		// If this repository is hosted by Phabricator, it should be handled by
+		// an OtherExternalServiceConnection.
+		return "", nil
+	case *schema.OtherExternalServiceConnection:
+		rs = reposource.Other{OtherExternalServiceConnection: c}
+		host = c.Url
+	default:
+		return "", errors.Errorf("unexpected connection type: %T", cfg)
+	}
+
+	// Submodules are allowed to have relative paths for their .gitmodules URL.
+	// In that case, we default to stripping any relative prefix and crafting
+	// a new URL based on the reposource's host, if available.
+	if strings.HasPrefix(cloneURL, "../") && host != "" {
+		u, err := neturl.Parse(cloneURL)
+		if err != nil {
+			return "", err
+		}
+		base, err := neturl.Parse(host)
+		if err != nil {
+			return "", err
+		}
+		cloneURL = base.ResolveReference(u).String()
+	}
+
 	return rs.CloneURLToRepoName(cloneURL)
 }

--- a/cmd/frontend/internal/cloneurls/clone_urls.go
+++ b/cmd/frontend/internal/cloneurls/clone_urls.go
@@ -80,7 +80,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL st
 }
 
 func getRepoNameFromService(ctx context.Context, cloneURL string, svc *types.ExternalService) (api.RepoName, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "getRepoNameFromService")
+	span, _ := ot.StartSpanFromContext(ctx, "getRepoNameFromService")
 	defer span.Finish()
 	span.SetTag("ExternalService.ID", svc.ID)
 	span.SetTag("ExternalService.Kind", svc.Kind)

--- a/internal/conf/reposource/common.go
+++ b/internal/conf/reposource/common.go
@@ -15,7 +15,7 @@ import (
 // RepoSource is a wrapper around a repository source (typically a code host config) that provides a
 // method to map clone URLs to repo names using only the configuration (i.e., no network requests).
 type RepoSource interface {
-	// cloneURLToRepoName maps a Git clone URL (format documented here:
+	// CloneURLToRepoName maps a Git clone URL (format documented here:
 	// https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a) to the expected repo name for the
 	// repository on the code host.  It does not actually check if the repository exists in the code
 	// host. It merely does the mapping based on the rules set in the code host config.

--- a/internal/conf/reposource/custom.go
+++ b/internal/conf/reposource/custom.go
@@ -55,7 +55,7 @@ func CustomCloneURLToRepoName(cloneURL string) (repoName api.RepoName) {
 			return api.RepoName(name)
 		}
 	}
-	return api.RepoName("")
+	return ""
 }
 
 func mapString(r *regexp.Regexp, in string, outTmpl string) string {


### PR DESCRIPTION
We loop over all external services trying to find a repo name from a
clone URL. It looks like one of them is slow but we can't trace which
one until we extract into a separate function and add tracing.
