### PR TITLE
codeintel: Add RepositoryIDsForRetentionScan

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -61,6 +61,7 @@ type operations struct {
 	referencesForUpload                    *observation.Operation
 	refreshCommitResolvability             *observation.Operation
 	repoName                               *observation.Operation
+	repositoryIDsForRetentionScan          *observation.Operation
 	requeue                                *observation.Operation
 	requeueIndex                           *observation.Operation
 	softDeleteOldUploads                   *observation.Operation
@@ -151,6 +152,7 @@ func newOperations(observationContext *observation.Context, metrics *metrics.Ope
 		referencesForUpload:                    op("ReferencesForUpload"),
 		refreshCommitResolvability:             op("RefreshCommitResolvability"),
 		repoName:                               op("RepoName"),
+		repositoryIDsForRetentionScan:          op("RepositoryIDsForRetentionScan"),
 		requeue:                                op("Requeue"),
 		requeueIndex:                           op("RequeueIndex"),
 		softDeleteOldUploads:                   op("SoftDeleteOldUploads"),

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -705,6 +705,55 @@ const hardDeleteUploadByIDQuery = `
 DELETE FROM lsif_uploads WHERE id IN (%s)
 `
 
+// RepositoryIDsForRetentionScan returns a set of identifiers of repositories that are
+// due to be scanned for removable code intelligence data. Repositories that were returned
+// previously from this call within the given process delay are not returned.
+func (s *Store) RepositoryIDsForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) (_ []int, err error) {
+	return s.repositoryIDsForRetentionScan(ctx, processDelay, limit, time.Now())
+}
+
+func (s *Store) repositoryIDsForRetentionScan(ctx context.Context, processDelay time.Duration, limit int, now time.Time) (_ []int, err error) {
+	ctx, endObservation := s.operations.repositoryIDsForRetentionScan.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return basestore.ScanInts(s.Query(ctx, sqlf.Sprintf(
+		repositoryIDsForRetentionScanQuery,
+		now,
+		int(processDelay/time.Second),
+		limit,
+		now,
+		now,
+	)))
+}
+
+//
+// TODO - should not return dirty repositories
+//
+
+const repositoryIDsForRetentionScanQuery = `
+-- source: enterprise/internal/codeintel/stores/dbstore/uploads.go:repositoryIDsForRetentionScan
+WITH candidate_repositories AS (
+	SELECT DISTINCT u.repository_id AS id
+	FROM lsif_uploads u
+	WHERE u.state = 'completed'
+),
+repositories AS (
+	SELECT cr.id FROM candidate_repositories cr
+	LEFT JOIN lsif_last_retention_scan lrs
+	ON lrs.repository_id = cr.id
+	-- Ignore records that have been checked recently. Note this condition is
+	-- true for a null last_retention_scan_at (which has never been checked).
+	WHERE (%s - lrs.last_retention_scan_at > (%s * '1 second'::interval)) IS DISTINCT FROM FALSE
+	ORDER BY lrs.last_retention_scan_at NULLS FIRST, cr.id
+	LIMIT %s
+)
+INSERT INTO lsif_last_retention_scan (repository_id, last_retention_scan_at)
+SELECT id, %s::timestamp FROM repositories
+ON CONFLICT (repository_id) DO UPDATE
+SET last_retention_scan_at = %s
+RETURNING repository_id
+`
+
 // UpdateNumReferences calculates the number of existant uploads that reference any
 // of the given upload identifiers and updates the num_references field of each
 // upload.

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -762,9 +762,6 @@ SET last_retention_scan_at = %s
 RETURNING repository_id
 `
 
-
-
-
 // UpdateUploadRetention updates the last data retention scan timestamp on the upload
 // records with the given protected identifiers and sets the expired field on the upload
 // records with the given expired identifiers.
@@ -822,7 +819,6 @@ const updateUploadRetentionQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/uploads.go:UpdateUploadRetention
 UPDATE lsif_uploads SET %s WHERE id IN (%s)`
 
->>>>>>> main
 // UpdateNumReferences calculates the number of existant uploads that reference any
 // of the given upload identifiers and updates the num_references field of each
 // upload.

--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -949,7 +949,7 @@ func TestRepositoryIDsForRetentionScan(t *testing.T) {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
-	// Make repository 54 newly visible
+	// Make repository 5 newly visible
 	if _, err := db.Exec(`UPDATE lsif_uploads SET state = 'completed' WHERE id = 5`); err != nil {
 		t.Fatalf("unexpected error updating upload: %s", err)
 	}

--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -899,6 +900,65 @@ func TestHardDeleteUploadByID(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedNumReferencesByID, numReferencesByID); diff != "" {
 		t.Errorf("unexpected reference count (-want +got):\n%s", diff)
+	}
+}
+
+func TestRepositoryIDsForRetentionScan(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	db := dbtesting.GetDB(t)
+	store := testStore(db)
+
+	insertUploads(t, db,
+		Upload{ID: 1, RepositoryID: 50, State: "completed"},
+		Upload{ID: 2, RepositoryID: 51, State: "completed"},
+		Upload{ID: 3, RepositoryID: 52, State: "completed"},
+		Upload{ID: 4, RepositoryID: 53, State: "completed"},
+		Upload{ID: 5, RepositoryID: 54, State: "errored"},
+		Upload{ID: 6, RepositoryID: 54, State: "deleted"},
+	)
+
+	now := timeutil.Now()
+
+	// Can return nulls
+	if repositoryIDs, err := store.repositoryIDsForRetentionScan(context.Background(), time.Hour, 2, now); err != nil {
+		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
+	} else if diff := cmp.Diff([]int{50, 51}, repositoryIDs); diff != "" {
+		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
+	}
+
+	// 20 minutes later, first two repositories are still on cooldown
+	if repositoryIDs, err := store.repositoryIDsForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*20)); err != nil {
+		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
+	} else if diff := cmp.Diff([]int{52, 53}, repositoryIDs); diff != "" {
+		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
+	}
+
+	// 30 minutes later, all repositories are still on cooldown
+	if repositoryIDs, err := store.repositoryIDsForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*30)); err != nil {
+		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
+	} else if diff := cmp.Diff([]int(nil), repositoryIDs); diff != "" {
+		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
+	}
+
+	// 90 minutes later, all repositories are visible
+	if repositoryIDs, err := store.repositoryIDsForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*90)); err != nil {
+		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
+	} else if diff := cmp.Diff([]int{50, 51, 52, 53}, repositoryIDs); diff != "" {
+		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
+	}
+
+	// Make repository 54 newly visible
+	if _, err := db.Exec(`UPDATE lsif_uploads SET state = 'completed' WHERE id = 5`); err != nil {
+		t.Fatalf("unexpected error updating upload: %s", err)
+	}
+
+	// 95 minutes later, only new repository is visible
+	if repositoryIDs, err := store.repositoryIDsForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*95)); err != nil {
+		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
+	} else if diff := cmp.Diff([]int{54}, repositoryIDs); diff != "" {
+		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
This PR adds the `RepositoryIDsForRetentionScan` method to dbstore. This method will be used when comparing upload records against data retention policies.

The worker will have the following rough outline:

```go
for {
    repositories, err := dbStore.RepositoryIDsForRetentionScan(ctx, time.Hour * 24, 100)
    if err != nil { /* ... */ }

    for _, repository := range repositories {
        // handle repository
    }

    // small sleep
}
```

This snippet ensures that a set of up to 100 upload records that haven't been processed within 24 hours are dequeued and immediately marked as processed.