### PR TITLE
gitserver: Reduce error writing security event logs

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	codeinteldbstore "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
@@ -119,7 +120,10 @@ func main() {
 			return "", errors.Errorf("no sources for %q", repo)
 		},
 		GetVCSSyncer: func(ctx context.Context, repo api.RepoName) (server.VCSSyncer, error) {
-			r, err := repoStore.GetByName(ctx, repo)
+			// We need an internal actor in case we are trying to access a private repo. We
+			// only need access in order to find out the type of code host we're using, so
+			// it's safe.
+			r, err := repoStore.GetByName(actor.WithInternalActor(ctx), repo)
 			if err != nil {
 				return nil, errors.Wrap(err, "get repository")
 			}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -589,7 +589,11 @@ func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var syncer VCSSyncer
-	remoteURL, err := s.getRemoteURL(r.Context(), req.Repo)
+	// We use an internal actor here as the repo may be private. It is safe since all
+	// we return is a bool indicating whether the repo us cloneable or not. Perhaps
+	// the only things that could leak here is whether a private repo exists although
+	// the endpoint is only available internally so it's low risk.
+	remoteURL, err := s.getRemoteURL(actor.WithInternalActor(r.Context()), req.Repo)
 	if err != nil {
 		// We use this endpoint to verify if a repo exists without consuming
 		// API rate limit, since many users visit private or bogus repos,

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -590,7 +590,7 @@ func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {
 
 	var syncer VCSSyncer
 	// We use an internal actor here as the repo may be private. It is safe since all
-	// we return is a bool indicating whether the repo us cloneable or not. Perhaps
+	// we return is a bool indicating whether the repo is cloneable or not. Perhaps
 	// the only things that could leak here is whether a private repo exists although
 	// the endpoint is only available internally so it's low risk.
 	remoteURL, err := s.getRemoteURL(actor.WithInternalActor(r.Context()), req.Repo)


### PR DESCRIPTION
We need to use an internal actor in a couple more places so that we don't trigger the
`security_event_logs_check_has_user` constraint.