### PR TITLE
migration tests: migrate only database under test

### DIFF
--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -98,18 +98,14 @@ func testMigrations(t *testing.T, db *sql.DB, database *dbconn.Database) {
 		t.Errorf("error constructing migrations: %s", err)
 	}
 
-	for _, database := range []*dbconn.Database{
-		dbconn.Frontend,
-		dbconn.CodeIntel,
-	} {
-		if err := dbconn.MigrateDB(dbconn.Global, database); err != nil {
-			t.Errorf("unexpected error running initial migrations: %s", err)
-		}
+	if err := dbconn.DoMigrate(m); err != nil {
+		t.Errorf("unexpected error migration database: %s", err)
 	}
 
 	if err := m.Down(); err != nil && err != migrate.ErrNoChange {
 		t.Errorf("unexpected error running down migrations: %s", err)
 	}
+
 	if _, err := db.Exec("DROP SCHEMA public CASCADE; CREATE SCHEMA public;"); err != nil {
 		t.Fatalf("failed to recreate schema")
 	}


### PR DESCRIPTION
I think this is the result of a refactor: previously we had the loop to
migrate all databases, but now we have separate test functions
(`TestFrontendMigrations`, `TestCodeIntelMigrations`) that pass the
database in.

I don't see how it makes sense to migrate both databases in both tests.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
