### PR TITLE
deprecate SourcegraphWebApp class component in favor of adjacent function component

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -226,8 +226,6 @@ interface SourcegraphWebAppOldClassComponentExtraProps
 }
 
 interface SourcegraphWebAppState {
-    error?: Error
-
     /*
      * The version context the instance is in. If undefined, it means no version context is selected.
      */

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -217,15 +217,16 @@ interface SourcegraphWebAppOldClassComponentExtraProps
      * Evaluated feature flags for the current viewer
      */
     featureFlags: FlagSet
-}
-
-interface SourcegraphWebAppState {
-    error?: Error
 
     /**
      * The current search query in the navbar.
      */
     navbarSearchQueryState: QueryState
+    onNavbarQueryChange: (queryState: QueryState) => void
+}
+
+interface SourcegraphWebAppState {
+    error?: Error
 
     /*
      * The version context the instance is in. If undefined, it means no version context is selected.
@@ -288,7 +289,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
             : undefined
 
         this.state = {
-            navbarSearchQueryState: { query: '' },
             versionContext: resolvedVersionContext,
             availableVersionContexts,
             previousVersionContext,
@@ -393,8 +393,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
                                                     authenticatedUser={authenticatedUser}
                                                     batchChangesEnabled={this.props.batchChangesEnabled}
                                                     // Search query
-                                                    navbarSearchQueryState={this.state.navbarSearchQueryState}
-                                                    onNavbarQueryChange={this.onNavbarQueryChange}
                                                     fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                                     versionContext={this.state.versionContext}
                                                     setVersionContext={this.setVersionContext}
@@ -439,10 +437,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
                 </ErrorBoundary>
             </ApolloProvider>
         )
-    }
-
-    private onNavbarQueryChange = (navbarSearchQueryState: QueryState): void => {
-        this.setState({ navbarSearchQueryState })
     }
 
     private setVersionContext = async (versionContext: string | undefined): Promise<void> => {
@@ -637,6 +631,8 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
 
     const featureFlags = useObservable(useMemo(() => fetchFeatureFlags(), [])) ?? new Map<FeatureFlagName, boolean>()
 
+    const [navbarSearchQueryState, onNavbarQueryChange] = useState<QueryState>({ query: '' })
+
     return userAndSettingsProps ? (
         <SourcegraphWebAppOldClassComponent
             {...props}
@@ -655,6 +651,8 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
             onUserExternalServicesOrRepositoriesUpdate={onUserExternalServicesOrRepositoriesUpdate}
             onSyncedPublicRepositoriesUpdate={onSyncedPublicRepositoriesUpdate}
             featureFlags={featureFlags}
+            navbarSearchQueryState={navbarSearchQueryState}
+            onNavbarQueryChange={onNavbarQueryChange}
         />
     ) : null
 }

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -243,9 +243,12 @@ const LayoutWithActivation = window.context.sourcegraphDotComMode ? Layout : wit
 const history = createBrowserHistory()
 
 /**
- * The root component.
+ * The old class component for the root component. This class component's behavior is being migrated
+ * to the {@link SourcegraphWebApp} function component, which uses React hooks.
+ *
+ * @deprecated Add behavior to {@link SourcegraphWebApp} instead.
  */
-export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, SourcegraphWebAppState> {
+class SourcegraphWebAppOldClassComponent extends React.Component<SourcegraphWebAppProps, SourcegraphWebAppState> {
     private readonly subscriptions = new Subscription()
     private readonly userRepositoriesUpdates = new Subject<void>()
     private readonly platformContext: PlatformContext = createPlatformContext()
@@ -649,3 +652,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
         await extensionHostAPI.setSearchContext(spec)
     }
 }
+
+export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> = props => (
+    <SourcegraphWebAppOldClassComponent {...props} />
+)

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -298,8 +298,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
     }
 
     public componentDidMount(): void {
-        document.documentElement.classList.add('theme')
-
         /**
          * Listens for uncaught 401 errors when a user when a user was previously authenticated.
          *
@@ -645,6 +643,8 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
         false
     const hasUserAddedExternalServices =
         hasUserAddedProps2?.hasUserAddedExternalServices || hasUserAddedProps?.hasUserAddedExternalServices || false
+
+    useEffect(() => document.documentElement.classList.add('theme'), [])
 
     return userAndSettingsProps ? (
         <SourcegraphWebAppOldClassComponent

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -1,12 +1,12 @@
 import 'focus-visible'
 
-import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/client'
+import { ApolloProvider } from '@apollo/client'
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
-import H, { createBrowserHistory } from 'history'
+import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
 import React, { useMemo, useEffect, useState, useCallback } from 'react'
 import { Route, Router } from 'react-router'
-import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
+import { combineLatest, from, fromEvent, of, Subject } from 'rxjs'
 import { bufferCount, catchError, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators'
 
 import { Tooltip } from '@sourcegraph/branded/src/components/tooltip/Tooltip'
@@ -15,22 +15,17 @@ import { preloadExtensions } from '@sourcegraph/shared/src/api/client/preload'
 import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { HTTPStatusError } from '@sourcegraph/shared/src/backend/fetch'
 import { setLinkComponent } from '@sourcegraph/shared/src/components/Link'
-import {
-    Controller as ExtensionsController,
-    createController as createExtensionsController,
-} from '@sourcegraph/shared/src/extensions/controller'
+import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { Notifications } from '@sourcegraph/shared/src/notifications/Notifications'
-import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
-import { authenticatedUser, AuthenticatedUser } from './auth'
+import { authenticatedUser } from './auth'
 import { getWebGraphQLClient } from './backend/graphql'
 import { BatchChangesProps } from './batches'
 import { CodeIntelligenceProps } from './codeintel'
@@ -43,11 +38,11 @@ import { ExtensionAreaRoute } from './extensions/extension/ExtensionArea'
 import { ExtensionAreaHeaderNavItem } from './extensions/extension/ExtensionAreaHeader'
 import { ExtensionsAreaRoute } from './extensions/ExtensionsArea'
 import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHeader'
-import { FeatureFlagName, fetchFeatureFlags, FlagSet } from './featureFlags/featureFlags'
+import { FeatureFlagName, fetchFeatureFlags } from './featureFlags/featureFlags'
 import { logInsightMetrics } from './insights/analytics'
 import { CodeInsightsProps } from './insights/types'
 import { KeyboardShortcutsProps } from './keyboardShortcuts/keyboardShortcuts'
-import { Layout, LayoutProps } from './Layout'
+import { Layout } from './Layout'
 import { updateUserSessionStores } from './marketing/util'
 import { OrgAreaRoute } from './org/area/OrgArea'
 import { OrgAreaHeaderNavItem } from './org/area/OrgHeader'
@@ -92,7 +87,6 @@ import { UserAreaRoute } from './user/area/UserArea'
 import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
-import { UserExternalServicesOrRepositoriesUpdateProps } from './util'
 import { globbingEnabledFromSettings } from './util/globbing'
 import { observeLocation } from './util/location'
 import {
@@ -128,114 +122,6 @@ export interface SourcegraphWebAppProps
     routes: readonly LayoutRouteProps<any>[]
 }
 
-/**
- * Props passed from the {@link SourcegraphWebApp} function component to the old class component.
- * Only used during the migration from the old class component; will be removed when the migration
- * is complete.
- */
-interface SourcegraphWebAppOldClassComponentExtraProps
-    extends SettingsCascadeProps,
-        UserExternalServicesOrRepositoriesUpdateProps,
-        Pick<
-            React.ComponentProps<typeof Layout>,
-            | 'versionContext'
-            | 'setVersionContext'
-            | 'availableVersionContexts'
-            | 'previousVersionContext'
-            | 'selectedSearchContextSpec'
-            | 'setSelectedSearchContextSpec'
-            | 'defaultSearchContextSpec'
-        > {
-    history: H.History
-    location: H.Location
-
-    platformContext: PlatformContext
-    extensionsController: ExtensionsController
-
-    /** GraphQL client initialized asynchronously to restore persisted cache. */
-    graphqlClient?: ApolloClient<NormalizedCacheObject>
-
-    /**
-     * Whether globbing is enabled for filters.
-     */
-    globbing: boolean
-
-    /**
-     * Whether the current search is case sensitive.
-     */
-    caseSensitive: boolean
-
-    /**
-     * The current search pattern type.
-     */
-    patternType: SearchPatternType
-
-    /**
-     * The current parsed search query, with all UI-configurable parameters
-     * (eg. pattern type, case sensitivity, version context) removed
-     */
-    parsedSearchQuery: string
-
-    setParsedSearchQuery: (value: string) => void
-    setPatternType: (value: SearchPatternType) => void
-    setCaseSensitivity: (value: boolean) => void
-
-    viewerSubject: LayoutProps['viewerSubject']
-
-    showRepogroupHomepage: boolean
-
-    showOnboardingTour: boolean
-
-    showEnterpriseHomePanels: boolean
-
-    /**
-     * Whether we show the mulitiline editor at /search/console
-     */
-    showMultilineSearchConsole: boolean
-
-    /**
-     * Whether we show the search notebook.
-     */
-    showSearchNotebook: boolean
-
-    showSearchContext: boolean
-    showSearchContextManagement: boolean
-
-    /**
-     * Whether we show the multiline editor at /search/query-builder
-     */
-    showQueryBuilder: boolean
-
-    /**
-     * Whether the code monitoring feature flag is enabled.
-     */
-    enableCodeMonitoring: boolean
-
-    /**
-     * Whether the API docs feature flag is enabled.
-     */
-    enableAPIDocs: boolean
-
-    /** The currently authenticated user (or null if the viewer is anonymous). */
-    authenticatedUser?: AuthenticatedUser | null
-
-    hasUserAddedRepositories: boolean
-    hasUserAddedExternalServices: boolean
-
-    /**
-     * Evaluated feature flags for the current viewer
-     */
-    featureFlags: FlagSet
-
-    /**
-     * The current search query in the navbar.
-     */
-    navbarSearchQueryState: QueryState
-    onNavbarQueryChange: (queryState: QueryState) => void
-}
-
-interface SourcegraphWebAppState {}
-
 const notificationClassNames = {
     [NotificationType.Log]: 'alert alert-secondary',
     [NotificationType.Success]: 'alert alert-success',
@@ -254,111 +140,9 @@ const LayoutWithActivation = window.context.sourcegraphDotComMode ? Layout : wit
 const history = createBrowserHistory()
 
 /**
- * The old class component for the root component. This class component's behavior is being migrated
- * to the {@link SourcegraphWebApp} function component, which uses React hooks.
- *
- * @deprecated Add behavior to {@link SourcegraphWebApp} instead.
+ * The root component.
  */
-class SourcegraphWebAppOldClassComponent extends React.Component<
-    SourcegraphWebAppProps & SourcegraphWebAppOldClassComponentExtraProps,
-    SourcegraphWebAppState
-> {
-    private readonly subscriptions = new Subscription()
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    public render(): React.ReactFragment | null {
-        if (window.pageError && window.pageError.statusCode !== 404) {
-            const statusCode = window.pageError.statusCode
-            const statusText = window.pageError.statusText
-            const errorMessage = window.pageError.error
-            const errorID = window.pageError.errorID
-
-            let subtitle: JSX.Element | undefined
-            if (errorID) {
-                subtitle = <FeedbackText headerText="Sorry, there's been a problem." />
-            }
-            if (errorMessage) {
-                subtitle = (
-                    <div className="app__error">
-                        {subtitle}
-                        {subtitle && <hr className="my-3" />}
-                        <pre>{errorMessage}</pre>
-                    </div>
-                )
-            } else {
-                subtitle = <div className="app__error">{subtitle}</div>
-            }
-            return <HeroPage icon={ServerIcon} title={`${statusCode}: ${statusText}`} subtitle={subtitle} />
-        }
-
-        const { authenticatedUser, graphqlClient } = this.props
-        if (authenticatedUser === undefined || graphqlClient === undefined) {
-            return null
-        }
-
-        const { children, ...props } = this.props
-
-        return (
-            <ApolloProvider client={graphqlClient}>
-                <ErrorBoundary location={null}>
-                    <ShortcutProvider>
-                        <TemporarySettingsProvider authenticatedUser={authenticatedUser}>
-                            <SearchResultsCacheProvider>
-                                <Router history={history} key={0}>
-                                    <Route
-                                        path="/"
-                                        render={routeComponentProps => (
-                                            <CodeHostScopeProvider authenticatedUser={authenticatedUser}>
-                                                <LayoutWithActivation
-                                                    {...props}
-                                                    {...routeComponentProps}
-                                                    authenticatedUser={authenticatedUser}
-                                                    batchChangesEnabled={this.props.batchChangesEnabled}
-                                                    // Search query
-                                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                                                    // Extensions
-                                                    telemetryService={eventLogger}
-                                                    isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                                    getUserSearchContextNamespaces={getUserSearchContextNamespaces}
-                                                    fetchAutoDefinedSearchContexts={fetchAutoDefinedSearchContexts}
-                                                    fetchSearchContexts={fetchSearchContexts}
-                                                    fetchSearchContextBySpec={fetchSearchContextBySpec}
-                                                    fetchSearchContext={fetchSearchContext}
-                                                    createSearchContext={createSearchContext}
-                                                    updateSearchContext={updateSearchContext}
-                                                    deleteSearchContext={deleteSearchContext}
-                                                    convertVersionContextToSearchContext={
-                                                        convertVersionContextToSearchContext
-                                                    }
-                                                    isSearchContextSpecAvailable={isSearchContextSpecAvailable}
-                                                    fetchSavedSearches={fetchSavedSearches}
-                                                    fetchRecentSearches={fetchRecentSearches}
-                                                    fetchRecentFileViews={fetchRecentFileViews}
-                                                    streamSearch={aggregateStreamingSearch}
-                                                />
-                                            </CodeHostScopeProvider>
-                                        )}
-                                    />
-                                </Router>
-                                <Tooltip key={1} />
-                                <Notifications
-                                    key={2}
-                                    extensionsController={this.props.extensionsController}
-                                    notificationClassNames={notificationClassNames}
-                                />
-                            </SearchResultsCacheProvider>
-                        </TemporarySettingsProvider>
-                    </ShortcutProvider>
-                </ErrorBoundary>
-            </ApolloProvider>
-        )
-    }
-}
-
-export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> = props => {
+export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> = ({ children, ...props }) => {
     const location = history.location
 
     const platformContext = useMemo(() => createPlatformContext(), [])
@@ -621,33 +405,115 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
-    return userAndSettingsProps ? (
-        <SourcegraphWebAppOldClassComponent
-            {...props}
-            history={history}
-            location={location}
-            platformContext={platformContext}
-            extensionsController={extensionsController}
-            graphqlClient={graphqlClient}
-            {...userAndSettingsProps}
-            parsedSearchQuery={parsedSearchQuery}
-            setParsedSearchQuery={setParsedSearchQuery}
-            setPatternType={setPatternType}
-            setCaseSensitivity={setCaseSensitivity}
-            hasUserAddedRepositories={hasUserAddedRepositories}
-            hasUserAddedExternalServices={hasUserAddedExternalServices}
-            onUserExternalServicesOrRepositoriesUpdate={onUserExternalServicesOrRepositoriesUpdate}
-            onSyncedPublicRepositoriesUpdate={onSyncedPublicRepositoriesUpdate}
-            featureFlags={featureFlags}
-            navbarSearchQueryState={navbarSearchQueryState}
-            onNavbarQueryChange={onNavbarQueryChange}
-            versionContext={versionContext}
-            setVersionContext={setVersionContext2}
-            availableVersionContexts={availableVersionContexts}
-            previousVersionContext={previousVersionContext}
-            defaultSearchContextSpec={defaultSearchContextSpec}
-            selectedSearchContextSpec={getSelectedSearchContextSpec()}
-            setSelectedSearchContextSpec={setSelectedSearchContextSpec2}
-        />
-    ) : null
+    if (!userAndSettingsProps) {
+        return null
+    }
+    if (!graphqlClient) {
+        return null
+    }
+
+    if (window.pageError && window.pageError.statusCode !== 404) {
+        const statusCode = window.pageError.statusCode
+        const statusText = window.pageError.statusText
+        const errorMessage = window.pageError.error
+        const errorID = window.pageError.errorID
+
+        let subtitle: JSX.Element | undefined
+        if (errorID) {
+            subtitle = <FeedbackText headerText="Sorry, there's been a problem." />
+        }
+        if (errorMessage) {
+            subtitle = (
+                <div className="app__error">
+                    {subtitle}
+                    {subtitle && <hr className="my-3" />}
+                    <pre>{errorMessage}</pre>
+                </div>
+            )
+        } else {
+            subtitle = <div className="app__error">{subtitle}</div>
+        }
+        return <HeroPage icon={ServerIcon} title={`${statusCode}: ${statusText}`} subtitle={subtitle} />
+    }
+
+    return (
+        <ApolloProvider client={graphqlClient}>
+            <ErrorBoundary location={null}>
+                <ShortcutProvider>
+                    <TemporarySettingsProvider authenticatedUser={userAndSettingsProps.authenticatedUser}>
+                        <SearchResultsCacheProvider>
+                            <Router history={history} key={0}>
+                                <Route
+                                    path="/"
+                                    render={routeComponentProps => (
+                                        <CodeHostScopeProvider
+                                            authenticatedUser={userAndSettingsProps.authenticatedUser}
+                                        >
+                                            <LayoutWithActivation
+                                                {...props}
+                                                {...routeComponentProps}
+                                                history={history}
+                                                location={location}
+                                                platformContext={platformContext}
+                                                extensionsController={extensionsController}
+                                                {...userAndSettingsProps}
+                                                parsedSearchQuery={parsedSearchQuery}
+                                                setParsedSearchQuery={setParsedSearchQuery}
+                                                setPatternType={setPatternType}
+                                                setCaseSensitivity={setCaseSensitivity}
+                                                hasUserAddedRepositories={hasUserAddedRepositories}
+                                                hasUserAddedExternalServices={hasUserAddedExternalServices}
+                                                onUserExternalServicesOrRepositoriesUpdate={
+                                                    onUserExternalServicesOrRepositoriesUpdate
+                                                }
+                                                onSyncedPublicRepositoriesUpdate={onSyncedPublicRepositoriesUpdate}
+                                                featureFlags={featureFlags}
+                                                navbarSearchQueryState={navbarSearchQueryState}
+                                                onNavbarQueryChange={onNavbarQueryChange}
+                                                versionContext={versionContext}
+                                                setVersionContext={setVersionContext2}
+                                                availableVersionContexts={availableVersionContexts}
+                                                previousVersionContext={previousVersionContext}
+                                                defaultSearchContextSpec={defaultSearchContextSpec}
+                                                selectedSearchContextSpec={getSelectedSearchContextSpec()}
+                                                setSelectedSearchContextSpec={setSelectedSearchContextSpec2}
+                                                authenticatedUser={userAndSettingsProps.authenticatedUser}
+                                                // Search query
+                                                fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                                // Extensions
+                                                telemetryService={eventLogger}
+                                                isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                                getUserSearchContextNamespaces={getUserSearchContextNamespaces}
+                                                fetchAutoDefinedSearchContexts={fetchAutoDefinedSearchContexts}
+                                                fetchSearchContexts={fetchSearchContexts}
+                                                fetchSearchContextBySpec={fetchSearchContextBySpec}
+                                                fetchSearchContext={fetchSearchContext}
+                                                createSearchContext={createSearchContext}
+                                                updateSearchContext={updateSearchContext}
+                                                deleteSearchContext={deleteSearchContext}
+                                                convertVersionContextToSearchContext={
+                                                    convertVersionContextToSearchContext
+                                                }
+                                                isSearchContextSpecAvailable={isSearchContextSpecAvailable}
+                                                fetchSavedSearches={fetchSavedSearches}
+                                                fetchRecentSearches={fetchRecentSearches}
+                                                fetchRecentFileViews={fetchRecentFileViews}
+                                                streamSearch={aggregateStreamingSearch}
+                                            />
+                                        </CodeHostScopeProvider>
+                                    )}
+                                />
+                            </Router>
+                            <Tooltip key={1} />
+                            <Notifications
+                                key={2}
+                                extensionsController={extensionsController}
+                                notificationClassNames={notificationClassNames}
+                            />
+                        </SearchResultsCacheProvider>
+                    </TemporarySettingsProvider>
+                </ShortcutProvider>
+            </ErrorBoundary>
+        </ApolloProvider>
+    )
 }

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -301,19 +301,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
     public componentDidMount(): void {
         document.documentElement.classList.add('theme')
 
-        // Track static metrics fo code insights.
-        // Insight count, insights settings, observe settings mutations for analytics
-        // Track add delete and update events of code insights via
-        this.subscriptions.add(
-            combineLatest([from(this.props.platformContext.settings), authenticatedUser])
-                .pipe(bufferCount(2, 1))
-                .subscribe(([[oldSettings], [newSettings, authUser]]) => {
-                    if (authUser) {
-                        logInsightMetrics(oldSettings, newSettings, eventLogger)
-                    }
-                })
-        )
-
         this.subscriptions.add(
             combineLatest([this.userRepositoriesUpdates, authenticatedUser])
                 .pipe(
@@ -638,6 +625,24 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
                     }))
                 ),
             [platformContext.settings, searchCaseSensitivity, searchPatternType]
+        )
+    )
+
+    // Track static metrics for code insights.
+    // Insight count, insights settings, observe settings mutations for analytics
+    // Track add delete and update events of code insights via
+    useObservable(
+        useMemo(
+            () =>
+                combineLatest([from(platformContext.settings), authenticatedUser]).pipe(
+                    bufferCount(2, 1),
+                    tap(([[oldSettings], [newSettings, authUser]]) => {
+                        if (authUser) {
+                            logInsightMetrics(oldSettings, newSettings, eventLogger)
+                        }
+                    })
+                ),
+            [platformContext.settings]
         )
     )
 

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -4,7 +4,7 @@ import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/cli
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import H, { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
-import React, { useMemo, useEffect } from 'react'
+import React, { useMemo, useEffect, useState } from 'react'
 import { Route, Router } from 'react-router'
 import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
 import { bufferCount, catchError, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators'
@@ -26,7 +26,7 @@ import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
-import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
@@ -96,7 +96,6 @@ import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
 import { globbingEnabledFromSettings } from './util/globbing'
 import { observeLocation } from './util/location'
 import {
-    SITE_SUBJECT_NO_ADMIN,
     viewerSubjectFromSettings,
     defaultCaseSensitiveFromSettings,
     defaultPatternTypeFromSettings,
@@ -134,7 +133,7 @@ export interface SourcegraphWebAppProps
  * Only used during the migration from the old class component; will be removed when the migration
  * is complete.
  */
-interface SourcegraphWebAppOldClassComponentExtraProps {
+interface SourcegraphWebAppOldClassComponentExtraProps extends SettingsCascadeProps {
     history: H.History
     location: H.Location
 
@@ -143,20 +142,21 @@ interface SourcegraphWebAppOldClassComponentExtraProps {
 
     /** GraphQL client initialized asynchronously to restore persisted cache. */
     graphqlClient?: ApolloClient<NormalizedCacheObject>
-}
-
-interface SourcegraphWebAppState extends SettingsCascadeProps {
-    error?: Error
-
-    /** The currently authenticated user (or null if the viewer is anonymous). */
-    authenticatedUser?: AuthenticatedUser | null
-
-    viewerSubject: LayoutProps['viewerSubject']
 
     /**
-     * The current search query in the navbar.
+     * Whether globbing is enabled for filters.
      */
-    navbarSearchQueryState: QueryState
+    globbing: boolean
+
+    /**
+     * Whether the current search is case sensitive.
+     */
+    caseSensitive: boolean
+
+    /**
+     * The current search pattern type.
+     */
+    patternType: SearchPatternType
 
     /**
      * The current parsed search query, with all UI-configurable parameters
@@ -164,15 +164,57 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
      */
     parsedSearchQuery: string
 
-    /**
-     * The current search pattern type.
-     */
-    searchPatternType: SearchPatternType
+    setParsedSearchQuery: (value: string) => void
+    setPatternType: (value: SearchPatternType) => void
+    setCaseSensitivity: (value: boolean) => void
+
+    viewerSubject: LayoutProps['viewerSubject']
+
+    showRepogroupHomepage: boolean
+
+    showOnboardingTour: boolean
+
+    showEnterpriseHomePanels: boolean
 
     /**
-     * Whether the current search is case sensitive.
+     * Whether we show the mulitiline editor at /search/console
      */
-    searchCaseSensitivity: boolean
+    showMultilineSearchConsole: boolean
+
+    /**
+     * Whether we show the search notebook.
+     */
+    showSearchNotebook: boolean
+
+    showSearchContext: boolean
+    showSearchContextManagement: boolean
+
+    /**
+     * Whether we show the multiline editor at /search/query-builder
+     */
+    showQueryBuilder: boolean
+
+    /**
+     * Whether the code monitoring feature flag is enabled.
+     */
+    enableCodeMonitoring: boolean
+
+    /**
+     * Whether the API docs feature flag is enabled.
+     */
+    enableAPIDocs: boolean
+
+    /** The currently authenticated user (or null if the viewer is anonymous). */
+    authenticatedUser?: AuthenticatedUser | null
+}
+
+interface SourcegraphWebAppState {
+    error?: Error
+
+    /**
+     * The current search query in the navbar.
+     */
+    navbarSearchQueryState: QueryState
 
     /*
      * The version context the instance is in. If undefined, it means no version context is selected.
@@ -189,49 +231,11 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
      */
     previousVersionContext: string | null
 
-    showRepogroupHomepage: boolean
-
-    showOnboardingTour: boolean
-
-    showEnterpriseHomePanels: boolean
-
-    showSearchContext: boolean
-    showSearchContextManagement: boolean
     selectedSearchContextSpec?: string
     defaultSearchContextSpec: string
     hasUserAddedRepositories: boolean
     hasUserSyncedPublicRepositories: boolean
     hasUserAddedExternalServices: boolean
-
-    /**
-     * Whether globbing is enabled for filters.
-     */
-    globbing: boolean
-
-    /**
-     * Whether we show the mulitiline editor at /search/console
-     */
-    showMultilineSearchConsole: boolean
-
-    /**
-     * Whether we show the search notebook.
-     */
-    showSearchNotebook: boolean
-
-    /**
-     * Whether we show the multiline editor at /search/query-builder
-     */
-    showQueryBuilder: boolean
-
-    /**
-     * Whether the code monitoring feature flag is enabled.
-     */
-    enableCodeMonitoring: boolean
-
-    /**
-     * Whether the API docs feature flag is enabled.
-     */
-    enableAPIDocs: boolean
 
     /**
      * Evaluated feature flags for the current viewer
@@ -273,10 +277,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
         super(props)
 
         const parsedSearchURL = parseSearchURL(window.location.search)
-        // The patternType in the URL query parameter. If none is provided, default to literal.
-        // This will be updated with the default in settings when the web app mounts.
-        const urlPatternType = parsedSearchURL.patternType || SearchPatternType.literal
-        const urlCase = parsedSearchURL.caseSensitive
         const availableVersionContexts = window.context.experimentalFeatures.versionContexts
         const previousVersionContext = localStorage.getItem(LAST_VERSION_CONTEXT_KEY)
         const resolvedVersionContext = availableVersionContexts
@@ -287,59 +287,19 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
 
         this.state = {
             navbarSearchQueryState: { query: '' },
-            settingsCascade: EMPTY_SETTINGS_CASCADE,
-            viewerSubject: SITE_SUBJECT_NO_ADMIN,
-            parsedSearchQuery: parsedSearchURL.query || '',
-            searchPatternType: urlPatternType,
-            searchCaseSensitivity: urlCase,
             versionContext: resolvedVersionContext,
             availableVersionContexts,
             previousVersionContext,
-            showRepogroupHomepage: false,
-            showOnboardingTour: false,
-            showSearchContext: false,
-            showSearchContextManagement: false,
             defaultSearchContextSpec: 'global', // global is default for now, user will be able to change this at some point
             hasUserAddedRepositories: false,
             hasUserSyncedPublicRepositories: false,
             hasUserAddedExternalServices: false,
-            showEnterpriseHomePanels: false,
-            globbing: false,
-            showMultilineSearchConsole: false,
-            showSearchNotebook: false,
-            showQueryBuilder: false,
-            enableCodeMonitoring: false,
-            // Disabling linter here as otherwise the application fails to compile. Bad lint?
-            // See 7a137b201330eb2118c746f8cc5acddf63c1f039
-            // eslint-disable-next-line react/no-unused-state
-            enableAPIDocs: false,
             featureFlags: new Map<FeatureFlagName, boolean>(),
         }
     }
 
     public componentDidMount(): void {
         document.documentElement.classList.add('theme')
-
-        this.subscriptions.add(
-            combineLatest([
-                from(this.props.platformContext.settings),
-                authenticatedUser.pipe(startWith(null)),
-            ]).subscribe(
-                ([settingsCascade, authenticatedUser]) => {
-                    this.setState(state => ({
-                        settingsCascade,
-                        authenticatedUser,
-                        ...experimentalFeaturesFromSettings(settingsCascade),
-                        globbing: globbingEnabledFromSettings(settingsCascade),
-                        searchCaseSensitivity:
-                            defaultCaseSensitiveFromSettings(settingsCascade) || state.searchCaseSensitivity,
-                        searchPatternType: defaultPatternTypeFromSettings(settingsCascade) || state.searchPatternType,
-                        viewerSubject: viewerSubjectFromSettings(settingsCascade, authenticatedUser),
-                    }))
-                },
-                () => this.setState({ authenticatedUser: null })
-            )
-        )
 
         // Track static metrics fo code insights.
         // Insight count, insights settings, observe settings mutations for analytics
@@ -407,13 +367,13 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
             })
         )
 
-        if (this.state.parsedSearchQuery && !filterExists(this.state.parsedSearchQuery, FilterType.context)) {
+        if (this.props.parsedSearchQuery && !filterExists(this.props.parsedSearchQuery, FilterType.context)) {
             // If a context filter does not exist in the query, we have to switch the selected context
             // to global to match the UI with the backend semantics (if no context is specified in the query,
             // the query is run in global context).
             this.setSelectedSearchContextSpec('global')
         }
-        if (!this.state.parsedSearchQuery) {
+        if (!this.props.parsedSearchQuery) {
             // If no query is present (e.g. search page, settings page), select the last saved
             // search context from localStorage as currently selected search context.
             const lastSelectedSearchContextSpec = localStorage.getItem(LAST_SEARCH_CONTEXT_KEY) || 'global'
@@ -461,8 +421,7 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
             return <HeroPage icon={ServerIcon} title={`${statusCode}: ${statusText}`} subtitle={subtitle} />
         }
 
-        const { authenticatedUser } = this.state
-        const graphqlClient = this.props.graphqlClient
+        const { authenticatedUser, graphqlClient } = this.props
         if (authenticatedUser === undefined || graphqlClient === undefined) {
             return null
         }
@@ -484,19 +443,11 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
                                                     {...props}
                                                     {...routeComponentProps}
                                                     authenticatedUser={authenticatedUser}
-                                                    viewerSubject={this.state.viewerSubject}
-                                                    settingsCascade={this.state.settingsCascade}
                                                     batchChangesEnabled={this.props.batchChangesEnabled}
                                                     // Search query
                                                     navbarSearchQueryState={this.state.navbarSearchQueryState}
                                                     onNavbarQueryChange={this.onNavbarQueryChange}
                                                     fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                                                    parsedSearchQuery={this.state.parsedSearchQuery}
-                                                    setParsedSearchQuery={this.setParsedSearchQuery}
-                                                    patternType={this.state.searchPatternType}
-                                                    setPatternType={this.setPatternType}
-                                                    caseSensitive={this.state.searchCaseSensitivity}
-                                                    setCaseSensitivity={this.setCaseSensitivity}
                                                     versionContext={this.state.versionContext}
                                                     setVersionContext={this.setVersionContext}
                                                     availableVersionContexts={this.state.availableVersionContexts}
@@ -504,14 +455,10 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
                                                     // Extensions
                                                     telemetryService={eventLogger}
                                                     isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                                    showRepogroupHomepage={this.state.showRepogroupHomepage}
-                                                    showOnboardingTour={this.state.showOnboardingTour}
-                                                    showSearchContext={this.state.showSearchContext}
                                                     hasUserAddedRepositories={this.hasUserAddedRepositories()}
                                                     hasUserAddedExternalServices={
                                                         this.state.hasUserAddedExternalServices
                                                     }
-                                                    showSearchContextManagement={this.state.showSearchContextManagement}
                                                     selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
                                                     setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
                                                     getUserSearchContextNamespaces={getUserSearchContextNamespaces}
@@ -527,12 +474,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
                                                     }
                                                     isSearchContextSpecAvailable={isSearchContextSpecAvailable}
                                                     defaultSearchContextSpec={this.state.defaultSearchContextSpec}
-                                                    showEnterpriseHomePanels={this.state.showEnterpriseHomePanels}
-                                                    globbing={this.state.globbing}
-                                                    showMultilineSearchConsole={this.state.showMultilineSearchConsole}
-                                                    showSearchNotebook={this.state.showSearchNotebook}
-                                                    showQueryBuilder={this.state.showQueryBuilder}
-                                                    enableCodeMonitoring={this.state.enableCodeMonitoring}
                                                     fetchSavedSearches={fetchSavedSearches}
                                                     fetchRecentSearches={fetchRecentSearches}
                                                     fetchRecentFileViews={fetchRecentFileViews}
@@ -565,22 +506,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
 
     private onNavbarQueryChange = (navbarSearchQueryState: QueryState): void => {
         this.setState({ navbarSearchQueryState })
-    }
-
-    private setParsedSearchQuery = (query: string): void => {
-        this.setState({ parsedSearchQuery: query })
-    }
-
-    private setPatternType = (patternType: SearchPatternType): void => {
-        this.setState({
-            searchPatternType: patternType,
-        })
-    }
-
-    private setCaseSensitivity = (caseSensitive: boolean): void => {
-        this.setState({
-            searchCaseSensitivity: caseSensitive,
-        })
     }
 
     private setVersionContext = async (versionContext: string | undefined): Promise<void> => {
@@ -620,7 +545,7 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
         this.state.hasUserAddedRepositories || this.state.hasUserSyncedPublicRepositories
 
     private getSelectedSearchContextSpec = (): string | undefined =>
-        this.state.showSearchContext ? this.state.selectedSearchContextSpec : undefined
+        this.props.showSearchContext ? this.state.selectedSearchContextSpec : undefined
 
     private setSelectedSearchContextSpec = (spec: string): void => {
         const { defaultSearchContextSpec } = this.state
@@ -691,7 +616,32 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
         updateUserSessionStores()
     }, [])
 
-    return (
+    const parsedSearchURL = useMemo(() => parseSearchURL(location.search), [location.search])
+    const [parsedSearchQuery, setParsedSearchQuery] = useState(parsedSearchURL.query || '')
+    // The search patternType, and case in the URL query parameter. If none is provided, default to
+    // literal, and these will be updated with the defaults in settings when the web app mounts.
+    const [searchPatternType, setPatternType] = useState(parsedSearchURL.patternType || SearchPatternType.literal)
+    const [searchCaseSensitivity, setCaseSensitivity] = useState(parsedSearchURL.caseSensitive)
+
+    const userAndSettingsProps = useObservable(
+        useMemo(
+            () =>
+                combineLatest([from(platformContext.settings), authenticatedUser.pipe(startWith(null))]).pipe(
+                    map(([settingsCascade, authenticatedUser]) => ({
+                        settingsCascade,
+                        authenticatedUser,
+                        ...experimentalFeaturesFromSettings(settingsCascade),
+                        globbing: globbingEnabledFromSettings(settingsCascade),
+                        caseSensitive: defaultCaseSensitiveFromSettings(settingsCascade) ?? searchCaseSensitivity,
+                        patternType: defaultPatternTypeFromSettings(settingsCascade) ?? searchPatternType,
+                        viewerSubject: viewerSubjectFromSettings(settingsCascade, authenticatedUser),
+                    }))
+                ),
+            [platformContext.settings, searchCaseSensitivity, searchPatternType]
+        )
+    )
+
+    return userAndSettingsProps ? (
         <SourcegraphWebAppOldClassComponent
             {...props}
             history={history}
@@ -699,6 +649,11 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
             platformContext={platformContext}
             extensionsController={extensionsController}
             graphqlClient={graphqlClient}
+            {...userAndSettingsProps}
+            parsedSearchQuery={parsedSearchQuery}
+            setParsedSearchQuery={setParsedSearchQuery}
+            setPatternType={setPatternType}
+            setCaseSensitivity={setCaseSensitivity}
         />
-    )
+    ) : null
 }

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -212,6 +212,11 @@ interface SourcegraphWebAppOldClassComponentExtraProps
 
     hasUserAddedRepositories: boolean
     hasUserAddedExternalServices: boolean
+
+    /**
+     * Evaluated feature flags for the current viewer
+     */
+    featureFlags: FlagSet
 }
 
 interface SourcegraphWebAppState {
@@ -239,11 +244,6 @@ interface SourcegraphWebAppState {
 
     selectedSearchContextSpec?: string
     defaultSearchContextSpec: string
-
-    /**
-     * Evaluated feature flags for the current viewer
-     */
-    featureFlags: FlagSet
 }
 
 const notificationClassNames = {
@@ -293,7 +293,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
             availableVersionContexts,
             previousVersionContext,
             defaultSearchContextSpec: 'global', // global is default for now, user will be able to change this at some point
-            featureFlags: new Map<FeatureFlagName, boolean>(),
         }
     }
 
@@ -316,15 +315,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
                         location.reload()
                     }
                 })
-        )
-
-        this.subscriptions.add(
-            fetchFeatureFlags().subscribe(event => {
-                // Disabling linter here because this is not yet used anywhere.
-                // This can be re-enabled as soon as feature flags are leveraged.
-                // eslint-disable-next-line react/no-unused-state
-                this.setState({ featureFlags: event })
-            })
         )
 
         if (this.props.parsedSearchQuery && !filterExists(this.props.parsedSearchQuery, FilterType.context)) {
@@ -432,7 +422,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
                                                     fetchRecentSearches={fetchRecentSearches}
                                                     fetchRecentFileViews={fetchRecentFileViews}
                                                     streamSearch={aggregateStreamingSearch}
-                                                    featureFlags={this.state.featureFlags}
                                                 />
                                             </CodeHostScopeProvider>
                                         )}
@@ -646,6 +635,8 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
 
     useEffect(() => document.documentElement.classList.add('theme'), [])
 
+    const featureFlags = useObservable(useMemo(() => fetchFeatureFlags(), [])) ?? new Map<FeatureFlagName, boolean>()
+
     return userAndSettingsProps ? (
         <SourcegraphWebAppOldClassComponent
             {...props}
@@ -663,6 +654,7 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
             hasUserAddedExternalServices={hasUserAddedExternalServices}
             onUserExternalServicesOrRepositoriesUpdate={onUserExternalServicesOrRepositoriesUpdate}
             onSyncedPublicRepositoriesUpdate={onSyncedPublicRepositoriesUpdate}
+            featureFlags={featureFlags}
         />
     ) : null
 }

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -4,7 +4,7 @@ import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/cli
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import H, { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import { Route, Router } from 'react-router'
 import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
 import { bufferCount, catchError, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators'
@@ -318,8 +318,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
     }
 
     public componentDidMount(): void {
-        updateUserSessionStores()
-
         document.documentElement.classList.add('theme')
 
         this.subscriptions.add(
@@ -688,6 +686,10 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
             []
         )
     )
+
+    useEffect(() => {
+        updateUserSessionStores()
+    }, [])
 
     return (
         <SourcegraphWebAppOldClassComponent

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -140,6 +140,9 @@ interface SourcegraphWebAppOldClassComponentExtraProps {
 
     platformContext: PlatformContext
     extensionsController: ExtensionsController
+
+    /** GraphQL client initialized asynchronously to restore persisted cache. */
+    graphqlClient?: ApolloClient<NormalizedCacheObject>
 }
 
 interface SourcegraphWebAppState extends SettingsCascadeProps {
@@ -147,9 +150,6 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
 
     /** The currently authenticated user (or null if the viewer is anonymous). */
     authenticatedUser?: AuthenticatedUser | null
-
-    /** GraphQL client initialized asynchronously to restore persisted cache. */
-    graphqlClient?: ApolloClient<NormalizedCacheObject>
 
     viewerSubject: LayoutProps['viewerSubject']
 
@@ -322,12 +322,6 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
 
         document.documentElement.classList.add('theme')
 
-        getWebGraphQLClient()
-            .then(graphqlClient => this.setState({ graphqlClient }))
-            .catch(error => {
-                console.error('Error initalizing GraphQL client', error)
-            })
-
         this.subscriptions.add(
             combineLatest([
                 from(this.props.platformContext.settings),
@@ -469,7 +463,8 @@ class SourcegraphWebAppOldClassComponent extends React.Component<
             return <HeroPage icon={ServerIcon} title={`${statusCode}: ${statusText}`} subtitle={subtitle} />
         }
 
-        const { authenticatedUser, graphqlClient } = this.state
+        const { authenticatedUser } = this.state
+        const graphqlClient = this.props.graphqlClient
         if (authenticatedUser === undefined || graphqlClient === undefined) {
             return null
         }
@@ -681,6 +676,19 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
         )
     )
 
+    const graphqlClient = useObservable(
+        useMemo(
+            () =>
+                from(getWebGraphQLClient()).pipe(
+                    catchError(error => {
+                        console.error('Error initalizing GraphQL client', error)
+                        return of(undefined)
+                    })
+                ),
+            []
+        )
+    )
+
     return (
         <SourcegraphWebAppOldClassComponent
             {...props}
@@ -688,6 +696,7 @@ export const SourcegraphWebApp: React.FunctionComponent<SourcegraphWebAppProps> 
             location={location}
             platformContext={platformContext}
             extensionsController={extensionsController}
+            graphqlClient={graphqlClient}
         />
     )
 }

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -45,7 +45,7 @@ export function defaultPatternTypeFromSettings(settingsCascade: SettingsCascadeO
     return
 }
 
-export function defaultCaseSensitiveFromSettings(settingsCascade: SettingsCascadeOrError): boolean {
+export function defaultCaseSensitiveFromSettings(settingsCascade: SettingsCascadeOrError): boolean | undefined {
     // Analogous to defaultPatternTypeFromSettings, but for case sensitivity.
     if (!parseSearchURLPatternType(window.location.search)) {
         const defaultCaseSensitive =
@@ -54,7 +54,7 @@ export function defaultCaseSensitiveFromSettings(settingsCascade: SettingsCascad
             (settingsCascade.final['search.defaultCaseSensitive'] as boolean)
         return defaultCaseSensitive || false
     }
-    return false
+    return undefined
 }
 
 export function experimentalFeaturesFromSettings(


### PR DESCRIPTION
**DRAFT**

Class components are being deprecated in React in favor of function components using hooks. Using hooks allows for greater composition and less complexity, and it will also make server-side rendering possible.

Reviewers: I didn't make an attempt to factor out all of the behaviors in the SourcegraphWebApp class component to a separate hook (as in #24227 for theming). I also didn't add any tests yet. I'd love your advice on the best way to go about this refactor before investing more effort here (and if you feel that the general integration tests have good enough coverage so that this otherwise good refactor shouldn't block on a bunch more unit test coverage).

(I'm doing this because it will help with server-side rendering, which is my current fun hack project. :)