### PR TITLE
Remove starting blank line from migration template

### DIFF
--- a/dev/sg/internal/migration/migration.go
+++ b/dev/sg/internal/migration/migration.go
@@ -261,8 +261,7 @@ func ParseMigrationName(name string) (string, bool) {
 	return migrationName, true
 }
 
-const migrationFileTemplate = `
-BEGIN;
+const migrationFileTemplate = `BEGIN;
 
 -- Insert migration here. See README.md. Highlights:
 --  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;


### PR DESCRIPTION
Be gone, blank line, for we don't want you! In fact, you drove me wild.