### PR TITLE
Fix Github command palette icon vertical alignment

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -417,7 +417,7 @@ export const githubCodeHost: CodeHost = {
     getCommandPaletteMount,
     notificationClassNames,
     commandPaletteClassProps: {
-        buttonClassName: 'Header-link',
+        buttonClassName: 'Header-link d-flex flex-items-baseline',
         popoverClassName: 'Box',
         formClassName: 'p-1',
         inputClassName: 'form-control input-sm header-search-input jump-to-field',


### PR DESCRIPTION
Partially solves https://github.com/sourcegraph/sourcegraph/issues/23761. 

| Before | After |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/133293526-63ba016c-2d57-49bb-93c3-74d1e909dd06.png) |  ![image](https://user-images.githubusercontent.com/6717049/133293618-5a7c3210-0eb6-4749-8685-742aa7927086.png) |

