### PR TITLE
codeintel: Add UpdateUploadRetention

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -486,6 +486,7 @@ func makeGetUploadsOptions(ctx context.Context, args *gql.LSIFRepositoryUploadsQ
 		DependentOf:  int(dependentOf),
 		Limit:        derefInt32(args.First, DefaultUploadPageSize),
 		Offset:       offset,
+		AllowExpired: true,
 	}, nil
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -129,6 +129,7 @@ func TestMakeGetUploadsOptions(t *testing.T) {
 		VisibleAtTip: true,
 		Limit:        5,
 		Offset:       25,
+		AllowExpired: true,
 	}
 	if diff := cmp.Diff(expected, opts); diff != "" {
 		t.Errorf("unexpected opts (-want +got):\n%s", diff)
@@ -150,6 +151,7 @@ func TestMakeGetUploadsOptionsDefaults(t *testing.T) {
 		VisibleAtTip: false,
 		Limit:        DefaultUploadPageSize,
 		Offset:       0,
+		AllowExpired: true,
 	}
 	if diff := cmp.Diff(expected, opts); diff != "" {
 		t.Errorf("unexpected opts (-want +got):\n%s", diff)

--- a/enterprise/cmd/worker/internal/codeintel/janitor/hard_delete.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/hard_delete.go
@@ -42,8 +42,9 @@ const uploadsBatchSize = 100
 
 func (d *hardDeleter) Handle(ctx context.Context) error {
 	options := store.GetUploadsOptions{
-		State: "deleted",
-		Limit: uploadsBatchSize,
+		State:        "deleted",
+		Limit:        uploadsBatchSize,
+		AllowExpired: true,
 	}
 
 	for {

--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -72,6 +72,7 @@ type operations struct {
 	updateNumReferences                    *observation.Operation
 	updatePackageReferences                *observation.Operation
 	updatePackages                         *observation.Operation
+	updateUploadRetention                  *observation.Operation
 
 	persistNearestUploads      *observation.Operation
 	persistNearestUploadsLinks *observation.Operation
@@ -117,7 +118,7 @@ func newOperations(observationContext *observation.Context, metrics *metrics.Ope
 		dirtyRepositories:                      op("DirtyRepositories"),
 		findClosestDumps:                       op("FindClosestDumps"),
 		findClosestDumpsFromGraphFragment:      op("FindClosestDumpsFromGraphFragment"),
-		getAutoindexDisabledRepositories:       op("getAutoindexDisabledRepositories"),
+		getAutoindexDisabledRepositories:       op("GetAutoindexDisabledRepositories"),
 		getConfigurationPolicies:               op("GetConfigurationPolicies"),
 		getConfigurationPolicyByID:             op("GetConfigurationPolicyByID"),
 		getDumpsByIDs:                          op("GetDumpsByIDs"),
@@ -162,6 +163,7 @@ func newOperations(observationContext *observation.Context, metrics *metrics.Ope
 		updateNumReferences:                    op("UpdateNumReferences"),
 		updatePackageReferences:                op("UpdatePackageReferences"),
 		updatePackages:                         op("UpdatePackages"),
+		updateUploadRetention:                  op("UpdateUploadRetention"),
 
 		persistNearestUploads:      subOp("persistNearestUploads"),
 		persistNearestUploadsLinks: subOp("persistNearestUploadsLinks"),

--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -901,6 +902,40 @@ func TestHardDeleteUploadByID(t *testing.T) {
 		t.Errorf("unexpected reference count (-want +got):\n%s", diff)
 	}
 }
+
+
+
+func TestUpdateUploadRetention(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	db := dbtesting.GetDB(t)
+	store := testStore(db)
+
+	insertUploads(t, db,
+		Upload{ID: 1, State: "completed"},
+		Upload{ID: 2, State: "completed"},
+		Upload{ID: 3, State: "completed"},
+		Upload{ID: 4, State: "completed"},
+		Upload{ID: 5, State: "completed"},
+	)
+
+	now := timeutil.Now()
+
+	if err := store.updateUploadRetention(context.Background(), []int{}, []int{2, 3, 4}, now); err != nil {
+		t.Fatalf("unexpected error marking uploads as expired: %s", err)
+	}
+
+	count, _, err := basestore.ScanFirstInt(db.Query(`SELECT COUNT(*) FROM lsif_uploads WHERE expired`))
+	if err != nil {
+		t.Fatalf("unexpected error counting uploads: %s", err)
+	}
+
+	if count != 3 {
+		t.Fatalf("unexpected count. want=%d have=%d", 3, count)
+	}
+}
+
 
 func TestUpdateNumReferences(t *testing.T) {
 	if testing.Short() {

--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -903,8 +903,6 @@ func TestHardDeleteUploadByID(t *testing.T) {
 	}
 }
 
-
-
 func TestUpdateUploadRetention(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -935,7 +933,6 @@ func TestUpdateUploadRetention(t *testing.T) {
 		t.Fatalf("unexpected count. want=%d have=%d", 3, count)
 	}
 }
-
 
 func TestUpdateNumReferences(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
This PR adds the `UpdateUploadRetention` method to dbstore. This method bulk updates a set of uploads to either be marked as expired, or to have their last data retention scan timestamp updated. We also add additional options to `GetUploads` to control conditions relating to the expired flag and last data retention scan timestamp.

The worker will have the following rough outline:

```
func processUploadsFor(repositoryID int) {
    var protected []int
    var expired []int
    for _, upload := range dbStore.GetUploads(ctx, {AllowExpired: false, LastRetentionScanBefore: start}) {
        // process upload
        if isExpired {
          expired = append(expired, upload.ID)
        } else {
          protected = append(protected, uploadID)
        }
    }

    dbStore.UpdateUploadRetention(ctx, protected, expired)
}
```