### PR TITLE
executors: Bump src cli to latest version

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.31.0"
+const MinimumVersion = "3.31.1"


### PR DESCRIPTION
Contains the latest improvements to our logging UI and such, bringing them to our executor.