### PR TITLE
httptrace: improve logging of slow/unexpected http requests

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -216,7 +216,7 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 		if minDuration == 0 {
 			minDuration = time.Second
 		}
-		if customDuration, ok := slowPaths[r.URL.String()]; ok {
+		if customDuration, ok := slowPaths[r.URL.Path]; ok {
 			minDuration = customDuration
 		}
 

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -122,6 +122,13 @@ func RequestSource(ctx context.Context) SourceType {
 	return v.(SourceType)
 }
 
+// slowPaths is a list of endpoints that are slower than the average and for
+// which we only want to log a message if the duration is slower than the
+// threshold here..
+var slowPaths = map[string]time.Duration{
+	"/repo-update": 5 * time.Second,
+}
+
 // HTTPTraceMiddleware captures and exports metrics to Prometheus, etc.
 //
 // 🚨 SECURITY: This handler is served to all clients, even on private servers to clients who have
@@ -209,6 +216,9 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 		if minDuration == 0 {
 			minDuration = time.Second
 		}
+		if customDuration, ok := slowPaths[r.URL.String()]; ok {
+			minDuration = customDuration
+		}
 
 		if m.Duration >= minDuration || m.Code >= minCode {
 			kvs := make([]interface{}, 0, 20)
@@ -234,8 +244,13 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 			if gqlErr {
 				kvs = append(kvs, "graphql_error", gqlErr)
 			}
-
-			log15.Warn("http", kvs...)
+			var parts []string
+			if m.Duration >= minDuration {
+				parts = append(parts, "slow http request")
+			} else if m.Code >= minCode {
+				parts = append(parts, "unexpected status code")
+			}
+			log15.Warn(strings.Join(parts, ", "), kvs...)
 		}
 
 		// Notify sentry if the status code indicates our system had an error (e.g. 5xx).

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -247,7 +247,8 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 			var parts []string
 			if m.Duration >= minDuration {
 				parts = append(parts, "slow http request")
-			} else if m.Code >= minCode {
+			}
+			if m.Code >= minCode {
 				parts = append(parts, "unexpected status code")
 			}
 			log15.Warn(strings.Join(parts, ", "), kvs...)

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -124,7 +124,7 @@ func RequestSource(ctx context.Context) SourceType {
 
 // slowPaths is a list of endpoints that are slower than the average and for
 // which we only want to log a message if the duration is slower than the
-// threshold here..
+// threshold here.
 var slowPaths = map[string]time.Duration{
 	"/repo-update": 5 * time.Second,
 }


### PR DESCRIPTION
This does two things:

1. Prints more specific log messages if a request is either too slow or
   has an unexpected status code (or both!)
2. Introduces per-route overwriting of the threshold. Some routes are
   slower than others and I don't want to bump the general threshold to
   5 seconds for _every route_, but only for this specific one.

---

In practice: this removes the majority of these logs

![image](https://user-images.githubusercontent.com/1185253/132352591-1453e1f3-caa3-4564-822e-f5c37ebbc948.png)
