### PR TITLE
extensibility: only lookup repos for supported cloud code hosts

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -1237,7 +1237,34 @@ const CODE_HOSTS: CodeHost[] = [
     phabricatorCodeHost,
     gerritCodeHost,
 ]
-export const determineCodeHost = (): CodeHost | undefined => CODE_HOSTS.find(codeHost => codeHost.check())
+
+const CLOUD_CODE_HOST_HOSTS = ['github.com', 'gitlab.com']
+
+export const determineCodeHost = (sourcegraphURL?: string): CodeHost | undefined => {
+    const codeHost = CODE_HOSTS.find(codeHost => codeHost.check())
+
+    if (!codeHost) {
+        return undefined
+    }
+
+    // Prevent repo lookups for code hosts that we know cannot have repositories
+    // cloned on sourcegraph.com. Repo lookups trigger cloning, which will
+    // inevitably fail in this case.
+    if (sourcegraphURL === DEFAULT_SOURCEGRAPH_URL) {
+        const { hostname } = new URL(location.href)
+        const validCodeHost = CLOUD_CODE_HOST_HOSTS.some(cloudHost => cloudHost === hostname)
+        if (!validCodeHost) {
+            console.log(
+                `Sourcegraph code host integration: stopped initialization since ${hostname} is not a supported code host when Sourcegraph URL is ${DEFAULT_SOURCEGRAPH_URL}.\n List of supported code hosts on ${DEFAULT_SOURCEGRAPH_URL}: ${CLOUD_CODE_HOST_HOSTS.join(
+                    ', '
+                )}`
+            )
+            return undefined
+        }
+    }
+
+    return codeHost
+}
 
 export function injectCodeIntelligenceToCodeHost(
     mutations: Observable<MutationRecordLike[]>,

--- a/client/browser/src/shared/code-hosts/shared/inject.ts
+++ b/client/browser/src/shared/code-hosts/shared/inject.ts
@@ -20,7 +20,7 @@ export async function injectCodeIntelligence(
     onCodeHostFound?: (codeHost: CodeHost) => Promise<void>
 ): Promise<Subscription> {
     const subscriptions = new Subscription()
-    const codeHost = determineCodeHost()
+    const codeHost = determineCodeHost(urls.sourcegraphURL)
     if (codeHost) {
         console.log('Sourcegraph: Detected code host:', codeHost.type)
 


### PR DESCRIPTION
Close #23914.

If the browser extension is pointed towards Cloud and the currently viewed page is a supported code host, check the hostname to see if it's a valid Cloud code host (which is a subset of supported code hosts?). If not, do not inject extension features (which stops repo lookups).