### PR TITLE
Code Insights: fix Homepage extension and insight views rendering by experimental flag 

### DIFF
--- a/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
@@ -45,6 +45,10 @@ export const ExtensionViewsHomepageSection: React.FunctionComponent<ExtensionVie
 
     const allViewIds = useMemo(() => [...extensionViews, ...insights].map(view => view.id), [extensionViews, insights])
 
+    if (!showCodeInsights) {
+        return null
+    }
+
     return (
         <ViewGrid viewIds={allViewIds} telemetryService={telemetryService} className={className}>
             {/* Render extension views for the search page */}

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -48,7 +48,7 @@ export const enterpriseRoutes: readonly LayoutRouteProps<{}>[] = [
     {
         path: '/insights',
         render: lazyComponent(() => import('./insights/InsightsRouter'), 'InsightsRouter'),
-        condition: props => isCodeInsightsEnabled(props.settingsCascade, { insightsPage: true }),
+        condition: props => isCodeInsightsEnabled(props.settingsCascade),
     },
     ...routes,
 ]

--- a/client/web/src/insights/sections/ExtensionViewsHomepageSection.tsx
+++ b/client/web/src/insights/sections/ExtensionViewsHomepageSection.tsx
@@ -35,6 +35,10 @@ export const ExtensionViewsHomepageSection: React.FunctionComponent<ExtensionVie
             )
         ) ?? []
 
+    if (!showCodeInsights) {
+        return null
+    }
+
     return (
         <ViewGrid
             viewIds={extensionViews.map(view => view.id)}

--- a/client/web/src/insights/utils/is-code-insights-enabled.ts
+++ b/client/web/src/insights/utils/is-code-insights-enabled.ts
@@ -8,7 +8,6 @@ import { SettingsExperimentalFeatures } from '../../schema/settings.schema'
  * to show code insights components.
  */
 interface CodeInsightsDisplayLocation {
-    insightsPage: boolean
     homepage: boolean
     directory: boolean
 }

--- a/client/web/src/insights/utils/is-code-insights-enabled.ts
+++ b/client/web/src/insights/utils/is-code-insights-enabled.ts
@@ -37,7 +37,7 @@ export function isCodeInsightsEnabled(
 
     return viewsKeys.every(viewKey => {
         if (views[viewKey]) {
-            return final?.[`insights.displayLocation.${viewKey}`] !== false
+            return !!final?.[`insights.displayLocation.${viewKey}`]
         }
 
         return true


### PR DESCRIPTION
Fix insights appearing by the experimental feature flag `insights.displayLocation.homepage` at the homepage