### PR TITLE
web: stop diff line number hover errors

### DIFF
--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -86,7 +86,13 @@ export const DiffHunk: React.FunctionComponent<DiffHunkProps> = ({
                         {lineNumbers && (
                             <>
                                 {line.kind !== DiffHunkLineType.ADDED ? (
-                                    <td className={styles.num} data-line={oldLine - 1} data-part="base" id={oldAnchor}>
+                                    <td
+                                        className={styles.num}
+                                        data-line={oldLine - 1}
+                                        data-part="base"
+                                        id={oldAnchor}
+                                        data-hunk-num=" "
+                                    >
                                         {persistLines && (
                                             <Link className={styles.numLine} to={{ hash: oldAnchor }}>
                                                 {oldLine - 1}
@@ -98,7 +104,13 @@ export const DiffHunk: React.FunctionComponent<DiffHunkProps> = ({
                                 )}
 
                                 {line.kind !== DiffHunkLineType.DELETED ? (
-                                    <td className={styles.num} data-line={newLine - 1} data-part="head" id={newAnchor}>
+                                    <td
+                                        className={styles.num}
+                                        data-line={newLine - 1}
+                                        data-part="head"
+                                        id={newAnchor}
+                                        data-hunk-num=" "
+                                    >
                                         {persistLines && (
                                             <Link className={styles.numLine} to={{ hash: newAnchor }}>
                                                 {newLine - 1}

--- a/client/web/src/components/diff/Lines.tsx
+++ b/client/web/src/components/diff/Lines.tsx
@@ -85,6 +85,7 @@ export const Line: React.FunctionComponent<Line> = ({
                     data-line={lineNumber}
                     data-part={dataPart}
                     id={id || anchor}
+                    data-hunk-num=" "
                 >
                     {persistLines && (
                         <Link className={diffHunkStyles.numLine} to={{ hash: anchor }}>

--- a/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
@@ -35,6 +35,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={159}
       data-part="base"
       id="anchor_L159"
@@ -49,6 +50,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={159}
       data-part="head"
       id="anchor_R159"
@@ -82,6 +84,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={160}
       data-part="base"
       id="anchor_L160"
@@ -96,6 +99,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={160}
       data-part="head"
       id="anchor_R160"
@@ -129,6 +133,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={161}
       data-part="base"
       id="anchor_L161"
@@ -143,6 +148,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={161}
       data-part="head"
       id="anchor_R161"
@@ -176,6 +182,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={162}
       data-part="base"
       id="anchor_L162"
@@ -215,6 +222,7 @@ Array [
     />
     <td
       className="num"
+      data-hunk-num=" "
       data-line={162}
       data-part="head"
       id="anchor_R162"
@@ -248,6 +256,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={163}
       data-part="base"
       id="anchor_L163"
@@ -262,6 +271,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={163}
       data-part="head"
       id="anchor_R163"
@@ -295,6 +305,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={164}
       data-part="base"
       id="anchor_L164"
@@ -309,6 +320,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={164}
       data-part="head"
       id="anchor_R164"
@@ -342,6 +354,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={165}
       data-part="base"
       id="anchor_L165"
@@ -356,6 +369,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={165}
       data-part="head"
       id="anchor_R165"
@@ -421,6 +435,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={159}
       data-part="base"
       id="anchor_L159"
@@ -435,6 +450,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={159}
       data-part="head"
       id="anchor_R159"
@@ -485,6 +501,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={160}
       data-part="base"
       id="anchor_L160"
@@ -499,6 +516,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={160}
       data-part="head"
       id="anchor_R160"
@@ -532,6 +550,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={161}
       data-part="base"
       id="anchor_L161"
@@ -546,6 +565,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={161}
       data-part="head"
       id="anchor_R161"
@@ -579,6 +599,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={162}
       data-part="base"
       id="anchor_L162"
@@ -635,6 +656,7 @@ Array [
     />
     <td
       className="num"
+      data-hunk-num=" "
       data-line={162}
       data-part="head"
       id="anchor_R162"
@@ -668,6 +690,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={163}
       data-part="base"
       id="anchor_L163"
@@ -682,6 +705,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={163}
       data-part="head"
       id="anchor_R163"
@@ -715,6 +739,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={164}
       data-part="base"
       id="anchor_L164"
@@ -729,6 +754,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={164}
       data-part="head"
       id="anchor_R164"
@@ -762,6 +788,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={165}
       data-part="base"
       id="anchor_L165"
@@ -776,6 +803,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={165}
       data-part="head"
       id="anchor_R165"
@@ -841,6 +869,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={159}
       data-part="base"
       id="anchor_L159"
@@ -855,6 +884,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={159}
       data-part="head"
       id="anchor_R159"
@@ -904,6 +934,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={160}
       data-part="base"
       id="anchor_L160"
@@ -918,6 +949,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={160}
       data-part="head"
       id="anchor_R160"
@@ -951,6 +983,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={161}
       data-part="base"
       id="anchor_L161"
@@ -965,6 +998,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={161}
       data-part="head"
       id="anchor_R161"
@@ -998,6 +1032,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={162}
       data-part="base"
       id="anchor_L162"
@@ -1053,6 +1088,7 @@ Array [
     />
     <td
       className="num"
+      data-hunk-num=" "
       data-line={162}
       data-part="head"
       id="anchor_R162"
@@ -1086,6 +1122,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={163}
       data-part="base"
       id="anchor_L163"
@@ -1100,6 +1137,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={163}
       data-part="head"
       id="anchor_R163"
@@ -1133,6 +1171,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={164}
       data-part="base"
       id="anchor_L164"
@@ -1147,6 +1186,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={164}
       data-part="head"
       id="anchor_R164"
@@ -1180,6 +1220,7 @@ Array [
   >
     <td
       className="num"
+      data-hunk-num=" "
       data-line={165}
       data-part="base"
       id="anchor_L165"
@@ -1194,6 +1235,7 @@ Array [
     </td>
     <td
       className="num"
+      data-hunk-num=" "
       data-line={165}
       data-part="head"
       id="anchor_R165"


### PR DESCRIPTION
fix #24762.

After applying the CSS modules codemod to `web/diff` components (#24660), we forgot to add the new data attributes diff hunk line number `<td>`s (that `diffDomFunctions.getCodeElementFromTarget` looks for to determine that a `<td>` is not a code element to).