### PR TITLE
codeintel: fix maven packages commit env var

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -480,9 +480,9 @@ func runCommandInDirectory(ctx context.Context, cmd *exec.Cmd, workingDirectory 
 	cmd.Env = append(cmd.Env, "GIT_AUTHOR_NAME="+gitName)
 	cmd.Env = append(cmd.Env, "GIT_AUTHOR_EMAIL="+gitEmail)
 	cmd.Env = append(cmd.Env, "GIT_AUTHOR_DATE="+stableGitCommitDate)
-	cmd.Env = append(cmd.Env, "COMMITTER_AUTHOR_NAME="+gitName)
-	cmd.Env = append(cmd.Env, "COMMITTER_AUTHOR_EMAIL="+gitEmail)
-	cmd.Env = append(cmd.Env, "COMMITTER_AUTHOR_DATE="+stableGitCommitDate)
+	cmd.Env = append(cmd.Env, "GIT_COMMITTER_NAME="+gitName)
+	cmd.Env = append(cmd.Env, "GIT_COMMITTER_EMAIL="+gitEmail)
+	cmd.Env = append(cmd.Env, "GIT_COMMITTER_DATE="+stableGitCommitDate)
 	output, err := runWith(ctx, cmd, false, nil)
 	if err != nil {
 		return "", errors.Wrapf(err, "command %s failed with output %s", cmd.Args, string(output))


### PR DESCRIPTION
This issue did not affect production, some particular quirk in my environment. 

Associated error that this fixes:

![image](https://user-images.githubusercontent.com/18282288/132880536-28a596bc-f816-40ef-93b2-14df7352d065.png)
