### PR TITLE
web: do not skip `__typename` generation, required for Apollo Client mocking

### DIFF
--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -53,7 +53,6 @@ async function generateGraphQlOperations() {
         preResolveTypes: true,
         operationResultSuffix: 'Result',
         omitOperationSuffix: true,
-        skipTypename: true,
         namingConvention: {
           typeNames: 'keep',
           enumValues: 'keep',


### PR DESCRIPTION
## Context

`__typename` property is required for Apollo Client to generate a valid cache. Without this property in generated types, it's impossible to [add correct mocks](https://github.com/sourcegraph/sourcegraph/commit/a28341f204072a386678d6e86a0e83a5a411f03b) without manual type amendment. This PR enables `__typename` property generation.

## Changes

- Graphql codegen now generates optional `__typename` field.