### PR TITLE
Fix unterminated string in doc HTML creating_an_access_token

### DIFF
--- a/doc/cli/how-tos/creating_an_access_token.md
+++ b/doc/cli/how-tos/creating_an_access_token.md
@@ -5,7 +5,7 @@ Access tokens permit authenticated access to the Sourcegraph API. This is requir
 Creating an access token is done through your user settings. This video shows the steps, which are then described below:
 
 <video width="1920" height="1080" autoplay controls loop muted playsinline style="width: 100%; height: auto; max-width: 50rem">
-  <source src="https://sourcegraphstatic.com/docs/images/integration/cli/token.webm type="video/webm">
+  <source src="https://sourcegraphstatic.com/docs/images/integration/cli/token.webm" type="video/webm">
   <source src="https://sourcegraphstatic.com/docs/images/integration/cli/token.mp4" type="video/mp4">
 </video>
 


### PR DESCRIPTION
Amazingly, the video still worked in the browser (falling back to MP4 though)! (browsers are truly incredible pieces of software. Gotta love web technologies)

![image](https://user-images.githubusercontent.com/10532611/131910212-0cd9826c-fda3-41b3-b863-887a7bb22a9e.png)
