### PR TITLE
insights: configure worker to retry on network timeout

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -128,6 +128,7 @@ func CreateDBWorkerStore(s *basestore.Store, observationContext *observation.Con
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        30 * time.Minute,
 		MaxNumRetries:     100,
+		MaxNumResets:      10,
 		OrderByExpression: sqlf.Sprintf("priority, id"),
 	}, observationContext)
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/24825

Configuring the code insights worker to retry on network timeouts, which is a separate configuration from error-based retries.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
