### PR TITLE
authz/github: allocate less memory for groupsCache disabled path

### DIFF
--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -140,25 +140,23 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 		perms = &authz.ExternalUserPermissions{
 			Exacts: make([]extsvc.RepoID, 0, repoSetSize),
 		}
-		// seenRepos helps prevent duplication if necessary for groupsCache
+		// seenRepos helps prevent duplication if necessary for groupsCache. Left unset
+		// indicates it is unused.
 		seenRepos map[extsvc.RepoID]struct{}
 		// addRepoToUserPerms checks if the given repos are already tracked before adding
 		// it to perms for groupsCache, otherwise just adds directly
 		addRepoToUserPerms func(repos ...extsvc.RepoID)
-		// Repository affiliations to list for - groupsCache only lists for a subset
+		// Repository affiliations to list for - groupsCache only lists for a subset. Left
+		// unset indicates all affiliations should be sync'd.
 		affiliations []github.RepositoryAffiliation
 	)
 
 	// If cache is disabled the code path is simpler, avoid allocating memory
 	if p.groupsCache == nil { // Groups cache is disabled
-		// seenRepos is unused
-		seenRepos = nil
 		// addRepoToUserPerms just appends
 		addRepoToUserPerms = func(repos ...extsvc.RepoID) {
 			perms.Exacts = append(perms.Exacts, repos...)
 		}
-		// Sync all direct affiliations.
-		affiliations = nil
 	} else { // Groups cache is enabled
 		// Instantiate map for deduplicating repos
 		seenRepos = make(map[extsvc.RepoID]struct{}, repoSetSize)
@@ -319,25 +317,23 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 	var (
 		// userIDs tracks users with access to this repo
 		userIDs = make([]extsvc.AccountID, 0, userPageSize)
-		// seenUsers helps deduplication of userIDs for groupsCache
+		// seenUsers helps deduplication of userIDs for groupsCache. Left unset indicates
+		// it is unused.
 		seenUsers map[extsvc.AccountID]struct{}
 		// addUserToRepoPerms checks if the given users are already tracked before adding
 		// it to perms for groupsCache, otherwise just adds directly
 		addUserToRepoPerms func(users ...extsvc.AccountID)
-		// affiliations to list for - groupCache only lists for a subset
+		// affiliations to list for - groupCache only lists for a subset. Left unset indicates
+		// all affiliations should be sync'd.
 		affiliation github.CollaboratorAffiliation
 	)
 
 	// If cache is disabled the code path is simpler, avoid allocating memory
 	if p.groupsCache == nil { // groups cache is disabled
-		// seenUsers is unused
-		seenUsers = nil
 		// addUserToRepoPerms just adds to perms.
 		addUserToRepoPerms = func(users ...extsvc.AccountID) {
 			userIDs = append(userIDs, users...)
 		}
-		// Sync all affiliations.
-		affiliation = ""
 	} else { // groups cache is enabled
 		// instantiate map to help with deduplication
 		seenUsers = make(map[extsvc.AccountID]struct{}, userPageSize)

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -134,27 +134,46 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
 	const repoSetSize = 100
-	perms := &authz.ExternalUserPermissions{
-		Exacts: make([]extsvc.RepoID, 0, repoSetSize),
-	}
-	seenRepos := make(map[extsvc.RepoID]struct{}, repoSetSize)
 
-	// addRepoToUserPerms checks if the given repos are already tracked before adding it to perms.
-	addRepoToUserPerms := func(repos ...extsvc.RepoID) {
-		for _, repo := range repos {
-			if _, exists := seenRepos[repo]; !exists {
-				seenRepos[repo] = struct{}{}
-				perms.Exacts = append(perms.Exacts, repo)
+	var (
+		// perms tracks repos this user has access to
+		perms = &authz.ExternalUserPermissions{
+			Exacts: make([]extsvc.RepoID, 0, repoSetSize),
+		}
+		// seenRepos helps prevent duplication if necessary for groupsCache
+		seenRepos map[extsvc.RepoID]struct{}
+		// addRepoToUserPerms checks if the given repos are already tracked before adding
+		// it to perms for groupsCache, otherwise just adds directly
+		addRepoToUserPerms func(repos ...extsvc.RepoID)
+		// Repository affiliations to list for - groupsCache only lists for a subset
+		affiliations []github.RepositoryAffiliation
+	)
+
+	// If cache is disabled the code path is simpler, avoid allocating memory
+	if p.groupsCache == nil { // Groups cache is disabled
+		// seenRepos is unused
+		seenRepos = nil
+		// addRepoToUserPerms just appends
+		addRepoToUserPerms = func(repos ...extsvc.RepoID) {
+			perms.Exacts = append(perms.Exacts, repos...)
+		}
+		// Sync all direct affiliations.
+		affiliations = nil
+	} else { // Groups cache is enabled
+		// Instantiate map for deduplicating repos
+		seenRepos = make(map[extsvc.RepoID]struct{}, repoSetSize)
+		// addRepoToUserPerms checks for duplicates before appending
+		addRepoToUserPerms = func(repos ...extsvc.RepoID) {
+			for _, repo := range repos {
+				if _, exists := seenRepos[repo]; !exists {
+					seenRepos[repo] = struct{}{}
+					perms.Exacts = append(perms.Exacts, repo)
+				}
 			}
 		}
-	}
-
-	// If groups caching is enabled, we sync just a subset of direct affiliations - we let
-	// other permissions ('organization' affiliation) be sync'd by teams/orgs.
-	affiliations := []github.RepositoryAffiliation{github.AffiliationOwner, github.AffiliationCollaborator}
-	if p.groupsCache == nil {
-		// Otherwise, sync all direct affiliations.
-		affiliations = nil
+		// We sync just a subset of direct affiliations - we let other permissions
+		// ('organization' affiliation) be sync'd by teams/orgs.
+		affiliations = []github.RepositoryAffiliation{github.AffiliationOwner, github.AffiliationCollaborator}
 	}
 
 	// Sync direct affiliations
@@ -296,25 +315,44 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
 	const userPageSize = 100
-	userIDs := make([]extsvc.AccountID, 0, userPageSize)
-	seenUsers := make(map[extsvc.AccountID]struct{}, userPageSize)
 
-	// addUserToRepoPerms checks if the given users are already tracked before adding it to perms.
-	addUserToRepoPerms := func(users ...extsvc.AccountID) {
-		for _, user := range users {
-			if _, exists := seenUsers[user]; !exists {
-				seenUsers[user] = struct{}{}
-				userIDs = append(userIDs, user)
+	var (
+		// userIDs tracks users with access to this repo
+		userIDs = make([]extsvc.AccountID, 0, userPageSize)
+		// seenUsers helps deduplication of userIDs for groupsCache
+		seenUsers map[extsvc.AccountID]struct{}
+		// addUserToRepoPerms checks if the given users are already tracked before adding
+		// it to perms for groupsCache, otherwise just adds directly
+		addUserToRepoPerms func(users ...extsvc.AccountID)
+		// affiliations to list for - groupCache only lists for a subset
+		affiliation github.CollaboratorAffiliation
+	)
+
+	// If cache is disabled the code path is simpler, avoid allocating memory
+	if p.groupsCache == nil { // groups cache is disabled
+		// seenUsers is unused
+		seenUsers = nil
+		// addUserToRepoPerms just adds to perms.
+		addUserToRepoPerms = func(users ...extsvc.AccountID) {
+			userIDs = append(userIDs, users...)
+		}
+		// Sync all affiliations.
+		affiliation = ""
+	} else { // groups cache is enabled
+		// instantiate map to help with deduplication
+		seenUsers = make(map[extsvc.AccountID]struct{}, userPageSize)
+		// addUserToRepoPerms checks if the given users are already tracked before adding it to perms.
+		addUserToRepoPerms = func(users ...extsvc.AccountID) {
+			for _, user := range users {
+				if _, exists := seenUsers[user]; !exists {
+					seenUsers[user] = struct{}{}
+					userIDs = append(userIDs, user)
+				}
 			}
 		}
-	}
-
-	// If groups caching is enabled, we sync just direct affiliations, and sync org/team
-	// collaborators separately from cache
-	affiliation := github.AffiliationDirect
-	if p.groupsCache == nil {
-		// Otherwise, sync all affiliations.
-		affiliation = ""
+		// If groups caching is enabled, we sync just direct affiliations, and sync org/team
+		// collaborators separately from cache
+		affiliation = github.AffiliationDirect
 	}
 
 	// Sync collaborators


### PR DESCRIPTION
We assign to `seenUsers` and `seenRepos` while syncing users, this can double the memory usage of a sync for no use because the groupsCache disabled code path does not make use of the maps for deduplication (none is necessary).

Follow-up to the groupsCache permissions work. Prompted by some performance discussion on Slack. Tests already cover behaviour of both code paths, and they passed locally.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
