### PR TITLE
search: remove redundant loops over repos

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -228,8 +228,10 @@ func (r *searchResolver) protocol() search.Protocol {
 	return search.Batch
 }
 
-const defaultMaxSearchResults = 30
-const defaultMaxSearchResultsStreaming = 500
+const (
+	defaultMaxSearchResults          = 30
+	defaultMaxSearchResultsStreaming = 500
+)
 
 var mockDecodedViewerFinalSettings *schema.Settings
 
@@ -299,7 +301,6 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, options search
 
 	repositoryResolver := &searchrepos.Resolver{
 		DB:                  r.db,
-		Zoekt:               r.zoekt,
 		SearchableReposFunc: backend.Repos.ListSearchable,
 	}
 

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -111,7 +111,6 @@ func (r *searchResolver) reposExist(ctx context.Context, options search.RepoOpti
 	options.UserSettings = r.UserSettings
 	repositoryResolver := &searchrepos.Resolver{
 		DB:                  r.db,
-		Zoekt:               r.zoekt,
 		SearchableReposFunc: backend.Repos.ListSearchable,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
@@ -178,7 +177,6 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context, q query.Q)
 					title:       "No repositories or code hosts configured",
 					description: "To start searching code, first go to site admin to configure repositories and code hosts.",
 				}
-
 			} else {
 				return &searchAlert{
 					title:       "No repositories or code hosts configured",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1545,21 +1545,13 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		agg.Error(&missingRepoRevsError{Missing: resolved.MissingRepoRevs})
 	}
 
-	// Send down our first bit of progress.
-	{
-		repos := make(map[api.RepoID]types.RepoName, len(args.Repos))
-		for _, repoRev := range args.Repos {
-			repos[repoRev.Repo.ID] = repoRev.Repo
-		}
-
-		agg.Send(streaming.SearchEvent{
-			Stats: streaming.Stats{
-				Repos:            repos,
-				ExcludedForks:    resolved.ExcludedRepos.Forks,
-				ExcludedArchived: resolved.ExcludedRepos.Archived,
-			},
-		})
-	}
+	agg.Send(streaming.SearchEvent{
+		Stats: streaming.Stats{
+			Repos:            resolved.RepoSet,
+			ExcludedForks:    resolved.ExcludedRepos.Forks,
+			ExcludedArchived: resolved.ExcludedRepos.Archived,
+		},
+	})
 
 	if args.ResultTypes.Has(result.TypeRepo) {
 		wg := waitGroup(true)

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -51,7 +50,6 @@ func (r *Resolved) String() string {
 
 type Resolver struct {
 	DB                  dbutil.DB
-	Zoekt               *searchbackend.Zoekt
 	SearchableReposFunc searchableReposFunc
 }
 
@@ -129,7 +127,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 
 	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 && !query.HasTypeRepo(op.Query) && searchcontexts.IsGlobalSearchContext(searchContext) {
 		start := time.Now()
-		searchableRepos, err = searchableRepositories(ctx, r.SearchableReposFunc, r.Zoekt, excludePatterns)
+		searchableRepos, err = searchableRepositories(ctx, r.SearchableReposFunc, excludePatterns)
 		if err != nil {
 			return Resolved{}, errors.Wrap(err, "getting list of indexable repos")
 		}
@@ -527,7 +525,7 @@ type searchableReposFunc func(ctx context.Context) ([]types.RepoName, error)
 
 // searchableRepositories returns the intersection of calling gettRawSearchableRepos
 // (db) and indexed repos (zoekt), minus repos matching excludePatterns.
-func searchableRepositories(ctx context.Context, getRawSearchableRepos searchableReposFunc, z *searchbackend.Zoekt, excludePatterns []string) (_ []types.RepoName, err error) {
+func searchableRepositories(ctx context.Context, getRawSearchableRepos searchableReposFunc, excludePatterns []string) (_ []types.RepoName, err error) {
 	tr, ctx := trace.New(ctx, "searchableRepositories", "")
 	defer func() {
 		tr.SetError(err)
@@ -554,25 +552,7 @@ func searchableRepositories(ctx context.Context, getRawSearchableRepos searchabl
 		tr.LazyPrintf("remove excluded repos - done")
 	}
 
-	// Ask Zoekt which repos it has indexed.
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-	set, err := z.ListAll(ctx)
-	if err != nil {
-		return nil, err
-	}
-	tr.LazyPrintf("zoekt.ListAll - done")
-
-	// In place filtering of searchableRepos to only include names from set.
-	repos := searchableRepos[:0]
-	for _, r := range searchableRepos {
-		if _, ok := set[string(r.Name)]; ok {
-			repos = append(repos, r)
-		}
-	}
-	tr.LazyPrintf("filtering - done")
-
-	return repos, nil
+	return searchableRepos, nil
 }
 
 func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.RepositoryRevisions, after string) ([]*search.RepositoryRevisions, error) {

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -353,11 +353,6 @@ func TestSearchableRepositories(t *testing.T) {
 				return drs, nil
 			}
 
-			var indexed []*zoekt.RepoListEntry
-			for name := range tc.searchableRepoNames {
-				indexed = append(indexed, &zoekt.RepoListEntry{Repository: zoekt.Repository{Name: name}})
-			}
-
 			ctx := context.Background()
 			drs, err := searchableRepositories(ctx, getRawSearchableRepos, tc.excludePatterns)
 			if err != nil {

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -319,24 +318,18 @@ func TestSearchableRepositories(t *testing.T) {
 			want:                nil,
 		},
 		{
-			name:                "two in database, one indexed => indexed repo returned",
-			defaultsInDb:        []string{"unindexedrepo", "indexedrepo"},
-			searchableRepoNames: map[string]bool{"indexedrepo": true},
-			want:                []string{"indexedrepo"},
-		},
-		{
 			name:                "should not return excluded repo",
 			defaultsInDb:        []string{"unindexedrepo1", "indexedrepo1", "indexedrepo2", "indexedrepo3"},
 			searchableRepoNames: map[string]bool{"indexedrepo1": true, "indexedrepo2": true, "indexedrepo3": true},
 			excludePatterns:     []string{"indexedrepo3"},
-			want:                []string{"indexedrepo1", "indexedrepo2"},
+			want:                []string{"unindexedrepo1", "indexedrepo1", "indexedrepo2"},
 		},
 		{
 			name:                "should not return excluded repo (case insensitive)",
 			defaultsInDb:        []string{"unindexedrepo1", "indexedrepo1", "indexedrepo2", "Indexedrepo3"},
 			searchableRepoNames: map[string]bool{"indexedrepo1": true, "indexedrepo2": true, "Indexedrepo3": true},
 			excludePatterns:     []string{"indexedrepo3"},
-			want:                []string{"indexedrepo1", "indexedrepo2"},
+			want:                []string{"unindexedrepo1", "indexedrepo1", "indexedrepo2"},
 		},
 		{
 			name:                "should not return excluded repos ending in `test`",
@@ -364,13 +357,9 @@ func TestSearchableRepositories(t *testing.T) {
 			for name := range tc.searchableRepoNames {
 				indexed = append(indexed, &zoekt.RepoListEntry{Repository: zoekt.Repository{Name: name}})
 			}
-			z := &searchbackend.Zoekt{
-				Client:       &searchbackend.FakeSearcher{Repos: indexed},
-				DisableCache: true,
-			}
 
 			ctx := context.Background()
-			drs, err := searchableRepositories(ctx, getRawSearchableRepos, z, tc.excludePatterns)
+			drs, err := searchableRepositories(ctx, getRawSearchableRepos, tc.excludePatterns)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -416,11 +405,6 @@ func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 		}
 	}
 
-	mockZoekt := &searchbackend.Zoekt{
-		Client:       &searchbackend.FakeSearcher{Repos: zoektRepoListEntries},
-		DisableCache: true,
-	}
-
 	tests := []struct {
 		name              string
 		searchContextSpec string
@@ -435,7 +419,7 @@ func TestUseIndexableReposIfMissingOrGlobalSearchContext(t *testing.T) {
 				SearchContextSpec: tt.searchContextSpec,
 				Query:             queryInfo,
 			}
-			repositoryResolver := &Resolver{Zoekt: mockZoekt, SearchableReposFunc: mockSearchableReposFunc}
+			repositoryResolver := &Resolver{SearchableReposFunc: mockSearchableReposFunc}
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
We remove 2 bottlenecks for global searches.

1. We precompute repo sets to speed up sending back stats to the UI.
2. We remove a slow loop in repo resolution which scaled lineraly with the number of repos.

Possible side effect: `searchableRepos` now returns repos which we haven't indexed yet. 