### PR TITLE
web: codemod template literal to `classNames` call [2]

### DIFF
--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -1,4 +1,5 @@
 /* eslint jsx-a11y/click-events-have-key-events: warn, jsx-a11y/no-noninteractive-element-interactions: warn */
+import classNames from 'classnames'
 import * as React from 'react'
 import { useLocation } from 'react-router'
 import { Link } from 'react-router-dom'
@@ -76,16 +77,15 @@ export const DiffHunk: React.FunctionComponent<DiffHunkProps> = ({
                 return (
                     <tr
                         key={index}
-                        className={`diff-hunk__line ${
-                            line.kind === DiffHunkLineType.UNCHANGED ? 'diff-hunk__line--both' : ''
-                        } ${line.kind === DiffHunkLineType.DELETED ? 'diff-hunk__line--deletion' : ''} ${
-                            line.kind === DiffHunkLineType.ADDED ? 'diff-hunk__line--addition' : ''
-                        } ${
-                            (line.kind !== DiffHunkLineType.ADDED && location.hash === '#' + oldAnchor) ||
-                            (line.kind !== DiffHunkLineType.DELETED && location.hash === '#' + newAnchor)
-                                ? 'diff-hunk__line--active'
-                                : ''
-                        }`}
+                        className={classNames(
+                            'diff-hunk__line',
+                            line.kind === DiffHunkLineType.UNCHANGED && 'diff-hunk__line--both',
+                            line.kind === DiffHunkLineType.DELETED && 'diff-hunk__line--deletion',
+                            line.kind === DiffHunkLineType.ADDED && 'diff-hunk__line--addition',
+                            ((line.kind !== DiffHunkLineType.ADDED && location.hash === '#' + oldAnchor) ||
+                                (line.kind !== DiffHunkLineType.DELETED && location.hash === '#' + newAnchor)) &&
+                                'diff-hunk__line--active'
+                        )}
                     >
                         {lineNumbers && (
                             <>

--- a/client/web/src/components/diff/DiffSplitHunk.tsx
+++ b/client/web/src/components/diff/DiffSplitHunk.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { useLocation } from 'react-router'
 
@@ -173,9 +174,9 @@ export const DiffSplitHunk: React.FunctionComponent<DiffHunkProps> = ({
                                     lineNumber={next.newLine}
                                     anchor={next.anchor}
                                     html={next.html}
-                                    className={
-                                        location.hash === `#${next.anchor}` ? 'diff-hunk--split__line--active' : ''
-                                    }
+                                    className={classNames(
+                                        location.hash === `#${next.anchor}` && 'diff-hunk--split__line--active'
+                                    )}
                                     dataPart="head"
                                 />
                             </tr>

--- a/client/web/src/components/diff/DiffStat.tsx
+++ b/client/web/src/components/diff/DiffStat.tsx
@@ -103,7 +103,7 @@ export const DiffStatSquares: React.FunctionComponent<DiffProps> = React.memo(fu
         <div className="diff-stat__squares">
             {squares.map((className, index) => (
                 // eslint-disable-next-line react/no-array-index-key
-                <div key={index} className={`diff-stat__square ${className}`} />
+                <div key={index} className={classNames('diff-stat__square', className)} />
             ))}
         </div>
     )

--- a/client/web/src/components/diff/FileDiffHunks.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.tsx
@@ -252,7 +252,7 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                     />
                 </div>
             )}
-            <div className={`file-diff-hunks ${className}`} ref={nextBlobElement}>
+            <div className={classNames('file-diff-hunks', className)} ref={nextBlobElement}>
                 {hunks.length === 0 ? (
                     <div className="text-muted m-2">No changes</div>
                 ) : (

--- a/client/web/src/components/diff/Lines.tsx
+++ b/client/web/src/components/diff/Lines.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { DecorationAttachmentRenderOptions, ThemableDecorationStyle } from 'sourcegraph'
@@ -81,7 +82,7 @@ export const Line: React.FunctionComponent<Line> = ({
         <>
             {lineNumbers && (
                 <td
-                    className={`diff-hunk__num ${hunkStyles.hunkContent}-num ${className}-num`}
+                    className={classNames('diff-hunk__num', `${hunkStyles.hunkContent}-num`, `${className}-num`)}
                     data-line={lineNumber}
                     data-part={dataPart}
                     id={id || anchor}
@@ -94,7 +95,11 @@ export const Line: React.FunctionComponent<Line> = ({
                 </td>
             )}
             <td
-                className={`diff-hunk--split__line align-baseline diff-hunk__content ${hunkStyles.hunkContent} ${className}`}
+                className={classNames(
+                    'diff-hunk--split__line align-baseline diff-hunk__content',
+                    hunkStyles.hunkContent,
+                    className
+                )}
                 // eslint-disable-next-line react/forbid-dom-props
                 style={lineStyle}
                 data-diff-marker={diffHunkTypeIndicators[kind]}

--- a/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
@@ -30,7 +30,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -76,7 +76,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -122,7 +122,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -168,7 +168,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line  diff-hunk__line--deletion  "
+    className="diff-hunk__line diff-hunk__line--deletion"
   >
     <td
       className="diff-hunk__num"
@@ -203,7 +203,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line   diff-hunk__line--addition "
+    className="diff-hunk__line diff-hunk__line--addition"
   >
     <td
       className="diff-hunk__num diff-hunk__num--empty"
@@ -238,7 +238,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -284,7 +284,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -330,7 +330,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -408,7 +408,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -471,7 +471,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -517,7 +517,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -563,7 +563,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line  diff-hunk__line--deletion  "
+    className="diff-hunk__line diff-hunk__line--deletion"
   >
     <td
       className="diff-hunk__num"
@@ -615,7 +615,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line   diff-hunk__line--addition "
+    className="diff-hunk__line diff-hunk__line--addition"
   >
     <td
       className="diff-hunk__num diff-hunk__num--empty"
@@ -650,7 +650,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -696,7 +696,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -742,7 +742,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -820,7 +820,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -882,7 +882,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -928,7 +928,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -974,7 +974,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line  diff-hunk__line--deletion  "
+    className="diff-hunk__line diff-hunk__line--deletion"
   >
     <td
       className="diff-hunk__num"
@@ -1025,7 +1025,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line   diff-hunk__line--addition "
+    className="diff-hunk__line diff-hunk__line--addition"
   >
     <td
       className="diff-hunk__num diff-hunk__num--empty"
@@ -1060,7 +1060,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -1106,7 +1106,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"
@@ -1152,7 +1152,7 @@ Array [
     </td>
   </tr>,
   <tr
-    className="diff-hunk__line diff-hunk__line--both   "
+    className="diff-hunk__line diff-hunk__line--both"
   >
     <td
       className="diff-hunk__num"

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import UserIcon from 'mdi-react/UserIcon'
@@ -41,7 +42,7 @@ export const ExternalServiceCard: React.FunctionComponent<ExternalServiceCardPro
     className = '',
 }) => {
     const children = (
-        <div className={`p-3 d-flex align-items-start border ${className}`}>
+        <div className={classNames('p-3 d-flex align-items-start border', className)}>
             <Icon className="icon-inline h3 mb-0 mr-3" />
             <div className="flex-1">
                 <h3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import React, { useCallback } from 'react'
 
@@ -113,9 +114,10 @@ export const ExternalServiceForm: React.FunctionComponent<Props> = ({
             </div>
             <button
                 type="submit"
-                className={`btn btn-primary mb-3 ${
+                className={classNames(
+                    'btn btn-primary mb-3',
                     mode === 'create' ? 'test-add-external-service-button' : 'test-update-external-service-button'
-                }`}
+                )}
                 disabled={loading}
             >
                 {loading && <LoadingSpinner className="icon-inline" />}

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -145,7 +145,7 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
                         Find file
                     </h3>
                     <button type="button" className="btn btn-icon" onClick={() => props.onClose()} aria-label="Close">
-                        <CloseIcon className={`icon-inline ${styles.closeIcon}`} />
+                        <CloseIcon className={classNames('icon-inline', styles.closeIcon)} />
                     </button>
                 </div>
                 <input

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -152,9 +152,10 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                     <div className="flex mt-1">
                         <button
                             type="button"
-                            className={`btn btn-sm mr-2 ${
+                            className={classNames(
+                                'btn btn-sm mr-2',
                                 isSendTestEmailButtonDisabled ? 'btn-secondary' : 'btn-outline-secondary'
-                            }`}
+                            )}
                             disabled={isSendTestEmailButtonDisabled}
                             onClick={triggerTestEmailActionRequest}
                         >

--- a/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useCallback, useMemo } from 'react'
 import { Observable } from 'rxjs'
 import { catchError, map, startWith, tap } from 'rxjs/operators'
@@ -72,7 +73,7 @@ export const ProductPlanFormControl: React.FunctionComponent<Props> = ({
     const disableInputs = disabled || plans === LOADING || isErrorLike(plans)
 
     return (
-        <div className={`product-plan-form-control ${className}`}>
+        <div className={classNames('product-plan-form-control', className)}>
             {plans === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(plans) ? (

--- a/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useCallback } from 'react'
 
 interface Props {
@@ -39,7 +40,7 @@ export const ProductSubscriptionUserCountFormControl: React.FunctionComponent<Pr
     )
 
     return (
-        <div className={`product-subscription-user-count-control form-group align-items-center ${className}`}>
+        <div className={classNames('product-subscription-user-count-control form-group align-items-center', className)}>
             <label htmlFor="product-subscription-user-count-control__userCount" className="mb-0 mr-2 font-weight-bold">
                 Users
             </label>

--- a/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductPlanFormControl.test.tsx.snap
+++ b/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductPlanFormControl.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProductPlanFormControl new subscription 1`] = `
 <div
-  className="product-plan-form-control "
+  className="product-plan-form-control"
 >
   <div
     className="list-group"

--- a/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductSubscriptionUserCountFormControl.test.tsx.snap
+++ b/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductSubscriptionUserCountFormControl.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProductSubscriptionUserCountFormControl renders 1`] = `
 <div
-  className="product-subscription-user-count-control form-group align-items-center "
+  className="product-subscription-user-count-control form-group align-items-center"
 >
   <label
     className="mb-0 mr-2 font-weight-bold"

--- a/client/web/src/enterprise/dotcom/productSubscriptions/AccountEmailAddresses.tsx
+++ b/client/web/src/enterprise/dotcom/productSubscriptions/AccountEmailAddresses.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
@@ -10,7 +11,10 @@ export const AccountEmailAddresses: React.FunctionComponent<{
 }> = ({ emails }) => (
     <>
         {emails.map(({ email, verified }, index) => (
-            <span key={index} className={`text-nowrap d-inline-block mr-2 ${verified ? '' : 'text-muted font-italic'}`}>
+            <span
+                key={index}
+                className={classNames('text-nowrap d-inline-block mr-2', !verified && 'text-muted font-italic')}
+            >
                 <a href={`mailto:${email}`}>{email}</a> {verified ? '(verified)' : '(unverified)'}
             </span>
         ))}

--- a/client/web/src/enterprise/dotcom/productSubscriptions/ProductLicenseValidity.tsx
+++ b/client/web/src/enterprise/dotcom/productSubscriptions/ProductLicenseValidity.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { parseISO } from 'date-fns'
 import format from 'date-fns/format'
 import React from 'react'
@@ -18,11 +19,13 @@ export const ProductLicenseValidity: React.FunctionComponent<{
     const validityClass = isExpired ? 'danger' : 'success'
     return (
         <div
-            className={`${className} ${primary ? `alert alert-${validityClass} py-1 px-2` : ''}`}
+            className={classNames(className, primary && `alert alert-${validityClass} py-1 px-2`)}
             data-tooltip={format(parseISO(expiresAt), 'PPpp')}
         >
-            <strong className={primary ? '' : `text-${validityClass}`}>{isExpired ? 'Expired' : 'Valid'}</strong> (
-            {formatRelativeExpirationDate(expiresAt)})
+            <strong className={classNames(!primary && `text-${validityClass}`)}>
+                {isExpired ? 'Expired' : 'Valid'}
+            </strong>{' '}
+            ({formatRelativeExpirationDate(expiresAt)})
         </div>
     )
 }

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
@@ -23,7 +24,7 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
     disabled?: boolean
     onChange?: React.FormEventHandler<HTMLSelectElement>
 }> = ({ className = '', value, publishersOrError, disabled, onChange }) => (
-    <div className={`form-group ${className}`}>
+    <div className={classNames('form-group', className)}>
         <label htmlFor="extension-registry-create-extension-page__publisher">Publisher</label>
         {isErrorLike(publishersOrError) ? (
             <ErrorAlert error={publishersOrError} />
@@ -59,7 +60,7 @@ export const RegistryExtensionNameFormGroup: React.FunctionComponent<{
     disabled?: boolean
     onChange: React.FormEventHandler<HTMLInputElement>
 }> = ({ className = '', value, disabled, onChange }) => (
-    <div className={`form-group ${className}`}>
+    <div className={classNames('form-group', className)}>
         <label htmlFor="extension-registry-form__name">Name</label>
         <input
             type="text"

--- a/client/web/src/enterprise/extensions/registry/RegistryExtensionSourceBadge.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryExtensionSourceBadge.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import DoNotDisturbIcon from 'mdi-react/DoNotDisturbIcon'
 import WebIcon from 'mdi-react/WebIcon'
 import * as React from 'react'
@@ -16,7 +17,7 @@ export const RegistryExtensionSourceBadge: React.FunctionComponent<{
         to={extension.remoteURL}
         target="_blank"
         rel="noopener noreferrer"
-        className={`text-muted text-nowrap d-inline-flex align-items-center ${className}`}
+        className={classNames('text-muted text-nowrap d-inline-flex align-items-center', className)}
         data-tooltip={
             extension.isLocal
                 ? 'Published on this site'

--- a/client/web/src/enterprise/productSubscription/LicenseGenerationKeyWarning.tsx
+++ b/client/web/src/enterprise/productSubscription/LicenseGenerationKeyWarning.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 /**
@@ -11,7 +12,7 @@ import React from 'react'
  */
 export const LicenseGenerationKeyWarning: React.FunctionComponent<{ className?: string }> = ({ className = '' }) =>
     window.context?.debug ? (
-        <div className={`alert alert-warning ${className}`}>
+        <div className={classNames('alert alert-warning', className)}>
             License keys generated in dev mode are <strong>NOT VALID</strong>.{' '}
             <a href="https://sourcegraph.com/site-admin/dotcom/product/subscriptions">
                 Use Sourcegraph.com to generate valid license keys.

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
         )
       </span>
       <div
-        className="d-inline-block mr-3 "
+        className="d-inline-block mr-3"
         data-tooltip="Jan 1, 2021, 12:00:00 AM"
       >
         <strong
@@ -45,7 +45,8 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
         >
           Valid
         </strong>
-         (
+         
+        (
         15 years remaining
         )
       </div>

--- a/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { CardElement, ReactStripeElements } from 'react-stripe-elements'
 
@@ -21,9 +22,10 @@ export const PaymentTokenFormControl: React.FunctionComponent<Props> = props => 
     return (
         <div className="payment-token-form-control">
             <PatchedCardElement
-                className={`form-control payment-token-form-control__card payment-token-form-control__card--${
-                    props.disabled ? 'disabled' : ''
-                }`}
+                className={classNames(
+                    'form-control payment-token-form-control__card',
+                    props.disabled && 'payment-token-form-control__card--disabled'
+                )}
                 disabled={props.disabled}
                 style={{
                     base: {

--- a/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionBeforeAfterInvoiceItem.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionBeforeAfterInvoiceItem.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { parseISO } from 'date-fns'
 import React from 'react'
 
@@ -18,9 +19,9 @@ export const ProductSubscriptionBeforeAfterInvoiceItem: React.FunctionComponent<
     const planChanged = beforeInvoiceItem.plan.billingPlanID !== afterInvoiceItem.plan.billingPlanID
     const userCountChanged = beforeInvoiceItem.userCount !== afterInvoiceItem.userCount
     return !planChanged && !userCountChanged ? (
-        <div className={`text-muted ${className}`}>No changes to subscription.</div>
+        <div className={classNames('text-muted', className)}>No changes to subscription.</div>
     ) : (
-        <ul className={`pl-3 ${className}`}>
+        <ul className={classNames('pl-3', className)}>
             {planChanged && (
                 <li>
                     {afterInvoiceItem.plan.pricePerUserPerYear > beforeInvoiceItem.plan.pricePerUserPerYear

--- a/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import React, { useState, useMemo, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
@@ -250,9 +251,10 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
                             <button
                                 type="submit"
                                 disabled={disableForm || !accountID}
-                                className={`btn btn-lg btn-${
-                                    disableForm || !accountID ? 'secondary' : 'success'
-                                } w-100 d-flex align-items-center justify-content-center`}
+                                className={classNames(
+                                    'btn btn-l w-100 d-flex align-items-center justify-content-center',
+                                    disableForm || !accountID ? 'btn-secondary' : 'btn-success'
+                                )}
                             >
                                 {paymentToken === LOADING || submissionState === LOADING ? (
                                     <>

--- a/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -252,8 +252,9 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
                                 type="submit"
                                 disabled={disableForm || !accountID}
                                 className={classNames(
-                                    'btn btn-l w-100 d-flex align-items-center justify-content-center',
-                                    disableForm || !accountID ? 'btn-secondary' : 'btn-success'
+                                    'btn btn-lg',
+                                    disableForm || !accountID ? 'btn-secondary' : 'btn-success',
+                                    'w-100 d-flex align-items-center justify-content-center'
                                 )}
                             >
                                 {paymentToken === LOADING || submissionState === LOADING ? (

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -78,7 +78,7 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
     }, [ctaTimeoutManager, showCta, props.authenticatedUser])
 
     return (
-        <div className={`extension-area-header ${props.className || ''}`}>
+        <div className={classNames('extension-area-header', props.className)}>
             <div className="container">
                 {props.extension && (
                     <>

--- a/client/web/src/extensions/extension/ExtensionConfigurationState.tsx
+++ b/client/web/src/extensions/extension/ExtensionConfigurationState.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import CheckIcon from 'mdi-react/CheckIcon'
 import * as React from 'react'
 
@@ -11,9 +12,9 @@ export const ExtensionConfigurationState: React.FunctionComponent<{
     className?: string
 }> = ({ isAdded, isEnabled, enabledIconOnly, className = '' }) =>
     isAdded && isEnabled ? (
-        <span className={`text-success ${className}`}>
+        <span className={classNames('text-success', className)}>
             <CheckIcon className="icon-inline" /> {!enabledIconOnly && 'Enabled'}
         </span>
     ) : (
-        <span className={`text-muted ${className}`}>Disabled</span>
+        <span className={classNames('text-muted', className)}>Disabled</span>
     )

--- a/client/web/src/extensions/extension/RegistryExtensionReadme.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionReadme.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 
@@ -14,7 +15,7 @@ const PublishNewManifestAlert: React.FunctionComponent<{
     buttonLabel: string
     alertClass: 'alert-info' | 'alert-danger'
 }> = ({ extension, text, buttonLabel, alertClass }) => (
-    <div className={`alert ${alertClass}`}>
+    <div className={classNames('alert', alertClass)}>
         {text}
         {extension.registryExtension?.viewerCanAdminister && (
             <>

--- a/client/web/src/global/Notices.tsx
+++ b/client/web/src/global/Notices.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
@@ -11,11 +12,14 @@ const NoticeAlert: React.FunctionComponent<{ notice: Notice; className?: string 
     const content = <Markdown dangerousInnerHTML={renderMarkdown(notice.message)} />
     const baseClassName = notice.location === 'top' ? 'alert-info' : 'bg-transparent border'
     return notice.dismissible ? (
-        <DismissibleAlert className={`${baseClassName} ${className}`} partialStorageKey={`notice.${notice.message}`}>
+        <DismissibleAlert
+            className={classNames(baseClassName, className)}
+            partialStorageKey={`notice.${notice.message}`}
+        >
             {content}
         </DismissibleAlert>
     ) : (
-        <div className={`alert ${baseClassName} ${className}`}>{content}</div>
+        <div className={classNames('alert', baseClassName, className)}>{content}</div>
     )
 }
 
@@ -50,7 +54,7 @@ export const Notices: React.FunctionComponent<Props> = ({
         return null
     }
     return (
-        <div className={`notices ${className}`}>
+        <div className={classNames('notices', className)}>
             {notices.map((notice, index) => (
                 <NoticeAlert key={index} className={alertClassName} notice={notice} />
             ))}

--- a/client/web/src/global/__snapshots__/Notices.test.tsx.snap
+++ b/client/web/src/global/__snapshots__/Notices.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`Notices no notices 1`] = `null`;
 
 exports[`Notices shows notices for location 1`] = `
 <div
-  className="notices "
+  className="notices"
 >
   <div
-    className="alert bg-transparent border "
+    className="alert bg-transparent border"
   >
     <div
       className="markdown"
@@ -21,7 +21,7 @@ exports[`Notices shows notices for location 1`] = `
     />
   </div>
   <div
-    className="alert container bg-transparent border "
+    className="alert container bg-transparent border"
   >
     <div
       className="content"


### PR DESCRIPTION
## Context 

To improve consistency of class names creation in React components and avoid processing template literal cases in the [global-css-to-css-modules](https://github.com/sourcegraph/codemod/tree/main/src/transforms/globalCssToCssModule) codemod another codemod [was added](https://github.com/sourcegraph/codemod/pull/28) to automatically transform template literals to `classNames()` utility calls:

```tsx
<div className={`cool-class ${props.className || ''}`} />
// turns into 
<div className={classNames('cool-class', props.className)} />
```

This PR applies a newly added codemod to the part of the codebase. 

## Changes

- Converted template literals usage in `className` prop to `classNames()` utility call.