### PR TITLE
Address deprecation in highlight.js

### DIFF
--- a/client/shared/src/util/markdown.ts
+++ b/client/shared/src/util/markdown.ts
@@ -33,7 +33,7 @@ export const highlightCodeSafe = (code: string, language?: string): string => {
             return code
         }
         if (language) {
-            return highlight(language, code, true).value
+            return highlight(code, { language, ignoreIllegals: true }).value
         }
         return highlightAuto(code).value
     } catch (error) {


### PR DESCRIPTION
The [highlight.js API changed](https://github.com/highlightjs/highlight.js/issues/2277) and this set of arguments is now deprecated. It logs a warning in the browser console on each page load, so it's rather noisy. This fixes it.
