### PR TITLE
search: allow precomputing highlight decoration for streamed results

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -424,7 +424,7 @@ function search({
             ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
-            ['dl', '15'],
+            ['dl', '0'],
             ['dk', (decorationKinds || ['html']).join('|')],
             ['dc', (decorationContextLines || '1').toString()],
             ['display', '1500'],

--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -7,6 +7,7 @@ import (
 
 	"html/template"
 
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -121,17 +122,15 @@ func DecorateFileHTML(ctx context.Context, repo api.RepoName, commit api.CommitI
 }
 
 // DecorateFileHunksHTML returns decorated file hunks given a file match.
-func DecorateFileHunksHTML(ctx context.Context, fm result.FileMatch) []stream.DecoratedHunk {
+func DecorateFileHunksHTML(ctx context.Context, fm *result.FileMatch) []stream.DecoratedHunk {
 	html, err := DecorateFileHTML(ctx, fm.Repo.Name, fm.CommitID, fm.Path)
 	if err != nil {
-		// TODO(rvantonder): log error and swallow if we can't highlight
-		// the entire file.
+		log15.Warn("stream result decoration could not highlight file", "error", err)
 		return nil
 	}
 	lines, err := highlight.SplitHighlightedLines(html, true)
 	if err != nil {
-		// TODO(rvantonder): log error and swallow if we can't split the
-		// highlighted file (parse error, malformed HTML).
+		log15.Warn("stream result decoration could not split highlighted file", "error", err)
 		return nil
 	}
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -158,14 +158,18 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log15.Error("failed to get repo metadata", "error", err)
 			return
 		}
-		for _, match := range event.Results {
+		for i, match := range event.Results {
 			// Don't send matches which we cannot map to a repo the actor has access to. This
 			// check is expected to always pass. Missing metadata is a sign that we have
 			// searched repos that user shouldn't have access to.
 			if md, ok := repoMetadata[match.RepoName().ID]; !ok || md.Name != match.RepoName().Name {
 				continue
 			}
-			_ = matchesBuf.Append(fromMatch(match, repoMetadata))
+			eventMatch := fromMatch(match, repoMetadata)
+			if args.DecorationLimit == -1 || args.DecorationLimit > i {
+				eventMatch = withDecoration(ctx, eventMatch, match, args.DecorationKind, args.DecorationContextLines)
+			}
+			_ = matchesBuf.Append(eventMatch)
 		}
 
 		// Instantly send results if we have not sent any yet.
@@ -329,6 +333,13 @@ type args struct {
 	PatternType    string
 	VersionContext string
 	Display        int
+
+	// Optional decoration parameters for server-side rendering a result set
+	// or subset. Decorations may specify, e.g., highlighting results with
+	// HTML markup up-front, and/or including context lines around file results.
+	DecorationLimit        int    // The initial number of files to decorate in the result set.
+	DecorationKind         string // The kind of decoration to apply (HTML highlighting, plaintext, etc.)
+	DecorationContextLines int    // The number of lines of context to include around lines with matches.
 }
 
 func parseURLQuery(q url.Values) (*args, error) {
@@ -345,6 +356,7 @@ func parseURLQuery(q url.Values) (*args, error) {
 		Version:        get("v", "V2"),
 		PatternType:    get("t", ""),
 		VersionContext: get("vc", ""),
+		DecorationKind: get("dk", "html"),
 	}
 
 	if a.Query == "" {
@@ -355,6 +367,16 @@ func parseURLQuery(q url.Values) (*args, error) {
 	var err error
 	if a.Display, err = strconv.Atoi(display); err != nil {
 		return nil, errors.Errorf("display must be an integer, got %q: %w", display, err)
+	}
+
+	decorationLimit := get("dl", "0")
+	if a.DecorationLimit, err = strconv.Atoi(decorationLimit); err != nil {
+		return nil, errors.Errorf("decorationLimit must be an integer, got %q: %w", decorationLimit, err)
+	}
+
+	decorationContextLines := get("dc", "1")
+	if a.DecorationContextLines, err = strconv.Atoi(decorationContextLines); err != nil {
+		return nil, errors.Errorf("decorationLimit must be an integer, got %q: %w", decorationContextLines, err)
 	}
 
 	return &a, nil
@@ -372,6 +394,21 @@ func fromStrPtr(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// withDecoration hydrates event match with decorated hunks for a corresponding file match.
+func withDecoration(ctx context.Context, eventMatch streamhttp.EventMatch, internalResult result.Match, kind string, contextLines int) streamhttp.EventMatch {
+	if _, ok := internalResult.(*result.FileMatch); !ok {
+		return eventMatch
+	}
+	if _, ok := eventMatch.(*streamhttp.EventContentMatch); !ok {
+		return eventMatch
+	}
+	if kind == "html" {
+		eventMatch.(*streamhttp.EventContentMatch).Hunks = DecorateFileHunksHTML(ctx, internalResult.(*result.FileMatch))
+	}
+	// TODO(team/search-product): support additional decoration for terminal clients #24617.
+	return eventMatch
 }
 
 func fromMatch(match result.Match, repoCache map[api.RepoID]*types.SearchedRepo) streamhttp.EventMatch {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -376,7 +376,7 @@ func parseURLQuery(q url.Values) (*args, error) {
 
 	decorationContextLines := get("dc", "1")
 	if a.DecorationContextLines, err = strconv.Atoi(decorationContextLines); err != nil {
-		return nil, errors.Errorf("decorationLimit must be an integer, got %q: %w", decorationContextLines, err)
+		return nil, errors.Errorf("decorationContextLines must be an integer, got %q: %w", decorationContextLines, err)
 	}
 
 	return &a, nil
@@ -401,12 +401,16 @@ func withDecoration(ctx context.Context, eventMatch streamhttp.EventMatch, inter
 	if _, ok := internalResult.(*result.FileMatch); !ok {
 		return eventMatch
 	}
-	if _, ok := eventMatch.(*streamhttp.EventContentMatch); !ok {
+
+	event, ok := eventMatch.(*streamhttp.EventContentMatch)
+	if !ok {
 		return eventMatch
 	}
+
 	if kind == "html" {
-		eventMatch.(*streamhttp.EventContentMatch).Hunks = DecorateFileHunksHTML(ctx, internalResult.(*result.FileMatch))
+		event.Hunks = DecorateFileHunksHTML(ctx, internalResult.(*result.FileMatch))
 	}
+
 	// TODO(team/search-product): support additional decoration for terminal clients #24617.
 	return eventMatch
 }


### PR DESCRIPTION
This makes it possible to stream precomputed highlighted content results via URL parameters. The hardcoded parameters in our web client means this change isn't "live" via the webapp until we implement a feature flag that overrides the parameters. It can be seen in action when using a plain URL like:

`http://localhost:3081/search/stream?q=test%20type%3Afile%20&v=V2&t=literal&dl=10&dk=html&dc=1&display=1500`

(the important part being `dl=10`).

⚠️⚠️⚠️ Crucial thing I noticed ⚠️⚠️⚠️: **Streaming doesn't work locally because of some proxy issue**. I believe it's because of the express proxy in the dev environment. If you try the above stream query on port `3080` or the https port, it _won't stream_ for local dev, and this is not our backend issue. I spent a couple of hours trying to understand why flush didn't work. However, the results do stream for the ports behind the proxy, at `3081`, and also `3082` I believe. I looked at some express http proxy stuff but couldn't figure out a fix.

In this PR, what _doesn't_ work yet:

`dc` (for `decorationContextLines` argument) doesn't do anything yet. I have a work-in-progress branch for computing context lines and merging groups for rendering, but it needs more polish. Right now activating the stream highlighting will apply 0 context lines. The important part is that this PR will make it possible to stream end-to-end with some limit on the number of results, if we put it behind a feature flag. Context lines will just have to wait till I'm back 🙂 