### PR TITLE
codeintel: Drop and re-create lsif_configuration_policy table

### DIFF
--- a/migrations/frontend/1528395879_repair_lsif_configuration_policies.down.sql
+++ b/migrations/frontend/1528395879_repair_lsif_configuration_policies.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Nothing on down
+
+COMMIT;

--- a/migrations/frontend/1528395879_repair_lsif_configuration_policies.up.sql
+++ b/migrations/frontend/1528395879_repair_lsif_configuration_policies.up.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
+DROP TABLE lsif_configuration_policies;
+
 CREATE TABLE lsif_configuration_policies (
     id SERIAL PRIMARY KEY,
     repository_id int,


### PR DESCRIPTION
The original migration did not close its transaction, so _somehow_ half of the commit has been applied in Cloud. This table is trivially empty on all instances (we don't use it yet in the backend) and can be destroyed.

In order to ensure the table is the same in all environments, the easiest solution is to simply recreate the entire table.