### PR TITLE
web: Add wildcard Button

### DIFF
--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
@@ -1,0 +1,34 @@
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { WebStory } from '@sourcegraph/web/src/components/WebStory'
+
+import { InsightDashboard, InsightsDashboardType } from '../../../../../../../core/types'
+
+import { EmptyInsightDashboard } from './EmptyInsightDashboard'
+
+const { add } = storiesOf('web/insights/EmptyInsightDashboard', module)
+    .addDecorator(story => <WebStory>{() => story()}</WebStory>)
+    .addParameters({
+        chromatic: {
+            viewports: [576, 1440],
+        },
+    })
+
+add('EmptyInsightDashboard', () => {
+    const dashboard: InsightDashboard = {
+        type: InsightsDashboardType.Personal,
+        id: '101',
+        title: 'Personal',
+        builtIn: true,
+        insightIds: [],
+        owner: {
+            id: '101',
+            name: 'Pesonal',
+        },
+        settingsKey: 'test',
+    }
+    const settingsCascade = {} as any
+    return <EmptyInsightDashboard dashboard={dashboard} onAddInsight={noop} settingsCascade={settingsCascade} />
+})

--- a/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { Button } from '@sourcegraph/wildcard'
 
 import { Settings } from '../../../../../../../../schema/settings.schema'
 import { InsightDashboard } from '../../../../../../../core/types'
@@ -60,11 +61,12 @@ export const EmptySettingsBasedDashboard: React.FunctionComponent<EmptyInsightDa
 
     return (
         <section className={styles.emptySection}>
-            <button
+            <Button
                 type="button"
                 disabled={!permissions.isConfigurable}
                 onClick={onAddInsight}
-                className="btn btn-secondary p-0 w-100 border-0"
+                variant="secondary"
+                className="p-0 w-100 border-0"
             >
                 <div
                     data-tooltip={!permissions.isConfigurable ? getTooltipMessage(dashboard, permissions) : undefined}
@@ -74,7 +76,7 @@ export const EmptySettingsBasedDashboard: React.FunctionComponent<EmptyInsightDa
                     <PlusIcon size="2rem" />
                     <span>Add insights</span>
                 </div>
-            </button>
+            </Button>
             <span className="d-flex justify-content-center mt-3">
                 <Link to={`/insights/create?dashboardId=${dashboard.id}`}>or, create new insight</Link>
             </span>


### PR DESCRIPTION
Add wildcard Button component + Story for `EmptyInsightDashboard`

| Before | After |
|---|---|
|<img width="381" alt="before" src="https://user-images.githubusercontent.com/1855233/131923790-da9a232c-4cc7-423b-8e27-c75470c19351.png">|<img width="381" alt="after" src="https://user-images.githubusercontent.com/1855233/131923808-19d096c8-b228-4b92-a18a-5e5ad22ed389.png">|

Related to https://github.com/sourcegraph/sourcegraph/issues/24235