### PR TITLE
web: codemod template literal to `classNames` call [3]

### DIFF
--- a/client/web/src/insights/components/insight-view-content/chart-view-content/ChartViewContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/ChartViewContent.tsx
@@ -1,4 +1,5 @@
 import { ParentSize } from '@visx/responsive'
+import classNames from 'classnames'
 import React, { FunctionComponent, useCallback } from 'react'
 import { ChartContent } from 'sourcegraph'
 
@@ -9,7 +10,6 @@ import { LineChart } from './charts/line/LineChart'
 import { DatumZoneClickEvent } from './charts/line/types'
 import { PieChart } from './charts/pie/PieChart'
 import { getInsightTypeByViewId } from './utils/get-insight-type-by-view-id'
-import classNames from "classnames";
 
 /**
  * Displays chart view content.
@@ -58,7 +58,7 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
     )
 
     return (
-        <div className={classNames("chart-view-content", className)}>
+        <div className={classNames('chart-view-content', className)}>
             <ParentSize className="chart-view-content__chart">
                 {({ width, height }) => {
                     if (content.chart === 'line') {

--- a/client/web/src/insights/components/insight-view-content/chart-view-content/ChartViewContent.tsx
+++ b/client/web/src/insights/components/insight-view-content/chart-view-content/ChartViewContent.tsx
@@ -9,6 +9,7 @@ import { LineChart } from './charts/line/LineChart'
 import { DatumZoneClickEvent } from './charts/line/types'
 import { PieChart } from './charts/pie/PieChart'
 import { getInsightTypeByViewId } from './utils/get-insight-type-by-view-id'
+import classNames from "classnames";
 
 /**
  * Displays chart view content.
@@ -57,7 +58,7 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
     )
 
     return (
-        <div className={`chart-view-content ${className}`}>
+        <div className={classNames("chart-view-content", className)}>
             <ParentSize className="chart-view-content__chart">
                 {({ width, height }) => {
                     if (content.chart === 'line') {

--- a/client/web/src/org/OrgAvatar.tsx
+++ b/client/web/src/org/OrgAvatar.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 /**
@@ -11,5 +12,5 @@ export const OrgAvatar: React.FunctionComponent<{
 
     className?: string
 }> = ({ org, size = 'md', className = '' }) => (
-    <div className={`org-avatar org-avatar--${size} ${className}`}>{org.slice(0, 2).toUpperCase()}</div>
+    <div className={classNames(`org-avatar org-avatar--${size}`, className)}>{org.slice(0, 2).toUpperCase()}</div>
 )

--- a/client/web/src/person/PersonLink.tsx
+++ b/client/web/src/person/PersonLink.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
@@ -39,7 +40,7 @@ export const PersonLink: React.FunctionComponent<{
 }> = ({ person, className = '', userClassName = '' }) => (
     <LinkOrSpan
         to={person.user?.url}
-        className={`${className} ${person.user ? userClassName : ''}`}
+        className={classNames(className, person.user && userClassName)}
         data-tooltip={
             person.user && (person.user.displayName || person.displayName)
                 ? `${person.user.displayName || person.displayName} <${person.email}>`

--- a/client/web/src/person/__snapshots__/PersonLink.test.tsx.snap
+++ b/client/web/src/person/__snapshots__/PersonLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PersonLink no user account 1`] = `
 <span
-  className="a "
+  className="a"
   data-tooltip="alice@example.com"
 >
   alice

--- a/client/web/src/repo/DirectImportRepoAlert.tsx
+++ b/client/web/src/repo/DirectImportRepoAlert.tsx
@@ -1,10 +1,11 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 
 export const DirectImportRepoAlert: React.FunctionComponent<{ className?: string }> = ({ className = '' }) => (
     <>
         {['dev', 'docker-container'].includes(window.context.deployType) && (
-            <div className={`alert alert-info ${className}`}>
+            <div className={classNames('alert alert-info', className)}>
                 Very large repository? See{' '}
                 <Link to="/help/admin/repo/pre_load_from_local_disk#add-repositories-already-cloned-to-disk">
                     how to reuse an existing local clone

--- a/client/web/src/repo/RepositoriesPopover.tsx
+++ b/client/web/src/repo/RepositoriesPopover.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useCallback, useEffect } from 'react'
 import { Link, useHistory, useLocation } from 'react-router-dom'
 import { Observable } from 'rxjs'
@@ -49,9 +50,10 @@ const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({ node, cu
     <li key={node.id} className="connection-popover__node">
         <Link
             to={`/${node.name}`}
-            className={`connection-popover__node-link ${
-                node.id === currentRepo ? 'connection-popover__node-link--active' : ''
-            }`}
+            className={classNames(
+                'connection-popover__node-link',
+                node.id === currentRepo && 'connection-popover__node-link--active'
+            )}
         >
             {displayRepoName(node.name)}
         </Link>

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { Remote } from 'comlink'
 import * as H from 'history'
 import iterate from 'iterare'
@@ -597,9 +598,9 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
 
     return (
         <>
-            <div className={`blob ${props.className}`} ref={nextBlobElement}>
+            <div className={classNames('blob', props.className)} ref={nextBlobElement}>
                 <code
-                    className={`blob__code ${props.wrapCode ? ' blob__code--wrapped' : ''} test-blob`}
+                    className={classNames('blob__code test-blob', props.wrapCode && 'blob__code--wrapped')}
                     ref={nextCodeViewElement}
                     dangerouslySetInnerHTML={{
                         __html: blobInfo.html,

--- a/client/web/src/repo/branches/RepositoryBranchesNavbar.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesNavbar.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { NavLink } from 'react-router-dom'
 
@@ -5,7 +6,7 @@ export const RepositoryBranchesNavbar: React.FunctionComponent<{ repo: string; c
     repo,
     className,
 }) => (
-    <ul className={`nav ${className}`}>
+    <ul className={classNames('nav', className)}>
         <li className="nav-item">
             <NavLink className="nav-link" exact={true} activeClassName="font-weight-bold" to={`/${repo}/-/branches`}>
                 Overview

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -191,10 +191,7 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
 
     const oidElement = <code className="git-commit-node__oid">{node.abbreviatedOID}</code>
     return (
-        <div
-            key={node.id}
-            className={`git-commit-node ${compact ? 'git-commit-node--compact' : ''} ${className || ''}`}
-        >
+        <div key={node.id} className={classNames('git-commit-node', compact && 'git-commit-node--compact', className)}>
             <>
                 {!compact ? (
                     <>

--- a/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`GitCommitNodeByline author (compact) 1`] = `
   <div>
     committed by 
     <span
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="alice@example.com"
     >
       Alice Zhao
@@ -50,7 +50,7 @@ exports[`GitCommitNodeByline author 1`] = `
   <div>
     committed by 
     <span
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="alice@example.com"
     >
       Alice Zhao
@@ -90,7 +90,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
   </div>
   <div>
     <span
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="alice@example.com"
     >
       Alice Zhao
@@ -98,7 +98,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
      authored and
      
     <a
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="Bob Yang <bob@example.com>"
       href="https://example.com/bobyang"
     >
@@ -140,7 +140,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
   </div>
   <div>
     <span
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="alice@example.com"
     >
       Alice Zhao
@@ -148,7 +148,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
      authored and
      
     <a
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="Bob Yang <bob@example.com>"
       href="https://example.com/bobyang"
     >
@@ -183,7 +183,7 @@ exports[`GitCommitNodeByline omit GitHub committer 1`] = `
   <div>
     committed by 
     <span
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="alice@example.com"
     >
       Alice Zhao
@@ -216,7 +216,7 @@ exports[`GitCommitNodeByline same author and committer 1`] = `
   <div>
     committed by 
     <span
-      className="font-weight-bold "
+      className="font-weight-bold"
       data-tooltip="alice@example.com"
     >
       Alice Zhao

--- a/client/web/src/repo/docs/DocumentationIcon.tsx
+++ b/client/web/src/repo/docs/DocumentationIcon.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { MdiReactIconComponentType } from 'mdi-react'
 import AccountMultipleIcon from 'mdi-react/AccountMultipleIcon'
 import ClockFastIcon from 'mdi-react/ClockFastIcon'
@@ -122,5 +123,10 @@ interface Props {
  */
 export const DocumentationIcon: React.FunctionComponent<Props> = ({ tag, className = '' }) => {
     const Icon = getDocumentationIconComponent(tag)
-    return <Icon className={`documentation-icon documentation-icon--tag-${tag} ${className}`} data-tooltip={tag} />
+    return (
+        <Icon
+            className={classNames('documentation-icon', `documentation-icon--tag-${tag}`, className)}
+            data-tooltip={tag}
+        />
+    )
 }

--- a/client/web/src/repo/docs/DocumentationIndexNode.tsx
+++ b/client/web/src/repo/docs/DocumentationIndexNode.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import { isEqual } from 'lodash'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
@@ -148,13 +149,14 @@ export const DocumentationIndexNode: React.FunctionComponent<Props> = React.memo
         const styleAsExpandable = !styleAsActive && depth !== 0 && node.children.length > 0
         return (
             <div
-                className={`documentation-index-node d-flex flex-column${depth !== 0 ? ' mt-2' : ''}`}
+                className={classNames('documentation-index-node d-flex flex-column', depth !== 0 && 'mt-2')}
                 ref={nodeReference}
             >
                 <span
-                    className={`d-flex align-items-center text-nowrap documentation-index-node-row${
-                        styleAsActive || styleAsExpandable ? ' documentation-index-node-row--shift-left' : ''
-                    }`}
+                    className={classNames(
+                        'd-flex align-items-center text-nowrap documentation-index-node-row',
+                        (styleAsActive || styleAsExpandable) && 'documentation-index-node-row--shift-left'
+                    )}
                 >
                     {styleAsActive && (
                         <CircleMediumIcon className="d-flex flex-shrink-0 mr-1 icon-inline documentation-index-node-active-circle" />

--- a/client/web/src/repo/docs/DocumentationNode.tsx
+++ b/client/web/src/repo/docs/DocumentationNode.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import BookOpenVariantIcon from 'mdi-react/BookOpenVariantIcon'
 import HelpCircleOutlineIcon from 'mdi-react/HelpCircleOutlineIcon'
@@ -121,21 +122,21 @@ export const DocumentationNode: React.FunctionComponent<Props> = React.memo(
         const headingLevel = depth + 1 < 4 ? depth + 1 : 4
         const topMargin =
             depth === 0
-                ? ' mt-3' // Level 0 header ("Package foo")
+                ? 'mt-3' // Level 0 header ("Package foo")
                 : onlyPathID
-                ? ' mt-3' // Single-node display margin
+                ? 'mt-3' // Single-node display margin
                 : depth === 1
-                ? ' mt-5' // Level 1 headers ("Constants", "Variables", etc.)
+                ? 'mt-5' // Level 1 headers ("Constants", "Variables", etc.)
                 : isFirstChild
-                ? ' mt-4'
-                : ' mt-5' // Lowest level headers
+                ? 'mt-4'
+                : 'mt-5' // Lowest level headers
 
         if (onlyPathID && node.pathID !== onlyPathID && !hasDescendent(node, onlyPathID)) {
             return null
         }
         const renderContent = !onlyPathID || node.pathID === onlyPathID || depth === 0
         return (
-            <div className={`documentation-node mb-5${topMargin}`}>
+            <div className={classNames('documentation-node mb-5', topMargin)}>
                 {renderContent && (
                     <div ref={reference}>
                         <Heading level={headingLevel} className="d-flex align-items-center documentation-node__heading">

--- a/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
+++ b/client/web/src/repo/docs/RepositoryDocumentationPage.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import { upperFirst } from 'lodash'
 import BookOpenVariantIcon from 'mdi-react/BookOpenVariantIcon'
@@ -250,9 +251,10 @@ export const RepositoryDocumentationPage: React.FunctionComponent<Props> = React
                     />
                     <div className="repository-docs-page__container" ref={containerReference}>
                         <div
-                            className={`repository-docs-page__container-content${
-                                sidebarVisible ? ' repository-docs-page__container-content--sidebar-visible' : ''
-                            }`}
+                            className={classNames(
+                                'repository-docs-page__container-content',
+                                sidebarVisible && 'repository-docs-page__container-content--sidebar-visible'
+                            )}
                         >
                             {/*
                                 TODO(apidocs): Eventually this welcome alert should go away entirely, but for now

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import prettyBytes from 'pretty-bytes'
 import * as React from 'react'
@@ -76,20 +77,18 @@ const TextSearchIndexedReference: React.FunctionComponent<{
     repo: SettingsAreaRepositoryFields
     indexedRef: GQL.IRepositoryTextSearchIndexedRef
 }> = ({ repo, indexedRef }) => {
-    let Icon: React.ComponentType<{ className?: string }>
-    let iconClassName: string
-    if (indexedRef.indexed && indexedRef.current) {
-        Icon = CheckCircleIcon
-        iconClassName = 'current'
-    } else {
-        Icon = LoadingSpinner
-        iconClassName = 'stale'
-    }
+    const isCurrent = indexedRef.indexed && indexedRef.current
+    const Icon = isCurrent ? CheckCircleIcon : LoadingSpinner
 
     return (
         <li className="repo-settings-index-page__ref">
             <Icon
-                className={`icon-inline repo-settings-index-page__ref-icon repo-settings-index-page__ref-icon--${iconClassName}`}
+                className={classNames(
+                    'icon-inline repo-settings-index-page__ref-icon',
+                    isCurrent
+                        ? 'repo-settings-index-page__ref-icon--current'
+                        : 'repo-settings-index-page__ref-icon--stale'
+                )}
             />
             <LinkOrSpan to={indexedRef.ref.url}>
                 <strong>

--- a/client/web/src/repo/settings/components/ActionContainer.tsx
+++ b/client/web/src/repo/settings/components/ActionContainer.tsx
@@ -75,7 +75,10 @@ export class ActionContainer extends React.PureComponent<Props, State> {
                     <>
                         <button
                             type="button"
-                            className={`btn ${this.props.buttonClassName || 'btn-primary'} action-container__btn`}
+                            className={classNames(
+                                'btn action-container__btn',
+                                this.props.buttonClassName || 'btn-primary'
+                            )}
                             onClick={this.onClick}
                             data-tooltip={this.props.buttonSubtitle}
                             disabled={this.props.buttonDisabled || this.state.loading}

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { escapeRegExp, isEqual } from 'lodash'
 import * as React from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
@@ -251,34 +252,41 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                                         <div className="btn-group">
                                             <button
                                                 type="button"
-                                                className={`btn btn-secondary ${
-                                                    this.state.after === '7 days ago' ? 'active' : ''
-                                                } repository-stats-page__btn-no-left-rounded-corners`}
+                                                className={classNames(
+                                                    'btn btn-secondary',
+                                                    this.state.after === '7 days ago' && 'active',
+                                                    'repository-stats-page__btn-no-left-rounded-corners'
+                                                )}
                                                 onClick={() => this.setStateAfterAndSubmit('7 days ago')}
                                             >
                                                 Last 7 days
                                             </button>
                                             <button
                                                 type="button"
-                                                className={`btn btn-secondary ${
-                                                    this.state.after === '30 days ago' ? 'active' : ''
-                                                }`}
+                                                className={classNames(
+                                                    'btn btn-secondary',
+                                                    this.state.after === '30 days ago' && 'active'
+                                                )}
                                                 onClick={() => this.setStateAfterAndSubmit('30 days ago')}
                                             >
                                                 Last 30 days
                                             </button>
                                             <button
                                                 type="button"
-                                                className={`btn btn-secondary ${
-                                                    this.state.after === '1 year ago' ? 'active' : ''
-                                                }`}
+                                                className={classNames(
+                                                    'btn btn-secondary',
+                                                    this.state.after === '1 year ago' && 'active'
+                                                )}
                                                 onClick={() => this.setStateAfterAndSubmit('1 year ago')}
                                             >
                                                 Last year
                                             </button>
                                             <button
                                                 type="button"
-                                                className={`btn btn-secondary ${!this.state.after ? 'active' : ''}`}
+                                                className={classNames(
+                                                    'btn btn-secondary',
+                                                    !this.state.after && 'active'
+                                                )}
                                                 onClick={() => this.setStateAfterAndSubmit(null)}
                                             >
                                                 All time

--- a/client/web/src/repo/stats/RepositoryStatsNavbar.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsNavbar.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { NavLink } from 'react-router-dom'
 
@@ -5,7 +6,7 @@ export const RepositoryStatsNavbar: React.FunctionComponent<{ repo: string; clas
     repo,
     className,
 }) => (
-    <ul className={`nav ${className}`}>
+    <ul className={classNames('nav', className)}>
         <li className="nav-item">
             <NavLink
                 className="nav-link"

--- a/client/web/src/search/input/SearchBox.tsx
+++ b/client/web/src/search/input/SearchBox.tsx
@@ -71,7 +71,7 @@ export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
                     className={styles.searchBoxVersionContextDropdown}
                 />
             )}
-            <div className={`${styles.searchBoxBackgroundContainer} flex-shrink-past-contents`}>
+            <div className={classNames(styles.searchBoxBackgroundContainer, 'flex-shrink-past-contents')}>
                 {props.showSearchContext && (
                     <>
                         <SearchContextDropdown
@@ -83,7 +83,7 @@ export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
                         <div className={styles.searchBoxSeparator} />
                     </>
                 )}
-                <div className={`${styles.searchBoxFocusContainer} flex-shrink-past-contents`}>
+                <div className={classNames(styles.searchBoxFocusContainer, 'flex-shrink-past-contents')}>
                     <LazyMonacoQueryInput {...props} className={styles.searchBoxInput} />
                     <Toggles {...props} navbarSearchQuery={queryState.query} className={styles.searchBoxToggles} />
                 </div>

--- a/client/web/src/search/queryBuilder/QueryBuilderPage.tsx
+++ b/client/web/src/search/queryBuilder/QueryBuilderPage.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -42,7 +43,7 @@ export const QueryBuilderPage: React.FunctionComponent<Props> = ({
                     data-tooltip={query === '' ? '' : `Read-only field. ${helpText}.`}
                 />
                 <Link
-                    className={`btn btn-primary ${query === '' ? 'disabled' : ''}`}
+                    className={classNames('btn btn-primary', query === '' && 'disabled')}
                     to={`/search?${buildSearchURLQuery(
                         query,
                         patternType,

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import * as React from 'react'
@@ -165,7 +166,7 @@ export class SettingsArea extends React.Component<Props, State> {
         }
 
         return (
-            <div className={`h-100 d-flex flex-column ${this.props.className || ''}`}>
+            <div className={classNames('h-100 d-flex flex-column', this.props.className)}>
                 <PageHeader headingElement="h2" path={[{ text: `${term} settings` }]} className="mb-3" />
                 {this.props.extraHeader}
                 <Switch>

--- a/client/web/src/site-admin/SiteAdminAlert.tsx
+++ b/client/web/src/site-admin/SiteAdminAlert.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import LockIcon from 'mdi-react/LockIcon'
 import * as React from 'react'
 
@@ -8,7 +9,7 @@ export const SiteAdminAlert: React.FunctionComponent<{ children: React.ReactFrag
     children,
     className = '',
 }) => (
-    <div className={`alert alert-warning site-admin-alert ${className}`}>
+    <div className={classNames('alert alert-warning site-admin-alert', className)}>
         <h5>
             <LockIcon className="icon-inline" /> Site admin
         </h5>

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { ListGroup, ListGroupItem } from 'reactstrap'
@@ -25,7 +26,7 @@ export interface SiteAdminSidebarProps extends BatchChangesProps {
  * Sidebar for the site admin area.
  */
 export const SiteAdminSidebar: React.FunctionComponent<SiteAdminSidebarProps> = ({ className, groups, ...props }) => (
-    <div className={`site-admin-sidebar ${className}`}>
+    <div className={classNames('site-admin-sidebar', className)}>
         <ListGroup>
             {groups.map(
                 ({ header, items, condition = () => true }, index) =>

--- a/client/web/src/site-admin/SiteAdminTokensPage.tsx
+++ b/client/web/src/site-admin/SiteAdminTokensPage.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import AddIcon from 'mdi-react/AddIcon'
 import React, { useCallback, useMemo } from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -46,7 +47,7 @@ export const SiteAdminTokensPage: React.FunctionComponent<Props> = ({
                 <h2 className="mb-0">Access tokens</h2>
                 <LinkOrSpan
                     title={accessTokensEnabled ? '' : 'Access token creation is disabled in site configuration'}
-                    className={`btn btn-primary ml-2 ${accessTokensEnabled ? '' : 'disabled'}`}
+                    className={classNames('btn btn-primary ml-2', !accessTokensEnabled && 'disabled')}
                     to={accessTokensEnabled ? `${authenticatedUser.settingsURL!}/tokens/new` : null}
                 >
                     <AddIcon className="icon-inline" /> Generate access token

--- a/client/web/src/site/FreeUsersExceededAlert.tsx
+++ b/client/web/src/site/FreeUsersExceededAlert.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 /**
@@ -7,7 +8,7 @@ export const FreeUsersExceededAlert: React.FunctionComponent<{
     noLicenseWarningUserCount: number | null
     className?: string
 }> = ({ noLicenseWarningUserCount, className = '' }) => (
-    <div className={`alert alert-danger ${className}`}>
+    <div className={classNames('alert alert-danger', className)}>
         This Sourcegraph instance has reached{' '}
         {noLicenseWarningUserCount === null ? 'the limit for' : noLicenseWarningUserCount} free users, and an admin must{' '}
         <a className="site-alert__link" href="https://sourcegraph.com/user/subscriptions/new">

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -68,7 +68,7 @@ export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, on
     }
 
     return (
-        <div className={`add-user-email-form ${className || ''}`}>
+        <div className={classNames('add-user-email-form', className)}>
             <label
                 htmlFor="AddUserEmailForm-email"
                 className={classNames('align-self-start', {

--- a/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
+++ b/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useState, FunctionComponent, useCallback } from 'react'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
@@ -70,7 +71,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<Props> = ({ user, emails
     )
 
     return (
-        <div className={`add-user-email-form ${className || ''}`}>
+        <div className={classNames('add-user-email-form', className)}>
             <label htmlFor="setUserPrimaryEmailForm-email">Primary email address</label>
             <Form className="form-inline" onSubmit={onSubmit}>
                 <select


### PR DESCRIPTION
## Context 

To improve consistency of class names creation in React components and avoid processing template literal cases in the [global-css-to-css-modules](https://github.com/sourcegraph/codemod/tree/main/src/transforms/globalCssToCssModule) codemod another codemod [was added](https://github.com/sourcegraph/codemod/pull/28) to automatically transform template literals to `classNames()` utility calls:

```tsx
<div className={`cool-class ${props.className || ''}`} />
// turns into 
<div className={classNames('cool-class', props.className)} />
```

This PR applies a newly added codemod to the part of the codebase. 

## Changes

- Converted template literals usage in `className` prop to `classNames()` utility call.