### PR TITLE
extensibility: deduplicate panel menu items

### DIFF
--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -12,7 +12,7 @@ import { ActionsNavItems } from '@sourcegraph/shared/src/actions/ActionsNavItems
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { PanelViewData } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/features'
-import { ContributableMenu } from '@sourcegraph/shared/src/api/protocol'
+import { ContributableMenu, Contributions, Evaluated } from '@sourcegraph/shared/src/api/protocol'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
 import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
@@ -264,6 +264,7 @@ export const Panel = React.memo<Props>(props => {
                                 }}
                                 wrapInList={true}
                                 location={location}
+                                transformContributions={transformPanelContributions}
                             />
                         )}
                     </small>
@@ -304,3 +305,26 @@ export const ResizablePanel: React.FunctionComponent<Props> = props => (
         element={<Panel {...props} />}
     />
 )
+
+/**
+ * Temporary solution to code intel extensions all contributing the same panel actions.
+ */
+function transformPanelContributions(contributions: Evaluated<Contributions>): Evaluated<Contributions> {
+    const panelMenuItems = contributions.menus?.['panel/toolbar']
+    if (!panelMenuItems || panelMenuItems.length === 0) {
+        return contributions
+    }
+    // This won't dedup e.g. [{action: 'a', when: 'b'}, {when: 'b', action: 'a'}], but should
+    // work for the case this is hackily trying to prevent: multiple extensions generated with the
+    // same manifest.
+    const strings = new Set(panelMenuItems.map(menuItem => JSON.stringify(menuItem)))
+    const uniquePanelMenuItems = [...strings].map(string => JSON.parse(string))
+
+    return {
+        ...contributions,
+        menus: {
+            ...contributions.menus,
+            'panel/toolbar': uniquePanelMenuItems,
+        },
+    }
+}

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -310,21 +310,25 @@ export const ResizablePanel: React.FunctionComponent<Props> = props => (
  * Temporary solution to code intel extensions all contributing the same panel actions.
  */
 function transformPanelContributions(contributions: Evaluated<Contributions>): Evaluated<Contributions> {
-    const panelMenuItems = contributions.menus?.['panel/toolbar']
-    if (!panelMenuItems || panelMenuItems.length === 0) {
-        return contributions
-    }
-    // This won't dedup e.g. [{action: 'a', when: 'b'}, {when: 'b', action: 'a'}], but should
-    // work for the case this is hackily trying to prevent: multiple extensions generated with the
-    // same manifest.
-    const strings = new Set(panelMenuItems.map(menuItem => JSON.stringify(menuItem)))
-    const uniquePanelMenuItems = [...strings].map(string => JSON.parse(string))
+    try {
+        const panelMenuItems = contributions.menus?.['panel/toolbar']
+        if (!panelMenuItems || panelMenuItems.length === 0) {
+            return contributions
+        }
+        // This won't dedup e.g. [{action: 'a', when: 'b'}, {when: 'b', action: 'a'}], but should
+        // work for the case this is hackily trying to prevent: multiple extensions generated with the
+        // same manifest.
+        const strings = new Set(panelMenuItems.map(menuItem => JSON.stringify(menuItem)))
+        const uniquePanelMenuItems = [...strings].map(string => JSON.parse(string))
 
-    return {
-        ...contributions,
-        menus: {
-            ...contributions.menus,
-            'panel/toolbar': uniquePanelMenuItems,
-        },
+        return {
+            ...contributions,
+            menus: {
+                ...contributions.menus,
+                'panel/toolbar': uniquePanelMenuItems,
+            },
+        }
+    } catch {
+        return contributions
     }
 }

--- a/client/shared/src/api/extension/api/contribution.ts
+++ b/client/shared/src/api/extension/api/contribution.ts
@@ -142,9 +142,7 @@ function evaluateActionContributions<T>(
 }
 
 /**
- * Evaluates expressions in contribution definitions against the given context.
- * TODO(tj): wrong description, fix
- * also, make sure to parse on extension host side, even for builtin contributions!
+ * Parses expressions in contribution defitions so that they can be evaluated against various contexts.
  */
 export function parseContributionExpressions(contributions: Raw<Contributions>): Contributions {
     return {


### PR DESCRIPTION
close #23393.

Code intel extensions contribute the ["Mix precise and search-based results"](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions/-/blob/extensions/typescript/package.json?L58-61) (and for ["Show other repositories"](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions/-/blob/extensions/typescript/package.json?L54-57) for TypeScript/Go) action to the references panel.

The problem is that there's no `id` property on `MenuItemContribution`, so we can't cleanly deduplicate these menu items as users navigate between files of different languages; we can't _determine_ that they're intended to be the same menu item. We can most safely _assume_ that they're the same menu item when all properties are identical.  

This PR adds a **band-aid solution*** of deduplicating only panel menu items. We serialize panel menu items in one pass, then parse unique strings into menu items. I thought about doing deep equality checks for all the panel menu item objects, but that would run in quadratic time in the worst case. I also thought about adding this logic in the extension host so that , but 1) it would run way too often for e.g. hover actions, and 2) this is a temporary solution. We should look into applying memoization to context computation, but this may be tough given structured cloning etc.

---

Desired longer term solution is for code intel extensions to add language checks to `when` so the panel only shows code intel panel menu items for the active editor, which depends on adding [`activeEditor` info to context when `scope` isn't an editor](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/api/extension/api/context/context.ts?L58:58)). This is blocked by extension versioning issues. Adding an identifier that isn't in context for older versions of Sourcegraph would make menu items never show up. We can explore this solution once we have a versioning system that loads the latest compatible extension by default.

We can also add `id` to `MenuItemContribution`, but it's not desirable to give extension authors yet another thing to name. If people think this is reasonable, I think we could add this without many issues with regards to backwards compatibility.

*why a band-aid? Most extensions won't run into this problem. It's only because code intel extensions have essentially the same manifest, but loaded once for each language.