### PR TITLE
extensibility: improve registry search experience

### DIFF
--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -172,12 +172,16 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
             return applyWIPFilter(enablementFilteredExtensionIDs, showExperimentalExtensions, extensions)
         })
 
-        categorySections = ORDERED_EXTENSION_CATEGORIES.filter(
-            category =>
-                filteredExtensionIDsByCategory[category].length > 0 &&
-                // Only show Programming Languages when it is the selected category
-                category !== 'Programming languages'
-        ).map(category => {
+        categorySections = ORDERED_EXTENSION_CATEGORIES.filter(category => {
+            // Hide category if there are no results
+            if (filteredExtensionIDsByCategory[category].length === 0) {
+                return false
+            }
+            // Only show Programming Languages when it is the selected category
+            // AND there is no search query. We shouldn't hide language extensions
+            // if users are looking for them.
+            return category !== 'Programming languages' || !!query.trim()
+        }).map(category => {
             const extensionIDsForCategory = filteredExtensionIDsByCategory[category]
 
             return (

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -270,7 +270,11 @@ func (o dbExtensionsListOptions) sqlConditions() []*sqlf.Query {
 			// "Other" or extensions with a manifest with no category. (Extensions with no manifest
 			// are omitted.) HACK: This ideally would be implemented at a different layer, but it is
 			// so much simpler to just special-case it here.
-			categoryConds = append(categoryConds, sqlf.Sprintf(`CASE WHEN rer.manifest IS NOT NULL THEN (rer.manifest->>'categories')::jsonb IS NULL ELSE false END`))
+			categoryConds = append(categoryConds, sqlf.Sprintf(`
+				CASE WHEN rer.manifest IS NOT NULL
+					THEN (rer.manifest->>'categories')::jsonb IS NULL
+					OR (rer.manifest->>'categories')::jsonb = '[]'
+				ELSE false END`))
 		}
 		conds = append(conds, sqlf.Sprintf("(%s)", sqlf.Join(categoryConds, ") OR (")))
 	}


### PR DESCRIPTION
Fix #24301: We intentionally hid programming language extensions in the extension registry when no category was selected. However, we shouldn't hide programming language extensions if users are explicitly searching for them (`query` is present).

Fix #22171: We previously only returned extensions with no `categories` property in their manifest. Now, return extensions with empty `categories` arrays as well. 