### PR TITLE
search: return repo filters for diff/commit search

### DIFF
--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -150,6 +150,10 @@ func (s *SearchFilters) Update(event SearchEvent) {
 			// can only be used with the 'repo:' scope. In that case,
 			// we shouldn't be getting any repositoy name matches back.
 			addRepoFilter(v.Name, v.ID, "", 1)
+		case *result.CommitMatch:
+			// We leave "rev" empty, instead of using "CommitMatch.Commit.ID". This way we
+			// get 1 filter per repo instead of 1 filter per sha in the side-bar.
+			addRepoFilter(v.Repo.Name, v.Repo.ID, "", int32(v.ResultCount()))
 		}
 	}
 }

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -1,0 +1,98 @@
+package streaming
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestSearchFiltersUpdate(t *testing.T) {
+	repo := types.RepoName{
+		Name: "foo",
+	}
+
+	cases := []struct {
+		name            string
+		events          []SearchEvent
+		wantFilterName  string
+		wantFilterCount int
+		wantFilterKind  string
+	}{
+		{
+			name: "CommitMatch",
+			events: []SearchEvent{
+				{
+					Results: []result.Match{
+						&result.CommitMatch{
+							Repo: repo,
+							Body: result.HighlightedString{Highlights: make([]result.HighlightedRange, 2)}},
+						&result.CommitMatch{
+							Repo: repo,
+							Body: result.HighlightedString{Highlights: make([]result.HighlightedRange, 1)}},
+					},
+				}},
+			wantFilterName:  "repo:^foo$",
+			wantFilterKind:  "repo",
+			wantFilterCount: 3,
+		},
+		{
+			name: "RepoMatch",
+			events: []SearchEvent{
+				{
+					Results: []result.Match{
+						&result.RepoMatch{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			wantFilterName:  "repo:^foo$",
+			wantFilterKind:  "repo",
+			wantFilterCount: 1,
+		},
+		{
+			name: "FileMatch, repo: filter",
+			events: []SearchEvent{
+				{
+					Results: []result.Match{
+						&result.FileMatch{
+							File: result.File{
+								Repo: repo,
+							},
+							LineMatches: []*result.LineMatch{{
+								OffsetAndLengths: make([][2]int32, 2),
+							}},
+						},
+					},
+				},
+			},
+			wantFilterName:  "repo:^foo$",
+			wantFilterKind:  "repo",
+			wantFilterCount: 2,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+
+			s := &SearchFilters{}
+			for _, event := range c.events {
+				s.Update(event)
+			}
+
+			f, ok := s.filters[c.wantFilterName]
+			if !ok {
+				t.Fatalf("expected %s", c.wantFilterName)
+			}
+
+			if f.Kind != c.wantFilterKind {
+				t.Fatalf("want %s, got %s", c.wantFilterKind, f.Kind)
+			}
+
+			if f.Count != c.wantFilterCount {
+				t.Fatalf("want %d, got %d", c.wantFilterCount, f.Count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #24394

With this change we add repo filters whenever we return events of type
CommitMatch.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
