### PR TITLE
codeintel: move lsifstore.Package[Reference] -> shared package

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/bloomfilter"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -96,12 +97,12 @@ func TestReferencesRemote(t *testing.T) {
 		t.Fatalf("unexpected error encoding bloom filter: %s", err)
 	}
 	scanner1 := dbstore.PackageReferenceScannerFromSlice(
-		lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 250}, Filter: filter},
-		lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 251}, Filter: filter},
+		shared.PackageReference{Package: shared.Package{DumpID: 250}, Filter: filter},
+		shared.PackageReference{Package: shared.Package{DumpID: 251}, Filter: filter},
 	)
 	scanner2 := dbstore.PackageReferenceScannerFromSlice(
-		lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 252}, Filter: filter},
-		lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 253}, Filter: filter},
+		shared.PackageReference{Package: shared.Package{DumpID: 252}, Filter: filter},
+		shared.PackageReference{Package: shared.Package{DumpID: 253}, Filter: filter},
 	)
 	mockDBStore.ReferenceIDsAndFiltersFunc.PushReturn(scanner1, 4, nil)
 	mockDBStore.ReferenceIDsAndFiltersFunc.PushReturn(scanner2, 2, nil)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/bloomfilter"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
@@ -20,13 +20,13 @@ func TestDependencyIndexingSchedulerHandler(t *testing.T) {
 	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(dbstore.Upload{ID: 42, RepositoryID: 50, Indexer: "lsif-go"}, true, nil)
 	mockDBStore.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 
-	mockScanner.NextFunc.PushReturn(lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 42, Scheme: "test", Name: "name1", Version: "v2.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 42, Scheme: "test", Name: "name1", Version: "v3.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 42, Scheme: "test", Name: "name2", Version: "v3.2.2"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 42, Scheme: "test", Name: "name2", Version: "v2.2.1"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 42, Scheme: "test", Name: "name2", Version: "v4.2.3"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(lsifstore.PackageReference{Package: lsifstore.Package{DumpID: 42, Scheme: "test", Name: "name1", Version: "v1.2.0"}}, true, nil)
-	mockScanner.NextFunc.SetDefaultReturn(lsifstore.PackageReference{}, false, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "test", Name: "name1", Version: "v2.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "test", Name: "name1", Version: "v3.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "test", Name: "name2", Version: "v3.2.2"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "test", Name: "name2", Version: "v2.2.1"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "test", Name: "name2", Version: "v4.2.3"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "test", Name: "name1", Version: "v1.2.0"}}, true, nil)
+	mockScanner.NextFunc.SetDefaultReturn(shared.PackageReference{}, false, nil)
 
 	indexEnqueuer := NewMockIndexEnqueuer()
 

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mock_scanner_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mock_scanner_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	shared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 )
 
 // MockPackageReferenceScanner is a mock implementation of the
@@ -33,8 +33,8 @@ func NewMockPackageReferenceScanner() *MockPackageReferenceScanner {
 			},
 		},
 		NextFunc: &PackageReferenceScannerNextFunc{
-			defaultHook: func() (lsifstore.PackageReference, bool, error) {
-				return lsifstore.PackageReference{}, false, nil
+			defaultHook: func() (shared.PackageReference, bool, error) {
+				return shared.PackageReference{}, false, nil
 			},
 		},
 	}
@@ -157,15 +157,15 @@ func (c PackageReferenceScannerCloseFuncCall) Results() []interface{} {
 // PackageReferenceScannerNextFunc describes the behavior when the Next
 // method of the parent MockPackageReferenceScanner instance is invoked.
 type PackageReferenceScannerNextFunc struct {
-	defaultHook func() (lsifstore.PackageReference, bool, error)
-	hooks       []func() (lsifstore.PackageReference, bool, error)
+	defaultHook func() (shared.PackageReference, bool, error)
+	hooks       []func() (shared.PackageReference, bool, error)
 	history     []PackageReferenceScannerNextFuncCall
 	mutex       sync.Mutex
 }
 
 // Next delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockPackageReferenceScanner) Next() (lsifstore.PackageReference, bool, error) {
+func (m *MockPackageReferenceScanner) Next() (shared.PackageReference, bool, error) {
 	r0, r1, r2 := m.NextFunc.nextHook()()
 	m.NextFunc.appendCall(PackageReferenceScannerNextFuncCall{r0, r1, r2})
 	return r0, r1, r2
@@ -174,7 +174,7 @@ func (m *MockPackageReferenceScanner) Next() (lsifstore.PackageReference, bool, 
 // SetDefaultHook sets function that is called when the Next method of the
 // parent MockPackageReferenceScanner instance is invoked and the hook queue
 // is empty.
-func (f *PackageReferenceScannerNextFunc) SetDefaultHook(hook func() (lsifstore.PackageReference, bool, error)) {
+func (f *PackageReferenceScannerNextFunc) SetDefaultHook(hook func() (shared.PackageReference, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -182,7 +182,7 @@ func (f *PackageReferenceScannerNextFunc) SetDefaultHook(hook func() (lsifstore.
 // Next method of the parent MockPackageReferenceScanner instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *PackageReferenceScannerNextFunc) PushHook(hook func() (lsifstore.PackageReference, bool, error)) {
+func (f *PackageReferenceScannerNextFunc) PushHook(hook func() (shared.PackageReference, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -190,21 +190,21 @@ func (f *PackageReferenceScannerNextFunc) PushHook(hook func() (lsifstore.Packag
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *PackageReferenceScannerNextFunc) SetDefaultReturn(r0 lsifstore.PackageReference, r1 bool, r2 error) {
-	f.SetDefaultHook(func() (lsifstore.PackageReference, bool, error) {
+func (f *PackageReferenceScannerNextFunc) SetDefaultReturn(r0 shared.PackageReference, r1 bool, r2 error) {
+	f.SetDefaultHook(func() (shared.PackageReference, bool, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *PackageReferenceScannerNextFunc) PushReturn(r0 lsifstore.PackageReference, r1 bool, r2 error) {
-	f.PushHook(func() (lsifstore.PackageReference, bool, error) {
+func (f *PackageReferenceScannerNextFunc) PushReturn(r0 shared.PackageReference, r1 bool, r2 error) {
+	f.PushHook(func() (shared.PackageReference, bool, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *PackageReferenceScannerNextFunc) nextHook() func() (lsifstore.PackageReference, bool, error) {
+func (f *PackageReferenceScannerNextFunc) nextHook() func() (shared.PackageReference, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -239,7 +239,7 @@ func (f *PackageReferenceScannerNextFunc) History() []PackageReferenceScannerNex
 type PackageReferenceScannerNextFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 lsifstore.PackageReference
+	Result0 shared.PackageReference
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 bool

--- a/enterprise/internal/codeintel/stores/dbstore/helpers_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/helpers_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/commitgraph"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
@@ -207,7 +207,7 @@ func deleteRepo(t testing.TB, db *sql.DB, id int, deleted_at time.Time) {
 }
 
 // insertPackages populates the lsif_packages table with the given packages.
-func insertPackages(t testing.TB, store *Store, packages []lsifstore.Package) {
+func insertPackages(t testing.TB, store *Store, packages []shared.Package) {
 	for _, pkg := range packages {
 		if err := store.UpdatePackages(context.Background(), pkg.DumpID, []precise.Package{
 			{
@@ -222,7 +222,7 @@ func insertPackages(t testing.TB, store *Store, packages []lsifstore.Package) {
 }
 
 // insertPackageReferences populates the lsif_references table with the given package references.
-func insertPackageReferences(t testing.TB, store *Store, packageReferences []lsifstore.PackageReference) {
+func insertPackageReferences(t testing.TB, store *Store, packageReferences []shared.PackageReference) {
 	for _, packageReference := range packageReferences {
 		if err := store.UpdatePackageReferences(context.Background(), packageReference.DumpID, []precise.PackageReference{
 			{

--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -326,13 +326,13 @@ func TestGetUploads(t *testing.T) {
 	insertVisibleAtTip(t, db, 50, 2, 5, 7, 8)
 
 	// upload 10 depends on uploads 7 and 8
-	insertPackages(t, store, []lsifstore.Package{
+	insertPackages(t, store, []shared.Package{
 		{DumpID: 7, Scheme: "npm", Name: "foo", Version: "0.1.0"},
 		{DumpID: 8, Scheme: "npm", Name: "bar", Version: "1.2.3"},
 	})
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 10, Scheme: "npm", Name: "foo", Version: "0.1.0"}},
-		{Package: lsifstore.Package{DumpID: 10, Scheme: "npm", Name: "bar", Version: "1.2.3"}},
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 10, Scheme: "npm", Name: "foo", Version: "0.1.0"}},
+		{Package: shared.Package{DumpID: 10, Scheme: "npm", Name: "bar", Version: "1.2.3"}},
 	})
 
 	testCases := []struct {
@@ -869,15 +869,15 @@ func TestHardDeleteUploadByID(t *testing.T) {
 		Upload{ID: 53, State: "completed"},
 		Upload{ID: 54, State: "completed"},
 	)
-	insertPackages(t, store, []lsifstore.Package{
+	insertPackages(t, store, []shared.Package{
 		{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"},
 		{DumpID: 53, Scheme: "test", Name: "p2", Version: "1.2.3"},
 	})
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 54, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 54, Scheme: "test", Name: "p2", Version: "1.2.3"}},
 	})
 
 	if err := store.UpdateNumReferences(context.Background(), []int{51, 52, 53, 54}); err != nil {
@@ -1029,23 +1029,23 @@ func TestUpdateNumReferences(t *testing.T) {
 		Upload{ID: 55, State: "completed"},
 		Upload{ID: 56, State: "completed"},
 	)
-	insertPackages(t, store, []lsifstore.Package{
+	insertPackages(t, store, []shared.Package{
 		{DumpID: 53, Scheme: "test", Name: "p1", Version: "1.2.3"},
 		{DumpID: 54, Scheme: "test", Name: "p2", Version: "1.2.3"},
 		{DumpID: 55, Scheme: "test", Name: "p3", Version: "1.2.3"},
 		{DumpID: 56, Scheme: "test", Name: "p4", Version: "1.2.3"},
 	})
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
 
-		{Package: lsifstore.Package{DumpID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
 	})
 
 	if err := store.UpdateNumReferences(context.Background(), []int{50, 51, 52, 53, 54, 55, 56}); err != nil {
@@ -1087,25 +1087,25 @@ func TestUpdateDependencyNumReferences(t *testing.T) {
 		Upload{ID: 55, State: "completed"},
 		Upload{ID: 56, State: "completed"},
 	)
-	insertPackages(t, store, []lsifstore.Package{
+	insertPackages(t, store, []shared.Package{
 		{DumpID: 53, Scheme: "test", Name: "p1", Version: "1.2.3"},
 		{DumpID: 54, Scheme: "test", Name: "p2", Version: "1.2.3"},
 		{DumpID: 55, Scheme: "test", Name: "p3", Version: "1.2.3"},
 		{DumpID: 56, Scheme: "test", Name: "p4", Version: "1.2.3"},
 	})
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
+	insertPackageReferences(t, store, []shared.PackageReference{
 		// References removed
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
 
 		// Remaining references
-		{Package: lsifstore.Package{DumpID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
 	})
 
 	// Set correct initial counts
@@ -1153,25 +1153,25 @@ func TestSoftDeleteExpiredUploads(t *testing.T) {
 		Upload{ID: 55, State: "completed"}, // referenced by 51
 		Upload{ID: 56, State: "completed"}, // referenced by 52, 53
 	)
-	insertPackages(t, store, []lsifstore.Package{
+	insertPackages(t, store, []shared.Package{
 		{DumpID: 53, Scheme: "test", Name: "p1", Version: "1.2.3"},
 		{DumpID: 54, Scheme: "test", Name: "p2", Version: "1.2.3"},
 		{DumpID: 55, Scheme: "test", Name: "p3", Version: "1.2.3"},
 		{DumpID: 56, Scheme: "test", Name: "p4", Version: "1.2.3"},
 	})
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
+	insertPackageReferences(t, store, []shared.PackageReference{
 		// References removed
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
 
 		// Remaining references
-		{Package: lsifstore.Package{DumpID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: lsifstore.Package{DumpID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
 	})
 
 	if err := store.UpdateUploadRetention(context.Background(), []int{}, []int{51, 52, 53, 54}); err != nil {

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo_scanner.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo_scanner.go
@@ -3,7 +3,7 @@ package dbstore
 import (
 	"database/sql"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 )
 
@@ -15,7 +15,7 @@ import (
 // a single bloom filter in memory at any give time during reference requests.
 type PackageReferenceScanner interface {
 	// Next reads the next package reference value from the database cursor.
-	Next() (lsifstore.PackageReference, bool, error)
+	Next() (shared.PackageReference, bool, error)
 
 	// Close the underlying row object.
 	Close() error
@@ -33,9 +33,9 @@ func packageReferenceScannerFromRows(rows *sql.Rows) PackageReferenceScanner {
 }
 
 // Next reads the next package reference value from the database cursor.
-func (s *rowScanner) Next() (reference lsifstore.PackageReference, _ bool, _ error) {
+func (s *rowScanner) Next() (reference shared.PackageReference, _ bool, _ error) {
 	if !s.rows.Next() {
-		return lsifstore.PackageReference{}, false, nil
+		return shared.PackageReference{}, false, nil
 	}
 
 	if err := s.rows.Scan(
@@ -45,7 +45,7 @@ func (s *rowScanner) Next() (reference lsifstore.PackageReference, _ bool, _ err
 		&reference.Version,
 		&reference.Filter,
 	); err != nil {
-		return lsifstore.PackageReference{}, false, err
+		return shared.PackageReference{}, false, err
 	}
 
 	return reference, true, nil
@@ -57,19 +57,19 @@ func (s *rowScanner) Close() error {
 }
 
 type sliceScanner struct {
-	references []lsifstore.PackageReference
+	references []shared.PackageReference
 }
 
 // PackageReferenceScannerFromSlice creates a PackageReferenceScanner that feeds the given values.
-func PackageReferenceScannerFromSlice(references ...lsifstore.PackageReference) PackageReferenceScanner {
+func PackageReferenceScannerFromSlice(references ...shared.PackageReference) PackageReferenceScanner {
 	return &sliceScanner{
 		references: references,
 	}
 }
 
-func (s *sliceScanner) Next() (lsifstore.PackageReference, bool, error) {
+func (s *sliceScanner) Next() (shared.PackageReference, bool, error) {
 	if len(s.references) == 0 {
-		return lsifstore.PackageReference{}, false, nil
+		return shared.PackageReference{}, false, nil
 	}
 
 	next := s.references[0]

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/commitgraph"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
@@ -162,12 +162,12 @@ func TestReferenceIDsAndFilters(t *testing.T) {
 		},
 	})
 
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
-		{Package: lsifstore.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
-		{Package: lsifstore.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
-		{Package: lsifstore.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
+		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
+		{Package: shared.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
+		{Package: shared.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
 	})
 
 	moniker := precise.QualifiedMonikerData{
@@ -180,18 +180,18 @@ func TestReferenceIDsAndFilters(t *testing.T) {
 		},
 	}
 
-	refs := []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
-		{Package: lsifstore.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
-		{Package: lsifstore.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
-		{Package: lsifstore.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
+	refs := []shared.PackageReference{
+		{Package: shared.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
+		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
+		{Package: shared.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
+		{Package: shared.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
 	}
 
 	testCases := []struct {
 		limit    int
 		offset   int
-		expected []lsifstore.PackageReference
+		expected []shared.PackageReference
 	}{
 		{5, 0, refs},
 		{5, 2, refs[2:]},
@@ -246,12 +246,12 @@ func TestReferenceIDsAndFiltersVisibility(t *testing.T) {
 		makeCommit(6): {{UploadID: 3, Distance: 3}, {UploadID: 4, Distance: 2}, {UploadID: 5, Distance: 1}},
 	})
 
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
-		{Package: lsifstore.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
-		{Package: lsifstore.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
-		{Package: lsifstore.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
+		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
+		{Package: shared.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
+		{Package: shared.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
 	})
 
 	moniker := precise.QualifiedMonikerData{
@@ -278,10 +278,10 @@ func TestReferenceIDsAndFiltersVisibility(t *testing.T) {
 		t.Fatalf("unexpected error from scanner: %s", err)
 	}
 
-	expected := []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
-		{Package: lsifstore.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
-		{Package: lsifstore.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
+	expected := []shared.PackageReference{
+		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
+		{Package: shared.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
+		{Package: shared.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
 	}
 	if diff := cmp.Diff(expected, filters); diff != "" {
 		t.Errorf("unexpected filters (-want +got):\n%s", diff)
@@ -313,15 +313,15 @@ func TestReferenceIDsAndFiltersRemoteVisibility(t *testing.T) {
 	insertVisibleAtTip(t, db, 56, 7)
 	insertVisibleAtTipNonDefaultBranch(t, db, 57, 8)
 
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")}, // same repo, not visible in git
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
-		{Package: lsifstore.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
-		{Package: lsifstore.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
-		{Package: lsifstore.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
-		{Package: lsifstore.Package{DumpID: 6, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f6")}, // remote repo not visible at tip
-		{Package: lsifstore.Package{DumpID: 7, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f7")},
-		{Package: lsifstore.Package{DumpID: 8, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f8")}, // visible on non-default branch
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f1")}, // same repo, not visible in git
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
+		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
+		{Package: shared.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
+		{Package: shared.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
+		{Package: shared.Package{DumpID: 6, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f6")}, // remote repo not visible at tip
+		{Package: shared.Package{DumpID: 7, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f7")},
+		{Package: shared.Package{DumpID: 8, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f8")}, // visible on non-default branch
 	})
 
 	moniker := precise.QualifiedMonikerData{
@@ -348,12 +348,12 @@ func TestReferenceIDsAndFiltersRemoteVisibility(t *testing.T) {
 		t.Fatalf("unexpected error from scanner: %s", err)
 	}
 
-	expected := []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
-		{Package: lsifstore.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
-		{Package: lsifstore.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
-		{Package: lsifstore.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
-		{Package: lsifstore.Package{DumpID: 7, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f7")},
+	expected := []shared.PackageReference{
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f2")},
+		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f3")},
+		{Package: shared.Package{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f4")},
+		{Package: shared.Package{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f5")},
+		{Package: shared.Package{DumpID: 7, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"}, Filter: []byte("f7")},
 	}
 	if diff := cmp.Diff(expected, filters); diff != "" {
 		t.Errorf("unexpected filters (-want +got):\n%s", diff)
@@ -375,12 +375,12 @@ func TestReferencesForUpload(t *testing.T) {
 		Upload{ID: 5, Commit: makeCommit(2), Root: "sub5/"},
 	)
 
-	insertPackageReferences(t, store, []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "1.1.0"}, Filter: []byte("f1")},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}, Filter: []byte("f2")},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}, Filter: []byte("f3")},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}, Filter: []byte("f4")},
-		{Package: lsifstore.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "5.1.0"}, Filter: []byte("f5")},
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "1.1.0"}, Filter: []byte("f1")},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}, Filter: []byte("f2")},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}, Filter: []byte("f3")},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}, Filter: []byte("f4")},
+		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "5.1.0"}, Filter: []byte("f5")},
 	})
 
 	scanner, err := store.ReferencesForUpload(context.Background(), 2)
@@ -393,10 +393,10 @@ func TestReferencesForUpload(t *testing.T) {
 		t.Fatalf("unexpected error from scanner: %s", err)
 	}
 
-	expected := []lsifstore.PackageReference{
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}, Filter: nil},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}, Filter: nil},
-		{Package: lsifstore.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}, Filter: nil},
+	expected := []shared.PackageReference{
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}, Filter: nil},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}, Filter: nil},
+		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}, Filter: nil},
 	}
 	if diff := cmp.Diff(expected, filters); diff != "" {
 		t.Errorf("unexpected filters (-want +got):\n%s", diff)
@@ -404,7 +404,7 @@ func TestReferencesForUpload(t *testing.T) {
 }
 
 // consumeScanner reads all values from the scanner into memory.
-func consumeScanner(scanner PackageReferenceScanner) (references []lsifstore.PackageReference, _ error) {
+func consumeScanner(scanner PackageReferenceScanner) (references []shared.PackageReference, _ error) {
 	for {
 		reference, exists, err := scanner.Next()
 		if err != nil {

--- a/enterprise/internal/codeintel/stores/lsifstore/types.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/types.go
@@ -2,20 +2,6 @@ package lsifstore
 
 import "github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 
-// Package pairs a package name and the dump that provides it.
-type Package struct {
-	DumpID  int
-	Scheme  string
-	Name    string
-	Version string
-}
-
-// PackageReferences pairs a package name/version with a dump that depends on it.
-type PackageReference struct {
-	Package
-	Filter []byte // a bloom filter of identifiers imported by this dependent
-}
-
 // Location is an LSP-like location scoped to a dump.
 type Location struct {
 	DumpID int

--- a/enterprise/internal/codeintel/stores/shared/xrepo_types.go
+++ b/enterprise/internal/codeintel/stores/shared/xrepo_types.go
@@ -1,0 +1,15 @@
+package lsifstore
+
+// Package pairs a package name and the dump that provides it.
+type Package struct {
+	DumpID  int
+	Scheme  string
+	Name    string
+	Version string
+}
+
+// PackageReferences pairs a package name/version with a dump that depends on it.
+type PackageReference struct {
+	Package
+	Filter []byte // a bloom filter of identifiers imported by this dependent
+}

--- a/enterprise/internal/codeintel/stores/shared/xrepo_types.go
+++ b/enterprise/internal/codeintel/stores/shared/xrepo_types.go
@@ -1,4 +1,4 @@
-package lsifstore
+package shared
 
 // Package pairs a package name and the dump that provides it.
 type Package struct {


### PR DESCRIPTION
This change moves the `lsifstore.Package` and `lsifstore.PackageReference` types
into a new `enterprise/internal/codeintel/stores/shared` package.

This eliminates `dbstore`s dependency on `lsifstore`, which will allow me to create
the inverse dependency (make lsifstore depend on `dbstore.Upload`, which will
simplify some code I am introducing for API doc search.)

Helps #21938

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>