### PR TITLE
fix diff search for git version 2.33.0

### DIFF
--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -471,6 +471,9 @@ func logDiffCommonArgs(opt RawLogDiffSearchOptions) []string {
 	if opt.Query.Pattern != "" && opt.Diff {
 		var queryArg string
 		if opt.MatchChangedOccurrenceCount {
+			if opt.Query.IsRegExp {
+				args = append(args, "--pickaxe-regex")
+			}
 			queryArg = "-S"
 		} else {
 			queryArg = "-G"
@@ -478,9 +481,6 @@ func logDiffCommonArgs(opt RawLogDiffSearchOptions) []string {
 		args = append(args, queryArg+opt.Query.Pattern)
 		if !opt.Query.IsCaseSensitive {
 			args = append(args, "--regexp-ignore-case")
-		}
-		if opt.Query.IsRegExp {
-			args = append(args, "--pickaxe-regex")
 		}
 	}
 	if opt.Paths.IsRegExp {


### PR DESCRIPTION
The latest version of git makes adding `--pickaxe-regex` and `-G` in the
same command a hard error. We are currently adding `--pickaxe-regex` to
every search that uses a regex pattern, even if we're using `-G` instead
of `-S`. This commit changes the logic to only add `--pickaxe-regex` if
we are using `-S` instead of `-G`.

Fixes #24801 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
