### PR TITLE
Fix sg command instruction

### DIFF
--- a/doc/dev/getting-started/quickstart_3_initialize_database.md
+++ b/doc/dev/getting-started/quickstart_3_initialize_database.md
@@ -14,7 +14,7 @@ createdb --user=sourcegraph --owner=sourcegraph --encoding=UTF8 --template=templ
 
 You can also use the `PGDATA_DIR` environment variable to specify a local folder (instead of a volume) to store the database files. See the `dev/redis-postgres.yml` file for more details.
 
-This can also be spun up using [`sg start redis-postgres`](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md), with the following `sg.config.override.yaml`:
+This can also be spun up using [`sg run redis-postgres`](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md), with the following `sg.config.override.yaml`:
 
 ```yaml
 env:


### PR DESCRIPTION
First day here, I was going through the getting started guide and stumbled on this :) 

This change fixes the `sg` instruction to spin up redis and postgres.

The guide was previously advising to use `sg start redis-postgres`,
but `redis-postgres` is a command and thus using it with `start`, which
is for command sets, returned an error.
