### PR TITLE
Add WorkspacesExecutionInput to lib/batches

### DIFF
--- a/lib/batches/workspaces_execution_input.go
+++ b/lib/batches/workspaces_execution_input.go
@@ -1,0 +1,29 @@
+package batches
+
+type WorkspacesExecutionInput struct {
+	RawSpec    string       `json:"rawSpec"`
+	Workspaces []*Workspace `json:"workspaces"`
+}
+
+type Workspace struct {
+	Repository         WorkspaceRepo   `json:"repository"`
+	Branch             WorkspaceBranch `json:"branch"`
+	Path               string          `json:"path"`
+	OnlyFetchWorkspace bool            `json:"onlyFetchWorkspace"`
+	Steps              []Step          `json:"steps"`
+	SearchResultPaths  []string        `json:"searchResultPaths"`
+}
+
+type WorkspaceRepo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type WorkspaceBranch struct {
+	Name   string `json:"name"`
+	Target Commit `json:"target"`
+}
+
+type Commit struct {
+	OID string `json:"oid"`
+}

--- a/lib/batches/workspaces_execution_input.go
+++ b/lib/batches/workspaces_execution_input.go
@@ -15,6 +15,7 @@ type Workspace struct {
 }
 
 type WorkspaceRepo struct {
+	// ID is the GraphQL ID of the repository.
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }


### PR DESCRIPTION
`WorkspacesExecutionInput` is the struct that will be serialized on
the Sourcegraph side and de-serialized in src-cli when we run single
workspaces.

Not 100% sure yet the names will stay like this forever or whether we
run into a collision but I think they're good for now.