### PR TITLE
Let caddy wait for webpack dev server to be up

### DIFF
--- a/dev/Caddyfile
+++ b/dev/Caddyfile
@@ -9,7 +9,9 @@
 # Caddy (tls :3443) -> webpack (:3080) -> Caddy (:3081) -> sourcegraph-frontend (:3082)
 {$SOURCEGRAPH_HTTPS_DOMAIN}:{$SOURCEGRAPH_HTTPS_PORT} {
   tls internal
-  reverse_proxy localhost:3080
+  reverse_proxy localhost:3080 {
+      lb_try_duration 60s
+  }
 }
 
 # Caddy (:3081) -> sourcegraph-frontend (:3082)


### PR DESCRIPTION
Previously, for the first couple of seconds after starting the dev env, all requests would fail with 502 errors because the proxied to Webpack dev server isn't running yet. This config change gives it up to 60s to start up before the connection is closed with 502. NO MORE RELENTLESS SMASHING OF cmd + R.
Do you agree this is better? Or can anyone think of any drawbacks of this method? 

https://user-images.githubusercontent.com/19534377/132603443-8182aefe-ea71-4ade-a0a1-00c3b9c55f0f.mov