### PR TITLE
Suppress Github URL parse Error

### DIFF
--- a/client/browser/src/shared/code-hosts/github/util.tsx
+++ b/client/browser/src/shared/code-hosts/github/util.tsx
@@ -1,6 +1,7 @@
 import { RawRepoSpec } from '@sourcegraph/shared/src/util/url'
 
 import { DiffResolvedRevisionSpec } from '../../repo'
+import { RepoURLParseError } from '../shared/errors'
 
 /**
  * Returns the elements on the page which should be marked
@@ -248,7 +249,7 @@ export function parseURL(location: Pick<Location, 'host' | 'pathname' | 'href'> 
     const { host, pathname } = location
     const [user, ghRepoName, pageType, ...rest] = pathname.slice(1).split('/')
     if (!user || !ghRepoName) {
-        throw new Error(`Could not parse repoName from GitHub url: ${location.href}`)
+        throw new RepoURLParseError(`Could not parse repoName from GitHub url: ${location.href}`)
     }
     const rawRepoName = `${host}/${user}/${ghRepoName}`
     switch (pageType) {

--- a/client/browser/src/shared/code-hosts/shared/errors.ts
+++ b/client/browser/src/shared/code-hosts/shared/errors.ts
@@ -1,0 +1,1 @@
+export class RepoURLParseError extends Error {}


### PR DESCRIPTION
### Description

We seem to try to load code intelligence on every page. The issue with GH is that we try to parse repo out of URL and if it doesn't match we fail early. However, we don't wanna pollute Sentry + still be able to continue working on the page (rest of the functionality). 

This PR:
- Suppress Github URL parse Error

Closes #24099.