### PR TITLE
docs(ts/js): update GH action specification

### DIFF
--- a/doc/code_intelligence/how-to/index_a_typescript_and_javascript_repository.md
+++ b/doc/code_intelligence/how-to/index_a_typescript_and_javascript_repository.md
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-node:latest
     steps:
-      - uses: actions/checkout@v1
       - name: Install dependencies
+        uses: actions/checkout@v1
         run: npm install
       - name: Generate LSIF data
         run: lsif-tsc -p .
@@ -39,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     container: my-awesome-container
     steps:
-      - uses: actions/checkout@v1
       - name: Install dependencies
+        uses: actions/checkout@v1
         run: <install dependencies>
       - name: Generate LSIF data
         uses: docker://sourcegraph/lsif-node:latest


### PR DESCRIPTION
### Overview
This PR updates the GitHub Actions example to index a typescript and javascript repository in order to make it copy-pastable.

the `-` in YAML is creating a new item in the list, and the current syntax was not behaving as expected, it ws creating a named step but not using the right base action.

with this proposed change the step will:
- have a name
- use a base action
- run the given command

GH Action docs relevant to this change here https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses
