### PR TITLE
Speed up fetching/loading of extensions via `graphql?Extensions`

### DIFF
--- a/client/shared/src/api/extension/test/activation.test.ts
+++ b/client/shared/src/api/extension/test/activation.test.ts
@@ -23,7 +23,7 @@ describe('Extension activation', () => {
             const FIXTURE_EXTENSION: ExecutableExtension = {
                 scriptURL: 'https://fixture.extension',
                 id: 'sourcegraph/fixture-extension',
-                manifest: { url: 'a', activationEvents: ['*'] },
+                manifest: { url: 'a', contributes: {}, activationEvents: ['*'] },
             }
 
             const haveInitialExtensionsLoaded = new BehaviorSubject<boolean>(false)

--- a/client/shared/src/extensions/extension.ts
+++ b/client/shared/src/extensions/extension.ts
@@ -5,9 +5,19 @@ import { asError, ErrorLike, isErrorLike } from '../util/errors'
 import { ExtensionManifest, parseExtensionManifestOrError } from './extensionManifest'
 
 /**
- * Describes a configured extension.
+ * The default fields in the {@link ConfiguredExtension} manifest (i.e., the default value of the
+ * `K` type parameter).
  */
-export interface ConfiguredExtension {
+export const CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS = ['contributes', 'activationEvents', 'url'] as const
+export type ConfiguredExtensionManifestDefaultFields = typeof CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS[number]
+
+/**
+ * Describes a configured extension.
+ *
+ * @template K To reduce API surface, by default the manifest only contains the small subset of
+ * extension manifest fields that are needed to execute the extension.
+ */
+export interface ConfiguredExtension<K extends keyof ExtensionManifest = ConfiguredExtensionManifestDefaultFields> {
     /**
      * The extension's extension ID.
      *
@@ -16,7 +26,7 @@ export interface ConfiguredExtension {
     readonly id: string
 
     /** The parsed extension manifest, null if there is none, or a parse error. */
-    readonly manifest: ExtensionManifest | null | ErrorLike
+    readonly manifest: Pick<ExtensionManifest, K> | null | ErrorLike
 }
 
 /**
@@ -30,7 +40,7 @@ export interface ConfiguredRegistryExtension<
         GQL.IRegistryExtension,
         'id' | 'url' | 'viewerCanAdminister'
     >
-> extends ConfiguredExtension {
+> extends ConfiguredExtension<keyof ExtensionManifest> {
     /** The extension's metadata on the registry, if this is a registry extension. */
     readonly registryExtension?: X
 

--- a/client/shared/src/extensions/helpers.test.ts
+++ b/client/shared/src/extensions/helpers.test.ts
@@ -1,0 +1,70 @@
+import { GraphQLError } from 'graphql'
+import { of } from 'rxjs'
+import { TestScheduler } from 'rxjs/testing'
+
+import { ErrorGraphQLResult, SuccessGraphQLResult } from '../graphql/graphql'
+import { PlatformContext } from '../platform/context'
+
+import { ConfiguredExtension } from './extension'
+import { ExtensionManifest } from './extensionManifest'
+import { queryConfiguredRegistryExtensions } from './helpers'
+
+const TEST_MANIFEST_RAW = '{"publisher":"a","url":"https://example.com","activationEvents":[]}'
+const TEST_MANIFEST: ExtensionManifest = { publisher: 'a', url: 'https://example.com', activationEvents: [] }
+
+const scheduler = (): TestScheduler => new TestScheduler((actual, expected) => expect(actual).toStrictEqual(expected))
+
+describe('queryConfiguredRegistryExtensions', () => {
+    it('gets extensions from GraphQL servers supporting extensions(extensionIDs)', () => {
+        const requestGraphQL: PlatformContext['requestGraphQL'] = () =>
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            of({
+                data: {
+                    extensionRegistry: {
+                        extensions: {
+                            nodes: [{ extensionID: 'a/b', manifest: { raw: TEST_MANIFEST_RAW } }],
+                        },
+                    },
+                },
+            } as SuccessGraphQLResult<any>)
+        scheduler().run(({ expectObservable }) => {
+            expectObservable(queryConfiguredRegistryExtensions({ requestGraphQL }, ['a/b'])).toBe('(a|)', {
+                a: [{ id: 'a/b', manifest: TEST_MANIFEST }] as ConfiguredExtension[],
+            })
+        })
+    })
+
+    it('gets extensions from GraphQL servers not supporting extensions(extensionIDs) and only supporting prioritizeExtensionIDs', () => {
+        let calledWithExtensionIDsParameter = false
+        const requestGraphQL: PlatformContext['requestGraphQL'] = ({ request }) => {
+            if (request.includes('prioritizeExtensionIDs: ')) {
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                return of({
+                    data: {
+                        extensionRegistry: {
+                            extensions: {
+                                nodes: [{ extensionID: 'a/b', manifest: { raw: TEST_MANIFEST_RAW } }],
+                            },
+                        },
+                    },
+                } as SuccessGraphQLResult<any>)
+            }
+            calledWithExtensionIDsParameter = true
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            return of({
+                data: undefined,
+                errors: [
+                    {
+                        message: 'Unknown argument "extensionIDs" on field "extensions" of type "ExtensionRegistry".',
+                    },
+                ] as GraphQLError[],
+            } as ErrorGraphQLResult)
+        }
+        scheduler().run(({ expectObservable }) => {
+            expectObservable(queryConfiguredRegistryExtensions({ requestGraphQL }, ['a/b'])).toBe('(a|)', {
+                a: [{ id: 'a/b', manifest: TEST_MANIFEST }] as ConfiguredExtension[],
+            })
+        })
+        expect(calledWithExtensionIDsParameter).toBeTruthy()
+    })
+})

--- a/client/shared/src/extensions/helpers.test.ts
+++ b/client/shared/src/extensions/helpers.test.ts
@@ -5,12 +5,16 @@ import { TestScheduler } from 'rxjs/testing'
 import { ErrorGraphQLResult, SuccessGraphQLResult } from '../graphql/graphql'
 import { PlatformContext } from '../platform/context'
 
-import { ConfiguredExtension } from './extension'
+import { ConfiguredExtension, ConfiguredExtensionManifestDefaultFields } from './extension'
 import { ExtensionManifest } from './extensionManifest'
 import { queryConfiguredRegistryExtensions } from './helpers'
 
 const TEST_MANIFEST_RAW = '{"publisher":"a","url":"https://example.com","activationEvents":[]}'
-const TEST_MANIFEST: ExtensionManifest = { publisher: 'a', url: 'https://example.com', activationEvents: [] }
+const TEST_MANIFEST: Pick<ExtensionManifest, ConfiguredExtensionManifestDefaultFields | 'publisher'> = {
+    publisher: 'a',
+    url: 'https://example.com',
+    activationEvents: [],
+}
 
 const scheduler = (): TestScheduler => new TestScheduler((actual, expected) => expect(actual).toStrictEqual(expected))
 
@@ -22,7 +26,7 @@ describe('queryConfiguredRegistryExtensions', () => {
                 data: {
                     extensionRegistry: {
                         extensions: {
-                            nodes: [{ extensionID: 'a/b', manifest: { raw: TEST_MANIFEST_RAW } }],
+                            nodes: [{ extensionID: 'a/b', manifest: { jsonFields: TEST_MANIFEST } }],
                         },
                     },
                 },
@@ -34,10 +38,10 @@ describe('queryConfiguredRegistryExtensions', () => {
         })
     })
 
-    it('gets extensions from GraphQL servers not supporting extensions(extensionIDs) and only supporting prioritizeExtensionIDs', () => {
+    it('gets extensions from GraphQL servers not supporting extensions(extensionIDs)/jsonFields and only supporting prioritizeExtensionIDs', () => {
         let calledWithExtensionIDsParameter = false
         const requestGraphQL: PlatformContext['requestGraphQL'] = ({ request }) => {
-            if (request.includes('prioritizeExtensionIDs: ')) {
+            if (request.includes('prioritizeExtensionIDs: ') && !request.includes('jsonFields(')) {
                 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 return of({
                     data: {
@@ -56,6 +60,9 @@ describe('queryConfiguredRegistryExtensions', () => {
                 errors: [
                     {
                         message: 'Unknown argument "extensionIDs" on field "extensions" of type "ExtensionRegistry".',
+                    },
+                    {
+                        message: 'Cannot query field "jsonFields" on type "ExtensionManifest".',
                     },
                 ] as GraphQLError[],
             } as ErrorGraphQLResult)

--- a/client/shared/src/testing/integration/mockExtension.ts
+++ b/client/shared/src/testing/integration/mockExtension.ts
@@ -73,7 +73,7 @@ export function setupExtensionMocking({
             extensionsResult.extensionRegistry.extensions.nodes.push({
                 extensionID: id,
                 manifest: {
-                    raw: JSON.stringify(extensionManifest),
+                    jsonFields: extensionManifest,
                 },
             })
 

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -223,13 +223,10 @@ describe('Blob viewer', () => {
                         extensions: {
                             nodes: [
                                 {
-                                    id: 'TestExtensionID',
                                     extensionID: 'test/test',
                                     manifest: {
-                                        raw: JSON.stringify(extensionManifest),
+                                        jsonFields: extensionManifest,
                                     },
-                                    url: '/extensions/test/test',
-                                    viewerCanAdminister: false,
                                 },
                             ],
                         },
@@ -295,12 +292,8 @@ describe('Blob viewer', () => {
         })
 
         interface MockExtension {
-            id: string
             extensionID: string
             extensionManifest: ExtensionManifest
-            /** The URL of the JavaScript bundle */
-            url: string
-            viewerCanAdminister: boolean
             /**
              * A function whose body is a Sourcegraph extension.
              *
@@ -315,7 +308,6 @@ describe('Blob viewer', () => {
         it('adds and clears line decoration attachments properly', async () => {
             const mockExtensions: MockExtension[] = [
                 {
-                    id: 'TestFixedLineID',
                     extensionID: 'test/fixed-line',
                     extensionManifest: {
                         url: new URL(
@@ -324,8 +316,6 @@ describe('Blob viewer', () => {
                         ).href,
                         activationEvents: ['*'],
                     },
-                    url: '/extensions/test/fixed-line',
-                    viewerCanAdminister: false,
                     bundle: function extensionBundle(): void {
                         // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
                         const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
@@ -379,7 +369,6 @@ describe('Blob viewer', () => {
                     },
                 },
                 {
-                    id: 'TestSelectedLineID',
                     extensionID: 'test/selected-line',
                     extensionManifest: {
                         url: new URL(
@@ -388,8 +377,6 @@ describe('Blob viewer', () => {
                         ).href,
                         activationEvents: ['*'],
                     },
-                    url: '/extensions/test/selected-line',
-                    viewerCanAdminister: false,
                     bundle: function extensionBundle(): void {
                         // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
                         const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
@@ -513,7 +500,7 @@ describe('Blob viewer', () => {
                         extensions: {
                             nodes: mockExtensions.map(mockExtension => ({
                                 ...mockExtension,
-                                manifest: { raw: JSON.stringify(mockExtension.extensionManifest) },
+                                manifest: { jsonFields: mockExtension.extensionManifest },
                             })),
                         },
                     },
@@ -629,7 +616,6 @@ describe('Blob viewer', () => {
              */
 
             const wordFinder: MockExtension = {
-                id: 'TestWordFinderID',
                 extensionID: 'test/word-finder',
                 extensionManifest: {
                     url: new URL(
@@ -638,8 +624,6 @@ describe('Blob viewer', () => {
                     ).href,
                     activationEvents: ['*'],
                 },
-                url: '/extensions/test/word-finder',
-                viewerCanAdminister: false,
                 bundle: function extensionBundle(): void {
                     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
                     const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
@@ -782,7 +766,7 @@ describe('Blob viewer', () => {
                                 {
                                     ...wordFinder,
                                     manifest: {
-                                        raw: JSON.stringify(wordFinder.extensionManifest),
+                                        jsonFields: wordFinder.extensionManifest,
                                     },
                                 },
                             ],
@@ -920,13 +904,10 @@ describe('Blob viewer', () => {
                         extensions: {
                             nodes: [
                                 {
-                                    id: 'TestExtensionID',
                                     extensionID: 'test/references',
                                     manifest: {
-                                        raw: JSON.stringify(extensionManifest),
+                                        jsonFields: extensionManifest,
                                     },
-                                    url: '/extensions/test/references',
-                                    viewerCanAdminister: false,
                                 },
                             ],
                         },

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -95,13 +95,13 @@ const extensionNodes: ExtensionsResult['extensionRegistry']['extensions']['nodes
     {
         extensionID: 'sourcegraph/typescript',
         manifest: {
-            raw: typescriptRawManifest,
+            jsonFields: typescriptRawManifest,
         },
     },
     {
         extensionID: 'sqs/word-count',
         manifest: {
-            raw: wordCountRawManifest,
+            jsonFields: wordCountRawManifest,
         },
     },
 ]

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -752,13 +752,10 @@ describe('Repository', () => {
                         extensions: {
                             nodes: [
                                 {
-                                    id: 'TestExtensionID',
                                     extensionID: 'test/test',
                                     manifest: {
-                                        raw: JSON.stringify(extensionManifest),
+                                        jsonFields: extensionManifest,
                                     },
-                                    url: '/extensions/test/test',
-                                    viewerCanAdminister: false,
                                 },
                             ],
                         },

--- a/client/web/src/settings/configuration.test.ts
+++ b/client/web/src/settings/configuration.test.ts
@@ -13,8 +13,6 @@ describe('mergeSettingsSchemas', () => {
             mergeSettingsSchemas([
                 {
                     manifest: {
-                        url: '',
-                        activationEvents: [],
                         contributes: {
                             configuration: { additionalProperties: false, properties: { a: { type: 'string' } } },
                         },
@@ -22,8 +20,6 @@ describe('mergeSettingsSchemas', () => {
                 },
                 {
                     manifest: {
-                        url: '',
-                        activationEvents: [],
                         contributes: {
                             configuration: { required: ['b'], properties: { b: { type: 'string' } } },
                         },
@@ -43,8 +39,6 @@ describe('mergeSettingsSchemas', () => {
             mergeSettingsSchemas([
                 {
                     manifest: {
-                        url: '',
-                        activationEvents: [],
                         contributes: {
                             configuration: { additionalProperties: false, properties: { a: { type: 'string' } } },
                         },
@@ -57,10 +51,10 @@ describe('mergeSettingsSchemas', () => {
                     manifest: null,
                 },
                 {
-                    manifest: { url: '', activationEvents: [] },
+                    manifest: {},
                 },
                 {
-                    manifest: { url: '', activationEvents: [], contributes: {} },
+                    manifest: { contributes: {} },
                 },
             ])
         ).toEqual({

--- a/client/web/src/settings/configuration.ts
+++ b/client/web/src/settings/configuration.ts
@@ -1,4 +1,4 @@
-import { ConfiguredRegistryExtension } from '@sourcegraph/shared/src/extensions/extension'
+import { ConfiguredExtension } from '@sourcegraph/shared/src/extensions/extension'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import settingsSchemaJSON from '../../../../schema/settings.schema.json'
@@ -9,7 +9,9 @@ import settingsSchemaJSON from '../../../../schema/settings.schema.json'
  * @param configuredExtensions
  * @returns A JSON Schema that describes an instance of settings for a particular subject.
  */
-export function mergeSettingsSchemas(configuredExtensions: Pick<ConfiguredRegistryExtension, 'manifest'>[]): any {
+export function mergeSettingsSchemas(
+    configuredExtensions: Pick<ConfiguredExtension<'contributes'>, 'manifest'>[]
+): { allOf: object } {
     return {
         allOf: [
             { $ref: settingsSchemaJSON.$id },

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -128,6 +128,7 @@ type RegistryExtension interface {
 // ExtensionManifest is the interface for the GraphQL type ExtensionManifest.
 type ExtensionManifest interface {
 	Raw() string
+	JSONFields(*struct{ Fields []string }) JSONValue
 	Description() (*string, error)
 	BundleURL() (*string, error)
 }

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -62,6 +62,7 @@ type RegistryExtensionConnectionArgs struct {
 	Publisher              *graphql.ID
 	Local                  bool
 	Remote                 bool
+	ExtensionIDs           *[]string
 	PrioritizeExtensionIDs *[]string
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5824,9 +5824,11 @@ type ExtensionRegistry {
         """
         remote: Boolean = true
         """
+        Returns only extensions with the given IDs.
+        """
+        extensionIDs: [String!]
+        """
         Sorts the list of extension results such that the extensions with these IDs are first in the result set.
-        Typically, the client passes the list of added and enabled extension IDs in this parameter so that the
-        results include those extensions first (which is typically what the user prefers).
         """
         prioritizeExtensionIDs: [String!]
     ): RegistryExtensionConnection!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6067,9 +6067,19 @@ A description of the extension, how to run or access it, and when to activate it
 """
 type ExtensionManifest {
     """
-    The raw JSON contents of the manifest.
+    The raw JSON (or JSONC) contents of the manifest. This value may be large (because many
+    manifests contain README and icon data), and it is JSONC (not strict JSON), which means
+    it must be parsed with a JSON parser that supports trailing commas and comments. Consider
+    using jsonFields instead.
     """
     raw: String!
+    """
+    The manifest as JSON (not JSONC, even if the raw manifest is JSONC) with only the
+    specified fields. This is useful for callers that only need certain fields and want
+    to avoid fetching a large amount of data (because many manifests contain README
+    and icon data).
+    """
+    jsonFields(fields: [String!]!): JSONValue!
     """
     The description specified in the manifest, if any.
     """

--- a/cmd/frontend/registry/api/extension_connection_graphql.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql.go
@@ -25,18 +25,24 @@ func makePrioritizeExtensionIDsSet(args graphqlbackend.RegistryExtensionConnecti
 }
 
 func (r *extensionRegistryResolver) Extensions(ctx context.Context, args *graphqlbackend.RegistryExtensionConnectionArgs) (graphqlbackend.RegistryExtensionConnection, error) {
-	return &registryExtensionConnectionResolver{args: *args, db: r.db}, nil
+	return &registryExtensionConnectionResolver{
+		args:                         *args,
+		db:                           r.db,
+		listRemoteRegistryExtensions: listRemoteRegistryExtensions,
+	}, nil
 }
 
 // registryExtensionConnectionResolver resolves a list of registry extensions.
 type registryExtensionConnectionResolver struct {
 	args graphqlbackend.RegistryExtensionConnectionArgs
 
+	db                           dbutil.DB
+	listRemoteRegistryExtensions func(_ context.Context, query string) ([]*registry.Extension, error)
+
 	// cache results because they are used by multiple fields
 	once               sync.Once
 	registryExtensions []graphqlbackend.RegistryExtension
 	err                error
-	db                 dbutil.DB
 }
 
 var (
@@ -76,13 +82,29 @@ func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]gr
 		// Query remote registry extensions, if filters would match any.
 		var remote []*registry.Extension
 		if args2.Publisher == nil && r.args.Remote {
-			xs, err := listRemoteRegistryExtensions(ctx, query)
+			xs, err := r.listRemoteRegistryExtensions(ctx, query)
 			if err != nil {
 				// Continue execution even if r.err != nil so that partial (local) results are returned
 				// even when the remote registry is inaccessible.
 				r.err = err
 			}
-			remote = append(remote, xs...)
+
+			if r.args.ExtensionIDs == nil {
+				remote = append(remote, xs...)
+			} else {
+				// The ExtensionIDs arg ("only include extensions specified by these IDs") is only
+				// applied at query time for local extensions, not remote extensions, so apply it
+				// here.
+				include := map[string]struct{}{}
+				for _, id := range *r.args.ExtensionIDs {
+					include[id] = struct{}{}
+				}
+				for _, x := range xs {
+					if _, ok := include[x.ExtensionID]; ok {
+						remote = append(remote, x)
+					}
+				}
+			}
 		}
 
 		r.registryExtensions = make([]graphqlbackend.RegistryExtension, len(local)+len(remote))
@@ -96,7 +118,9 @@ func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]gr
 		})
 
 		// Sort WIP extensions last. (The local extensions list is already sorted in that way, but
-		// the remote extensions list isn't, so therefore the combined list isn't.)
+		// the remote extensions list isn't, so therefore the combined list isn't.) Determining
+		// whether an extension is WIP is slow because it requires jsonc-parsing the manifest, so we
+		// precompute it for each element to avoid incurring the cost for each sort comparison.
 		sort.SliceStable(r.registryExtensions, func(i, j int) bool {
 			return !r.registryExtensions[i].IsWorkInProgress() && r.registryExtensions[j].IsWorkInProgress()
 		})

--- a/cmd/frontend/registry/api/extension_connection_graphql_test.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+func TestRegistryExtensionConnectionResolver(t *testing.T) {
+	int32Ptr := func(v int32) *int32 { return &v }
+	stringSlicePtr := func(s []string) *[]string { return &s }
+	extensionIDs := func(xs []graphqlbackend.RegistryExtension) (ids []string) {
+		for _, x := range xs {
+			ids = append(ids, x.ExtensionID())
+		}
+		return ids
+	}
+
+	ListLocalRegistryExtensions = func(context.Context, dbutil.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
+		return nil, nil
+	}
+	defer func() {
+		ListLocalRegistryExtensions = nil
+	}()
+
+	ctx := context.Background()
+
+	t.Run("first, prioritizeExtensionIDs", func(t *testing.T) {
+		r := registryExtensionConnectionResolver{
+			args: graphqlbackend.RegistryExtensionConnectionArgs{
+				ConnectionArgs:         graphqlutil.ConnectionArgs{First: int32Ptr(3)},
+				Remote:                 true,
+				Local:                  true,
+				PrioritizeExtensionIDs: stringSlicePtr([]string{"a/z1"}),
+			},
+			listRemoteRegistryExtensions: func(_ context.Context, query string) ([]*registry.Extension, error) {
+				return []*registry.Extension{
+					{ExtensionID: "a/wip0", Manifest: strptr(`{"wip": true}`)},
+					{ExtensionID: "a/z0", Manifest: strptr(`{}`)},
+					{ExtensionID: "a/z1", Manifest: strptr(`{}`)},
+					{ExtensionID: "z/z", Manifest: strptr(`{"wip": true}`)},
+				}, nil
+			},
+		}
+
+		nodes, err := r.Nodes(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ids, want := extensionIDs(nodes), []string{"a/z1", "a/z0", "a/wip0"}; !reflect.DeepEqual(ids, want) {
+			t.Errorf("got ids %v, want %v", ids, want)
+		}
+
+		totalCount, err := r.TotalCount(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := int32(4); totalCount != want {
+			t.Errorf("got totalCount %d, want %d", totalCount, want)
+		}
+	})
+
+	t.Run("extensionIDs", func(t *testing.T) {
+		r := registryExtensionConnectionResolver{
+			args: graphqlbackend.RegistryExtensionConnectionArgs{
+				Remote:       true,
+				Local:        true,
+				ExtensionIDs: stringSlicePtr([]string{"a/a"}),
+			},
+			listRemoteRegistryExtensions: func(_ context.Context, query string) ([]*registry.Extension, error) {
+				return []*registry.Extension{
+					{ExtensionID: "a/b", Manifest: strptr(`{}`)},
+					{ExtensionID: "a/a", Manifest: strptr(`{}`)},
+				}, nil
+			},
+		}
+
+		nodes, err := r.Nodes(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ids, want := extensionIDs(nodes), []string{"a/a"}; !reflect.DeepEqual(ids, want) {
+			t.Errorf("got ids %v, want %v", ids, want)
+		}
+
+		totalCount, err := r.TotalCount(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := int32(1); totalCount != want {
+			t.Errorf("got totalCount %d, want %d", totalCount, want)
+		}
+	})
+}

--- a/cmd/frontend/registry/api/extension_manifest.go
+++ b/cmd/frontend/registry/api/extension_manifest.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -35,6 +36,30 @@ func (r *extensionManifest) parse() (*schema.SourcegraphExtensionManifest, error
 }
 
 func (r *extensionManifest) Raw() string { return r.raw }
+
+func (r *extensionManifest) JSONFields(args *struct{ Fields []string }) graphqlbackend.JSONValue {
+	return jsonValueWithFields(r.raw, args.Fields)
+}
+
+func jsonValueWithFields(jsoncStr string, fields []string) graphqlbackend.JSONValue {
+	o := map[string]json.RawMessage{}
+	jsonc.Unmarshal(jsoncStr, &o) // ignore error and treat as empty object
+
+	keepField := func(field string) bool {
+		for _, f := range fields {
+			if f == field {
+				return true
+			}
+		}
+		return false
+	}
+	for field := range o {
+		if !keepField(field) {
+			delete(o, field)
+		}
+	}
+	return graphqlbackend.JSONValue{Value: o}
+}
 
 func (r *extensionManifest) Description() (*string, error) {
 	parsed, err := r.parse()

--- a/cmd/frontend/registry/api/extension_manifest_test.go
+++ b/cmd/frontend/registry/api/extension_manifest_test.go
@@ -1,0 +1,39 @@
+package api
+
+import "testing"
+
+func TestJSONValueWithFields(t *testing.T) {
+	tests := map[string]struct {
+		jsoncStr string
+		fields   []string
+		want     string
+	}{
+		"invalid json top-level": {
+			jsoncStr: `{`,
+			fields:   []string{"x"},
+			want:     `{}`,
+		},
+		"invalid json in field": {
+			jsoncStr: `{"a": {"b": }, "c": 3}`,
+			fields:   []string{"a", "c"},
+			want:     `{}`,
+		},
+		"subset of fields": {
+			jsoncStr: `{"a": 1, "b": {"c": 3,}, "d": true,}`,
+			fields:   []string{"d", "b", "x"},
+			want:     `{"b":{"c":3},"d":true}`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := jsonValueWithFields(test.jsoncStr, test.fields)
+			got, err := v.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.want {
+				t.Errorf("got %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
@@ -66,6 +66,9 @@ func toDBExtensionsListOptions(args graphqlbackend.RegistryExtensionConnectionAr
 	if args.Query != nil {
 		opt.Query, opt.Category, opt.Tag = parseExtensionQuery(*args.Query)
 	}
+	if args.ExtensionIDs != nil {
+		opt.ExtensionIDs = *args.ExtensionIDs
+	}
 	if args.PrioritizeExtensionIDs != nil {
 		opt.PrioritizeExtensionIDs = *args.PrioritizeExtensionIDs
 	}

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
@@ -66,6 +66,10 @@ func TestToDBExtensionsListOptions(t *testing.T) {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b tag:"T🚀" c`)},
 			want: dbExtensionsListOptions{Query: "a b c", Tag: "T🚀"},
 		},
+		"ExensionIDs": {
+			args: graphqlbackend.RegistryExtensionConnectionArgs{ExtensionIDs: strarrayptr([]string{"a", "b"})},
+			want: dbExtensionsListOptions{ExtensionIDs: []string{"a", "b"}},
+		},
 		"PrioritizeExensionIDs": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{PrioritizeExtensionIDs: strarrayptr([]string{"a", "b"})},
 			want: dbExtensionsListOptions{PrioritizeExtensionIDs: []string{"a", "b"}},

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -226,6 +226,10 @@ func TestRegistryExtensions(t *testing.T) {
 			t.Run("List/Count by Publisher.Query one", func(t *testing.T) {
 				testListCount(t, dbExtensionsListOptions{Query: c.publisherName + "/" + x.Name}, wantByCurrent)
 			})
+			t.Run("List/Count with ExtensionIDs", func(t *testing.T) {
+				testList(t, dbExtensionsListOptions{ExtensionIDs: []string{xu.NonCanonicalExtensionID}}, []*dbExtension{xu})
+				testList(t, dbExtensionsListOptions{ExtensionIDs: []string{xo.NonCanonicalExtensionID}}, []*dbExtension{xo})
+			})
 			t.Run("List/Count with prioritizeExtensionIDs", func(t *testing.T) {
 				testList(t, dbExtensionsListOptions{PrioritizeExtensionIDs: []string{xu.NonCanonicalExtensionID}, LimitOffset: &database.LimitOffset{Limit: 1}}, []*dbExtension{xu})
 				testList(t, dbExtensionsListOptions{PrioritizeExtensionIDs: []string{xo.NonCanonicalExtensionID}, LimitOffset: &database.LimitOffset{Limit: 1}}, []*dbExtension{xo})


### PR DESCRIPTION
> **NOTE:** This PR is based on a branch that includes both #24627 and #24626. When those are merged, I'll rebase it onto `main`. You can review the diff now if you'd like.

These 2 perf improvements:

- Cut the `graphql?Extensions` response size from ~800kb to ~5kb (compressed), or ~1.3MB to ~86kb (uncompressed).
- Eliminate the need to JSONC-parse the result (which is slower than parsing JSON)
- Speed up the `graphql?Extensions` processing on the server from ~220ms to ~140ms.

Because this introduces 2 new things to the GraphQL API, it handles backcompat. Initially it tries to query `graphql?Extensions` with the new query. If that returns an error that indicates that the server is old, then it uses the old query. (This is important for, e.g., browser extensions updated from the Chrome Web Store with the new code running against a Sourcegraph instance that hasn't yet been updated.)

---

See commit messages:

- support fetching a subset of extension manifest fields for faster loads

   This cuts the `graphql?Extensions` response 

   Previously, the `graphql?Extensions` result was very large and slow to
   load/parse (~800kb compressed, ~1.3MB uncompressed, for the default set of
   extensions) because it included the full JSON `package.json` manifest for
   each extension. This file contains base64-encoded images and the full
   Markdown README contents, neither of which are necessary to execute
   extensions.

   Now, only a subset of the manifest's fields are fetched (`url`,
   `contributes`, `activationEvents`). TypeScript types are used to enforce
   that no callers are using fields that aren't fetched.
-  add `extensionIDs` param to GraphQL extensions queries

   This significantly speeds up the `graphql?Extensions` query that needs to
   run on each page load. Previously, the query to get the user's list of
   enabled extensions used the `prioritizeExtensionIDs` param (and a `first`
   param of the length), which means that only their enabled extensions are
   included in the result. That sounds right, but it doesn't "hint" the intent
   of the query enough to make it fast. Because the intent is just to sort
   ("prioritize"), the GraphQL backend still needs to process all possible
   extensions. (As it turns out, processing them is slow because it must sort
   a fairly large list based on properties that sometimes require parsing a
   lot of JSON to determine.)

   Using the new `extensionIDs` param (instead of `prioritizeExtensionIDs`)
   tells the GraphQL backend that it can ignore extensions not listed, so it
   doesn't need to sort them or otherwise process them.

   This speeds up the `graphql?Extensions` timing from ~220ms to ~140ms. It is
   also a simpler API that more closely matches the intent of this popular way
   of filtering the extensions results.

   Adds tests for GraphQL and DB interactions.