### PR TITLE
search: pin down gap in traces

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1543,6 +1543,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	if len(resolved.MissingRepoRevs) > 0 {
 		agg.Error(&missingRepoRevsError{Missing: resolved.MissingRepoRevs})
+		tr.LazyPrintf("adding error for missing repo revs - done")
 	}
 
 	agg.Send(streaming.SearchEvent{
@@ -1552,6 +1553,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			ExcludedArchived: resolved.ExcludedRepos.Archived,
 		},
 	})
+	tr.LazyPrintf("sending first stats (repos %d, excluded repos %+v) - done", len(resolved.RepoSet), resolved.ExcludedRepos)
 
 	if args.ResultTypes.Has(result.TypeRepo) {
 		wg := waitGroup(true)


### PR DESCRIPTION
With this little change it should be clear which part of the code is
responsible for the gap in the traces.

Either we are waiting to acquire the lock for appending to multierror or
we spend more time than we think on sending results to the UI.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
