### PR TITLE
Add SRC_DISABLE_PROFILER env var to sg config

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -15,6 +15,9 @@ env:
   # Enable sharded indexed search mode:
   INDEXED_SEARCH_SERVERS: localhost:3070 localhost:3071
 
+  # The profiler is a GCP feature and so is not supported locally.
+  SRC_DISABLE_PROFILER: 'true'
+
   GO111MODULE: 'on'
 
   DEPLOY_TYPE: dev


### PR DESCRIPTION
Based on a [conversation on another PR](https://github.com/sourcegraph/sourcegraph/pull/24688#discussion_r703642837), we determined that this env var should always be set in local dev.
