### PR TITLE
web: codemod template literal to `classNames` call [1]

### DIFF
--- a/client/branded/src/components/Form.tsx
+++ b/client/branded/src/components/Form.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import classNames from "classnames";
 
 interface FormProps extends React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> {
     children: React.ReactNode
@@ -24,7 +25,7 @@ export class Form extends React.PureComponent<FormProps, FormState> {
             // eslint-disable-next-line react/forbid-elements
             <form
                 {...this.props}
-                className={`${this.props.className || ''} ${this.state.wasValidated ? 'was-validated' : ''}`}
+                className={classNames(this.props.className, this.state.wasValidated && 'was-validated')}
                 onInvalid={this.onInvalid}
             >
                 {this.props.children}

--- a/client/branded/src/components/Form.tsx
+++ b/client/branded/src/components/Form.tsx
@@ -1,5 +1,5 @@
+import classNames from 'classnames'
 import * as React from 'react'
-import classNames from "classnames";
 
 interface FormProps extends React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> {
     children: React.ReactNode

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -18,6 +18,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isDefined, property } from '@sourcegraph/shared/src/util/types'
 import { parseRepoURI } from '@sourcegraph/shared/src/util/url'
+import classNames from "classnames";
 
 export const FileLocationsError: React.FunctionComponent<{ error: ErrorLike }> = ({ error }) => (
     <div className="file-locations__error alert alert-danger m-2">
@@ -147,7 +148,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
         }
 
         return (
-            <div className={`file-locations ${this.props.className || ''}`}>
+            <div className={classNames("file-locations", this.props.className)}>
                 <VirtualList<OrderedURI, { locationsByURI: Map<string, Location[]> }>
                     itemsToShow={this.state.itemsToShow}
                     onShowMoreItems={this.onShowMoreItems}

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import { upperFirst } from 'lodash'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
@@ -18,7 +19,6 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isDefined, property } from '@sourcegraph/shared/src/util/types'
 import { parseRepoURI } from '@sourcegraph/shared/src/util/url'
-import classNames from "classnames";
 
 export const FileLocationsError: React.FunctionComponent<{ error: ErrorLike }> = ({ error }) => (
     <div className="file-locations__error alert alert-danger m-2">
@@ -148,7 +148,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
         }
 
         return (
-            <div className={classNames("file-locations", this.props.className)}>
+            <div className={classNames('file-locations', this.props.className)}>
                 <VirtualList<OrderedURI, { locationsByURI: Map<string, Location[]> }>
                     itemsToShow={this.state.itemsToShow}
                     onShowMoreItems={this.onShowMoreItems}

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -210,7 +210,7 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
                 <span
                     data-tooltip={tooltip}
                     data-content={this.props.dataContent}
-                    className={classNames("action-item", this.props.className, variantClassName)}
+                    className={classNames('action-item', this.props.className, variantClassName)}
                     tabIndex={this.props.tabIndex}
                 >
                     {content}

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -210,7 +210,7 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
                 <span
                     data-tooltip={tooltip}
                     data-content={this.props.dataContent}
-                    className={`action-item ${this.props.className || ''} ${variantClassName}`}
+                    className={classNames("action-item", this.props.className, variantClassName)}
                     tabIndex={this.props.tabIndex}
                 >
                     {content}

--- a/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`ActionItem non-pressed actionItem 1`] = `
 
 exports[`ActionItem noop command 1`] = `
 <span
-  className="action-item  "
+  className="action-item"
   data-tooltip="d"
 >
   <img

--- a/client/shared/src/components/CodeExcerpt.tsx
+++ b/client/shared/src/components/CodeExcerpt.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { range, isEqual } from 'lodash'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import React from 'react'
@@ -124,9 +125,11 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
                 offset={this.visibilitySensorOffset}
             >
                 <code
-                    className={`code-excerpt ${this.props.className || ''}${
-                        isErrorLike(this.state.blobLinesOrError) ? ' code-excerpt-error' : ''
-                    }`}
+                    className={classNames(
+                        'code-excerpt',
+                        this.props.className,
+                        isErrorLike(this.state.blobLinesOrError) && 'code-excerpt-error'
+                    )}
                 >
                     {this.state.blobLinesOrError && !isErrorLike(this.state.blobLinesOrError) && (
                         <div

--- a/client/shared/src/components/activation/ActivationChecklist.tsx
+++ b/client/shared/src/components/activation/ActivationChecklist.tsx
@@ -63,7 +63,7 @@ export const ActivationChecklist: React.FunctionComponent<ActivationChecklistPro
     }
 
     return (
-        <div className={`activation-checklist list-group list-group-flush ${className || ''}`}>
+        <div className={classNames('activation-checklist list-group list-group-flush', className)}>
             <Accordion collapsible={true}>
                 {steps.map(step => (
                     <AccordionItem key={step.id} className="activation-checklist__container list-group-item">

--- a/client/shared/src/components/activation/__snapshots__/ActivationChecklist.test.tsx.snap
+++ b/client/shared/src/components/activation/__snapshots__/ActivationChecklist.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ActivationChecklist render 0/1 complete 1`] = `
 <div
-  className="activation-checklist list-group list-group-flush "
+  className="activation-checklist list-group list-group-flush"
 >
   <div
     data-reach-accordion=""
@@ -99,7 +99,7 @@ exports[`ActivationChecklist render 0/1 complete 1`] = `
 
 exports[`ActivationChecklist render 0/1 complete 2`] = `
 <div
-  className="activation-checklist list-group list-group-flush "
+  className="activation-checklist list-group list-group-flush"
 >
   <div
     data-reach-accordion=""
@@ -196,7 +196,7 @@ exports[`ActivationChecklist render 0/1 complete 2`] = `
 
 exports[`ActivationChecklist render 1/1 complete 1`] = `
 <div
-  className="activation-checklist list-group list-group-flush "
+  className="activation-checklist list-group list-group-flush"
 >
   <div
     data-reach-accordion=""

--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 export interface IconProps {
@@ -17,30 +18,25 @@ function sizeProps(props: IconProps): { width: number; height: number; viewBox: 
 }
 
 export const ChatIcon: React.FunctionComponent<IconProps> = props => (
-    <svg {...props} {...sizeProps(props)} className={`mdi-icon${props.className ? ' ' + props.className : ''}`}>
+    <svg {...props} {...sizeProps(props)} className={classNames('mdi-icon', props.className)}>
         <path d="M 2 11.636 A 10 8 0 0 0 4.75 17.146 A 9 9 0 0 1 2 21.636 A 10.4 10.4 0 0 0 8.5 19.13 A 10 8 0 0 0 12 19.636 A 10 8 0 0 0 22 11.636 A 10 8 0 0 0 12 3.636 A 10 8 0 0 0 2 11.636 Z" />
     </svg>
 )
 
 export const CircleChevronLeftIcon: React.FunctionComponent<IconProps> = props => (
-    <svg {...props} {...sizeProps(props)} className={`mdi-icon${props.className ? ' ' + props.className : ''}`}>
+    <svg {...props} {...sizeProps(props)} className={classNames('mdi-icon', props.className)}>
         <path d="M22,12c0,5.5-4.5,10-10,10S2,17.5,2,12S6.5,2,12,2S22,6.5,22,12z M15.4,16.6L10.8,12l4.6-4.6L14,6l-6,6l6,6L15.4,16.6z" />
     </svg>
 )
 
 export const CircleChevronRightIcon: React.FunctionComponent<IconProps> = props => (
-    <svg {...props} {...sizeProps(props)} className={`mdi-icon${props.className ? ' ' + props.className : ''}`}>
+    <svg {...props} {...sizeProps(props)} className={classNames('mdi-icon', props.className)}>
         <path d="M22,12c0,5.5-4.5,10-10,10S2,17.5,2,12S6.5,2,12,2S22,6.5,22,12z M10,18l6-6l-6-6L8.6,7.4l4.6,4.6l-4.6,4.6L10,18z" />
     </svg>
 )
 
 export const RepoQuestionIcon: React.FunctionComponent<IconProps> = props => (
-    <svg
-        {...props}
-        {...sizeProps(props)}
-        className={`mdi-icon${props.className ? ' ' + props.className : ''}`}
-        viewBox="0 0 64 64"
-    >
+    <svg {...props} {...sizeProps(props)} className={classNames('mdi-icon', props.className)} viewBox="0 0 64 64">
         <title>Icons 400</title>
         <g>
             <path
@@ -56,7 +52,7 @@ export const RepoQuestionIcon: React.FunctionComponent<IconProps> = props => (
 )
 
 export const FormatListBulletedIcon: React.FunctionComponent<IconProps> = props => (
-    <svg {...props} {...sizeProps(props)} className={`mdi-icon${props.className ? ' ' + props.className : ''}`}>
+    <svg {...props} {...sizeProps(props)} className={classNames('mdi-icon', props.className)}>
         <path d="M7,5H21V7H7V5M7,13V11H21V13H7M4,4.5A1.5,1.5 0 0,1 5.5,6A1.5,1.5 0 0,1 4,7.5A1.5,1.5 0 0,1 2.5,6A1.5,1.5 0 0,1 4,4.5M4,10.5A1.5,1.5 0 0,1 5.5,12A1.5,1.5 0 0,1 4,13.5A1.5,1.5 0 0,1 2.5,12A1.5,1.5 0 0,1 4,10.5M7,19V17H21V19H7M4,16.5A1.5,1.5 0 0,1 5.5,18A1.5,1.5 0 0,1 4,19.5A1.5,1.5 0 0,1 2.5,18A1.5,1.5 0 0,1 4,16.5Z" />
     </svg>
 )
@@ -65,7 +61,7 @@ export const PhabricatorIcon: React.FunctionComponent<IconProps> = props => (
     <svg
         {...props}
         {...sizeProps(props)}
-        className={`phabricator-icon mdi-icon${props.className ? ' ' + props.className : ''}`}
+        className={classNames('phabricator-icon mdi-icon', props.className)}
         viewBox="0 0 64 64"
         fill="currentColor"
     >
@@ -98,7 +94,7 @@ export const PhabricatorIcon: React.FunctionComponent<IconProps> = props => (
 )
 
 export const WrapDisabledIcon: React.FunctionComponent<IconProps> = props => (
-    <svg {...props} {...sizeProps(props)} className={`mdi-icon${props.className ? ' ' + props.className : ''}`}>
+    <svg {...props} {...sizeProps(props)} className={classNames('mdi-icon', props.className)}>
         <path d="M16,7H3V5H16ZM3,19H16V17H3Zm19-7L18,9v2H3v2H18v2Z" />
     </svg>
 )
@@ -108,7 +104,7 @@ export const CloudAlertIconRefresh: React.FunctionComponent<IconProps> = props =
     <svg
         {...props}
         {...sizeProps(props)}
-        className={`phabricator-icon mdi-icon${props.className ? ' ' + props.className : ''}`}
+        className={classNames('phabricator-icon mdi-icon', props.className)}
         viewBox="0 0 20 20"
         fill="currentColor"
     >
@@ -135,7 +131,7 @@ export const CloudSyncIconRefresh: React.FunctionComponent<IconProps> = props =>
     <svg
         {...props}
         {...sizeProps(props)}
-        className={`phabricator-icon mdi-icon${props.className ? ' ' + props.className : ''}`}
+        className={classNames('phabricator-icon mdi-icon', props.className)}
         viewBox="0 0 20 20"
         fill="currentColor"
     >
@@ -166,7 +162,7 @@ export const CloudCheckIconRefresh: React.FunctionComponent<IconProps> = props =
     <svg
         {...props}
         {...sizeProps(props)}
-        className={`phabricator-icon mdi-icon${props.className ? ' ' + props.className : ''}`}
+        className={classNames('phabricator-icon mdi-icon', props.className)}
         viewBox="0 -4 20 20"
         fill="currentColor"
     >

--- a/client/shared/src/symbols/SymbolIcon.tsx
+++ b/client/shared/src/symbols/SymbolIcon.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { kebabCase } from 'lodash'
 import { MdiReactIconComponentType } from 'mdi-react'
 import CodeArrayIcon from 'mdi-react/CodeArrayIcon'
@@ -103,7 +104,7 @@ export const SymbolIcon: React.FunctionComponent<SymbolIconProps> = ({ kind, cla
     const Icon = getSymbolIconComponent(kind)
     return (
         <Icon
-            className={`symbol-icon symbol-icon--kind-${kebabCase(kind)} ${className}`}
+            className={classNames(`symbol-icon symbol-icon--kind-${kebabCase(kind)}`, className)}
             data-tooltip={kind.toLowerCase()}
         />
     )

--- a/client/web/src/auth/SignInSignUpCommon.tsx
+++ b/client/web/src/auth/SignInSignUpCommon.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import * as React from 'react'
 
@@ -14,7 +15,7 @@ export const PasswordInput: React.FunctionComponent<InputProps> = props => {
             name="password"
             id="password"
             {...other}
-            className={`form-control ${props.className || ''}`}
+            className={classNames('form-control', props.className)}
             placeholder={props.placeholder || 'Password'}
             type="password"
             required={true}
@@ -30,7 +31,7 @@ export const EmailInput: React.FunctionComponent<InputProps> = props => {
             name="email"
             id="email"
             {...other}
-            className={`form-control ${props.className || ''}`}
+            className={classNames('form-control', props.className)}
             type="email"
             placeholder={props.placeholder || 'Email'}
             spellCheck={false}
@@ -47,7 +48,7 @@ export const UsernameInput: React.FunctionComponent<InputProps> = props => {
             name="username"
             id="username"
             {...other}
-            className={`form-control ${props.className || ''}`}
+            className={classNames('form-control', props.className)}
             type="text"
             placeholder={props.placeholder || 'Username'}
             spellCheck={false}

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
         className="signin-signup-form signin-form test-signin-form rounded p-4 my-3 mt-4"
       >
         <form
-          className=" "
+          className=""
           onInvalid={[Function]}
           onSubmit={[Function]}
         >
@@ -219,7 +219,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
         className="signin-signup-form signin-form test-signin-form rounded p-4 my-3 mt-4"
       >
         <form
-          className=" "
+          className=""
           onInvalid={[Function]}
           onSubmit={[Function]}
         >

--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import copy from 'copy-to-clipboard'
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 import * as React from 'react'
@@ -31,7 +32,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <div className={`copyable-text form-inline ${this.props.className || ''}`}>
+            <div className={classNames('copyable-text form-inline', this.props.className)}>
                 <div className="input-group">
                     <input
                         type={this.props.password ? 'password' : 'text'}

--- a/client/web/src/components/FeedbackText.tsx
+++ b/client/web/src/components/FeedbackText.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 interface Props {
@@ -7,7 +8,7 @@ interface Props {
 }
 
 export const FeedbackText: React.FunctionComponent<Props> = (props: Props) => (
-    <p className={`feedback-text ${props.className || ''}`}>
+    <p className={classNames('feedback-text', props.className)}>
         {props.headerText || 'Questions/feedback?'} Contact us at{' '}
         <a href="https://twitter.com/sourcegraph" target="_blank" rel="noopener noreferrer">
             @sourcegraph

--- a/client/web/src/components/ModalPage.tsx
+++ b/client/web/src/components/ModalPage.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 interface Props {
@@ -11,7 +12,7 @@ interface Props {
  * A page that displays a modal prompt in the middle of the screen.
  */
 export const ModalPage: React.FunctionComponent<Props> = ({ icon, className = '', children }) => (
-    <div className={`modal-page ${className}`}>
+    <div className={classNames('modal-page', className)}>
         <div className="card">
             <div className="modal-page__card-body card-body">
                 {icon && <div className="modal-page__icon">{icon}</div>}

--- a/client/web/src/components/RadioButtons.tsx
+++ b/client/web/src/components/RadioButtons.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 /**
@@ -55,7 +56,7 @@ export const RadioButtons: React.FunctionComponent<Props> = ({ nodes, onChange, 
         {nodes.map(node => (
             <label key={node.key ? node.key : node.id.toString()} className="radio-buttons__item" title={node.tooltip}>
                 <input
-                    className={`radio-buttons__input ${className || ''}`}
+                    className={classNames('radio-buttons__input', className)}
                     name="filter"
                     type="radio"
                     onChange={onChange}

--- a/client/web/src/components/SingleValueCard.tsx
+++ b/client/web/src/components/SingleValueCard.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
@@ -15,13 +16,16 @@ export const SingleValueCard: React.FunctionComponent<{
     valueTooltip?: string
     subText?: string
 }> = ({ title, value, subTitle, link, className, valueClassName, valueTooltip, subText }) => (
-    <div className={`card single-value-card ${className || ''}`}>
+    <div className={classNames('card single-value-card', className)}>
         <div className="card-body text-center">
             <h4 className="card-title mb-0">{title}</h4>
             <small className="card-text">{subTitle || ''}</small>
             <p
                 data-tooltip={valueTooltip}
-                className={`card-text font-weight-bold text-nowrap single-value-card__value ${valueClassName || ''}`}
+                className={classNames(
+                    'card-text font-weight-bold text-nowrap single-value-card__value',
+                    valueClassName
+                )}
             >
                 <LinkOrSpan to={link}>{value}</LinkOrSpan>
             </p>

--- a/client/web/src/components/diff/DiffBoundary.tsx
+++ b/client/web/src/components/diff/DiffBoundary.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 import { FileDiffHunkFields } from '../../graphql-operations'
@@ -16,7 +17,7 @@ interface DiffBoundaryContentProps extends DiffBoundaryProps {
 const DiffBoundaryContent: React.FunctionComponent<DiffBoundaryContentProps> = props => (
     <>
         {props.lineNumbers && <td className="diff-boundary__num" colSpan={props.colspan} />}
-        <td className={`diff-boundary__content ${props.contentClassName}`} data-diff-marker=" ">
+        <td className={classNames('diff-boundary__content', props.contentClassName)} data-diff-marker=" ">
             {props.oldRange.lines !== undefined && props.newRange.lines !== undefined && (
                 <code className="diff-hunk__line--code diff-hunk__content">
                     @@ -{props.oldRange.startLine},{props.oldRange.lines} +{props.newRange.startLine},

--- a/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
+++ b/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ExternalServiceForm create GitHub 1`] = `
 <form
-  className="external-service-form "
+  className="external-service-form"
   onInvalid={[Function]}
   onSubmit={[Function]}
 >
@@ -53,7 +53,7 @@ exports[`ExternalServiceForm create GitHub 1`] = `
 
 exports[`ExternalServiceForm edit GitHub 1`] = `
 <form
-  className="external-service-form "
+  className="external-service-form"
   onInvalid={[Function]}
   onSubmit={[Function]}
 >
@@ -104,7 +104,7 @@ exports[`ExternalServiceForm edit GitHub 1`] = `
 
 exports[`ExternalServiceForm edit GitHub, loading 1`] = `
 <form
-  className="external-service-form "
+  className="external-service-form"
   onInvalid={[Function]}
   onSubmit={[Function]}
 >

--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`SearchStatsPage limitHit 1`] = `
     </h2>
   </header>
   <form
-    className="form "
+    className="form"
     onInvalid={[Function]}
     onSubmit={[Function]}
   >
@@ -99,7 +99,7 @@ exports[`SearchStatsPage renders 1`] = `
     </h2>
   </header>
   <form
-    className="form "
+    className="form"
     onInvalid={[Function]}
     onSubmit={[Function]}
   >

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
   className="site-admin-generate-product-license-for-subscription-form"
 >
   <form
-    className=" "
+    className=""
     onInvalid={[Function]}
     onSubmit={[Function]}
   >

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ProductSubscriptionForm edit existing subscription 1`] = `
   className="product-subscription-form"
 >
   <form
-    className=" "
+    className=""
     onInvalid={[Function]}
     onSubmit={[Function]}
   >
@@ -89,7 +89,7 @@ exports[`ProductSubscriptionForm new subscription for anonymous viewer (no accou
   className="product-subscription-form"
 >
   <form
-    className=" "
+    className=""
     onInvalid={[Function]}
     onSubmit={[Function]}
   >
@@ -191,7 +191,7 @@ exports[`ProductSubscriptionForm new subscription for existing account 1`] = `
   className="product-subscription-form"
 >
   <form
-    className=" "
+    className=""
     onInvalid={[Function]}
     onSubmit={[Function]}
   >

--- a/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
+++ b/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
@@ -228,7 +228,7 @@ exports[`SiteAdminOverviewPage activation in progress 1`] = `
         </button>
       </div>
       <div
-        className="activation-checklist list-group list-group-flush "
+        className="activation-checklist list-group list-group-flush"
       >
         <div
           data-reach-accordion=""


### PR DESCRIPTION
## Context 

To improve consistency of class names creation in React components and avoid processing template literal cases in the [global-css-to-css-modules](https://github.com/sourcegraph/codemod/tree/main/src/transforms/globalCssToCssModule) codemod another codemod [was added](https://github.com/sourcegraph/codemod/pull/28) to automatically transform template literals to `classNames()` utility calls:

```tsx
<div className={`cool-class ${props.className || ''}`} />
// turns into 
<div className={classNames('cool-class', props.className)} />
```

This PR applies a newly added codemod to the part of the codebase. 

## Changes

- Converted template literals usage in `className` prop to `classNames()` utility call.