### PR TITLE
extensibility: handle theming on code hosts

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -633,6 +633,13 @@ export function handleCodeHost({
         filter(isInstanceOf(HTMLElement))
     )
 
+    // Handle theming
+    subscriptions.add(
+        (codeHost.isLightTheme ?? of(true)).subscribe(isLightTheme => {
+            document.body.classList.toggle('theme-light', isLightTheme)
+            document.body.classList.toggle('theme-dark', !isLightTheme)
+        })
+    )
     const nativeTooltipsEnabled = codeHost.nativeTooltipResolvers
         ? nativeTooltipsEnabledFromSettings(platformContext.settings)
         : of(false)
@@ -1061,7 +1068,7 @@ export function handleCodeHost({
                 } else if (diffOrFileInfoWithEditor.head) {
                     scopeEditor = diffOrFileInfoWithEditor.head.editor
                 } else {
-                    scopeEditor = diffOrFileInfoWithEditor.base!.editor
+                    scopeEditor = diffOrFileInfoWithEditor.base.editor
                 }
 
                 if (wasRemoved) {


### PR DESCRIPTION
Fix #24157 (and possibly other unknown visual bugs).

We added the ability to observe code host themes in #16589 to fix line decorations, but we didn't apply theme classes to `document.body`. As a result, we used GitHub's `--secondary` var, which is red for some reason.

TODO: scope styles (#23251). This PR will add a bunch more generic variable names that other code hosts will inevitably use (like `--secondary`). Currently looking into `postcss-prefix-selector`