### PR TITLE
executors: Switch away from deprecated docker bridge CNI

### DIFF
--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -66,7 +66,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 		Command: flatten(
 			"ignite", "run",
 			"--runtime", "docker",
-			"--network-plugin", "docker-bridge",
+			"--network-plugin", "cni",
 			firecrackerResourceFlags(options.ResourceOptions),
 			firecrackerCopyfileFlags(repoDir, options.FirecrackerOptions.VMStartupScriptPath),
 			"--ssh",

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -130,7 +130,7 @@ func TestSetupFirecracker(t *testing.T) {
 	expected := []string{
 		strings.Join([]string{
 			"ignite run",
-			"--runtime docker --network-plugin docker-bridge",
+			"--runtime docker --network-plugin cni",
 			"--cpus 4 --memory 20G --size 1T",
 			"--copy-files /proj:/work",
 			"--copy-files /vm-startup.sh:/vm-startup.sh",


### PR DESCRIPTION
No idea if this works, no firecracker on mac :( Worth a try?