### PR TITLE
Clean up code to mark BatchSpecWorkspaceExecutionJob as complete

### DIFF
--- a/enterprise/internal/batches/background/batch_spec_workspace_execution_worker.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_execution_worker.go
@@ -80,28 +80,6 @@ type batchSpecWorkspaceExecutionWorkerStore struct {
 	observationContext *observation.Context
 }
 
-// markCompleteQuery is taken from internal/workerutil/dbworker/store/store.go
-//
-// If that one changes we need to update this one here too.
-const markBatchSpecWorkspaceExecutionJobCompleteQuery = `
-UPDATE batch_spec_workspace_execution_jobs
-SET state = 'completed', finished_at = clock_timestamp()
-WHERE id = %s AND state = 'processing' AND worker_hostname = %s
-RETURNING id
-`
-
-const setChangesetSpecIDsOnBatchSpecWorkspace = `
-UPDATE batch_spec_workspaces
-SET changeset_spec_ids = %s
-WHERE id = %s
-`
-
-const setBatchSpecIDOnChangesetSpecs = `
-UPDATE changeset_specs
-SET batch_spec_id = (SELECT batch_spec_id FROM batch_spec_workspaces WHERE id = %s LIMIT 1)
-WHERE id IN (%s)
-`
-
 func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Context, id int, options dbworkerstore.MarkFinalOptions) (_ bool, err error) {
 	batchesStore := store.New(s.Store.Handle().DB(), s.observationContext, nil)
 
@@ -111,48 +89,13 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Contex
 	}
 	defer func() { err = tx.Done(err) }()
 
-	changesetSpecIDs, err := loadAndExtractChangesetSpecIDs(ctx, tx, int64(id))
+	job, changesetSpecIDs, err := loadAndExtractChangesetSpecIDs(ctx, tx, int64(id))
 	if err != nil {
 		// If we couldn't extract the changeset IDs, we mark the job as failed
 		return s.Store.MarkFailed(ctx, id, fmt.Sprintf("failed to extract changeset IDs ID: %s", err), options)
 	}
 
-	// TODO: What's happening after this point should probably be moved to the
-	// batchesStore.
-
-	m := make(map[int64]struct{}, len(changesetSpecIDs))
-	for _, id := range changesetSpecIDs {
-		m[id] = struct{}{}
-	}
-
-	marshaledIDs, err := json.Marshal(m)
-	if err != nil {
-		return false, err
-	}
-
-	job, err := tx.GetBatchSpecWorkspaceExecutionJob(ctx, store.GetBatchSpecWorkspaceExecutionJobOpts{ID: int64(id)})
-	if err != nil {
-		return false, err
-	}
-
-	ids := []*sqlf.Query{}
-	for _, id := range changesetSpecIDs {
-		ids = append(ids, sqlf.Sprintf("%s", id))
-	}
-	err = tx.Exec(ctx, sqlf.Sprintf(setBatchSpecIDOnChangesetSpecs, job.BatchSpecWorkspaceID, sqlf.Join(ids, ",")))
-	if err != nil {
-		return false, err
-	}
-
-	// Set changeset_spec_ids on the batch_spec_workspace
-	err = tx.Exec(ctx, sqlf.Sprintf(setChangesetSpecIDsOnBatchSpecWorkspace, marshaledIDs, job.BatchSpecWorkspaceID))
-	if err != nil {
-		return false, err
-	}
-
-	// Mark batch_spec_workspace_execution_jobs as completed
-	_, ok, err := basestore.ScanFirstInt(tx.Query(ctx, sqlf.Sprintf(markBatchSpecWorkspaceExecutionJobCompleteQuery, id, options.WorkerHostname)))
-	return ok, err
+	return markBatchSpecWorkspaceExecutionJobComplete(ctx, tx, job, changesetSpecIDs, options.WorkerHostname)
 }
 
 func (s *batchSpecWorkspaceExecutionWorkerStore) FetchCanceled(ctx context.Context, executorName string) (canceledIDs []int, err error) {
@@ -175,24 +118,74 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) FetchCanceled(ctx context.Conte
 	return ids, nil
 }
 
-func loadAndExtractChangesetSpecIDs(ctx context.Context, s *store.Store, id int64) ([]int64, error) {
+// markBatchSpecWorkspaceExecutionJobCompleteQuery is taken from internal/workerutil/dbworker/store/store.go
+//
+// If that one changes we need to update this one here too.
+const markBatchSpecWorkspaceExecutionJobCompleteQuery = `
+UPDATE batch_spec_workspace_execution_jobs
+SET state = 'completed', finished_at = clock_timestamp()
+WHERE id = %s AND state = 'processing' AND worker_hostname = %s
+RETURNING id
+`
+
+const setChangesetSpecIDsOnBatchSpecWorkspace = `
+UPDATE batch_spec_workspaces SET changeset_spec_ids = %s WHERE id = %s
+`
+
+const setBatchSpecIDOnChangesetSpecs = `
+UPDATE changeset_specs
+SET batch_spec_id = (SELECT batch_spec_id FROM batch_spec_workspaces WHERE id = %s LIMIT 1)
+WHERE id IN (%s)
+`
+
+func markBatchSpecWorkspaceExecutionJobComplete(ctx context.Context, tx *store.Store, job *btypes.BatchSpecWorkspaceExecutionJob, changesetSpecIDs []int64, workerHostname string) (bool, error) {
+	ids := []*sqlf.Query{}
+	m := make(map[int64]struct{}, len(changesetSpecIDs))
+	for _, id := range changesetSpecIDs {
+		ids = append(ids, sqlf.Sprintf("%s", id))
+		m[id] = struct{}{}
+	}
+
+	// Set the batch_spec_id on the changeset_specs that were created
+	err := tx.Exec(ctx, sqlf.Sprintf(setBatchSpecIDOnChangesetSpecs, job.BatchSpecWorkspaceID, sqlf.Join(ids, ",")))
+	if err != nil {
+		return false, err
+	}
+
+	marshaledIDs, err := json.Marshal(m)
+	if err != nil {
+		return false, err
+	}
+
+	// Set changeset_spec_ids on the batch_spec_workspace
+	err = tx.Exec(ctx, sqlf.Sprintf(setChangesetSpecIDsOnBatchSpecWorkspace, marshaledIDs, job.BatchSpecWorkspaceID))
+	if err != nil {
+		return false, err
+	}
+
+	// Finally mark batch_spec_workspace_execution_jobs as completed
+	_, ok, err := basestore.ScanFirstInt(tx.Query(ctx, sqlf.Sprintf(markBatchSpecWorkspaceExecutionJobCompleteQuery, job.ID, workerHostname)))
+	return ok, err
+}
+
+func loadAndExtractChangesetSpecIDs(ctx context.Context, s *store.Store, id int64) (*btypes.BatchSpecWorkspaceExecutionJob, []int64, error) {
 	job, err := s.GetBatchSpecWorkspaceExecutionJob(ctx, store.GetBatchSpecWorkspaceExecutionJobOpts{ID: id})
 	if err != nil {
-		return []int64{}, err
+		return job, []int64{}, err
 	}
 
 	if len(job.ExecutionLogs) < 1 {
-		return []int64{}, errors.New("no execution logs")
+		return job, []int64{}, errors.New("no execution logs")
 	}
 
 	randIDs, err := extractChangesetSpecRandIDs(job.ExecutionLogs)
 	if err != nil {
-		return []int64{}, err
+		return job, []int64{}, err
 	}
 
 	specs, _, err := s.ListChangesetSpecs(ctx, store.ListChangesetSpecsOpts{LimitOpts: store.LimitOpts{Limit: 0}, RandIDs: randIDs})
 	if err != nil {
-		return []int64{}, err
+		return job, []int64{}, err
 	}
 
 	var ids []int64
@@ -200,7 +193,7 @@ func loadAndExtractChangesetSpecIDs(ctx context.Context, s *store.Store, id int6
 		ids = append(ids, spec.ID)
 	}
 
-	return ids, nil
+	return job, ids, nil
 }
 
 var ErrNoChangesetSpecIDs = errors.New("no changeset ids found in execution logs")

--- a/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
@@ -100,7 +100,7 @@ stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:3
 			}
 		}
 
-		have, err := loadAndExtractChangesetSpecIDs(context.Background(), s, job.ID)
+		_, have, err := loadAndExtractChangesetSpecIDs(context.Background(), s, job.ID)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -119,7 +119,7 @@ stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:3
 			t.Fatal(err)
 		}
 
-		_, err := loadAndExtractChangesetSpecIDs(context.Background(), s, job.ID)
+		_, _, err := loadAndExtractChangesetSpecIDs(context.Background(), s, job.ID)
 		if err == nil {
 			t.Fatalf("expected error but got none")
 		}

--- a/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -19,29 +20,39 @@ import (
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
-func TestLoadAndExtractChangesetSpecIDs(t *testing.T) {
+func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
+	ctx := context.Background()
 	db := dbtest.NewDB(t, "")
 	user := ct.CreateTestUser(t, db, true)
 
-	repo, _ := ct.CreateTestRepo(t, context.Background(), db)
+	repo, _ := ct.CreateTestRepo(t, ctx, db)
 
 	s := store.New(db, &observation.TestContext, nil)
 	workStore := dbworkerstore.NewWithMetrics(s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions, &observation.TestContext)
 
+	// Setup all the associations
 	batchSpec := &btypes.BatchSpec{UserID: user.ID, NamespaceUserID: user.ID, RawSpec: "horse"}
-	if err := s.CreateBatchSpec(context.Background(), batchSpec); err != nil {
+	if err := s.CreateBatchSpec(ctx, batchSpec); err != nil {
 		t.Fatal(err)
 	}
 
-	workspace := &btypes.BatchSpecWorkspace{
-		BatchSpecID: batchSpec.ID,
-		RepoID:      repo.ID,
-		Steps:       []batcheslib.Step{},
-	}
-	if err := s.CreateBatchSpecWorkspace(context.Background(), workspace); err != nil {
+	workspace := &btypes.BatchSpecWorkspace{BatchSpecID: batchSpec.ID, RepoID: repo.ID, Steps: []batcheslib.Step{}}
+	if err := s.CreateBatchSpecWorkspace(ctx, workspace); err != nil {
 		t.Fatal(err)
 	}
 
+	job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: workspace.ID}
+	if err := s.CreateBatchSpecWorkspaceExecutionJob(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+
+	job.State = btypes.BatchSpecWorkspaceExecutionJobStateProcessing
+	job.WorkerHostname = "worker-1"
+	if err := s.Exec(ctx, sqlf.Sprintf("UPDATE batch_spec_workspace_execution_jobs SET worker_hostname = %s, state = %s WHERE id = %s", job.WorkerHostname, job.State, job.ID)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create changeset_specs to simulate the job resulting in changeset_specs being created
 	var (
 		changesetSpecIDs        []int64
 		changesetSpecGraphQLIDs []string
@@ -49,85 +60,62 @@ func TestLoadAndExtractChangesetSpecIDs(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		spec := &btypes.ChangesetSpec{RepoID: repo.ID, UserID: user.ID}
-		if err := s.CreateChangesetSpec(context.Background(), spec); err != nil {
+		if err := s.CreateChangesetSpec(ctx, spec); err != nil {
 			t.Fatal(err)
 		}
 		changesetSpecIDs = append(changesetSpecIDs, spec.ID)
 		changesetSpecGraphQLIDs = append(changesetSpecGraphQLIDs, fmt.Sprintf("%q", relay.MarshalID("doesnotmatter", spec.RandID)))
 	}
 
+	// Add a log entry that contains the changeset spec IDs
 	jsonArray := `[` + strings.Join(changesetSpecGraphQLIDs, ",") + `]`
+	entry := workerutil.ExecutionLogEntry{
+		Key:        "step.src.0",
+		Command:    []string{"src", "batch", "preview", "-f", "spec.yml", "-text-only"},
+		StartTime:  time.Now().Add(-5 * time.Second),
+		Out:        `stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":` + jsonArray + `}} `,
+		DurationMs: intptr(200),
+	}
 
-	t.Run("success", func(t *testing.T) {
-		job := &btypes.BatchSpecWorkspaceExecutionJob{
-			State:                btypes.BatchSpecWorkspaceExecutionJobStateProcessing,
-			BatchSpecWorkspaceID: workspace.ID,
-		}
+	_, err := workStore.AddExecutionLogEntry(ctx, int(job.ID), entry, dbworkerstore.ExecutionLogEntryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		if err := s.CreateBatchSpecWorkspaceExecutionJob(context.Background(), job); err != nil {
-			t.Fatal(err)
-		}
+	executionStore := &batchSpecWorkspaceExecutionWorkerStore{Store: workStore, observationContext: &observation.TestContext}
+	opts := dbworkerstore.MarkFinalOptions{WorkerHostname: job.WorkerHostname}
+	ok, err := executionStore.MarkComplete(context.Background(), int(job.ID), opts)
+	if !ok || err != nil {
+		t.Fatalf("MarkComplete failed. ok=%t, err=%s", ok, err)
+	}
 
-		entries := []workerutil.ExecutionLogEntry{
-			{
-				Key:        "setup.firecracker.start",
-				Command:    []string{"ignite", "run"},
-				StartTime:  time.Now().Add(-5 * time.Second),
-				Out:        `stdout: cool`,
-				DurationMs: intptr(200),
-			},
-			{
-				Key:       "step.src.0",
-				Command:   []string{"src", "batch", "preview", "-f", "spec.yml", "-text-only"},
-				StartTime: time.Now().Add(-5 * time.Second),
-				Out: `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
-stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"SUCCESS"}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.942Z","status":"STARTED","metadata":{"total":1}}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"PROGRESS","metadata":{"done":1,"total":1}}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":` + jsonArray + `}}
-`,
-				DurationMs: intptr(200),
-			},
-		}
+	// Now reload the involved entities and make sure they've been updated correctly
+	reloadedJob, err := s.GetBatchSpecWorkspaceExecutionJob(ctx, store.GetBatchSpecWorkspaceExecutionJobOpts{ID: job.ID})
+	if err != nil {
+		t.Fatalf("failed to reload job: %s", err)
+	}
 
-		for i, e := range entries {
-			entryID, err := workStore.AddExecutionLogEntry(context.Background(), int(job.ID), e, dbworkerstore.ExecutionLogEntryOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if entryID != i+1 {
-				t.Fatalf("AddExecutionLogEntry returned wrong entryID. want=%d, have=%d", i+1, entryID)
-			}
-		}
+	if reloadedJob.State != btypes.BatchSpecWorkspaceExecutionJobStateCompleted {
+		t.Fatalf("wrong state: %s", reloadedJob.State)
+	}
 
-		_, have, err := loadAndExtractChangesetSpecIDs(context.Background(), s, job.ID)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		if diff := cmp.Diff(changesetSpecIDs, have); diff != "" {
-			t.Fatalf("wrong diff: %s", diff)
-		}
-	})
+	reloadedWorkspace, err := s.GetBatchSpecWorkspace(ctx, store.GetBatchSpecWorkspaceOpts{ID: workspace.ID})
+	if err != nil {
+		t.Fatalf("failed to reload workspace: %s", err)
+	}
+	if diff := cmp.Diff(changesetSpecIDs, reloadedWorkspace.ChangesetSpecIDs); diff != "" {
+		t.Fatalf("reloaded workspace has wrong changeset spec IDs: %s", diff)
+	}
 
-	t.Run("without log entry", func(t *testing.T) {
-		job := &btypes.BatchSpecWorkspaceExecutionJob{
-			State:                btypes.BatchSpecWorkspaceExecutionJobStateProcessing,
-			BatchSpecWorkspaceID: workspace.ID,
+	reloadedSpecs, _, err := s.ListChangesetSpecs(ctx, store.ListChangesetSpecsOpts{LimitOpts: store.LimitOpts{Limit: 0}, IDs: changesetSpecIDs})
+	if err != nil {
+		t.Fatalf("failed to reload changeset specs: %s", err)
+	}
+	for _, reloadedSpec := range reloadedSpecs {
+		if reloadedSpec.BatchSpecID != batchSpec.ID {
+			t.Fatalf("reloaded changeset spec does not have correct batch spec id: %d", reloadedSpec.BatchSpecID)
 		}
-
-		if err := s.CreateBatchSpecWorkspaceExecutionJob(context.Background(), job); err != nil {
-			t.Fatal(err)
-		}
-
-		_, _, err := loadAndExtractChangesetSpecIDs(context.Background(), s, job.ID)
-		if err == nil {
-			t.Fatalf("expected error but got none")
-		}
-
-		if err.Error() != "no execution logs" {
-			t.Fatalf("wrong error: %q", err.Error())
-		}
-	})
+	}
 }
 
 func TestExtractChangesetSpecIDs(t *testing.T) {

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -335,7 +335,7 @@ func newOperations(observationContext *observation.Context) *operations {
 			createBatchSpecWorkspaceExecutionJob: op("CreateBatchSpecWorkspaceExecutionJob"),
 			getBatchSpecWorkspaceExecutionJob:    op("GetBatchSpecWorkspaceExecutionJob"),
 			listBatchSpecWorkspaceExecutionJobs:  op("ListBatchSpecWorkspaceExecutionJobs"),
-			cancelBatchSpecWorkspaceExecutionJob: op("GetBatchSpecWorkspaceExecutionJob"),
+			cancelBatchSpecWorkspaceExecutionJob: op("CancelBatchSpecWorkspaceExecutionJob"),
 
 			createBatchSpecResolutionJob: op("CreateBatchSpecResolutionJob"),
 			getBatchSpecResolutionJob:    op("GetBatchSpecResolutionJob"),


### PR DESCRIPTION
This is another #24421 follow-up and cleans up the big function in `MarkComplete`. I decided _against_ pulling this into `service` or `store`, because I think that _this_ store is actually the best place to keep this logic.