### PR TITLE
web: prepare to enable Apollo Client for extensions query

### DIFF
--- a/client/shared/src/graphql/cache.ts
+++ b/client/shared/src/graphql/cache.ts
@@ -2,9 +2,17 @@ import { InMemoryCache } from '@apollo/client'
 
 import { TypedTypePolicies } from '../graphql-operations'
 
+import { IExtensionRegistry } from './schema'
+
 // Defines how the Apollo cache interacts with our GraphQL schema.
 // See https://www.apollographql.com/docs/react/caching/cache-configuration/#typepolicy-fields
 const typePolicies: TypedTypePolicies = {
+    ExtensionRegistry: {
+        // Replace existing `ExtensionRegistry` with the incoming value. Required because of the missing `id` field.
+        merge(existing: IExtensionRegistry, incoming: IExtensionRegistry): IExtensionRegistry {
+            return incoming
+        },
+    },
     Query: {
         fields: {
             node: {

--- a/client/shared/src/graphql/cache.ts
+++ b/client/shared/src/graphql/cache.ts
@@ -2,17 +2,9 @@ import { InMemoryCache } from '@apollo/client'
 
 import { TypedTypePolicies } from '../graphql-operations'
 
-import { IExtensionRegistry } from './schema'
-
 // Defines how the Apollo cache interacts with our GraphQL schema.
 // See https://www.apollographql.com/docs/react/caching/cache-configuration/#typepolicy-fields
 const typePolicies: TypedTypePolicies = {
-    ExtensionRegistry: {
-        // Replace existing `ExtensionRegistry` with the incoming value. Required because of the missing `id` field.
-        merge(existing: IExtensionRegistry, incoming: IExtensionRegistry): IExtensionRegistry {
-            return incoming
-        },
-    },
     Query: {
         fields: {
             node: {

--- a/client/shared/src/graphql/fromObservableQuery.test.ts
+++ b/client/shared/src/graphql/fromObservableQuery.test.ts
@@ -1,0 +1,74 @@
+import { Observable as ZenObservable, ObservableQuery } from '@apollo/client'
+import delay from 'delay'
+import { isObservable } from 'rxjs'
+import sinon from 'sinon'
+
+import { fromObservableQuery, fromObservableQueryPromise } from './fromObservableQuery'
+
+const QUERY_RESULT = { data: {}, loading: false, networkStatus: 1 }
+const UNSUBSCRIBE = sinon.spy()
+
+function createObservableQuery() {
+    return new ZenObservable(observer => {
+        observer.next(QUERY_RESULT)
+        observer.complete()
+
+        return UNSUBSCRIBE
+    }) as ObservableQuery
+}
+
+describe('fromObservableQuery', () => {
+    it('converts `ObservableQuery` to `rxjs` observable', () => {
+        const observable = fromObservableQuery(createObservableQuery())
+
+        expect(isObservable(observable)).toBe(true)
+    })
+
+    it('subscribes to `ObservableQuery` data', done => {
+        const observable = fromObservableQuery(createObservableQuery())
+
+        observable.subscribe(data => {
+            expect(data).toEqual(QUERY_RESULT)
+            done()
+        })
+    })
+
+    it('exposes `ObservableQuery` unsubscribe method', () => {
+        const observable = fromObservableQuery(createObservableQuery())
+
+        observable.subscribe().unsubscribe()
+        sinon.assert.called(UNSUBSCRIBE)
+    })
+})
+
+describe('fromObservableQueryPromise', () => {
+    it('converts `Promise<ObservableQuery>` to `rxjs` observable', () => {
+        const observable = fromObservableQueryPromise(Promise.resolve(createObservableQuery()))
+
+        expect(isObservable(observable)).toBe(true)
+    })
+
+    it('subscribes to `ObservableQuery` data', done => {
+        const observable = fromObservableQueryPromise(Promise.resolve(createObservableQuery()))
+
+        observable.subscribe(data => {
+            expect(data).toEqual(QUERY_RESULT)
+            done()
+        })
+    })
+
+    it('exposes `ObservableQuery` unsubscribe method', () => {
+        const observable = fromObservableQueryPromise(Promise.resolve(createObservableQuery()))
+
+        observable.subscribe().unsubscribe()
+        sinon.assert.called(UNSUBSCRIBE)
+    })
+
+    it('unsubscribes on Promise rejection', async () => {
+        const observable = fromObservableQueryPromise(Promise.reject<ObservableQuery>(new Error('oops')))
+
+        const subscription = observable.subscribe()
+        await delay(0)
+        expect(subscription.closed).toBe(true)
+    })
+})

--- a/client/shared/src/graphql/fromObservableQuery.ts
+++ b/client/shared/src/graphql/fromObservableQuery.ts
@@ -1,0 +1,45 @@
+import { ApolloQueryResult, ObservableQuery } from '@apollo/client'
+import { Observable } from 'rxjs'
+
+/**
+ * Converts ObservableQuery returned by `client.watchQuery` to `rxjs` Observable.
+ *
+ * ```ts
+ * const rxjsObservable = fromObservableQuery(client.watchQuery(query))
+ * ```
+ */
+export function fromObservableQuery<T extends object>(
+    observableQuery: ObservableQuery<T>
+): Observable<ApolloQueryResult<T>> {
+    return new Observable<ApolloQueryResult<T>>(subscriber => {
+        const subscription = observableQuery.subscribe(subscriber)
+
+        return function unsubscribe() {
+            subscription.unsubscribe()
+        }
+    })
+}
+
+/**
+ * Converts Promise<ObservableQuery> to `rxjs` Observable.
+ *
+ * ```ts
+ * const rxjsObservable = fromObservableQuery(
+ *   getGraphqlClient().then(client => client.watchQuery(query))
+ * )
+ * ```
+ */
+export function fromObservableQueryPromise<T extends object, V extends object>(
+    observableQueryPromise: Promise<ObservableQuery<T, V>>
+): Observable<ApolloQueryResult<T>> {
+    return new Observable<ApolloQueryResult<T>>(subscriber => {
+        const subscriptionPromise = observableQueryPromise
+            .then(observableQuery => observableQuery.subscribe(subscriber))
+            .catch(() => subscriber.unsubscribe())
+
+        return function unsubscribe() {
+            subscriber.unsubscribe()
+            subscriptionPromise.then(subscription => subscription?.unsubscribe()).catch(error => console.log(error))
+        }
+    })
+}

--- a/client/shared/src/graphql/graphql.ts
+++ b/client/shared/src/graphql/graphql.ts
@@ -93,22 +93,14 @@ export function requestGraphQLCommon<T, V = object>({
     })
 }
 
-export const graphQLClient = ({ headers }: { headers: RequestInit['headers'] }): ApolloClient<NormalizedCacheObject> =>
-    new ApolloClient({
-        uri: GRAPHQL_URI,
-        cache,
-        link: createHttpLink({
-            uri: ({ operationName }) => `${GRAPHQL_URI}?${operationName}`,
-            headers,
-        }),
-    })
-
 interface GetGraphqlClientOptions {
     headers: RequestInit['headers']
 }
 
+export type GraphQLClient = ApolloClient<NormalizedCacheObject>
+
 export const getGraphQLClient = once(
-    async (options: GetGraphqlClientOptions): Promise<ApolloClient<NormalizedCacheObject>> => {
+    async (options: GetGraphqlClientOptions): Promise<GraphQLClient> => {
         const { headers } = options
 
         const apolloClient = new ApolloClient({

--- a/client/shared/src/platform/context.ts
+++ b/client/shared/src/platform/context.ts
@@ -1,4 +1,3 @@
-import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { Endpoint } from 'comlink'
 import { isObject } from 'lodash'
 import { NextObserver, Observable, Subscribable, Subscription } from 'rxjs'
@@ -9,7 +8,7 @@ import { DiffPart } from '@sourcegraph/codeintellify'
 import { SettingsEdit } from '../api/client/services/settings'
 import { ExecutableExtension } from '../api/extension/activation'
 import { Scalars } from '../graphql-operations'
-import { GraphQLResult } from '../graphql/graphql'
+import { GraphQLClient, GraphQLResult } from '../graphql/graphql'
 import { Settings, SettingsCascadeOrError } from '../settings/settings'
 import { TelemetryService } from '../telemetry/telemetryService'
 import { ErrorLike } from '../util/errors'
@@ -96,7 +95,7 @@ export interface PlatformContext {
     /**
      * Returns promise that resolves into Apollo Client instance after cache restoration.
      */
-    getGraphQLClient: () => Promise<ApolloClient<NormalizedCacheObject>>
+    getGraphQLClient: () => Promise<GraphQLClient>
 
     /**
      * Sends a request to the Sourcegraph GraphQL API and returns the response.

--- a/client/shared/src/testing/apollo/index.ts
+++ b/client/shared/src/testing/apollo/index.ts
@@ -1,0 +1,9 @@
+import { act } from '@testing-library/react'
+
+/**
+ * Wait one tick to load the next response from Apollo
+ * https://www.apollographql.com/docs/react/development-testing/testing/#testing-the-success-state
+ */
+export const waitForNextApolloResponse = (): Promise<void> => act(() => new Promise(resolve => setTimeout(resolve, 0)))
+
+export * from './mockedTestProvider'

--- a/client/shared/src/testing/apollo/mockedTestProvider.tsx
+++ b/client/shared/src/testing/apollo/mockedTestProvider.tsx
@@ -1,14 +1,7 @@
 import { MockedProvider, MockedProviderProps } from '@apollo/client/testing'
-import { act } from '@testing-library/react'
 import React, { useMemo } from 'react'
 
-import { generateCache } from '../graphql/cache'
-
-/*
- * Wait one tick to load the next response from Apollo
- * https://www.apollographql.com/docs/react/development-testing/testing/#testing-the-success-state
- */
-export const waitForNextApolloResponse = (): Promise<void> => act(() => new Promise(resolve => setTimeout(resolve, 0)))
+import { generateCache } from '../../graphql/cache'
 
 export const MockedTestProvider: React.FunctionComponent<MockedProviderProps> = ({ children, ...props }) => {
     /**

--- a/client/shared/src/testing/coverage.ts
+++ b/client/shared/src/testing/coverage.ts
@@ -23,7 +23,7 @@ let warnedNoCoverage = false
  * Saves coverage recorded by the instrumented code in `.nyc_output` after each test.
  */
 export function afterEachRecordCoverage(getDriver: () => Driver): void {
-    afterEach('Record coverage', () => recordCoverage(getDriver().browser))
+    afterEach(() => recordCoverage(getDriver().browser))
 }
 
 /**

--- a/client/shared/src/testing/integration/mockExtension.ts
+++ b/client/shared/src/testing/integration/mockExtension.ts
@@ -35,6 +35,12 @@ interface ExtensionMockingUtils {
     extensionSettings: Settings['extensions']
 }
 
+interface ExtensionsResultMock {
+    extensionRegistry: ExtensionsResult['extensionRegistry'] & {
+        __typename: 'ExtensionRegistry'
+    }
+}
+
 /**
  * Set up Sourcegraph extension mocking for an integration test.
  */
@@ -45,8 +51,9 @@ export function setupExtensionMocking({
     let internalID = 0
 
     const extensionSettings: Settings['extensions'] = {}
-    const extensionsResult: ExtensionsResult = {
+    const extensionsResult: ExtensionsResultMock = {
         extensionRegistry: {
+            __typename: 'ExtensionRegistry',
             extensions: {
                 nodes: [],
             },

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -1,6 +1,6 @@
 import 'focus-visible'
 
-import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/client'
+import { ApolloProvider } from '@apollo/client'
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
@@ -20,6 +20,7 @@ import {
     createController as createExtensionsController,
 } from '@sourcegraph/shared/src/extensions/controller'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { GraphQLClient } from '@sourcegraph/shared/src/graphql/graphql'
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { Notifications } from '@sourcegraph/shared/src/notifications/Notifications'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
@@ -135,7 +136,7 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
     authenticatedUser?: AuthenticatedUser | null
 
     /** GraphQL client initialized asynchronously to restore persisted cache. */
-    graphqlClient?: ApolloClient<NormalizedCacheObject>
+    graphqlClient?: GraphQLClient
 
     viewerSubject: LayoutProps['viewerSubject']
 

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -1,4 +1,3 @@
-import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { memoize } from 'lodash'
 import { Observable } from 'rxjs'
 
@@ -67,13 +66,12 @@ export const mutateGraphQL = (request: string, variables?: {}): Observable<Graph
  * Memoized Apollo Client getter. It should be executed once to restore the cache from the local storage.
  * After that, the same instance should be used by all consumers.
  */
-export const getWebGraphQLClient = memoize(
-    (): Promise<ApolloClient<NormalizedCacheObject>> =>
-        getGraphQLClient({
-            headers: {
-                ...window?.context?.xhrHeaders,
-                'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
-                // Note: Do not use getHeaders() here due to a bug that Apollo has duplicating headers with different letter casing. Issue to fix: https://github.com/apollographql/apollo-client/issues/8447
-            },
-        })
+export const getWebGraphQLClient = memoize(() =>
+    getGraphQLClient({
+        headers: {
+            ...window?.context?.xhrHeaders,
+            'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
+            // Note: Do not use getHeaders() here due to a bug that Apollo has duplicating headers with different letter casing. Issue to fix: https://github.com/apollographql/apollo-client/issues/8447
+        },
+    })
 )

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -37,8 +37,8 @@ describe('Code monitoring', () => {
                 autoDefinedSearchContexts: [],
             }),
             ViewerSettings: () => ({
-                __typename: 'SettingsCascade',
                 viewerSettings: {
+                    __typename: 'SettingsCascade',
                     subjects: [
                         {
                             __typename: 'DefaultSettings',

--- a/client/web/src/settings/temporary/TemporarySettingsStorage.ts
+++ b/client/web/src/settings/temporary/TemporarySettingsStorage.ts
@@ -3,6 +3,8 @@ import { isEqual } from 'lodash'
 import { Observable, of, Subscription, from, ReplaySubject } from 'rxjs'
 import { distinctUntilChanged, map } from 'rxjs/operators'
 
+import { fromObservableQuery } from '@sourcegraph/shared/src/graphql/fromObservableQuery'
+
 import { GetTemporarySettingsResult } from '../../graphql-operations'
 
 import { TemporarySettings } from './TemporarySettings'
@@ -117,32 +119,24 @@ class ServersideSettingsBackend implements SettingsBackend {
     constructor(private apolloClient: ApolloClient<object>) {}
 
     public load(): Observable<TemporarySettings> {
-        return new Observable<TemporarySettings>(observer => {
-            const subscription = this.apolloClient
-                .watchQuery<GetTemporarySettingsResult>({ query: this.GetTemporarySettingsQuery })
-                .subscribe({
-                    next: result => {
-                        let parsedSettings: TemporarySettings = {}
-                        try {
-                            const settings = result.data.temporarySettings.contents
-                            parsedSettings = JSON.parse(settings) as TemporarySettings
-                        } catch (error: unknown) {
-                            console.error(error)
-                        }
-
-                        observer.next(parsedSettings || {})
-                    },
-                    error: error => {
-                        console.error(error)
-                        observer.error(error)
-                    },
-                    complete: () => {
-                        observer.complete()
-                    },
-                })
-
-            return () => subscription.unsubscribe()
+        const temporarySettingsQuery = this.apolloClient.watchQuery<GetTemporarySettingsResult>({
+            query: this.GetTemporarySettingsQuery,
         })
+
+        return fromObservableQuery(temporarySettingsQuery).pipe(
+            map(({ data }) => {
+                let parsedSettings: TemporarySettings = {}
+
+                try {
+                    const settings = data.temporarySettings.contents
+                    parsedSettings = JSON.parse(settings) as TemporarySettings
+                } catch (error: unknown) {
+                    console.error(error)
+                }
+
+                return parsedSettings || {}
+            })
+        )
     }
 
     public save(settings: TemporarySettings): Observable<void> {


### PR DESCRIPTION
## Context

Preparation to land https://github.com/sourcegraph/sourcegraph/pull/23351, where Apollo Client persistent cache will be enabled. 

## Changes

- Removed redundant `graphQLClient` variable
- Added `ExtensionRegistry` type policy 
