### PR TITLE
codeintel: forward $USER

### DIFF
--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -153,7 +153,7 @@ func prepCommand(ctx context.Context, command command) (cmd *exec.Cmd, stdout, s
 // forwardedHostEnvVars is a list of environment variable names that are inherited
 // when executing a command on the host. These are commonly required by programs
 // we shell out to, such a docker.
-var forwardedHostEnvVars = []string{"HOME", "PATH"}
+var forwardedHostEnvVars = []string{"HOME", "PATH", "USER"}
 
 func readProcessPipes(logWriter io.WriteCloser, stdout, stderr io.Reader) *sync.WaitGroup {
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
**Prior to this change**, when auto-indexing LSIF data for a repo, I encountered this error:

> Current requires cgo or $USER set in environment

This error refers to [`user.Current()`](https://pkg.go.dev/os/user#Current). It errored out because my `src` command does not have cgo ([cgo is disabled during cross-compilation]((https://github.com/golang/go/issues/6376#issuecomment-66085388)), and I'm on an M1 Mac) and the $USER environment variable is not being passed through the code intel executor.

**After this change**, the $USER environment variable is passed through the code intel executor.

Alternatives considered:

- Replace `user.Current()` with `os.UserHomeDir()` in src-cli (this works, but forwarding $USER is more general)
- Compile src-cli on macOS for cgo (requires more CI infra)
- Don't use an M1 Mac (it seems Apple silicon is only going to grow in popularity)