### PR TITLE
opensource redis images

### DIFF
--- a/docker-images/redis-cache/Dockerfile
+++ b/docker-images/redis-cache/Dockerfile
@@ -1,6 +1,7 @@
 FROM redis:5-alpine@sha256:fea243676a4d2d67f5990ddcbd4a56db9423b7f25e55758491e39988efc1cfbe
 
 RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
+# hadolint ignore=DL3018
 RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0
 
 USER redis

--- a/docker-images/redis-cache/Dockerfile
+++ b/docker-images/redis-cache/Dockerfile
@@ -1,0 +1,10 @@
+FROM redis:5-alpine@sha256:fea243676a4d2d67f5990ddcbd4a56db9423b7f25e55758491e39988efc1cfbe
+
+RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
+RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0
+
+USER redis
+COPY redis.conf /etc/redis/redis.conf
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["redis-server", "/etc/redis/redis.conf"]

--- a/docker-images/redis-cache/build.sh
+++ b/docker-images/redis-cache/build.sh
@@ -3,9 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# This merely re-tags the image to match our official versioning scheme. The
-# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
-#
-# TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/redis-cache:21-08-13_c096e0d35@sha256:2e41070dbe579686ce421e556dd648f8d5a489505b9842262ba5a8b8a35fbd6c
-docker tag index.docker.io/sourcegraph/redis-cache:21-08-13_c096e0d35a@sha256:2e41070dbe579686ce421e556dd648f8d5a489505b9842262ba5a8b8a35fbd6c "$IMAGE"
+docker build -t "${IMAGE:-sourcegraph/redis-cache}" .

--- a/docker-images/redis-cache/redis.conf
+++ b/docker-images/redis-cache/redis.conf
@@ -1,0 +1,9 @@
+# allow access from all instances
+protected-mode no
+# limit memory usage, discard unused keys when hitting limit
+maxmemory 6gb
+maxmemory-policy allkeys-lru
+# snapshots on disk every minute
+dir /redis-data/
+appendonly no
+save 60 1

--- a/docker-images/redis-store/Dockerfile
+++ b/docker-images/redis-store/Dockerfile
@@ -1,6 +1,7 @@
 FROM redis:5-alpine@sha256:fea243676a4d2d67f5990ddcbd4a56db9423b7f25e55758491e39988efc1cfbe
 
 RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
+# hadolint ignore=DL3018
 RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0
 
 USER redis

--- a/docker-images/redis-store/Dockerfile
+++ b/docker-images/redis-store/Dockerfile
@@ -1,0 +1,10 @@
+FROM redis:5-alpine@sha256:fea243676a4d2d67f5990ddcbd4a56db9423b7f25e55758491e39988efc1cfbe
+
+RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
+RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0
+
+USER redis
+COPY redis.conf /etc/redis/redis.conf
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["redis-server", "/etc/redis/redis.conf"]

--- a/docker-images/redis-store/build.sh
+++ b/docker-images/redis-store/build.sh
@@ -3,9 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# This merely re-tags the image to match our official versioning scheme. The
-# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
-#
-# TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/redis-store:21-08-13_c096e0d35@sha256:3afb95c520eb9f32cc02b4f1d1208ff68360411a1b992a056aeb6020eb95499e
-docker tag index.docker.io/sourcegraph/redis-store:21-08-13_c096e0d35@sha256:3afb95c520eb9f32cc02b4f1d1208ff68360411a1b992a056aeb6020eb95499e "$IMAGE"
+docker build -t "${IMAGE:-sourcegraph/redis-store}" .

--- a/docker-images/redis-store/redis.conf
+++ b/docker-images/redis-store/redis.conf
@@ -1,0 +1,10 @@
+# allow access from all instances
+protected-mode no
+# limit memory usage, return error when hitting limit
+maxmemory 6gb
+maxmemory-policy noeviction
+# live commit log to disk, additionally snapshot every 5 minutes
+dir /redis-data/
+appendonly yes
+aof-use-rdb-preamble yes
+save 300 1


### PR DESCRIPTION
Builds are redis images in the SG repo, meaning they're not longer manually built from the [infra ](https://github.com/sourcegraph/infrastructure/tree/main/docker-images/redis-cache)repo. 