### PR TITLE
Update cmd in ./dev/generate.sh to remove deprecation warning

### DIFF
--- a/dev/generate.sh
+++ b/dev/generate.sh
@@ -6,5 +6,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 # We'll exclude generating the CLI reference documentation by default due to the
 # relatively high cost of fetching and building src-cli.
 go list ./... | grep -v 'doc/cli/references' | xargs go generate -x
-GOBIN="$PWD/.bin" go get golang.org/x/tools/cmd/goimports && ./.bin/goimports -w .
+GOBIN="$PWD/.bin" go install golang.org/x/tools/cmd/goimports@latest && ./.bin/goimports -w .
 go mod tidy


### PR DESCRIPTION
Previously this would print:

   go get: installing executables with 'go get' in module mode is deprecated.
           To adjust and download dependencies of the current module, use 'go get -d'.
           To install using requirements of the current module, use 'go install'.
           To install ignoring the current module, use 'go install' with a version,
           like 'go install example.com/cmd@latest'.
           For more information, see https://golang.org/doc/go-get-install-deprecation
           or run 'go help get' or 'go help install'.

And since I have no idea how go modules work, I simply followed the
instructions printed here and updated the command accordingly.
