### PR TITLE
Remove isLightTheme GraphQL flag from codebase

### DIFF
--- a/client/web/src/backend/diff.ts
+++ b/client/web/src/backend/diff.ts
@@ -27,7 +27,7 @@ export const fileDiffHunkFields = gql`
             lines
         }
         section
-        highlight(disableTimeout: false, isLightTheme: $isLightTheme) {
+        highlight(disableTimeout: false) {
             aborted
             lines {
                 kind

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -450,16 +450,10 @@ export const queryExternalChangesetWithFileDiffs = ({
     externalChangeset,
     first,
     after,
-    isLightTheme,
 }: ExternalChangesetFileDiffsVariables): Observable<ExternalChangesetFileDiffsFields> =>
     requestGraphQL<ExternalChangesetFileDiffsResult, ExternalChangesetFileDiffsVariables>(
         gql`
-            query ExternalChangesetFileDiffs(
-                $externalChangeset: ID!
-                $first: Int
-                $after: String
-                $isLightTheme: Boolean!
-            ) {
+            query ExternalChangesetFileDiffs($externalChangeset: ID!, $first: Int, $after: String) {
                 node(id: $externalChangeset) {
                     __typename
                     ...ExternalChangesetFileDiffsFields
@@ -468,7 +462,7 @@ export const queryExternalChangesetWithFileDiffs = ({
 
             ${externalChangesetFileDiffsFields}
         `,
-        { externalChangeset, first, after, isLightTheme }
+        { externalChangeset, first, after }
     ).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFileDiff.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFileDiff.tsx
@@ -52,7 +52,6 @@ export const ChangesetFileDiff: React.FunctionComponent<ChangesetFileDiffProps> 
                 after: args.after ?? null,
                 first: args.first ?? null,
                 externalChangeset: changesetID,
-                isLightTheme,
             }).pipe(
                 map(changeset => changeset.diff),
                 tap(diff => {
@@ -74,7 +73,7 @@ export const ChangesetFileDiff: React.FunctionComponent<ChangesetFileDiffProps> 
                         }
                 )
             ),
-        [changesetID, isLightTheme, queryExternalChangesetWithFileDiffs]
+        [changesetID, queryExternalChangesetWithFileDiffs]
     )
 
     const hydratedExtensionInfo = useMemo(() => {

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -458,9 +458,8 @@ const ChangesetSpecFileDiffConnection: React.FunctionComponent<
                 after: args.after ?? null,
                 first: args.first ?? null,
                 changesetSpec: spec.id,
-                isLightTheme,
             }),
-        [spec.id, isLightTheme, queryChangesetSpecFileDiffs]
+        [spec.id, queryChangesetSpecFileDiffs]
     )
     return (
         <FileDiffConnection

--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -304,11 +304,10 @@ export const queryChangesetSpecFileDiffs = ({
     changesetSpec,
     first,
     after,
-    isLightTheme,
 }: ChangesetSpecFileDiffsVariables): Observable<ChangesetSpecFileDiffConnectionFields> =>
     requestGraphQL<ChangesetSpecFileDiffsResult, ChangesetSpecFileDiffsVariables>(
         gql`
-            query ChangesetSpecFileDiffs($changesetSpec: ID!, $first: Int, $after: String, $isLightTheme: Boolean!) {
+            query ChangesetSpecFileDiffs($changesetSpec: ID!, $first: Int, $after: String) {
                 node(id: $changesetSpec) {
                     __typename
                     ...ChangesetSpecFileDiffsFields
@@ -317,7 +316,7 @@ export const queryChangesetSpecFileDiffs = ({
 
             ${changesetSpecFileDiffsFields}
         `,
-        { changesetSpec, first, after, isLightTheme }
+        { changesetSpec, first, after }
     ).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -97,7 +97,7 @@ interface BlobProps
     blobInfo: BlobInfo
 }
 
-export interface BlobInfo extends AbsoluteRepoFile, ThemeProps, ModeSpec {
+export interface BlobInfo extends AbsoluteRepoFile, ModeSpec {
     /** The raw content of the blob. */
     content: string
 

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -70,7 +70,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
     useEffect(() => {
         props.telemetryService.logViewEvent('Blob', { repoName, filePath })
-    }, [repoName, commitID, filePath, isLightTheme, renderMode, props.telemetryService])
+    }, [repoName, commitID, filePath, renderMode, props.telemetryService])
 
     useBreadcrumb(
         useMemo(() => {
@@ -113,7 +113,6 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                             repoName,
                             commitID,
                             filePath,
-                            isLightTheme,
                             disableTimeout,
                         })
                     ),
@@ -129,7 +128,6 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                             commitID,
                             filePath,
                             mode,
-                            isLightTheme,
                             // Properties used in `BlobPage` but not `Blob`
                             richHTML: blob.richHTML,
                             aborted: blob.highlight.aborted,
@@ -141,7 +139,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                         return [asError(error)]
                     })
                 ),
-            [repoName, revision, commitID, filePath, isLightTheme, mode]
+            [repoName, revision, commitID, filePath, mode]
         )
     )
 

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -8,8 +8,8 @@ import { ParsedRepoURI, makeRepoURI } from '@sourcegraph/shared/src/util/url'
 import { requestGraphQL } from '../../backend/graphql'
 import { BlobFileFields, BlobResult, BlobVariables } from '../../graphql-operations'
 
-function fetchBlobCacheKey(parsed: ParsedRepoURI & { isLightTheme: boolean; disableTimeout: boolean }): string {
-    return makeRepoURI(parsed) + String(parsed.isLightTheme) + String(parsed.disableTimeout)
+function fetchBlobCacheKey(parsed: ParsedRepoURI & { disableTimeout: boolean }): string {
+    return makeRepoURI(parsed) + String(parsed.disableTimeout)
 }
 
 export const fetchBlob = memoizeObservable(
@@ -17,18 +17,11 @@ export const fetchBlob = memoizeObservable(
         repoName: string
         commitID: string
         filePath: string
-        isLightTheme: boolean
         disableTimeout: boolean
     }): Observable<BlobFileFields | null> =>
         requestGraphQL<BlobResult, BlobVariables>(
             gql`
-                query Blob(
-                    $repoName: String!
-                    $commitID: String!
-                    $filePath: String!
-                    $isLightTheme: Boolean!
-                    $disableTimeout: Boolean!
-                ) {
+                query Blob($repoName: String!, $commitID: String!, $filePath: String!, $disableTimeout: Boolean!) {
                     repository(name: $repoName) {
                         commit(rev: $commitID) {
                             file(path: $filePath) {
@@ -41,7 +34,7 @@ export const fetchBlob = memoizeObservable(
                 fragment BlobFileFields on File2 {
                     content
                     richHTML
-                    highlight(disableTimeout: $disableTimeout, isLightTheme: $isLightTheme) {
+                    highlight(disableTimeout: $disableTimeout) {
                         aborted
                         html
                     }

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -285,9 +285,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                                 lineNumbers: true,
                                 diffMode: this.state.diffMode,
                             }}
-                            updateOnChange={`${this.props.repo.id}:${this.state.commitOrError.oid}:${String(
-                                this.props.isLightTheme
-                            )}`}
+                            updateOnChange={`${this.props.repo.id}:${this.state.commitOrError.oid}`}
                             defaultFirst={15}
                             hideSearch={true}
                             noSummaryIfAllNodesVisible={true}
@@ -316,7 +314,6 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
             repo: this.props.repo.id,
             base: commitParentOrEmpty(this.state.commitOrError as GitCommitFields),
             head: (this.state.commitOrError as GitCommitFields).oid,
-            isLightTheme: this.props.isLightTheme,
         })
 }
 

--- a/client/web/src/repo/compare/RepositoryCompareDiffPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareDiffPage.tsx
@@ -28,18 +28,10 @@ export function queryRepositoryComparisonFileDiffs(args: {
     head: string | null
     first?: number
     after?: string
-    isLightTheme: boolean
 }): Observable<GQL.IFileDiffConnection> {
     return queryGraphQL(
         gql`
-            query RepositoryComparisonDiff(
-                $repo: ID!
-                $base: String
-                $head: String
-                $first: Int
-                $after: String
-                $isLightTheme: Boolean!
-            ) {
+            query RepositoryComparisonDiff($repo: ID!, $base: String, $head: String, $first: Int, $after: String) {
                 node(id: $repo) {
                     ... on Repository {
                         comparison(base: $base, head: $head) {
@@ -115,7 +107,6 @@ export class RepositoryCompareDiffPage extends React.PureComponent<RepositoryCom
                         },
                         lineNumbers: true,
                     }}
-                    updateOnChange={String(this.props.isLightTheme)}
                     defaultFirst={15}
                     hideSearch={true}
                     noSummaryIfAllNodesVisible={true}
@@ -133,6 +124,5 @@ export class RepositoryCompareDiffPage extends React.PureComponent<RepositoryCom
             repo: this.props.repo.id,
             base: this.props.base.commitID,
             head: this.props.head.commitID,
-            isLightTheme: this.props.isLightTheme,
         })
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1211,9 +1211,14 @@ type Query {
     renderMarkdown(markdown: String!, options: MarkdownOptions): String!
     """
     EXPERIMENTAL: Syntax highlights a code string.
-    The isLightTheme argument is deprecated and ignored. It may be removed in the future.
     """
-    highlightCode(code: String!, fuzzyLanguage: String!, disableTimeout: Boolean!, isLightTheme: Boolean): String!
+    highlightCode(
+        code: String!
+        fuzzyLanguage: String!
+        disableTimeout: Boolean!
+        isLightTheme: Boolean
+            @deprecated(reason: "Not required anymore, highlighting is based on dynamic CSS variables now.")
+    ): String!
     """
     Looks up an instance of a type that implements SettingsSubject (i.e., something that has settings). This can
     be a site (which has global settings), an organization, or a user.
@@ -3096,10 +3101,8 @@ type FileDiffHunk {
     """
     highlight(
         disableTimeout: Boolean!
-        """
-        DEPRECATED: isLightTheme will be ignored since all highlights are done with CSS classes now
-        """
         isLightTheme: Boolean
+            @deprecated(reason: "Not required anymore, highlighting is based on dynamic CSS variables now.")
         """
         If highlightLongLines is true, lines which are longer than 2000 bytes are highlighted.
         2000 bytes is enabled. This may produce a significant amount of HTML
@@ -4098,10 +4101,8 @@ interface File2 {
     """
     highlight(
         disableTimeout: Boolean!
-        """
-        DEPRECATED: isLightTheme will be ignored since all highlights are done with CSS classes now
-        """
         isLightTheme: Boolean
+            @deprecated(reason: "Not required anymore, highlighting is based on dynamic CSS variables now.")
         """
         If highlightLongLines is true, lines which are longer than 2000 bytes are highlighted.
         2000 bytes is enabled. This may produce a significant amount of HTML
@@ -4163,10 +4164,8 @@ type VirtualFile implements File2 {
     """
     highlight(
         disableTimeout: Boolean!
-        """
-        DEPRECATED: isLightTheme will be ignored since all highlights are done with CSS classes now
-        """
         isLightTheme: Boolean
+            @deprecated(reason: "Not required anymore, highlighting is based on dynamic CSS variables now.")
         """
         If highlightLongLines is true, lines which are longer than 2000 bytes are highlighted.
         2000 bytes is enabled. This may produce a significant amount of HTML
@@ -4266,10 +4265,8 @@ type GitBlob implements TreeEntry & File2 {
     """
     highlight(
         disableTimeout: Boolean!
-        """
-        DEPRECATED: isLightTheme will be ignored since all highlights are done with CSS classes now
-        """
         isLightTheme: Boolean
+            @deprecated(reason: "Not required anymore, highlighting is based on dynamic CSS variables now.")
         """
         If highlightLongLines is true, lines which are longer than 2000 bytes are highlighted.
         2000 bytes is enabled. This may produce a significant amount of HTML


### PR DESCRIPTION
Also, adds a GraphQL deprecation annotation to the flag, so customers are more likely to discover it.
After this PR, we won't need to reload blobs after a theme change. I originally started this effort in https://github.com/sourcegraph/sourcegraph/pull/20625, but the diff became stale so started over here. Lot's of the things from the other PR have already been done by now.