### PR TITLE
httpcli: only log to trace if retry occurred

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -394,9 +394,11 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 		status := 0
 
 		defer func() {
-			if span := opentracing.SpanFromContext(a.Request.Context()); span != nil {
+			// Avoid trace log spam if we haven't invoked the retry policy.
+			shouldTraceLog := retry || a.Index > 0
+			if span := opentracing.SpanFromContext(a.Request.Context()); span != nil && shouldTraceLog {
 				fields := []otlog.Field{
-					otlog.Event("request-failed"),
+					otlog.Event("request-retry-decision"),
 					otlog.Bool("retry", retry),
 					otlog.Int("attempt", a.Index),
 					otlog.String("method", a.Request.Method),


### PR DESCRIPTION
I didn't realise, but the retry policy function is always called even
after a successful request. To avoid trace log spam, I've updated the
tracing to only occur if we decide to retry or if we have done more than
one attempt. Additionally I've updated the event name to be clearer.

Follow-up from https://github.com/sourcegraph/sourcegraph/pull/24497#issuecomment-913091059