### PR TITLE
web: run puppeteer only if `client` is affected

### DIFF
--- a/enterprise/dev/ci/internal/ci/is-client-affected.go
+++ b/enterprise/dev/ci/internal/ci/is-client-affected.go
@@ -52,7 +52,7 @@ func isAllowedRootFile(p string) bool {
 	return filepath.Dir(p) == "." && !contains(ignoredRootFiles, p)
 }
 
-// Run Storybook workflow only if related files were changed.
+// Check if files that affect client code were changed. Used to detect if we need to run Puppeteer or Chromatic tests.
 func (c Config) isClientAffected() bool {
 	for _, p := range c.changedFiles {
 		if !strings.HasSuffix(p, ".md") && (strings.HasPrefix(p, "client/") || isAllowedRootFile(p)) {

--- a/enterprise/dev/ci/internal/ci/is-storybook-affected.go
+++ b/enterprise/dev/ci/internal/ci/is-storybook-affected.go
@@ -53,7 +53,7 @@ func isAllowedRootFile(p string) bool {
 }
 
 // Run Storybook workflow only if related files were changed.
-func (c Config) isStorybookAffected() bool {
+func (c Config) isClientAffected() bool {
 	for _, p := range c.changedFiles {
 		if !strings.HasSuffix(p, ".md") && (strings.HasPrefix(p, "client/") || isAllowedRootFile(p)) {
 			return true

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -96,18 +96,18 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
 		// Client integration tests
-		pipeline.AddStep(":puppeteer::electric_plug: Puppeteer tests",
-			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", "true"), // Don't download browser, we use "download-puppeteer-browser" script instead
-			bk.Env("ENTERPRISE", "1"),
-			bk.Env("PERCY_ON", "true"),
-			bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-build.sh client/web"),
-			bk.Cmd("echo \"--- Install puppeteer\" && yarn --cwd client/shared run download-puppeteer-browser"),
-			bk.Cmd("echo \"--- Run integration test suite\" && yarn percy exec -- yarn run cover-integration"),
-			bk.Cmd("echo \"--- Process NYC report\" && yarn nyc report -r json"),
-			bk.Cmd("echo \"--- Upload coverage report\" && dev/ci/codecov.sh -c -F typescript -F integration"),
-			bk.ArtifactPaths("./puppeteer/*.png"))
+		if c.isMainDryRun || c.isClientAffected() {
+			pipeline.AddStep(":puppeteer::electric_plug: Puppeteer tests",
+				bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", "true"), // Don't download browser, we use "download-puppeteer-browser" script instead
+				bk.Env("ENTERPRISE", "1"),
+				bk.Env("PERCY_ON", "true"),
+				bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-build.sh client/web"),
+				bk.Cmd("echo \"--- Install puppeteer\" && yarn --cwd client/shared run download-puppeteer-browser"),
+				bk.Cmd("echo \"--- Run integration test suite\" && yarn percy exec -- yarn run cover-integration"),
+				bk.Cmd("echo \"--- Process NYC report\" && yarn nyc report -r json"),
+				bk.Cmd("echo \"--- Upload coverage report\" && dev/ci/codecov.sh -c -F typescript -F integration"),
+				bk.ArtifactPaths("./puppeteer/*.png"))
 
-		if c.isMainDryRun || c.isStorybookAffected() {
 			// Upload storybook to Chromatic
 			chromaticCommand := "yarn chromatic --exit-zero-on-changes --exit-once-uploaded"
 			if c.isMainBranch() {

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -95,8 +95,8 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 // Adds the shared frontend tests (shared between the web app and browser extension).
 func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		// Client integration tests
 		if c.isMainDryRun || c.isClientAffected() {
+			// Client integration tests
 			pipeline.AddStep(":puppeteer::electric_plug: Puppeteer tests",
 				bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", "true"), // Don't download browser, we use "download-puppeteer-browser" script instead
 				bk.Env("ENTERPRISE", "1"),


### PR DESCRIPTION
Puppeteer tests take a lot of time. Since we mock API responses, changes that do not affect `client` won't change Puppeteer tests results. This PR disables Puppeteer tests if `client` is not affected in the diff. It uses the same logic we apply to skip Chromatic visual tests.

Tested CI pipeline with different changes in this [test PR](https://github.com/sourcegraph/sourcegraph/pull/24750).

Closes https://github.com/sourcegraph/sourcegraph/issues/20880.
Slack [thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1631113626227800). 