### PR TITLE
Add missing indexes to codeintel tables

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -968,6 +968,7 @@ Stores the configuration used for code intel index jobs for a repository.
 Indexes:
     "lsif_indexes_pkey" PRIMARY KEY, btree (id)
     "lsif_indexes_commit_last_checked_at" btree (commit_last_checked_at) WHERE state <> 'deleted'::text
+    "lsif_indexes_repository_id_commit" btree (repository_id, commit)
 Check constraints:
     "lsif_uploads_commit_valid_chars" CHECK (commit ~ '^[a-z0-9]{40}$'::text)
 
@@ -1163,6 +1164,7 @@ Indexes:
     "lsif_uploads_associated_index_id" btree (associated_index_id)
     "lsif_uploads_commit_last_checked_at" btree (commit_last_checked_at) WHERE state <> 'deleted'::text
     "lsif_uploads_committed_at" btree (committed_at) WHERE state = 'completed'::text
+    "lsif_uploads_repository_id" btree (repository_id)
     "lsif_uploads_state" btree (state)
     "lsif_uploads_uploaded_at" btree (uploaded_at)
 Check constraints:

--- a/migrations/frontend/1528395877_index-lsif-uploads-repo.down.sql
+++ b/migrations/frontend/1528395877_index-lsif-uploads-repo.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS lsif_uploads_repository_id;
+
+COMMIT;

--- a/migrations/frontend/1528395877_index-lsif-uploads-repo.up.sql
+++ b/migrations/frontend/1528395877_index-lsif-uploads-repo.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_uploads_repository_id ON lsif_uploads (repository_id);

--- a/migrations/frontend/1528395878_index-lsif-indexes-repo.down.sql
+++ b/migrations/frontend/1528395878_index-lsif-indexes-repo.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS lsif_indexes_repository_id_commit;
+
+COMMIT;

--- a/migrations/frontend/1528395878_index-lsif-indexes-repo.up.sql
+++ b/migrations/frontend/1528395878_index-lsif-indexes-repo.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_indexes_repository_id_commit ON lsif_indexes (repository_id, commit);


### PR DESCRIPTION
There were two really slow queries I found on dotcom; as it turns out, they were missing and index on two columns that were filtered by. This brings down the `HasRepository` query from 580ms to 0.082, and the `IsQueued` query from ~1100ms to 0.141ms.
This also seems to propagate into other codeintel queries as the congestion on these tables is reduced. Overall, we see a 10% CPU usage reduction on dotcom.
