### PR TITLE
codeintel: Add additional config values to upload expirer

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
@@ -49,6 +49,8 @@ func NewUploadExpirer(
 		repositoryBatchSize:    repositoryBatchSize,
 		uploadProcessDelay:     uploadProcessDelay,
 		uploadBatchSize:        uploadBatchSize,
+		commitBatchSize:        commitBatchSize,
+		branchesCacheMaxKeys:   branchesCacheMaxKeys,
 	})
 }
 

--- a/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
@@ -17,16 +17,18 @@ type uploadExpirer struct {
 	repositoryBatchSize    int
 	uploadProcessDelay     time.Duration
 	uploadBatchSize        int
+	commitBatchSize        int
+	branchesCacheMaxKeys   int
 }
 
 var _ goroutine.Handler = &uploadExpirer{}
 var _ goroutine.ErrorHandler = &uploadExpirer{}
 
-// NewUploadExpirer returns a background routine that periodically compares the age of upload records against
-// the age of uploads protected by global and repository specific data retention policies.
+// NewUploadExpirer returns a background routine that periodically compares the age of upload records
+// against the age of uploads protected by global and repository specific data retention policies.
 //
-// Uploads that are older than the protected retention age are marked as expired. Expired records with no
-// dependents will be removed by the expiredUploadDeleter.
+// Uploads that are older than the protected retention age are marked as expired. Expired records with
+// no dependents will be removed by the expiredUploadDeleter.
 func NewUploadExpirer(
 	dbStore DBStore,
 	gitserverClient GitserverClient,
@@ -34,6 +36,8 @@ func NewUploadExpirer(
 	repositoryBatchSize int,
 	uploadProcessDelay time.Duration,
 	uploadBatchSize int,
+	commitBatchSize int,
+	branchesCacheMaxKeys int,
 	interval time.Duration,
 	metrics *metrics,
 ) goroutine.BackgroundRoutine {

--- a/enterprise/cmd/worker/internal/codeintel/janitor_config.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_config.go
@@ -19,6 +19,8 @@ type janitorConfig struct {
 	RepositoryBatchSize                     int
 	UploadProcessDelay                      time.Duration
 	UploadBatchSize                         int
+	CommitBatchSize                         int
+	BranchesCacheMaxKeys                    int
 }
 
 var janitorConfigInst = &janitorConfig{}
@@ -34,4 +36,6 @@ func (c *janitorConfig) Load() {
 	c.RepositoryBatchSize = c.GetInt("PRECISE_CODE_INTEL_RETENTION_REPOSITORY_BATCH_SIZE", "100", "The number of repositories to consider for expiration at a time.")
 	c.UploadProcessDelay = c.GetInterval("PRECISE_CODE_INTEL_RETENTION_UPLOAD_PROCESS_DELAY", "24h", "The minimum frequency that the same upload record can be considered for expiration.")
 	c.UploadBatchSize = c.GetInt("PRECISE_CODE_INTEL_RETENTION_UPLOAD_BATCH_SIZE", "100", "The number of uploads to consider for expiration at a time.")
+	c.CommitBatchSize = c.GetInt("PRECISE_CODE_INTEL_RETENTION_COMMIT_BATCH_SIZE", "100", "The number of commits to process per upload at a time.")
+	c.BranchesCacheMaxKeys = c.GetInt("PRECISE_CODE_INTEL_RETENTION_BRANCHES_CACHE_MAX_KEYS", "10000", "The number of maximum keys used to cache the set of branches visible from a commit.")
 }

--- a/enterprise/cmd/worker/internal/codeintel/janitor_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_job.go
@@ -67,7 +67,7 @@ func (j *janitorJob) Routines(ctx context.Context) ([]goroutine.BackgroundRoutin
 		janitor.NewIndexResetter(indexWorkerStore, janitorConfigInst.CleanupTaskInterval, metrics, observationContext),
 		janitor.NewDependencyIndexResetter(dependencyIndexStore, janitorConfigInst.CleanupTaskInterval, metrics, observationContext),
 		janitor.NewUnknownCommitJanitor(dbStoreShim, janitorConfigInst.CommitResolverMinimumTimeSinceLastCheck, janitorConfigInst.CommitResolverBatchSize, janitorConfigInst.CommitResolverTaskInterval, metrics),
-		janitor.NewUploadExpirer(dbStoreShim, gitserverClient, janitorConfigInst.RepositoryProcessDelay, janitorConfigInst.RepositoryBatchSize, janitorConfigInst.UploadProcessDelay, janitorConfigInst.UploadBatchSize, janitorConfigInst.CleanupTaskInterval, metrics),
+		janitor.NewUploadExpirer(dbStoreShim, gitserverClient, janitorConfigInst.RepositoryProcessDelay, janitorConfigInst.RepositoryBatchSize, janitorConfigInst.UploadProcessDelay, janitorConfigInst.UploadBatchSize, janitorConfigInst.CommitBatchSize, janitorConfigInst.BranchesCacheMaxKeys, janitorConfigInst.CleanupTaskInterval, metrics),
 	}
 
 	if !envvar.SourcegraphDotComMode() {


### PR DESCRIPTION
This PR adds `PRECISE_CODE_INTEL_RETENTION_COMMIT_BATCH_SIZE` and `PRECISE_CODE_INTEL_RETENTION_BRANCHES_CACHE_MAX_KEYS` to the worker server that will be used by the upload expirer background process.