### PR TITLE
Code Insights: Update frontend.md

### DIFF
--- a/doc/dev/background-information/insights/frontend.md
+++ b/doc/dev/background-information/insights/frontend.md
@@ -8,14 +8,14 @@
 - [Quick intro to the setting cascade](#quick-intro-to-the-setting-cascade)
 - [Insight consumers](#insight-consumers)
   - [The dashboard page](#the-dashboard-page)
-  - [The directory and homepage](#the-directory-page)
+  - [The directory and homepage](#the-directory-and-search-(home)-pages)
 - [Code Insights loading logic in details](#code-insights-loading-logic-in-details)
 
 
 ## Insights directory structure
 
 We store all insights related parts of components and logic in the `insights` directory.
-The full path to this folder is `./client/web/src/insights`. There you can find all components
+The full path to this folder is `./client/web/src/enterprise/insights`. There you can find all components
 and code insights shared logic.
 
 This directory has the following structure
@@ -25,33 +25,38 @@ This directory has the following structure
 - `/hooks` - all shared across insights components hook-based logic.
 - `/mocks` - mock collections for unit tests and storybook stories.
 - `/pages` - all pages-like code insights components (such as `DashboardPage` or `InsightCreationPage`)
+- `/sections` - Enterprise version of insights grid components that are rendered at the homepage and the directory page.
 - `/utils` - common helpers
-- `insight-global-styles.css` All code insight related non-css-module styles that must be included into the main css bundle
-  via scss `@import` in `SourcegraphWebApp.scss` file.
 - `InsightsRouter.tsx` - The main entry point for all code-insights pages.
 
+Note: that some part of insights logic is stored in `./client/web/src/insights`
+
+- `analytics.ts` - analytics logic to get insights setting cascade related metrics (such as code insights count)
+- `types.ts` - code insights related types for top-level component props.
+- `utils` - utils functionality such as code insights experimental flags checkers.
+- `./sections` - OSS version of insights grid components that are rendered at the homepage and the directory page .
 
 ## Insight types
 
 At the moment, we have two different types of insights.
 
-1. **Extension based insights.** <br/>
-These types of insights fetch data via Extension API. At the moment, we have at least two
-insight extensions that work this way.
+1. **Built-in (former Extension based) insights.** <br/>
+These types of insights fetch data via frontend insight fetcher function. That means that we make a few network request to our search 
+API to collect and process insight data on the frontend [(source)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx).
+At some point we used Extension API to get information about these insights
+via Extension API. You still can find these extension by links below but they currently are not used for insight data fetching.
 <br /> &nbsp;
    - [Search-based insight (line chart)](https://github.com/sourcegraph/sourcegraph-search-insights)
    - [Code stats insight (pie chart)](https://github.com/sourcegraph/sourcegraph-code-stats-insights). <br />
 
-> These extensions are running on the frontend and making multiple network requests to prepare and process
-insight data and then pass this data to the React page component to render charts.
-> You can find extension documentation here [Sourcegraph extensions](../sourcegraph_extensions.md)
+At the moment we use the main-tread built-in insight fetchers [source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/core/backend/api/get-built-in-insight.ts)
 
 2. **Backend based insights.** <br/>
 These insights are working via our graphql API only. At the moment, only search based insights (line chart)
 can be backend-based. Code stats insights (pie chart) only work via extension API.
 
 You can find typescript types that describe these insight entities
-in [core/types/insights/index.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/core/types/insight/index.ts)
+in [core/types/insights/index.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/core/types/insight/index.ts)
 
 ## Insight configuration storing
 
@@ -78,30 +83,6 @@ something like this
 }
 ```
 
-The search-based insight extension [takes this configuration](https://github.com/sourcegraph/sourcegraph-search-insights/blob/master/src/search-insights.ts#L47-L56)
-and runs network requests according to this information.
-
-_Example from the search based insight codebase._
-
-```ts
-const settings = from(sourcegraph.configuration).pipe(
-        startWith(null),
-        map(() => sourcegraph.configuration.get().value)
-    )
-
-const insightConfigs = settings.pipe(
-    map(
-        settings =>
-            Object.entries(settings)
-              .filter(([key]) => key.startsWith('searchInsights.insight.')) as [
-                string,
-                Insight | null | false
-            ][]
-    )
-)
-```
-
-> Code stats extension insight does exactly this thing to get insight configurations and get insights data.
 
 Backend based insights also have their insight configurations, and they are also stored
 in the same settings cascade but by special property key `insights.allrepos`
@@ -130,17 +111,18 @@ in the same settings cascade but by special property key `insights.allrepos`
 ```
 
 You can find typescript types that describe these insight entities
-in [core/types/insights/index.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/core/types/insight/index.ts)
+in [core/types/insights/index.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/core/types/insight/index.ts)
 
 > This way to store insights isn't the best, but this is the easiest way to get insight configs from extensions.
-> Eventually, we want to migrate all insights to our BE and store them in real DB.
+> Eventually, we want to migrate all insights to our BE and store them in real DB. At the moment we already have moved 
+> our extension based insight to the main app. 
 
 We also can write to these `jsonc` files and therefore create or delete some insights. This is actually how it works
 on the creation UI. After submitting, we just produce a valid insight configuration, write this config to the setting subject `jsonc` file,
 and upload this new config back via GQL API.
 
 
-**Important note:** Each insight (search backend or extension based or code stats insight) has the
+**Important note:** Each insight (search backend or built-in based or code stats insight) has the
 visibility setting.
 
 ![insight-visibility](https://storage.googleapis.com/sourcegraph-assets/code_insights/insight-visibility.png)
@@ -250,31 +232,31 @@ We use setting cascade subject to store dashboard configurations.
 }
 ```
 
-You can find dashboard typescript types for these dashboard properties in [core/types/dashboard/index.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/core/types/dashboard/index.ts)
+You can find dashboard typescript types for these dashboard properties in [core/types/dashboard/index.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/core/types/dashboard/index.ts)
 
 Let's take a look at the dashboard system in action. For example, let's describe what will happen when we go to the `/insights/dashboard/<personal subject id>`
 
 1. We extract the dashboard id from the URL in the `DashboardPage` component via react-router URL options.
-2. With the [`useDashboard` hook](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/hooks/use-dashboards/use-dashboards.ts)) we select/extract all
+2. With the [`useDashboard` hook](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/hooks/use-dashboards/use-dashboards.ts)) we select/extract all
 reachable dashboards from all settings cascade levels.
 3. Then we map the dashboard id from the URL and all dashboard configs, extract information about dashboard
 like insights ids (`insightIds` property)
 4. Pass `insightsId` information to component for rendering insights (in case of the dashboard page this component
-is [`SmartInsightsViewGrid.tsx`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx))
+is `SmartInsightsViewGrid.tsx`[(source)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx))
 5. `SmartInsightsViewGrid.tsx` component will iterate over all `insightIds` get insight configuration from setting
-cascade by [`useInsight()`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/hooks/use-insight/use-insight.ts) hook and pick the right component
-(either [`BackendInsight.tsx`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx)
-or [`ExtensionInsight.tsx`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/components/insights-view-grid/components/extension-insight/ExtensionInsight.tsx))
-6. Then this backend or extension insight component will load insight data either by GQL API in the case of Backend Insight or
-by Extension API in case of extension insight.
+cascade by `useInsight()` [(source)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/hooks/use-insight/use-insight.ts) hook and pick the right component
+(either `BackendInsight.tsx` [(source)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx)
+or `BuiltInInsight.tsx` [(source)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx)
+6. Then this backend or built-in insight component will load insight data either by GQL API in the case of Backend Insight or
+by few FE network search API requests in case of Built-In insight.
 
 <object data="./assets/insight-dashboard-loading.svg"></object>
 
 > NOTE: We load our insights one by one with a maximum of two insight data requests in parallel to avoid HTTP request bombarding and HTTP 1 limit
-> with only six requests in parallel. To do that, we use [`useParallelRequests` react hook](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/hooks/use-parallel-requests/use-parallel-request.ts)
+> with only six requests in parallel. To do that, we use [`useParallelRequests` react hook](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/hooks/use-parallel-requests/use-parallel-request.ts)
 
 
-### The directory page
+### The directory and search (home) pages
 
 ![directory-page.png](https://storage.googleapis.com/sourcegraph-assets/code_insights/directory-page.png)
 
@@ -282,46 +264,51 @@ The directory page is another place where you can find insights (and other exten
 This page renders an insight grid component with all insights that you have in your subject settings so that we could say that
 this is kind of analog of the All insights dashboard on the dashboard page.
 
-But this page uses a slightly different approach how to load insights data. If on the dashboard page
-insights card components were responsible for fetching logic, then on the directory page, the component that renders
-the insight grid component (in this case, directory pages renders the [`StaticInsightsViewGrid`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/components/insights-view-grid/StaticInsightsViewGrid.tsx))
-this component has to load insight data on its own. In fact, the **home (search) pages use exactly the same approach** to fetch and display insight data.
+But this page uses a slightly different approach how to load insights data. The directory and search pages render `ExtensionViewsSection` 
+component. This component is deffirent from the OSS to Enterprise version. But in both cases this component is responsible for loading 
+extension and insight like views and render them into the grid layout views component as it's shown on the picture above. 
+
+- In OSS version it renders only extension views [source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/sections/ExtenstionViewsSection.tsx)
+- In Enterprise it renders extension and insight like views together. (Code insights is part of enterprise version)
+[source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/sections/ExtenstionViewsSection.tsx)
 
 
-## Code Insights loading logic in details
+
+## Code Insights loading logic (InsightsApiContext)
 
 All async operation which is related to fetching data or calling something from the extension API is produced and provided via
-React Context system. Code Insights API is accessible via [`InsightAPIContext`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/core/backend/insights-api.ts)
+React Context system. Code Insights API is accessible via `InsightAPIContext`[source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/core/backend/create)
 
 This was done in this way to mock and change the implementation of async (backend API or extension API) calls in unit tests.
 
-Let's take a look on simple version of `ExtensionInsight` component
+Let's take a look on simple version of `BuiltInInsight` component
 
 
 ```tsx
-function ExtensionInsight(props) {
+function BuiltInInsight(props) {
   const { viewId } = props
   const { getExtensionViewById } = useContext(InsightsApiContext)
 
   const { data, loading } = useParallelRequests(
-    useMemo(() => () => getExtensionViewById(viewId), [viewId])
+    useMemo(() => () => getBuiltInInsight(viewId), [viewId])
   )
 
   return (/* Render insight chart */)
 }
 ```
 
-So in this component we use `getExtensionViewById` function from our `InsightsApiContext` context. If we go to [`InsightsApiContext`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/core/backend/insights-api.ts) definition we will see that this is just an object with some async function collection.
-All these functions and their interfaces are described in this one interface [`ApiService`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/core/backend/types.ts)
+So in this component we use `getBuiltInInsight` function from our `InsightsApiContext` context. If we go to [`InsightsApiContext`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/core/backend/create-insights-api.ts) 
+definition we will see that this is just an object with some async function collection.
+All these functions and their interfaces are described in this one interface [`ApiService`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/core/backend/types.ts)
 
-Then if we want to write some unit test for the `ExtensionInsight` component we will write something like this
+Then if we want to write some unit test for the `BuiltInInsight` component we will write something like this
 
 ```tsx
 const mockAPI = createMockInsightAPI({
-  getExtensionViewById: () => ({ /* Some mock insight data */})
+  getBuiltInInsight: () => ({ /* Some mock insight data */})
 })
 
-it('ExtensionInsight should render', () => {
+it('BuiltInInsight should render', () => {
 
   const { getByRole } = render(
     <InsightsApiContext.Provider value={mockAPI}>

--- a/doc/dev/background-information/insights/frontend.md
+++ b/doc/dev/background-information/insights/frontend.md
@@ -265,8 +265,8 @@ This page renders an insight grid component with all insights that you have in y
 this is kind of analog of the All insights dashboard on the dashboard page.
 
 But this page uses a slightly different approach how to load insights data. The directory and search pages render `ExtensionViewsSection` 
-component. This component is deffirent from the OSS to Enterprise version. But in both cases this component is responsible for loading 
-extension and insight like views and render them into the grid layout views component as it's shown on the picture above. 
+component. This component is different from the OSS to Enterprise version. But in both cases, this component is responsible for loading 
+extension and insight-like views and render them into the grid layout views component as it's shown in the picture above. 
 
 - In OSS version it renders only extension views [source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/sections/ExtenstionViewsSection.tsx)
 - In Enterprise it renders extension and insight like views together. (Code insights is part of enterprise version)

--- a/doc/dev/background-information/insights/frontend.md
+++ b/doc/dev/background-information/insights/frontend.md
@@ -43,8 +43,8 @@ At the moment, we have two different types of insights.
 1. **Built-in (former Extension based) insights.** <br/>
 These types of insights fetch data via frontend insight fetcher function. That means that we make a few network request to our search 
 API to collect and process insight data on the frontend [(source)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx).
-At some point we used Extension API to get information about these insights
-via Extension API. You still can find these extension by links below but they currently are not used for insight data fetching.
+At some point, we used Extension API to get information about these insights.
+You still can find these extensions by links below but they currently are not used for insight data fetching.
 <br /> &nbsp;
    - [Search-based insight (line chart)](https://github.com/sourcegraph/sourcegraph-search-insights)
    - [Code stats insight (pie chart)](https://github.com/sourcegraph/sourcegraph-code-stats-insights). <br />


### PR DESCRIPTION
Since the last time we had updated our FE doc, we moved the code insights codebase to the enterprise directory. And added some OSS and Enterprise separation for the extension and insights views at the directory and search pages.

This PR updates docs and fixes broken links to the code insights code examples.