### PR TITLE
web: add missing typename to `viewerSettings` and `extensionsRegistry` queries in tests

### DIFF
--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -372,25 +372,28 @@ describe('Batches', () => {
             batchChanges: true,
         }),
     }
+    const batchChangesListResults = {
+        BatchChanges: () => ({
+            batchChanges: {
+                nodes: [batchChangeListNode],
+                pageInfo: {
+                    endCursor: null,
+                    hasNextPage: false,
+                },
+                totalCount: 1,
+            },
+            allBatchChanges: {
+                totalCount: 1,
+            },
+        }),
+    }
 
     describe('Batch changes list', () => {
         it('lists global batch changes', async () => {
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
                 ...batchChangeLicenseGraphQlResults,
-                BatchChanges: () => ({
-                    batchChanges: {
-                        nodes: [batchChangeListNode],
-                        pageInfo: {
-                            endCursor: null,
-                            hasNextPage: false,
-                        },
-                        totalCount: 1,
-                    },
-                    allBatchChanges: {
-                        totalCount: 1,
-                    },
-                }),
+                ...batchChangesListResults,
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/batch-changes')
             await driver.page.waitForSelector('.test-batches-list-page')
@@ -414,6 +417,7 @@ describe('Batches', () => {
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
                 ...batchChangeLicenseGraphQlResults,
+                ...batchChangesListResults,
                 ...mockCommonGraphQLResponses('user'),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/users/alice/batch-changes')
@@ -431,6 +435,7 @@ describe('Batches', () => {
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
                 ...batchChangeLicenseGraphQlResults,
+                ...batchChangesListResults,
                 ...mockCommonGraphQLResponses('org'),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/batch-changes')
@@ -452,6 +457,7 @@ describe('Batches', () => {
                 testContext.overrideGraphQL({
                     ...commonWebGraphQlResults,
                     ...batchChangeLicenseGraphQlResults,
+                    ...batchChangesListResults,
                     ...mockCommonGraphQLResponses(entityType),
                     BatchChangeChangesets,
                     ChangesetCountsOverTime,

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -168,6 +168,7 @@ describe('Blob viewer', () => {
                 ...commonBlobGraphQlResults,
                 ViewerSettings: () => ({
                     viewerSettings: {
+                        __typename: 'SettingsCascade',
                         final: JSON.stringify(userSettings),
                         subjects: [
                             {
@@ -218,6 +219,7 @@ describe('Blob viewer', () => {
                 }),
                 Extensions: () => ({
                     extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
                         extensions: {
                             nodes: [
                                 {
@@ -454,6 +456,7 @@ describe('Blob viewer', () => {
                 ...commonBlobGraphQlResults,
                 ViewerSettings: () => ({
                     viewerSettings: {
+                        __typename: 'SettingsCascade',
                         final: JSON.stringify(userSettings),
                         subjects: [
                             {
@@ -506,6 +509,7 @@ describe('Blob viewer', () => {
                 }),
                 Extensions: () => ({
                     extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
                         extensions: {
                             nodes: mockExtensions.map(mockExtension => ({
                                 ...mockExtension,
@@ -716,6 +720,7 @@ describe('Blob viewer', () => {
                     createTreeEntriesResult(repositorySourcegraphUrl, ['README.md', 'test.ts', 'fake.ts']),
                 ViewerSettings: () => ({
                     viewerSettings: {
+                        __typename: 'SettingsCascade',
                         final: JSON.stringify(userSettings),
                         subjects: [
                             {
@@ -771,6 +776,7 @@ describe('Blob viewer', () => {
                 },
                 Extensions: () => ({
                     extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
                         extensions: {
                             nodes: [
                                 {
@@ -890,6 +896,7 @@ describe('Blob viewer', () => {
                 ...commonBlobGraphQlResults,
                 ViewerSettings: () => ({
                     viewerSettings: {
+                        __typename: 'SettingsCascade',
                         final: JSON.stringify(userSettings),
                         subjects: [
                             {
@@ -909,6 +916,7 @@ describe('Blob viewer', () => {
                 }),
                 Extensions: () => ({
                     extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
                         extensions: {
                             nodes: [
                                 {

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -37,6 +37,7 @@ describe('Code monitoring', () => {
                 autoDefinedSearchContexts: [],
             }),
             ViewerSettings: () => ({
+                __typename: 'SettingsCascade',
                 viewerSettings: {
                     subjects: [
                         {

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -134,6 +134,7 @@ describe('Extension Registry', () => {
             ...commonWebGraphQlResults,
             ViewerSettings: () => ({
                 viewerSettings: {
+                    __typename: 'SettingsCascade',
                     subjects: [
                         {
                             __typename: 'DefaultSettings',
@@ -192,6 +193,7 @@ describe('Extension Registry', () => {
             }),
             RegistryExtensions: () => ({
                 extensionRegistry: {
+                    __typename: 'ExtensionRegistry',
                     extensions: {
                         error: null,
                         nodes: registryExtensionNodes,
@@ -201,6 +203,7 @@ describe('Extension Registry', () => {
             }),
             Extensions: () => ({
                 extensionRegistry: {
+                    __typename: 'ExtensionRegistry',
                     extensions: {
                         nodes: extensionNodes,
                     },

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -30,6 +30,7 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
     }),
     ViewerSettings: () => ({
         viewerSettings: {
+            __typename: 'SettingsCascade',
             subjects: [
                 {
                     __typename: 'DefaultSettings',
@@ -93,6 +94,8 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
         },
         repositories: { totalCount: 9 },
         viewerSettings: {
+            __typename: 'SettingsCascade',
+            subjects: [],
             final: JSON.stringify({}),
         },
         users: { totalCount: 2 },
@@ -109,6 +112,8 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
         // externalServices: { totalCount: 3 },
         // repositories: { totalCount: 9 },
         // viewerSettings: {
+        //     __typename: 'SettingsCascade',
+        //     subjects: [],
         //     final: JSON.stringify({}),
         // },
         // users: { totalCount: 2 },

--- a/client/web/src/integration/insights/utils/override-graphql-with-extensions.ts
+++ b/client/web/src/integration/insights/utils/override-graphql-with-extensions.ts
@@ -160,6 +160,7 @@ export function overrideGraphQLExtensions(props: OverrideGraphQLExtensionsProps)
         }),
         ViewerSettings: () => ({
             viewerSettings: {
+                __typename: 'SettingsCascade',
                 subjects: [
                     {
                         __typename: 'DefaultSettings',
@@ -223,6 +224,7 @@ export function overrideGraphQLExtensions(props: OverrideGraphQLExtensionsProps)
         }),
         Extensions: () => ({
             extensionRegistry: {
+                __typename: 'ExtensionRegistry',
                 extensions: {
                     nodes: extensionNodes,
                 },

--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -15,6 +15,7 @@ import { highlightFileResult, mixedSearchStreamEvents } from './streaming-search
 const viewerSettings: Partial<WebGraphQlOperations> = {
     ViewerSettings: () => ({
         viewerSettings: {
+            __typename: 'SettingsCascade',
             subjects: [
                 {
                     __typename: 'DefaultSettings',

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -604,6 +604,7 @@ describe('Repository', () => {
                     ),
                 ViewerSettings: () => ({
                     viewerSettings: {
+                        __typename: 'SettingsCascade',
                         final: JSON.stringify(userSettings),
                         subjects: [
                             {
@@ -747,6 +748,7 @@ describe('Repository', () => {
                 },
                 Extensions: () => ({
                     extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
                         extensions: {
                             nodes: [
                                 {

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -62,6 +62,7 @@ describe('Search contexts', () => {
     const viewerSettingsWithSearchContexts: Partial<WebGraphQlOperations> = {
         ViewerSettings: () => ({
             viewerSettings: {
+                __typename: 'SettingsCascade',
                 subjects: [
                     {
                         __typename: 'DefaultSettings',

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -37,6 +37,7 @@ describe('Search onboarding', () => {
             }),
             ViewerSettings: () => ({
                 viewerSettings: {
+                    __typename: 'SettingsCascade',
                     subjects: [
                         {
                             __typename: 'DefaultSettings',

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -223,7 +223,11 @@ describe('Search', () => {
             testContext.overrideGraphQL({
                 ...commonSearchGraphQLResults,
                 RegistryExtensions: () => ({
-                    extensionRegistry: { extensions: { error: null, nodes: [] }, featuredExtensions: null },
+                    extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
+                        extensions: { error: null, nodes: [] },
+                        featuredExtensions: null,
+                    },
                 }),
             })
             testContext.overrideSearchStreamEvents(mockDefaultStreamEvents)


### PR DESCRIPTION
## Context

Preparation to land https://github.com/sourcegraph/sourcegraph/pull/23351. 

## Changes

- Fixed GraphQL query response mocks for `viewerSettings` and `extensionRegistry` queries.
- Fixed incomplete mock for `Batch changes list`, which worked previously because another test was executed faster and overridden QraphQL responses mock. 