### PR TITLE
codeintel: Update return of {RepositoryIDs,SelectRepositories}ForRetentionScan

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -61,9 +61,9 @@ type operations struct {
 	referencesForUpload                    *observation.Operation
 	refreshCommitResolvability             *observation.Operation
 	repoName                               *observation.Operation
-	repositoryIDsForRetentionScan          *observation.Operation
 	requeue                                *observation.Operation
 	requeueIndex                           *observation.Operation
+	selectRepositoriesForRetentionScan     *observation.Operation
 	softDeleteExpiredUploads               *observation.Operation
 	softDeleteOldUploads                   *observation.Operation
 	staleSourcedCommits                    *observation.Operation
@@ -154,9 +154,9 @@ func newOperations(observationContext *observation.Context, metrics *metrics.Ope
 		referencesForUpload:                    op("ReferencesForUpload"),
 		refreshCommitResolvability:             op("RefreshCommitResolvability"),
 		repoName:                               op("RepoName"),
-		repositoryIDsForRetentionScan:          op("RepositoryIDsForRetentionScan"),
 		requeue:                                op("Requeue"),
 		requeueIndex:                           op("RequeueIndex"),
+		selectRepositoriesForRetentionScan:     op("SelectRepositoriesForRetentionScan"),
 		softDeleteExpiredUploads:               op("SoftDeleteExpiredUploads"),
 		softDeleteOldUploads:                   op("SoftDeleteOldUploads"),
 		staleSourcedCommits:                    op("StaleSourcedCommits"),

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -715,18 +715,40 @@ const hardDeleteUploadByIDQuery = `
 DELETE FROM lsif_uploads WHERE id IN (%s)
 `
 
-// RepositoryIDsForRetentionScan returns a set of identifiers of repositories that are
-// due to be scanned for removable code intelligence data. Repositories that were returned
-// previously from this call within the given process delay are not returned.
-func (s *Store) RepositoryIDsForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) (_ []int, err error) {
-	return s.repositoryIDsForRetentionScan(ctx, processDelay, limit, time.Now())
+// scanIntTimePairs returns a map from ints to nullable times from the return value of `*Store.query`.
+func scanIntTimePairs(rows *sql.Rows, queryErr error) (_ map[int]*time.Time, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	m := map[int]*time.Time{}
+	for rows.Next() {
+		var repositoryID int
+		var updatedAt *time.Time
+		if err := rows.Scan(&repositoryID, &updatedAt); err != nil {
+			return nil, err
+		}
+
+		m[repositoryID] = updatedAt
+	}
+
+	return m, nil
 }
 
-func (s *Store) repositoryIDsForRetentionScan(ctx context.Context, processDelay time.Duration, limit int, now time.Time) (_ []int, err error) {
-	ctx, endObservation := s.operations.repositoryIDsForRetentionScan.With(ctx, &err, observation.Args{})
+// SelectRepositoriesForRetentionScan returns a map from repository identifiers to the last
+// time the repository's commit graph was refreshed (or null). This method returns repository
+// identifiers with live code intelligence data. Repositories that were returned previously
+// from this call within the given process delay are not returned.
+func (s *Store) SelectRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) (_ map[int]*time.Time, err error) {
+	return s.selectRepositoriesForRetentionScan(ctx, processDelay, limit, time.Now())
+}
+
+func (s *Store) selectRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int, now time.Time) (_ map[int]*time.Time, err error) {
+	ctx, endObservation := s.operations.selectRepositoriesForRetentionScan.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	return basestore.ScanInts(s.Query(ctx, sqlf.Sprintf(
+	return scanIntTimePairs(s.Query(ctx, sqlf.Sprintf(
 		repositoryIDsForRetentionScanQuery,
 		now,
 		int(processDelay/time.Second),
@@ -744,9 +766,11 @@ WITH candidate_repositories AS (
 	WHERE u.state = 'completed'
 ),
 repositories AS (
-	SELECT cr.id FROM candidate_repositories cr
-	LEFT JOIN lsif_last_retention_scan lrs
-	ON lrs.repository_id = cr.id
+	SELECT cr.id, dr.updated_at
+	FROM candidate_repositories cr
+	LEFT JOIN lsif_last_retention_scan lrs ON lrs.repository_id = cr.id
+	LEFT JOIN lsif_dirty_repositories dr ON dr.repository_id = cr.id
+
 	-- Ignore records that have been checked recently. Note this condition is
 	-- true for a null last_retention_scan_at (which has never been checked).
 	WHERE (%s - lrs.last_retention_scan_at > (%s * '1 second'::interval)) IS DISTINCT FROM FALSE
@@ -754,12 +778,14 @@ repositories AS (
 		lrs.last_retention_scan_at NULLS FIRST,
 		cr.id -- tie breaker
 	LIMIT %s
+),
+inserted AS (
+	INSERT INTO lsif_last_retention_scan (repository_id, last_retention_scan_at)
+	SELECT r.id, %s::timestamp FROM repositories r
+	ON CONFLICT (repository_id) DO UPDATE
+	SET last_retention_scan_at = %s
 )
-INSERT INTO lsif_last_retention_scan (repository_id, last_retention_scan_at)
-SELECT id, %s::timestamp FROM repositories
-ON CONFLICT (repository_id) DO UPDATE
-SET last_retention_scan_at = %s
-RETURNING repository_id
+SELECT r.id, r.updated_at FROM repositories r
 `
 
 // UpdateUploadRetention updates the last data retention scan timestamp on the upload

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -741,7 +741,7 @@ func scanIntTimePairs(rows *sql.Rows, queryErr error) (_ map[int]*time.Time, err
 // identifiers with live code intelligence data. Repositories that were returned previously
 // from this call within the given process delay are not returned.
 func (s *Store) SelectRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) (_ map[int]*time.Time, err error) {
-	return s.selectRepositoriesForRetentionScan(ctx, processDelay, limit, time.Now())
+	return s.selectRepositoriesForRetentionScan(ctx, processDelay, limit, timeutil.Now())
 }
 
 func (s *Store) selectRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int, now time.Time) (_ map[int]*time.Time, err error) {


### PR DESCRIPTION
This PR updates (and renames) the `RepositoryIDsForRetentionScan` dbstore method. Previously, this method returned only a flat list of repository ids. Now, this method returns a map from the previous repository ids to the last time that repository's commit graph was updated.

This is necessary as we don't want to evict _detached_ upload before they have been inserted into the repository's commit graph (an async process). If we ignore all uploads that are newer than the last refresh time, we shouldn't consider these new uploads as eviction candidates.