### PR TITLE
chore: add team/distribution label-to-project config

### DIFF
--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -36,12 +36,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.LABELER_GITHUB_TOKEN }}
     steps:
     - name: Get issue if relevant
-      if: ${{ github.event.issue && contains(github.event.issue.labels.*.name, 'team/distribution') }}
+      if: ${{ contains(github.event.issue.labels.*.name, 'team/distribution') }}
       env:
         NODE_ID: ${{ github.event.issue.node_id }}
       run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
     - name: Get pull request if relevant
-      if: ${{ github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'team/distribution') }}
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'team/distribution') }}
       env:
         NODE_ID: ${{ github.event.pull_request.node_id }}
       run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -27,9 +27,32 @@ jobs:
         column-name: "Triage"
         label-name: "team/batchers"
         columns-to-ignore: "*"
-    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
-      with:
-        action-token: "${{ secrets.LABELER_GITHUB_TOKEN }}"
-        project-url: "https://github.com/orgs/sourcegraph/projects/197"
-        label-name: "team/distribution"
-        columns-to-ignore: "*"
+
+  # Uses issues beta API - see https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects#example-workflow
+  distribution-board:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT: MDExOlByb2plY3ROZXh0MzIxNw== # https://github.com/orgs/sourcegraph/projects/197
+      GITHUB_TOKEN: ${{ secrets.LABELER_GITHUB_TOKEN }}
+    steps:
+    - name: Get issue if relevant
+      if: ${{ github.event.issue && contains(github.event.issue.labels.*.name, 'team/distribution') }}
+      env:
+        NODE_ID: ${{ github.event.issue.node_id }}
+      run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
+    - name: Get pull request if relevant
+      if: ${{ github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'team/distribution') }}
+      env:
+        NODE_ID: ${{ github.event.pull_request.node_id }}
+      run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
+    - name: Add to Distribution board
+      if: ${{ env.NODE_ID != '' }}
+      run: |
+        gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+          mutation($project:ID!, $node_id:ID!) {
+            addProjectNextItem(input: {projectId: $project, contentId: $node_id}) {
+              projectNextItem {
+                id
+              }
+            }
+          }' -f project=$PROJECT_ID -f node_id=$NODE_ID

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -27,3 +27,9 @@ jobs:
         column-name: "Triage"
         label-name: "team/batchers"
         columns-to-ignore: "*"
+    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.LABELER_GITHUB_TOKEN }}"
+        project-url: "https://github.com/orgs/sourcegraph/projects/197"
+        label-name: "team/distribution"
+        columns-to-ignore: "*"


### PR DESCRIPTION
This should automatically move issues labeled 'team/distribution' to our project board (hopefully works with the new boards)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
