### PR TITLE
ssbc: Reimplement file result matches

### DIFF
--- a/client/web/src/enterprise/batches/create/examples/ExampleTabs.tsx
+++ b/client/web/src/enterprise/batches/create/examples/ExampleTabs.tsx
@@ -191,6 +191,7 @@ const PreviewWorkspaces: React.FunctionComponent<{ preview: BatchSpecWorkspacesF
                         <p>
                             {item.repository.name}:{item.branch.abbrevName}@{item.branch.target.oid} Path: {item.path}
                         </p>
+                        <p>{item.fileResultPaths.join(', ')}</p>
                         <ul>
                             {item.steps.map((step, index) => (
                                 <li key={index}>

--- a/client/web/src/enterprise/batches/create/examples/ExampleTabs.tsx
+++ b/client/web/src/enterprise/batches/create/examples/ExampleTabs.tsx
@@ -191,7 +191,7 @@ const PreviewWorkspaces: React.FunctionComponent<{ preview: BatchSpecWorkspacesF
                         <p>
                             {item.repository.name}:{item.branch.abbrevName}@{item.branch.target.oid} Path: {item.path}
                         </p>
-                        <p>{item.fileResultPaths.join(', ')}</p>
+                        <p>{item.searchResultPaths.join(', ')}</p>
                         <ul>
                             {item.steps.map((step, index) => (
                                 <li key={index}>

--- a/client/web/src/enterprise/batches/create/examples/backend.ts
+++ b/client/web/src/enterprise/batches/create/examples/backend.ts
@@ -57,7 +57,7 @@ export function resolveWorkspacesForBatchSpec(spec: string): Observable<BatchSpe
                     command
                     container
                 }
-                fileResultPaths
+                searchResultPaths
             }
         `,
         { spec }

--- a/client/web/src/enterprise/batches/create/examples/backend.ts
+++ b/client/web/src/enterprise/batches/create/examples/backend.ts
@@ -57,6 +57,7 @@ export function resolveWorkspacesForBatchSpec(spec: string): Observable<BatchSpe
                     command
                     container
                 }
+                fileResultPaths
             }
         `,
         { spec }

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -777,6 +777,7 @@ type BatchSpecWorkspaceResolver interface {
 	Path() string
 	OnlyFetchWorkspace() bool
 	Steps() []BatchSpecWorkspaceStepResolver
+	FileResultPaths() []string
 }
 
 type BatchSpecWorkspaceStepResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -764,6 +764,7 @@ type BatchSpecExecutionStepsResolver interface {
 }
 
 type BatchSpecWorkspacesResolver interface {
+	RawSpec() string
 	AllowIgnored() bool
 	AllowUnsupported() bool
 	Workspaces() []BatchSpecWorkspaceResolver
@@ -777,7 +778,7 @@ type BatchSpecWorkspaceResolver interface {
 	Path() string
 	OnlyFetchWorkspace() bool
 	Steps() []BatchSpecWorkspaceStepResolver
-	FileResultPaths() []string
+	SearchResultPaths() []string
 }
 
 type BatchSpecWorkspaceStepResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2311,6 +2311,12 @@ type BatchSpecWorkspace {
     List of steps that will need to run over this workspace.
     """
     steps: [BatchSpecWorkspaceStep!]!
+
+    """
+    If this workspace was resolved based on a search, this is the list of paths
+    to files that have been included in the search results.
+    """
+    fileResultPaths: [String!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2257,6 +2257,11 @@ A bag for all info around resolving workspaces.
 """
 type BatchSpecWorkspaces {
     """
+    The raw input given to produce this preview.
+    """
+    rawSpec: String!
+
+    """
     If true, repos with a .batchignore file will still be included.
     """
     allowIgnored: Boolean!
@@ -2316,7 +2321,7 @@ type BatchSpecWorkspace {
     If this workspace was resolved based on a search, this is the list of paths
     to files that have been included in the search results.
     """
-    fileResultPaths: [String!]!
+    searchResultPaths: [String!]!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -36,7 +36,7 @@ func (r *batchSpecWorkspaceResolver) OnlyFetchWorkspace() bool {
 	return r.node.OnlyFetchWorkspace
 }
 
-func (r *batchSpecWorkspaceResolver) FileResultPaths() []string {
+func (r *batchSpecWorkspaceResolver) SearchResultPaths() []string {
 	return r.node.FileMatches
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -36,6 +36,10 @@ func (r *batchSpecWorkspaceResolver) OnlyFetchWorkspace() bool {
 	return r.node.OnlyFetchWorkspace
 }
 
+func (r *batchSpecWorkspaceResolver) FileResultPaths() []string {
+	return r.node.FileMatches
+}
+
 func (r *batchSpecWorkspaceResolver) Steps() []graphqlbackend.BatchSpecWorkspaceStepResolver {
 	resolvers := make([]graphqlbackend.BatchSpecWorkspaceStepResolver, 0, len(r.node.Steps))
 	for _, step := range r.node.Steps {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspaces.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspaces.go
@@ -14,6 +14,7 @@ type batchSpecWorkspacesResolver struct {
 	unsupported      map[*types.Repo]struct{}
 	ignored          map[*types.Repo]struct{}
 	workspaces       []*service.RepoWorkspace
+	rawSpec          string
 }
 
 var _ graphqlbackend.BatchSpecWorkspacesResolver = &batchSpecWorkspacesResolver{}
@@ -24,6 +25,10 @@ func (r *batchSpecWorkspacesResolver) AllowIgnored() bool {
 
 func (r *batchSpecWorkspacesResolver) AllowUnsupported() bool {
 	return r.allowUnsupported
+}
+
+func (r *batchSpecWorkspacesResolver) RawSpec() string {
+	return r.rawSpec
 }
 
 func (r *batchSpecWorkspacesResolver) Workspaces() []graphqlbackend.BatchSpecWorkspaceResolver {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1537,6 +1537,7 @@ func (r *Resolver) ResolveWorkspacesForBatchSpec(ctx context.Context, args *grap
 
 	return &batchSpecWorkspacesResolver{
 		store:            r.store,
+		rawSpec:          args.BatchSpec,
 		allowUnsupported: args.AllowUnsupported,
 		allowIgnored:     args.AllowIgnored,
 		workspaces:       workspaces,

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -640,9 +640,10 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 
 // RepoRevision describes a repository on a branch at a fixed revision.
 type RepoRevision struct {
-	Repo   *types.Repo
-	Branch string
-	Commit api.CommitID
+	Repo        *types.Repo
+	Branch      string
+	Commit      api.CommitID
+	FileMatches []string
 }
 
 func (r *RepoRevision) HasBranch() bool {

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -429,7 +429,14 @@ func (wr *workspaceResolver) FindDirectoriesInRepos(ctx context.Context, fileNam
 					// src-cli might be executed on Windows, we need the paths to
 					// be Unix paths, since they will be used inside Docker
 					// containers.
-					results = append(results, path.Dir(m.Path))
+					dir := path.Dir(m.Path)
+
+					// "." means the path is root, but in the executor we use "" to signify root.
+					if dir == "." {
+						dir = ""
+					}
+
+					results = append(results, dir)
 				}
 			}
 		})

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"regexp"
 	"sort"
 	"sync"
@@ -225,7 +226,12 @@ func (wr *workspaceResolver) resolveRepositoryName(ctx context.Context, name str
 		return nil, err
 	}
 
-	return repoToRepoRevisionWithDefaultBranch(ctx, repo)
+	return repoToRepoRevisionWithDefaultBranch(
+		ctx,
+		repo,
+		// Directly resolved repos don't have any file matches.
+		[]string{},
+	)
 }
 
 func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context, name, branch string) (_ *RepoRevision, err error) {
@@ -251,6 +257,8 @@ func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context,
 		Repo:   repo,
 		Branch: branch,
 		Commit: commit,
+		// Directly resolved repos don't have any file matches.
+		FileMatches: []string{},
 	}, nil
 }
 
@@ -262,9 +270,19 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 	}()
 
 	query = setDefaultQueryCount(query)
-	query = setDefaultQuerySelect(query)
 
 	repoIDs := []api.RepoID{}
+	repoFileMatches := make(map[api.RepoID]map[string]bool)
+	addRepoFilePatch := func(repoID api.RepoID, path string) {
+		repoMap, ok := repoFileMatches[repoID]
+		if !ok {
+			repoMap = make(map[string]bool)
+			repoFileMatches[repoID] = repoMap
+		}
+		if _, ok := repoMap[path]; !ok {
+			repoMap[path] = true
+		}
+	}
 	wr.runSearch(ctx, query, func(matches []streamhttp.EventMatch) {
 		for _, match := range matches {
 			switch m := match.(type) {
@@ -272,10 +290,13 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
 			case *streamhttp.EventContentMatch:
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
+				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Path)
 			case *streamhttp.EventPathMatch:
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
+				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Path)
 			case *streamhttp.EventSymbolMatch:
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
+				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Path)
 			}
 		}
 	})
@@ -289,7 +310,11 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 
 	revs := make([]*RepoRevision, 0, len(accessibleRepos))
 	for _, repo := range accessibleRepos {
-		rev, err := repoToRepoRevisionWithDefaultBranch(ctx, repo)
+		fileMatches := make([]string, 0, len(repoFileMatches[repo.ID]))
+		for path := range repoFileMatches[repo.ID] {
+			fileMatches = append(fileMatches, path)
+		}
+		rev, err := repoToRepoRevisionWithDefaultBranch(ctx, repo, fileMatches)
 		if err != nil {
 			return nil, err
 		}
@@ -331,7 +356,7 @@ func (wr *workspaceResolver) runSearch(ctx context.Context, query string, onMatc
 	return dec.ReadAll(resp.Body)
 }
 
-func repoToRepoRevisionWithDefaultBranch(ctx context.Context, repo *types.Repo) (_ *RepoRevision, err error) {
+func repoToRepoRevisionWithDefaultBranch(ctx context.Context, repo *types.Repo, fileMatches []string) (_ *RepoRevision, err error) {
 	tr, ctx := trace.New(ctx, "repoToRepoRevision", "")
 	defer func() {
 		tr.SetError(err)
@@ -344,9 +369,10 @@ func repoToRepoRevisionWithDefaultBranch(ctx context.Context, repo *types.Repo) 
 	}
 
 	repoRev := &RepoRevision{
-		Repo:   repo,
-		Branch: branch,
-		Commit: commit,
+		Repo:        repo,
+		Branch:      branch,
+		Commit:      commit,
+		FileMatches: fileMatches,
 	}
 	return repoRev, nil
 }
@@ -385,18 +411,6 @@ func setDefaultQueryCount(query string) string {
 	return query + hardCodedCount
 }
 
-var selectRegex = regexp.MustCompile(`\bselect:(.+)\b`)
-
-const hardCodedSelectRepo = " select:repo"
-
-func setDefaultQuerySelect(query string) string {
-	if selectRegex.MatchString(query) {
-		return query
-	}
-
-	return query + hardCodedSelectRepo
-}
-
 // FindDirectoriesInRepos returns a map of repositories and the locations of
 // files matching the given file name in the repository.
 // The locations are paths relative to the root of the directory.
@@ -411,7 +425,11 @@ func (wr *workspaceResolver) FindDirectoriesInRepos(ctx context.Context, fileNam
 			for _, match := range matches {
 				switch m := match.(type) {
 				case (*streamhttp.EventPathMatch):
-					results = append(results, m.Path)
+					// We use path.Dir and not filepath.Dir here, because while
+					// src-cli might be executed on Windows, we need the paths to
+					// be Unix paths, since they will be used inside Docker
+					// containers.
+					results = append(results, path.Dir(m.Path))
 				}
 			}
 		})
@@ -565,7 +583,11 @@ func findWorkspaces(
 
 	workspaces := make([]*RepoWorkspace, 0, len(workspacesByRepoRev))
 	for _, workspace := range workspacesByRepoRev {
-		steps, err := stepsForRepoRevision(spec, workspace.RepoRevision)
+		steps, err := stepsForRepo(
+			spec,
+			string(workspace.RepoRevision.Repo.Name),
+			workspace.RepoRevision.FileMatches,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -601,8 +623,8 @@ func findWorkspaces(
 	return workspaces, nil
 }
 
-// stepsForRepoRevision calculates the steps required to run on the given repo.
-func stepsForRepoRevision(spec *batcheslib.BatchSpec, repoRev *RepoRevision) ([]batcheslib.Step, error) {
+// stepsForRepo calculates the steps required to run on the given repo.
+func stepsForRepo(spec *batcheslib.BatchSpec, repoName string, fileMatches []string) ([]batcheslib.Step, error) {
 	taskSteps := []batcheslib.Step{}
 
 	for _, step := range spec.Steps {
@@ -618,9 +640,8 @@ func stepsForRepoRevision(spec *batcheslib.BatchSpec, repoRev *RepoRevision) ([]
 		}
 		stepCtx := &template.StepContext{
 			Repository: template.Repository{
-				Name: string(repoRev.Repo.Name),
-				// TODO: Reimplement.
-				FileMatches: make(map[string]bool),
+				Name:        repoName,
+				FileMatches: fileMatches,
 			},
 			BatchChange: batchChange,
 		}

--- a/lib/batches/template/main_test.go
+++ b/lib/batches/template/main_test.go
@@ -2,8 +2,7 @@ package template
 
 var testRepo1 = &Repository{
 	Name: "github.com/sourcegraph/src-cli",
-	FileMatches: map[string]bool{
-		"README.md": true,
-		"main.go":   true,
+	FileMatches: []string{
+		"README.md", "main.go",
 	},
 }

--- a/lib/batches/template/partial_eval_test.go
+++ b/lib/batches/template/partial_eval_test.go
@@ -14,9 +14,8 @@ var partialEvalStepCtx = &StepContext{
 	// Step is not set when evalStepCondition is called
 	Repository: Repository{
 		Name: "github.com/sourcegraph/src-cli",
-		FileMatches: map[string]bool{
-			"README.md": true,
-			"main.go":   true,
+		FileMatches: []string{
+			"README.md", "main.go",
 		},
 	},
 }

--- a/lib/batches/template/templating.go
+++ b/lib/batches/template/templating.go
@@ -88,16 +88,12 @@ type BatchChangeAttributes struct {
 
 type Repository struct {
 	Name        string
-	FileMatches map[string]bool
+	FileMatches []string
 }
 
 func (r Repository) SearchResultPaths() (list fileMatchPathList) {
-	var files []string
-	for f := range r.FileMatches {
-		files = append(files, f)
-	}
-	sort.Strings(files)
-	return fileMatchPathList(files)
+	sort.Strings(r.FileMatches)
+	return fileMatchPathList(r.FileMatches)
 }
 
 type fileMatchPathList []string


### PR DESCRIPTION
This wasn't implemented so far. It is required for a 100% feature parity on conditional execution, though so adding it now.
