### PR TITLE
Update LSIF GitHub actions

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -17,31 +17,12 @@ jobs:
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
         run: lsif-go --no-animation
+      - name: Upload lsif-go dump
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.root }}-dump
+          path: ${{ matrix.root }}/dump.lsif
 
-  lsif-go-upload:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-go
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      matrix:
-        root:
-          - ''
-          - lib/
-        endpoint:
-          - https://sourcegraph.com/
-          - https://k8s.sgdev.org/
-          - https://demo.sourcegraph.com/
-        experimental: [false]
-    steps:
-      - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: ${{ matrix.endpoint }}
-        
   lsif-tsc-eslint:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -71,7 +52,46 @@ jobs:
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
         run: yarn eslint -f lsif -o dump-lint.lsif
+      - name: Upload lsif-tsc dump
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.root }}-dump
+          path: ${{ matrix.root }}/dump.lsif
+      - name: Upload lsif-eslint dump
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.root }}-dump-lint
+          path: ${{ matrix.root }}/dump-lint.lsif
 
+  lsif-go-upload:
+    # Skip running on forks
+    if: github.repository == 'sourcegraph/sourcegraph'
+    needs: lsif-go
+    runs-on: ubuntu-latest
+    container: sourcegraph/lsif-go
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        endpoint:
+          - https://sourcegraph.com/
+          - https://k8s.sgdev.org/
+          - https://demo.sourcegraph.com/
+        experimental:
+          - false
+        root:
+          - ''
+          - lib/
+    steps:
+      - name: Download lsif-go dump
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.root }}-dump
+      - name: Upload lsif-go data to ${{ matrix.endpoint }}
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump.lsif
+        env:
+          SRC_ENDPOINT: ${{ matrix.endpoint }}
+        
   lsif-tsc-eslint-upload:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -80,23 +100,32 @@ jobs:
     container: sourcegraph/lsif-go
     strategy:
       matrix:
+        endpoint:
+          - https://sourcegraph.com/
+          - https://k8s.sgdev.org/
+          - https://demo.sourcegraph.com/
+        experimental:
+          - false
         root:
           - client/branded/
           - client/browser/
           - client/shared/
           - client/web/
           - client/wildcard/
-        endpoint:
-          - https://sourcegraph.com/
-          - https://k8s.sgdev.org/
-          - https://demo.sourcegraph.com/
-        experimental: [false]
     steps:
+      - name: Download lsif-tsc dump
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.root }}-dump
       - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-lint.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
+      - name: Download lsif-eslint dump
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.root }}-dump-lint
       - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
         working-directory: ${{ matrix.root }}
         run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-lint.lsif

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-go
       - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root ${{ matrix.root }} -file dump-go.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GIT_COMMIT}" -root '${{ matrix.root }}' -file dump-go.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 
@@ -126,7 +126,7 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-tsc
       - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -file dump-tsc.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GIT_COMMIT}" -root 'client/${{ matrix.root }}' -file dump-tsc.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 
@@ -135,6 +135,6 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-eslint
       - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -file dump-eslint.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GIT_COMMIT}" -root 'client/${{ matrix.root }}' -file dump-eslint.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -23,6 +23,35 @@ jobs:
           name: ${{ matrix.root }}-dump
           path: ${{ matrix.root }}/dump.lsif
 
+  lsif-go-upload:
+    # Skip running on forks
+    if: github.repository == 'sourcegraph/sourcegraph'
+    needs: lsif-go
+    runs-on: ubuntu-latest
+    container: sourcegraph/lsif-go
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        endpoint:
+          - https://sourcegraph.com/
+          - https://k8s.sgdev.org/
+          - https://demo.sourcegraph.com/
+        experimental:
+          - false
+        root:
+          - ''
+          - lib
+    steps:
+      - name: Download lsif-go dump
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.root }}-dump
+      - name: Upload lsif-go data to ${{ matrix.endpoint }}
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump.lsif
+        env:
+          SRC_ENDPOINT: ${{ matrix.endpoint }}
+
   lsif-tsc-eslint:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -63,41 +92,13 @@ jobs:
           name: ${{ matrix.root }}-dump-lint
           path: ${{ matrix.root }}/dump-lint.lsif
 
-  lsif-go-upload:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-go
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      matrix:
-        endpoint:
-          - https://sourcegraph.com/
-          - https://k8s.sgdev.org/
-          - https://demo.sourcegraph.com/
-        experimental:
-          - false
-        root:
-          - ''
-          - lib
-    steps:
-      - name: Download lsif-go dump
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.root }}-dump
-      - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump.lsif
-        env:
-          SRC_ENDPOINT: ${{ matrix.endpoint }}
-        
   lsif-tsc-eslint-upload:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     needs: lsif-tsc-eslint
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
+    container: sourcegraph/lsif-node
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         endpoint:
@@ -118,16 +119,15 @@ jobs:
         with:
           name: ${{ matrix.root }}-dump
       - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
-        working-directory: client/${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
+
       - name: Download lsif-eslint dump
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.root }}-dump-lint
       - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
-        working-directory: client/${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-lint.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump-lint.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -13,44 +13,19 @@ jobs:
           - ''
           - lib
     steps:
-      - uses: actions/checkout@v2
-      - name: Generate LSIF data
+      # Setup
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Run lsif-go
+      - name: Run lsif-go
         working-directory: ${{ matrix.root }}
-        run: lsif-go --no-animation
+        run: lsif-go --no-animation -f dump-go.lsif
       - name: Upload lsif-go dump
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.root }}-dump
-          path: ${{ matrix.root }}/dump.lsif
-
-  lsif-go-upload:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-go
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      matrix:
-        endpoint:
-          - https://sourcegraph.com/
-          - https://k8s.sgdev.org/
-          - https://demo.sourcegraph.com/
-        experimental:
-          - false
-        root:
-          - ''
-          - lib
-    steps:
-      - name: Download lsif-go dump
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.root }}-dump
-      - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump.lsif
-        env:
-          SRC_ENDPOINT: ${{ matrix.endpoint }}
+          name: dump-${{ matrix.root }}-go
+          path: ${{ matrix.root }}/dump-go.lsif
 
   lsif-tsc-eslint:
     # Skip running on forks
@@ -66,31 +41,65 @@ jobs:
           - web
           - wildcard
     steps:
-      - uses: actions/checkout@v2
+      # Setup
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Install build dependencies
         run: apk --no-cache add python g++ make git
       - name: Install dependencies
         run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
+      - name: Run gulp generate
         run: ./node_modules/.bin/gulp generate
-      - name: Generate LSIF data
+
+      # Run lsif-tsc
+      - name: Run lsif-tsc
         working-directory: client/${{ matrix.root }}
-        run: lsif-tsc -p . -o dump.lsif
-      - name: Build TypeScript
-        run: yarn run --ignore-engines build-ts
-      - name: Generate LSIF data
-        working-directory: client/${{ matrix.root }}
-        run: yarn eslint -f lsif -o dump-lint.lsif
+        run: lsif-tsc -p . -o dump-tsc.lsif
       - name: Upload lsif-tsc dump
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.root }}-dump
-          path: ${{ matrix.root }}/dump.lsif
+          name: dump-${{ matrix.root }}-tsc
+          path: ${{ matrix.root }}/dump-tsc.lsif
+          
+      # Run lsif-eslint
+      - name: Build TypeScript
+        run: yarn run --ignore-engines build-ts
+      - name: Run lsif-eslint
+        working-directory: client/${{ matrix.root }}
+        run: yarn eslint -f lsif -o dump-eslint.lsif
       - name: Upload lsif-eslint dump
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.root }}-dump-lint
-          path: ${{ matrix.root }}/dump-lint.lsif
+          name: dump-${{ matrix.root }}-eslint
+          path: ${{ matrix.root }}/dump-eslint.lsif
+
+  lsif-go-upload:
+    # Skip running on forks
+    if: github.repository == 'sourcegraph/sourcegraph'
+    needs: lsif-go
+    runs-on: ubuntu-latest
+    container: sourcegraph/lsif-go
+    # Only fail the job if upload to Cloud fails
+    continue-on-error: ${{ matrix.endpoint != 'https://sourcegraph.com/' }}
+    strategy:
+      matrix:
+        endpoint:
+          - https://sourcegraph.com/
+          - https://k8s.sgdev.org/
+          - https://demo.sourcegraph.com/
+        root:
+          - ''
+          - lib
+    steps:
+      - name: Download lsif-go dump
+        uses: actions/download-artifact@v2
+        with:
+          name: dump-${{ matrix.root }}-go
+      - name: Upload lsif-go data to ${{ matrix.endpoint }}
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-go.lsif
+        env:
+          SRC_ENDPOINT: ${{ matrix.endpoint }}
 
   lsif-tsc-eslint-upload:
     # Skip running on forks
@@ -98,15 +107,14 @@ jobs:
     needs: lsif-tsc-eslint
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-node
-    continue-on-error: ${{ matrix.experimental }}
+    # Only fail the job if upload to Cloud fails
+    continue-on-error: ${{ matrix.endpoint != 'https://sourcegraph.com/' }}
     strategy:
       matrix:
         endpoint:
           - https://sourcegraph.com/
           - https://k8s.sgdev.org/
           - https://demo.sourcegraph.com/
-        experimental:
-          - false
         root:
           - branded
           - browser
@@ -117,17 +125,17 @@ jobs:
       - name: Download lsif-tsc dump
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.root }}-dump
+          name: dump-${{ matrix.root }}-tsc
       - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump-tsc.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 
       - name: Download lsif-eslint dump
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.root }}-dump-lint
+          name: dump-${{ matrix.root }}-eslint
       - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump-lint.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump-eslint.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -68,20 +68,20 @@ jobs:
         working-directory: ${{ matrix.root }}
         run: lsif-tsc -p .
           
-      # Upload lsif-eslint data to Cloud, Dogfood, and Demo instances
+      # Upload lsif-tsc data to Cloud, Dogfood, and Demo instances
       - name: Upload lsif-tsc dump to Cloud
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.com/
       - name: Upload lsif-tsc dump to Dogfood
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
       - name: Upload lsif-tsc dump to Demo
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://demo.sourcegraph.com/
 
@@ -95,16 +95,16 @@ jobs:
       # Upload lsif-eslint data to Cloud, Dogfood, and Demo instances
       - name: Upload lsif-eslint dump to Cloud
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.com/
       - name: Upload lsif-eslint dump to Dogfood
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
       - name: Upload lsif-eslint dump to Demo
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://demo.sourcegraph.com/

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -24,6 +24,7 @@ jobs:
     needs: lsif-go
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         root:
@@ -33,14 +34,15 @@ jobs:
           - https://sourcegraph.com/
           - https://k8s.sgdev.org/
           - https://demo.sourcegraph.com/
+        experimental: [false]
     steps:
-      - name: Upload LSIF data to ${{ matrix.endpoint }}
+      - name: Upload lsif-go data to ${{ matrix.endpoint }}
         working-directory: ${{ matrix.root }}
         run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
-
-  lsif-tsc:
+        
+  lsif-tsc-eslint:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
@@ -63,64 +65,17 @@ jobs:
         run: ./node_modules/.bin/gulp generate
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
-        run: lsif-tsc -p .
-
-  lsif-tsc-upload:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-tsc
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
-    strategy:
-      matrix:
-        root:
-          - client/branded/
-          - client/browser/
-          - client/shared/
-          - client/web/
-          - client/wildcard/
-        endpoint:
-          - https://sourcegraph.com/
-          - https://k8s.sgdev.org/
-          - https://demo.sourcegraph.com/
-    steps:
-      - name: Upload LSIF data to ${{ matrix.endpoint }}
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: ${{ matrix.endpoint }}
-
-  lsif-eslint:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    strategy:
-      matrix:
-        root:
-          - client/branded/
-          - client/browser/
-          - client/shared/
-          - client/web/
-          - client/wildcard/
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
+        run: lsif-tsc -p . -o dump.lsif
       - name: Build TypeScript
         run: yarn run --ignore-engines build-ts
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
-        run: yarn eslint -f lsif -o dump.lsif
+        run: yarn eslint -f lsif -o dump-lint.lsif
 
-  lsif-eslint-upload:
+  lsif-tsc-eslint-upload:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-eslint
+    needs: lsif-tsc-eslint
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
     strategy:
@@ -135,9 +90,15 @@ jobs:
           - https://sourcegraph.com/
           - https://k8s.sgdev.org/
           - https://demo.sourcegraph.com/
+        experimental: [false]
     steps:
-      - name: Upload LSIF data to ${{ matrix.endpoint }}
+      - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-lint.lsif
+        env:
+          SRC_ENDPOINT: ${{ matrix.endpoint }}
+      - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-lint.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-go
       - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GIT_COMMIT}" -root '${{ matrix.root }}' -file dump-go.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GITHUB_SHA}" -root '${{ matrix.root }}' -file dump-go.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 
@@ -126,7 +126,7 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-tsc
       - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GIT_COMMIT}" -root 'client/${{ matrix.root }}' -file dump-tsc.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GITHUB_SHA}" -root 'client/${{ matrix.root }}' -file dump-tsc.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 
@@ -135,6 +135,6 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-eslint
       - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GIT_COMMIT}" -root 'client/${{ matrix.root }}' -file dump-eslint.lsif
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GITHUB_SHA}" -root 'client/${{ matrix.root }}' -file dump-eslint.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         root:
           - ''
-          - lib/
+          - lib
     steps:
       - uses: actions/checkout@v2
       - name: Generate LSIF data
@@ -31,11 +31,11 @@ jobs:
     strategy:
       matrix:
         root:
-          - client/branded/
-          - client/browser/
-          - client/shared/
-          - client/web/
-          - client/wildcard/
+          - branded
+          - browser
+          - shared
+          - web
+          - wildcard
     steps:
       - uses: actions/checkout@v2
       - name: Install build dependencies
@@ -45,12 +45,12 @@ jobs:
       - name: Generate
         run: ./node_modules/.bin/gulp generate
       - name: Generate LSIF data
-        working-directory: ${{ matrix.root }}
+        working-directory: client/${{ matrix.root }}
         run: lsif-tsc -p . -o dump.lsif
       - name: Build TypeScript
         run: yarn run --ignore-engines build-ts
       - name: Generate LSIF data
-        working-directory: ${{ matrix.root }}
+        working-directory: client/${{ matrix.root }}
         run: yarn eslint -f lsif -o dump-lint.lsif
       - name: Upload lsif-tsc dump
         uses: actions/upload-artifact@v2
@@ -80,7 +80,7 @@ jobs:
           - false
         root:
           - ''
-          - lib/
+          - lib
     steps:
       - name: Download lsif-go dump
         uses: actions/download-artifact@v2
@@ -107,18 +107,18 @@ jobs:
         experimental:
           - false
         root:
-          - client/branded/
-          - client/browser/
-          - client/shared/
-          - client/web/
-          - client/wildcard/
+          - branded
+          - browser
+          - shared
+          - web
+          - wildcard
     steps:
       - name: Download lsif-tsc dump
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.root }}-dump
       - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
-        working-directory: ${{ matrix.root }}
+        working-directory: client/${{ matrix.root }}
         run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
@@ -127,7 +127,7 @@ jobs:
         with:
           name: ${{ matrix.root }}-dump-lint
       - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
-        working-directory: ${{ matrix.root }}
+        working-directory: client/${{ matrix.root }}
         run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-lint.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -20,12 +20,24 @@ jobs:
       # Run lsif-go
       - name: Run lsif-go
         working-directory: ${{ matrix.root }}
-        run: lsif-go --no-animation -o ~/dump-go.lsif
-      - name: Upload lsif-go dump
-        uses: actions/upload-artifact@v2
-        with:
-          name: dump-${{ matrix.root }}-go
-          path: ~/dump-go.lsif
+        run: lsif-go --no-animation
+      
+      # Upload lsif-go data to Cloud, Dogfood, and Demo instances
+      - name: Upload lsif-go dump to Cloud
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.com/
+      - name: Upload lsif-go dump to Dogfood
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
+      - name: Upload lsif-go dump to Demo
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        env:
+          SRC_ENDPOINT: https://demo.sourcegraph.com/
 
   lsif-tsc-eslint:
     # Skip running on forks
@@ -35,11 +47,11 @@ jobs:
     strategy:
       matrix:
         root:
-          - branded
-          - browser
-          - shared
-          - web
-          - wildcard
+          - client/branded
+          - client/browser
+          - client/shared
+          - client/web
+          - client/wildcard
     steps:
       # Setup
       - name: Checkout
@@ -53,88 +65,46 @@ jobs:
 
       # Run lsif-tsc
       - name: Run lsif-tsc
-        working-directory: client/${{ matrix.root }}
-        run: lsif-tsc -p . -o ~/dump-tsc.lsif
-      - name: Upload lsif-tsc dump
-        uses: actions/upload-artifact@v2
-        with:
-          name: dump-${{ matrix.root }}-tsc
-          path: ~/dump-tsc.lsif
+        working-directory: ${{ matrix.root }}
+        run: lsif-tsc -p .
           
+      # Upload lsif-eslint data to Cloud, Dogfood, and Demo instances
+      - name: Upload lsif-tsc dump to Cloud
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif
+        env:
+          SRC_ENDPOINT: https://sourcegraph.com/
+      - name: Upload lsif-tsc dump to Dogfood
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
+      - name: Upload lsif-tsc dump to Demo
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
+        env:
+          SRC_ENDPOINT: https://demo.sourcegraph.com/
+
       # Run lsif-eslint
       - name: Build TypeScript
         run: yarn run --ignore-engines build-ts
       - name: Run lsif-eslint
-        working-directory: client/${{ matrix.root }}
-        run: yarn eslint -f lsif -o ~/dump-eslint.lsif
-      - name: Upload lsif-eslint dump
-        uses: actions/upload-artifact@v2
-        with:
-          name: dump-${{ matrix.root }}-eslint
-          path: ~/dump-eslint.lsif
+        working-directory: ${{ matrix.root }}
+        run: yarn eslint -f lsif
 
-  lsif-go-upload:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-go
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
-    # Only fail the job if upload to Cloud fails
-    continue-on-error: ${{ matrix.endpoint != 'https://sourcegraph.com/' }}
-    strategy:
-      matrix:
-        endpoint:
-          - https://sourcegraph.com/
-          - https://k8s.sgdev.org/
-          - https://demo.sourcegraph.com/
-        root:
-          - ''
-          - lib
-    steps:
-      - name: Download lsif-go dump
-        uses: actions/download-artifact@v2
-        with:
-          name: dump-${{ matrix.root }}-go
-      - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GITHUB_SHA}" -root '${{ matrix.root }}' -file dump-go.lsif
+      # Upload lsif-eslint data to Cloud, Dogfood, and Demo instances
+      - name: Upload lsif-eslint dump to Cloud
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif
         env:
-          SRC_ENDPOINT: ${{ matrix.endpoint }}
-
-  lsif-tsc-eslint-upload:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-tsc-eslint
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    # Only fail the job if upload to Cloud fails
-    continue-on-error: ${{ matrix.endpoint != 'https://sourcegraph.com/' }}
-    strategy:
-      matrix:
-        endpoint:
-          - https://sourcegraph.com/
-          - https://k8s.sgdev.org/
-          - https://demo.sourcegraph.com/
-        root:
-          - branded
-          - browser
-          - shared
-          - web
-          - wildcard
-    steps:
-      - name: Download lsif-tsc dump
-        uses: actions/download-artifact@v2
-        with:
-          name: dump-${{ matrix.root }}-tsc
-      - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GITHUB_SHA}" -root 'client/${{ matrix.root }}' -file dump-tsc.lsif
+          SRC_ENDPOINT: https://sourcegraph.com/
+      - name: Upload lsif-eslint dump to Dogfood
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
         env:
-          SRC_ENDPOINT: ${{ matrix.endpoint }}
-
-      - name: Download lsif-eslint dump
-        uses: actions/download-artifact@v2
-        with:
-          name: dump-${{ matrix.root }}-eslint
-      - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -repo='github.com/sourcegraph/sourcegraph' -commit="${GITHUB_SHA}" -root 'client/${{ matrix.root }}' -file dump-eslint.lsif
+          SRC_ENDPOINT: https://k8s.sgdev.org/
+      - name: Upload lsif-eslint dump to Demo
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress -f dump.lsif || true
         env:
-          SRC_ENDPOINT: ${{ matrix.endpoint }}
+          SRC_ENDPOINT: https://demo.sourcegraph.com/

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -18,6 +18,28 @@ jobs:
         working-directory: ${{ matrix.root }}
         run: lsif-go --no-animation
 
+  lsif-go-upload:
+    # Skip running on forks
+    if: github.repository == 'sourcegraph/sourcegraph'
+    needs: lsif-go
+    runs-on: ubuntu-latest
+    container: sourcegraph/lsif-go
+    strategy:
+      matrix:
+        root:
+          - ''
+          - lib/
+        endpoint:
+          - https://sourcegraph.com/
+          - https://k8s.sgdev.org/
+          - https://demo.sourcegraph.com/
+    steps:
+      - name: Upload LSIF data to ${{ matrix.endpoint }}
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: ${{ matrix.endpoint }}
+
   lsif-tsc:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -42,6 +64,31 @@ jobs:
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
         run: lsif-tsc -p .
+
+  lsif-tsc-upload:
+    # Skip running on forks
+    if: github.repository == 'sourcegraph/sourcegraph'
+    needs: lsif-tsc
+    runs-on: ubuntu-latest
+    container: sourcegraph/lsif-go
+    strategy:
+      matrix:
+        root:
+          - client/branded/
+          - client/browser/
+          - client/shared/
+          - client/web/
+          - client/wildcard/
+        endpoint:
+          - https://sourcegraph.com/
+          - https://k8s.sgdev.org/
+          - https://demo.sourcegraph.com/
+    steps:
+      - name: Upload LSIF data to ${{ matrix.endpoint }}
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: ${{ matrix.endpoint }}
 
   lsif-eslint:
     # Skip running on forks
@@ -70,17 +117,15 @@ jobs:
         working-directory: ${{ matrix.root }}
         run: yarn eslint -f lsif -o dump.lsif
 
-  lsif-upload:
+  lsif-eslint-upload:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
-    needs: lsif-go # WTF WILL THIS DO?
+    needs: lsif-eslint
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
     strategy:
       matrix:
         root:
-          - ''
-          - lib/
           - client/branded/
           - client/browser/
           - client/shared/

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -2,43 +2,46 @@ name: LSIF
 on:
   - push
 jobs:
-  lsif-go-root:
+  lsif-go:
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
+    strategy:
+      matrix:
+        root:
+          - ''
+          - lib/
     steps:
       - uses: actions/checkout@v2
       - name: Generate LSIF data
-        run: lsif-go
-      - name: Upload LSIF data to .com
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        working-directory: ${{ matrix.root }}
+        run: lsif-go --no-animation
+      - name: Upload LSIF data to Cloud
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to Dogfood
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-go-lib:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
-    steps:
-      - uses: actions/checkout@v2
-      - name: Generate LSIF data
-        working-directory: lib/
-        run: lsif-go
-      - name: Upload LSIF data to .com
-        working-directory: lib/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: lib/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to Demo
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+          SRC_ENDPOINT: https://demo.sourcegraph.com/
 
-  lsif-tsc-web:
+  lsif-tsc:
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-node
+    strategy:
+      matrix:
+        root:
+          - client/branded/
+          - client/browser/
+          - client/shared/
+          - client/web/
+          - client/wildcard/
     steps:
       - uses: actions/checkout@v2
       - name: Install build dependencies
@@ -48,117 +51,34 @@ jobs:
       - name: Generate
         run: ./node_modules/.bin/gulp generate
       - name: Generate LSIF data
-        working-directory: client/web/
+        working-directory: ${{ matrix.root }}
         run: lsif-tsc -p .
-      - name: Upload LSIF data to .com
-        working-directory: client/web/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/web/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to Cloud
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to Dogfood
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
+      - name: Upload LSIF data to Demo
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://demo.sourcegraph.com/
 
-  lsif-tsc-shared:
+  lsif-eslint:
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-node
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
-      - name: Generate LSIF data
-        working-directory: client/shared/
-        run: lsif-tsc -p .
-      - name: Upload LSIF data to .com
-        working-directory: client/shared/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/shared/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-tsc-branded:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
-      - name: Generate LSIF data
-        working-directory: client/branded/
-        run: lsif-tsc -p .
-      - name: Upload LSIF data to .com
-        working-directory: client/branded/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/branded/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-tsc-browser:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
-      - name: Generate LSIF data
-        working-directory: client/browser/
-        run: lsif-tsc -p .
-      - name: Upload LSIF data to .com
-        working-directory: client/browser/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/browser/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-tsc-wildcard:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
-      - name: Generate LSIF data
-        working-directory: client/wildcard/
-        run: lsif-tsc -p .
-      - name: Upload LSIF data to .com
-        working-directory: client/wildcard/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/wildcard/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-eslint-web:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
+    strategy:
+      matrix:
+        root:
+          - client/branded/
+          - client/browser/
+          - client/shared/
+          - client/web/
+          - client/wildcard/
     steps:
       - uses: actions/checkout@v2
       - name: Install build dependencies
@@ -170,91 +90,18 @@ jobs:
       - name: Build TypeScript
         run: yarn run --ignore-engines build-ts
       - name: Generate LSIF data
-        working-directory: client/web/
+        working-directory: ${{ matrix.root }}
         run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data to .com
-        working-directory: client/web/
+      - name: Upload LSIF data to Cloud
+        working-directory: ${{ matrix.root }}
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/web/
+      - name: Upload LSIF data to Dogfood
+        working-directory: ${{ matrix.root }}
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-eslint-shared:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
-      - name: Build TypeScript
-        run: yarn run --ignore-engines build-ts
-      - name: Generate LSIF data
-        working-directory: client/shared/
-        run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data to .com
-        working-directory: client/shared/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/shared/
+      - name: Upload LSIF data to Demo
+        working-directory: ${{ matrix.root }}
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-eslint-browser:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
-      - name: Build TypeScript
-        run: yarn run --ignore-engines build-ts
-      - name: Generate LSIF data
-        working-directory: client/browser/
-        run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data to .com
-        working-directory: client/browser/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/browser/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-
-  lsif-eslint-wildcard:
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-node
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install build dependencies
-        run: apk --no-cache add python g++ make git
-      - name: Install dependencies
-        run: yarn --ignore-engines --ignore-scripts
-      - name: Generate
-        run: ./node_modules/.bin/gulp generate
-      - name: Build TypeScript
-        run: yarn run --ignore-engines build-ts
-      - name: Generate LSIF data
-        working-directory: client/wildcard/
-        run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data to .com
-        working-directory: client/wildcard/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/wildcard/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+          SRC_ENDPOINT: https://demo.sourcegraph.com

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -20,12 +20,12 @@ jobs:
       # Run lsif-go
       - name: Run lsif-go
         working-directory: ${{ matrix.root }}
-        run: lsif-go --no-animation -o dump-go.lsif
+        run: lsif-go --no-animation -o ~/dump-go.lsif
       - name: Upload lsif-go dump
         uses: actions/upload-artifact@v2
         with:
           name: dump-${{ matrix.root }}-go
-          path: ${{ matrix.root }}/dump-go.lsif
+          path: ~/dump-go.lsif
 
   lsif-tsc-eslint:
     # Skip running on forks
@@ -54,24 +54,24 @@ jobs:
       # Run lsif-tsc
       - name: Run lsif-tsc
         working-directory: client/${{ matrix.root }}
-        run: lsif-tsc -p . -o dump-tsc.lsif
+        run: lsif-tsc -p . -o ~/dump-tsc.lsif
       - name: Upload lsif-tsc dump
         uses: actions/upload-artifact@v2
         with:
           name: dump-${{ matrix.root }}-tsc
-          path: ${{ matrix.root }}/dump-tsc.lsif
+          path: ~/dump-tsc.lsif
           
       # Run lsif-eslint
       - name: Build TypeScript
         run: yarn run --ignore-engines build-ts
       - name: Run lsif-eslint
         working-directory: client/${{ matrix.root }}
-        run: yarn eslint -f lsif -o dump-eslint.lsif
+        run: yarn eslint -f lsif -o ~/dump-eslint.lsif
       - name: Upload lsif-eslint dump
         uses: actions/upload-artifact@v2
         with:
           name: dump-${{ matrix.root }}-eslint
-          path: ${{ matrix.root }}/dump-eslint.lsif
+          path: ~/dump-eslint.lsif
 
   lsif-go-upload:
     # Skip running on forks
@@ -96,7 +96,7 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-go
       - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root ${{ matrix.root }} -f dump-go.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root ${{ matrix.root }} -file dump-go.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 
@@ -126,7 +126,7 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-tsc
       - name: Upload lsif-tsc data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump-tsc.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -file dump-tsc.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 
@@ -135,6 +135,6 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-eslint
       - name: Upload lsif-eslint data to ${{ matrix.endpoint }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -f dump-eslint.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root client/${{ matrix.root }} -file dump-eslint.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -3,6 +3,7 @@ on:
   - push
 jobs:
   lsif-go:
+    # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
@@ -16,21 +17,9 @@ jobs:
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
         run: lsif-go --no-animation
-      - name: Upload LSIF data to Cloud
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to Dogfood
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-      - name: Upload LSIF data to Demo
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://demo.sourcegraph.com/
 
   lsif-tsc:
+    # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-node
@@ -53,21 +42,9 @@ jobs:
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
         run: lsif-tsc -p .
-      - name: Upload LSIF data to Cloud
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to Dogfood
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-      - name: Upload LSIF data to Demo
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://demo.sourcegraph.com/
 
   lsif-eslint:
+    # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-node
@@ -92,16 +69,30 @@ jobs:
       - name: Generate LSIF data
         working-directory: ${{ matrix.root }}
         run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data to Cloud
+
+  lsif-upload:
+    # Skip running on forks
+    if: github.repository == 'sourcegraph/sourcegraph'
+    needs: lsif-go # WTF WILL THIS DO?
+    runs-on: ubuntu-latest
+    container: sourcegraph/lsif-go
+    strategy:
+      matrix:
+        root:
+          - ''
+          - lib/
+          - client/branded/
+          - client/browser/
+          - client/shared/
+          - client/web/
+          - client/wildcard/
+        endpoint:
+          - https://sourcegraph.com/
+          - https://k8s.sgdev.org/
+          - https://demo.sourcegraph.com/
+    steps:
+      - name: Upload LSIF data to ${{ matrix.endpoint }}
         working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to Dogfood
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-      - name: Upload LSIF data to Demo
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://demo.sourcegraph.com
+          SRC_ENDPOINT: ${{ matrix.endpoint }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -96,8 +96,7 @@ jobs:
         with:
           name: dump-${{ matrix.root }}-go
       - name: Upload lsif-go data to ${{ matrix.endpoint }}
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -f dump-go.lsif
+        run: src lsif upload -no-progress -github-token=${{ secrets.GITHUB_TOKEN }} -root ${{ matrix.root }} -f dump-go.lsif
         env:
           SRC_ENDPOINT: ${{ matrix.endpoint }}
 

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -20,7 +20,7 @@ jobs:
       # Run lsif-go
       - name: Run lsif-go
         working-directory: ${{ matrix.root }}
-        run: lsif-go --no-animation -f dump-go.lsif
+        run: lsif-go --no-animation -o dump-go.lsif
       - name: Upload lsif-go dump
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Update LSIF actions definitions so that we upload to Cloud, Dogfood, and Demo (the first target being the only one that should fail the workflow).