### PR TITLE
Improve integration test suite CI run script

### DIFF
--- a/client/shared/dev/generateCssModulesTypes.js
+++ b/client/shared/dev/generateCssModulesTypes.js
@@ -3,6 +3,7 @@
 const { spawn } = require('child_process')
 const path = require('path')
 
+const REPO_ROOT = path.join(__dirname, '../../..')
 const CSS_MODULES_GLOB = path.resolve(__dirname, '../../*/src/**/*.module.scss')
 const TSM_COMMAND = `yarn --silent --ignore-engines --ignore-scripts tsm --logLevel error "${CSS_MODULES_GLOB}" --includePaths node_modules client`
 const [BIN, ...ARGS] = TSM_COMMAND.split(' ')
@@ -14,6 +15,7 @@ function cssModulesTypings() {
   return spawn(BIN, ARGS, {
     stdio: 'inherit',
     shell: true,
+    cwd: REPO_ROOT,
   })
 }
 
@@ -24,6 +26,7 @@ function watchCSSModulesTypings() {
   return spawn(BIN, [...ARGS, '--watch'], {
     stdio: 'inherit',
     shell: true,
+    cwd: REPO_ROOT,
   })
 }
 

--- a/client/web/dev/server/development.server.ts
+++ b/client/web/dev/server/development.server.ts
@@ -67,10 +67,9 @@ export async function startDevelopmentServer(): Promise<void> {
         })
     )
 
-    server.listen(SOURCEGRAPH_HTTPS_PORT, '0.0.0.0', () => {
-        signale.success(`Development server is ready at ${chalk.blue.bold(WEB_SERVER_URL)}`)
-        signale.await('Waiting for Webpack to compile assets')
-    })
+    await server.start()
+    signale.success(`Development server is ready at ${chalk.blue.bold(WEB_SERVER_URL)}`)
+    signale.await('Waiting for Webpack to compile assets')
 }
 
 startDevelopmentServer().catch(error => signale.error(error))

--- a/client/web/gulpfile.js
+++ b/client/web/gulpfile.js
@@ -137,27 +137,27 @@ async function webpackDevelopmentServer() {
 const developmentServer = DEV_WEB_BUILDER === 'webpack' ? webpackDevelopmentServer : esbuildDevelopmentServer
 
 // Ensure the typings that TypeScript depends on are build to avoid first-time-run errors
-const codeGen = gulp.parallel(schema, graphQlSchema, graphQlOperations, cssModulesTypings)
+const generate = gulp.parallel(schema, graphQlSchema, graphQlOperations, cssModulesTypings)
 
 // Watches code generation only, rebuilds on file changes
-const watchCodeGen = gulp.parallel(watchSchema, watchGraphQlSchema, watchGraphQlOperations, watchCSSModulesTypings)
+const watchGenerators = gulp.parallel(watchSchema, watchGraphQlSchema, watchGraphQlOperations, watchCSSModulesTypings)
 
 /**
  * Builds everything.
  */
-const build = gulp.series(codeGen, webBuild)
+const build = gulp.series(generate, webBuild)
 
 /**
  * Starts a development server without initial code generation, watches everything and rebuilds on file changes.
  */
-const developmentWithoutInitialCodeGen = gulp.parallel(watchCodeGen, developmentServer)
+const developmentWithoutInitialCodeGen = gulp.parallel(watchGenerators, developmentServer)
 
 /**
  * Runs code generation first, then starts a development server, watches everything and rebuilds on file changes.
  */
 const development = gulp.series(
   // Ensure the typings that TypeScript depends on are build to avoid first-time-run errors
-  codeGen,
+  generate,
   developmentWithoutInitialCodeGen
 )
 
@@ -167,8 +167,8 @@ const development = gulp.series(
  */
 const watch = gulp.series(
   // Ensure the typings that TypeScript depends on are build to avoid first-time-run errors
-  codeGen,
-  gulp.parallel(watchCodeGen, watchWebpack)
+  generate,
+  gulp.parallel(watchGenerators, watchWebpack)
 )
 
 module.exports = {
@@ -181,6 +181,6 @@ module.exports = {
   watchWebpack,
   webBuild,
   developmentServer,
-  codeGen,
-  watchCodeGen,
+  generate,
+  watchGenerators,
 }

--- a/client/web/gulpfile.js
+++ b/client/web/gulpfile.js
@@ -22,6 +22,8 @@ const {
   watchGraphQlSchema,
   watchGraphQlOperations,
   watchSchema,
+  cssModulesTypings,
+  watchCSSModulesTypings,
 } = require('../shared/gulpfile')
 
 const { build: buildEsbuild } = require('./dev/esbuild/build')
@@ -128,19 +130,17 @@ async function webpackDevelopmentServer() {
   }
 
   const server = new WebpackDevServer(options, createWebpackCompiler(webpackConfig))
-  await new Promise((resolve, reject) => {
-    signale.await('Waiting for Webpack to compile assets')
-    server.listen(3080, '0.0.0.0', error => (error ? reject(error) : resolve()))
-  })
+  signale.await('Waiting for Webpack to compile assets')
+  await server.start()
 }
 
 const developmentServer = DEV_WEB_BUILDER === 'webpack' ? webpackDevelopmentServer : esbuildDevelopmentServer
 
 // Ensure the typings that TypeScript depends on are build to avoid first-time-run errors
-const codeGen = gulp.parallel(schema, graphQlOperations, graphQlSchema)
+const codeGen = gulp.parallel(schema, graphQlSchema, graphQlOperations, cssModulesTypings)
 
 // Watches code generation only, rebuilds on file changes
-const watchCodeGen = gulp.parallel(watchSchema, watchGraphQlSchema, watchGraphQlOperations)
+const watchCodeGen = gulp.parallel(watchSchema, watchGraphQlSchema, watchGraphQlOperations, watchCSSModulesTypings)
 
 /**
  * Builds everything.
@@ -181,4 +181,6 @@ module.exports = {
   watchWebpack,
   webBuild,
   developmentServer,
+  codeGen,
+  watchCodeGen,
 }

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -100,11 +100,11 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", "true"), // Don't download browser, we use "download-puppeteer-browser" script instead
 			bk.Env("ENTERPRISE", "1"),
 			bk.Env("PERCY_ON", "true"),
-			bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-web"),
-			bk.Cmd("yarn --cwd client/shared run download-puppeteer-browser"),
-			bk.Cmd("yarn percy exec -- yarn run cover-integration"),
-			bk.Cmd("yarn nyc report -r json"),
-			bk.Cmd("dev/ci/codecov.sh -c -F typescript -F integration"),
+			bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-build.sh client/web"),
+			bk.Cmd("echo \"--- Install puppeteer\" && yarn --cwd client/shared run download-puppeteer-browser"),
+			bk.Cmd("echo \"--- Run integration test suite\" && yarn percy exec -- yarn run cover-integration"),
+			bk.Cmd("echo \"--- Process NYC report\" && yarn nyc report -r json"),
+			bk.Cmd("echo \"--- Upload coverage report\" && dev/ci/codecov.sh -c -F typescript -F integration"),
 			bk.ArtifactPaths("./puppeteer/*.png"))
 
 		if c.isMainDryRun || c.isStorybookAffected() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,12 +8,7 @@ const {
   watchGraphQlSchema,
   watchGraphQlOperations,
 } = require('./client/shared/gulpfile')
-const {
-  webpack: webWebpack,
-  developmentServer,
-  codeGen: generate,
-  watchCodeGen: watchGenerators,
-} = require('./client/web/gulpfile')
+const { webpack: webWebpack, developmentServer, generate, watchGenerators } = require('./client/web/gulpfile')
 
 /**
  * Generates files needed for builds whenever files change.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,21 +7,13 @@ const {
   schema,
   watchGraphQlSchema,
   watchGraphQlOperations,
-  watchSchema,
-  cssModulesTypings,
-  watchCSSModulesTypings,
 } = require('./client/shared/gulpfile')
-const { webpack: webWebpack, developmentServer } = require('./client/web/gulpfile')
-
-/**
- * Generates files needed for builds.
- */
-const generate = gulp.parallel(schema, graphQlSchema, graphQlOperations, cssModulesTypings)
-
-/**
- * Starts all watchers on schema files.
- */
-const watchGenerators = gulp.parallel(watchSchema, watchGraphQlSchema, watchGraphQlOperations, watchCSSModulesTypings)
+const {
+  webpack: webWebpack,
+  developmentServer,
+  codeGen: generate,
+  watchCodeGen: watchGenerators,
+} = require('./client/web/gulpfile')
 
 /**
  * Generates files needed for builds whenever files change.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook",
-    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=2  \"./client/web/src/integration/**/*.test.ts\"",
+    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=2 \"./client/web/src/integration/**/*.test.ts\"",
     "test-browser-integration": "yarn --cwd client/browser run test-integration",
     "cover-integration": "nyc --hook-require=false yarn test-integration",
     "cover-browser-integration": "nyc --hook-require=false yarn --cwd client/browser test-integration",


### PR DESCRIPTION
**The final result in the CI logs** 

![image](https://user-images.githubusercontent.com/19534377/132324165-5a56d893-24c4-435b-bb32-8ff81e56c429.png)

Otherwise this PR does the following improvements:
- Fixes the CSS modules types generator when run outside of the repo root (`client/web`, for example)
- Fixes a deprecation in the Webpack dev server, which I saw along the way
- Adds the CSS generator to the set of generators run for build-web. They were missing there
- Share the set of generators to run for build-web, so this issue doesn't arise again
- Switch to a different run script where `yarn generate` isn't run twice
- The above grouping of log outputs into "steps"