### PR TITLE
codeintel: Add expired flag to uploads

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1140,6 +1140,7 @@ Stores the retention policy of code intellience data for a repository.
  last_heartbeat_at      | timestamp with time zone |           |          | 
  execution_logs         | json[]                   |           |          | 
  num_references         | integer                  |           |          | 
+ expired                | boolean                  |           | not null | false
 Indexes:
     "lsif_uploads_pkey" PRIMARY KEY, btree (id)
     "lsif_uploads_repository_id_commit_root_indexer" UNIQUE, btree (repository_id, commit, root, indexer) WHERE state = 'completed'::text
@@ -1160,6 +1161,8 @@ Referenced by:
 Stores metadata about an LSIF index uploaded by a user.
 
 **commit**: A 40-char revhash. Note that this commit may not be resolvable in the future.
+
+**expired**: Whether or not this upload data is no longer protected by any data retention policy.
 
 **id**: Used as a logical foreign key with the (disjoint) codeintel database.
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2102,6 +2102,7 @@ Triggers:
  upload_size         | bigint                   |           |          | 
  num_failures        | integer                  |           |          | 
  associated_index_id | bigint                   |           |          | 
+ expired             | boolean                  |           |          | 
  processed_at        | timestamp with time zone |           |          | 
 
 ```
@@ -2126,6 +2127,7 @@ Triggers:
     u.upload_size,
     u.num_failures,
     u.associated_index_id,
+    u.expired,
     u.finished_at AS processed_at
    FROM lsif_uploads u
   WHERE ((u.state = 'completed'::text) OR (u.state = 'deleting'::text));
@@ -2152,6 +2154,7 @@ Triggers:
  upload_size         | bigint                   |           |          | 
  num_failures        | integer                  |           |          | 
  associated_index_id | bigint                   |           |          | 
+ expired             | boolean                  |           |          | 
  processed_at        | timestamp with time zone |           |          | 
  repository_name     | citext                   |           |          | 
 
@@ -2177,6 +2180,7 @@ Triggers:
     u.upload_size,
     u.num_failures,
     u.associated_index_id,
+    u.expired,
     u.processed_at,
     r.name AS repository_name
    FROM (lsif_dumps u
@@ -2260,6 +2264,7 @@ Triggers:
  upload_size         | bigint                   |           |          | 
  num_failures        | integer                  |           |          | 
  associated_index_id | bigint                   |           |          | 
+ expired             | boolean                  |           |          | 
  repository_name     | citext                   |           |          | 
 
 ```
@@ -2284,6 +2289,7 @@ Triggers:
     u.upload_size,
     u.num_failures,
     u.associated_index_id,
+    u.expired,
     r.name AS repository_name
    FROM (lsif_uploads u
      JOIN repo r ON ((r.id = u.repository_id)))

--- a/migrations/frontend/1528395875_lsif_upload_expired_flag.down.sql
+++ b/migrations/frontend/1528395875_lsif_upload_expired_flag.down.sql
@@ -1,0 +1,81 @@
+BEGIN;
+
+-- Drop dependent views
+DROP VIEW lsif_dumps_with_repository_name;
+DROP VIEW lsif_dumps;
+DROP VIEW lsif_uploads_with_repository_name;
+
+-- Drop new column
+ALTER TABLE lsif_uploads DROP COLUMN expired;
+
+-- Restore old views
+CREATE VIEW lsif_uploads_with_repository_name AS
+    SELECT u.id,
+        u.commit,
+        u.root,
+        u.uploaded_at,
+        u.state,
+        u.failure_message,
+        u.started_at,
+        u.finished_at,
+        u.repository_id,
+        u.indexer,
+        u.num_parts,
+        u.uploaded_parts,
+        u.process_after,
+        u.num_resets,
+        u.upload_size,
+        u.num_failures,
+        u.associated_index_id,
+        r.name AS repository_name
+    FROM lsif_uploads u
+    JOIN repo r ON r.id = u.repository_id
+    WHERE r.deleted_at IS NULL;
+
+CREATE VIEW lsif_dumps AS
+    SELECT u.id,
+        u.commit,
+        u.root,
+        u.uploaded_at,
+        u.state,
+        u.failure_message,
+        u.started_at,
+        u.finished_at,
+        u.repository_id,
+        u.indexer,
+        u.num_parts,
+        u.uploaded_parts,
+        u.process_after,
+        u.num_resets,
+        u.upload_size,
+        u.num_failures,
+        u.associated_index_id,
+        u.finished_at AS processed_at
+    FROM lsif_uploads u
+    WHERE u.state = 'completed'::text OR u.state = 'deleting'::text;
+
+CREATE VIEW lsif_dumps_with_repository_name AS
+    SELECT u.id,
+        u.commit,
+        u.root,
+        u.uploaded_at,
+        u.state,
+        u.failure_message,
+        u.started_at,
+        u.finished_at,
+        u.repository_id,
+        u.indexer,
+        u.num_parts,
+        u.uploaded_parts,
+        u.process_after,
+        u.num_resets,
+        u.upload_size,
+        u.num_failures,
+        u.associated_index_id,
+        u.processed_at,
+        r.name AS repository_name
+    FROM lsif_dumps u
+    JOIN repo r ON r.id = u.repository_id
+    WHERE r.deleted_at IS NULL;
+
+COMMIT;

--- a/migrations/frontend/1528395875_lsif_upload_expired_flag.up.sql
+++ b/migrations/frontend/1528395875_lsif_upload_expired_flag.up.sql
@@ -1,0 +1,85 @@
+BEGIN;
+
+-- Drop dependent views
+DROP VIEW lsif_dumps_with_repository_name;
+DROP VIEW lsif_dumps;
+DROP VIEW lsif_uploads_with_repository_name;
+
+-- Add new column
+ALTER TABLE lsif_uploads ADD COLUMN expired boolean not null default false;
+COMMENT ON COLUMN lsif_uploads.expired IS 'Whether or not this upload data is no longer protected by any data retention policy.';
+
+-- Update view definitions to include new fields
+CREATE VIEW lsif_uploads_with_repository_name AS
+    SELECT u.id,
+        u.commit,
+        u.root,
+        u.uploaded_at,
+        u.state,
+        u.failure_message,
+        u.started_at,
+        u.finished_at,
+        u.repository_id,
+        u.indexer,
+        u.num_parts,
+        u.uploaded_parts,
+        u.process_after,
+        u.num_resets,
+        u.upload_size,
+        u.num_failures,
+        u.associated_index_id,
+        u.expired,
+        r.name AS repository_name
+    FROM lsif_uploads u
+    JOIN repo r ON r.id = u.repository_id
+    WHERE r.deleted_at IS NULL;
+
+CREATE VIEW lsif_dumps AS
+    SELECT u.id,
+        u.commit,
+        u.root,
+        u.uploaded_at,
+        u.state,
+        u.failure_message,
+        u.started_at,
+        u.finished_at,
+        u.repository_id,
+        u.indexer,
+        u.num_parts,
+        u.uploaded_parts,
+        u.process_after,
+        u.num_resets,
+        u.upload_size,
+        u.num_failures,
+        u.associated_index_id,
+        u.expired,
+        u.finished_at AS processed_at
+    FROM lsif_uploads u
+    WHERE u.state = 'completed'::text OR u.state = 'deleting'::text;
+
+CREATE VIEW lsif_dumps_with_repository_name AS
+    SELECT u.id,
+        u.commit,
+        u.root,
+        u.uploaded_at,
+        u.state,
+        u.failure_message,
+        u.started_at,
+        u.finished_at,
+        u.repository_id,
+        u.indexer,
+        u.num_parts,
+        u.uploaded_parts,
+        u.process_after,
+        u.num_resets,
+        u.upload_size,
+        u.num_failures,
+        u.associated_index_id,
+        u.expired,
+        u.processed_at,
+        r.name AS repository_name
+    FROM lsif_dumps u
+    JOIN repo r ON r.id = u.repository_id
+    WHERE r.deleted_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
This PR adds an expired flag to upload records. This flag will eventually be set by a background process comparing upload visibility against data retention policies, and the expired flag combined with the number of of uploads referencing it will denote when LSIF data can be garbage collected.