### PR TITLE
perf: Reduce amount of list repo and search contexts SQL queries

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -144,7 +144,7 @@ func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, new
 	m.Get(apirouter.Telemetry).Handler(trace.Route(telemetryHandler(db)))
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(schema, rateLimitWatcher, true))))
 	m.Get(apirouter.Configuration).Handler(trace.Route(handler(serveConfiguration)))
-	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(serveSearchConfiguration)))
+	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(serveSearchConfiguration(db))))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)
 	m.Get(apirouter.StreamingSearch).Handler(trace.Route(frontendsearch.StreamHandler(db)))
 


### PR DESCRIPTION
We currently run both of these queries around 100M times an h in dotcom. As this grows linearly with the number of indexed repos, I suspect this might be one contributing factor to the increase in db connection wait times we've observed. This _might_ fix it by grouping lots of SQL queries together. I only got very few repos, but I got from 17ms to 5ms locally. Not sure what the impact would be on dotcom.
I think the memory usage should be around the same.

If you think this approach makes sense, we can clean the code up and address the TODOs around only 32k repos being supported. (Max number of arguments for prepared statements in psql). Even if we need to split into chunks of "only" 32k repos at a time, this still means we potentially need to run only a 1/32000th of the number of queries we had to run before. That _could_ mean we would only need to run around 100M/32k * 2 = 6250 instead of 200M queries per hour.
