### PR TITLE
internal/gitserver: Instrument calls to AddrForRepo

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -96,9 +96,16 @@ func (c *Client) addrForKey(key string) string {
 	return addrForKey(key, addrs)
 }
 
+var addForRepoInvoked = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "src_gitserver_addr_for_repo_invoked",
+	Help: "Number of times gitserver.AddrForRepo was invoked",
+})
+
 // AddrForRepo returns the gitserver address to use for the given repo name.
 // It should never be called with an empty slice.
 func AddrForRepo(repo api.RepoName, addrs []string) string {
+	addForRepoInvoked.Inc()
+
 	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
 	return addrForKey(string(repo), addrs)
 }


### PR DESCRIPTION
We would like to understand the invocation pattern of `AddrForRepo` to be able to better decide on a hashing algorithm for gitserver HA.

Tested locally, and this is what it looks like:

![s_2021-09-06_15:53:38](https://user-images.githubusercontent.com/2682729/132203119-86a2644f-c1f6-4e1f-ae7a-0189ac25addd.png)
