### PR TITLE
dev/ci: unify traps to ensure cluster cleanup

### DIFF
--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -7,6 +7,27 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)""
 root_dir="$(dirname "${BASH_SOURCE[0]}")/../../../.."
 cd "$root_dir"
 
+export NAMESPACE="cluster-ci-$BUILDKITE_BUILD_NUMBER"
+
+# Capture information about the state of the test cluster
+function cluster_capture_state() {
+  # Get status of all pods
+  kubectl get pods
+
+  # Get logs for some deployments
+  pushd "$root_dir"
+  FRONTEND_LOGS="frontend_logs.log"
+  kubectl logs deployment/sourcegraph-frontend --all-containers >$FRONTEND_LOGS
+  chmod 744 $FRONTEND_LOGS
+  popd
+}
+
+# Cleanup the cluster
+function cluster_cleanup() {
+  cluster_capture_state
+  kubectl delete namespace "$NAMESPACE"
+}
+
 function cluster_setup() {
   git clone --depth 1 \
     https://github.com/sourcegraph/deploy-sourcegraph.git \
@@ -14,10 +35,8 @@ function cluster_setup() {
 
   gcloud container clusters get-credentials default-buildkite --zone=us-central1-c --project=sourcegraph-ci
 
-  export NAMESPACE="cluster-ci-$BUILDKITE_BUILD_NUMBER"
   kubectl create ns "$NAMESPACE" -oyaml --dry-run | kubectl apply -f -
-  #shellcheck disable=SC2064
-  trap "kubectl delete namespace $NAMESPACE" EXIT
+  trap cluster_cleanup exit
   kubectl apply -f "$DIR/storageClass.yaml"
   kubectl config set-context --current --namespace="$NAMESPACE"
   kubectl config current-context
@@ -83,19 +102,6 @@ function e2e() {
   yarn run test:regression:config-settings
   # yarn run test:regression:integrations
   # yarn run test:regression:search
-  popd
-}
-
-# Capture information about the state of the test cluster before cleanup
-function capture_state() {
-  # Get status of all pods
-  kubectl get pods
-
-  # Get logs for some deployments
-  pushd "$root_dir"
-  FRONTEND_LOGS="frontend_logs.log"
-  kubectl logs deployment/sourcegraph-frontend --all-containers >$FRONTEND_LOGS
-  chmod 744 $FRONTEND_LOGS
   popd
 }
 

--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -107,7 +107,6 @@ function e2e() {
 
 # main
 cluster_setup
-trap capture_state exit
 test_setup
 # TODO: Failing tests do not fail the build
 set +o pipefail


### PR DESCRIPTION
Looks like https://github.com/sourcegraph/sourcegraph/pull/24600 caused the cluster cleanup to get overridden, I think this will fix it?

https://buildkite.com/sourcegraph/sourcegraph/builds/107622

https://buildkite.com/sourcegraph/qa/builds/5397#ea628b8b-8a4e-4704-8a96-b1aa61a34259/77-1127

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
