### PR TITLE
web: use Apollo Client for `extensions` query

### DIFF
--- a/client/browser/src/shared/backend/requestGraphQl.ts
+++ b/client/browser/src/shared/backend/requestGraphQl.ts
@@ -1,43 +1,112 @@
-import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { print } from 'graphql'
 import { once } from 'lodash'
-import { from } from 'rxjs'
+import { from, Observable } from 'rxjs'
+import { switchMap, take } from 'rxjs/operators'
 
-import { requestGraphQLCommon, getGraphQLClient } from '@sourcegraph/shared/src/graphql/graphql'
+import {
+    GraphQLResult,
+    getGraphQLClient,
+    GraphQLClient,
+    requestGraphQLCommon,
+} from '@sourcegraph/shared/src/graphql/graphql'
 
 import { background } from '../../browser-extension/web-extension-api/runtime'
 import { isBackground } from '../context'
+import { observeSourcegraphURL } from '../util/context'
 
 import { getHeaders } from './headers'
+
+interface RequestGraphQLOptions<V> {
+    request: string
+    variables: V
+    mightContainPrivateInfo: boolean
+    privateCloudErrors?: Observable<boolean>
+}
+
+interface GraphQLHelpers {
+    getBrowserGraphQLClient: () => Promise<GraphQLClient>
+    requestGraphQL: <T, V = object>(options: RequestGraphQLOptions<V>) => Observable<GraphQLResult<T>>
+}
+
+function createMainThreadExtensionGraphQLHelpers(): GraphQLHelpers {
+    /**
+     * Forward GraphQL request to the background script for execution.
+     */
+    const requestGraphQLInBackground = <T, V = object>(
+        options: RequestGraphQLOptions<V>
+        // Keep both helpers inside of the factory function.
+        // eslint-disable-next-line unicorn/consistent-function-scoping
+    ): Observable<GraphQLResult<T>> => from(background.requestGraphQL<T, V>(options))
+
+    /**
+     * Apollo-Client is not configured yet to execute requests in the background script.
+     * Fallback to `requestGraphQLInBackground` when `client.watchQuery` is called.
+     *
+     * The implementation should forward Apollo-Client method calls to the background script
+     * in the same manner as it's done for `requestGraphQL` method. Or we can consider executing
+     * API requests in the main thread.
+     */
+    const getBrowserGraphQLClient = once(() => {
+        if (process.env.NODE_ENV === 'development') {
+            console.warn(
+                'Apollo-Client mock is used in browser extension to forward GraphQL requests to the background script!'
+            )
+        }
+
+        const graphqlClient: Pick<GraphQLClient, 'watchQuery'> = {
+            watchQuery: ({ variables, query }) =>
+                // Temporary implementation till Apollo-Client is configured in the background script.
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                requestGraphQLInBackground({
+                    request: print(query),
+                    variables,
+                    mightContainPrivateInfo: false,
+                }) as any,
+        }
+
+        return Promise.resolve(graphqlClient) as Promise<GraphQLClient>
+    })
+
+    return { getBrowserGraphQLClient, requestGraphQL: requestGraphQLInBackground }
+}
 
 /**
  * Returns a platform-appropriate implementation of the function used to make requests to our GraphQL API.
  *
  * In the browser extension, the returned function will make all requests from the background page.
- *
  * In the native integration, the returned function will rely on the `requestGraphQL` implementation from `/shared`.
  */
-export const requestGraphQlHelper = (isExtension: boolean, baseUrl: string) => <T, V = object>({
-    request,
-    variables,
-}: {
-    request: string
-    variables: V
-}) =>
-    isExtension && !isBackground
-        ? from(
-              background.requestGraphQL<T, V>({ request, variables })
-          )
-        : requestGraphQLCommon<T, V>({
-              request,
-              variables,
-              baseUrl,
-              credentials: 'include',
-          })
+export function createGraphQLHelpers(sourcegraphURL: string, isExtension: boolean): GraphQLHelpers {
+    if (isExtension && !isBackground) {
+        if (process.env.NODE_ENV === 'development') {
+            console.warn('GraphQL requests initiated in the main thread are forwarded to the background script!')
+            console.warn('Check out the implementation of the `requestGraphQLInBackground` function above.')
+        }
 
-/**
- * Memoized Apollo Client getter. It should be executed once to restore the cache from the local storage.
- * After that, the same instance should be used by all consumers.
- */
-export const getBrowserGraphQLClient = once(
-    (): Promise<ApolloClient<NormalizedCacheObject>> => getGraphQLClient({ headers: getHeaders() })
-)
+        return createMainThreadExtensionGraphQLHelpers()
+    }
+
+    const requestGraphQL = <T, V = object>({
+        request,
+        variables,
+    }: RequestGraphQLOptions<V>): Observable<GraphQLResult<T>> =>
+        observeSourcegraphURL(isExtension).pipe(
+            take(1),
+            switchMap(sourcegraphURL =>
+                requestGraphQLCommon<T, V>({
+                    request,
+                    variables,
+                    baseUrl: sourcegraphURL,
+                    credentials: 'include',
+                })
+            )
+        )
+
+    /**
+     * Memoized Apollo Client getter. It should be executed once to restore the cache from the local storage.
+     * After that, the same instance should be used by all consumers.
+     */
+    const getBrowserGraphQLClient = once(() => getGraphQLClient({ headers: getHeaders(), baseUrl: sourcegraphURL }))
+
+    return { getBrowserGraphQLClient, requestGraphQL }
+}

--- a/client/browser/src/shared/backend/requestGraphQl.ts
+++ b/client/browser/src/shared/backend/requestGraphQl.ts
@@ -9,6 +9,7 @@ import {
     GraphQLClient,
     requestGraphQLCommon,
 } from '@sourcegraph/shared/src/graphql/graphql'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 
 import { background } from '../../browser-extension/web-extension-api/runtime'
 import { isBackground } from '../context'
@@ -24,7 +25,7 @@ interface RequestGraphQLOptions<V> {
 }
 
 interface GraphQLHelpers {
-    getBrowserGraphQLClient: () => Promise<GraphQLClient>
+    getBrowserGraphQLClient: PlatformContext['getGraphQLClient']
     requestGraphQL: <T, V = object>(options: RequestGraphQLOptions<V>) => Observable<GraphQLResult<T>>
 }
 

--- a/client/browser/src/shared/platform/context.ts
+++ b/client/browser/src/shared/platform/context.ts
@@ -1,8 +1,7 @@
-import { combineLatest, Observable, ReplaySubject } from 'rxjs'
-import { map, switchMap, take } from 'rxjs/operators'
+import { combineLatest, ReplaySubject } from 'rxjs'
+import { map } from 'rxjs/operators'
 
 import { isHTTPAuthError } from '@sourcegraph/shared/src/backend/fetch'
-import { GraphQLResult } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { mutateSettings, updateSettings } from '@sourcegraph/shared/src/settings/edit'
@@ -13,10 +12,9 @@ import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { ExtensionStorageSubject } from '../../browser-extension/web-extension-api/ExtensionStorageSubject'
 import { background } from '../../browser-extension/web-extension-api/runtime'
-import { requestGraphQlHelper, getBrowserGraphQLClient } from '../backend/requestGraphQl'
+import { createGraphQLHelpers } from '../backend/requestGraphQl'
 import { CodeHost } from '../code-hosts/shared/codeHost'
 import { isInPage } from '../context'
-import { observeSourcegraphURL } from '../util/context'
 
 import { createExtensionHost } from './extensionHost'
 import { getInlineExtensions, shouldUseInlineExtensions } from './inlineExtensionsService'
@@ -43,7 +41,7 @@ export interface SourcegraphIntegrationURLs {
  */
 export interface BrowserPlatformContext extends PlatformContext {
     /**
-     * Refetches the settings cascade from the Sourcegraph instance.
+     * Re-fetches the settings cascade from the Sourcegraph instance.
      */
     refreshSettings(): Promise<void>
 }
@@ -57,19 +55,7 @@ export function createPlatformContext(
     isExtension: boolean
 ): BrowserPlatformContext {
     const updatedViewerSettings = new ReplaySubject<Pick<GQL.ISettingsCascade, 'subjects' | 'final'>>(1)
-    const requestGraphQL: PlatformContext['requestGraphQL'] = <T, V = object>({
-        request,
-        variables,
-    }: {
-        request: string
-        variables: V
-        mightContainPrivateInfo: boolean
-        privateCloudErrors?: Observable<boolean>
-    }): Observable<GraphQLResult<T>> =>
-        observeSourcegraphURL(isExtension).pipe(
-            take(1),
-            switchMap(sourcegraphURL => requestGraphQlHelper(isExtension, sourcegraphURL)<T, V>({ request, variables }))
-        )
+    const { requestGraphQL, getBrowserGraphQLClient } = createGraphQLHelpers(sourcegraphURL, isExtension)
 
     const context: BrowserPlatformContext = {
         /**

--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -22,12 +22,12 @@ import { asError, isErrorLike } from '../../util/errors'
  */
 function viewerConfiguredExtensions({
     settings,
-    requestGraphQL,
-}: Pick<PlatformContext, 'settings' | 'requestGraphQL'>): Observable<ConfiguredExtension[]> {
+    getGraphQLClient,
+}: Pick<PlatformContext, 'settings' | 'getGraphQLClient'>): Observable<ConfiguredExtension[]> {
     return from(settings).pipe(
         map(settings => extensionIDsFromSettings(settings)),
         distinctUntilChanged((a, b) => isEqual(a, b)),
-        switchMap(extensionIDs => queryConfiguredRegistryExtensions({ requestGraphQL }, extensionIDs)),
+        switchMap(extensionIDs => queryConfiguredRegistryExtensions({ getGraphQLClient }, extensionIDs)),
         catchError(error => throwError(asError(error))),
         // TODO: Restore reference counter after refactoring contributions service
         // to not unsubscribe from existing entries when new entries are registered,
@@ -71,7 +71,7 @@ export const getEnabledExtensions = once(
     (
         context: Pick<
             PlatformContext,
-            'settings' | 'requestGraphQL' | 'sideloadedExtensionURL' | 'getScriptURLForExtension'
+            'settings' | 'getGraphQLClient' | 'sideloadedExtensionURL' | 'getScriptURLForExtension'
         >
     ): Observable<ConfiguredExtension[]> => {
         const sideloadedExtension = from(context.sideloadedExtensionURL).pipe(

--- a/client/shared/src/extensions/helpers.ts
+++ b/client/shared/src/extensions/helpers.ts
@@ -1,8 +1,14 @@
-import { from, Observable, of } from 'rxjs'
+import { Observable, of } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 
-import { gql } from '../graphql/graphql'
-import * as GQL from '../graphql/schema'
+import {
+    ExtensionsResult,
+    ExtensionsVariables,
+    ExtensionsWithPrioritizeExtensionIDsParamAndNoJSONFieldsResult,
+    ExtensionsWithPrioritizeExtensionIDsParamAndNoJSONFieldsVariables,
+} from '../graphql-operations'
+import { fromObservableQueryPromise } from '../graphql/fromObservableQuery'
+import { getDocumentNode, gql } from '../graphql/graphql'
 import { PlatformContext } from '../platform/context'
 import { createAggregateError } from '../util/errors'
 
@@ -13,6 +19,36 @@ import {
 } from './extension'
 import { parseExtensionManifestOrError, ExtensionManifest } from './extensionManifest'
 
+const ExtensionsQuery = gql`
+    query Extensions($first: Int!, $extensionIDs: [String!]!, $extensionManifestFields: [String!]!) {
+        extensionRegistry {
+            extensions(first: $first, extensionIDs: $extensionIDs) {
+                nodes {
+                    extensionID
+                    manifest {
+                        jsonFields(fields: $extensionManifestFields)
+                    }
+                }
+            }
+        }
+    }
+`
+
+const ExtensionsWithPrioritizeExtensionIDsParameterAndNoJSONFieldsQuery = gql`
+    query ExtensionsWithPrioritizeExtensionIDsParamAndNoJSONFields($first: Int!, $extensionIDs: [String!]!) {
+        extensionRegistry {
+            extensions(first: $first, prioritizeExtensionIDs: $extensionIDs) {
+                nodes {
+                    extensionID
+                    manifest {
+                        raw
+                    }
+                }
+            }
+        }
+    }
+`
+
 /**
  * Query the GraphQL API for registry metadata about the extensions given in {@link extensionIDs}.
  *
@@ -21,36 +57,31 @@ import { parseExtensionManifestOrError, ExtensionManifest } from './extensionMan
 export function queryConfiguredRegistryExtensions(
     // TODO(tj): can copy this over to extension host, just replace platformContext.requestGraphQL
     // with mainThreadAPI.requestGraphQL
-    { requestGraphQL }: Pick<PlatformContext, 'requestGraphQL'>,
+    { getGraphQLClient }: Pick<PlatformContext, 'getGraphQLClient'>,
     extensionIDs: string[]
 ): Observable<ConfiguredExtension[]> {
     if (extensionIDs.length === 0) {
         return of([])
     }
-    const variables: GQL.IExtensionsOnExtensionRegistryArguments = {
+
+    const variables: ExtensionsWithPrioritizeExtensionIDsParamAndNoJSONFieldsVariables = {
         first: extensionIDs.length,
         extensionIDs,
     }
-    return from(
-        requestGraphQL<GQL.IQuery>({
-            request: gql`
-                query Extensions($first: Int!, $extensionIDs: [String!]!, $extensionManifestFields: [String!]!) {
-                    extensionRegistry {
-                        extensions(first: $first, extensionIDs: $extensionIDs) {
-                            nodes {
-                                extensionID
-                                manifest {
-                                    jsonFields(fields: $extensionManifestFields)
-                                }
-                            }
-                        }
-                    }
-                }
-            `,
-            variables: { ...variables, extensionManifestFields: CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS },
-            mightContainPrivateInfo: false,
+
+    const queryObservablePromise = getGraphQLClient().then(client =>
+        client.watchQuery<ExtensionsResult, ExtensionsVariables>({
+            query: getDocumentNode(ExtensionsQuery),
+            variables: {
+                ...variables,
+                // `.slice()` is required to avoid Typescript error
+                // because of `readonly` type of `CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS`
+                extensionManifestFields: CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS.slice(),
+            },
         })
-    ).pipe(
+    )
+
+    return fromObservableQueryPromise(queryObservablePromise).pipe(
         switchMap(({ data, errors }) => {
             // BACKCOMPAT: The `extensionIDs` param to Query.extensionRegistry.extensions and the
             // ExtensionManifest#jsonFields field were added in 2021-09 and are not supported by
@@ -62,43 +93,50 @@ export function queryConfiguredRegistryExtensions(
                         'Unknown argument "extensionIDs" on field "extensions" of type "ExtensionRegistry".' ||
                     error.message === 'Cannot query field "jsonFields" on type "ExtensionManifest".'
             )
-            return hasUnknownArgumentExtensionIDsError
-                ? requestGraphQL<GQL.IQuery>({
-                      request: gql`
-                          query ExtensionsWithPrioritizeExtensionIDsParamAndNoJSONFields(
-                              $first: Int!
-                              $extensionIDs: [String!]!
-                          ) {
-                              extensionRegistry {
-                                  extensions(first: $first, prioritizeExtensionIDs: $extensionIDs) {
-                                      nodes {
-                                          extensionID
-                                          manifest {
-                                              raw
-                                          }
-                                      }
-                                  }
-                              }
-                          }
-                      `,
-                      variables,
-                      mightContainPrivateInfo: false,
-                  })
-                : of({ data, errors })
+
+            if (!hasUnknownArgumentExtensionIDsError) {
+                return of({ data, errors })
+            }
+
+            const queryObservablePromise = getGraphQLClient().then(client =>
+                client.watchQuery<
+                    ExtensionsWithPrioritizeExtensionIDsParamAndNoJSONFieldsResult,
+                    ExtensionsWithPrioritizeExtensionIDsParamAndNoJSONFieldsVariables
+                >({
+                    query: getDocumentNode(ExtensionsWithPrioritizeExtensionIDsParameterAndNoJSONFieldsQuery),
+                    variables,
+                })
+            )
+
+            return fromObservableQueryPromise(queryObservablePromise)
         }),
         map(({ data, errors }) => {
             if (!data?.extensionRegistry?.extensions?.nodes) {
                 throw createAggregateError(errors)
             }
-            return data.extensionRegistry.extensions.nodes
+
+            const { nodes } = data.extensionRegistry.extensions
+
+            return (nodes as typeof nodes[number][])
                 .filter(({ extensionID }) => extensionIDs.includes(extensionID))
-                .map(({ extensionID, manifest }) => ({
-                    id: extensionID,
-                    manifest: manifest
-                        ? (manifest.jsonFields as Pick<ExtensionManifest, ConfiguredExtensionManifestDefaultFields>) ||
-                          parseExtensionManifestOrError(manifest.raw)
-                        : null,
-                }))
+                .map(({ extensionID, manifest }) => {
+                    const getManifest = (value: typeof manifest): ConfiguredExtension['manifest'] => {
+                        if (!value) {
+                            return value
+                        }
+
+                        if ('jsonFields' in value) {
+                            return value.jsonFields as Pick<ExtensionManifest, ConfiguredExtensionManifestDefaultFields>
+                        }
+
+                        return parseExtensionManifestOrError(value.raw)
+                    }
+
+                    return {
+                        id: extensionID,
+                        manifest: getManifest(manifest),
+                    }
+                })
         })
     )
 }

--- a/client/shared/src/extensions/helpers.ts
+++ b/client/shared/src/extensions/helpers.ts
@@ -74,9 +74,9 @@ export function queryConfiguredRegistryExtensions(
             query: getDocumentNode(ExtensionsQuery),
             variables: {
                 ...variables,
-                // `.slice()` is required to avoid Typescript error
-                // because of `readonly` type of `CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS`
-                extensionManifestFields: CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS.slice(),
+                // Spread operator is required to avoid Typescript type error
+                // because of `readonly` type of `CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS`.
+                extensionManifestFields: [...CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS],
             },
         })
     )

--- a/client/shared/src/graphql/graphql.ts
+++ b/client/shared/src/graphql/graphql.ts
@@ -85,7 +85,8 @@ export function requestGraphQLCommon<T, V = object>({
 }): Observable<GraphQLResult<T>> {
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
     const apiURL = `${GRAPHQL_URI}${nameMatch ? '?' + nameMatch[1] : ''}`
-    return fromFetch(baseUrl ? new URL(apiURL, baseUrl).href : apiURL, {
+
+    return fromFetch<GraphQLResult<T>>(baseUrl ? new URL(apiURL, baseUrl).href : apiURL, {
         ...options,
         method: 'POST',
         body: JSON.stringify({ query: request, variables }),
@@ -95,16 +96,18 @@ export function requestGraphQLCommon<T, V = object>({
 
 interface GetGraphqlClientOptions {
     headers: RequestInit['headers']
+    baseUrl?: string
 }
 
 export type GraphQLClient = ApolloClient<NormalizedCacheObject>
 
 export const getGraphQLClient = once(
     async (options: GetGraphqlClientOptions): Promise<GraphQLClient> => {
-        const { headers } = options
+        const { headers, baseUrl } = options
+        const uri = baseUrl ? new URL(GRAPHQL_URI, baseUrl).href : GRAPHQL_URI
 
         const apolloClient = new ApolloClient({
-            uri: GRAPHQL_URI,
+            uri,
             cache,
             defaultOptions: {
                 /**
@@ -129,7 +132,7 @@ export const getGraphQLClient = once(
                 },
             },
             link: createHttpLink({
-                uri: ({ operationName }) => `${GRAPHQL_URI}?${operationName}`,
+                uri: ({ operationName }) => `${uri}?${operationName}`,
                 headers,
             }),
         })

--- a/client/shared/src/platform/context.ts
+++ b/client/shared/src/platform/context.ts
@@ -94,8 +94,9 @@ export interface PlatformContext {
 
     /**
      * Returns promise that resolves into Apollo Client instance after cache restoration.
+     * Only `watchQuery` is available till https://github.com/sourcegraph/sourcegraph/issues/24953 is implemented.
      */
-    getGraphQLClient: () => Promise<GraphQLClient>
+    getGraphQLClient: () => Promise<Pick<GraphQLClient, 'watchQuery'>>
 
     /**
      * Sends a request to the Sourcegraph GraphQL API and returns the response.

--- a/client/shared/src/testing/apollo/createGraphQLClientGetter.ts
+++ b/client/shared/src/testing/apollo/createGraphQLClientGetter.ts
@@ -11,6 +11,12 @@ interface CreateGraphQLClientGetterOptions {
     watchQueryMocks: object[]
 }
 
+/**
+ * Helper to mock Apollo-Client with subsequent `watchQuery` calls.
+ * It would be possible to use `import { createMockClient } from '@apollo/client/testing'`
+ * but it requires a lot of monkey patching because there's no straightforward way to mock
+ * `watchQuery` results for the returned client mock.
+ */
 export function createGraphQLClientGetter({
     watchQueryMocks,
 }: CreateGraphQLClientGetterOptions): PlatformContext['getGraphQLClient'] {

--- a/client/shared/src/testing/apollo/createGraphQLClientGetter.ts
+++ b/client/shared/src/testing/apollo/createGraphQLClientGetter.ts
@@ -1,0 +1,29 @@
+/* eslint-disable unicorn/filename-case */
+import { ObservableQuery } from '@apollo/client'
+import { mock } from 'jest-mock-extended'
+import { of, Subscriber } from 'rxjs'
+
+import { GraphQLClient } from '../../graphql/graphql'
+import { PlatformContext } from '../../platform/context'
+
+interface CreateGraphQLClientGetterOptions {
+    /** Responses emitted by watch query sequentially for each call. */
+    watchQueryMocks: object[]
+}
+
+export function createGraphQLClientGetter({
+    watchQueryMocks,
+}: CreateGraphQLClientGetterOptions): PlatformContext['getGraphQLClient'] {
+    const observableQuery = mock<ObservableQuery<unknown, unknown>>()
+    const graphQlClient = mock<GraphQLClient>()
+
+    graphQlClient.watchQuery.mockReturnValue(observableQuery)
+
+    for (const mockResponse of watchQueryMocks) {
+        observableQuery.subscribe.mockImplementationOnce((subscriber: unknown) =>
+            of(mockResponse).subscribe(subscriber as Subscriber<unknown>)
+        )
+    }
+
+    return () => Promise.resolve(graphQlClient)
+}

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^25.5.4",
     "jest-canvas-mock": "^2.3.0",
+    "jest-mock-extended": "^2.0.2-beta2",
     "jsdom": "^15.2.1",
     "json-schema-ref-parser": "^9.0.6",
     "json-schema-to-typescript": "^10.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14906,6 +14906,13 @@ jest-message-util@^26.5.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-mock-extended@^2.0.2-beta2:
+  version "2.0.2-beta2"
+  resolved "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-2.0.2-beta2.tgz#36a7e43c27df93aa30d1424f5360c4ae301d69b8"
+  integrity sha512-56zcpgRPs3YxQP0ejcaaNFxUinPyRxQCbuk7GGORZqEbAFuQVXWAAtru2tI1N4qcLBoDWEJ/hwUxwbEGY5hdyw==
+  dependencies:
+    ts-essentials "^7.0.3"
+
 jest-mock@^25.5.0:
   version "25.5.0"
   resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"
@@ -22550,6 +22557,11 @@ ts-essentials@^2.0.3:
   version "2.0.12"
   resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
+
+ts-essentials@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
 ts-invariant@^0.7.0:
   version "0.7.5"


### PR DESCRIPTION
## Context

Preparation to land https://github.com/sourcegraph/sourcegraph/pull/23351, where Apollo Client persistent cache will be enabled. 

## Changes

- Updated `browser` platform context GraphQL methods to be more explicit [about sending GraphQL requests to the background script](https://github.com/sourcegraph/sourcegraph/pull/24868/files#diff-4f989e3c3ce2c475598cbab25f6c1d0fca5d84ffab8a12193704e1350ceabf09R80-R84).
  - Added a fallback for Apollo Client `watchQuery`: GraphQL requests initiated via the `watchQuery` method in the main thread of the browser extensions will be sent to the background script to be handled by our `requestGraphQL` function.
  - Support for Apollo Client in the background script of the browser extensions can be implemented in a separate PR. Here's [an issue](https://github.com/sourcegraph/sourcegraph/issues/24953) about that I plan to discuss with @tjkandala.
- Used Apollo Client to fetch `ExtensionsRegistry`.
- Updated `queryConfiguredRegistryExtensions` to use modern generated GraphQL types.
- Added general test utility for Apollo Client instance `createGraphQLClientGetter`.

## Notes

[jest-mock-extended](https://github.com/marchaos/jest-mock-extended) library was added to create `createGraphQLClientGetter` helper. It's useful to avoid adding mocks for fields you don't actually need in tests, but Typescript requires them. We get type-safety benefits without a need to add redundant mocks. This library can be useful in a lot of our tests. If there're no concerns about it, I will add a note about it to our testing guidelines in a separate PR.
