### PR TITLE
authz/github: remove debug log

### DIFF
--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"strconv"
 	"strings"
@@ -380,7 +379,6 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 	// Perform a fresh sync with groups that need a sync.
 	repoID := extsvc.RepoID(repo.ID)
 	for _, group := range groups {
-		log.Printf("%+v\n", group)
 		// If this is a partial cache, add self to group
 		if len(group.Repositories) > 0 {
 			hasRepo := false


### PR DESCRIPTION
I need some kind of linter to ban imports and usage of `"log"`. The value being printed here _can_ be absolutely massive (up to tens of thousands of users and repos), and it might be the cause of some significant issues over at https://github.com/sourcegraph/customer/issues/470

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
