### PR TITLE
dotcom: redirect sitemap.xml.gz -> GCS

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -60,6 +60,7 @@ var (
 	// data or allow unprivileged users to perform undesired actions.
 	anonymousAccessibleAPIRoutes = map[string]struct{}{
 		router.RobotsTxt:          {},
+		router.SitemapXmlGz:       {},
 		router.Favicon:            {},
 		router.Logout:             {},
 		router.SignUp:             {},

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -34,6 +34,7 @@ func NewHandler(db dbutil.DB) http.Handler {
 	m.Handle("/", r)
 
 	r.Get(router.RobotsTxt).Handler(trace.Route(http.HandlerFunc(robotsTxt)))
+	r.Get(router.SitemapXmlGz).Handler(trace.Route(http.HandlerFunc(sitemapXmlGz)))
 	r.Get(router.Favicon).Handler(trace.Route(http.HandlerFunc(favicon)))
 	r.Get(router.OpenSearch).Handler(trace.Route(http.HandlerFunc(openSearch)))
 

--- a/cmd/frontend/internal/app/misc_handlers.go
+++ b/cmd/frontend/internal/app/misc_handlers.go
@@ -27,13 +27,21 @@ func robotsTxtHelper(w io.Writer, allowRobots bool) {
 	if allowRobots {
 		fmt.Fprintln(&buf, "Allow: /")
 		if envvar.SourcegraphDotComMode() {
-			fmt.Fprintln(&buf, "Sitemap: https://storage.googleapis.com/sitemap-sourcegraph-com/sitemap.xml.gz")
+			fmt.Fprintln(&buf, "Sitemap: https://sourcegraph.com/sitemap.xml.gz")
 		}
 	} else {
 		fmt.Fprintln(&buf, "Disallow: /")
 	}
 	fmt.Fprintln(&buf)
 	_, _ = buf.WriteTo(w)
+}
+
+func sitemapXmlGz(w http.ResponseWriter, r *http.Request) {
+	if envvar.SourcegraphDotComMode() {
+		http.Redirect(w, r, "https://storage.googleapis.com/sitemap-sourcegraph-com/sitemap.xml.gz", http.StatusFound)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
 }
 
 func favicon(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	RobotsTxt = "robots-txt"
-	Sitemap   = "sitemap"
-	Favicon   = "favicon"
+	RobotsTxt    = "robots-txt"
+	SitemapXmlGz = "sitemap-xml-gz"
+	Favicon      = "favicon"
 
 	OpenSearch = "opensearch"
 

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	RobotsTxt = "robots-txt"
+	Sitemap   = "sitemap"
 	Favicon   = "favicon"
 
 	OpenSearch = "opensearch"
@@ -64,6 +65,7 @@ func newRouter() *mux.Router {
 	base.StrictSlash(true)
 
 	base.Path("/robots.txt").Methods("GET").Name(RobotsTxt)
+	base.Path("/sitemap.xml.gz").Methods("GET").Name(SitemapXmlGz)
 	base.Path("/favicon.ico").Methods("GET").Name(Favicon)
 	base.Path("/opensearch.xml").Methods("GET").Name(OpenSearch)
 


### PR DESCRIPTION
Google should discover our sitemap from the sourcegraph.com/robots.txt entry,
but it not existing at sourcegraph.com/sitemap.xml.gz today makes it hard to
directly submit it for indexing. Thus, this PR makes sourcegraph.com/sitemap.xml.gz
redirect to the GCS bucket which should make it possible for us to submit the
sitemap easily via the Google Search Console.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
