### PR TITLE
Remove duplicated GraphQL query string

### DIFF
--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -227,25 +227,7 @@ export const EXTERNAL_SERVICES = gql`
 export function queryExternalServices(
     variables: ExternalServicesVariables
 ): Observable<ExternalServicesResult['externalServices']> {
-    return requestGraphQL<ExternalServicesResult, ExternalServicesVariables>(
-        gql`
-            query ExternalServices($first: Int, $after: String, $namespace: ID) {
-                externalServices(first: $first, after: $after, namespace: $namespace) {
-                    nodes {
-                        ...ListExternalServiceFields
-                    }
-                    totalCount
-                    pageInfo {
-                        endCursor
-                        hasNextPage
-                    }
-                }
-            }
-
-            ${listExternalServiceFragment}
-        `,
-        variables
-    ).pipe(
+    return requestGraphQL<ExternalServicesResult, ExternalServicesVariables>(EXTERNAL_SERVICES, variables).pipe(
         map(({ data, errors }) => {
             if (!data || !data.externalServices || errors) {
                 throw createAggregateError(errors)


### PR DESCRIPTION
This is 100% the same (right?), so we don't need both. It saves a little bundle size, and I remember that this would've caused errors with the generator, not sure why this didn't happen this time, though.
