### PR TITLE
Kelvin lee GitHub docs

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -131,8 +131,10 @@ const githubInstructions = (isEnterprise: boolean): JSX.Element => (
                 >
                     instructions
                 </a>
-                ) with <b>repo</b> scope, and set it to be the value of the <Field>token</Field> field in the
-                configuration below.
+                ) with <b>repo</b> scope.
+                <li>
+                    Set the value of the <Field>token</Field> field as your access token, in the configuration below.
+                </li>
             </li>
             <li>
                 Specify which repositories Sourcegraph should index using one of the following fields:

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -138,7 +138,7 @@ const githubInstructions = (isEnterprise: boolean): JSX.Element => (
                 Specify which repositories Sourcegraph should index using one of the following fields:
                 <ul>
                     <li>
-                        <Field>organizations</Field>: a list of GitHub organizations.
+                        <Field>orgs</Field>: a list of GitHub organizations.
                     </li>
                     <li>
                         <Field>repositoryQuery</Field>: a list of GitHub search queries.


### PR DESCRIPTION
Small changes to GitHub repository set up docs:

(1) (Subjective) Simplified language
(2) (Objective) Fixed old field-name (`organizations` -> [`orgs`](https://docs.sourcegraph.com/admin/external_service/github#orgs))