### PR TITLE
grafana: link to documentation on homepage

### DIFF
--- a/docker-images/grafana/home.json
+++ b/docker-images/grafana/home.json
@@ -19,10 +19,10 @@
   "links": [],
   "panels": [
     {
-      "content": "<div style=\"text-align: left;\">\n  <img src=\"https://sourcegraphstatic.com/sourcegraph-logo-light.png\" style=\"height:30px; margin:0.5rem\"></img>\n  <div style=\"margin-left: 1rem; margin-top: 0.5rem; font-size: 20px;\"><span style=\"color: #8e8e8e\">Overview:</span> High-level insight into the health of Sourcegraph.</span>\n</div>\n<div style=\"display: flex; padding-top: 1rem;\">\n  <div style=\"margin-left: 2rem; margin-right: 2rem;\">\n    <h4><span style=\"color: #8e8e8e\">Critical alerts</span> by service</h4>\n    <p>\n      The number of definitive issues each service has encountered. If this number is ever above 1.0, something is definitively wrong with Sourcegraph and a site admin should investigate.\n      <span style=\"color: #8e8e8e\">Configure paging for this metric.</span>\n      <div style=\"color: #8e8e8e\"><strong>Examples:</strong> Database inaccessible, out of disk space, out of memory.</div>\n    </p>\n  </div>\n  <div style=\"margin-left: 2rem; margin-right: 2rem;\">\n    <h4><span style=\"color: #8e8e8e\">Warning alerts</span> by service</h4>\n    <p>\n      The number of warnings each service has fired. If this number is ever above 1.0, something <em>may be</em> wrong with Sourcegraph and a site admin should take a closer look when convenient.\n      <span style=\"color: #8e8e8e\">Configure email alerting for this metric.</span>\n      <div style=\"color: #8e8e8e\"><strong>Examples:</strong> High latency, high search timeouts.</div>\n    </p>\n  </div>\n</div>",
+      "content": "<div style=\"text-align: left;\">\n  <img src=\"https://sourcegraphstatic.com/sourcegraph-logo-light.png\" style=\"height:30px; margin:1rem\"></img>\n  <div style=\"margin-left: 1rem; margin-top: 0.5rem; font-size: 20px;\"><span style=\"color: #8e8e8e\">Overview:</span> High-level insight into the health of Sourcegraph.</span>\n</div>\n<div style=\"margin-left: 1rem; margin-top: 0.5rem;\">To learn more, refer to the Sourcegraph <a href=\"/help/admin/observability/metrics\" />metrics and dashboards documentation</a> and <a href=\"/help/admin/observability/alerting\" />alerting documentation</a>.\n</div>\n",
       "datasource": null,
       "gridPos": {
-        "h": 6,
+        "h": 4,
         "w": 24,
         "x": 0,
         "y": 0


### PR DESCRIPTION
Link to relevant docs instead of having incomplete info here. Related to [feedback](https://sourcegraph.slack.com/archives/C0W2E592M/p1631557070127300?thread_ts=1631545290.120100&cid=C0W2E592M)

![image](https://user-images.githubusercontent.com/23356519/133140951-19413005-0cfb-44c9-8e5f-505dc5f6f903.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
