### PR TITLE
web: add `getGraphQLClient` to the `platformContext`

### DIFF
--- a/client/browser/src/shared/backend/requestGraphQl.ts
+++ b/client/browser/src/shared/backend/requestGraphQl.ts
@@ -1,9 +1,13 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { memoize } from 'lodash'
 import { from } from 'rxjs'
 
-import { requestGraphQLCommon } from '@sourcegraph/shared/src/graphql/graphql'
+import { requestGraphQLCommon, getGraphQLClient } from '@sourcegraph/shared/src/graphql/graphql'
 
 import { background } from '../../browser-extension/web-extension-api/runtime'
 import { isBackground } from '../context'
+
+import { getHeaders } from './headers'
 
 /**
  * Returns a platform-appropriate implementation of the function used to make requests to our GraphQL API.
@@ -29,3 +33,11 @@ export const requestGraphQlHelper = (isExtension: boolean, baseUrl: string) => <
               baseUrl,
               credentials: 'include',
           })
+
+/**
+ * Memoized Apollo Client getter. It should be executed once to restore the cache from the local storage.
+ * After that, the same instance should be used by all consumers.
+ */
+export const getBrowserGraphQLClient = memoize(
+    (): Promise<ApolloClient<NormalizedCacheObject>> => getGraphQLClient({ headers: getHeaders() })
+)

--- a/client/browser/src/shared/backend/requestGraphQl.ts
+++ b/client/browser/src/shared/backend/requestGraphQl.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
-import { memoize } from 'lodash'
+import { once } from 'lodash'
 import { from } from 'rxjs'
 
 import { requestGraphQLCommon, getGraphQLClient } from '@sourcegraph/shared/src/graphql/graphql'
@@ -38,6 +38,6 @@ export const requestGraphQlHelper = (isExtension: boolean, baseUrl: string) => <
  * Memoized Apollo Client getter. It should be executed once to restore the cache from the local storage.
  * After that, the same instance should be used by all consumers.
  */
-export const getBrowserGraphQLClient = memoize(
+export const getBrowserGraphQLClient = once(
     (): Promise<ApolloClient<NormalizedCacheObject>> => getGraphQLClient({ headers: getHeaders() })
 )

--- a/client/browser/src/shared/platform/context.ts
+++ b/client/browser/src/shared/platform/context.ts
@@ -13,7 +13,7 @@ import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { ExtensionStorageSubject } from '../../browser-extension/web-extension-api/ExtensionStorageSubject'
 import { background } from '../../browser-extension/web-extension-api/runtime'
-import { requestGraphQlHelper } from '../backend/requestGraphQl'
+import { requestGraphQlHelper, getBrowserGraphQLClient } from '../backend/requestGraphQl'
 import { CodeHost } from '../code-hosts/shared/codeHost'
 import { isInPage } from '../context'
 import { observeSourcegraphURL } from '../util/context'
@@ -130,6 +130,7 @@ export function createPlatformContext(
             await context.refreshSettings()
         },
         requestGraphQL,
+        getGraphQLClient: getBrowserGraphQLClient,
         forceUpdateTooltip: () => {
             // TODO(sqs): implement tooltips on the browser extension
         },

--- a/client/shared/src/api/client/connection.ts
+++ b/client/shared/src/api/client/connection.ts
@@ -45,6 +45,7 @@ export async function createExtensionHostClientConnection(
         PlatformContext,
         | 'settings'
         | 'updateSettings'
+        | 'getGraphQLClient'
         | 'requestGraphQL'
         | 'telemetryService'
         | 'sideloadedExtensionURL'

--- a/client/shared/src/api/client/mainthread-api.test.ts
+++ b/client/shared/src/api/client/mainthread-api.test.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, EMPTY, of, Subject } from 'rxjs'
 import sinon from 'sinon'
 
-import { SuccessGraphQLResult } from '../../graphql/graphql'
+import { getGraphQLClient as getGraphQLClientBase, SuccessGraphQLResult } from '../../graphql/graphql'
 import { PlatformContext } from '../../platform/context'
 import { SettingsCascade } from '../../settings/settings'
 import { FlatExtensionHostAPI } from '../contract'
@@ -12,6 +12,7 @@ import { SettingsEdit } from './services/settings'
 
 describe('MainThreadAPI', () => {
     // TODO(tj): commands, notifications
+    const getGraphQLClient = () => getGraphQLClientBase({ headers: {} })
 
     describe('graphQL', () => {
         test('PlatformContext#requestGraphQL is called with the correct arguments', async () => {
@@ -21,12 +22,14 @@ describe('MainThreadAPI', () => {
                 PlatformContext,
                 | 'updateSettings'
                 | 'settings'
+                | 'getGraphQLClient'
                 | 'requestGraphQL'
                 | 'getScriptURLForExtension'
                 | 'sideloadedExtensionURL'
                 | 'clientApplication'
             > = {
                 settings: EMPTY,
+                getGraphQLClient,
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL,
                 getScriptURLForExtension: () => undefined,
@@ -60,12 +63,14 @@ describe('MainThreadAPI', () => {
                 PlatformContext,
                 | 'updateSettings'
                 | 'settings'
+                | 'getGraphQLClient'
                 | 'requestGraphQL'
                 | 'getScriptURLForExtension'
                 | 'sideloadedExtensionURL'
                 | 'clientApplication'
             > = {
                 settings: EMPTY,
+                getGraphQLClient,
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL,
                 getScriptURLForExtension: () => undefined,
@@ -93,6 +98,7 @@ describe('MainThreadAPI', () => {
                 | 'updateSettings'
                 | 'settings'
                 | 'requestGraphQL'
+                | 'getGraphQLClient'
                 | 'getScriptURLForExtension'
                 | 'sideloadedExtensionURL'
                 | 'clientApplication'
@@ -114,6 +120,7 @@ describe('MainThreadAPI', () => {
                     final: { a: 'value' },
                 }),
                 updateSettings,
+                getGraphQLClient,
                 requestGraphQL: () => EMPTY,
                 getScriptURLForExtension: () => undefined,
                 sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
@@ -148,11 +155,13 @@ describe('MainThreadAPI', () => {
                 PlatformContext,
                 | 'updateSettings'
                 | 'settings'
+                | 'getGraphQLClient'
                 | 'requestGraphQL'
                 | 'getScriptURLForExtension'
                 | 'sideloadedExtensionURL'
                 | 'clientApplication'
             > = {
+                getGraphQLClient,
                 settings: of(...values),
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL: () => EMPTY,
@@ -180,6 +189,7 @@ describe('MainThreadAPI', () => {
                 PlatformContext,
                 | 'updateSettings'
                 | 'settings'
+                | 'getGraphQLClient'
                 | 'requestGraphQL'
                 | 'getScriptURLForExtension'
                 | 'sideloadedExtensionURL'
@@ -187,6 +197,7 @@ describe('MainThreadAPI', () => {
             > = {
                 settings: values.asObservable(),
                 updateSettings: () => Promise.resolve(),
+                getGraphQLClient,
                 requestGraphQL: () => EMPTY,
                 getScriptURLForExtension: () => undefined,
                 sideloadedExtensionURL: new BehaviorSubject<string | null>(null),

--- a/client/shared/src/api/client/mainthread-api.ts
+++ b/client/shared/src/api/client/mainthread-api.ts
@@ -60,6 +60,7 @@ export const initMainThreadAPI = (
         PlatformContext,
         | 'updateSettings'
         | 'settings'
+        | 'getGraphQLClient'
         | 'requestGraphQL'
         | 'showMessage'
         | 'showInputBox'

--- a/client/shared/src/api/integration-test/testHelpers.ts
+++ b/client/shared/src/api/integration-test/testHelpers.ts
@@ -42,6 +42,7 @@ interface Mocks
         PlatformContext,
         | 'settings'
         | 'updateSettings'
+        | 'getGraphQLClient'
         | 'requestGraphQL'
         | 'getScriptURLForExtension'
         | 'clientApplication'
@@ -53,6 +54,7 @@ interface Mocks
 const NOOP_MOCKS: Mocks = {
     settings: of({ final: {}, subjects: [] }),
     updateSettings: () => Promise.reject(new Error('Mocks#updateSettings not implemented')),
+    getGraphQLClient: () => Promise.reject(new Error('Mocks#getGraphQLClient not implemented')),
     requestGraphQL: () => throwError(new Error('Mocks#queryGraphQL not implemented')),
     getScriptURLForExtension: () => undefined,
     clientApplication: 'sourcegraph',

--- a/client/shared/src/graphql/graphql.ts
+++ b/client/shared/src/graphql/graphql.ts
@@ -15,6 +15,7 @@ import {
     QueryTuple,
 } from '@apollo/client'
 import { GraphQLError } from 'graphql'
+import { memoize } from 'lodash'
 import { useMemo } from 'react'
 import { Observable } from 'rxjs'
 import { fromFetch } from 'rxjs/fetch'
@@ -101,6 +102,49 @@ export const graphQLClient = ({ headers }: { headers: RequestInit['headers'] }):
             headers,
         }),
     })
+
+interface GetGraphqlClientOptions {
+    headers: RequestInit['headers']
+}
+
+export const getGraphQLClient = memoize(
+    async (options: GetGraphqlClientOptions): Promise<ApolloClient<NormalizedCacheObject>> => {
+        const { headers } = options
+
+        const apolloClient = new ApolloClient({
+            uri: GRAPHQL_URI,
+            cache,
+            defaultOptions: {
+                /**
+                 * The default `fetchPolicy` is `cache-first`, which returns a cached response
+                 * and doesn't trigger cache update. This is undesirable default behavior because
+                 * we want to keep our cache updated to avoid confusing the user with stale data.
+                 * `cache-and-network` allows us to return a cached result right away and then update
+                 * all consumers with the fresh data from the network request.
+                 */
+                watchQuery: {
+                    fetchPolicy: 'cache-and-network',
+                },
+                /**
+                 * `client.query()` returns promise, so it can only resolve one response.
+                 * Meaning we cannot return the cached result first and then update it with
+                 * the response from the network as it's done in `client.watchQuery()`.
+                 * So we always need to make a network request to get data unless another
+                 * `fetchPolicy` is specified in the `client.query()` call.
+                 */
+                query: {
+                    fetchPolicy: 'network-only',
+                },
+            },
+            link: createHttpLink({
+                uri: ({ operationName }) => `${GRAPHQL_URI}?${operationName}`,
+                headers,
+            }),
+        })
+
+        return Promise.resolve(apolloClient)
+    }
+)
 
 type RequestDocument = string | DocumentNode
 

--- a/client/shared/src/graphql/graphql.ts
+++ b/client/shared/src/graphql/graphql.ts
@@ -15,7 +15,7 @@ import {
     QueryTuple,
 } from '@apollo/client'
 import { GraphQLError } from 'graphql'
-import { memoize } from 'lodash'
+import { once } from 'lodash'
 import { useMemo } from 'react'
 import { Observable } from 'rxjs'
 import { fromFetch } from 'rxjs/fetch'
@@ -107,7 +107,7 @@ interface GetGraphqlClientOptions {
     headers: RequestInit['headers']
 }
 
-export const getGraphQLClient = memoize(
+export const getGraphQLClient = once(
     async (options: GetGraphqlClientOptions): Promise<ApolloClient<NormalizedCacheObject>> => {
         const { headers } = options
 

--- a/client/shared/src/platform/context.ts
+++ b/client/shared/src/platform/context.ts
@@ -1,3 +1,4 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { Endpoint } from 'comlink'
 import { isObject } from 'lodash'
 import { NextObserver, Observable, Subscribable, Subscription } from 'rxjs'
@@ -91,6 +92,11 @@ export interface PlatformContext {
      * update.
      */
     updateSettings: (subject: Scalars['ID'], edit: SettingsEdit | string) => Promise<void>
+
+    /**
+     * Returns promise that resolves into Apollo Client instance after cache restoration.
+     */
+    getGraphQLClient: () => Promise<ApolloClient<NormalizedCacheObject>>
 
     /**
      * Sends a request to the Sourcegraph GraphQL API and returns the response.

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -1,6 +1,6 @@
 import 'focus-visible'
 
-import { ApolloProvider } from '@apollo/client'
+import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/client'
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
@@ -30,7 +30,7 @@ import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '@sourcegraph/share
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { authenticatedUser, AuthenticatedUser } from './auth'
-import { client } from './backend/graphql'
+import { getWebGraphQLClient } from './backend/graphql'
 import { BatchChangesProps } from './batches'
 import { CodeIntelligenceProps } from './codeintel'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -128,6 +128,9 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
 
     /** The currently authenticated user (or null if the viewer is anonymous). */
     authenticatedUser?: AuthenticatedUser | null
+
+    /** GraphQL client initialized asynchronously to restore persisted cache. */
+    graphqlClient?: ApolloClient<NormalizedCacheObject>
 
     viewerSubject: LayoutProps['viewerSubject']
 
@@ -350,6 +353,12 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
 
         document.documentElement.classList.add('theme')
 
+        getWebGraphQLClient()
+            .then(graphqlClient => this.setState({ graphqlClient }))
+            .catch(error => {
+                console.error('Error initalizing GraphQL client', error)
+            })
+
         this.subscriptions.add(
             combineLatest([from(this.platformContext.settings), authenticatedUser.pipe(startWith(null))]).subscribe(
                 ([settingsCascade, authenticatedUser]) => {
@@ -502,15 +511,15 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
             return <HeroPage icon={ServerIcon} title={`${statusCode}: ${statusText}`} subtitle={subtitle} />
         }
 
-        const { authenticatedUser } = this.state
-        if (authenticatedUser === undefined) {
+        const { authenticatedUser, graphqlClient } = this.state
+        if (authenticatedUser === undefined || graphqlClient === undefined) {
             return null
         }
 
         const { children, ...props } = this.props
 
         return (
-            <ApolloProvider client={client}>
+            <ApolloProvider client={graphqlClient}>
                 <ErrorBoundary location={null}>
                     <ShortcutProvider>
                         <TemporarySettingsProvider authenticatedUser={authenticatedUser}>

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -1,6 +1,8 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { memoize } from 'lodash'
 import { Observable } from 'rxjs'
 
-import { graphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/shared/src/graphql/graphql'
+import { getGraphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 
 const getHeaders = (): { [header: string]: string } => ({
@@ -61,10 +63,17 @@ export const mutateGraphQL = (request: string, variables?: {}): Observable<Graph
         headers: getHeaders(),
     })
 
-export const client = graphQLClient({
-    headers: {
-        ...window?.context?.xhrHeaders,
-        'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
-        // Note: Do not use getHeaders() here due to a bug that Apollo has duplicating headers with different letter casing. Issue to fix: https://github.com/apollographql/apollo-client/issues/8447
-    },
-})
+/**
+ * Memoized Apollo Client getter. It should be executed once to restore the cache from the local storage.
+ * After that, the same instance should be used by all consumers.
+ */
+export const getWebGraphQLClient = memoize(
+    (): Promise<ApolloClient<NormalizedCacheObject>> =>
+        getGraphQLClient({
+            headers: {
+                ...window?.context?.xhrHeaders,
+                'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
+                // Note: Do not use getHeaders() here due to a bug that Apollo has duplicating headers with different letter casing. Issue to fix: https://github.com/apollographql/apollo-client/issues/8447
+            },
+        })
+)

--- a/client/web/src/platform/context.ts
+++ b/client/web/src/platform/context.ts
@@ -20,7 +20,7 @@ import {
     appendSubtreeQueryParameter,
 } from '@sourcegraph/shared/src/util/url'
 
-import { queryGraphQL, requestGraphQL } from '../backend/graphql'
+import { getWebGraphQLClient, queryGraphQL, requestGraphQL } from '../backend/graphql'
 import { eventLogger } from '../tracking/eventLogger'
 
 /**
@@ -61,6 +61,7 @@ export function createPlatformContext(): PlatformContext {
             }
             updatedSettings.next(await fetchViewerSettings().toPromise())
         },
+        getGraphQLClient: getWebGraphQLClient,
         requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
         forceUpdateTooltip: () => Tooltip.forceUpdate(),
         createExtensionHost: () => Promise.resolve(createExtensionHost()),

--- a/client/web/src/settings/temporary/TemporarySettingsProvider.tsx
+++ b/client/web/src/settings/temporary/TemporarySettingsProvider.tsx
@@ -2,12 +2,11 @@ import { useApolloClient } from '@apollo/client'
 import React, { createContext, useEffect, useState } from 'react'
 
 import { AuthenticatedUser } from '../../auth'
-import { client } from '../../backend/graphql'
 
 import { TemporarySettingsStorage } from './TemporarySettingsStorage'
 
 export const TemporarySettingsContext = createContext<TemporarySettingsStorage>(
-    new TemporarySettingsStorage(client, null)
+    new TemporarySettingsStorage(null, null)
 )
 TemporarySettingsContext.displayName = 'TemporarySettingsContext'
 

--- a/client/web/src/settings/temporary/TemporarySettingsStorage.ts
+++ b/client/web/src/settings/temporary/TemporarySettingsStorage.ts
@@ -22,7 +22,7 @@ export class TemporarySettingsStorage {
         this.saveSubscription?.unsubscribe()
     }
 
-    constructor(private apolloClient: ApolloClient<object>, authenticatedUser: AuthenticatedUser | null) {
+    constructor(private apolloClient: ApolloClient<object> | null, authenticatedUser: AuthenticatedUser | null) {
         this.setAuthenticatedUser(authenticatedUser)
     }
 
@@ -31,6 +31,10 @@ export class TemporarySettingsStorage {
             this.authenticatedUser = user
 
             if (this.authenticatedUser) {
+                if (!this.apolloClient) {
+                    throw new Error('Apollo-Client should be initialized for authenticated user')
+                }
+
                 this.setSettingsBackend(new ServersideSettingsBackend(this.apolloClient))
             } else {
                 this.setSettingsBackend(new LocalStorageSettingsBackend())


### PR DESCRIPTION
## Context

Preparation to land https://github.com/sourcegraph/sourcegraph/pull/23351. To leverage Apollo-Client cache in different parts of the app, we need to make it available everywhere without global imports. Similar to distributing the `requestGraphql` function, we can now access `getGraphQLClient` from the `platformContext`.

## Changes

- Added `getGraphQLClient` to the `platformContext`.
- Added separate methods to initialize Apollo Client for the web app and the browser extension.
  - Apollo Client instance is created asynchronously to restore persistent cache in an async manner in the [follow-up PR](https://github.com/sourcegraph/sourcegraph/pull/23351). 
  - The delay for async client init is negligible and doesn't affect the perceived performance.
- Updated  [default fetch](https://www.apollographql.com/docs/react/data/queries/#cache-first) policies for Apollo Client to avoid always serving stale cached data:
  -  The default `fetchPolicy` was [cache-first](https://www.apollographql.com/docs/react/data/queries/#cache-first).
  - `client.watchQuery` now uses [cache-and-network](https://www.apollographql.com/docs/react/data/queries/#cache-and-network) policy.
  - `client.query` uses [network-only](https://www.apollographql.com/docs/react/data/queries/#network-only) policy.
  - It's possible to use custom `fetchPolicy` in places where it makes sense through [query options](https://www.apollographql.com/docs/react/data/queries/#fetchpolicy). 