### PR TITLE
Refactors to queryConfiguredRegistryExtensions and related code

### DIFF
--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -1,15 +1,40 @@
-import { once } from 'lodash'
-import { combineLatest, from, Observable, of } from 'rxjs'
+import { isEqual, once } from 'lodash'
+import { combineLatest, from, Observable, of, throwError } from 'rxjs'
 import { fromFetch } from 'rxjs/fetch'
-import { catchError, distinctUntilChanged, map, publishReplay, refCount, switchMap } from 'rxjs/operators'
+import { catchError, distinctUntilChanged, map, publishReplay, refCount, shareReplay, switchMap } from 'rxjs/operators'
 
 import { checkOk } from '../../backend/fetch'
-import { ConfiguredExtension, isExtensionEnabled } from '../../extensions/extension'
+import {
+    ConfiguredExtension,
+    ConfiguredRegistryExtension,
+    extensionIDsFromSettings,
+    isExtensionEnabled,
+} from '../../extensions/extension'
 import { ExtensionManifest } from '../../extensions/extensionManifest'
 import { areExtensionsSame } from '../../extensions/extensions'
-import { viewerConfiguredExtensions } from '../../extensions/helpers'
+import { queryConfiguredRegistryExtensions } from '../../extensions/helpers'
 import { PlatformContext } from '../../platform/context'
-import { isErrorLike } from '../../util/errors'
+import { asError, isErrorLike } from '../../util/errors'
+
+/**
+ * @returns An observable that emits the list of extensions configured in the viewer's final settings upon
+ * subscription and each time it changes.
+ */
+function viewerConfiguredExtensions({
+    settings,
+    requestGraphQL,
+}: Pick<PlatformContext, 'settings' | 'requestGraphQL'>): Observable<ConfiguredRegistryExtension[]> {
+    return from(settings).pipe(
+        map(settings => extensionIDsFromSettings(settings)),
+        distinctUntilChanged((a, b) => isEqual(a, b)),
+        switchMap(extensionIDs => queryConfiguredRegistryExtensions({ requestGraphQL }, extensionIDs)),
+        catchError(error => throwError(asError(error))),
+        // TODO: Restore reference counter after refactoring contributions service
+        // to not unsubscribe from existing entries when new entries are registered,
+        // in order to ensure that the source is unsubscribed from.
+        shareReplay(1)
+    )
+}
 
 /**
  * The manifest of an extension sideloaded during local development.

--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -52,7 +52,6 @@ export const getConfiguredSideloadedExtension = (baseUrl: string): Observable<Co
                     ...response,
                     url: `${baseUrl}/${response.main.replace('dist/', '')}`,
                 },
-                rawManifest: null,
             })
         )
     )

--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -4,12 +4,7 @@ import { fromFetch } from 'rxjs/fetch'
 import { catchError, distinctUntilChanged, map, publishReplay, refCount, shareReplay, switchMap } from 'rxjs/operators'
 
 import { checkOk } from '../../backend/fetch'
-import {
-    ConfiguredExtension,
-    ConfiguredRegistryExtension,
-    extensionIDsFromSettings,
-    isExtensionEnabled,
-} from '../../extensions/extension'
+import { ConfiguredExtension, extensionIDsFromSettings, isExtensionEnabled } from '../../extensions/extension'
 import { ExtensionManifest } from '../../extensions/extensionManifest'
 import { areExtensionsSame } from '../../extensions/extensions'
 import { queryConfiguredRegistryExtensions } from '../../extensions/helpers'
@@ -23,7 +18,7 @@ import { asError, isErrorLike } from '../../util/errors'
 function viewerConfiguredExtensions({
     settings,
     requestGraphQL,
-}: Pick<PlatformContext, 'settings' | 'requestGraphQL'>): Observable<ConfiguredRegistryExtension[]> {
+}: Pick<PlatformContext, 'settings' | 'requestGraphQL'>): Observable<ConfiguredExtension[]> {
     return from(settings).pipe(
         map(settings => extensionIDsFromSettings(settings)),
         distinctUntilChanged((a, b) => isEqual(a, b)),

--- a/client/shared/src/extensions/extension.ts
+++ b/client/shared/src/extensions/extension.ts
@@ -17,9 +17,6 @@ export interface ConfiguredExtension {
 
     /** The parsed extension manifest, null if there is none, or a parse error. */
     readonly manifest: ExtensionManifest | null | ErrorLike
-
-    /** The raw extension manifest (JSON), or null if there is none. */
-    readonly rawManifest: string | null
 }
 
 /**
@@ -36,6 +33,9 @@ export interface ConfiguredRegistryExtension<
 > extends ConfiguredExtension {
     /** The extension's metadata on the registry, if this is a registry extension. */
     readonly registryExtension?: X
+
+    /** The raw extension manifest (JSON), or null if there is none. */
+    readonly rawManifest: string | null
 }
 
 type MinimalRegistryExtension = Pick<GQL.IRegistryExtension, 'extensionID' | 'id' | 'url' | 'viewerCanAdminister'> & {

--- a/client/shared/src/extensions/helpers.ts
+++ b/client/shared/src/extensions/helpers.ts
@@ -1,33 +1,12 @@
-import { isEqual } from 'lodash'
-import { from, Observable, of, throwError } from 'rxjs'
-import { catchError, distinctUntilChanged, map, shareReplay, switchMap } from 'rxjs/operators'
+import { from, Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
 
 import { gql } from '../graphql/graphql'
 import * as GQL from '../graphql/schema'
 import { PlatformContext } from '../platform/context'
-import { asError, createAggregateError } from '../util/errors'
+import { createAggregateError } from '../util/errors'
 
-import { ConfiguredRegistryExtension, extensionIDsFromSettings, toConfiguredRegistryExtension } from './extension'
-
-/**
- * @returns An observable that emits the list of extensions configured in the viewer's final settings upon
- * subscription and each time it changes.
- */
-export function viewerConfiguredExtensions({
-    settings,
-    requestGraphQL,
-}: Pick<PlatformContext, 'settings' | 'requestGraphQL'>): Observable<ConfiguredRegistryExtension[]> {
-    return from(settings).pipe(
-        map(settings => extensionIDsFromSettings(settings)),
-        distinctUntilChanged((a, b) => isEqual(a, b)),
-        switchMap(extensionIDs => queryConfiguredRegistryExtensions({ requestGraphQL }, extensionIDs)),
-        catchError(error => throwError(asError(error))),
-        // TODO: Restore reference counter after refactoring contributions service
-        // to not unsubscribe from existing entries when new entries are registered,
-        // in order to ensure that the source is unsubscribed from.
-        shareReplay(1)
-    )
-}
+import { ConfiguredRegistryExtension, toConfiguredRegistryExtension } from './extension'
 
 /**
  * Query the GraphQL API for registry metadata about the extensions given in {@link extensionIDs}.

--- a/client/shared/src/testing/integration/mockExtension.ts
+++ b/client/shared/src/testing/integration/mockExtension.ts
@@ -71,13 +71,10 @@ export function setupExtensionMocking({
             // Mutate mock data objects
             extensionSettings[id] = true
             extensionsResult.extensionRegistry.extensions.nodes.push({
-                id: `TestExtensionID${internalID}`,
                 extensionID: id,
                 manifest: {
                     raw: JSON.stringify(extensionManifest),
                 },
-                url: `/extensions/${id}`,
-                viewerCanAdminister: false,
             })
 
             pollyServer.get(bundleURL).intercept((request, response) => {

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -94,21 +94,15 @@ const registryExtensionNodes: RegistryExtensionFieldsForList[] = [
 const extensionNodes: ExtensionsResult['extensionRegistry']['extensions']['nodes'] = [
     {
         extensionID: 'sourcegraph/typescript',
-        id: 'test-extension-1',
         manifest: {
             raw: typescriptRawManifest,
         },
-        url: '/extensions/sourcegraph/typescript',
-        viewerCanAdminister: false,
     },
     {
         extensionID: 'sqs/word-count',
-        id: 'test-extension-2',
         manifest: {
             raw: wordCountRawManifest,
         },
-        url: '/extensions/sqs/word-count',
-        viewerCanAdminister: false,
     },
 ]
 


### PR DESCRIPTION
- narrow return type of queryConfiguredRegistryExtensions

   Callers of this function don't need the full ConfiguredRegistryExtension
   type. This type narrowing will make it easier to optimize the GraphQL API
   calls to fetch the list of enabled extensions. That will come in future
   commits; this is just a refactor that makes sense regardless.
-  refactor: unexport viewerConfiguredExtensions and move to only file where it is used