### PR TITLE
Fix user avatar flickering on page navigation

### DIFF
--- a/client/web/src/user/area/UserAreaHeader.tsx
+++ b/client/web/src/user/area/UserAreaHeader.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import * as React from 'react'
+import React, { useMemo } from 'react'
 import { NavLink } from 'react-router-dom'
 
 import { PageHeader } from '@sourcegraph/wildcard'
@@ -24,47 +24,61 @@ export interface UserAreaHeaderNavItem extends NavItemWithIconDescriptor<UserAre
 /**
  * Header for the user area.
  */
-export const UserAreaHeader: React.FunctionComponent<Props> = ({ url, navItems, className = '', ...props }) => (
-    <div className={classNames('user-area-header', className)}>
-        <div className="container">
-            <PageHeader
-                path={[
-                    {
-                        text: (
-                            <span className="align-middle">
-                                {props.user.displayName ? (
-                                    <>
-                                        {props.user.displayName} ({props.user.username})
-                                    </>
-                                ) : (
-                                    props.user.username
-                                )}
-                            </span>
-                        ),
-                        icon: () => <UserAvatar className="user-area-header__avatar" user={props.user} />,
-                    },
-                ]}
-                className="mb-3"
-            />
-            <div className="d-flex align-items-end justify-content-between">
-                <ul className="nav nav-tabs w-100">
-                    {navItems.map(
-                        ({ to, label, exact, icon: Icon, condition = () => true }) =>
-                            condition(props) && (
-                                <li key={label} className="nav-item">
-                                    <NavLink to={url + to} className="nav-link" activeClassName="active" exact={exact}>
-                                        <span>
-                                            {Icon && <Icon className="icon-inline" />}{' '}
-                                            <span className="text-content" data-tab-content={label}>
-                                                {label}
+export const UserAreaHeader: React.FunctionComponent<Props> = ({ url, navItems, className = '', ...props }) => {
+    /*
+     * The path segment would always be recreated on rerenders, thus invalidating the loop over it in PageHeader.
+     * As a result, the UserAvatar was always reinstanciated and rendered again, whenever the header rerenders
+     * (every location change, for example). This prevents it from flickering.
+     */
+    const path = useMemo(
+        () => [
+            {
+                text: (
+                    <span className="align-middle">
+                        {props.user.displayName ? (
+                            <>
+                                {props.user.displayName} ({props.user.username})
+                            </>
+                        ) : (
+                            props.user.username
+                        )}
+                    </span>
+                ),
+                icon: () => <UserAvatar className="user-area-header__avatar" user={props.user} />,
+            },
+        ],
+        [props.user]
+    )
+
+    return (
+        <div className={classNames('user-area-header', className)}>
+            <div className="container">
+                <PageHeader path={path} className="mb-3" />
+                <div className="d-flex align-items-end justify-content-between">
+                    <ul className="nav nav-tabs w-100">
+                        {navItems.map(
+                            ({ to, label, exact, icon: Icon, condition = () => true }) =>
+                                condition(props) && (
+                                    <li key={label} className="nav-item">
+                                        <NavLink
+                                            to={url + to}
+                                            className="nav-link"
+                                            activeClassName="active"
+                                            exact={exact}
+                                        >
+                                            <span>
+                                                {Icon && <Icon className="icon-inline" />}{' '}
+                                                <span className="text-content" data-tab-content={label}>
+                                                    {label}
+                                                </span>
                                             </span>
-                                        </span>
-                                    </NavLink>
-                                </li>
-                            )
-                    )}
-                </ul>
+                                        </NavLink>
+                                    </li>
+                                )
+                        )}
+                    </ul>
+                </div>
             </div>
         </div>
-    </div>
-)
+    )
+}


### PR DESCRIPTION
The path segment was always recreated, thus invalidating the loop over it in PageHeader. As a result, the UserAvatar was always reinstanciated and rendered again, whenever the header rerenders (every location change, for example). This prevents it from flickering.


https://user-images.githubusercontent.com/19534377/132387760-a7217675-84fb-4d53-b852-caa844e84790.mov

