### PR TITLE
gomod: update zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210908064810-6a4adda25a6c
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210914071702-65ca553d3a98
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20210809100802-88b656a8713e

--- a/go.sum
+++ b/go.sum
@@ -1416,8 +1416,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210908064810-6a4adda25a6c h1:umB1hI5ORIwdFBtcsOsZOP6EWC9SXG7o534YeGbG29E=
-github.com/sourcegraph/zoekt v0.0.0-20210908064810-6a4adda25a6c/go.mod h1:lFzo+otquSTC1CI6SZ4+wOKjmL3qrsqfeA/vFUGExTg=
+github.com/sourcegraph/zoekt v0.0.0-20210914071702-65ca553d3a98 h1:1HvfcMM9ULp9K7KJ6DwStJAHe22rQ5HjkH3sTqQiA7g=
+github.com/sourcegraph/zoekt v0.0.0-20210914071702-65ca553d3a98/go.mod h1:lFzo+otquSTC1CI6SZ4+wOKjmL3qrsqfeA/vFUGExTg=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
We haven't updated zoekt in a while.

- https://github.com/sourcegraph/zoekt/commit/65ca553 indexserver: compound shard support
- https://github.com/sourcegraph/zoekt/commit/a585b18 indexserver: only show logs in test if verbose
- https://github.com/sourcegraph/zoekt/commit/769a9fc merge: return compound filename from Merge
- https://github.com/sourcegraph/zoekt/commit/e2c9792 update base Dockerfile
- https://github.com/sourcegraph/zoekt/commit/1a4a28c update all packages each build to avoid CVEs
- https://github.com/sourcegraph/zoekt/commit/62b7b9a Make repo config batch size configurable
- https://github.com/sourcegraph/zoekt/commit/fbbfd2e build: don't count content of skipped files
- https://github.com/sourcegraph/zoekt/commit/89fbe6e indexserver: SIGUSR1 triggers updates
- https://github.com/sourcegraph/zoekt/commit/a3bd8ee indexserver: remove codehost label from metrics