### PR TITLE
support standalone dev server for esbuild

### DIFF
--- a/client/web/README.md
+++ b/client/web/README.md
@@ -37,8 +37,7 @@ For enterprise version:
 sg run enterprise-web-standalone-prod
 ```
 
-Web app should be available at `http://${SOURCEGRAPH_HTTPS_DOMAIN}:${SOURCEGRAPH_HTTPS_PORT}`.
-Build artifacts will be served from `<rootRepoPath>/ui/assets`.
+Web app should be available at `http://${SOURCEGRAPH_HTTPS_DOMAIN}:${SOURCEGRAPH_HTTPS_PORT}` (note the `http` not `https`). Build artifacts will be served from `<rootRepoPath>/ui/assets`.
 
 ### API proxy
 

--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -65,7 +65,6 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
         },
     ],
     define: Object.fromEntries(
-        // esbuild is not yet usable with SOURCEGRAPH_API_URL, so omit that.
         Object.entries({ ...environmentConfig, SOURCEGRAPH_API_URL: undefined }).map(([key, value]) => [
             `process.env.${key}`,
             JSON.stringify(value),

--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -64,12 +64,15 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
             },
         },
     ],
-    define: Object.fromEntries(
-        Object.entries({ ...environmentConfig, SOURCEGRAPH_API_URL: undefined }).map(([key, value]) => [
-            `process.env.${key}`,
-            JSON.stringify(value),
-        ])
-    ),
+    define: {
+        ...Object.fromEntries(
+            Object.entries({ ...environmentConfig, SOURCEGRAPH_API_URL: undefined }).map(([key, value]) => [
+                `process.env.${key}`,
+                JSON.stringify(value),
+            ])
+        ),
+        global: 'window',
+    },
     loader: {
         '.yaml': 'text',
         '.ttf': 'file',

--- a/client/web/dev/esbuild/manifestPlugin.ts
+++ b/client/web/dev/esbuild/manifestPlugin.ts
@@ -5,13 +5,19 @@ import * as esbuild from 'esbuild'
 
 import { STATIC_ASSETS_PATH } from '../utils'
 
-export const assetPathPrefix = '/.assets/'
+export const assetPathPrefix = '/.assets'
 
 interface Manifest {
     'app.js': string
     'app.css': string
     isModule: boolean
 }
+
+export const getManifest = (): Manifest => ({
+    'app.js': path.join(assetPathPrefix, 'scripts/app.js'),
+    'app.css': path.join(assetPathPrefix, 'scripts/app.css'),
+    isModule: true,
+})
 
 const writeManifest = async (manifest: Manifest): Promise<void> => {
     const manifestPath = path.join(STATIC_ASSETS_PATH, 'webpack.manifest.json')
@@ -29,11 +35,7 @@ export const manifestPlugin: esbuild.Plugin = {
             // The bug https://github.com/evanw/esbuild/issues/1384 means that onEnd isn't called in
             // serve mode, so write it here instead of waiting for onEnd. This is OK because we
             // don't actually need any information that's only available in onEnd.
-            await writeManifest({
-                'app.js': path.join(assetPathPrefix, 'scripts/app.js'),
-                'app.css': path.join(assetPathPrefix, 'scripts/app.css'),
-                isModule: true,
-            })
+            await writeManifest(getManifest())
         })
     },
 }

--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -1,15 +1,19 @@
-import http from 'http'
 import path from 'path'
 
 import { serve } from 'esbuild'
+import express from 'express'
+import { createProxyMiddleware } from 'http-proxy-middleware'
 import signale from 'signale'
 
-import { DEV_SERVER_LISTEN_ADDR, DEV_SERVER_PROXY_TARGET_ADDR, STATIC_ASSETS_PATH } from '../utils'
+import { STATIC_ASSETS_PATH } from '../utils'
 
 import { buildMonaco, BUILD_OPTIONS } from './build'
 import { assetPathPrefix } from './manifestPlugin'
 
-export const esbuildDevelopmentServer = async (): Promise<void> => {
+export const esbuildDevelopmentServer = async (
+    listenAddress: { host: string; port: number },
+    configureProxy: (app: express.Application) => void
+): Promise<void> => {
     // One-time build (these files only change when the monaco-editor npm package is changed, which
     // is rare enough to ignore here).
     await buildMonaco()
@@ -22,55 +26,24 @@ export const esbuildDevelopmentServer = async (): Promise<void> => {
 
     // Start a proxy at :3080. Asset requests (underneath /.assets/) go to esbuild; all other
     // requests go to the upstream.
-    const proxyServer = http
-        .createServer((request, response) => {
-            const commonRequestOptions: http.RequestOptions = {
-                method: request.method,
-                headers: request.headers,
-            }
-
-            const isAssetRequest = request.url!.startsWith(assetPathPrefix)
-            if (isAssetRequest) {
-                // Forward to esbuild.
-                const esbuildRequest = http.request(
-                    {
-                        ...commonRequestOptions,
-                        hostname: esbuildHost,
-                        port: esbuildPort,
-                        path: request.url!.slice(assetPathPrefix.length - 1),
-                    },
-                    proxyResponse => {
-                        const isCacheableChunk = path.basename(request.url!).startsWith('chunk-')
-
-                        response.writeHead(proxyResponse.statusCode!, {
-                            ...proxyResponse.headers,
-
-                            // Cache chunks because their filename includes a hash of the content.
-                            'Cache-Control': isCacheableChunk ? 'max-age=3600' : 'no-cache',
-                        })
-                        proxyResponse.pipe(response, { end: true })
-                    }
-                )
-                request.pipe(esbuildRequest, { end: true })
-            } else {
-                // Forward to upstream.
-                const upstreamRequest = http.request(
-                    {
-                        ...commonRequestOptions,
-                        hostname: DEV_SERVER_PROXY_TARGET_ADDR.host,
-                        port: DEV_SERVER_PROXY_TARGET_ADDR.port,
-                        path: request.url!,
-                    },
-                    proxyResponse => {
-                        response.writeHead(proxyResponse.statusCode!, proxyResponse.headers)
-                        proxyResponse.pipe(response, { end: true })
-                    }
-                )
-                request.pipe(upstreamRequest, { end: true })
-            }
+    const proxyApp = express()
+    proxyApp.use(
+        assetPathPrefix,
+        createProxyMiddleware({
+            target: { protocol: 'http:', host: esbuildHost, port: esbuildPort },
+            pathRewrite: { [`^${assetPathPrefix}`]: '' },
+            onProxyRes: (proxyResponse, request) => {
+                // Cache chunks because their filename includes a hash of the content.
+                const isCacheableChunk = path.basename(request.url).startsWith('chunk-')
+                proxyResponse.headers['Cache-Control'] = isCacheableChunk ? 'max-age=3600' : 'no-cache'
+            },
+            logLevel: 'error',
         })
-        .listen(DEV_SERVER_LISTEN_ADDR)
-    await new Promise<void>((resolve, reject) => {
+    )
+    configureProxy(proxyApp)
+
+    const proxyServer = proxyApp.listen(listenAddress)
+    return await new Promise<void>((resolve, reject) => {
         proxyServer.once('listening', () => {
             signale.success('esbuild server is ready')
             esbuildStopped.finally(() => proxyServer.close(error => (error ? reject(error) : resolve())))

--- a/client/web/dev/server/development.server.ts
+++ b/client/web/dev/server/development.server.ts
@@ -1,9 +1,13 @@
 import chalk from 'chalk'
+import { RequestHandler } from 'express'
+import { createProxyMiddleware, Options as HTTPProxyMiddlewareOptions } from 'http-proxy-middleware'
 import { once } from 'lodash'
 import signale from 'signale'
 import createWebpackCompiler, { Configuration } from 'webpack'
 import WebpackDevServer, { ProxyConfigArrayItem } from 'webpack-dev-server'
 
+import { getManifest } from '../esbuild/manifestPlugin'
+import { esbuildDevelopmentServer } from '../esbuild/server'
 import {
     getCSRFTokenCookieMiddleware,
     PROXY_ROUTES,
@@ -14,23 +18,56 @@ import {
     STATIC_ASSETS_URL,
     WEB_SERVER_URL,
 } from '../utils'
+import { getHTMLPage } from '../webpack/get-html-webpack-plugins'
 
 // TODO: migrate webpack.config.js to TS to use `import` in this file.
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const webpackConfig = require('../../webpack.config') as Configuration
 const { SOURCEGRAPH_API_URL, SOURCEGRAPH_HTTPS_PORT, IS_HOT_RELOAD_ENABLED } = environmentConfig
 
-export async function startDevelopmentServer(): Promise<void> {
+interface DevelopmentServerInit {
+    proxyRoutes: string[]
+    proxyMiddlewareOptions: HTTPProxyMiddlewareOptions
+    csrfTokenCookieMiddleware: RequestHandler
+}
+
+async function startDevelopmentServer(): Promise<void> {
+    signale.start(
+        `Starting ${environmentConfig.DEV_WEB_BUILDER} dev server with environment config:\n`,
+        environmentConfig
+    )
+
     // Get CSRF token value from the `SOURCEGRAPH_API_URL`.
     const { csrfContextValue, csrfCookieValue } = await getCSRFTokenAndCookie(SOURCEGRAPH_API_URL)
-    signale.start('Starting webpack-dev-server with environment config:\n', environmentConfig)
 
-    const proxyConfig: ProxyConfigArrayItem = {
-        context: PROXY_ROUTES,
-        ...getAPIProxySettings({
+    const init: DevelopmentServerInit = {
+        proxyRoutes: PROXY_ROUTES,
+        proxyMiddlewareOptions: getAPIProxySettings({
             csrfContextValue,
             apiURL: SOURCEGRAPH_API_URL,
         }),
+        csrfTokenCookieMiddleware: getCSRFTokenCookieMiddleware(csrfCookieValue),
+    }
+
+    switch (environmentConfig.DEV_WEB_BUILDER) {
+        case 'webpack':
+            await startWebpackDevelopmentServer(init)
+            break
+
+        case 'esbuild':
+            await startEsbuildDevelopmentServer(init)
+            break
+    }
+}
+
+async function startWebpackDevelopmentServer({
+    proxyRoutes,
+    proxyMiddlewareOptions,
+    csrfTokenCookieMiddleware,
+}: DevelopmentServerInit): Promise<void> {
+    const proxyConfig: ProxyConfigArrayItem = {
+        context: proxyRoutes,
+        ...proxyMiddlewareOptions,
     }
 
     const developmentServerConfig: WebpackDevServer.Configuration = {
@@ -53,7 +90,7 @@ export async function startDevelopmentServer(): Promise<void> {
         },
         proxy: [proxyConfig],
         onBeforeSetupMiddleware: developmentServer => {
-            developmentServer.app.use(getCSRFTokenCookieMiddleware(csrfCookieValue))
+            developmentServer.app.use(csrfTokenCookieMiddleware)
         },
     }
 
@@ -70,6 +107,26 @@ export async function startDevelopmentServer(): Promise<void> {
     await server.start()
     signale.success(`Development server is ready at ${chalk.blue.bold(WEB_SERVER_URL)}`)
     signale.await('Waiting for Webpack to compile assets')
+}
+
+async function startEsbuildDevelopmentServer({
+    proxyRoutes,
+    proxyMiddlewareOptions,
+    csrfTokenCookieMiddleware,
+}: DevelopmentServerInit): Promise<void> {
+    const manifest = getManifest()
+    const htmlPage = getHTMLPage({
+        head: `<link rel="stylesheet" href="${manifest['app.css']}">`,
+        bodyEnd: `<script src="${manifest['app.js']}" type="module"></script>`,
+    })
+
+    await esbuildDevelopmentServer({ host: '0.0.0.0', port: SOURCEGRAPH_HTTPS_PORT }, app => {
+        app.use(csrfTokenCookieMiddleware)
+        app.use(createProxyMiddleware(proxyRoutes, proxyMiddlewareOptions))
+        app.get(/.*/, (_request, response) => {
+            response.send(htmlPage)
+        })
+    })
 }
 
 startDevelopmentServer().catch(error => signale.error(error))

--- a/client/web/dev/server/development.server.ts
+++ b/client/web/dev/server/development.server.ts
@@ -37,6 +37,10 @@ async function startDevelopmentServer(): Promise<void> {
         environmentConfig
     )
 
+    if (!SOURCEGRAPH_API_URL) {
+        throw new Error('development.server.ts only supports *web-standalone* usage')
+    }
+
     // Get CSRF token value from the `SOURCEGRAPH_API_URL`.
     const { csrfContextValue, csrfCookieValue } = await getCSRFTokenAndCookie(SOURCEGRAPH_API_URL)
 

--- a/client/web/dev/server/production.server.ts
+++ b/client/web/dev/server/production.server.ts
@@ -17,6 +17,10 @@ import {
 const { SOURCEGRAPH_API_URL, SOURCEGRAPH_HTTPS_PORT } = environmentConfig
 
 async function startProductionServer(): Promise<void> {
+    if (!SOURCEGRAPH_API_URL) {
+        throw new Error('production.server.ts only supports *web-standalone* usage')
+    }
+
     // Get CSRF token value from the `SOURCEGRAPH_API_URL`.
     const { csrfContextValue, csrfCookieValue } = await getCSRFTokenAndCookie(SOURCEGRAPH_API_URL)
     signale.await('Production server', { ...environmentConfig, csrfContextValue, csrfCookieValue })

--- a/client/web/dev/utils/csrf/get-csrf-token-and-cookie.ts
+++ b/client/web/dev/utils/csrf/get-csrf-token-and-cookie.ts
@@ -6,7 +6,7 @@ const CSRF_CONTEXT_VALUE_REGEXP = new RegExp(`${CSRF_CONTEXT_KEY}":"(.*?)"`)
 export const CSRF_COOKIE_NAME = 'sg_csrf_token'
 const CSRF_COOKIE_VALUE_REGEXP = new RegExp(`${CSRF_COOKIE_NAME}=(.*?);`)
 
-interface CSFRTokenAndCookie {
+interface CSRFTokenAndCookie {
     csrfContextValue: string
     csrfCookieValue: string
 }
@@ -19,7 +19,7 @@ interface CSFRTokenAndCookie {
  * 2. value from JS context under `CSRF_CONTEXT_KEY` key.
  *
  */
-export async function getCSRFTokenAndCookie(proxyUrl: string): Promise<CSFRTokenAndCookie> {
+export async function getCSRFTokenAndCookie(proxyUrl: string): Promise<CSRFTokenAndCookie> {
     const response = await fetch(`${proxyUrl}/sign-in`)
 
     const html = await response.text()

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -6,7 +6,7 @@ const DEFAULT_SITE_CONFIG_PATH = path.resolve(ROOT_PATH, '../dev-private/enterpr
 
 export const environmentConfig = {
     NODE_ENV: process.env.NODE_ENV || 'development',
-    SOURCEGRAPH_API_URL: process.env.SOURCEGRAPH_API_URL || 'https://k8s.sgdev.org',
+    SOURCEGRAPH_API_URL: process.env.SOURCEGRAPH_API_URL,
     SOURCEGRAPH_HTTPS_DOMAIN: process.env.SOURCEGRAPH_HTTPS_DOMAIN || 'sourcegraph.test',
     SOURCEGRAPH_HTTPS_PORT: Number(process.env.SOURCEGRAPH_HTTPS_PORT) || 3443,
     WEBPACK_SERVE_INDEX: process.env.WEBPACK_SERVE_INDEX === 'true',

--- a/client/web/dev/webpack/get-html-webpack-plugins.ts
+++ b/client/web/dev/webpack/get-html-webpack-plugins.ts
@@ -8,43 +8,50 @@ import { createJsContext, environmentConfig, STATIC_ASSETS_PATH } from '../utils
 
 const { SOURCEGRAPH_HTTPS_PORT, NODE_ENV } = environmentConfig
 
+interface HTMLPageData {
+    head: string
+    bodyEnd: string
+}
+
+/**
+ * Returns an HTML page similar to `cmd/frontend/internal/app/ui/app.html` but when running
+ * without the `frontend` service.
+ */
+export const getHTMLPage = ({ head, bodyEnd }: HTMLPageData): string => `
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Sourcegraph</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, viewport-fit=cover" />
+        <meta name="referrer" content="origin-when-cross-origin"/>
+        <meta name="color-scheme" content="light dark"/>
+        ${head}
+    </head>
+    <body>
+        <div id="root"></div>
+        <script>
+            // Optional value useful for checking if index.html is created by HtmlWebpackPlugin with the right NODE_ENV.
+            window.webpackBuildEnvironment = '${NODE_ENV}'
+
+            // Required mock of the JS context object.
+            window.context = ${JSON.stringify(
+                createJsContext({ sourcegraphBaseUrl: `http://localhost:${SOURCEGRAPH_HTTPS_PORT}` })
+            )}
+        </script>
+        ${bodyEnd}
+    </body>
+</html>
+`
+
 export const getHTMLWebpackPlugins = (): WebpackPluginInstance[] => {
-    const jsContext = createJsContext({ sourcegraphBaseUrl: `http://localhost:${SOURCEGRAPH_HTTPS_PORT}` })
-
-    /**
-     * To match `cmd/frontend/internal/app/ui/app.html` template used by our `frontend` server
-     * script tags are injected after the <body> tag.
-     */
-    const templateContent = ({ htmlWebpackPlugin }: TemplateParameter): string => `
-        <!DOCTYPE html>
-        <html lang="en">
-            <head>
-                <title>Sourcegraph</title>
-                ${htmlWebpackPlugin.tags.headTags.filter(tag => tag.tagName !== 'script').toString()}
-            </head>
-            <body>
-                <div id="root"></div>
-                <script>
-                    // Optional value useful for checking if index.html is created by HtmlWebpackPlugin with the right NODE_ENV.
-                    window.webpackBuildEnvironment = '${NODE_ENV}'
-
-                    // Required mock of the JS context object.
-                    window.context = ${JSON.stringify(jsContext)}
-                </script>
-                ${htmlWebpackPlugin.tags.headTags.filter(tag => tag.tagName === 'script').toString()}
-            </body>
-        </html>
-        `
-
     const htmlWebpackPlugin = new HtmlWebpackPlugin({
         // `TemplateParameter` can be mutated. We need to tell TS that we didn't touch it.
-        templateContent: templateContent as Options['templateContent'],
-        meta: {
-            charset: 'utf-8',
-            viewport: 'width=device-width, viewport-fit=cover, initial-scale=1',
-            referrer: 'origin-when-cross-origin',
-            'color-scheme': 'light dark',
-        },
+        templateContent: (({ htmlWebpackPlugin }: TemplateParameter): string =>
+            getHTMLPage({
+                head: htmlWebpackPlugin.tags.headTags.filter(tag => tag.tagName !== 'script').toString(),
+                bodyEnd: htmlWebpackPlugin.tags.headTags.filter(tag => tag.tagName === 'script').toString(),
+            })) as Options['templateContent'],
         filename: path.resolve(STATIC_ASSETS_PATH, 'index.html'),
         alwaysWriteToDisk: true,
         inject: false,

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -107,7 +107,7 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                     >
                         <div>
                             <strong>Warning!</strong> This build uses data from the proxied API:{' '}
-                            <a target="__blank" href="process.env.SOURCEGRAPH_API_URL">
+                            <a target="__blank" href={process.env.SOURCEGRAPH_API_URL}>
                                 {process.env.SOURCEGRAPH_API_URL}
                             </a>
                         </div>

--- a/doc/dev/background-information/web/build.md
+++ b/doc/dev/background-information/web/build.md
@@ -58,7 +58,7 @@ Run `yarn upgrade -L PACKAGE`.
 To use esbuild instead of Webpack, set the env var `DEV_WEB_BUILDER=esbuild`:
 
 - For the `start.sh` script: `DEV_WEB_BUILDER=esbuild enterprise/dev/start.sh`
-- For `sg`: add `DEV_WEB_BUILDER: esbuild` to the `env` section of the `web` or `enterprise-web` commands (the `web-standalone` and `enterprise-web-standalone` commands aren't yet supported for esbuild)
+- For `sg`: add `DEV_WEB_BUILDER: esbuild` to the `env` section of any of the following commands: `web`, `enterprise-web` `web-standalone`, `enterprise-web-standalone`
 
 Comparison vs. Webpack:
 


### PR DESCRIPTION
Refactors some other Webpack standalone dev server so that proxy config and HTML page content can be shared between Webpack and esbuild.

Also includes some other fixes in other commits.

Tested and confirmed working:

- `enterprise/dev/start.sh` (existing Webpack mode, no regressions)
- `sg run enterprise-web-standalone` (existing Webpack mode, no regressions)
- `DEV_WEB_BUILDER=esbuild enterprise/dev/start.sh` (existing esbuild mode, no regressions)
- `DEV_WEB_BUILDER=esbuild sg run enterprise-web-standalone` (**NEW** esbuild mode, works same as the corresponding Webpack mode)