### PR TITLE
codeintel: Add BranchesContaining to gitserver client

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -32,7 +33,7 @@ func New(dbStore DBStore, observationContext *observation.Context) *Client {
 	}
 }
 
-// Head determines the tip commit of the default branch for the given repository.
+// CommitExists determines if the given commit exists in the given repository.
 func (c *Client) CommitExists(ctx context.Context, repositoryID int, commit string) (_ bool, err error) {
 	ctx, endObservation := c.operations.commitExists.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
@@ -278,6 +279,41 @@ func parseRefDescriptions(lines []string) (map[string]RefDescription, error) {
 	}
 
 	return refDescriptions, nil
+}
+
+// BranchesContaining returns a map from branch names to branch tip hashes for each brach
+// containing the given commit.
+func (c *Client) BranchesContaining(ctx context.Context, repositoryID int, commit string) ([]string, error) {
+	out, err := c.execGitCommand(ctx, repositoryID, "branch", "--contains", commit, "--format", "%(refname)")
+	if err != nil {
+		return nil, err
+	}
+
+	return parseBranchesContaining(strings.Split(out, "\n")), nil
+}
+
+func parseBranchesContaining(lines []string) []string {
+	names := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		refname := line
+
+		// Remove refs/heads/ or ref/tags/ prefix
+		for prefix := range refPrefixes {
+			if strings.HasPrefix(line, prefix) {
+				refname = line[len(prefix):]
+			}
+		}
+
+		names = append(names, refname)
+	}
+	sort.Strings(names)
+
+	return names
 }
 
 // RawContents returns the contents of a file in a particular commit of a repository.

--- a/enterprise/internal/codeintel/gitserver/client_test.go
+++ b/enterprise/internal/codeintel/gitserver/client_test.go
@@ -207,3 +207,73 @@ func TestParseRefDescriptions(t *testing.T) {
 		t.Errorf("unexpected ref descriptions (-want +got):\n%s", diff)
 	}
 }
+
+func TestParseBranchesContaining(t *testing.T) {
+	names := parseBranchesContaining([]string{
+		"refs/tags/v0.7.0",
+		"refs/tags/v0.5.1",
+		"refs/tags/v1.1.4",
+		"refs/heads/symbols", "refs/heads/bl/symbols",
+		"refs/tags/v1.2.0",
+		"refs/tags/v1.1.0",
+		"refs/tags/v0.10.0",
+		"refs/tags/v1.0.0",
+		"refs/heads/garo/index-specific-files",
+		"refs/heads/bl/symbols-2",
+		"refs/tags/v1.3.1",
+		"refs/tags/v0.5.2",
+		"refs/tags/v1.1.2",
+		"refs/tags/v0.8.0",
+		"refs/heads/ef/wtf",
+		"refs/tags/v1.5.0",
+		"refs/tags/v0.9.0",
+		"refs/heads/garo/go-and-typescript-lsif-indexing",
+		"refs/heads/master",
+		"refs/heads/sg/document-symbols",
+		"refs/tags/v1.1.1",
+		"refs/tags/v1.4.0",
+		"refs/heads/nsc/bump-go-version",
+		"refs/heads/nsc/random",
+		"refs/heads/nsc/markupcontent",
+		"refs/tags/v0.6.0",
+		"refs/tags/v1.1.3",
+		"refs/tags/v0.5.3",
+		"refs/tags/v1.3.0",
+	})
+
+	expectedNames := []string{
+		"bl/symbols",
+		"bl/symbols-2",
+		"ef/wtf",
+		"garo/go-and-typescript-lsif-indexing",
+		"garo/index-specific-files",
+		"master",
+		"nsc/bump-go-version",
+		"nsc/markupcontent",
+		"nsc/random",
+		"sg/document-symbols",
+		"symbols",
+		"v0.10.0",
+		"v0.5.1",
+		"v0.5.2",
+		"v0.5.3",
+		"v0.6.0",
+		"v0.7.0",
+		"v0.8.0",
+		"v0.9.0",
+		"v1.0.0",
+		"v1.1.0",
+		"v1.1.1",
+		"v1.1.2",
+		"v1.1.3",
+		"v1.1.4",
+		"v1.2.0",
+		"v1.3.0",
+		"v1.3.1",
+		"v1.4.0",
+		"v1.5.0",
+	}
+	if diff := cmp.Diff(expectedNames, names); diff != "" {
+		t.Errorf("unexpected names (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Add a method to the gitserver client that returns the names of branches that contain a given revision. This will be necessary to perform data retention properly, as we can protect all commits on a branch who's name matches a given pattern.