### PR TITLE
search: add HTML decoration functions for streaming highlighted results

### DIFF
--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -287,14 +287,14 @@ func CodeAsLines(ctx context.Context, p Params) ([]template.HTML, bool, error) {
 	if err != nil {
 		return nil, aborted, err
 	}
-	lines, err := splitHighlightedLines(html, false)
+	lines, err := SplitHighlightedLines(html, false)
 	return lines, aborted, err
 }
 
-// splitHighlightedLines takes the highlighted HTML table and returns a slice
+// SplitHighlightedLines takes the highlighted HTML table and returns a slice
 // of highlighted strings, where each string corresponds a single line in the
 // original, highlighted file.
-func splitHighlightedLines(input template.HTML, wholeRow bool) ([]template.HTML, error) {
+func SplitHighlightedLines(input template.HTML, wholeRow bool) ([]template.HTML, error) {
 	doc, err := html.Parse(strings.NewReader(string(input)))
 	if err != nil {
 		return nil, err
@@ -365,7 +365,7 @@ type LineRange struct {
 //
 // Input line ranges will automatically be clamped within the bounds of the file.
 func SplitLineRanges(html template.HTML, ranges []LineRange) ([][]string, error) {
-	lines, err := splitHighlightedLines(html, true)
+	lines, err := SplitHighlightedLines(html, true)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/highlight/highlight_test.go
+++ b/cmd/frontend/internal/highlight/highlight_test.go
@@ -68,7 +68,7 @@ func TestSplitHighlightedLines(t *testing.T) {
 		`<div><span style="color:#323232;">
 </span></div>`,
 		`<div></div>`}
-	have, err := splitHighlightedLines(template.HTML(input), false)
+	have, err := SplitHighlightedLines(template.HTML(input), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/internal/search/decorate_test.go
+++ b/cmd/frontend/internal/search/decorate_test.go
@@ -57,72 +57,58 @@ func TestToHunk(t *testing.T) {
 		},
 	}
 
-	want := []stream.DecoratedHunk{
+	want := [][]stream.Range{
 		{
-			Content:   stream.DecoratedContent{Plaintext: "Placeholder"},
-			LineStart: 1,
-			LineCount: 3,
-			Matches: []stream.Range{
-				{
-					Start: stream.Location{Offset: -1, Line: 1, Column: 0},
-					End:   stream.Location{Offset: -1, Line: 1, Column: 1},
-				},
-				{
-					Start: stream.Location{Offset: -1, Line: 2, Column: 2},
-					End:   stream.Location{Offset: -1, Line: 2, Column: 5},
-				},
-				{
-					Start: stream.Location{Offset: -1, Line: 2, Column: 4},
-					End:   stream.Location{Offset: -1, Line: 2, Column: 9},
-				},
-				{
-					Start: stream.Location{Offset: -1, Line: 3, Column: 6},
-					End:   stream.Location{Offset: -1, Line: 3, Column: 13},
-				},
-				{
-					Start: stream.Location{Offset: -1, Line: 3, Column: 8},
-					End:   stream.Location{Offset: -1, Line: 3, Column: 17},
-				},
+			{
+				Start: stream.Location{Offset: -1, Line: 1, Column: 0},
+				End:   stream.Location{Offset: -1, Line: 1, Column: 1},
+			},
+			{
+				Start: stream.Location{Offset: -1, Line: 2, Column: 2},
+				End:   stream.Location{Offset: -1, Line: 2, Column: 5},
+			},
+			{
+				Start: stream.Location{Offset: -1, Line: 2, Column: 4},
+				End:   stream.Location{Offset: -1, Line: 2, Column: 9},
+			},
+			{
+				Start: stream.Location{Offset: -1, Line: 3, Column: 6},
+				End:   stream.Location{Offset: -1, Line: 3, Column: 13},
+			},
+			{
+				Start: stream.Location{Offset: -1, Line: 3, Column: 8},
+				End:   stream.Location{Offset: -1, Line: 3, Column: 17},
 			},
 		},
 		{
-			Content:   stream.DecoratedContent{Plaintext: "Placeholder"},
-			LineStart: 5,
-			LineCount: 2,
-			Matches: []stream.Range{
-				{
-					Start: stream.Location{Offset: -1, Line: 5, Column: 0},
-					End:   stream.Location{Offset: -1, Line: 5, Column: 1},
-				},
-				{
-					Start: stream.Location{Offset: -1, Line: 6, Column: 2},
-					End:   stream.Location{Offset: -1, Line: 6, Column: 5},
-				},
-				{
-					Start: stream.Location{Offset: -1, Line: 6, Column: 4},
-					End:   stream.Location{Offset: -1, Line: 6, Column: 9},
-				},
+			{
+				Start: stream.Location{Offset: -1, Line: 5, Column: 0},
+				End:   stream.Location{Offset: -1, Line: 5, Column: 1},
+			},
+			{
+				Start: stream.Location{Offset: -1, Line: 6, Column: 2},
+				End:   stream.Location{Offset: -1, Line: 6, Column: 5},
+			},
+			{
+				Start: stream.Location{Offset: -1, Line: 6, Column: 4},
+				End:   stream.Location{Offset: -1, Line: 6, Column: 9},
 			},
 		},
 		{
-			Content:   stream.DecoratedContent{Plaintext: "Placeholder"},
-			LineStart: 8,
-			LineCount: 1,
-			Matches: []stream.Range{
-				{
-					Start: stream.Location{Offset: -1, Line: 8, Column: 6},
-					End:   stream.Location{Offset: -1, Line: 8, Column: 13},
-				},
-				{
-					Start: stream.Location{Offset: -1, Line: 8, Column: 8},
-					End:   stream.Location{Offset: -1, Line: 8, Column: 17},
-				},
-			}},
+			{
+				Start: stream.Location{Offset: -1, Line: 8, Column: 6},
+				End:   stream.Location{Offset: -1, Line: 8, Column: 13},
+			},
+			{
+				Start: stream.Location{Offset: -1, Line: 8, Column: 8},
+				End:   stream.Location{Offset: -1, Line: 8, Column: 17},
+			},
+		},
 	}
 
-	var got []stream.DecoratedHunk
+	var got [][]stream.Range
 	for _, group := range data {
-		got = append(got, toHunk(group))
+		got = append(got, toMatchRanges(group))
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
Adds the top level function `DecorateFileHunksHTML` function to convert file matches to decorated hunks. Also introduces helper function `DecorateFileHTML` for decorating an entire file with HTML so that highlighting with constituent values of file matches can be used in other contexts (I have `compute` package in mind).

This isn't hooked up yet, and doesn't propagate `ctx` yet from the caller that will use this. So it's safe to rubber stamp and merge, end-to-end tests. Restructured some functions for this end-to-end case, see inline comments.
