### PR TITLE
Perf and other improvements for querying extensions

### DIFF
--- a/cmd/frontend/registry/api/extensions.go
+++ b/cmd/frontend/registry/api/extensions.go
@@ -249,6 +249,12 @@ func IsWorkInProgressExtension(manifest *string) bool {
 		return true
 	}
 
+	// jsonc-parsing the manifest can be slow, so do a first pass. If the manifest doesn't even
+	// contain `"wip"`, then there is no way that it could be WIP.
+	if !strings.Contains(*manifest, `"wip"`) {
+		return false
+	}
+
 	var result schema.SourcegraphExtensionManifest
 	if err := jsonc.Unmarshal(*manifest, &result); err != nil {
 		// An extension whose manifest fails to parse is problematic for other reasons (and an error

--- a/cmd/frontend/registry/api/extensions_test.go
+++ b/cmd/frontend/registry/api/extensions_test.go
@@ -191,17 +191,11 @@ func TestGetExtensionByExtensionID(t *testing.T) {
 
 func TestIsWorkInProgressExtension(t *testing.T) {
 	tests := map[*string]bool{
-		nil:                                        true,
-		strptr(`{`):                                false,
-		strptr(`{}`):                               false,
-		strptr(`{"title":null}`):                   false,
-		strptr(`{"title":""}`):                     false,
-		strptr(`{"title":"a b"}`):                  false,
-		strptr(`{"title":"WIP: a"}`):               true,
-		strptr(`{"title":"[WIP] a"}`):              true,
-		strptr(`{"wip": true, "title":"a"}`):       true,
-		strptr(`{"wip": false, "title":"a"}`):      false,
-		strptr(`{"wip": false, "title":"WIP: a"}`): true,
+		nil:                      true,
+		strptr(`{`):              false,
+		strptr(`{}`):             false,
+		strptr(`{"wip": true}`):  true,
+		strptr(`{"wip": false}`): false,
 	}
 	for manifest, want := range tests {
 		got := IsWorkInProgressExtension(manifest)

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -103,6 +103,7 @@ func httpGet(ctx context.Context, op, urlStr string, result interface{}) (err er
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if v := strings.TrimSpace(resp.Header.Get(MediaTypeHeaderName)); v != MediaType {
 		return &url.Error{Op: op, URL: urlStr, Err: errors.Errorf("not a valid Sourcegraph registry (invalid media type %q, expected %q)", v, MediaType)}
 	}

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
+	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 const (
@@ -31,14 +33,27 @@ const (
 )
 
 // List lists extensions on the remote registry matching the query (or all if the query is empty).
-func List(ctx context.Context, registry *url.URL, query string) ([]*Extension, error) {
+func List(ctx context.Context, registry *url.URL, query string) (xs []*Extension, err error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "registry/client.List")
+	span.SetTag("registry", registry.String())
+	span.SetTag("query", query)
+	defer func() {
+		if xs != nil {
+			span.SetTag("results", len(xs))
+		}
+		if err != nil {
+			ext.Error.Set(span, true)
+			span.SetTag("error", err.Error())
+		}
+		span.Finish()
+	}()
+
 	var q url.Values
 	if query != "" {
 		q = url.Values{"q": []string{query}}
 	}
 
-	var xs []*Extension
-	err := httpGet(ctx, "registry.List", toURL(registry, "extensions", q), &xs)
+	err = httpGet(ctx, "registry.List", toURL(registry, "extensions", q), &xs)
 	return xs, err
 }
 

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )
@@ -238,9 +237,7 @@ type dbExtensionsListOptions struct {
 }
 
 // extensionIsWIPExpr is the SQL expression for whether the extension is a WIP extension.
-//
-// BACKCOMPAT: It still reads the title property even though extensions no longer have titles.
-var extensionIsWIPExpr = sqlf.Sprintf(`rer.manifest IS NULL OR COALESCE((rer.manifest->>'wip')::jsonb = 'true'::jsonb, rer.manifest->>'title' SIMILAR TO %s, false)`, registry.WorkInProgressExtensionTitlePostgreSQLPattern)
+var extensionIsWIPExpr = sqlf.Sprintf(`rer.manifest IS NULL OR COALESCE((rer.manifest->>'wip')::jsonb = 'true'::jsonb, false)`)
 
 func (o dbExtensionsListOptions) sqlConditions() []*sqlf.Query {
 	var conds []*sqlf.Query

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -271,27 +271,13 @@ func TestRegistryExtensions(t *testing.T) {
 	})
 
 	t.Run("List sort non-WIP first", func(t *testing.T) {
-		// xwip1 is a WIP extension because its title begins with "WIP:".
+		// xwip1 is a WIP extension because it has no published releases.
 		xwip1 := createAndGet(t, user.ID, 0, "wiptest1")
-		_, err := dbReleases{}.Create(ctx, &dbRelease{
-			RegistryExtensionID: xwip1.ID,
-			CreatorUserID:       user.ID,
-			ReleaseTag:          "release",
-			Manifest:            `{"title": "WIP: x"}`,
-			Bundle:              strptr(""),
-			SourceMap:           strptr(""),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 
-		// xwip2 is a WIP extension because it has no published releases.
+		// xwip2 is a WIP extension because it has a "wip": true property.
 		xwip2 := createAndGet(t, user.ID, 0, "wiptest2")
-
-		// xwip3 is a WIP extension because it has a "wip": true property.
-		xwip3 := createAndGet(t, user.ID, 0, "wiptest3")
 		_, err = dbReleases{}.Create(ctx, &dbRelease{
-			RegistryExtensionID: xwip3.ID,
+			RegistryExtensionID: xwip2.ID,
 			CreatorUserID:       user.ID,
 			ReleaseTag:          "release",
 			Manifest:            `{"wip": true}`,
@@ -303,7 +289,7 @@ func TestRegistryExtensions(t *testing.T) {
 		}
 
 		// xnonwip1 is a non-WIP extension.
-		xnonwip1 := createAndGet(t, user.ID, 0, "wiptest4")
+		xnonwip1 := createAndGet(t, user.ID, 0, "wiptest3")
 		_, err = dbReleases{}.Create(ctx, &dbRelease{
 			RegistryExtensionID: xnonwip1.ID,
 			CreatorUserID:       user.ID,
@@ -318,7 +304,7 @@ func TestRegistryExtensions(t *testing.T) {
 		xnonwip1.NonCanonicalIsWorkInProgress = false
 
 		// xnonwip2 is a non-WIP extension because its wip property is not true.
-		xnonwip2 := createAndGet(t, user.ID, 0, "wiptest5")
+		xnonwip2 := createAndGet(t, user.ID, 0, "wiptest4")
 		_, err = dbReleases{}.Create(ctx, &dbRelease{
 			RegistryExtensionID: xnonwip2.ID,
 			CreatorUserID:       user.ID,
@@ -333,7 +319,7 @@ func TestRegistryExtensions(t *testing.T) {
 		xnonwip2.NonCanonicalIsWorkInProgress = false
 
 		// The non-WIP extension should be sorted first.
-		testList(t, dbExtensionsListOptions{Query: "wiptest", LimitOffset: &database.LimitOffset{Limit: 5}}, []*dbExtension{xnonwip1, xnonwip2, xwip1, xwip2, xwip3})
+		testList(t, dbExtensionsListOptions{Query: "wiptest", LimitOffset: &database.LimitOffset{Limit: 5}}, []*dbExtension{xnonwip1, xnonwip2, xwip1, xwip2})
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/registry/http_api.go
+++ b/enterprise/cmd/frontend/internal/registry/http_api.go
@@ -168,7 +168,12 @@ func handleRegistry(w http.ResponseWriter, r *http.Request) (err error) {
 
 	// Identify this response as coming from the registry API.
 	w.Header().Set(registry.MediaTypeHeaderName, registry.MediaType)
-	w.Header().Set("Vary", registry.MediaTypeHeaderName)
+
+	// The response differs based on some request headers, and we need to tell caches which ones.
+	//
+	// Accept, User-Agent: because these encode the registry client's API version, and responses are
+	// not cacheable across versions.
+	w.Header().Set("Vary", "Accept, User-Agent")
 
 	// Validate API version.
 	if v := r.Header.Get("Accept"); v != registry.AcceptHeader {
@@ -240,7 +245,7 @@ func handleRegistry(w http.ResponseWriter, r *http.Request) (err error) {
 		return nil
 	}
 
-	w.Header().Set("Cache-Control", "max-age=30, private")
+	w.Header().Set("Cache-Control", "max-age=120, private")
 	return json.NewEncoder(w).Encode(result)
 }
 


### PR DESCRIPTION
Overall, this makes the `graphql?Extensions` call ~820ms faster (which helps every page load) and lengthens the time that a Sourcegraph instance caches the Sourcegraph.com extension registry data.

Partially (but not fully) fixes #10554. Further perf improvements will require GraphQL schema changes, which are more complex.

See individual commits:

- better Cache-Control and fixed Vary header for extension registry API responses

   The HTTP request from the extension registry listing all the extensions is
   now cached for 120s (was 30s). This HTTP request needs to fetch ~800kb
   (compressed) of JSON data from Sourcegraph.com, and caching it for longer
   will have minimal negative consequences (because extensions don't change
   very often) and will marginally reduce how often this data needs to be
   re-fetched and a user needs to wait for it.

   The extension registry's Vary header was being set incorrectly. The Vary
   header should list the names of *request* headers that help determine if a
   cached response is valid. But we were including *response* headers, which
   didn't cause any issues (because the requests didn't even include this
   header).
- trace list API call to extension registry

   There is now tracing for the registry API client's HTTP requests to get a
   list of all extensions from the registry (usually Sourcegraph.com). This is
   a slow HTTP request and it fetches a lot of data (~800kb uncompressed), so
   it's helpful to see it in traces.
- close HTTP response body in extension registry fetch

   The response body was most likely buffered by some transport wrapper, so
   this probably didn't actually result in a leak, but of course it's good
   practice to always close the response body.
- fast path for IsWorkInProgressExtension (speeds up graphql?Extensions)

   The GraphQL RegistryExtensionConnectionResolver sorts extensions in several
   ways, most of which are fast. However, sorting by WIP (i.e., showing WIP
   extensions last) is very slow (~900ms on my machine on the list of
   extensions returned by Sourcegraph.com), because it needs to jsonc-parse
   each extension manifest for each sort comparison.

   This fast path reduces the total time for the sort from ~900ms to ~74ms
   (which means the `graphql?Extensions` query, which runs on each page load,
   takes that much less time). Further improvements can be gained by caching
   this so that it just needs to be run `n` times (to sort `n` items) instead
   of `O(n*log(n))` times.
- remove backcompat for extension titles starting with "WIP:"

   Work-in-progress extensions are indicated by having `"wip": true` in their
   package.json manifest. Previously, in 2018, we considered extensions WIP if
   their `title` started with `WIP: ` or `[WIP] `. When we introduced the
   simpler `wip` field on package.json, we left in backcompat for extensions
   that indicated WIP in their `title`.

   It is safe to remove this backcompat because the `wip` field on
   package.json has been present for ~3 years. (Also, even the `title` field
   was removed for extensions back in 2018 (in favor of just `name`, like
   npm).)