### PR TITLE
perf: Don't load user from DB where not necessary

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -191,11 +191,8 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	Name        string
 	DisplayName *string
 }) (*OrgResolver, error) {
-	currentUser, err := CurrentUser(ctx, r.db)
-	if err != nil {
-		return nil, err
-	}
-	if currentUser == nil {
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
 		return nil, errors.New("no current user")
 	}
 
@@ -208,7 +205,7 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	}
 
 	// Add the current user as the first member of the new org.
-	_, err = database.OrgMembers(r.db).Create(ctx, newOrg.ID, currentUser.user.ID)
+	_, err = database.OrgMembers(r.db).Create(ctx, newOrg.ID, a.UID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -114,18 +114,17 @@ func (r *schemaResolver) toSavedSearchResolver(entry types.SavedSearch) *savedSe
 }
 
 func (r *schemaResolver) SavedSearches(ctx context.Context) ([]*savedSearchResolver, error) {
-	var savedSearches []*savedSearchResolver
-	currentUser, err := CurrentUser(ctx, r.db)
-	if currentUser == nil {
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
 		return nil, errors.New("no currently authenticated user")
 	}
+
+	allSavedSearches, err := database.SavedSearches(r.db).ListSavedSearchesByUserID(ctx, a.UID)
 	if err != nil {
 		return nil, err
 	}
-	allSavedSearches, err := database.SavedSearches(r.db).ListSavedSearchesByUserID(ctx, currentUser.DatabaseID())
-	if err != nil {
-		return nil, err
-	}
+
+	var savedSearches []*savedSearchResolver
 	for _, savedSearch := range allSavedSearches {
 		savedSearches = append(savedSearches, r.toSavedSearchResolver(*savedSearch))
 	}

--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -28,7 +28,7 @@ func TestSavedSearches(t *testing.T) {
 		return []*types.SavedSearch{{ID: key, Description: "test query", Query: "test type:diff patternType:regexp", Notify: true, NotifySlack: false, UserID: &userID, OrgID: nil}}, nil
 	}
 
-	savedSearches, err := (&schemaResolver{db: db}).SavedSearches(ctx)
+	savedSearches, err := (&schemaResolver{db: db}).SavedSearches(actor.WithActor(ctx, actor.FromUser(key)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -31,11 +32,9 @@ func (r *schemaResolver) DeleteUser(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	currentUser, err := CurrentUser(ctx, r.db)
-	if err != nil {
-		return nil, err
-	}
-	if currentUser.ID() == args.User {
+	// a must be authenticated at this point, CheckCurrentUserIsSiteAdmin enforces it.
+	a := actor.FromContext(ctx)
+	if a.UID == userID {
 		return nil, errors.New("unable to delete current user")
 	}
 


### PR DESCRIPTION
In a couple of places, we used CurrentUser, which reaches out to the DB to get the entire user record. However, we only ever needed the user ID, which we already validated in the context, so we can just use the actor package. It saves a DB request :)
