### PR TITLE
fix: sync cloud icon in search results

### DIFF
--- a/client/shared/src/components/LastSyncedIcon.module.scss
+++ b/client/shared/src/components/LastSyncedIcon.module.scss
@@ -4,5 +4,6 @@
     top: 0.5rem;
     height: 1rem;
     isolation: isolate;
+    z-index: 1;
     background-color: inherit;
 }

--- a/client/shared/src/components/LastSyncedIcon.module.scss
+++ b/client/shared/src/components/LastSyncedIcon.module.scss
@@ -3,6 +3,6 @@
     right: 0.5rem;
     top: 0.5rem;
     height: 1rem;
-    z-index: 1000;
+    isolation: isolate;
     background-color: inherit;
 }


### PR DESCRIPTION
in result list sync the cloud icon stack context is set with a high z-index value.

**before**
![Screen Shot 2021-09-07 at 9 32 21 AM](https://user-images.githubusercontent.com/989826/132362918-d77903b0-f7e6-401d-8cd7-02c729190554.png)



**after**
![Screen Shot 2021-09-07 at 9 31 51 AM](https://user-images.githubusercontent.com/989826/132362889-d410b486-1042-48b5-8b06-3a3319c1bc7e.png)