### PR TITLE
cmd/sitemap: fix validation error

### DIFF
--- a/cmd/sitemap/main.go
+++ b/cmd/sitemap/main.go
@@ -273,11 +273,7 @@ func (g *generator) generate(ctx context.Context) error {
 	for _, docSubPage := range docsSubPages {
 		if addedURLs >= 50000 {
 			addedURLs = 0
-			url := &sitemap.URL{
-				Loc:        fmt.Sprintf("https://storage.googleapis.com/sitemap-sourcegraph-com/sitemap_%03d.xml.gz", len(sitemaps)),
-				ChangeFreq: sitemap.Weekly,
-				Priority:   float32(999 - len(sitemaps)),
-			}
+			url := &sitemap.URL{Loc: fmt.Sprintf("https://storage.googleapis.com/sitemap-sourcegraph-com/sitemap_%03d.xml.gz", len(sitemaps))}
 			sitemapIndex.Add(url)
 			sitemaps = append(sitemaps, sm)
 			sm = sitemap.New()


### PR DESCRIPTION
`<changefreq>` and `<priority>` tags are illegal under `<sitemap>` according to
Google's validator, so remove them. The Go package definition is wrong here because
URL is a shared type between `<sitemapindex>` and `<sitemap>`.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
