### PR TITLE
CODENOTIFY: subscribe to files may touch `external_service_repos` table

### DIFF
--- a/internal/database/CODENOTIFY
+++ b/internal/database/CODENOTIFY
@@ -1,4 +1,6 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
 external* @eseliger
 namespaces* @eseliger
-repos* @eseliger
-repos_perm* @unknwon
+repos* @eseliger @unknwon
+external_services* @unknwon

--- a/internal/repos/CODENOTIFY
+++ b/internal/repos/CODENOTIFY
@@ -1,5 +1,5 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-store* @asdine
+store* @asdine @unknwon
 * @tsenart
 * @indradhanush


### PR DESCRIPTION
This is one of (undefined) steps to help ensure inserts to `external_service_repos` table are legit since it is the source of truth for user-added repository permissions.