### PR TITLE
fix combineLatestOrDefault for builtin panels

### DIFF
--- a/client/shared/src/util/rxjs/combineLatestOrDefault.ts
+++ b/client/shared/src/util/rxjs/combineLatestOrDefault.ts
@@ -1,18 +1,9 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint rxjs/no-internal: warn */
-import {
-    asapScheduler,
-    from,
-    Observable,
-    ObservableInput,
-    of,
-    Operator,
-    PartialObserver,
-    Subscriber,
-    TeardownLogic,
-    zip,
-} from 'rxjs'
+import { asapScheduler, ObservableInput, of, Operator, PartialObserver, Subscriber, TeardownLogic, zip } from 'rxjs'
+import { Observable } from 'rxjs/internal/Observable'
 import { OuterSubscriber } from 'rxjs/internal/OuterSubscriber'
+import { subscribeToArray } from 'rxjs/internal/util/subscribeToArray'
 import { subscribeToResult } from 'rxjs/internal/util/subscribeToResult'
 
 /**
@@ -50,7 +41,7 @@ export function combineLatestOrDefault<T>(observables: ObservableInput<T>[], def
             // Only one source observable: no need to handle emission accumulation or default values
             return zip(...observables)
         default:
-            return from(observables).lift(new CombineLatestOperator(defaultValue))
+            return new Observable<T[]>(subscribeToArray(observables)).lift(new CombineLatestOperator(defaultValue))
     }
 }
 

--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -41,6 +41,8 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
             // https://stackoverflow.com/questions/53758889/rxjs-subscribeto-js-observable-check-works-in-chrome-but-fails-in-chrome-incogn.
             'rxjs/internal/OuterSubscriber': require.resolve('rxjs/_esm5/internal/OuterSubscriber'),
             'rxjs/internal/util/subscribeToResult': require.resolve('rxjs/_esm5/internal/util/subscribeToResult'),
+            'rxjs/internal/util/subscribeToArray': require.resolve('rxjs/_esm5/internal/util/subscribeToArray'),
+            'rxjs/internal/Observable': require.resolve('rxjs/_esm5/internal/Observable'),
         }),
         monacoPlugin(MONACO_LANGUAGES_AND_FEATURES),
         {


### PR DESCRIPTION
Fix #24535. 

`combineLatestOrDefault` used to create Observables with `fromArray`, but was [changed](https://github.com/sourcegraph/sourcegraph/pull/24487/files#diff-b975924c796682179c2a57625716ebd7ec2ae0f017d7ff10815617a8d616c437) in  #24487 to use `from`. At face value, this shouldn't affect anything - `from` and `fromArray` share the same implementation for arrays, after all - but this broke `combineLatestOrDefault`, which we use for our panel component.

I debugged the issue and it turns out that importing from `rxjs/internal/...` imports `node_modules/rxjs/internal/...`, whereas importing from `rxjs` imports from `node_modules/rxjs/_esm2015/internal...` for webpack. [This comment](https://github.com/sourcegraph/sourcegraph/pull/24487#issuecomment-910610320) suggests that webpack handles RxJS internal imports differently from esbuild, but that doesn't seem to be the case.

I (think) I've narrowed down the issue to the `Observable` import itself. We can recreate `fromArray` with a couple of internal imports to the `subscribeToArray` util and `Observable`, which breaks when we import `Observable` from `rxjs` (fortunately, since it means we're onto something).

---

I'm perplexed as to why importing a different variant of RxJS works, but importing from the same RxJS doesn't. I will investigate further, but for now we should revert the changes to fix this serious bug. 

I should also write an integration test to protect the "link to references panel" flow. We currently only have a test for clicking "Find references"