### PR TITLE
tracer: Don't load user for slow query logging

### DIFF
--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -105,7 +105,7 @@ func TestSearch(t *testing.T) {
 			db := new(dbtesting.MockDB)
 			database.Mocks.Repos.List = tc.reposListMock
 			sr := &schemaResolver{db: db}
-			schema, err := graphql.ParseSchema(mainSchema, sr, graphql.Tracer(&prometheusTracer{db: db}))
+			schema, err := graphql.ParseSchema(mainSchema, sr, graphql.Tracer(&prometheusTracer{}))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This adds some overhead that is unnecessary in 99% of cases because the query isn't actually slow. ID should be good enough for now.
