### PR TITLE
Fix flaky TestDeleteSnapshots by using fixed point in time

### DIFF
--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -244,7 +244,7 @@ func TestRecordSeriesPoints(t *testing.T) {
 	optionalString := func(v string) *string { return &v }
 	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
 
-	current := time.Now().Truncate(24 * time.Hour)
+	current := time.Date(2021, time.September, 10, 10, 0, 0, 0, time.UTC)
 
 	// Metadata is currently not queried and will not resolve to reduce cardinality.
 	for _, record := range []RecordSeriesPointArgs{
@@ -348,7 +348,7 @@ func TestRecordSeriesPointsSnapshotOnly(t *testing.T) {
 	optionalString := func(v string) *string { return &v }
 	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
 
-	current := time.Now().Truncate(24 * time.Hour)
+	current := time.Date(2021, time.September, 10, 10, 0, 0, 0, time.UTC)
 
 	// Metadata is currently not queried and will not resolve to reduce cardinality.
 	for _, record := range []RecordSeriesPointArgs{
@@ -414,7 +414,7 @@ func TestRecordSeriesPointsRecordingOnly(t *testing.T) {
 	optionalString := func(v string) *string { return &v }
 	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
 
-	current := time.Now().Truncate(24 * time.Hour)
+	current := time.Date(2021, time.September, 10, 10, 0, 0, 0, time.UTC)
 
 	// Metadata is currently not queried and will not resolve to reduce cardinality.
 	for _, record := range []RecordSeriesPointArgs{
@@ -480,7 +480,7 @@ func TestDeleteSnapshots(t *testing.T) {
 	optionalString := func(v string) *string { return &v }
 	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
 
-	current := time.Now().Truncate(24 * time.Hour)
+	current := time.Date(2021, time.September, 10, 10, 0, 0, 0, time.UTC)
 
 	seriesID := "one"
 	// Metadata is currently not queried and will not resolve to reduce cardinality.

--- a/enterprise/internal/insights/store/testdata/TestDeleteSnapshots.golden
+++ b/enterprise/internal/insights/store/testdata/TestDeleteSnapshots.golden
@@ -1,7 +1,7 @@
 []store.SeriesPoint{store.SeriesPoint{
 	SeriesID: "one",
 	Time: time.Time{
-		ext: 63766746000,
+		ext: 63766868400,
 		loc: &time.Location{
 			name: "UTC",
 		},


### PR DESCRIPTION
As [reported by @valerybugakov on Slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1631265491269800), the test seems to fail when the current time is >24hrs off from the time stored in the autogold fixture file.

So what I did here is to use a fixed point in time (since `time.Now`
didn't seem relevant to the tests) and save that in the autogold file. I
also updated the other tests to use this point in time.