### PR TITLE
playground: unconditionally renders HTML hunks

### DIFF
--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -121,7 +121,7 @@ func DecorateFileHTML(ctx context.Context, repo api.RepoName, commit api.CommitI
 }
 
 // DecorateFileHunksHTML returns decorated file hunks given a file match.
-func DecorateFileHunksHTML(ctx context.Context, fm result.FileMatch) []stream.DecoratedHunk {
+func DecorateFileHunksHTML(ctx context.Context, fm *result.FileMatch) []stream.DecoratedHunk {
 	html, err := DecorateFileHTML(ctx, fm.Repo.Name, fm.CommitID, fm.Path)
 	if err != nil {
 		// TODO(rvantonder): log error and swallow if we can't highlight


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/24577.

This doesn't yet process URL arguments or contexts, and unconditionally creates hunks with HTML highlighting with 0 lines of contexts and sends them over. If you run Sourcegraph with this branch it works with the frontend bits.

I'm running into the `event.Result` loop "blocking" on each highlight request (as expected). Haven't attempted to background the requests yet. Weird thing is that it seems basically sending all events block, even when I hackily put a `matchesFlush` inside a loop, I'm probably missing something. You can try it out by running Sourcegraph and then searching `repo:^github\.com/sourcegraph/sourcegraph$ test type:file` to see the blocking.