### PR TITLE
[WIP] search: further reduce redundant conversions and iteration over large repo lists

### DIFF
--- a/cmd/frontend/graphqlbackend/compute.go
+++ b/cmd/frontend/graphqlbackend/compute.go
@@ -156,7 +156,7 @@ func toComputeMatchContextResolver(fm *result.FileMatch, mc *compute.MatchContex
 		computeMatches = append(computeMatches, &computeMatchResolver{m: &mCopy})
 	}
 	return &computeMatchContextResolver{
-		repository: getRepoResolver(fm.Repo, ""),
+		repository: getRepoResolver(*fm.Repo, ""),
 		commit:     string(fm.CommitID),
 		path:       fm.Path,
 		matches:    computeMatches,

--- a/cmd/frontend/graphqlbackend/compute_test.go
+++ b/cmd/frontend/graphqlbackend/compute_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestToResultResolverList(t *testing.T) {
 	matches := []result.Match{
 		&result.FileMatch{
+			File: result.File{Repo: &types.RepoName{ID: 1, Name: "foo"}},
 			LineMatches: []*result.LineMatch{
 				{Preview: "a"},
 				{Preview: "b"},

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -66,7 +66,7 @@ func searchResultsStatsLanguages(ctx context.Context, matches []result.Match) ([
 	}
 
 	var (
-		repos    = map[api.RepoID]types.RepoName{}
+		repos    = map[api.RepoID]*types.RepoName{}
 		filesMap = map[repoCommit]*fileStatsWork{}
 
 		run = parallel.NewRun(16)
@@ -76,7 +76,7 @@ func searchResultsStatsLanguages(ctx context.Context, matches []result.Match) ([
 	)
 
 	// Track the mapping of repo ID -> repo object as we iterate.
-	sawRepo := func(repo types.RepoName) {
+	sawRepo := func(repo *types.RepoName) {
 		if _, ok := repos[repo.ID]; !ok {
 			repos[repo.ID] = repo
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -55,7 +55,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	defer git.ResetMocks()
 
 	mkResult := func(path string, lineNumbers ...int32) *result.FileMatch {
-		rn := types.RepoName{
+		rn := &types.RepoName{
 			Name: "r",
 		}
 		fm := mkFileMatch(rn, path, lineNumbers...)

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -242,7 +242,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 
 			if symbolMatch, _ := symbol.GetMatchAtLineCharacter(
 				ctx,
-				types.RepoName{ID: common.Repo.ID, Name: common.Repo.Name},
+				&types.RepoName{ID: common.Repo.ID, Name: common.Repo.Name},
 				common.CommitID,
 				strings.TrimLeft(blobPath, "/"),
 				lineRange.StartLine-1,

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -246,7 +246,7 @@ type reposListServer struct {
 	// interface for testing.
 	Repos interface {
 		// ListIndexable returns the repositories to index on Sourcegraph.com
-		ListIndexable(context.Context) ([]types.RepoName, error)
+		ListIndexable(context.Context) (*types.RepoSet, error)
 		// List returns a list of repositories
 		List(context.Context, database.ReposListOptions) ([]*types.Repo, error)
 	}
@@ -284,8 +284,8 @@ func (h *reposListServer) serveIndex(w http.ResponseWriter, r *http.Request) err
 		if err != nil {
 			return errors.Wrap(err, "listing repos")
 		}
-		names = make([]string, len(res))
-		for i, r := range res {
+		names = make([]string, res.Len())
+		for i, r := range res.Repos {
 			names[i] = string(r.Name)
 		}
 	} else {

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -150,12 +150,10 @@ type mockRepos struct {
 	repos          []string
 }
 
-func (r *mockRepos) ListIndexable(context.Context) ([]types.RepoName, error) {
-	var repos []types.RepoName
+func (r *mockRepos) ListIndexable(context.Context) (*types.RepoSet, error) {
+	repos := types.NewRepoSet()
 	for _, name := range r.indexableRepos {
-		repos = append(repos, types.RepoName{
-			Name: api.RepoName(name),
-		})
+		repos.Add(&types.RepoName{Name: api.RepoName(name)})
 	}
 	return repos, nil
 }

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -74,7 +74,7 @@ func (p *progressAggregator) Final() api.Progress {
 
 	// We only send RepositoriesCount at the end because the number is
 	// confusing to users to see while searching.
-	if c := len(p.Stats.Repos); c > 0 {
+	if c := p.Stats.Repos.Len(); c > 0 {
 		s.RepositoriesCount = intPtr(c)
 	}
 
@@ -92,8 +92,8 @@ func (n namerFunc) Name() string {
 func getNames(stats streaming.Stats, status searchshared.RepoStatus) []api.Namer {
 	var names []api.Namer
 	stats.Status.Filter(status, func(id sgapi.RepoID) {
-		if name, ok := stats.Repos[id]; ok {
-			names = append(names, namerFunc(name.Name))
+		if r := stats.Repos.GetByID(id); r != nil {
+			names = append(names, namerFunc(r.Name))
 		} else {
 			names = append(names, namerFunc(fmt.Sprintf("UNKNOWN{ID=%d}", id)))
 		}

--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -18,7 +18,7 @@ import (
 
 // IndexableReposLister is a subset of the API exposed by the backend.ListIndexable.
 type IndexableReposLister interface {
-	List(ctx context.Context) ([]types.RepoName, error)
+	List(ctx context.Context) (*types.RepoSet, error)
 }
 
 // RepoStore is a subset of the API exposed by the database.Repos() store.
@@ -82,7 +82,7 @@ func (a *AllReposIterator) ForEach(ctx context.Context, forEach func(repoName st
 			if err != nil {
 				return errors.Wrap(err, "IndexableReposLister.List")
 			}
-			for _, r := range res {
+			for _, r := range res.Repos {
 				a.cachedRepoNames = append(a.cachedRepoNames, string(r.Name))
 			}
 			a.cachedRepoNamesAge = a.Clock()

--- a/enterprise/internal/insights/discovery/all_repos_iterator_test.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator_test.go
@@ -164,12 +164,12 @@ func TestAllReposIterator_DotCom(t *testing.T) {
 		indexableReposListCall int // There is no pagination with this store! We'll probably want that, eventually.
 		nextRepoID             api.RepoID
 	)
-	indexableReposLister.ListFunc.SetDefaultHook(func(ctx context.Context) ([]types.RepoName, error) {
+	indexableReposLister.ListFunc.SetDefaultHook(func(ctx context.Context) (*types.RepoSet, error) {
 		indexableReposListCall++
-		var result []types.RepoName
+		result := types.NewRepoSet()
 		for i := 0; i < 9; i++ {
 			nextRepoID++
-			result = append(result, types.RepoName{ID: nextRepoID, Name: api.RepoName(fmt.Sprint(nextRepoID))})
+			result.Add(&types.RepoName{ID: nextRepoID, Name: api.RepoName(fmt.Sprint(nextRepoID))})
 		}
 		return result, nil
 	})

--- a/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
+++ b/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
@@ -25,7 +25,7 @@ type MockIndexableReposLister struct {
 func NewMockIndexableReposLister() *MockIndexableReposLister {
 	return &MockIndexableReposLister{
 		ListFunc: &IndexableReposListerListFunc{
-			defaultHook: func(context.Context) ([]types.RepoName, error) {
+			defaultHook: func(context.Context) (*types.RepoSet, error) {
 				return nil, nil
 			},
 		},
@@ -46,15 +46,15 @@ func NewMockIndexableReposListerFrom(i IndexableReposLister) *MockIndexableRepos
 // IndexableReposListerListFunc describes the behavior when the List method
 // of the parent MockIndexableReposLister instance is invoked.
 type IndexableReposListerListFunc struct {
-	defaultHook func(context.Context) ([]types.RepoName, error)
-	hooks       []func(context.Context) ([]types.RepoName, error)
+	defaultHook func(context.Context) (*types.RepoSet, error)
+	hooks       []func(context.Context) (*types.RepoSet, error)
 	history     []IndexableReposListerListFuncCall
 	mutex       sync.Mutex
 }
 
 // List delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockIndexableReposLister) List(v0 context.Context) ([]types.RepoName, error) {
+func (m *MockIndexableReposLister) List(v0 context.Context) (*types.RepoSet, error) {
 	r0, r1 := m.ListFunc.nextHook()(v0)
 	m.ListFunc.appendCall(IndexableReposListerListFuncCall{v0, r0, r1})
 	return r0, r1
@@ -63,7 +63,7 @@ func (m *MockIndexableReposLister) List(v0 context.Context) ([]types.RepoName, e
 // SetDefaultHook sets function that is called when the List method of the
 // parent MockIndexableReposLister instance is invoked and the hook queue is
 // empty.
-func (f *IndexableReposListerListFunc) SetDefaultHook(hook func(context.Context) ([]types.RepoName, error)) {
+func (f *IndexableReposListerListFunc) SetDefaultHook(hook func(context.Context) (*types.RepoSet, error)) {
 	f.defaultHook = hook
 }
 
@@ -71,7 +71,7 @@ func (f *IndexableReposListerListFunc) SetDefaultHook(hook func(context.Context)
 // List method of the parent MockIndexableReposLister instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *IndexableReposListerListFunc) PushHook(hook func(context.Context) ([]types.RepoName, error)) {
+func (f *IndexableReposListerListFunc) PushHook(hook func(context.Context) (*types.RepoSet, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -79,21 +79,21 @@ func (f *IndexableReposListerListFunc) PushHook(hook func(context.Context) ([]ty
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *IndexableReposListerListFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]types.RepoName, error) {
+func (f *IndexableReposListerListFunc) SetDefaultReturn(r0 *types.RepoSet, r1 error) {
+	f.SetDefaultHook(func(context.Context) (*types.RepoSet, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *IndexableReposListerListFunc) PushReturn(r0 []types.RepoName, r1 error) {
-	f.PushHook(func(context.Context) ([]types.RepoName, error) {
+func (f *IndexableReposListerListFunc) PushReturn(r0 *types.RepoSet, r1 error) {
+	f.PushHook(func(context.Context) (*types.RepoSet, error) {
 		return r0, r1
 	})
 }
 
-func (f *IndexableReposListerListFunc) nextHook() func(context.Context) ([]types.RepoName, error) {
+func (f *IndexableReposListerListFunc) nextHook() func(context.Context) (*types.RepoSet, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -131,7 +131,7 @@ type IndexableReposListerListFuncCall struct {
 	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.RepoName
+	Result0 *types.RepoSet
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -80,24 +80,25 @@ func TestListIndexableRepos(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []types.RepoName{
-				{
+			want := types.NewRepoSet(
+				&types.RepoName{
 					ID:   api.RepoID(11),
 					Name: "github.com/foo/bar11",
 				},
-				{
+				&types.RepoName{
 					ID:   api.RepoID(10),
 					Name: "github.com/foo/bar10",
 				},
-				{
+				&types.RepoName{
 					ID:   api.RepoID(14),
 					Name: "github.com/foo/bar14",
 				},
-				{
-					ID:   api.RepoID(15),
-					Name: "github.com/foo/bar15",
+				&types.RepoName{
+					ID:      api.RepoID(15),
+					Name:    "github.com/foo/bar15",
+					Private: true,
 				},
-			}
+			)
 			if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -108,20 +109,20 @@ func TestListIndexableRepos(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []types.RepoName{
-				{
+			want := types.NewRepoSet(
+				&types.RepoName{
 					ID:   api.RepoID(11),
 					Name: "github.com/foo/bar11",
 				},
-				{
+				&types.RepoName{
 					ID:   api.RepoID(10),
 					Name: "github.com/foo/bar10",
 				},
-				{
+				&types.RepoName{
 					ID:   api.RepoID(14),
 					Name: "github.com/foo/bar14",
 				},
-			}
+			)
 			if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -85,7 +85,7 @@ func mustCreate(ctx context.Context, t *testing.T, db *sql.DB, repo *types.Repo,
 func repoNamesFromRepos(repos []*types.Repo) []types.RepoName {
 	rnames := make([]types.RepoName, 0, len(repos))
 	for _, repo := range repos {
-		rnames = append(rnames, types.RepoName{ID: repo.ID, Name: repo.Name})
+		rnames = append(rnames, types.RepoName{ID: repo.ID, Name: repo.Name, Private: repo.Private})
 	}
 
 	return rnames
@@ -94,7 +94,7 @@ func repoNamesFromRepos(repos []*types.Repo) []types.RepoName {
 func reposFromRepoNames(names []types.RepoName) []*types.Repo {
 	repos := make([]*types.Repo, 0, len(names))
 	for _, name := range names {
-		repos = append(repos, &types.Repo{ID: name.ID, Name: name.Name})
+		repos = append(repos, &types.Repo{ID: name.ID, Name: name.Name, Private: name.Private})
 	}
 
 	return repos
@@ -435,7 +435,7 @@ func TestRepos_ListRepoNames_userID(t *testing.T) {
 	}
 
 	want := []types.RepoName{
-		{ID: repo.ID, Name: repo.Name},
+		{ID: repo.ID, Name: repo.Name, Private: repo.Private},
 	}
 
 	have, err := Repos(db).ListRepoNames(ctx, ReposListOptions{UserID: user.ID})
@@ -1045,7 +1045,8 @@ func TestRepos_createRepo(t *testing.T) {
 	// Add a repo.
 	createRepo(ctx, t, db, &types.Repo{
 		Name:        "a/b",
-		Description: "test"})
+		Description: "test",
+	})
 
 	repo, err := Repos(db).GetByName(ctx, "a/b")
 	if err != nil {

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -10,14 +10,15 @@ import (
 )
 
 type MockRepos struct {
-	Get           func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
-	GetByName     func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
-	GetByIDs      func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
-	List          func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
-	ListRepoNames func(v0 context.Context, v1 ReposListOptions) ([]types.RepoName, error)
-	Metadata      func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
-	Create        func(ctx context.Context, repos ...*types.Repo) (err error)
-	Count         func(ctx context.Context, opt ReposListOptions) (int, error)
+	Get                    func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
+	GetByName              func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
+	GetByIDs               func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
+	List                   func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
+	ListRepoNames          func(v0 context.Context, v1 ReposListOptions) ([]types.RepoName, error)
+	StreamingListRepoNames func(v0 context.Context, v1 ReposListOptions, cb func(*types.RepoName)) error
+	Metadata               func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
+	Create                 func(ctx context.Context, repos ...*types.Repo) (err error)
+	Count                  func(ctx context.Context, opt ReposListOptions) (int, error)
 
 	// TODO: we're knowingly taking on a little tech debt by placing these here for now.
 	ListExternalServiceUserIDsByRepoID func(ctx context.Context, repoID api.RepoID) ([]int32, error)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -862,6 +862,7 @@ func (s *schedule) reset() {
 // i.e. heap.Fix, heap.Remove, heap.Push, heap.Pop.
 
 func (s *schedule) Len() int { return len(s.heap) }
+
 func (s *schedule) Less(i, j int) bool {
 	return s.heap[i].Due.Before(s.heap[j].Due)
 }

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -57,12 +57,12 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repoRevs := &search.RepositoryRevisions{
-		Repo: types.RepoName{ID: 1, Name: "repo"},
-		Revs: []search.RevisionSpecifier{{RevSpec: "rev"}},
-	}
+
+	repo := &types.RepoName{ID: 1, Name: "repo"}
+	revs := search.RevSpecs{{RevSpec: "rev"}}
 	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, db, search.CommitParameters{
-		RepoRevs:    repoRevs,
+		Repo:        repo,
+		Revs:        revs,
 		PatternInfo: &search.CommitPatternInfo{Pattern: "p", FileMatchLimit: int32(search.DefaultMaxSearchResults)},
 		Query:       q,
 		Diff:        true,
@@ -73,7 +73,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 
 	want := []*result.CommitMatch{{
 		Commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
-		Repo:        types.RepoName{ID: 1, Name: "repo"},
+		Repo:        repo,
 		DiffPreview: &result.HighlightedString{Value: "x", Highlights: []result.HighlightedRange{}},
 		Body:        result.HighlightedString{Value: "```diff\nx```", Highlights: []result.HighlightedRange{}},
 	}}

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -1,15 +1,27 @@
 package search
 
 import (
-	"context"
-	"reflect"
 	"strings"
-	"sync"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
+
+// DefaultRevSpecs is the default RevSpecs assumed when no specific rev specs
+// are defined in a search, either through `rev:` or through `r:foo@rev`.
+// All search backends that deal with rev specs must use this default if a repo's revs are empty.
+var DefaultRevSpecs = RevSpecs{{RevSpec: "HEAD"}}
+
+// RevSpecs is a list type of RevisionSpecifiers
+type RevSpecs []RevisionSpecifier
+
+// RevSpecs returns all non empty RevSpec values.
+func (rs RevSpecs) RevSpecs() []string {
+	revSpecs := make([]string, 0, len(rs))
+	for _, r := range rs {
+		if r.RevSpec != "" {
+			revSpecs = append(revSpecs, r.RevSpec)
+		}
+	}
+	return revSpecs
+}
 
 // RevisionSpecifier represents either a revspec or a ref glob. At most one
 // field is set. The default branch is represented by all fields being empty.
@@ -25,6 +37,10 @@ type RevisionSpecifier struct {
 	// ExcludeRefGlob is a glob for references to exclude. See the
 	// documentation for "--exclude" in git-log.
 	ExcludeRefGlob string
+}
+
+func (r RevisionSpecifier) IsGlob() bool {
+	return r.RefGlob != "" || r.ExcludeRefGlob != ""
 }
 
 func (r1 RevisionSpecifier) String() string {
@@ -50,45 +66,6 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 		return r1.RefGlob < r2.RefGlob
 	}
 	return r1.ExcludeRefGlob < r2.ExcludeRefGlob
-}
-
-// RepositoryRevisions specifies a repository and 0 or more revspecs and ref
-// globs.  If no revspecs and no ref globs are specified, then the
-// repository's default branch is used.
-type RepositoryRevisions struct {
-	Repo types.RepoName
-	Revs []RevisionSpecifier
-
-	// resolveOnce protects resolvedRevs
-	resolveOnce sync.Once
-
-	// resolvedRevs is set by ExpandedRevSpecs and contains all revisions
-	// including resolved ref-globs.
-	resolvedRevs []string
-
-	// resolveErr stores the error returned by the first call to ExpandedRevSpecs. It
-	// gives the caller the chance to distinguish between an error and an empty resolvedRevs.
-	resolveErr error
-
-	// ListRefs is called to list all Git refs for a repository. It is intended to be mocked by
-	// tests. If nil, git.ListRefs is used.
-	ListRefs func(context.Context, api.RepoName) ([]git.Ref, error)
-}
-
-func (r *RepositoryRevisions) Copy() *RepositoryRevisions {
-	repo := r.Repo
-	revs := make([]RevisionSpecifier, len(r.Revs))
-	copy(revs, r.Revs)
-	return &RepositoryRevisions{
-		Repo:     repo,
-		Revs:     revs,
-		ListRefs: r.ListRefs,
-	}
-}
-
-// Equal provides custom comparison which is used by go-cmp
-func (r *RepositoryRevisions) Equal(other *RepositoryRevisions) bool {
-	return reflect.DeepEqual(r.Repo, other.Repo) && reflect.DeepEqual(r.Revs, other.Revs)
 }
 
 // ParseRepositoryRevisions parses strings that refer to a repository and 0
@@ -142,114 +119,4 @@ func parseRev(spec string) RevisionSpecifier {
 		return RevisionSpecifier{RefGlob: spec[1:]}
 	}
 	return RevisionSpecifier{RevSpec: spec}
-}
-
-// GitserverRepo is a convenience function to return the api.RepoName for
-// r.Repo. The returned Repo will not have the URL set, only the name.
-func (r *RepositoryRevisions) GitserverRepo() api.RepoName {
-	return r.Repo.Name
-}
-
-func (r *RepositoryRevisions) String() string {
-	if len(r.Revs) == 0 {
-		return string(r.Repo.Name)
-	}
-
-	parts := make([]string, len(r.Revs))
-	for i, rev := range r.Revs {
-		parts[i] = rev.String()
-	}
-	return string(r.Repo.Name) + "@" + strings.Join(parts, ":")
-}
-
-// OnlyExplicit returns true if all revspecs in Revs are explicit.
-func (r *RepositoryRevisions) OnlyExplicit() bool {
-	for _, rev := range r.Revs {
-		if rev.RefGlob != "" || rev.ExcludeRefGlob != "" {
-			return false
-		}
-	}
-	return true
-}
-
-// RevSpecs returns a list of all explicitly listed Git revspecs. It does not expand ref globs to
-// their matching revspecs.
-func (r *RepositoryRevisions) RevSpecs() []string {
-	var revspecs []string
-	for _, rev := range r.Revs {
-		if rev.RefGlob == "" && rev.ExcludeRefGlob == "" {
-			revspecs = append(revspecs, rev.RevSpec)
-		}
-	}
-	return revspecs
-}
-
-// ExpandedRevSpecs is a wrapper around expandedRevSpecs. It uses a sync.Once
-// to ensure we only resolve revisions once. The resolved revisions and the error response
-// are stored in r and returned to future callers.
-//
-// Note that storing the error causes all callers to return the same error. For example,
-// if the first caller has a context error, all other callers will return a context error, too.
-//
-// Not all callers need to expand ref glob expressions. If a caller is passing the ref globs as
-// command-line args to `git` directly (e.g., to `git log --glob ... --exclude ...`), it does not
-// need to use this function.
-func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) ([]string, error) {
-	r.resolveOnce.Do(func() {
-		revSpecsList, err := expandedRevSpec(ctx, r)
-		if err != nil {
-			r.resolveErr = err
-			return
-		}
-		r.resolvedRevs = revSpecsList
-	})
-	return r.resolvedRevs, r.resolveErr
-}
-
-// expandedRevSpecs evaluates all of r's ref glob expressions and returns the full, current list of
-// refs matched or resolved by them, plus the explicitly listed Git revspecs. See
-// git.CompileRefGlobs for information on how ref include/exclude globs are handled.
-func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, error) {
-	listRefs := r.ListRefs
-	if listRefs == nil {
-		listRefs = git.ListRefs
-	}
-
-	var (
-		revSpecs = map[string]struct{}{}
-		globs    []git.RefGlob
-	)
-	for _, rev := range r.Revs {
-		switch {
-		case rev.RefGlob != "":
-			globs = append(globs, git.RefGlob{Include: rev.RefGlob})
-		case rev.ExcludeRefGlob != "":
-			globs = append(globs, git.RefGlob{Exclude: rev.ExcludeRefGlob})
-		default:
-			revSpecs[rev.RevSpec] = struct{}{}
-		}
-	}
-	if len(globs) > 0 {
-		allRefs, err := listRefs(ctx, r.GitserverRepo())
-		if err != nil {
-			return nil, err
-		}
-
-		rg, err := git.CompileRefGlobs(globs)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, ref := range allRefs {
-			if rg.Match(ref.Name) {
-				revSpecs[strings.TrimPrefix(ref.Name, "refs/heads/")] = struct{}{}
-			}
-		}
-	}
-
-	revSpecsList := make([]string, 0, len(revSpecs))
-	for revSpec := range revSpecs {
-		revSpecsList = append(revSpecsList, revSpec)
-	}
-	return revSpecsList, nil
 }

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -13,7 +13,7 @@ import (
 
 type CommitMatch struct {
 	Commit         git.Commit
-	Repo           types.RepoName
+	Repo           *types.RepoName
 	Refs           []string
 	SourceRefs     []string
 	MessagePreview *HighlightedString
@@ -35,7 +35,7 @@ func (r *CommitMatch) ResultCount() int {
 	return 1
 }
 
-func (r *CommitMatch) RepoName() types.RepoName {
+func (r *CommitMatch) RepoName() *types.RepoName {
 	return r.Repo
 }
 

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -13,7 +13,7 @@ import (
 func TestDeduper(t *testing.T) {
 	commit := func(repo, id string) *CommitMatch {
 		return &CommitMatch{
-			Repo: types.RepoName{
+			Repo: &types.RepoName{
 				Name: api.RepoName(repo),
 			},
 			Commit: git.Commit{
@@ -24,7 +24,7 @@ func TestDeduper(t *testing.T) {
 
 	diff := func(repo, id string) *CommitMatch {
 		return &CommitMatch{
-			Repo: types.RepoName{
+			Repo: &types.RepoName{
 				Name: api.RepoName(repo),
 			},
 			Commit: git.Commit{
@@ -44,7 +44,7 @@ func TestDeduper(t *testing.T) {
 	file := func(repo, commit, path string, lines []*LineMatch) *FileMatch {
 		return &FileMatch{
 			File: File{
-				Repo: types.RepoName{
+				Repo: &types.RepoName{
 					Name: api.RepoName(repo),
 				},
 				CommitID: api.CommitID(commit),

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -2,9 +2,8 @@ package result
 
 import (
 	"net/url"
-	"strings"
-
 	"path"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
@@ -16,9 +15,9 @@ type File struct {
 	// InputRev is the Git revspec that the user originally requested to search. It is used to
 	// preserve the original revision specifier from the user instead of navigating them to the
 	// absolute commit ID when they select a result.
-	InputRev *string        `json:"-"`
-	Repo     types.RepoName `json:"-"`
-	CommitID api.CommitID   `json:"-"`
+	InputRev *string         `json:"-"`
+	Repo     *types.RepoName `json:"-"`
+	CommitID api.CommitID    `json:"-"`
 	Path     string
 }
 
@@ -49,7 +48,7 @@ type FileMatch struct {
 	LimitHit bool
 }
 
-func (fm *FileMatch) RepoName() types.RepoName {
+func (fm *FileMatch) RepoName() *types.RepoName {
 	return fm.File.Repo
 }
 

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -12,7 +12,7 @@ type Match interface {
 	ResultCount() int
 	Limit(int) int
 	Select(filter.SelectPath) Match
-	RepoName() types.RepoName
+	RepoName() *types.RepoName
 
 	// Key returns a key which uniquely identifies this match.
 	Key() Key

--- a/internal/search/result/merge_test.go
+++ b/internal/search/result/merge_test.go
@@ -13,7 +13,7 @@ import (
 
 func commitResult(repo, commit string) *CommitMatch {
 	return &CommitMatch{
-		Repo: types.RepoName{Name: api.RepoName(repo)},
+		Repo: &types.RepoName{Name: api.RepoName(repo)},
 		Commit: git.Commit{
 			ID: api.CommitID(commit),
 		},
@@ -23,7 +23,7 @@ func commitResult(repo, commit string) *CommitMatch {
 func diffResult(repo, commit string) *CommitMatch {
 	return &CommitMatch{
 		DiffPreview: &HighlightedString{},
-		Repo:        types.RepoName{Name: api.RepoName(repo)},
+		Repo:        &types.RepoName{Name: api.RepoName(repo)},
 		Commit: git.Commit{
 			ID: api.CommitID(commit),
 		},
@@ -39,7 +39,7 @@ func repoResult(name string) *RepoMatch {
 func fileResult(repo string, lineMatches []*LineMatch, symbolMatches []*SymbolMatch) *FileMatch {
 	return &FileMatch{
 		File: File{
-			Repo: types.RepoName{Name: api.RepoName(repo)},
+			Repo: &types.RepoName{Name: api.RepoName(repo)},
 		},
 		Symbols:     symbolMatches,
 		LineMatches: lineMatches,

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -16,8 +16,8 @@ type RepoMatch struct {
 	Rev string
 }
 
-func (r RepoMatch) RepoName() types.RepoName {
-	return types.RepoName{
+func (r RepoMatch) RepoName() *types.RepoName {
+	return &types.RepoName{
 		Name: r.Name,
 		ID:   r.ID,
 	}

--- a/internal/search/result/symbol_test.go
+++ b/internal/search/result/symbol_test.go
@@ -24,10 +24,10 @@ func TestSymbolRange(t *testing.T) {
 
 func TestSymbolURL(t *testing.T) {
 	repoA := types.RepoName{Name: "repo/A", ID: 1}
-	fileAA := File{Repo: repoA, Path: "A"}
+	fileAA := File{Repo: &repoA, Path: "A"}
 
 	rev := "testrev"
-	fileAB := File{Repo: repoA, Path: "B", InputRev: &rev}
+	fileAB := File{Repo: &repoA, Path: "B", InputRev: &rev}
 
 	cases := []struct {
 		name   string

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -100,7 +100,6 @@ func (a *Aggregator) DoSearch(ctx context.Context, job Job, mode search.GlobalSe
 
 	err = job.Run(ctx, a)
 	return errors.Wrap(err, jobName(job)+" search failed")
-
 }
 
 func (a *Aggregator) DoSymbolSearch(ctx context.Context, args *search.TextParameters, limit int) (err error) {
@@ -179,10 +178,10 @@ func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameter
 	}
 
 	limits := search.SearchLimits(conf.Get())
-	if max := limits.CommitDiffMaxRepos; !hasTimeFilter && len(args.Repos) > max {
+	if max := limits.CommitDiffMaxRepos; !hasTimeFilter && args.Repos.Len() > max {
 		return &RepoLimitError{ResultType: resultType, Max: max}
 	}
-	if max := limits.CommitDiffWithTimeFilterMaxRepos; hasTimeFilter && len(args.Repos) > max {
+	if max := limits.CommitDiffWithTimeFilterMaxRepos; hasTimeFilter && args.Repos.Len() > max {
 		return &TimeLimitError{ResultType: resultType, Max: max}
 	}
 	return nil
@@ -193,8 +192,10 @@ type DiffCommitError struct {
 	Max        int
 }
 
-type RepoLimitError DiffCommitError
-type TimeLimitError DiffCommitError
+type (
+	RepoLimitError DiffCommitError
+	TimeLimitError DiffCommitError
+)
 
 func (*RepoLimitError) Error() string {
 	return "repo limit error"

--- a/internal/search/run/aggregator_test.go
+++ b/internal/search/run/aggregator_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -61,23 +62,23 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		repoRevs := make([]*search.RepositoryRevisions, test.numRepoRevs)
-		for i := range repoRevs {
-			repoRevs[i] = &search.RepositoryRevisions{
-				Repo: types.RepoName{ID: api.RepoID(i)},
+		t.Run(test.name, func(t *testing.T) {
+			repos := search.NewRepos()
+			for i := 0; i < test.numRepoRevs; i++ {
+				repos.Add(&types.RepoName{ID: api.RepoID(i), Name: api.RepoName(fmt.Sprintf("repo-%d", i))})
 			}
-		}
 
-		haveErr := checkDiffCommitSearchLimits(
-			context.Background(),
-			&search.TextParameters{
-				Repos: repoRevs,
-				Query: test.fields,
-			},
-			test.resultType)
+			haveErr := checkDiffCommitSearchLimits(
+				context.Background(),
+				&search.TextParameters{
+					Repos: repos,
+					Query: test.fields,
+				},
+				test.resultType)
 
-		if diff := cmp.Diff(test.wantError, haveErr); diff != "" {
-			t.Fatalf("test %s, mismatched error (-want, +got):\n%s", test.name, diff)
-		}
+			if diff := cmp.Diff(test.wantError, haveErr); diff != "" {
+				t.Fatalf("test %s, mismatched error (-want, +got):\n%s", test.name, diff)
+			}
+		})
 	}
 }

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -123,4 +123,4 @@ func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k
 
 // repoRevFunc is a function which maps repository names returned from Zoekt
 // into the Sourcegraph's resolved repository revisions for the search.
-type repoRevFunc func(file *zoekt.FileMatch) (repo types.RepoName, revs []string)
+type repoRevFunc func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -389,10 +389,67 @@ func (rs Repos) Filter(pred func(*Repo) bool) (fs Repos) {
 	return fs
 }
 
+// RepoSet contains set of repos.
+type RepoSet struct {
+	Repos []*RepoName // order matters
+	IDs   map[api.RepoID]*RepoName
+	Names map[api.RepoName]*RepoName
+}
+
+func NewRepoSet(rs ...*RepoName) *RepoSet {
+	sr := &RepoSet{
+		Repos: make([]*RepoName, 0, len(rs)),
+		IDs:   make(map[api.RepoID]*RepoName, len(rs)),
+		Names: make(map[api.RepoName]*RepoName, len(rs)),
+	}
+
+	for _, r := range rs {
+		sr.Add(r)
+	}
+
+	return sr
+}
+
+func (rs *RepoSet) String() string {
+	if rs == nil {
+		return "RepoSet(nil)"
+	}
+	return fmt.Sprintf("RepoSet{Repos: %d}", rs.Len())
+}
+
+func (rs *RepoSet) Add(r *RepoName) {
+	if rs == nil {
+		return
+	}
+
+	if _, ok := rs.Names[r.Name]; !ok {
+		rs.Repos = append(rs.Repos, r)
+		rs.IDs[r.ID] = r
+		rs.Names[r.Name] = r
+	}
+}
+
+func (rs *RepoSet) Includes(id api.RepoID) bool {
+	if rs == nil {
+		return false
+	}
+
+	_, ok := rs.IDs[id]
+	return ok
+}
+
+func (rs *RepoSet) Len() int {
+	if rs == nil {
+		return 0
+	}
+	return len(rs.Repos)
+}
+
 // RepoName represents a source code repository name and its ID.
 type RepoName struct {
-	ID   api.RepoID
-	Name api.RepoName
+	ID      api.RepoID
+	Name    api.RepoName
+	Private bool
 }
 
 func (r *RepoName) ToRepo() *Repo {

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -21,6 +21,8 @@ var Mocks, emptyMocks struct {
 	ReadDir          func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error)
 	LsFiles          func(repo api.RepoName, commit api.CommitID) ([]string, error)
 	ResolveRevision  func(spec string, opt ResolveRevisionOptions) (api.CommitID, error)
+	ListRefs         func(repo api.RepoName) ([]Ref, error)
+	ExpandRefGlobs   func(repo api.RepoName, globs []RefGlob) ([]Ref, error)
 	Stat             func(commit api.CommitID, name string) (fs.FileInfo, error)
 	GetObject        func(objectName string) (OID, ObjectType, error)
 	Commits          func(repo api.RepoName, opt CommitsOptions) ([]*Commit, error)

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -302,6 +302,10 @@ func (p byteSlices) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // ListRefs returns a list of all refs in the repository.
 func ListRefs(ctx context.Context, repo api.RepoName) ([]Ref, error) {
+	if Mocks.ListRefs != nil {
+		return Mocks.ListRefs(repo)
+	}
+
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: ListRefs")
 	defer span.Finish()
 	return showRef(ctx, repo)


### PR DESCRIPTION
This PR further reduces redundant conversions and iterations over large repo lists on the critical search path. This is done by:

- No longer converting `[]types.RepoName` lists to `[]*search.RepositoryRevisions`. Instead, we pass around a larger shared `*search.Repos` that contains revisions in a `RepoRevs map[api.RepoName]search.RevSpecs` field.
- We also no longer add `HEAD` revisions to `RevRepos` unless explicitly specified by the user. Search backends must check if revs for a repo are empty and if so, use `search.DefaultRevSpecs`. This should shave off **1s** of latency on dot-com today.

- Avoiding copying cached repos in `ListSearchable` and `ListIndexable`. This is done by:
  - Never mutating these lists, and instead populating an `Excluded *types.RepoSet` field in `*search.Repos` when we need to exclude repos from the final result set. This field is checked by `search.Repos.ForEach` which is the canonical way to iterate over this type.
  - Separating private and public repos returned by these methods, so that the dynamic private repos which are dependent on the signed-in user don't have to be merged with public repos which don't change per-request.


Additionally, this PR:
- Moves ref glob expansion to repo resolution. Since we were already calling `git.ResolveRevision` for each non HEAD RevSpec, is it that bad to call out to gitserver for globs at this stage too? It really simplifies the code.
- Introduces `StreamingListRepoNames` and `StreamingListIndexableRepos` which take a callback function which gets called as soon as a record has been read from the DB. This allowed keeping the API of the non streaming versions of these methods intact and paves the way to make repo resolution a streaming operation instead of batch like it is today.

I recognize this is a large change. I'm happy to either pair review live or split it up into smaller independent PRs.