### PR TITLE
search: Port server side query validation to frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- More rules have been added to the search query validation so that user get faster feedback on issues with their query. [#24747](https://github.com/sourcegraph/sourcegraph/pull/24747)
 
 ### Changed
 

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -91,7 +91,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -103,7 +103,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -117,7 +117,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -125,7 +125,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 11,
@@ -133,7 +133,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 28,
@@ -141,7 +141,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 46,
@@ -154,7 +154,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -162,7 +162,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 17,
@@ -170,7 +170,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
+                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 35,
@@ -205,7 +205,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: query contains \\"rev:\\" without \\"repo:\\". Add a \\"repo:\\" filter.",
+                    "message": "Error: query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -217,7 +217,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: query contains \\"rev:\\" without \\"repo:\\". Add a \\"repo:\\" filter.",
+                    "message": "Error: query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -232,7 +232,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
+                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 10,
@@ -240,7 +240,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
+                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -252,7 +252,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
+                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 10,
@@ -260,7 +260,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
+                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -283,7 +283,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: query contains \\"rev:\\" with an empty \\"repo:\\" filter. Add a non-empty \\"repo:\\" filter.",
+                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 10,
@@ -291,7 +291,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: query contains \\"rev:\\" with an empty \\"repo:\\" filter. Add a non-empty \\"repo:\\" filter.",
+                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -324,7 +324,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \\"type:\\". Remove this filter or switch to a different search type.",
+                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -337,7 +337,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \\"type:\\". Remove this filter or switch to a different search type.",
+                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -91,7 +91,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -103,7 +103,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -117,7 +117,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -125,7 +125,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 11,
@@ -133,7 +133,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 28,
@@ -141,7 +141,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 46,
@@ -154,7 +154,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -162,7 +162,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 17,
@@ -170,7 +170,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "message": "Error: this filter requires \\"type:commit\\" or \\"type:diff\\" in the query",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 35,
@@ -205,7 +205,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: query contains 'rev:' without 'repo:'. Add a 'repo:' filter.",
+                    "message": "Error: query contains \\"rev:\\" without \\"repo:\\". Add a \\"repo:\\" filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -217,7 +217,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: query contains 'rev:' without 'repo:'. Add a 'repo:' filter.",
+                    "message": "Error: query contains \\"rev:\\" without \\"repo:\\". Add a \\"repo:\\" filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -232,7 +232,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both '@' and 'rev:' for a repo filter and I don't know how to interpret this. Remove either '@' or 'rev:'",
+                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 10,
@@ -240,7 +240,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both '@' and 'rev:' for a repo filter and I don't know how to interpret this. Remove either '@' or 'rev:'",
+                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -252,7 +252,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both '@' and 'rev:' for a repo filter and I don't know how to interpret this. Remove either '@' or 'rev:'",
+                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 10,
@@ -260,7 +260,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: You have specified both '@' and 'rev:' for a repo filter and I don't know how to interpret this. Remove either '@' or 'rev:'",
+                    "message": "Error: You have specified both \\"@\\" and \\"rev:\\" for a repo filter and I don\\"t know how to interpret this. Remove either \\"@\\" or \\"rev:\\"",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -283,7 +283,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: query contains 'rev:' with an empty 'repo:' filter. Add a non-empty 'repo:' filter.",
+                    "message": "Error: query contains \\"rev:\\" with an empty \\"repo:\\" filter. Add a non-empty \\"repo:\\" filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 10,
@@ -291,7 +291,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": 8,
-                    "message": "Error: query contains 'rev:' with an empty 'repo:' filter. Add a non-empty 'repo:' filter.",
+                    "message": "Error: query contains \\"rev:\\" with an empty \\"repo:\\" filter. Add a non-empty \\"repo:\\" filter.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -324,7 +324,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with 'type:'. Remove this filter or switch to a different search type.",
+                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \\"type:\\". Remove this filter or switch to a different search type.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,
@@ -337,7 +337,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": 8,
-                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with 'type:'. Remove this filter or switch to a different search type.",
+                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \\"type:\\". Remove this filter or switch to a different search type.",
                     "startLineNumber": 1,
                     "endLineNumber": 1,
                     "startColumn": 1,

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -11,76 +11,162 @@ expect.addSnapshotSerializer({
 
 const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
 
+function parseAndDiagnose(query: string, searchPattern: SearchPatternType): ReturnType<typeof getDiagnostics> {
+    return getDiagnostics(toSuccess(scanSearchQuery(query)), searchPattern)
+}
+
 describe('getDiagnostics()', () => {
-    test('do not raise invalid filter type', () => {
-        expect(
-            getDiagnostics(toSuccess(scanSearchQuery('repos:^github.com/sourcegraph')), SearchPatternType.literal)
-        ).toMatchInlineSnapshot('[]')
+    describe('empty and invalid filter values', () => {
+        test('do not raise invalid filter type', () => {
+            expect(parseAndDiagnose('repos:^github.com/sourcegraph', SearchPatternType.literal)).toMatchInlineSnapshot(
+                '[]'
+            )
+        })
+
+        test('invalid filter value', () => {
+            expect(parseAndDiagnose('case:maybe', SearchPatternType.literal)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": 8,
+                    "message": "Error: Invalid filter value, expected one of: yes, no.",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 1,
+                    "endColumn": 5
+                  }
+                ]
+            `)
+        })
+
+        test('search query containing colon, literal pattern type, do not raise error', () => {
+            expect(parseAndDiagnose('Configuration::doStuff(...)', SearchPatternType.literal)).toMatchInlineSnapshot(
+                '[]'
+            )
+        })
+
+        test('search query containing quoted token, regexp pattern type', () => {
+            expect(parseAndDiagnose('"Configuration::doStuff(...)"', SearchPatternType.regexp)).toMatchInlineSnapshot(
+                '[]'
+            )
+        })
+
+        test('search query containing parenthesized parameterss', () => {
+            expect(parseAndDiagnose('repo:a (file:b and c)', SearchPatternType.regexp)).toMatchInlineSnapshot('[]')
+        })
+
+        test('search query with empty filter diagnostic', () => {
+            expect(parseAndDiagnose('meatadata file: ', SearchPatternType.regexp)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": 4,
+                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., file:\\" a term\\".",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 11,
+                    "endColumn": 15
+                  }
+                ]
+            `)
+        })
+
+        test('search query with both invalid filter and empty filter returns only one diagnostic for the first issue', () => {
+            expect(parseAndDiagnose('meatadata type: ', SearchPatternType.regexp)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": 8,
+                    "message": "Error: Invalid filter value, expected one of: diff, commit, symbol, repo, path, file.",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 11,
+                    "endColumn": 15
+                  }
+                ]
+            `)
+        })
     })
 
-    test('invalid filter value', () => {
-        expect(getDiagnostics(toSuccess(scanSearchQuery('case:maybe')), SearchPatternType.literal))
-            .toMatchInlineSnapshot(`
-            [
-              {
-                "severity": 8,
-                "message": "Error: Invalid filter value, expected one of: yes, no.",
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 1,
-                "endColumn": 5
-              }
-            ]
-        `)
-    })
+    describe('diff and commit only filters', () => {
+        test('detects invalid author/before/after/message filters', () => {
+            expect(parseAndDiagnose('author:me', SearchPatternType.literal)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": 8,
+                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 1,
+                    "endColumn": 7
+                  }
+                ]
+            `)
+            expect(parseAndDiagnose('author:me test', SearchPatternType.literal)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": 8,
+                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 1,
+                    "endColumn": 7
+                  }
+                ]
+            `)
+            expect(
+                parseAndDiagnose('author:me before:yesterday after:"last week" message:test', SearchPatternType.literal)
+            ).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": 8,
+                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 1,
+                    "endColumn": 7
+                  },
+                  {
+                    "severity": 8,
+                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 11,
+                    "endColumn": 17
+                  },
+                  {
+                    "severity": 8,
+                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 28,
+                    "endColumn": 33
+                  },
+                  {
+                    "severity": 8,
+                    "message": "Error: this filter requires 'type:commit' or 'type:diff' in the query",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 46,
+                    "endColumn": 53
+                  }
+                ]
+            `)
+        })
 
-    test('search query containing colon, literal pattern type, do not raise error', () => {
-        expect(
-            getDiagnostics(toSuccess(scanSearchQuery('Configuration::doStuff(...)')), SearchPatternType.literal)
-        ).toMatchInlineSnapshot('[]')
-    })
+        test('accepts author/before/after/message filters if type:diff is present', () => {
+            expect(
+                parseAndDiagnose(
+                    'author:me before:yesterday after:"last week" message:test type:diff',
+                    SearchPatternType.literal
+                )
+            ).toMatchInlineSnapshot(`[]`)
+        })
 
-    test('search query containing quoted token, regexp pattern type', () => {
-        expect(
-            getDiagnostics(toSuccess(scanSearchQuery('"Configuration::doStuff(...)"')), SearchPatternType.regexp)
-        ).toMatchInlineSnapshot('[]')
-    })
-
-    test('search query containing parenthesized parameterss', () => {
-        expect(
-            getDiagnostics(toSuccess(scanSearchQuery('repo:a (file:b and c)')), SearchPatternType.regexp)
-        ).toMatchInlineSnapshot('[]')
-    })
-
-    test('search query with empty filter diagnostic', () => {
-        expect(getDiagnostics(toSuccess(scanSearchQuery('meatadata file: ')), SearchPatternType.regexp))
-            .toMatchInlineSnapshot(`
-            [
-              {
-                "severity": 4,
-                "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., file:\\" a term\\".",
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 11,
-                "endColumn": 15
-              }
-            ]
-        `)
-    })
-
-    test('search query with both invalid filter and empty filter returns only one diagnostic for the first issue', () => {
-        expect(getDiagnostics(toSuccess(scanSearchQuery('meatadata type: ')), SearchPatternType.regexp))
-            .toMatchInlineSnapshot(`
-            [
-              {
-                "severity": 8,
-                "message": "Error: Invalid filter value, expected one of: diff, commit, symbol, repo, path, file.",
-                "startLineNumber": 1,
-                "endLineNumber": 1,
-                "startColumn": 11,
-                "endColumn": 15
-              }
-            ]
-        `)
+        test('accepts author/before/after/message filters if type:commit is present', () => {
+            expect(
+                parseAndDiagnose(
+                    'author:me before:yesterday after:"last week" message:test type:diff',
+                    SearchPatternType.literal
+                )
+            ).toMatchInlineSnapshot(`[]`)
+        })
     })
 })

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -96,7 +96,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
         not(some({ field: { value: 'type' }, value: { value: oneOf('diff', 'commit') } })),
         each({
             field: { value: oneOf('author', 'before', 'until', 'after', 'since', 'message', 'msg', 'm') },
-            $data: addFilterDiagnostic('Error: this filter requires "type:commit" or "type:diff" in the query'),
+            $data: addFilterDiagnostic('Error: this filter requires `type:commit` or `type:diff` in the query'),
         })
     ),
 
@@ -114,7 +114,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
                 $data: (_tokens, context) => {
                     context.data.marker.push(
                         createMarker(
-                            'Error: query contains "rev:" without "repo:". Add a "repo:" filter.',
+                            'Error: query contains `rev:` without `repo:`. Add a `repo:` filter.',
                             context.data.revFilter!
                         )
                     )
@@ -128,7 +128,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
                     value: { value: '' },
                     $data: (token: Token, context: MatchContext<PatternData>) => {
                         const errorMessage =
-                            'Error: query contains "rev:" with an empty "repo:" filter. Add a non-empty "repo:" filter.'
+                            'Error: query contains `rev:` with an empty `repo:` filter. Add a non-empty `repo:` filter.'
                         context.data.marker.push(
                             createMarker(errorMessage, token as Filter),
                             createMarker(errorMessage, context.data.revFilter!)
@@ -142,7 +142,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
                 value: { value: value => value.includes('@') },
                 $data: (token: Token, context: MatchContext<PatternData>) => {
                     const errorMessage =
-                        'Error: You have specified both "@" and "rev:" for a repo filter and I don"t know how to interpret this. Remove either "@" or "rev:"'
+                        'Error: You have specified both `@` and `rev:` for a repo filter and I don`t know how to interpret this. Remove either `@` or `rev:`'
                     context.data.marker.push(
                         createMarker(errorMessage, token as Filter),
                         createMarker(errorMessage, context.data.revFilter!)
@@ -164,7 +164,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
         some({
             field: { value: 'type' },
             $data: addFilterDiagnostic(
-                'Error: Structural search syntax only applies to searching file contents and is not compatible with "type:". Remove this filter or switch to a different search type.'
+                'Error: Structural search syntax only applies to searching file contents and is not compatible with `type:`. Remove this filter or switch to a different search type.'
             ),
         })
     ),

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -4,23 +4,40 @@ import { SearchPatternType } from '../../graphql-operations'
 
 import { validateFilter } from './filters'
 import { toMonacoSingleLineRange } from './monaco'
-import { PatternOf, each, matchesValue, eachOf, allOf, some, oneOf, every, not } from './patternMatcher'
+import {
+    PatternOf,
+    each,
+    matchesValue,
+    eachOf,
+    allOf,
+    some,
+    oneOf,
+    not,
+    DataMapper,
+    MatchContext,
+} from './patternMatcher'
 import { Filter, Token } from './token'
 
 type FilterCheck = (f: Filter) => Monaco.editor.IMarkerData[]
+
+function createMarker(
+    message: string,
+    filter: Filter,
+    severity = Monaco.MarkerSeverity.Error
+): Monaco.editor.IMarkerData {
+    return {
+        severity,
+        message,
+        ...toMonacoSingleLineRange(filter.field.range),
+    }
+}
 
 export function validFilterValue(filter: Filter): Monaco.editor.IMarkerData[] {
     const validationResult = validateFilter(filter.field.value, filter.value)
     if (validationResult.valid) {
         return []
     }
-    return [
-        {
-            severity: Monaco.MarkerSeverity.Error,
-            message: `Error: ${validationResult.reason}`,
-            ...toMonacoSingleLineRange(filter.field.range),
-        },
-    ]
+    return [createMarker(`Error: ${validationResult.reason}`, filter)]
 }
 
 export function emptyFilterValue(filter: Filter): Monaco.editor.IMarkerData[] {
@@ -28,11 +45,11 @@ export function emptyFilterValue(filter: Filter): Monaco.editor.IMarkerData[] {
         return []
     }
     return [
-        {
-            severity: Monaco.MarkerSeverity.Warning,
-            message: `Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., ${filter.field.value}:" a term".`,
-            ...toMonacoSingleLineRange(filter.field.range),
-        },
+        createMarker(
+            `Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., ${filter.field.value}:" a term".`,
+            filter,
+            Monaco.MarkerSeverity.Warning
+        ),
     ]
 }
 
@@ -43,26 +60,114 @@ export function checkFilter(filter: Filter): Monaco.editor.IMarkerData[] {
     const checks: FilterCheck[] = [validFilterValue, emptyFilterValue]
     return checks.map(check => check(filter)).find(value => value.length !== 0) || []
 }
-const rules: PatternOf<Token[], Monaco.editor.IMarkerData[]>[] = [
+
+// There should be a better way to pass additional data to patterns, or for
+// patterns to keep internal state than piggybacking on `data`
+// (tracked in https://github.com/sourcegraph/sourcegraph/issues/25070)
+interface PatternData {
+    // Used to make the search pattern type available to patterns
+    searchPatternType: SearchPatternType
+    // Used by patterns to "export" markers
+    marker: Monaco.editor.IMarkerData[]
+    // Used by the rev+repo patterns to keep track of the rev filter
+    revFilter?: Filter
+}
+
+function addFilterDiagnostic(message: string, severity = Monaco.MarkerSeverity.Error): DataMapper<Token, PatternData> {
+    return (token, context) => {
+        context.data.marker.push(createMarker(message, token as Filter, severity))
+    }
+}
+
+const repoFilterPattern: PatternOf<Token, any> = {
+    field: { value: oneOf('repo', 'r') },
+}
+
+const rules: PatternOf<Token[], PatternData>[] = [
     // Validate the value of each filter
     each({
         type: 'filter',
-        $data: (token, context) => {
-            context.data.push(...checkFilter(token as Filter))
+        $data: (token: Token, context: MatchContext<PatternData>) => {
+            context.data.marker.push(...checkFilter(token as Filter))
         },
     }),
+
+    // Validates that author/before/after/message fields are only valid
+    // type:diff/commit queries
     allOf(
-        not(some({ type: 'filter', field: { value: 'type' }, value: { value: oneOf('diff', 'commit') } })),
+        not(some({ field: { value: 'type' }, value: { value: oneOf('diff', 'commit') } })),
         each({
-            type: 'filter',
-            field: { value: oneOf('author', 'before', 'after', 'message') },
-            $data: (token, context) => {
-                context.data.push({
-                    severity: Monaco.MarkerSeverity.Error,
-                    message: `Error: this filter requires 'type:commit' or 'type:diff' in the query`,
-                    ...toMonacoSingleLineRange((token as Filter).field.range),
-                })
+            field: { value: oneOf('author', 'before', 'until', 'after', 'since', 'message', 'msg', 'm') },
+            $data: addFilterDiagnostic('Error: this filter requires "type:commit" or "type:diff" in the query'),
+        })
+    ),
+
+    // Validates that query contains a valid repo: filter if it contains a rev:
+    // filter.
+    // NOTE: We don't have to explicitly verify that the repo: filters are
+    // negated because they cannot be matched by these patterns anyway (the
+    // field value would be `-repo`, not `repo`).
+    allOf(
+        some({ field: { value: oneOf('rev', 'revision') }, $data: { revFilter: token => token as Filter } }), // "remember" rev filter token
+        oneOf(
+            // No repo: filter
+            {
+                $pattern: not(some(repoFilterPattern)),
+                $data: (_tokens, context) => {
+                    context.data.marker.push(
+                        createMarker(
+                            'Error: query contains "rev:" without "repo:". Add a "repo:" filter.',
+                            context.data.revFilter!
+                        )
+                    )
+                },
             },
+            // Only empty repo: filter
+            allOf(
+                not(some({ ...repoFilterPattern, value: { value: value => value !== '' } })),
+                some({
+                    ...repoFilterPattern,
+                    value: { value: '' },
+                    $data: (token: Token, context: MatchContext<PatternData>) => {
+                        const errorMessage =
+                            'Error: query contains "rev:" with an empty "repo:" filter. Add a non-empty "repo:" filter.'
+                        context.data.marker.push(
+                            createMarker(errorMessage, token as Filter),
+                            createMarker(errorMessage, context.data.revFilter!)
+                        )
+                    },
+                })
+            ),
+            // Repo filter that contains a revision "tag"
+            some({
+                ...repoFilterPattern,
+                value: { value: value => value.includes('@') },
+                $data: (token: Token, context: MatchContext<PatternData>) => {
+                    const errorMessage =
+                        'Error: You have specified both "@" and "rev:" for a repo filter and I don"t know how to interpret this. Remove either "@" or "rev:"'
+                    context.data.marker.push(
+                        createMarker(errorMessage, token as Filter),
+                        createMarker(errorMessage, context.data.revFilter!)
+                    )
+                },
+            })
+        )
+    ),
+
+    // Validates that query can be evaluated as structural search query
+    allOf(
+        oneOf(
+            some({ field: { value: 'patterntype' }, value: { value: 'structural' } }),
+            allOf(
+                (_tokens, context) => context.data.searchPatternType === SearchPatternType.structural,
+                not(some({ field: { value: 'patterntype' }, value: { value: not('structural') } }))
+            )
+        ),
+        some({
+            field: { value: 'type' },
+            $data: addFilterDiagnostic(
+                'Error: Structural search syntax only applies to searching file contents and is not compatible with "type:". Remove this filter or switch to a different search type.'
+            ),
         })
     ),
 ]
@@ -70,10 +175,10 @@ const rules: PatternOf<Token[], Monaco.editor.IMarkerData[]>[] = [
 /**
  * Returns the diagnostics for a scanned search query to be displayed in the Monaco query input.
  */
-export function getDiagnostics(tokens: Token[], patternType: SearchPatternType): Monaco.editor.IMarkerData[] {
-    const result = matchesValue<Token[], Monaco.editor.IMarkerData[]>(tokens, eachOf(...rules), [])
+export function getDiagnostics(tokens: Token[], searchPatternType: SearchPatternType): Monaco.editor.IMarkerData[] {
+    const result = matchesValue<Token[], PatternData>(tokens, eachOf(...rules), { searchPatternType, marker: [] })
     if (result.success) {
-        return result.data
+        return result.data.marker
     }
     return []
 }

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -61,9 +61,7 @@ export function checkFilter(filter: Filter): Monaco.editor.IMarkerData[] {
     return checks.map(check => check(filter)).find(value => value.length !== 0) || []
 }
 
-// There should be a better way to pass additional data to patterns, or for
-// patterns to keep internal state than piggybacking on `data`
-// (tracked in https://github.com/sourcegraph/sourcegraph/issues/25070)
+// TODO(fkling): Improve how we pass additional data to patterns #25070
 interface PatternData {
     // Used to make the search pattern type available to patterns
     searchPatternType: SearchPatternType


### PR DESCRIPTION
See #24689

This adds validation for commit/diff filters, repo+rev filters and structural search. The validation isn't triggered when the pattern search type is changed via the buttons. That's because the validation logic is only triggered when input changes. Something to consider for the future.


https://user-images.githubusercontent.com/179026/133822215-6d43fe98-2a71-4fa4-a478-0ba66233d12e.mp4



