### PR TITLE
fix docker command

### DIFF
--- a/doc/admin/install/docker-compose/operations.md
+++ b/doc/admin/install/docker-compose/operations.md
@@ -204,7 +204,7 @@ The following command allows a user to shell into a Sourcegraph database contain
 
 ```bash
 docker exec -it pgsql psql -U sg #access pgsql container and run psql
-docker exec -it codeintel-db -U sg #access codeintel-db container and run psql
+docker exec -it codeintel-db psql -U sg #access codeintel-db container and run psql
 ```
 
 ## Backup and restore


### PR DESCRIPTION
Adding `psql` to the following docker command to access the code intel db `docker exec -it codeintel-db -U sg`



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
