### PR TITLE
Run go mod tidy

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1416,8 +1416,6 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210902181939-dbeb24571877 h1:sj/wZrlDV4nezBJzHw+jlmy9whHBEbnJBTv2RAZsidM=
-github.com/sourcegraph/zoekt v0.0.0-20210902181939-dbeb24571877/go.mod h1:lFzo+otquSTC1CI6SZ4+wOKjmL3qrsqfeA/vFUGExTg=
 github.com/sourcegraph/zoekt v0.0.0-20210906083022-183d10fe355d h1:yi2VHqLPt9/z2VnpINNSl6YBx7B0sg3D746SwovUFQI=
 github.com/sourcegraph/zoekt v0.0.0-20210906083022-183d10fe355d/go.mod h1:lFzo+otquSTC1CI6SZ4+wOKjmL3qrsqfeA/vFUGExTg=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Just ran `go mod tidy` on `main` after running into a dirty working
directory (with the changes below) a few times in the past days.
