### PR TITLE
Fix migration tests blocking infinitely if migrations fail

### DIFF
--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -70,24 +70,24 @@ func TestIDConstraints(t *testing.T) {
 	}
 }
 
-func TestFrontendMigrations(t *testing.T) {
+func TestMigrations(t *testing.T) {
 	if os.Getenv("SKIP_MIGRATION_TEST") != "" {
 		t.Skip()
 	}
 
-	// Setup a global test database
 	db := dbtesting.GetDB(t)
-	testMigrations(t, db, dbconn.Frontend)
-}
 
-func TestCodeIntelMigrations(t *testing.T) {
-	if os.Getenv("SKIP_MIGRATION_TEST") != "" {
-		t.Skip()
+	for _, tt := range []struct {
+		name     string
+		database *dbconn.Database
+	}{
+		{"Frontend", dbconn.Frontend},
+		{"CodeIntel", dbconn.CodeIntel},
+	} {
+
+		t.Logf("Running migrations in %s", tt.name)
+		testMigrations(t, db, tt.database)
 	}
-
-	// Setup a global test database
-	db := dbtesting.GetDB(t)
-	testMigrations(t, db, dbconn.CodeIntel)
 }
 
 // testMigrations runs all migrations up, then the migrations for the given database
@@ -95,15 +95,15 @@ func TestCodeIntelMigrations(t *testing.T) {
 func testMigrations(t *testing.T, db *sql.DB, database *dbconn.Database) {
 	m, err := dbconn.NewMigrate(db, database)
 	if err != nil {
-		t.Errorf("error constructing migrations: %s", err)
+		t.Fatalf("error constructing migrations: %s", err)
 	}
 
 	if err := dbconn.DoMigrate(m); err != nil {
-		t.Errorf("unexpected error migration database: %s", err)
+		t.Fatalf("unexpected error migration database: %s", err)
 	}
 
 	if err := m.Down(); err != nil && err != migrate.ErrNoChange {
-		t.Errorf("unexpected error running down migrations: %s", err)
+		t.Fatalf("unexpected error running down migrations: %s", err)
 	}
 
 	if _, err := db.Exec("DROP SCHEMA public CASCADE; CREATE SCHEMA public;"); err != nil {
@@ -112,9 +112,9 @@ func testMigrations(t *testing.T, db *sql.DB, database *dbconn.Database) {
 
 	m, err = dbconn.NewMigrate(db, database)
 	if err != nil {
-		t.Errorf("unexpected error constructing migrations: %s", err)
+		t.Fatalf("unexpected error constructing migrations: %s", err)
 	}
 	if err := m.Up(); err != nil {
-		t.Errorf("unexpected error re-running up migrations: %s", err)
+		t.Fatalf("unexpected error re-running up migrations: %s", err)
 	}
 }


### PR DESCRIPTION
I ran into this this morning (see [Slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1631264793268500)): migration was bad but I couldn't find out why
my tests were failing (locally and on Ci). No error message was printed,
just a timeout after 10min.

Walking up and down the stack trace I ended up here: if the up/down
migration would fail, the connection/transaction was aborted and the
next query would block until test timeout.

This changes the tests back to the old layout, because since they both
share the same global test database a failure in one would also
influence/block the other test.
