### PR TITLE
web: fix search-result-star styles

### DIFF
--- a/client/shared/src/components/ResultContainer.tsx
+++ b/client/shared/src/components/ResultContainer.tsx
@@ -4,10 +4,11 @@ import ArrowCollapseUpIcon from 'mdi-react/ArrowCollapseUpIcon'
 import ArrowExpandDownIcon from 'mdi-react/ArrowExpandDownIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
-import StarIcon from 'mdi-react/StarIcon'
 import React, { useEffect, useState } from 'react'
 
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
+
+import { SearchResultStar } from './SearchResultStar'
 
 export interface Props {
     /**
@@ -160,7 +161,7 @@ export const ResultContainer: React.FunctionComponent<Props> = ({
                 )}
                 {formattedRepositoryStarCount && (
                     <>
-                        <StarIcon className="search-result__star" />
+                        <SearchResultStar />
                         {formattedRepositoryStarCount}
                     </>
                 )}

--- a/client/shared/src/components/SearchResultStar.module.scss
+++ b/client/shared/src/components/SearchResultStar.module.scss
@@ -1,0 +1,7 @@
+.star {
+    fill: var(--yellow);
+    height: 1rem;
+    width: 1rem;
+    min-width: 1rem;
+    margin-right: 0.25rem;
+}

--- a/client/shared/src/components/SearchResultStar.tsx
+++ b/client/shared/src/components/SearchResultStar.tsx
@@ -1,0 +1,6 @@
+import StarIcon from 'mdi-react/StarIcon'
+import React from 'react'
+
+import styles from './SearchResultStar.module.scss'
+
+export const SearchResultStar: React.FunctionComponent = () => <StarIcon className={styles.star} />

--- a/client/web/src/components/SearchResult.module.scss
+++ b/client/web/src/components/SearchResult.module.scss
@@ -57,14 +57,6 @@
     margin-right: 0.25rem;
 }
 
-.star {
-    fill: var(--yellow);
-    height: 1rem;
-    width: 1rem;
-    min-width: 1rem;
-    margin-right: 0.25rem;
-}
-
 .match-type {
     white-space: nowrap;
 }

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -2,13 +2,13 @@ import classNames from 'classnames'
 import ArchiveIcon from 'mdi-react/ArchiveIcon'
 import LockIcon from 'mdi-react/LockIcon'
 import SourceForkIcon from 'mdi-react/SourceForkIcon'
-import StarIcon from 'mdi-react/StarIcon'
 import React from 'react'
 
 import { LastSyncedIcon } from '@sourcegraph/shared/src/components/LastSyncedIcon'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
+import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { CommitMatch, getMatchTitle, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
@@ -43,7 +43,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, icon, rep
                 )}
                 {formattedRepositoryStarCount && (
                     <>
-                        <StarIcon className={styles.star} />
+                        <SearchResultStar />
                         {formattedRepositoryStarCount}
                     </>
                 )}


### PR DESCRIPTION
## Context

`<SearchResult />` styles [were converted](https://github.com/sourcegraph/sourcegraph/pull/24664) to CSS module, but the `search-result__star` class is used outside of the component and was missed during the update. This PR moves these styles into a standalone `<SearchResultStar />` component to share properly. 