### PR TITLE
Surface info on outbound traffic with VPCs

### DIFF
--- a/doc/admin/install/kubernetes/configure.md
+++ b/doc/admin/install/kubernetes/configure.md
@@ -820,6 +820,10 @@ data:
     # ...
 ```
 
+## Outbound Traffic
+
+When working with an [Internet Gateway](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Internet_Gateway.html) or VPC it may be necessary to expose ports for outbound network traffic. Sourcegraph must open port 443 for outbound traffic to codehosts, and to enable [telemetry](https://docs.sourcegraph.com/admin/pings) with Sourcegraph.com. Port 22 must also be opened to enable git SSH cloning by Sourcegraph. Take care to secure your cluster in a manner that meets your organization's security requirements.
+
 ## Troubleshooting
 
 See the [Troubleshooting docs](troubleshoot.md).

--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -68,7 +68,9 @@ Once you are all set up, either [install Sourcegraph directly](#direct-installat
 > or other secure network that restricts unauthenticated access from the public Internet. You can later expose the
 > necessary ports via an
 > [Internet Gateway](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Internet_Gateway.html) or equivalent
-> mechanism. Take care to secure your cluster in a manner that meets your organization's security requirements.
+> mechanism. Note that SG must expose port 443 for outbound traffic to codehosts and to enable [telemetry](https://docs.sourcegraph.com/admin/pings) with 
+> Sourcegraph.com. Additionally port 22 may be opened to enable git SSH cloning by Sourcegraph. Take care to secure your cluster in a manner that meets your 
+> organization's security requirements.
 
 Follow the instructions linked in the table below to provision a Kubernetes cluster for the
 infrastructure provider of your choice, using the recommended node and list types in the


### PR DESCRIPTION
This change is intended to provide an answer to a customer inquiry:

> networking questions!
> I'm assuming out system will need outbound network to
> • our okta installation
> • http://github.comgithub.com> (443 only?)
> • http://sourcegraph.comsourcegraph.com> for telemetry (443 only?)

I'm not the happiest with putting this change here in the docs, but I wasn't sure where else to surface this.

The intention here is to provide a quick answer for a potential FAQ in the interim. I am hoping CS can later develop a FAQ doc covering network setup questions generally pertaining to VPCs, VPNs, and Load balancing relating to SG. Our team will likely be addressing more networking questions under the purview of how-to in the future.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
