### PR TITLE
gomod: update zoekt with perf improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210906083022-183d10fe355d
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210908064810-6a4adda25a6c
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20210809100802-88b656a8713e

--- a/go.sum
+++ b/go.sum
@@ -1416,8 +1416,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210906083022-183d10fe355d h1:yi2VHqLPt9/z2VnpINNSl6YBx7B0sg3D746SwovUFQI=
-github.com/sourcegraph/zoekt v0.0.0-20210906083022-183d10fe355d/go.mod h1:lFzo+otquSTC1CI6SZ4+wOKjmL3qrsqfeA/vFUGExTg=
+github.com/sourcegraph/zoekt v0.0.0-20210908064810-6a4adda25a6c h1:umB1hI5ORIwdFBtcsOsZOP6EWC9SXG7o534YeGbG29E=
+github.com/sourcegraph/zoekt v0.0.0-20210908064810-6a4adda25a6c/go.mod h1:lFzo+otquSTC1CI6SZ4+wOKjmL3qrsqfeA/vFUGExTg=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
A few commits since the last update:

- https://github.com/sourcegraph/zoekt/commit/6a4adda web: add repo RAM usage to repolist output.
- https://github.com/sourcegraph/zoekt/commit/35f2689 Revert "shards: give time for FS to settle before calling scan"
- https://github.com/sourcegraph/zoekt/commit/91d73c2 shards: give time for FS to settle before calling scan
- https://github.com/sourcegraph/zoekt/commit/4ddf390 shards: summarize unloading log messages
- https://github.com/sourcegraph/zoekt/commit/d994058 zoekt-webserver: SHUTDOWN_MODE fast support
- https://github.com/sourcegraph/zoekt/commit/0cfc3a4 eval: correct calculation for FilesSkipped in compound shards
- https://github.com/sourcegraph/zoekt/commit/cf3b33d shards: protect shardedSearcher.ranked with a simple mutex
- https://github.com/sourcegraph/zoekt/commit/77692e0 indexdata: smooth out IndexBytes reporting
- https://github.com/sourcegraph/zoekt/commit/d1bfe2f zoekt-merge-index: support reading filesnames in over stdin
- https://github.com/sourcegraph/zoekt/commit/8030512 shards: close Searcher after exclusive lock
