### PR TITLE
Fix GH search integration on "/search" page & when user is not logged in

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -321,7 +321,7 @@ const notificationClassNames = {
 
 const searchEnhancement: CodeHost['searchEnhancement'] = {
     searchViewResolver: {
-        selector: '.js-site-search-form input[type="text"]',
+        selector: '.js-site-search-form input[type="text"][aria-controls="jump-to-results"]',
         resolveView: element => ({ element }),
     },
     resultViewResolver: {
@@ -351,7 +351,9 @@ const searchEnhancement: CodeHost['searchEnhancement'] = {
             badge.parentNode?.insertBefore(logo, badge)
 
             /** Add sourcegraph item after GH item */
-            return ghElement.parentNode?.insertBefore(sgElement, ghElement.nextElementSibling) as HTMLElement
+            ghElement.parentNode?.insertBefore(sgElement, ghElement.nextElementSibling)
+
+            return sgElement
         }
 
         /** Update link and display value */

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -833,14 +833,19 @@ export function handleCodeHost({
 
         const searchView = mutations.pipe(
             trackViews([searchViewResolver]),
-            switchMap(({ element }) => fromEvent(element, 'input')),
-            map(event => ({
-                value: (event.target as HTMLInputElement).value,
+            switchMap(({ element }) =>
+                fromEvent(element, 'input').pipe(
+                    map(event => (event.target as HTMLInputElement).value),
+                    startWith((element as HTMLInputElement).value)
+                )
+            ),
+            map(value => ({
+                value,
                 searchURL: searchURL.href,
             })),
             observeOn(asyncScheduler)
         )
-        const resultView = mutations.pipe(trackViews([resultViewResolver])).pipe(observeOn(asyncScheduler))
+        const resultView = mutations.pipe(trackViews([resultViewResolver]), observeOn(asyncScheduler))
 
         const searchEnhancementSubscription = combineLatest([searchView, resultView])
             .pipe(map(([search, { element: resultElement }]) => ({ ...search, resultElement })))


### PR DESCRIPTION

### Description

This PR fixes GH search integration for the following scenarios:
  - When user is not logged in Github
  - When on `/search` page
  - When entering `search?q=some+initial+query` with some existing query in the URL (previously we were tracking only inputs after loading a page)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

### Screenshots
| Before | After |
| --: | :-- |
| Didn't work/inject for this particular case | ![image](https://user-images.githubusercontent.com/6717049/132830129-d13d3b90-70af-406a-90b3-b91a2a5616a4.png)|
| Didn't work/inject for this particular case | ![image](https://user-images.githubusercontent.com/6717049/132830228-b164ca4a-03d4-4719-a873-ab3f0a044671.png) |
