### PR TITLE
Set notifications polling interval to 60 seconds

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -183,8 +183,7 @@ interface State {
     isOpen: boolean
 }
 
-const REFRESH_INTERVAL_AFTER_ERROR_MS = 3000
-const REFRESH_INTERVAL_MS = 10000
+const REFRESH_INTERVAL_MS = 60000
 
 /**
  * Displays a status icon in the navbar reflecting the completion of backend
@@ -225,7 +224,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                     catchError(error => [asError(error) as ErrorLike]),
                     // Poll on REFRESH_INTERVAL_MS, or REFRESH_INTERVAL_AFTER_ERROR_MS if there is an error.
                     repeatUntil(messagesOrError => isErrorLike(messagesOrError), { delay: REFRESH_INTERVAL_MS }),
-                    repeatWhen(completions => completions.pipe(delay(REFRESH_INTERVAL_AFTER_ERROR_MS))),
+                    repeatWhen(completions => completions.pipe(delay(REFRESH_INTERVAL_MS))),
                     distinctUntilChanged((a, b) => isEqual(a, b))
                 )
                 .subscribe(messagesOrError => {


### PR DESCRIPTION
### Description

Set polling interval to 60 seconds for notifications. Even when we have an error interval stays the same.
As per [Jira ticket](https://sourcegraph.atlassian.net/browse/COREAPP-239)