### PR TITLE
Add CreateTestRepo helper to simplify code a bit

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
@@ -36,8 +36,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 
 	cstore := store.New(db, &observation.TestContext, nil)
 
-	ghRepos, _ := ct.CreateTestRepos(t, ctx, db, 1)
-	ghRepo := ghRepos[0]
+	ghRepo, _ := ct.CreateTestRepo(t, ctx, db)
 	glRepos, _ := ct.CreateGitlabTestRepos(t, ctx, db, 1)
 	glRepo := glRepos[0]
 	bbsRepos, _ := ct.CreateBbsTestRepos(t, ctx, db, 1)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -1288,8 +1288,7 @@ func TestCreateChangesetComments(t *testing.T) {
 	otherBatchSpec := ct.CreateBatchSpec(t, ctx, cstore, "test-comments-other", userID)
 	batchChange := ct.CreateBatchChange(t, ctx, cstore, "test-comments", userID, batchSpec.ID)
 	otherBatchChange := ct.CreateBatchChange(t, ctx, cstore, "test-comments-other", userID, otherBatchSpec.ID)
-	repos, _ := ct.CreateTestRepos(t, context.Background(), db, 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	changeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
 		Repo:             repo.ID,
 		BatchChange:      batchChange.ID,
@@ -1389,8 +1388,7 @@ func TestReenqueueChangesets(t *testing.T) {
 	otherBatchSpec := ct.CreateBatchSpec(t, ctx, cstore, "test-reenqueue-other", userID)
 	batchChange := ct.CreateBatchChange(t, ctx, cstore, "test-reenqueue", userID, batchSpec.ID)
 	otherBatchChange := ct.CreateBatchChange(t, ctx, cstore, "test-reenqueue-other", userID, otherBatchSpec.ID)
-	repos, _ := ct.CreateTestRepos(t, context.Background(), db, 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	changeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
 		Repo:             repo.ID,
 		BatchChange:      batchChange.ID,
@@ -1497,8 +1495,7 @@ func TestMergeChangesets(t *testing.T) {
 	otherBatchSpec := ct.CreateBatchSpec(t, ctx, cstore, "test-merge-other", userID)
 	batchChange := ct.CreateBatchChange(t, ctx, cstore, "test-merge", userID, batchSpec.ID)
 	otherBatchChange := ct.CreateBatchChange(t, ctx, cstore, "test-merge-other", userID, otherBatchSpec.ID)
-	repos, _ := ct.CreateTestRepos(t, context.Background(), db, 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	changeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
 		Repo:             repo.ID,
 		BatchChange:      batchChange.ID,
@@ -1682,8 +1679,7 @@ func TestCloseChangesets(t *testing.T) {
 	otherBatchSpec := ct.CreateBatchSpec(t, ctx, cstore, "test-close-other", userID)
 	batchChange := ct.CreateBatchChange(t, ctx, cstore, "test-close", userID, batchSpec.ID)
 	otherBatchChange := ct.CreateBatchChange(t, ctx, cstore, "test-close-other", userID, otherBatchSpec.ID)
-	repos, _ := ct.CreateTestRepos(t, context.Background(), db, 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	changeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
 		Repo:             repo.ID,
 		BatchChange:      batchChange.ID,
@@ -1793,8 +1789,7 @@ func TestPublishChangesets(t *testing.T) {
 	otherBatchSpec := ct.CreateBatchSpec(t, ctx, cstore, "test-close-other", userID)
 	batchChange := ct.CreateBatchChange(t, ctx, cstore, "test-close", userID, batchSpec.ID)
 	otherBatchChange := ct.CreateBatchChange(t, ctx, cstore, "test-close-other", userID, otherBatchSpec.ID)
-	repos, _ := ct.CreateTestRepos(t, context.Background(), db, 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	publishableChangesetSpec := ct.CreateChangesetSpec(t, ctx, cstore, ct.TestSpecOpts{
 		User:      userID,
 		Repo:      repo.ID,

--- a/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
@@ -23,8 +23,7 @@ func TestLoadAndExtractChangesetSpecIDs(t *testing.T) {
 	db := dbtest.NewDB(t, "")
 	user := ct.CreateTestUser(t, db, true)
 
-	repos, _ := ct.CreateTestRepos(t, context.Background(), db, 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, context.Background(), db)
 
 	s := store.New(db, &observation.TestContext, nil)
 	workStore := dbworkerstore.NewWithMetrics(s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions, &observation.TestContext)

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -25,8 +25,7 @@ func TestBulkProcessor(t *testing.T) {
 	tx := dbtest.NewTx(t, db)
 	bstore := store.New(tx, &observation.TestContext, nil)
 	user := ct.CreateTestUser(t, db, true)
-	repos, _ := ct.CreateTestRepos(t, ctx, db, 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	ct.CreateTestSiteCredential(t, bstore, repo)
 	batchSpec := ct.CreateBatchSpec(t, ctx, bstore, "test-bulk", user.ID)
 	batchChange := ct.CreateBatchChange(t, ctx, bstore, "test-bulk", user.ID, batchSpec.ID)

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -44,8 +44,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 
 	admin := ct.CreateTestUser(t, db, true)
 
-	rs, extSvc := ct.CreateTestRepos(t, ctx, db, 1)
-	repo := rs[0]
+	repo, extSvc := ct.CreateTestRepo(t, ctx, db)
 	ct.CreateTestSiteCredential(t, cstore, repo)
 
 	state := ct.MockChangesetSyncState(&protocol.RepoInfo{
@@ -599,8 +598,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 
 	cstore := store.New(db, &observation.TestContext, et.TestKey{})
 
-	rs, _ := ct.CreateTestRepos(t, ctx, db, 1)
-	repo := rs[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 
 	commonHeadRef := "refs/heads/collision"
 
@@ -645,8 +643,7 @@ func TestLoadChangesetSource(t *testing.T) {
 	admin := ct.CreateTestUser(t, db, true)
 	user := ct.CreateTestUser(t, db, false)
 
-	rs, _ := ct.CreateTestRepos(t, ctx, db, 1)
-	repo := rs[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 
 	batchSpec := ct.CreateBatchSpec(t, ctx, cstore, "reconciler-test-batch-change", admin.ID)
 	adminBatchChange := ct.CreateBatchChange(t, ctx, cstore, "reconciler-test-batch-change", admin.ID, batchSpec.ID)
@@ -805,8 +802,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 	admin := ct.CreateTestUser(t, db, true)
 	user := ct.CreateTestUser(t, db, false)
 
-	rs, gitHubExtSvc := ct.CreateTestRepos(t, ctx, db, 1)
-	gitHubRepo := rs[0]
+	gitHubRepo, gitHubExtSvc := ct.CreateTestRepo(t, ctx, db)
 
 	gitLabRepos, gitLabExtSvc := ct.CreateGitlabTestRepos(t, ctx, db, 1)
 	gitLabRepo := gitLabRepos[0]

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -29,12 +29,12 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 
 	admin := ct.CreateTestUser(t, db, true)
 
-	rs, extSvc := ct.CreateTestRepos(t, ctx, db, 1)
-	ct.CreateTestSiteCredential(t, store, rs[0])
+	repo, extSvc := ct.CreateTestRepo(t, ctx, db)
+	ct.CreateTestSiteCredential(t, store, repo)
 
 	state := ct.MockChangesetSyncState(&protocol.RepoInfo{
-		Name: rs[0].Name,
-		VCS:  protocol.VCSInfo{URL: rs[0].URI},
+		Name: repo.Name,
+		VCS:  protocol.VCSInfo{URL: repo.URI},
 	})
 	defer state.Unmock()
 
@@ -98,19 +98,19 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 			// Create the specs.
 			specOpts := *tc.currentSpec
 			specOpts.User = admin.ID
-			specOpts.Repo = rs[0].ID
+			specOpts.Repo = repo.ID
 			specOpts.BatchSpec = batchSpec.ID
 			changesetSpec := ct.CreateChangesetSpec(t, ctx, store, specOpts)
 
 			previousSpecOpts := *tc.previousSpec
 			previousSpecOpts.User = admin.ID
-			previousSpecOpts.Repo = rs[0].ID
+			previousSpecOpts.Repo = repo.ID
 			previousSpecOpts.BatchSpec = previousBatchSpec.ID
 			previousSpec := ct.CreateChangesetSpec(t, ctx, store, previousSpecOpts)
 
 			// Create the changeset with correct associations.
 			changesetOpts := tc.changeset
-			changesetOpts.Repo = rs[0].ID
+			changesetOpts.Repo = repo.ID
 			changesetOpts.BatchChanges = []btypes.BatchChangeAssoc{{BatchChangeID: batchChange.ID}}
 			changesetOpts.OwnedByBatchChange = batchChange.ID
 			if changesetSpec != nil {
@@ -151,7 +151,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 
 			// Assert that the changeset in the database looks like we want
 			assertions := tc.wantChangeset
-			assertions.Repo = rs[0].ID
+			assertions.Repo = repo.ID
 			assertions.OwnedByBatchChange = changesetOpts.OwnedByBatchChange
 			assertions.AttachedTo = []int64{batchChange.ID}
 			assertions.CurrentSpec = changesetSpec.ID

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -45,7 +45,7 @@ func TestServicePermissionLevels(t *testing.T) {
 	user := ct.CreateTestUser(t, db, false)
 	otherUser := ct.CreateTestUser(t, db, false)
 
-	rs, _ := ct.CreateTestRepos(t, ctx, db, 1)
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 
 	createTestData := func(t *testing.T, s *store.Store, svc *Service, author int32) (*btypes.BatchChange, *btypes.Changeset, *btypes.BatchSpec) {
 		spec := testBatchSpec(author)
@@ -58,7 +58,7 @@ func TestServicePermissionLevels(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		changeset := testChangeset(rs[0].ID, batchChange.ID, btypes.ChangesetExternalStateOpen)
+		changeset := testChangeset(repo.ID, batchChange.ID, btypes.ChangesetExternalStateOpen)
 		if err := s.CreateChangeset(ctx, changeset); err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -2145,8 +2145,7 @@ func TestCancelQueuedBatchChangeChangesets(t *testing.T) {
 	user := ct.CreateTestUser(t, db, true)
 	spec := ct.CreateBatchSpec(t, ctx, s, "test-batch-change", user.ID)
 	batchChange := ct.CreateBatchChange(t, ctx, s, "test-batch-change", user.ID, spec.ID)
-	repos, _ := ct.CreateTestRepos(t, ctx, s.DB(), 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 
 	c1 := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
 		Repo:               repo.ID,
@@ -2280,8 +2279,7 @@ func TestEnqueueChangesetsToClose(t *testing.T) {
 	user := ct.CreateTestUser(t, db, true)
 	spec := ct.CreateBatchSpec(t, ctx, s, "test-batch-change", user.ID)
 	batchChange := ct.CreateBatchChange(t, ctx, s, "test-batch-change", user.ID, spec.ID)
-	repos, _ := ct.CreateTestRepos(t, ctx, s.DB(), 1)
-	repo := repos[0]
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 
 	wantEnqueued := ct.ChangesetAssertions{
 		Repo:               repo.ID,

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -66,6 +66,11 @@ func TestRepoWithService(t *testing.T, store *database.ExternalServiceStore, nam
 	}
 }
 
+func CreateTestRepo(t *testing.T, ctx context.Context, db dbutil.DB) (*types.Repo, *types.ExternalService) {
+	repos, extSvc := CreateTestRepos(t, ctx, db, 1)
+	return repos[0], extSvc
+}
+
 func CreateTestRepos(t *testing.T, ctx context.Context, db dbutil.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 


### PR DESCRIPTION
While we do love copy&pasting in Go land, I thought it would be neater
to have a short helper for these two repeated lines.
