### PR TITLE
Deprecate "sg run-set", use "sg start" instead, rework help output

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -334,8 +334,27 @@ func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
 	return true, output.FancyLine{}
 }
 
+var deprecationStyle = output.CombineStyles(output.Fg256Color(255), output.Bg256Color(124))
+
 func runSetExec(ctx context.Context, args []string) error {
-	return errors.New("'sg run-set' is deprecated. Please use 'sg start' instead")
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, " _______________________________________________________________________ "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "/         `sg run-set` is deprecated - use `sg start` instead!          \\"))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "!                                                                       !"))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "!         Run `sg start -help` for usage information.                   !"))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "\\_______________________________________________________________________/"))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               L_ !                                      "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                              / _)!                                      "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                             / /__L                                      "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                       _____/ (____)                                     "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                              (____)                                     "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                       _____  (____)                                     "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                            \\_(____)                                     "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
+	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               \\__/                                      "))
+	return startExec(ctx, args)
 }
 
 // enrichWithLogLevels will add any logger level overrides to a given command if they have been specified.

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -36,34 +37,34 @@ var (
 		Name:       "run",
 		ShortUsage: "sg run <command>...",
 		ShortHelp:  "Run the given commands.",
+		LongHelp:   constructRunCmdLongHelp(),
 		FlagSet:    runFlagSet,
 		Exec:       runExec,
-		UsageFunc:  printRunUsage,
 	}
 
-	runSetFlagSet       = flag.NewFlagSet("sg run-set", flag.ExitOnError)
-	debugRunSetServices = runSetFlagSet.String("debug", "", "Comma separated list of services to set at debug log level.")
-	infoRunSetServices  = runSetFlagSet.String("info", "", "Comma separated list of services to set at info log level.")
-	warnRunSetServices  = runSetFlagSet.String("warn", "", "Comma separated list of services to set at warn log level.")
-	errorRunSetServices = runSetFlagSet.String("error", "", "Comma separated list of services to set at error log level.")
-	critRunSetServices  = runSetFlagSet.String("crit", "", "Comma separated list of services to set at crit log level.")
-	runSetCommand       = &ffcli.Command{
+	runSetFlagSet = flag.NewFlagSet("sg run-set", flag.ExitOnError)
+	runSetCommand = &ffcli.Command{
 		Name:       "run-set",
 		ShortUsage: "sg run-set <commandset>",
-		ShortHelp:  "Run the given command set.",
+		ShortHelp:  "DEPRECATED. Use 'sg start' instead. Run the given commandset.",
 		FlagSet:    runSetFlagSet,
 		Exec:       runSetExec,
-		UsageFunc:  printRunSetUsage,
 	}
 
-	startFlagSet = flag.NewFlagSet("sg start", flag.ExitOnError)
-	startCommand = &ffcli.Command{
+	startFlagSet       = flag.NewFlagSet("sg start", flag.ExitOnError)
+	debugStartServices = startFlagSet.String("debug", "", "Comma separated list of services to set at debug log level.")
+	infoStartServices  = startFlagSet.String("info", "", "Comma separated list of services to set at info log level.")
+	warnStartServices  = startFlagSet.String("warn", "", "Comma separated list of services to set at warn log level.")
+	errorStartServices = startFlagSet.String("error", "", "Comma separated list of services to set at error log level.")
+	critStartServices  = startFlagSet.String("crit", "", "Comma separated list of services to set at crit log level.")
+	startCommand       = &ffcli.Command{
 		Name:       "start",
-		ShortUsage: "sg start",
-		ShortHelp:  "Runs the commandset with the name 'start'.",
-		FlagSet:    startFlagSet,
-		Exec:       startExec,
-		UsageFunc:  printStartUsage,
+		ShortUsage: "sg start [commandset]",
+		ShortHelp:  "🌟Starts the given commandset. Without a commandset it starts the default Sourcegraph dev environment.",
+		LongHelp:   constructStartCmdLongHelp(),
+
+		FlagSet: startFlagSet,
+		Exec:    startExec,
 	}
 
 	testFlagSet = flag.NewFlagSet("sg test", flag.ExitOnError)
@@ -71,19 +72,21 @@ var (
 		Name:       "test",
 		ShortUsage: "sg test <testsuite>",
 		ShortHelp:  "Run the given test suite.",
+		LongHelp:   "Run the given test suite.",
 		FlagSet:    testFlagSet,
 		Exec:       testExec,
-		UsageFunc:  printTestUsage,
 	}
 
 	doctorFlagSet = flag.NewFlagSet("sg doctor", flag.ExitOnError)
 	doctorCommand = &ffcli.Command{
 		Name:       "doctor",
 		ShortUsage: "sg doctor",
-		ShortHelp:  "Run the checks defined in the config file to make sure your system is healthy.",
-		FlagSet:    doctorFlagSet,
-		Exec:       doctorExec,
-		UsageFunc:  printDoctorUsage,
+		ShortHelp:  "Run the checks defined in the sg config file.",
+		LongHelp: `Run the checks defined in the sg config file to make sure your system is healthy.
+
+See the "checks:" in the configuration file.`,
+		FlagSet: doctorFlagSet,
+		Exec:    doctorExec,
 	}
 
 	liveFlagSet = flag.NewFlagSet("sg live", flag.ExitOnError)
@@ -91,9 +94,9 @@ var (
 		Name:       "live",
 		ShortUsage: "sg live <environment>",
 		ShortHelp:  "Reports which version of Sourcegraph is currently live in the given environment",
+		LongHelp:   constructLiveCmdLongHelp(),
 		FlagSet:    liveFlagSet,
 		Exec:       liveExec,
-		UsageFunc:  printLiveUsage,
 	}
 
 	migrationAddFlagSet          = flag.NewFlagSet("sg migration add", flag.ExitOnError)
@@ -104,7 +107,7 @@ var (
 		ShortHelp:  "Add a new migration file",
 		FlagSet:    migrationAddFlagSet,
 		Exec:       migrationAddExec,
-		UsageFunc:  printMigrationAddUsage,
+		LongHelp:   constructMigrationSubcmdLongHelp(),
 	}
 
 	migrationUpFlagSet          = flag.NewFlagSet("sg migration up", flag.ExitOnError)
@@ -116,7 +119,7 @@ var (
 		ShortHelp:  "Run up migration files",
 		FlagSet:    migrationUpFlagSet,
 		Exec:       migrationUpExec,
-		UsageFunc:  printMigrationUpUsage,
+		LongHelp:   constructMigrationSubcmdLongHelp(),
 	}
 
 	migrationDownFlagSet          = flag.NewFlagSet("sg migration down", flag.ExitOnError)
@@ -128,7 +131,7 @@ var (
 		ShortHelp:  "Run down migration files",
 		FlagSet:    migrationDownFlagSet,
 		Exec:       migrationDownExec,
-		UsageFunc:  printMigrationDownUsage,
+		LongHelp:   constructMigrationSubcmdLongHelp(),
 	}
 
 	migrationSquashFlagSet          = flag.NewFlagSet("sg migration squash", flag.ExitOnError)
@@ -139,7 +142,7 @@ var (
 		ShortHelp:  "Collapse migration files from historic releases together",
 		FlagSet:    migrationSquashFlagSet,
 		Exec:       migrationSquashExec,
-		UsageFunc:  printMigrationSquashUsage,
+		LongHelp:   constructMigrationSubcmdLongHelp(),
 	}
 
 	migrationFixupFlagSet          = flag.NewFlagSet("sg migration fixup", flag.ExitOnError)
@@ -152,7 +155,7 @@ var (
 		ShortHelp:  "Find and fix any conflicting migration names from rebasing on main. Also properly migrates your local database",
 		FlagSet:    migrationFixupFlagSet,
 		Exec:       migrationFixupExec,
-		UsageFunc:  printMigrationFixupUsage,
+		LongHelp:   constructMigrationSubcmdLongHelp(),
 	}
 
 	migrationFlagSet = flag.NewFlagSet("sg migration", flag.ExitOnError)
@@ -164,7 +167,6 @@ var (
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
 		},
-		UsageFunc: printMigrationUsage,
 		Subcommands: []*ffcli.Command{
 			migrationAddCommand,
 			migrationUpCommand,
@@ -179,9 +181,9 @@ var (
 		Name:       "rfc",
 		ShortUsage: "sg rfc [list|search|open]",
 		ShortHelp:  "Run the given RFC command to manage RFCs.",
+		LongHelp:   `List, search and open Sourcegraph RFCs`,
 		FlagSet:    rfcFlagSet,
 		Exec:       rfcExec,
-		UsageFunc:  printRFCUsage,
 	}
 
 	funkyLogoFlagSet = flag.NewFlagSet("sg logo", flag.ExitOnError)
@@ -209,24 +211,6 @@ var (
 		FlagSet:    rootFlagSet,
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
-		},
-		UsageFunc: func(c *ffcli.Command) string {
-			var out strings.Builder
-
-			printLogo(&out)
-
-			fmt.Fprintf(&out, "USAGE\n")
-			fmt.Fprintf(&out, "  sg <subcommand>\n")
-
-			fmt.Fprintf(&out, "\n")
-			fmt.Fprintf(&out, "AVAILABLE COMMANDS\n")
-			for _, sub := range c.Subcommands {
-				fmt.Fprintf(&out, "  %s\n", sub.Name)
-			}
-
-			fmt.Fprintf(&out, "\nRun 'sg <subcommand> -help' to get help output for each subcommand\n")
-
-			return out.String()
 		},
 		Subcommands: []*ffcli.Command{
 			runCommand,
@@ -351,6 +335,53 @@ func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
 }
 
 func runSetExec(ctx context.Context, args []string) error {
+	return errors.New("'sg run-set' is deprecated. Please use 'sg start' instead")
+}
+
+// enrichWithLogLevels will add any logger level overrides to a given command if they have been specified.
+func enrichWithLogLevels(cmd *run.Command, overrides map[string]string) {
+	logLevelVariable := "SRC_LOG_LEVEL"
+
+	if level, ok := overrides[cmd.Name]; ok {
+		out.WriteLine(output.Linef("", output.StylePending, "Setting log level: %s for command %s.", level, cmd.Name))
+		if cmd.Env == nil {
+			cmd.Env = make(map[string]string, 1)
+			cmd.Env[logLevelVariable] = level
+		}
+		cmd.Env[logLevelVariable] = level
+	}
+}
+
+// parseCsv takes an input comma seperated string and returns a list of tokens each trimmed for whitespace
+func parseCsv(input string) []string {
+	tokens := strings.Split(input, ",")
+	results := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		results = append(results, strings.TrimSpace(token))
+	}
+	return results
+}
+
+// logLevelOverrides builds a map of commands -> log level that should be overridden in the environment.
+func logLevelOverrides() map[string]string {
+	levelServices := make(map[string][]string)
+	levelServices["debug"] = parseCsv(*debugStartServices)
+	levelServices["info"] = parseCsv(*infoStartServices)
+	levelServices["warn"] = parseCsv(*warnStartServices)
+	levelServices["error"] = parseCsv(*errorStartServices)
+	levelServices["crit"] = parseCsv(*critStartServices)
+
+	overrides := make(map[string]string)
+	for level, services := range levelServices {
+		for _, service := range services {
+			overrides[service] = level
+		}
+	}
+
+	return overrides
+}
+
+func testExec(ctx context.Context, args []string) error {
 	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
 	if !ok {
 		out.WriteLine(errLine)
@@ -358,13 +389,33 @@ func runSetExec(ctx context.Context, args []string) error {
 	}
 
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No commandset specified\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "No test suite specified\n"))
 		return flag.ErrHelp
+	}
+
+	cmd, ok := globalConf.Tests[args[0]]
+	if !ok {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(\n", args[0]))
+		return flag.ErrHelp
+	}
+
+	return run.Test(ctx, cmd, args[1:], globalConf.Env)
+}
+
+func startExec(ctx context.Context, args []string) error {
+	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
+	if !ok {
+		out.WriteLine(errLine)
+		os.Exit(1)
 	}
 
 	if len(args) > 2 {
 		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
 		return flag.ErrHelp
+	}
+
+	if len(args) == 0 {
+		args = append(args, "default")
 	}
 
 	set, ok := globalConf.Commandsets[args[0]]
@@ -408,85 +459,6 @@ func runSetExec(ctx context.Context, args []string) error {
 		enrichWithLogLevels(&cmd, levelOverrides)
 	}
 	return run.Commands(ctx, globalConf.Env, cmds...)
-}
-
-// enrichWithLogLevels will add any logger level overrides to a given command if they have been specified.
-func enrichWithLogLevels(cmd *run.Command, overrides map[string]string) {
-	logLevelVariable := "SRC_LOG_LEVEL"
-
-	if level, ok := overrides[cmd.Name]; ok {
-		out.WriteLine(output.Linef("", output.StylePending, "Setting log level: %s for command %s.", level, cmd.Name))
-		if cmd.Env == nil {
-			cmd.Env = make(map[string]string, 1)
-			cmd.Env[logLevelVariable] = level
-		}
-		cmd.Env[logLevelVariable] = level
-	}
-}
-
-// parseCsv takes an input comma seperated string and returns a list of tokens each trimmed for whitespace
-func parseCsv(input string) []string {
-	tokens := strings.Split(input, ",")
-	results := make([]string, 0, len(tokens))
-	for _, token := range tokens {
-		results = append(results, strings.TrimSpace(token))
-	}
-	return results
-}
-
-// logLevelOverrides builds a map of commands -> log level that should be overridden in the environment.
-func logLevelOverrides() map[string]string {
-	levelServices := make(map[string][]string)
-	levelServices["debug"] = parseCsv(*debugRunSetServices)
-	levelServices["info"] = parseCsv(*infoRunSetServices)
-	levelServices["warn"] = parseCsv(*warnRunSetServices)
-	levelServices["error"] = parseCsv(*errorRunSetServices)
-	levelServices["crit"] = parseCsv(*critRunSetServices)
-
-	overrides := make(map[string]string)
-	for level, services := range levelServices {
-		for _, service := range services {
-			overrides[service] = level
-		}
-	}
-
-	return overrides
-}
-
-func testExec(ctx context.Context, args []string) error {
-	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
-	if !ok {
-		out.WriteLine(errLine)
-		os.Exit(1)
-	}
-
-	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No test suite specified\n"))
-		return flag.ErrHelp
-	}
-
-	cmd, ok := globalConf.Tests[args[0]]
-	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(\n", args[0]))
-		return flag.ErrHelp
-	}
-
-	return run.Test(ctx, cmd, args[1:], globalConf.Env)
-}
-
-func startExec(ctx context.Context, args []string) error {
-	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
-	if !ok {
-		out.WriteLine(errLine)
-		os.Exit(1)
-	}
-
-	if len(args) != 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
-		return flag.ErrHelp
-	}
-
-	return runSetExec(ctx, []string{"default"})
 }
 
 func runExec(ctx context.Context, args []string) error {
@@ -672,12 +644,9 @@ func migrationSquashExec(ctx context.Context, args []string) (err error) {
 	return squash.Run(database, commit)
 }
 
-func printRunUsage(c *ffcli.Command) string {
+func constructRunCmdLongHelp() string {
 	var out strings.Builder
 
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg %s <command>...\n", c.Name)
-	fmt.Fprintln(&out, "")
 	fmt.Fprintf(&out, "  Runs the given command. If given a whitespace-separated list of commands it runs the set of commands.\n")
 
 	// Attempt to parse config to list available commands, but don't fail on
@@ -691,6 +660,42 @@ func printRunUsage(c *ffcli.Command) string {
 		for name := range globalConf.Commands {
 			fmt.Fprintf(&out, "  %s\n", name)
 		}
+	}
+
+	return out.String()
+}
+
+func constructStartCmdLongHelp() string {
+	var out strings.Builder
+
+	fmt.Fprintf(&out, `Runs the given commandset.
+
+If no commandset is specified, it starts the commandset with the name 'default'.
+
+Use this to start your Sourcegraph environment!
+`)
+
+	// Attempt to parse config to list available commands, but don't fail on
+	// error, because we should never error when the user wants --help output.
+	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
+
+	if globalConf != nil {
+		fmt.Fprintf(&out, "\n")
+		fmt.Fprintf(&out, "AVAILABLE COMMANDSETS IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
+
+		var names []string
+		for name := range globalConf.Commandsets {
+			switch name {
+			case "enterprise-codeintel":
+				names = append(names, fmt.Sprintf("  %s 🧠", name))
+			case "batches":
+				names = append(names, fmt.Sprintf("  %s 🦡", name))
+			default:
+				names = append(names, fmt.Sprintf("  %s", name))
+			}
+		}
+		sort.Strings(names)
+		fmt.Fprintf(&out, strings.Join(names, "\n"))
 	}
 
 	return out.String()
@@ -753,8 +758,16 @@ func printTestUsage(c *ffcli.Command) string {
 func printRunSetUsage(c *ffcli.Command) string {
 	var out strings.Builder
 
+	fmt.Fprintf(&out, "DEPRECATED! 'sg run-set' has been deprecated. Please use 'sg start' instead.\n")
+
+	return out.String()
+}
+
+func printStartUsage(c *ffcli.Command) string {
+	var out strings.Builder
+
 	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg %s <commandset>\n", c.Name)
+	fmt.Fprintf(&out, "  sg %s [commandset]\n", c.Name)
 
 	// Attempt to parse config so we can list available sets, but don't fail on
 	// error, because we should never error when the user wants --help output.
@@ -771,29 +784,11 @@ func printRunSetUsage(c *ffcli.Command) string {
 	return out.String()
 }
 
-func printStartUsage(c *ffcli.Command) string {
+func constructLiveCmdLongHelp() string {
 	var out strings.Builder
 
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintln(&out, "  sg start")
-
-	return out.String()
-}
-
-func printDoctorUsage(c *ffcli.Command) string {
-	var out strings.Builder
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg doctor\n")
-
-	return out.String()
-}
-
-func printLiveUsage(c *ffcli.Command) string {
-	var out strings.Builder
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg live <environment|url>\n")
+	fmt.Fprintf(&out, "Prints the Sourcegraph version deployed to the given environment.")
+	fmt.Fprintf(&out, "\n")
 	fmt.Fprintf(&out, "\n")
 	fmt.Fprintf(&out, "AVAILABLE PRESET ENVIRONMENTS\n")
 
@@ -804,96 +799,15 @@ func printLiveUsage(c *ffcli.Command) string {
 	return out.String()
 }
 
-func printMigrationUsage(c *ffcli.Command) string {
+func constructMigrationSubcmdLongHelp() string {
 	var out strings.Builder
 
-	printLogo(&out)
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg migration <subcommand>\n")
-
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE COMMANDS\n")
-	for _, sub := range c.Subcommands {
-		fmt.Fprintf(&out, "  %s\n", sub.Name)
-	}
-
-	fmt.Fprintf(&out, "\nRun 'sg migration <subcommand> -help' to get help output for each subcommand\n")
-
-	return out.String()
-}
-
-func printMigrationAddUsage(c *ffcli.Command) string {
-	var out strings.Builder
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  %s", c.ShortUsage)
-	fmt.Fprintf(&out, "\n")
 	fmt.Fprintf(&out, "AVAILABLE DATABASES\n")
-
+	var names []string
 	for _, name := range db.DatabaseNames() {
-		fmt.Fprintf(&out, "  %s\n", name)
+		names = append(names, fmt.Sprintf("  %s", name))
 	}
-
-	return out.String()
-}
-
-func printMigrationUpUsage(c *ffcli.Command) string {
-	var out strings.Builder
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg migration up [-db=%s] [-n]\n", db.DefaultDatabase.Name)
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE DATABASES\n")
-
-	for _, name := range db.DatabaseNames() {
-		fmt.Fprintf(&out, "  %s\n", name)
-	}
-
-	return out.String()
-}
-
-func printMigrationDownUsage(c *ffcli.Command) string {
-	var out strings.Builder
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg migration down [-db=%s] [-n=1]\n", db.DefaultDatabase.Name)
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE DATABASES\n")
-
-	for _, name := range db.DatabaseNames() {
-		fmt.Fprintf(&out, "  %s\n", name)
-	}
-
-	return out.String()
-}
-
-func printMigrationSquashUsage(c *ffcli.Command) string {
-	var out strings.Builder
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg migration squash [-db=%s] <current-release>\n", db.DefaultDatabase.Name)
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE DATABASES\n")
-
-	for _, name := range db.DatabaseNames() {
-		fmt.Fprintf(&out, "  %s\n", name)
-	}
-
-	return out.String()
-}
-
-func printMigrationFixupUsage(c *ffcli.Command) string {
-	var out strings.Builder
-
-	fmt.Fprintf(&out, "USAGE\n")
-	fmt.Fprintf(&out, "  sg migration fixup [-db=%s] [-main=%s] [-run=true]\n", db.DefaultDatabase.Name, "main")
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE DATABASES\n")
-
-	for _, name := range db.DatabaseNames() {
-		fmt.Fprintf(&out, "  %s\n", name)
-	}
+	fmt.Fprintf(&out, strings.Join(names, "\n"))
 
 	return out.String()
 }


### PR DESCRIPTION
Alright, this does two things:

* Deprecates `sg run-set`, because it's a confusing name. Instead we made `sg start` to everything that `run-set` did: `sg start`, without arguments, starts the default environment. `sg start <commandset>` starts the given commandset.
* Rework and fix the `sg -help` and `sg <subcommand> -help` output. Now it actually helps users.

~And when I say "deprecate" I mean: breaking change. `run-set` is gone. It breaks. `sg start` is the new thing.~

Update: it's deprecated, not broken. It'll print a message.

