### PR TITLE
web: use Apollo Client for `viewerSettings` query

### DIFF
--- a/client/shared/src/graphql/fromObservableQuery.test.ts
+++ b/client/shared/src/graphql/fromObservableQuery.test.ts
@@ -1,0 +1,74 @@
+import { Observable as ZenObservable, ObservableQuery } from '@apollo/client'
+import delay from 'delay'
+import { isObservable } from 'rxjs'
+import sinon from 'sinon'
+
+import { fromObservableQuery, fromObservableQueryPromise } from './fromObservableQuery'
+
+const QUERY_RESULT = { data: {}, loading: false, networkStatus: 1 }
+const UNSUBSCRIBE = sinon.spy()
+
+function createObservableQuery() {
+    return new ZenObservable(observer => {
+        observer.next(QUERY_RESULT)
+        observer.complete()
+
+        return UNSUBSCRIBE
+    }) as ObservableQuery
+}
+
+describe('fromObservableQuery', () => {
+    it('converts `ObservableQuery` to `rxjs` observable', () => {
+        const observable = fromObservableQuery(createObservableQuery())
+
+        expect(isObservable(observable)).toBe(true)
+    })
+
+    it('subscribes to `ObservableQuery` data', done => {
+        const observable = fromObservableQuery(createObservableQuery())
+
+        observable.subscribe(data => {
+            expect(data).toEqual(QUERY_RESULT)
+            done()
+        })
+    })
+
+    it('exposes `ObservableQuery` unsubscribe method', () => {
+        const observable = fromObservableQuery(createObservableQuery())
+
+        observable.subscribe().unsubscribe()
+        sinon.assert.called(UNSUBSCRIBE)
+    })
+})
+
+describe('fromObservableQueryPromise', () => {
+    it('converts `Promise<ObservableQuery>` to `rxjs` observable', () => {
+        const observable = fromObservableQueryPromise(Promise.resolve(createObservableQuery()))
+
+        expect(isObservable(observable)).toBe(true)
+    })
+
+    it('subscribes to `ObservableQuery` data', done => {
+        const observable = fromObservableQueryPromise(Promise.resolve(createObservableQuery()))
+
+        observable.subscribe(data => {
+            expect(data).toEqual(QUERY_RESULT)
+            done()
+        })
+    })
+
+    it('exposes `ObservableQuery` unsubscribe method', () => {
+        const observable = fromObservableQueryPromise(Promise.resolve(createObservableQuery()))
+
+        observable.subscribe().unsubscribe()
+        sinon.assert.called(UNSUBSCRIBE)
+    })
+
+    it('unsubscribes on Promise rejection', async () => {
+        const observable = fromObservableQueryPromise(Promise.reject<ObservableQuery>(new Error('oops')))
+
+        const subscription = observable.subscribe()
+        await delay(0)
+        expect(subscription.closed).toBe(true)
+    })
+})

--- a/client/shared/src/graphql/fromObservableQuery.ts
+++ b/client/shared/src/graphql/fromObservableQuery.ts
@@ -1,0 +1,45 @@
+import { ApolloQueryResult, ObservableQuery } from '@apollo/client'
+import { Observable } from 'rxjs'
+
+/**
+ * Converts ObservableQuery returned by `client.watchQuery` to `rxjs` Observable.
+ *
+ * ```ts
+ * const rxjsObservable = fromObservableQuery(client.watchQuery(query))
+ * ```
+ */
+export function fromObservableQuery<T extends object>(
+    observableQuery: ObservableQuery<T>
+): Observable<ApolloQueryResult<T>> {
+    return new Observable<ApolloQueryResult<T>>(subscriber => {
+        const subscription = observableQuery.subscribe(subscriber)
+
+        return function unsubscribe() {
+            subscription.unsubscribe()
+        }
+    })
+}
+
+/**
+ * Converts Promise<ObservableQuery> to `rxjs` Observable.
+ *
+ * ```ts
+ * const rxjsObservable = fromObservableQuery(
+ *   getGraphqlClient().then(client => client.watchQuery(query))
+ * )
+ * ```
+ */
+export function fromObservableQueryPromise<T extends object, V extends object>(
+    observableQueryPromise: Promise<ObservableQuery<T, V>>
+): Observable<ApolloQueryResult<T>> {
+    return new Observable<ApolloQueryResult<T>>(subscriber => {
+        const subscriptionPromise = observableQueryPromise
+            .then(observableQuery => observableQuery.subscribe(subscriber))
+            .catch(() => subscriber.unsubscribe())
+
+        return function unsubscribe() {
+            subscriber.unsubscribe()
+            subscriptionPromise.then(subscription => subscription?.unsubscribe()).catch(error => console.log(error))
+        }
+    })
+}

--- a/client/shared/src/testing/coverage.ts
+++ b/client/shared/src/testing/coverage.ts
@@ -23,7 +23,7 @@ let warnedNoCoverage = false
  * Saves coverage recorded by the instrumented code in `.nyc_output` after each test.
  */
 export function afterEachRecordCoverage(getDriver: () => Driver): void {
-    afterEach('Record coverage', () => recordCoverage(getDriver().browser))
+    afterEach(() => recordCoverage(getDriver().browser))
 }
 
 /**

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -37,8 +37,8 @@ describe('Code monitoring', () => {
                 autoDefinedSearchContexts: [],
             }),
             ViewerSettings: () => ({
-                __typename: 'SettingsCascade',
                 viewerSettings: {
+                    __typename: 'SettingsCascade',
                     subjects: [
                         {
                             __typename: 'DefaultSettings',

--- a/client/web/src/settings/temporary/TemporarySettingsStorage.ts
+++ b/client/web/src/settings/temporary/TemporarySettingsStorage.ts
@@ -3,6 +3,8 @@ import { isEqual } from 'lodash'
 import { Observable, of, Subscription, from, ReplaySubject } from 'rxjs'
 import { distinctUntilChanged, map } from 'rxjs/operators'
 
+import { fromObservableQuery } from '@sourcegraph/shared/src/graphql/fromObservableQuery'
+
 import { GetTemporarySettingsResult } from '../../graphql-operations'
 
 import { TemporarySettings } from './TemporarySettings'
@@ -117,32 +119,24 @@ class ServersideSettingsBackend implements SettingsBackend {
     constructor(private apolloClient: ApolloClient<object>) {}
 
     public load(): Observable<TemporarySettings> {
-        return new Observable<TemporarySettings>(observer => {
-            const subscription = this.apolloClient
-                .watchQuery<GetTemporarySettingsResult>({ query: this.GetTemporarySettingsQuery })
-                .subscribe({
-                    next: result => {
-                        let parsedSettings: TemporarySettings = {}
-                        try {
-                            const settings = result.data.temporarySettings.contents
-                            parsedSettings = JSON.parse(settings) as TemporarySettings
-                        } catch (error: unknown) {
-                            console.error(error)
-                        }
-
-                        observer.next(parsedSettings || {})
-                    },
-                    error: error => {
-                        console.error(error)
-                        observer.error(error)
-                    },
-                    complete: () => {
-                        observer.complete()
-                    },
-                })
-
-            return () => subscription.unsubscribe()
+        const temporarySettingsQuery = this.apolloClient.watchQuery<GetTemporarySettingsResult>({
+            query: this.GetTemporarySettingsQuery,
         })
+
+        return fromObservableQuery(temporarySettingsQuery).pipe(
+            map(({ data }) => {
+                let parsedSettings: TemporarySettings = {}
+
+                try {
+                    const settings = data.temporarySettings.contents
+                    parsedSettings = JSON.parse(settings) as TemporarySettings
+                } catch (error: unknown) {
+                    console.error(error)
+                }
+
+                return parsedSettings || {}
+            })
+        )
     }
 
     public save(settings: TemporarySettings): Observable<void> {


### PR DESCRIPTION
## Context

Preparation to land https://github.com/sourcegraph/sourcegraph/pull/23351, where Apollo Client persistent cache will be enabled. 

## Changes

- Added helpers to convert Apollo Client `ObservableQuery` to `rxjs` observable.
- Applied `fromObservableQuery` helper `ServersideSettingsBackend.load()`.
- Use Apollo Client to fetch `ViewerSettings`


Closes #24876
