### PR TITLE
gitserver: Use internal actor when cloning a repo

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1237,7 +1237,8 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 		return "", errors.Wrap(err, "get VCS syncer")
 	}
 
-	remoteURL, err := s.getRemoteURL(ctx, repo)
+	// We may be attempting to clone a private repo so we need an internal actor.
+	remoteURL, err := s.getRemoteURL(actor.WithInternalActor(ctx), repo)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
If we don't, we get an error trying to write our security event logs
since we don't have a user associated with the context.
