### PR TITLE
Fix can't access property "key", t is null error

### DIFF
--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -490,18 +490,19 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                 ))}
 
                                 {/* Render all code insights with proper directory page context */}
-                                {directoryPageContext &&
-                                    insights.map(insight => (
-                                        <SmartInsight
-                                            key={insight.id}
-                                            insight={insight}
-                                            telemetryService={props.telemetryService}
-                                            platformContext={props.platformContext}
-                                            settingsCascade={settingsCascade}
-                                            where="directory"
-                                            context={directoryPageContext}
-                                        />
-                                    ))}
+                                {directoryPageContext
+                                    ? insights.map(insight => (
+                                          <SmartInsight
+                                              key={insight.id}
+                                              insight={insight}
+                                              telemetryService={props.telemetryService}
+                                              platformContext={props.platformContext}
+                                              settingsCascade={settingsCascade}
+                                              where="directory"
+                                              context={directoryPageContext}
+                                          />
+                                      ))
+                                    : []}
                             </ViewGrid>
                         )}
                         <section className="tree-page__section test-tree-entries mb-3">


### PR DESCRIPTION
Apparently react-resize-grid really doesn't like null being passed (the case when directoryPageContext is undefined). Not sure if this is the proper long term fix, but it seems to be a stopgap for that nasty bug on dotcom until we have time to investigate properly.
