### PR TITLE
codeintel: Add missing foreign key indexes

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -963,6 +963,7 @@ Indexes:
  last_heartbeat_at | timestamp with time zone |           |          | 
 Indexes:
     "lsif_dependency_indexing_jobs_pkey" PRIMARY KEY, btree (id)
+    "lsif_dependency_indexing_jobs_upload_id" btree (upload_id)
 Foreign-key constraints:
     "lsif_dependency_indexing_jobs_upload_id_fkey" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
 
@@ -1151,6 +1152,7 @@ Associates commits with the closest ancestor commit with usable upload data. Tog
  dump_id | integer |           | not null | 
 Indexes:
     "lsif_packages_pkey" PRIMARY KEY, btree (id)
+    "lsif_packages_dump_id" btree (dump_id)
     "lsif_packages_scheme_name_version_dump_id" btree (scheme, name, version, dump_id)
 Foreign-key constraints:
     "lsif_packages_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
@@ -1179,6 +1181,7 @@ Associates an upload with the set of packages they provide within a given packag
  dump_id | integer |           | not null | 
 Indexes:
     "lsif_references_pkey" PRIMARY KEY, btree (id)
+    "lsif_references_dump_id" btree (dump_id)
     "lsif_references_scheme_name_version_dump_id" btree (scheme, name, version, dump_id)
 Foreign-key constraints:
     "lsif_references_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE

--- a/migrations/frontend/1528395886_add_missing_fk_indexes1.down.sql
+++ b/migrations/frontend/1528395886_add_missing_fk_indexes1.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS lsif_dependency_indexing_jobs_upload_id;
+COMMIT;

--- a/migrations/frontend/1528395886_add_missing_fk_indexes1.up.sql
+++ b/migrations/frontend/1528395886_add_missing_fk_indexes1.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_dependency_indexing_jobs_upload_id ON lsif_dependency_indexing_jobs(upload_id);

--- a/migrations/frontend/1528395887_add_missing_fk_indexes2.down.sql
+++ b/migrations/frontend/1528395887_add_missing_fk_indexes2.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS lsif_packages_dump_id;
+COMMIT;

--- a/migrations/frontend/1528395887_add_missing_fk_indexes2.up.sql
+++ b/migrations/frontend/1528395887_add_missing_fk_indexes2.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_packages_dump_id ON lsif_packages(dump_id);

--- a/migrations/frontend/1528395888_add_missing_fk_indexes3.down.sql
+++ b/migrations/frontend/1528395888_add_missing_fk_indexes3.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS lsif_references_dump_id;
+COMMIT;

--- a/migrations/frontend/1528395888_add_missing_fk_indexes3.up.sql
+++ b/migrations/frontend/1528395888_add_missing_fk_indexes3.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_references_dump_id ON lsif_references(dump_id);


### PR DESCRIPTION
On a foreign key from TA(x) -> TB(y), Postgres will create an index on TB(y) but not on TA(x) automatically. I think a lot of developers assume both directions are indexed.

This change massively increases the speed of the UpdateNumDependencyReferences query, which is the currently dominating factor of LSIF upload processing.

Note: I have created two indexes in Cloud that need to be removed after merging this PR (`eftemp1` and `eftemp2` on the `lsif_packages` and `lsif_references` tables).