### PR TITLE
search: remove feature fag for symbol suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph is now built with Go 1.17. [#24566](https://github.com/sourcegraph/sourcegraph/pull/24566)
 - Code Insights is now available only in the Sourcegraph enterprise. [#24741](https://github.com/sourcegraph/sourcegraph/pull/24741)
 - Prometheus in Sourcegraph with Docker Compose now scrapes Postgres and Redis instances for metrics. [deploy-sourcegraph-docker#580](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/580)
+- Symbol suggestions now leverage optimizations for global searches. [#24943](https://github.com/sourcegraph/sourcegraph/pull/24943)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -17,13 +17,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
-	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
-	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 )
 
 const maxSearchSuggestions = 100
@@ -359,55 +355,25 @@ func (r *searchResolver) showSymbolMatches(ctx context.Context) ([]SearchSuggest
 		return nil, nil
 	}
 
-	var fileMatches []result.Match
-	if featureflag.FromContext(ctx).GetBoolOr("sh_search_suggestions_symbols", false) {
-		args, jobs, err := r.toSearchInputs(r.Query)
-		if err != nil {
-			return nil, err
-		}
-		args.ResultTypes = result.TypeSymbol
+	args, jobs, err := r.toSearchInputs(r.Query)
+	if err != nil {
+		return nil, err
+	}
+	args.ResultTypes = result.TypeSymbol
 
-		results, err := r.doResults(ctx, args, jobs)
-		if errors.Is(err, context.DeadlineExceeded) {
-			err = nil
-		}
-		if err != nil {
-			return nil, err
-		}
-		if results != nil {
-			fileMatches = results.Matches
-		}
-	} else {
-		repoOptions := r.toRepoOptions(r.Query, resolveRepositoriesOpts{})
-		resolved, err := r.resolveRepositories(ctx, repoOptions)
-		if err != nil {
-			return nil, err
-		}
-
-		p := search.ToTextPatternInfo(b, search.Batch, query.Identity)
-		if p.Pattern == "" {
-			return nil, nil
-		}
-
-		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-		defer cancel()
-
-		fileMatches, _, err = streaming.CollectStream(func(stream streaming.Sender) error {
-			return symbol.Search(ctx, &search.TextParameters{
-				PatternInfo:  p,
-				Repos:        resolved.RepoRevs,
-				Query:        r.Query,
-				Zoekt:        r.zoekt,
-				SearcherURLs: r.searcherURLs,
-			}, 7, stream)
-		})
-		if err != nil {
-			return nil, err
-		}
+	results, err := r.doResults(ctx, args, jobs)
+	if errors.Is(err, context.DeadlineExceeded) {
+		err = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if results == nil {
+		return []SearchSuggestionResolver{}, nil
 	}
 
 	suggestions := make([]SearchSuggestionResolver, 0)
-	for _, match := range fileMatches {
+	for _, match := range results.Matches {
 		fileMatch, ok := match.(*result.FileMatch)
 		if !ok {
 			continue


### PR DESCRIPTION
The flag was enabled for the Sourcegraph org for a couple of weeks now
and is working fine. Time to get rid of it.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
