### PR TITLE
[COREAPP-251] status_messages: use vague language in descriptions

### DIFF
--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -100,7 +100,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
-						Message: "1 repository cloning...",
+						Message: "Some repositories cloning...",
 					},
 				},
 			},
@@ -117,7 +117,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
-						Message: "1 repository cloning...",
+						Message: "Some repositories cloning...",
 					},
 				},
 			},
@@ -132,7 +132,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
-						Message: "1 repository cloning...",
+						Message: "Some repositories cloning...",
 					},
 				},
 			},
@@ -156,7 +156,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
-						Message: "2 repositories cloning...",
+						Message: "Some repositories cloning...",
 					},
 				},
 			},
@@ -174,7 +174,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					SyncError: &SyncError{
-						Message: "1 repository could not be synced",
+						Message: "Some repositories could not be synced",
 					},
 				},
 			},
@@ -192,7 +192,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					SyncError: &SyncError{
-						Message: "2 repositories could not be synced",
+						Message: "Some repositories could not be synced",
 					},
 				},
 			},


### PR DESCRIPTION
Previously, we were trying to get the _accurate number_ of repositories that are either cloning or in failed sync state, which both are slow `COUNT` queries (that needs to scan over entire large tables). 

We instead using vague language of "Some repositories ..." to make fast `LIMIT 1` queries (that returns on first result). `LIMIT 1` is also not behaving as bad as `COUNT` when no results found at all in terms of execution time.

https://sourcegraph.atlassian.net/browse/COREAPP-251 #done