### PR TITLE
remove comment describing since-deleted fancyerror.html

### DIFF
--- a/cmd/frontend/internal/app/ui/error.html
+++ b/cmd/frontend/internal/app/ui/error.html
@@ -1,20 +1,3 @@
-{{/*
-	IMPORTANT! There are two error templates:
-
-	- error.html
-	- fancyerror.html
-
-	error.html is designed to be as minimal and reliable as possible. It does
-	not include ANY other templates, as they may require data that is not
-	present (e.g. *Common data, which may not exist if e.g. gitserver or other
-	relied upon servers are degraded). This template should render even when
-	the system is severely broken.
-
-	fancyerror.html is designed to be more user friendly, and we always try to
-	render it first. It uses data from *Common etc, and can include other
-	templates like base.html. In the event that it fails to render, error.html
-	is the fallback that is used.
-*/}}
 <!doctype html>
 <html lang="en">
 <head>


### PR DESCRIPTION
The fancyerror.html file was deleted a long time ago. This comment is obsolete and not needed anymore.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->