### PR TITLE
added documentation button to site-admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The search sidebar shows a revisions section if all search results are from a single repository. This makes it easier to search in and switch between different revisions. [#23835](https://github.com/sourcegraph/sourcegraph/pull/23835)
+- Added a `Documentation` tab to the Site Admin Maintenance panel that links to the official Sourcegraph documentation. [#24917](https://github.com/sourcegraph/sourcegraph/pull/24917)
 
 ### Changed
 

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -96,7 +96,7 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
         },
         {
             label: 'Documentation',
-            to: '/help'
+            to: '/help',
         },
         {
             label: 'Pings',

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -95,6 +95,11 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/updates',
         },
         {
+            label: 'Documentation',
+            to: 'https://docs.sourcegraph.com/',
+            source: 'server'
+        },
+        {
             label: 'Pings',
             to: '/site-admin/pings',
         },

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -96,8 +96,7 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
         },
         {
             label: 'Documentation',
-            to: 'https://docs.sourcegraph.com/',
-            source: 'server'
+            to: '/help'
         },
         {
             label: 'Pings',


### PR DESCRIPTION
Based on some customer [feedback](https://sourcegraph.slack.com/archives/C0W2E592M/p1631545290120100) it seems like the official Sourcegraph docs aren't necessarily intuitive or obvious that they are hosted separately from the installation.

This just adds a button to the site-admin panel that directs them to `docs.sourcegraph.com`.

cc @rrhyne Any issues from design perspective?

![CleanShot 2021-09-13 at 11 38 13](https://user-images.githubusercontent.com/5090588/133138852-f196c696-6083-4aab-a755-2794ae7dd5eb.gif)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
