### PR TITLE
sg: wait for cmd readers to close before waiting on cmd

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -87,9 +87,8 @@ type startedCmd struct {
 }
 
 func (sc *startedCmd) Wait() error {
-	err := sc.Cmd.Wait()
 	sc.outWg.Wait()
-	return err
+	return sc.Cmd.Wait()
 }
 
 func (sc *startedCmd) CapturedStdout() string {


### PR DESCRIPTION
The docs say that calling `cmd.Wait()` before waiting for the readers to
close is incorrect:

> `Wait` will close the pipe after seeing the command exit, so most callers
> need not close the pipe themselves. It is thus incorrect to call `Wait`
> before all reads from the pipe have completed. For the same reason, it
> is incorrect to call `Run` when using `StdoutPipe`. See the example for
> idiomatic usage.

See: https://pkg.go.dev/os/exec#example-Cmd.StdoutPipe