### PR TITLE
Fix gitignore in ui/assets

### DIFF
--- a/ui/assets/.gitignore
+++ b/ui/assets/.gitignore
@@ -6,4 +6,5 @@
 !img/**
 *.DS_Store
 *.ttf
+*.woff2
 *.png


### PR DESCRIPTION
After running `yarn build-web`, I got two untracked `.woff2` files in that directory as build artifacts. This excludes them properly. Not sure when we started generating these, though.
