### PR TITLE
Extract process-output utilities from sg into lib/process

### DIFF
--- a/dev/sg/go.sum
+++ b/dev/sg/go.sum
@@ -626,6 +626,7 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc h1:jUIKcSPO9MoMJBbEoyE/RJoE8vz7Mb8AjvifMMwSyvY=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -642,6 +643,7 @@ github.com/snowflakedb/gosnowflake v1.3.5/go.mod h1:13Ky+lxzIm3VqNDZJdyvu9MCGy+W
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/sourcegraph/batch-change-utils v0.0.0-20210708162152-c9f35b905d94/go.mod h1:kKNRPN6dxuXwC4UUhPVcAJsvz4EVEfI0jyN5HUJsazA=
+github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -123,7 +123,7 @@ func startCmd(ctx context.Context, dir string, cmd Command, globalEnv map[string
 	sc.Cmd.Env = makeEnv(globalEnv, cmd.Env)
 
 	var stdoutWriter, stderrWriter io.Writer
-	logger := newCmdLogger(cmd.Name, stdout.Out)
+	logger := newCmdLogger(commandCtx, cmd.Name, stdout.Out)
 	if cmd.IgnoreStdout {
 		stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "Ignoring stdout of %s", cmd.Name))
 		stdoutWriter = sc.stdoutBuf

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -1,15 +1,14 @@
 package run
 
 import (
-	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"os/exec"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/sourcegraph/lib/process"
 )
 
 type Command struct {
@@ -137,7 +136,7 @@ func startCmd(ctx context.Context, dir string, cmd Command, globalEnv map[string
 		stderrWriter = io.MultiWriter(logger, sc.stderrBuf)
 	}
 
-	wg, err := pipeProcessOutput(sc.Cmd, stdoutWriter, stderrWriter)
+	wg, err := process.PipeOutput(sc.Cmd, stdoutWriter, stderrWriter)
 	if err != nil {
 		return nil, err
 	}
@@ -148,33 +147,4 @@ func startCmd(ctx context.Context, dir string, cmd Command, globalEnv map[string
 	}
 
 	return sc, nil
-}
-
-func pipeProcessOutput(c *exec.Cmd, stdoutWriter, stderrWriter io.Writer) (*sync.WaitGroup, error) {
-	stdoutPipe, err := c.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	stderrPipe, err := c.StderrPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	wg := &sync.WaitGroup{}
-
-	readIntoBuf := func(w io.Writer, r io.Reader) {
-		defer wg.Done()
-
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			fmt.Fprintln(w, scanner.Text())
-		}
-	}
-
-	wg.Add(2)
-	go readIntoBuf(stdoutWriter, stdoutPipe)
-	go readIntoBuf(stderrWriter, stderrPipe)
-
-	return wg, nil
 }

--- a/dev/sg/internal/run/logger.go
+++ b/dev/sg/internal/run/logger.go
@@ -1,30 +1,12 @@
 package run
 
 import (
-	"bytes"
+	"context"
 	"hash/fnv"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/sourcegraph/lib/process"
 )
-
-// tickDuration is the time to wait before writing the buffer contents
-// without having received a newline.
-var tickDuration = 2 * time.Millisecond
-
-// cmdLogger is a simplified version of goreman's logger:
-// https://github.com/mattn/goreman/blob/master/log.go
-type cmdLogger struct {
-	out   *output.Output
-	name  string
-	color output.Style
-
-	// buf is used to keep partial lines buffered before flushing them (either
-	// on the next newline or after tickDuration)
-	buf    *bytes.Buffer
-	writes chan []byte
-	done   chan struct{}
-}
 
 func nameToColor(s string, v ...interface{}) output.Style {
 	h := fnv.New32()
@@ -33,90 +15,18 @@ func nameToColor(s string, v ...interface{}) output.Style {
 	return output.Fg256Color((int(h.Sum32()) % 220))
 }
 
-// newCmdLogger returns a new cmdLogger instance and spawns a goroutine in the
-// background that regularily flushed the logged output to the given output..
-func newCmdLogger(name string, out *output.Output) *cmdLogger {
-	l := &cmdLogger{
-		name:   name,
-		out:    out,
-		color:  nameToColor(name),
-		writes: make(chan []byte),
-		done:   make(chan struct{}),
-		buf:    &bytes.Buffer{},
+// newCmdLogger returns a new process.Logger with a unique color based on the name of the cmd.
+func newCmdLogger(ctx context.Context, name string, out *output.Output) *process.Logger {
+	color := nameToColor(name)
+
+	sink := func(data string) {
+		// TODO: This always adds a newline, which is not always what we want. When
+		// we flush partial lines, we don't want to add a newline character. What
+		// we need to do: extend the `*output.Output` type to have a
+		// `WritefNoNewline` (yes, bad name) method.
+		//
+		out.Writef("%s%s[%s]%s %s", output.StyleBold, color, name, output.StyleReset, data)
 	}
 
-	go l.writeLines()
-
-	return l
-}
-
-func (l *cmdLogger) bufLine(line []byte) error {
-	_, err := l.buf.Write(line)
-	return err
-}
-
-func (l *cmdLogger) flush() {
-	if l.buf.Len() == 0 {
-		return
-	}
-	// TODO: This always adds a newline, which is not always what we want. When
-	// we flush partial lines, we don't want to add a newline character. What
-	// we need to do: extend the `*output.Output` type to have a
-	// `WritefNoNewline` (yes, bad name) method.
-	l.out.Writef("%s%s[%s]%s %s", output.StyleBold, l.color, l.name, output.StyleReset, l.buf.String())
-	l.buf.Reset()
-}
-
-// Write handler of logger.
-func (l *cmdLogger) Write(p []byte) (int, error) {
-	l.writes <- p
-	<-l.done
-	return len(p), nil
-}
-
-func (l *cmdLogger) writeLines() {
-	tick := time.NewTicker(tickDuration)
-	for {
-		select {
-		case w, ok := <-l.writes:
-			if !ok {
-				l.flush()
-				return
-			}
-
-			buf := bytes.NewBuffer(w)
-			for {
-				line, err := buf.ReadBytes('\n')
-				if len(line) > 0 {
-					if line[len(line)-1] == '\n' {
-						// TODO: We currently add a newline in flush(), see comment there
-						line = line[0 : len(line)-1]
-
-						// But since there *was* a newline, we need to flush,
-						// but only if there is more than a newline or there
-						// was already content.
-						if len(line) != 1 || l.buf.Len() > 0 {
-							if err := l.bufLine(line); err != nil {
-								break
-							}
-							l.flush()
-						}
-						tick.Stop()
-					} else {
-						if err := l.bufLine(line); err != nil {
-							break
-						}
-						tick.Reset(tickDuration)
-					}
-				}
-				if err != nil {
-					break
-				}
-			}
-			l.done <- struct{}{}
-		case <-tick.C:
-			l.flush()
-			tick.Stop()
-		}
-	}
+	return process.NewLogger(ctx, sink)
 }

--- a/lib/process/logger.go
+++ b/lib/process/logger.go
@@ -1,0 +1,111 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"time"
+)
+
+// tickDuration is the time to wait before writing the buffer contents
+// without having received a newline.
+var tickDuration = 2 * time.Millisecond
+
+// Logger is a simplified version of goreman's logger:
+// https://github.com/mattn/goreman/blob/master/log.go
+type Logger struct {
+	sink func(string)
+
+	// buf is used to keep partial lines buffered before flushing them (either
+	// on the next newline or after tickDuration)
+	buf    *bytes.Buffer
+	writes chan []byte
+	done   chan struct{}
+}
+
+// NewLogger returns a new Logger instance and spawns a goroutine in the
+// background that regularily flushed the logged output to the given sink.
+//
+// If the passed in ctx is canceled the goroutine will exit.
+func NewLogger(ctx context.Context, sink func(string)) *Logger {
+	l := &Logger{
+		sink: sink,
+
+		writes: make(chan []byte),
+		done:   make(chan struct{}),
+		buf:    &bytes.Buffer{},
+	}
+
+	go l.writeLines(ctx)
+
+	return l
+}
+
+func (l *Logger) bufLine(line []byte) error {
+	_, err := l.buf.Write(line)
+	return err
+}
+
+func (l *Logger) flush() {
+	if l.buf.Len() == 0 {
+		return
+	}
+	l.sink(l.buf.String())
+	l.buf.Reset()
+}
+
+// Write handler of logger.
+func (l *Logger) Write(p []byte) (int, error) {
+	l.writes <- p
+	<-l.done
+	return len(p), nil
+}
+
+func (l *Logger) writeLines(ctx context.Context) {
+	tick := time.NewTicker(tickDuration)
+	for {
+		select {
+		case <-ctx.Done():
+			l.flush()
+			return
+		case w, ok := <-l.writes:
+			if !ok {
+				l.flush()
+				return
+			}
+
+			buf := bytes.NewBuffer(w)
+			for {
+				line, err := buf.ReadBytes('\n')
+				if len(line) > 0 {
+					if line[len(line)-1] == '\n' {
+						// TODO: We currently add a newline in flush(), see comment there
+						line = line[0 : len(line)-1]
+
+						// But since there *was* a newline, we need to flush,
+						// but only if there is more than a newline or there
+						// was already content.
+						if len(line) != 1 || l.buf.Len() > 0 {
+							if err := l.bufLine(line); err != nil {
+								break
+							}
+							l.flush()
+						}
+						tick.Stop()
+					} else {
+						if err := l.bufLine(line); err != nil {
+							break
+						}
+						tick.Reset(tickDuration)
+					}
+				}
+				if err != nil {
+					break
+				}
+			}
+			l.done <- struct{}{}
+		case <-tick.C:
+			l.flush()
+			tick.Stop()
+		}
+	}
+}

--- a/lib/process/pipe.go
+++ b/lib/process/pipe.go
@@ -1,0 +1,45 @@
+package process
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+)
+
+// PipeOutput reads stdout/stderr output of the given command into the two
+// io.Writers.
+//
+// It returns a sync.WaitGroup. The caller *must* call the Wait() method of the
+// WaitGroup after waiting for the *exec.Cmd to finish.
+//
+// See this issue for more details: https://github.com/golang/go/issues/21922
+func PipeOutput(c *exec.Cmd, stdoutWriter, stderrWriter io.Writer) (*sync.WaitGroup, error) {
+	stdoutPipe, err := c.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	stderrPipe, err := c.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	wg := &sync.WaitGroup{}
+
+	readIntoBuf := func(w io.Writer, r io.Reader) {
+		defer wg.Done()
+
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			fmt.Fprintln(w, scanner.Text())
+		}
+	}
+
+	wg.Add(2)
+	go readIntoBuf(stdoutWriter, stdoutPipe)
+	go readIntoBuf(stderrWriter, stderrPipe)
+
+	return wg, nil
+}


### PR DESCRIPTION
I need these two things in `src-cli`, so I thought I'd extract them.

Also tagging @efritz here because the `PipeOutput` function is a modified version from what's being done in `executor`. It's just different enough that I didn't want to modify the existing code there.