### PR TITLE
internal/repos: Add context for cloud_default repo syncing

### DIFF
--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -555,8 +555,8 @@ RETURNING updated_at
 // 1. cloud_default does not define any repos in its config
 // 2. repos under the cloud_default are lazily synced the first time a user accesses them
 //
-// This is a limitation of our current repo syncing architecture. The cloud_default only applies for
-// sourcegraph.com and manages greater than 4 million repositories.
+// This is a limitation of our current repo syncing architecture. The cloud_default flag is only set
+// on sourcegraph.com and manages public GitHub  and GitLab repositories that have been lazily synced```
 func (s *Store) EnqueueSingleSyncJob(ctx context.Context, extSvcID int64) (err error) {
 	q := sqlf.Sprintf(`
 INSERT INTO external_service_sync_jobs (external_service_id)

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -548,8 +548,15 @@ WHERE id = %s
 RETURNING updated_at
 `
 
-// EnqueueSingleSyncJob enqueues a single sync job for the given external
-// service if it is not already queued or processing.
+// EnqueueSingleSyncJob enqueues a single sync job for the given external service if it is not
+// already queued or processing. Additionally, it also skips queueing up a sync job for
+// cloud_default external services. This is done to avoid the sync job for the cloud_default
+// triggering a deletion of repos because:
+// 1. cloud_default does not define any repos in its config
+// 2. repos under the cloud_default are lazily synced the first time a user accesses them
+//
+// This is a limitation of our current repo syncing architecture. The cloud_default only applies for
+// sourcegraph.com and manages greater than 4 million repositories.
 func (s *Store) EnqueueSingleSyncJob(ctx context.Context, extSvcID int64) (err error) {
 	q := sqlf.Sprintf(`
 INSERT INTO external_service_sync_jobs (external_service_id)

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -556,7 +556,8 @@ RETURNING updated_at
 // 2. repos under the cloud_default are lazily synced the first time a user accesses them
 //
 // This is a limitation of our current repo syncing architecture. The cloud_default flag is only set
-// on sourcegraph.com and manages public GitHub  and GitLab repositories that have been lazily synced```
+// on sourcegraph.com and manages public GitHub and GitLab repositories that have been lazily
+// synced.
 func (s *Store) EnqueueSingleSyncJob(ctx context.Context, extSvcID int64) (err error) {
 	q := sqlf.Sprintf(`
 INSERT INTO external_service_sync_jobs (external_service_id)


### PR DESCRIPTION
Follow up of #24412.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
