### PR TITLE
web: keep diff line decorations on same line if possible

### DIFF
--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -118,7 +118,7 @@ export const DiffHunk: React.FunctionComponent<DiffHunkProps> = ({
                             style={lineStyle}
                             data-diff-marker={diffHunkTypeIndicators[line.kind]}
                         >
-                            <div className="d-inline" dangerouslySetInnerHTML={{ __html: line.html }} />
+                            <div className="d-inline-block" dangerouslySetInnerHTML={{ __html: line.html }} />
                             {decorationsForLine.filter(property('after', isDefined)).map((decoration, index) => {
                                 const style = decorationAttachmentStyleForTheme(decoration.after, isLightTheme)
                                 return (

--- a/client/web/src/components/diff/Lines.tsx
+++ b/client/web/src/components/diff/Lines.tsx
@@ -100,7 +100,11 @@ export const Line: React.FunctionComponent<Line> = ({
                 data-diff-marker={diffHunkTypeIndicators[kind]}
             >
                 <div className={classNames('d-inline', styles.lineCode)}>
-                    <div dangerouslySetInnerHTML={{ __html: html }} data-diff-marker={diffHunkTypeIndicators[kind]} />
+                    <div
+                        className="d-inline-block"
+                        dangerouslySetInnerHTML={{ __html: html }}
+                        data-diff-marker={diffHunkTypeIndicators[kind]}
+                    />
                     {decorations.map((decoration, index) => {
                         const style = decorationAttachmentStyleForTheme(decoration.after, isLightTheme)
                         return (

--- a/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
@@ -67,7 +67,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const subscriptions = new Subscription()",
@@ -114,7 +114,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const decorationType = sourcegraph.app.createDecorationType()",
@@ -161,7 +161,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const connection = await createConnection()",
@@ -197,7 +197,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        logger.log(\`WebSocket connection to TypeScript backend opened\`)",
@@ -233,7 +233,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        logger.log(\`WebSocket connection to language server opened\`)",
@@ -280,7 +280,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        subscriptions.add(",
@@ -327,7 +327,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "                connection.observeNotification(LogMessageNotification.type).subscribe(({ type, message }) => {",
@@ -374,7 +374,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "                    const method = LSP_TO_LOG_LEVEL[type]",
@@ -458,7 +458,7 @@ Array [
       }
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const subscriptions = new Subscription()",
@@ -517,7 +517,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const decorationType = sourcegraph.app.createDecorationType()",
@@ -564,7 +564,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const connection = await createConnection()",
@@ -605,7 +605,7 @@ Array [
       }
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        logger.log(\`WebSocket connection to TypeScript backend opened\`)",
@@ -653,7 +653,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        logger.log(\`WebSocket connection to language server opened\`)",
@@ -700,7 +700,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        subscriptions.add(",
@@ -747,7 +747,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "                connection.observeNotification(LogMessageNotification.type).subscribe(({ type, message }) => {",
@@ -794,7 +794,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "                    const method = LSP_TO_LOG_LEVEL[type]",
@@ -877,7 +877,7 @@ Array [
       }
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const subscriptions = new Subscription()",
@@ -936,7 +936,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const decorationType = sourcegraph.app.createDecorationType()",
@@ -983,7 +983,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        const connection = await createConnection()",
@@ -1023,7 +1023,7 @@ Array [
       }
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        logger.log(\`WebSocket connection to TypeScript backend opened\`)",
@@ -1071,7 +1071,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        logger.log(\`WebSocket connection to language server opened\`)",
@@ -1118,7 +1118,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "        subscriptions.add(",
@@ -1165,7 +1165,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "                connection.observeNotification(LogMessageNotification.type).subscribe(({ type, message }) => {",
@@ -1212,7 +1212,7 @@ Array [
       style={Object {}}
     >
       <div
-        className="d-inline"
+        className="d-inline-block"
         dangerouslySetInnerHTML={
           Object {
             "__html": "                    const method = LSP_TO_LOG_LEVEL[type]",


### PR DESCRIPTION
fix #24469.

#### Line wrapping

![Screenshot from 2021-09-08 17-07-26](https://user-images.githubusercontent.com/37420160/132586394-136474db-d8d7-4e6d-bd24-2029c851376d.png)

#### Unified

![Screenshot from 2021-09-08 17-07-11](https://user-images.githubusercontent.com/37420160/132586469-cf0a0f41-fa92-4853-bd6d-4a18f59a776f.png)


#### Split

![Screenshot from 2021-09-08 17-06-56](https://user-images.githubusercontent.com/37420160/132586460-e2c38050-0c87-4b33-8312-39a3a1c3d835.png)
