### PR TITLE
Don't do needless error handling around tx.Done()

### DIFF
--- a/enterprise/internal/batches/background/bulk_processor_worker.go
+++ b/enterprise/internal/batches/background/bulk_processor_worker.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/processor"
@@ -103,15 +102,7 @@ func (b *bulkProcessorWorker) HandlerFunc() workerutil.HandlerFunc {
 		if err != nil {
 			return err
 		}
-		defer func() {
-			doneErr := tx.Done(nil)
-			if err != nil && doneErr != nil {
-				err = multierror.Append(err, doneErr)
-			}
-			if doneErr != nil {
-				err = doneErr
-			}
-		}()
+		defer func() { err = tx.Done(err) }()
 
 		p := processor.New(tx, b.sourcer)
 

--- a/enterprise/internal/batches/reconciler/reconciler.go
+++ b/enterprise/internal/batches/reconciler/reconciler.go
@@ -3,7 +3,6 @@ package reconciler
 import (
 	"context"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
@@ -46,15 +45,7 @@ func (r *Reconciler) HandlerFunc() workerutil.HandlerFunc {
 		if err != nil {
 			return err
 		}
-		defer func() {
-			doneErr := tx.Done(nil)
-			if err != nil && doneErr != nil {
-				err = multierror.Append(err, doneErr)
-			}
-			if doneErr != nil {
-				err = doneErr
-			}
-		}()
+		defer func() { err = tx.Done(err) }()
 
 		return r.process(ctx, tx, record.(*btypes.Changeset))
 	}


### PR DESCRIPTION
As it turns out, `tx.Done(err)` already does what the code here
previously did: https://github.com/sourcegraph/sourcegraph/blob/b11636e4eb53ff6698fbd0ab4da7c7eac3496a1e/internal/database/basestore/store.go#L125-L132
