### PR TITLE
codeintel: make worker not depend on global repo store

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
@@ -18,6 +19,7 @@ func NewWorker(
 	dbStore DBStore,
 	workerStore dbworkerstore.Store,
 	lsifStore LSIFStore,
+	repoStore *database.RepoStore,
 	uploadStore uploadstore.Store,
 	gitserverClient GitserverClient,
 	pollInterval time.Duration,
@@ -31,6 +33,7 @@ func NewWorker(
 		dbStore:         dbStore,
 		workerStore:     workerStore,
 		lsifStore:       lsifStore,
+		repoStore:       repoStore,
 		uploadStore:     uploadStore,
 		gitserverClient: gitserverClient,
 		enableBudget:    budgetMax > 0,

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -101,6 +101,7 @@ func main() {
 		&worker.DBStoreShim{Store: dbStore},
 		workerStore,
 		&worker.LSIFStoreShim{Store: lsifStore},
+		database.Repos(db),
 		uploadStore,
 		gitserverClient,
 		config.WorkerPollInterval,


### PR DESCRIPTION
Before this PR, the worker handler - `requeueIfCloning` - would depend
on the global `backend.Repos` store. This is deprecated in favor of passing
stores around to where they are appropriate.

I intend to use the repo store elsewhere, so cleaning this up seems appropriate.

Helps #21938

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>