### PR TITLE
Fix error when unmarshalling non optional bool on diff endpoint

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3099,7 +3099,7 @@ type FileDiffHunk {
         """
         DEPRECATED: isLightTheme will be ignored since all highlights are done with CSS classes now
         """
-        isLightTheme: Boolean!
+        isLightTheme: Boolean
         """
         If highlightLongLines is true, lines which are longer than 2000 bytes are highlighted.
         2000 bytes is enabled. This may produce a significant amount of HTML

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/sourcegraph/gosyntect v0.0.0-20210422223331-645353f16ddc
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-00010101000000-000000000000
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210825111619-07362da90a1c
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210902215418-71593bf836f9
 	github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect


### PR DESCRIPTION
Graphql-Go logs the following error:
```
Could not unmarshal true (bool) into *bool: incompatible type
```
That is because the argument is non-optional in the schema, but a bool pointer in Go code. This has been introduced in 586b0ee3a0e4a6e5af2384f92efb4a299fd92da2.
