### PR TITLE
search: simplify event loop

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -132,11 +132,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			sendProgress()
 		}
 	}
-	matchesAppend := func(m streamhttp.EventMatch) {
-		// Only possible error is EOF, ignore
-		_ = matchesBuf.Append(m)
-	}
-
 	flushTicker := time.NewTicker(h.flushTickerInternal)
 	defer flushTicker.Stop()
 
@@ -170,7 +165,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if md, ok := repoMetadata[match.RepoName().ID]; !ok || md.Name != match.RepoName().Name {
 				continue
 			}
-			matchesAppend(fromMatch(match, repoMetadata))
+			_ = matchesBuf.Append(fromMatch(match, repoMetadata))
 		}
 
 		// Instantly send results if we have not sent any yet.

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -186,24 +186,19 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	}
 
+LOOP:
 	for {
-		var event streaming.SearchEvent
-		var ok bool
 		select {
-		case event, ok = <-events:
+		case event, ok := <-events:
+			if !ok {
+				break LOOP
+			}
+			handleEvent(event)
 		case <-flushTicker.C:
-			ok = true
 			matchesFlush()
 		case <-pingTicker.C:
-			ok = true
 			sendProgress()
 		}
-
-		if !ok {
-			break
-		}
-
-		handleEvent(event)
 	}
 
 	matchesFlush()


### PR DESCRIPTION
Just a small refactor to simplify the main streaming event loop to make it more clear what the exit conditions are, etc.

- Pulls event handling into a closure
- Simplifies the for/select loop to keep variables scoped
- Inlines matchesAppend because it is a single-line closure used in one place
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
 cc @keegancsmith @stefanhengl 