### PR TITLE
improve settings cascade performance

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -234,6 +234,7 @@ const (
 
 var mockDecodedViewerFinalSettings *schema.Settings
 
+// decodedViewerFinalSettings returns the final (merged) settings for the viewer
 func decodedViewerFinalSettings(ctx context.Context, db dbutil.DB) (_ *schema.Settings, err error) {
 	tr, ctx := trace.New(ctx, "decodedViewerFinalSettings", "")
 	defer func() {
@@ -243,7 +244,13 @@ func decodedViewerFinalSettings(ctx context.Context, db dbutil.DB) (_ *schema.Se
 	if mockDecodedViewerFinalSettings != nil {
 		return mockDecodedViewerFinalSettings, nil
 	}
-	return viewerFinalSettings(ctx, db)
+
+	cascade, err := (&schemaResolver{db: db}).ViewerSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return cascade.finalTyped(ctx)
 }
 
 type resolveRepositoriesOpts struct {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -244,15 +243,7 @@ func decodedViewerFinalSettings(ctx context.Context, db dbutil.DB) (_ *schema.Se
 	if mockDecodedViewerFinalSettings != nil {
 		return mockDecodedViewerFinalSettings, nil
 	}
-	merged, err := viewerFinalSettings(ctx, db)
-	if err != nil {
-		return nil, err
-	}
-	var settings schema.Settings
-	if err := json.Unmarshal([]byte(merged.Contents()), &settings); err != nil {
-		return nil, err
-	}
-	return &settings, nil
+	return viewerFinalSettings(ctx, db)
 }
 
 type resolveRepositoriesOpts struct {

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -3,15 +3,16 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"sort"
-
-	"github.com/cockroachdb/errors"
+	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // settingsCascade implements the GraphQL type SettingsCascade (and the deprecated type ConfigurationCascade).
@@ -73,25 +74,36 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 }
 
 // viewerFinalSettings returns the final (merged) settings for the viewer.
-func viewerFinalSettings(ctx context.Context, db dbutil.DB) (*configurationResolver, error) {
+func viewerFinalSettings(ctx context.Context, db dbutil.DB) (*schema.Settings, error) {
 	cascade, err := (&schemaResolver{db: db}).ViewerSettings(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return cascade.Merged(ctx)
+	return cascade.finalTyped(ctx)
 }
 
 func (r *settingsCascade) Final(ctx context.Context) (string, error) {
-	subjects, err := r.Subjects(ctx)
+	settings, err := r.finalTyped(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	// Each LatestSettings is a roundtrip to the database. So we do the
-	// requests concurrently. If the subject has no settings, then
-	// allSettings[i] will be the empty string. mergeSettings ignores empty
-	// strings.
-	allSettings := make([]string, len(subjects))
+	settingsBytes, err := json.Marshal(settings)
+	return string(settingsBytes), err
+}
+
+func (r *settingsCascade) finalTyped(ctx context.Context) (*schema.Settings, error) {
+	subjects, err := r.Subjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		mux         sync.Mutex
+		allSettings *schema.Settings
+	)
+
+	// Each LatestSettings is a roundtrip to the database. So we do the requests concurrently.
 	bounded := goroutine.NewBounded(8)
 	for i := range subjects {
 		i := i
@@ -100,19 +112,25 @@ func (r *settingsCascade) Final(ctx context.Context) (string, error) {
 			if err != nil {
 				return err
 			}
-			if settings != nil {
-				allSettings[i] = settings.settings.Contents
+
+			if settings == nil {
+				return nil
 			}
+
+			var o schema.Settings
+			if err := jsonc.Unmarshal(settings.settings.Contents, &o); err != nil {
+				return err
+			}
+
+			mux.Lock()
+			allSettings = mergeSettingsLeft(allSettings, &o)
+			mux.Unlock()
+
 			return nil
 		})
 	}
 
-	if err := bounded.Wait(); err != nil {
-		return "", err
-	}
-
-	final, err := mergeSettings(allSettings)
-	return string(final), err
+	return allSettings, bounded.Wait()
 }
 
 // Deprecated: in the GraphQL API
@@ -130,71 +148,81 @@ func (r *settingsCascade) Merged(ctx context.Context) (_ *configurationResolver,
 	return &configurationResolver{contents: s, messages: messages}, nil
 }
 
-// deeplyMergedSettingsFields contains the names of top-level settings fields whose values should be
-// merged if they appear in multiple cascading settings. The value is the merge depth (how many
-// levels into the object should the merging occur).
-//
-// For example, suppose org settings is {"a":[1]} and user settings is {"a":[2]}. If "a" is NOT a
-// deeply merged field, the merged settings would be {"a":[2]}. If "a" IS a deeply merged field with
-// depth >= 1, then the merged settings would be {"a":[1,2].}
-var deeplyMergedSettingsFields = map[string]int{
-	"search.scopes":           1,
-	"search.savedQueries":     1,
-	"search.repositoryGroups": 1,
-	"insights.dashboards":     1,
-	"insights.allrepos":       1,
-	"quicklinks":              1,
-	"motd":                    1,
-	"extensions":              1,
+var settingsFieldMergeDepths = map[string]int{
+	"SearchScopes":           1,
+	"SearchSavedQueries":     1,
+	"SearchRepositoryGroups": 1,
+	"InsightsDashboards":     1,
+	"InsightsAllRepos":       1,
+	"Quicklinks":             1,
+	"Motd":                   1,
+	"Extensions":             1,
 }
 
-// mergeSettings merges the specified JSON settings documents together to produce a single JSON
-// settings document. The deep merging behavior is described in the documentation for
-// deeplyMergedSettingsFields.
-func mergeSettings(jsonSettingsStrings []string) ([]byte, error) {
-	var errs []error
-	merged := map[string]interface{}{}
-	for _, s := range jsonSettingsStrings {
-		var o map[string]interface{}
-		if err := jsonc.Unmarshal(s, &o); err != nil {
-			errs = append(errs, err)
-		}
-		for name, value := range o {
-			depth := deeplyMergedSettingsFields[name]
-			mergeSettingsValues(merged, name, value, depth)
-		}
-	}
-	out, err := json.Marshal(merged)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	if len(errs) == 0 {
-		return out, nil
-	}
-	return out, errors.Errorf("errors merging settings: %q", errs)
+func mergeSettingsLeft(left, right *schema.Settings) *schema.Settings {
+	return mergeLeft(reflect.ValueOf(left), reflect.ValueOf(right), 1).Interface().(*schema.Settings)
 }
 
-func mergeSettingsValues(dst map[string]interface{}, field string, value interface{}, depth int) {
-	// Try to deeply merge this field.
-	if depth > 0 {
-		if mv, ok := dst[field].([]interface{}); dst[field] == nil || ok {
-			if cv, ok := value.([]interface{}); dst[field] != nil || (value != nil && ok) {
-				dst[field] = append(mv, cv...)
-				return
-			}
-		} else if mv, ok := dst[field].(map[string]interface{}); dst[field] == nil || ok {
-			if cv, ok := value.(map[string]interface{}); dst[field] != nil || (value != nil && ok) {
-				for key, value := range cv {
-					mergeSettingsValues(mv, key, value, depth-1)
-				}
-				dst[field] = mv
-				return
-			}
-		}
+// mergeLeft takes two values of the same type and merges them if possible, ignoring
+// any struct fields not listed in deeplyMergedSettingsFieldNames. Its depth parameter
+// specifies how many layers deeper to merge, and will be overridden if the struct
+// field name matches a name in settingsFieldMergeDepths.
+func mergeLeft(left, right reflect.Value, depth int) reflect.Value {
+	if left.IsZero() {
+		return right
 	}
 
-	// Otherwise just clobber any existing value.
-	dst[field] = value
+	if right.IsZero() {
+		return left
+	}
+
+	switch left.Kind() {
+	case reflect.Struct:
+		if depth <= 0 {
+			return right
+		}
+		leftType := left.Type()
+		for i := 0; i < left.NumField(); i++ {
+			fieldName := leftType.Field(i).Name
+			leftField := left.Field(i)
+			rightField := right.Field(i)
+
+			fieldDepth := settingsFieldMergeDepths[fieldName]
+			leftField.Set(mergeLeft(leftField, rightField, fieldDepth))
+		}
+		return left
+	case reflect.Map:
+		if depth <= 0 {
+			return right
+		}
+		iter := right.MapRange()
+		for iter.Next() {
+			k := iter.Key()
+			rightVal := iter.Value()
+			leftVal := left.MapIndex(k)
+			if (leftVal != reflect.Value{}) {
+				left.SetMapIndex(k, mergeLeft(leftVal, rightVal, depth-1))
+			} else {
+				left.SetMapIndex(k, rightVal)
+			}
+		}
+		return left
+	case reflect.Ptr:
+		if depth <= 0 {
+			return right
+		}
+		// Don't decrement depth for pointer deref
+		left.Elem().Set(mergeLeft(left.Elem(), right.Elem(), depth))
+		return left
+	case reflect.Slice:
+		if depth <= 0 {
+			return right
+		}
+		return reflect.AppendSlice(left, right)
+	}
+
+	// Type is not mergeable, so clobber existing value
+	return right
 }
 
 func (r schemaResolver) ViewerSettings(ctx context.Context) (*settingsCascade, error) {

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -73,15 +73,6 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 	return subjects, nil
 }
 
-// viewerFinalSettings returns the final (merged) settings for the viewer.
-func viewerFinalSettings(ctx context.Context, db dbutil.DB) (*schema.Settings, error) {
-	cascade, err := (&schemaResolver{db: db}).ViewerSettings(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return cascade.finalTyped(ctx)
-}
-
 func (r *settingsCascade) Final(ctx context.Context) (string, error) {
 	settings, err := r.finalTyped(ctx)
 	if err != nil {


### PR DESCRIPTION
This PR improves the performance of generating merged settings through the settings cascade on sourcegraph.com from ~20ms to ~9ms.

Generating the settings from a cascade of user, org, and site configs is on the critical path of every search request. Currently, it adds ~20ms to the latency of every search request on sourcegraph.com, which is roughly 30% of our backend latency for fast-responding searches. This PR reduces that latency to ~9ms.

Merging settings is surprisingly slow because:
1) We fetch settings string for each subject, unmarshal them into `map[string]interface{}`, merge them together, marshal back to a JSON string, then finally unmarshal _again_ back into `*schema.Settings` 
2) We wait until the settings for every subject is fetched before starting to merge
3) (last but not least) The JSON representation of the sourcegraph.com site settings is a whooping 244 kilobytes, composed mostly of repogroup definitions. `json.Unmarshal()` takes about 7 milliseconds for this.

What does this PR do to improve things?
- It pulls `(*settingsCascade).finalTyped()`, out of `(*settingsCascade).Final()` so our search backend can fetch a `*schema.Settings` without paying the JSON serialization roundtrip cost. `Final()` still behaves the same by marshalling the result of `finalTyped()` to a string.
- It unmarshals the settings for the subject _inside_ the goroutine pool instead of after the pool finishes so unmarshalling is done in parallel
- Instead of unmarshalling to `map[string]interface{}`, merging a bunch of interfaces, then marshalling back to a string before ultimately unmarshalling into `*schema.Settings` it merges `*schema.Settings` structs directly using reflection. This avoids a full JSON roundtrip, and (IMO), is easier to understand.
- Now that we use reflection, tests for merging can be more accurate, comprehensive, and descriptive because we can directly test merging `*schema.Settings` structs more easily. 
- Instead of duplicating the deeply-merged field names as strings which are separated from the types they refer to, merge depth is added as a struct tag.

How can we reduce this even further? Well, currently, ~7ms of the remaining ~9ms is spent on the single unmarshal of the sourcegraph.com global site settings. It takes a long time because of repogroups. With repogroups being deprecated, I expect them to be removed from the site settings and for this to just resolve itself, dropping down to the ~2ms that it now takes to fetch and cascade most normal settings.

P.S. I apologize for the bad diff. `git` chose some weird spots to hunk.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
