### PR TITLE
update upstream alpine

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,14 @@
     {
       "packageNames": ["react-grid-layout"],
       "reviewers": ["team:code-insights-frontend"]
+    },
+    {
+      "groupName": "Upstream Alpine 3.12 Docker image",
+      "matchDatasources": ["docker"],
+      "packagePatterns": ["^alpine:3.12"],
+      "fileMatch": ["^Dockerfile$"],
+      "paths": ["docker-images/**"],
+      "labels": ["automerge"]
     }
   ]
 }


### PR DESCRIPTION
often the upstream image is patched for CVEs that we currently don't catch, or have patched manually downstream. Those PR hopes to at least always build from the latest 3.12 sha so we benefit from any upstream fixes

