### PR TITLE
Code Insights: Add code insights beta modal UI

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -151,6 +151,7 @@ $theme-colors: (
     --diff-remove-bg: #ffecec;
     --code-selection-bg: var(--gray-03);
     --sourcegraph-logo-text-color: #000000;
+    --marketing-gradient: linear-gradient(90.64deg, #e4d3fc 3.11%, #d7f0fd 83.64%);
 }
 
 .theme-dark {
@@ -203,6 +204,7 @@ $theme-colors: (
     --diff-remove-bg: #3e1d1d;
     --code-selection-bg: var(--gray-08);
     --sourcegraph-logo-text-color: var(--white);
+    --marketing-gradient: linear-gradient(90.64deg, rgba(108, 8, 223, 0.5) 3.11%, rgba(0, 165, 213, 0.5) 83.64%);
 }
 
 // Additional colors global colors.

--- a/client/web/src/enterprise/insights/InsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/InsightsRouter.tsx
@@ -12,6 +12,7 @@ import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { HeroPage } from '../../components/HeroPage'
 import { lazyComponent } from '../../util/lazyComponent'
 
+import { BetaConfirmationModal } from './modals/BetaConfirmationModal'
 import { DashboardsRoutes } from './pages/dashboards/DasbhoardsRoutes'
 import { CreationRoutes } from './pages/insights/creation/CreationRoutes'
 
@@ -44,38 +45,41 @@ export const InsightsRouter = withAuthenticatedUser<InsightsRouterProps>(props =
     const match = useRouteMatch()
 
     return (
-        <Switch>
-            <Redirect from={match.url} exact={true} to={`${match.url}/dashboards/all`} />
+        <>
+            <Route path="*" component={BetaConfirmationModal} />
+            <Switch>
+                <Redirect from={match.url} exact={true} to={`${match.url}/dashboards/all`} />
 
-            <Route path={`${match.url}/create`}>
-                <CreationRoutes
-                    platformContext={platformContext}
-                    authenticatedUser={authenticatedUser}
-                    settingsCascade={settingsCascade}
-                    telemetryService={telemetryService}
-                />
-            </Route>
-
-            <Route
-                path={`${match.url}/edit/:insightID`}
-                render={(props: RouteComponentProps<{ insightID: string }>) => (
-                    <EditInsightLazyPage
+                <Route path={`${match.url}/create`}>
+                    <CreationRoutes
                         platformContext={platformContext}
                         authenticatedUser={authenticatedUser}
                         settingsCascade={settingsCascade}
-                        insightID={props.match.params.insightID}
+                        telemetryService={telemetryService}
                     />
-                )}
-            />
+                </Route>
 
-            <DashboardsRoutes
-                authenticatedUser={authenticatedUser}
-                telemetryService={telemetryService}
-                platformContext={platformContext}
-                settingsCascade={settingsCascade}
-            />
+                <Route
+                    path={`${match.url}/edit/:insightID`}
+                    render={(props: RouteComponentProps<{ insightID: string }>) => (
+                        <EditInsightLazyPage
+                            platformContext={platformContext}
+                            authenticatedUser={authenticatedUser}
+                            settingsCascade={settingsCascade}
+                            insightID={props.match.params.insightID}
+                        />
+                    )}
+                />
 
-            <Route component={NotFoundPage} key="hardcoded-key" />
-        </Switch>
+                <DashboardsRoutes
+                    authenticatedUser={authenticatedUser}
+                    telemetryService={telemetryService}
+                    platformContext={platformContext}
+                    settingsCascade={settingsCascade}
+                />
+
+                <Route component={NotFoundPage} key="hardcoded-key" />
+            </Switch>
+        </>
     )
 })

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
@@ -7,6 +7,7 @@
     bottom: 0;
     left: 0;
     overflow: auto;
+    padding: 1.5rem;
 }
 
 .content {
@@ -36,9 +37,9 @@
     display: flex;
     // Stretch the charts container to the full width ignore parent paddings and border
     margin: 1.5rem calc((-1px - 1.5rem));
-    padding: 1.5rem 1rem;
+    padding: 1rem 1.5rem;
     background: var(--marketing-gradient);
-    height: 11rem;
+    height: 10.625rem;
     gap: 0.5rem;
 }
 

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
@@ -1,0 +1,60 @@
+.overlay {
+    display: flex;
+    background-color: #343a4d4d; // --color-bg-3 with 30% opacity
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow: auto;
+}
+
+.content {
+    max-width: 32rem;
+    width: 100%;
+    margin: auto;
+    background-color: var(--color-bg-1);
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color);
+    padding: 1.5rem;
+}
+
+.title {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.media-hero-content {
+    :global(.theme-light) & {
+        --marketing-gradient: linear-gradient(90.64deg, #e4d3fc 3.11%, #d7f0fd 83.64%);
+    }
+
+    :global(.theme-dark) & {
+        --marketing-gradient: linear-gradient(90.64deg, rgba(108, 8, 223, 0.5) 3.11%, rgba(0, 165, 213, 0.5) 83.64%);
+    }
+
+    display: flex;
+    // Stretch the charts container to the full width ignore parent paddings and border
+    margin: 1.5rem calc((-1px - 1.5rem));
+    padding: 1.5rem 1rem;
+    background: var(--marketing-gradient);
+    height: 11rem;
+    gap: 0.5rem;
+}
+
+.chart {
+    box-shadow: 0 4px 16px -6px rgba(36, 41, 54, 0.2);
+    border-radius: var(--border-radius);
+}
+
+.text-content {
+    margin-top: 1.5rem;
+    margin-bottom: 0;
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+}

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
@@ -26,14 +26,6 @@
 }
 
 .media-hero-content {
-    :global(.theme-light) & {
-        --marketing-gradient: linear-gradient(90.64deg, #e4d3fc 3.11%, #d7f0fd 83.64%);
-    }
-
-    :global(.theme-dark) & {
-        --marketing-gradient: linear-gradient(90.64deg, rgba(108, 8, 223, 0.5) 3.11%, rgba(0, 165, 213, 0.5) 83.64%);
-    }
-
     display: flex;
     // Stretch the charts container to the full width ignore parent paddings and border
     margin: 1.5rem calc((-1px - 1.5rem));
@@ -44,7 +36,7 @@
 }
 
 .chart {
-    box-shadow: 0 4px 16px -6px rgba(36, 41, 54, 0.2);
+    box-shadow: var(--dropdown-shadow);
     border-radius: var(--border-radius);
 }
 

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.module.scss
@@ -28,6 +28,7 @@
 .media-hero-content {
     display: flex;
     // Stretch the charts container to the full width ignore parent paddings and border
+    // stylelint-disable-next-line declaration-property-unit-whitelist
     margin: 1.5rem calc((-1px - 1.5rem));
     padding: 1rem 1.5rem;
     background: var(--marketing-gradient);

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.story.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.story.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { createMockClient } from '@apollo/client/testing'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react'
 import { noop } from 'lodash'
 import React from 'react'
 
@@ -13,10 +13,6 @@ import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 
 import { BetaConfirmationModal, BetaConfirmationModalContent } from './BetaConfirmationModal'
 
-const { add } = storiesOf('web/insights/BetaConfirmationModal', module).addDecorator(story => (
-    <div className="p-3 container web-content">{story()}</div>
-))
-
 const mockClient = createMockClient(
     { contents: JSON.stringify({}) },
     gql`
@@ -28,25 +24,32 @@ const mockClient = createMockClient(
     `
 )
 
-add('Code Insights Beta modal UI', () => {
+const Story: Meta = {
+    title: 'web/insights/BetaConfirmationModal',
+    decorators: [
+        story => (
+            <EnterpriseWebStory>{() => <div className="p-3 container web-content">{story()}</div>}</EnterpriseWebStory>
+        ),
+    ],
+}
+
+export default Story
+
+export const BetaModalUI: React.FunctionComponent = () => {
     const settingsStorage = new TemporarySettingsStorage(mockClient, true)
 
     settingsStorage.setSettingsBackend(new InMemoryMockSettingsBackend({}))
 
     return (
-        <EnterpriseWebStory>
-            {() => (
-                <TemporarySettingsContext.Provider value={settingsStorage}>
-                    <div>
-                        <h2>Some content</h2>
-                        <BetaConfirmationModal />
-                    </div>
-                </TemporarySettingsContext.Provider>
-            )}
-        </EnterpriseWebStory>
+        <TemporarySettingsContext.Provider value={settingsStorage}>
+            <div>
+                <h2>Some content</h2>
+                <BetaConfirmationModal />
+            </div>
+        </TemporarySettingsContext.Provider>
     )
-})
+}
 
-add('Code Insights modal content', () => (
-    <EnterpriseWebStory>{() => <BetaConfirmationModalContent onAccept={noop} onDismiss={noop} />}</EnterpriseWebStory>
-))
+export const BetaModalContent: React.FunctionComponent = () => (
+    <BetaConfirmationModalContent onAccept={noop} onDismiss={noop} />
+)

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.story.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.story.tsx
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client'
 import { createMockClient } from '@apollo/client/testing'
 import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
 import React from 'react'
 
 import { TemporarySettingsContext } from '../../../settings/temporary/TemporarySettingsProvider'
@@ -10,7 +11,7 @@ import {
 } from '../../../settings/temporary/TemporarySettingsStorage'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 
-import { BetaConfirmationModal } from './BetaConfirmationModal'
+import { BetaConfirmationModal, BetaConfirmationModalContent } from './BetaConfirmationModal'
 
 const { add } = storiesOf('web/insights/BetaConfirmationModal', module).addDecorator(story => (
     <div className="p-3 container web-content">{story()}</div>
@@ -27,7 +28,7 @@ const mockClient = createMockClient(
     `
 )
 
-add('Beta modal UI', () => {
+add('Code Insights Beta modal UI', () => {
     const settingsStorage = new TemporarySettingsStorage(mockClient, true)
 
     settingsStorage.setSettingsBackend(new InMemoryMockSettingsBackend({}))
@@ -45,3 +46,7 @@ add('Beta modal UI', () => {
         </EnterpriseWebStory>
     )
 })
+
+add('Code Insights modal content', () => (
+    <EnterpriseWebStory>{() => <BetaConfirmationModalContent onAccept={noop} onDismiss={noop} />}</EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.story.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.story.tsx
@@ -1,0 +1,47 @@
+import { gql } from '@apollo/client'
+import { createMockClient } from '@apollo/client/testing'
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { TemporarySettingsContext } from '../../../settings/temporary/TemporarySettingsProvider'
+import {
+    InMemoryMockSettingsBackend,
+    TemporarySettingsStorage,
+} from '../../../settings/temporary/TemporarySettingsStorage'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+
+import { BetaConfirmationModal } from './BetaConfirmationModal'
+
+const { add } = storiesOf('web/insights/BetaConfirmationModal', module).addDecorator(story => (
+    <div className="p-3 container web-content">{story()}</div>
+))
+
+const mockClient = createMockClient(
+    { contents: JSON.stringify({}) },
+    gql`
+        query {
+            temporarySettings {
+                contents
+            }
+        }
+    `
+)
+
+add('Beta modal UI', () => {
+    const settingsStorage = new TemporarySettingsStorage(mockClient, true)
+
+    settingsStorage.setSettingsBackend(new InMemoryMockSettingsBackend({}))
+
+    return (
+        <EnterpriseWebStory>
+            {() => (
+                <TemporarySettingsContext.Provider value={settingsStorage}>
+                    <div>
+                        <h2>Some content</h2>
+                        <BetaConfirmationModal />
+                    </div>
+                </TemporarySettingsContext.Provider>
+            )}
+        </EnterpriseWebStory>
+    )
+})

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -26,7 +26,7 @@ export const BetaConfirmationModal: React.FunctionComponent = () => {
     return (
         <DialogOverlay className={styles.overlay}>
             <DialogContent className={styles.content}>
-                <h1 className={styles.title}>Welcome to Code Insights Free Beta!</h1>
+                <h1 className={styles.title}>Welcome to the Code Insights Beta!</h1>
 
                 <div className={styles.mediaHeroContent}>
                     <ThreeLineChart className={styles.chart} />
@@ -36,27 +36,26 @@ export const BetaConfirmationModal: React.FunctionComponent = () => {
 
                 <div className={styles.textContent}>
                     <p>
-                        <b>🥁 We’re introducing Code Insights</b>, the first code analytics tool that can tell you
-                        things about your code base at a <b>high level</b>!
+                        <b>🥁 We’re introducing Code Insights</b>: a new analytics tool that lets you track and
+                        understand what’s in your code and how it changes <b>over time</b>!
                     </p>
 
                     <p>
-                        Code Insights are based on our universal code search, making them <b>incredibly accurate</b>.
-                        Track anything that can be expressed with Sourcegraph search query: migrations, usage of
-                        packages and much much more.
+                        Track anything that can be expressed with a Sourcegraph search query: migrations, package
+                        use, version adoption, code smells, codebase size, and more, across 1,000s of repositories.
                     </p>
 
                     <p>
-                        We're still polishing Insights and you may experience some issues while in beta.{' '}
+                        We're still polishing Code Insights and you might find bugs while we’re in beta. Please{' '}
                         <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
-                            Share any bugs 🐛 or feedback
+                            share any bugs 🐛 or feedback
                         </a>{' '}
                         to help us make Code Insights better.
                     </p>
 
                     <p>
-                        Code Insights are <b>free and in beta through 2021</b>. In 2022, Code Insights may be included
-                        in a separate paid plan.
+                        Code Insights is <b>free and in beta through 2021</b>. When Code Insights is officially released,
+                        continued use may require a separate paid plan (at which time we’d notify you again).
                     </p>
                 </div>
 
@@ -66,7 +65,7 @@ export const BetaConfirmationModal: React.FunctionComponent = () => {
                     </Button>
 
                     <Button variant="primary" onClick={handleAcceptClick}>
-                        Understood, let's try it!
+                        Understood, let’s go!
                     </Button>
                 </footer>
             </DialogContent>

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -1,0 +1,75 @@
+import { DialogContent, DialogOverlay } from '@reach/dialog'
+import React from 'react'
+import { useHistory } from 'react-router'
+
+import { Button } from '@sourcegraph/wildcard'
+
+import { useTemporarySetting } from '../../../settings/temporary/useTemporarySetting'
+
+import styles from './BetaConfirmationModal.module.scss'
+import { FourLineChart, ThreeLineChart, TwoLineChart } from './components/MediaCharts'
+
+export const BetaConfirmationModal: React.FunctionComponent = () => {
+    const history = useHistory()
+    const [acceptFreeBetaValue, setAcceptFreeBeta] = useTemporarySetting('insights.acceptFreeBeta', false)
+
+    const handleAcceptClick = (): void => {
+        setAcceptFreeBeta(true)
+    }
+
+    // We should not render confirmation modal if we haven't got the temporary settings yet
+    // or cause users have already accepted the free beta info.
+    if (acceptFreeBetaValue === undefined || acceptFreeBetaValue) {
+        return null
+    }
+
+    return (
+        <DialogOverlay className={styles.overlay}>
+            <DialogContent className={styles.content}>
+                <h1 className={styles.title}>Welcome to Code Insights Free Beta!</h1>
+
+                <div className={styles.mediaHeroContent}>
+                    <ThreeLineChart className={styles.chart} />
+                    <FourLineChart className={styles.chart} />
+                    <TwoLineChart className={styles.chart} />
+                </div>
+
+                <div className={styles.textContent}>
+                    <p>
+                        <b>🥁 We’re introducing Code Insights</b>, the first code analytics tool that can tell you
+                        things about your code base at a <b>high level</b>!
+                    </p>
+
+                    <p>
+                        Code Insights are based on our universal code search, making them <b>incredibly accurate</b>.
+                        Track anything that can be expressed with Sourcegraph search query: migrations, usage of
+                        packages and much much more.
+                    </p>
+
+                    <p>
+                        We're still polishing Insights and you may experience some issues while in beta.{' '}
+                        <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                            Share any bugs 🐛 or feedback
+                        </a>{' '}
+                        to help us make Code Insights better.
+                    </p>
+
+                    <p>
+                        Code Insights are <b>free and in beta through 2021</b>. In 2022, Code Insights may be included
+                        in a separate paid plan.
+                    </p>
+                </div>
+
+                <footer className={styles.actions}>
+                    <Button variant="secondary" outline={true} onClick={() => history.push('/')}>
+                        Maybe later
+                    </Button>
+
+                    <Button variant="primary" onClick={handleAcceptClick}>
+                        Understood, let's try it!
+                    </Button>
+                </footer>
+            </DialogContent>
+        </DialogOverlay>
+    )
+}

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -1,8 +1,8 @@
 import { DialogContent, DialogOverlay } from '@reach/dialog'
-import React from 'react'
+import React, { useRef } from 'react'
 import { useHistory } from 'react-router'
 
-import { Button } from '@sourcegraph/wildcard'
+import { Button, useAutoFocus } from '@sourcegraph/wildcard'
 
 import { useTemporarySetting } from '../../../settings/temporary/useTemporarySetting'
 
@@ -46,9 +46,12 @@ interface BetaConfirmationModalContentProps {
  */
 export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmationModalContentProps> = props => {
     const { onAccept, onDismiss } = props
+    const dismissButtonReference = useRef<HTMLButtonElement>(null)
+
+    useAutoFocus({ autoFocus: true, reference: dismissButtonReference })
 
     return (
-        <DialogContent className={styles.content}>
+        <DialogContent aria-label="Code Insights Beta information" className={styles.content}>
             <h1 className={styles.title}>Welcome to the Code Insights Beta!</h1>
 
             <div className={styles.mediaHeroContent}>
@@ -87,7 +90,7 @@ export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmat
             </div>
 
             <footer className={styles.actions}>
-                <Button variant="secondary" outline={true} onClick={onDismiss}>
+                <Button ref={dismissButtonReference} variant="secondary" outline={true} onClick={onDismiss}>
                     Maybe later
                 </Button>
 

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -7,7 +7,7 @@ import { Button } from '@sourcegraph/wildcard'
 import { useTemporarySetting } from '../../../settings/temporary/useTemporarySetting'
 
 import styles from './BetaConfirmationModal.module.scss'
-import { FourLineChart, ThreeLineChart, TwoLineChart } from './components/MediaCharts'
+import { FourLineChart, PieChart, ThreeLineChart } from './components/MediaCharts'
 
 export const BetaConfirmationModal: React.FunctionComponent = () => {
     const history = useHistory()
@@ -31,7 +31,7 @@ export const BetaConfirmationModal: React.FunctionComponent = () => {
                 <div className={styles.mediaHeroContent}>
                     <ThreeLineChart className={styles.chart} />
                     <FourLineChart className={styles.chart} />
-                    <TwoLineChart className={styles.chart} />
+                    <PieChart className={styles.chart} />
                 </div>
 
                 <div className={styles.textContent}>
@@ -41,8 +41,8 @@ export const BetaConfirmationModal: React.FunctionComponent = () => {
                     </p>
 
                     <p>
-                        Track anything that can be expressed with a Sourcegraph search query: migrations, package
-                        use, version adoption, code smells, codebase size, and more, across 1,000s of repositories.
+                        Track anything that can be expressed with a Sourcegraph search query: migrations, package use,
+                        version adoption, code smells, codebase size, and more, across 1,000s of repositories.
                     </p>
 
                     <p>
@@ -54,8 +54,8 @@ export const BetaConfirmationModal: React.FunctionComponent = () => {
                     </p>
 
                     <p>
-                        Code Insights is <b>free and in beta through 2021</b>. When Code Insights is officially released,
-                        continued use may require a separate paid plan (at which time we’d notify you again).
+                        Code Insights is <b>free and in beta through 2021</b>. When Code Insights is officially
+                        released, continued use may require a separate paid plan (at which time we’d notify you again).
                     </p>
                 </div>
 

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -11,64 +11,86 @@ import { FourLineChart, PieChart, ThreeLineChart } from './components/MediaChart
 
 export const BetaConfirmationModal: React.FunctionComponent = () => {
     const history = useHistory()
-    const [acceptFreeBetaValue, setAcceptFreeBeta] = useTemporarySetting('insights.acceptFreeBeta', false)
+    const [isFreeBetaAccepted, setFreeBetaAccepted] = useTemporarySetting('insights.freeBetaAccepted', false)
 
-    const handleAcceptClick = (): void => {
-        setAcceptFreeBeta(true)
+    const handleAccept = (): void => {
+        setFreeBetaAccepted(true)
+    }
+
+    const handleDismiss = (): void => {
+        history.push('/')
     }
 
     // We should not render confirmation modal if we haven't got the temporary settings yet
     // or cause users have already accepted the free beta info.
-    if (acceptFreeBetaValue === undefined || acceptFreeBetaValue) {
+    if (isFreeBetaAccepted === undefined || isFreeBetaAccepted) {
         return null
     }
 
     return (
         <DialogOverlay className={styles.overlay}>
-            <DialogContent className={styles.content}>
-                <h1 className={styles.title}>Welcome to the Code Insights Beta!</h1>
-
-                <div className={styles.mediaHeroContent}>
-                    <ThreeLineChart className={styles.chart} />
-                    <FourLineChart className={styles.chart} />
-                    <PieChart className={styles.chart} />
-                </div>
-
-                <div className={styles.textContent}>
-                    <p>
-                        <b>🥁 We’re introducing Code Insights</b>: a new analytics tool that lets you track and
-                        understand what’s in your code and how it changes <b>over time</b>!
-                    </p>
-
-                    <p>
-                        Track anything that can be expressed with a Sourcegraph search query: migrations, package use,
-                        version adoption, code smells, codebase size, and more, across 1,000s of repositories.
-                    </p>
-
-                    <p>
-                        We're still polishing Code Insights and you might find bugs while we’re in beta. Please{' '}
-                        <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
-                            share any bugs 🐛 or feedback
-                        </a>{' '}
-                        to help us make Code Insights better.
-                    </p>
-
-                    <p>
-                        Code Insights is <b>free and in beta through 2021</b>. When Code Insights is officially
-                        released, continued use may require a separate paid plan (at which time we’d notify you again).
-                    </p>
-                </div>
-
-                <footer className={styles.actions}>
-                    <Button variant="secondary" outline={true} onClick={() => history.push('/')}>
-                        Maybe later
-                    </Button>
-
-                    <Button variant="primary" onClick={handleAcceptClick}>
-                        Understood, let’s go!
-                    </Button>
-                </footer>
-            </DialogContent>
+            <BetaConfirmationModalContent onAccept={handleAccept} onDismiss={handleDismiss} />
         </DialogOverlay>
+    )
+}
+
+interface BetaConfirmationModalContentProps {
+    onAccept: () => void
+    onDismiss: () => void
+}
+
+/**
+ * Renders Code Insights Beta modal content component.
+ * Exported especially for storybook story component cause chromatic has a problem of rendering modals
+ * on CI.
+ */
+export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmationModalContentProps> = props => {
+    const { onAccept, onDismiss } = props
+
+    return (
+        <DialogContent className={styles.content}>
+            <h1 className={styles.title}>Welcome to the Code Insights Beta!</h1>
+
+            <div className={styles.mediaHeroContent}>
+                <ThreeLineChart className={styles.chart} />
+                <FourLineChart className={styles.chart} />
+                <PieChart className={styles.chart} />
+            </div>
+
+            <div className={styles.textContent}>
+                <p>
+                    <b>🥁 We’re introducing Code Insights</b>: a new analytics tool that lets you track and understand
+                    what’s in your code and how it changes <b>over time</b>!
+                </p>
+
+                <p>
+                    Track anything that can be expressed with a Sourcegraph search query: migrations, package use,
+                    version adoption, code smells, codebase size, and more, across 1,000s of repositories.
+                </p>
+
+                <p>
+                    We're still polishing Code Insights and you might find bugs while we’re in beta. Please{' '}
+                    <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                        share any bugs 🐛 or feedback
+                    </a>{' '}
+                    to help us make Code Insights better.
+                </p>
+
+                <p>
+                    Code Insights is <b>free and in beta through 2021</b>. When Code Insights is officially released,
+                    continued use may require a separate paid plan (at which time we’d notify you again).
+                </p>
+            </div>
+
+            <footer className={styles.actions}>
+                <Button variant="secondary" outline={true} onClick={onDismiss}>
+                    Maybe later
+                </Button>
+
+                <Button variant="primary" onClick={onAccept}>
+                    Understood, let’s go!
+                </Button>
+            </footer>
+        </DialogContent>
     )
 }

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -70,14 +70,18 @@ export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmat
 
                 <p>
                     We're still polishing Code Insights and you might find bugs while we’re in beta. Please{' '}
-                    <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                    <a
+                        href="https://docs.sourcegraph.com/code_insights#code-insights-beta"
+                        target="_blank"
+                        rel="noopener"
+                    >
                         share any bugs 🐛 or feedback
                     </a>{' '}
                     to help us make Code Insights better.
                 </p>
 
                 <p>
-                    Code Insights is <b>free and in beta through 2021</b>. When Code Insights is officially released,
+                    Code Insights is <b>free while in beta through 2021</b>. When Code Insights is officially released,
                     continued use may require a separate paid plan (at which time we’d notify you again).
                 </p>
             </div>

--- a/client/web/src/enterprise/insights/modals/components/MediaCharts.module.scss
+++ b/client/web/src/enterprise/insights/modals/components/MediaCharts.module.scss
@@ -1,4 +1,12 @@
 .chart {
+    --red: var(--oc-red-7);
+    --pink: var(--oc-pink-7);
+    --blue: var(--oc-blue-7);
+    --dark-blue: var(--oc-indigo-7);
+    --green: var(--oc-teal-7);
+    --light-green: var(--oc-green-7);
+    --orange: var(--oc-orange-7);
+
     background-color: var(--color-bg-1);
     width: 100%;
     height: 100%;

--- a/client/web/src/enterprise/insights/modals/components/MediaCharts.module.scss
+++ b/client/web/src/enterprise/insights/modals/components/MediaCharts.module.scss
@@ -1,0 +1,9 @@
+.chart {
+    background-color: var(--color-bg-1);
+    width: 100%;
+    height: 100%;
+
+    rect {
+        fill: var(--border-color-2);
+    }
+}

--- a/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
+++ b/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
@@ -13,49 +13,53 @@ export const ThreeLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElemen
         {...props}
         className={classname(styles.chart, props.className)}
     >
-        <circle cx="60.5" cy="74" r="1.5" />
+        <circle cx="60.5" cy="74" r="1.5" fill="var(--red)" />
         <rect x="16" y="45" width="137" height="1" />
         <rect x="16" y="22" width="137" height="1" />
         <rect x="16" y="68" width="137" height="1" />
         <rect x="16" y="91" width="137" height="1" />
         <rect x="16" y="114" width="137" height="1" />
         <rect x="23" y="132.5" width="15" height="1" />
-        <circle cx="18" cy="133" r="2" fill="#DD4E47" />
+        <circle cx="18" cy="133" r="2" fill="var(--red)" />
         <rect x="57" y="132.5" width="15" height="1" />
-        <circle cx="52" cy="133" r="2" fill="#3C7ED0" />
+        <circle cx="52" cy="133" r="2" fill="var(--blue)" />
         <rect x="91" y="132.5" width="15" height="1" />
-        <circle cx="86" cy="133" r="2" fill="#4496AA" />
-        <circle cx="17.5" cy="107" r="1.5" fill="#4496AA" />
-        <circle cx="40" cy="107" r="1.5" fill="#4496AA" />
-        <circle cx="61" cy="92.5" r="1.5" fill="#4496AA" />
-        <circle cx="84" cy="91" r="1.5" fill="#4496AA" />
-        <circle cx="105" cy="103.5" r="1.5" fill="#4496AA" />
-        <circle cx="127.5" cy="103.7" r="1.5" fill="#4496AA" />
-        <circle cx="149" cy="103.7" r="1.5" fill="#4496AA" />
-        <circle cx="40" cy="78" r="1.5" fill="#DD4E47" />
-        <circle cx="18.5" cy="95.5" r="1.5" fill="#DD4E47" />
+        <circle cx="86" cy="133" r="2" fill="var(--green)" />
+        <circle cx="17.5" cy="107" r="1.5" fill="var(--green)" />
+        <circle cx="40" cy="107" r="1.5" fill="var(--green)" />
+        <circle cx="61" cy="92.5" r="1.5" fill="var(--green)" />
+        <circle cx="84" cy="91" r="1.5" fill="var(--green)" />
+        <circle cx="105" cy="103.5" r="1.5" fill="var(--green)" />
+        <circle cx="127.5" cy="103.7" r="1.5" fill="var(--green)" />
+        <circle cx="149" cy="103.7" r="1.5" fill="var(--green)" />
+        <circle cx="40" cy="78" r="1.5" fill="var(--red)" />
+        <circle cx="18.5" cy="95.5" r="1.5" fill="var(--red)" />
         <path
             d="M18 96L40.1498 77.8824L61.6667 74L83.8164 70.7647H105.333H127.483L149 63"
-            stroke="#DD4E47"
+            stroke="var(--red)"
             strokeWidth="1.2"
         />
-        <path d="M18 107H40.2115L61.7885 92.28L84 91L105.577 103.8H127.154H150" stroke="#4496AA" strokeWidth="1.2" />
+        <path
+            d="M18 107H40.2115L61.7885 92.28L84 91L105.577 103.8H127.154H150"
+            stroke="var(--green)"
+            strokeWidth="1.2"
+        />
         <path
             d="M18 93L40.1498 89.1553L61.6667 76.9806L83.8164 78.9029L105.966 68.0097L127.483 54.5534L149 27"
-            stroke="#3C7ED0"
+            stroke="var(--blue)"
             strokeWidth="1.2"
         />
-        <circle cx="17.5" cy="93" r="1.5" fill="#3C7ED0" />
-        <circle cx="40" cy="89" r="1.5" fill="#3C7ED0" />
-        <circle cx="61.5" cy="77" r="1.5" fill="#3C7ED0" />
-        <circle cx="83.5" cy="79" r="1.5" fill="#3C7ED0" />
-        <circle cx="106.5" cy="67.5" r="1.5" fill="#3C7ED0" />
-        <circle cx="127.5" cy="54.5" r="1.5" fill="#3C7ED0" />
-        <circle cx="148.5" cy="27.5" r="1.5" fill="#3C7ED0" />
-        <circle cx="127.5" cy="70.5" r="1.5" fill="#DD4E47" />
-        <circle cx="106.5" cy="71" r="1.5" fill="#DD4E47" />
-        <circle cx="148.5" cy="63" r="1.5" fill="#DD4E47" />
-        <circle cx="83.5" cy="71" r="1.5" fill="#DD4E47" />
+        <circle cx="17.5" cy="93" r="1.5" fill="var(--blue)" />
+        <circle cx="40" cy="89" r="1.5" fill="var(--blue)" />
+        <circle cx="61.5" cy="77" r="1.5" fill="var(--blue)" />
+        <circle cx="83.5" cy="79" r="1.5" fill="var(--blue)" />
+        <circle cx="106.5" cy="67.5" r="1.5" fill="var(--blue)" />
+        <circle cx="127.5" cy="54.5" r="1.5" fill="var(--blue)" />
+        <circle cx="148.5" cy="27.5" r="1.5" fill="var(--blue)" />
+        <circle cx="127.5" cy="70.5" r="1.5" fill="var(--red)" />
+        <circle cx="106.5" cy="71" r="1.5" fill="var(--red)" />
+        <circle cx="148.5" cy="63" r="1.5" fill="var(--red)" />
+        <circle cx="83.5" cy="71" r="1.5" fill="var(--red)" />
     </svg>
 )
 
@@ -75,52 +79,60 @@ export const FourLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElement
         <rect x="16" y="91" width="137" height="1" />
         <rect x="16" y="114" width="137" height="1" />
         <rect x="23" y="132.5" width="15" height="1" />
-        <circle cx="18" cy="133" r="2" fill="#E77334" />
+        <circle cx="18" cy="133" r="2" fill="var(--orange)" />
         <rect x="57" y="132.5" width="15" height="1" />
-        <circle cx="52" cy="133" r="2" fill="#C5436C" />
+        <circle cx="52" cy="133" r="2" fill="var(--pink)" />
         <rect x="89" y="132.5" width="15" height="1" />
-        <circle cx="84" cy="133" r="2" fill="#4865E3" />
+        <circle cx="84" cy="133" r="2" fill="var(--dark-blue)" />
         <rect x="123" y="132.5" width="15" height="1" />
-        <circle cx="118" cy="133" r="2" fill="#4BA37B" />
-        <circle cx="17.5" cy="45.5" r="1.5" fill="#C5436C" />
-        <circle cx="40" cy="45.5" r="1.5" fill="#C5436C" />
-        <circle cx="61" cy="85" r="1.5" fill="#C5436C" />
-        <circle cx="84" cy="91" r="1.5" fill="#C5436C" />
-        <circle cx="105" cy="91" r="1.5" fill="#C5436C" />
-        <circle cx="126.5" cy="80.7" r="1.5" fill="#C5436C" />
-        <circle cx="149" cy="80.7" r="1.5" fill="#C5436C" />
-        <circle cx="39.5" cy="91.5" r="1.5" fill="#4865E3" />
-        <circle cx="17.5" cy="113.5" r="1.5" fill="#4865E3" />
-        <circle cx="17.5" cy="100.5" r="1.5" fill="#4BA37B" />
-        <circle cx="41.5" cy="100.5" r="1.5" fill="#4BA37B" />
-        <circle cx="62" cy="114.5" r="1.5" fill="#4BA37B" />
-        <circle cx="85" cy="105" r="1.5" fill="#4BA37B" />
-        <circle cx="106.5" cy="104.5" r="1.5" fill="#4BA37B" />
-        <circle cx="127" cy="68" r="1.5" fill="#4BA37B" />
-        <circle cx="150.5" cy="68" r="1.5" fill="#4BA37B" />
+        <circle cx="118" cy="133" r="2" fill="var(--light-green)" />
+        <circle cx="17.5" cy="45.5" r="1.5" fill="var(--pink)" />
+        <circle cx="40" cy="45.5" r="1.5" fill="var(--pink)" />
+        <circle cx="61" cy="85" r="1.5" fill="var(--pink)" />
+        <circle cx="84" cy="91" r="1.5" fill="var(--pink)" />
+        <circle cx="105" cy="91" r="1.5" fill="var(--pink)" />
+        <circle cx="126.5" cy="80.7" r="1.5" fill="var(--pink)" />
+        <circle cx="149" cy="80.7" r="1.5" fill="var(--pink)" />
+        <circle cx="39.5" cy="91.5" r="1.5" fill="var(--dark-blue)" />
+        <circle cx="17.5" cy="113.5" r="1.5" fill="var(--dark-blue)" />
+        <circle cx="17.5" cy="100.5" r="1.5" fill="var(--light-green)" />
+        <circle cx="41.5" cy="100.5" r="1.5" fill="var(--light-green)" />
+        <circle cx="62" cy="114.5" r="1.5" fill="var(--light-green)" />
+        <circle cx="85" cy="105" r="1.5" fill="var(--light-green)" />
+        <circle cx="106.5" cy="104.5" r="1.5" fill="var(--light-green)" />
+        <circle cx="127" cy="68" r="1.5" fill="var(--light-green)" />
+        <circle cx="150.5" cy="68" r="1.5" fill="var(--light-green)" />
         <path
             d="M16.5 114.5L39.5 91.5H61.5L83.8164 70.7647H105.333L128 45.5H150.5"
-            stroke="#4865E3"
+            stroke="var(--dark-blue)"
             strokeWidth="1.2"
         />
-        <path d="M17 45.5H40.2115L61 85.5L84 91H105.577L126 81H149.5" stroke="#C5436C" strokeWidth="1.2" />
-        <path d="M18 100.5H41.2115L62 114.5L85 105H106.577L127 68H150.5" stroke="#4BA37B" strokeWidth="1.2" />
-        <path d="M18 93L39 23.5L61.6667 46.5H83.8164L102 23.5H126.5L151.5 46.5" stroke="#E77334" strokeWidth="1.2" />
-        <circle cx="17.5" cy="93" r="1.5" fill="#E77334" />
-        <circle cx="39" cy="23.5" r="1.5" fill="#E77334" />
-        <circle cx="61.5" cy="46.5" r="1.5" fill="#E77334" />
-        <circle cx="83.5" cy="46.5" r="1.5" fill="#E77334" />
-        <circle cx="101.5" cy="24" r="1.5" fill="#E77334" />
-        <circle cx="126.5" cy="23.5" r="1.5" fill="#E77334" />
-        <circle cx="150.5" cy="45.5" r="1.5" fill="#E77334" />
-        <circle cx="128" cy="45.5" r="1.5" fill="#4865E3" />
-        <circle cx="105.5" cy="70.5" r="1.5" fill="#4865E3" />
-        <circle cx="83.5" cy="71" r="1.5" fill="#4865E3" />
-        <circle cx="61" cy="91.5" r="1.5" fill="#4865E3" />
+        <path d="M17 45.5H40.2115L61 85.5L84 91H105.577L126 81H149.5" stroke="var(--pink)" strokeWidth="1.2" />
+        <path
+            d="M18 100.5H41.2115L62 114.5L85 105H106.577L127 68H150.5"
+            stroke="var(--light-green)"
+            strokeWidth="1.2"
+        />
+        <path
+            d="M18 93L39 23.5L61.6667 46.5H83.8164L102 23.5H126.5L151.5 46.5"
+            stroke="var(--orange)"
+            strokeWidth="1.2"
+        />
+        <circle cx="17.5" cy="93" r="1.5" fill="var(--orange)" />
+        <circle cx="39" cy="23.5" r="1.5" fill="var(--orange)" />
+        <circle cx="61.5" cy="46.5" r="1.5" fill="var(--orange)" />
+        <circle cx="83.5" cy="46.5" r="1.5" fill="var(--orange)" />
+        <circle cx="101.5" cy="24" r="1.5" fill="var(--orange)" />
+        <circle cx="126.5" cy="23.5" r="1.5" fill="var(--orange)" />
+        <circle cx="150.5" cy="45.5" r="1.5" fill="var(--orange)" />
+        <circle cx="128" cy="45.5" r="1.5" fill="var(--dark-blue)" />
+        <circle cx="105.5" cy="70.5" r="1.5" fill="var(--dark-blue)" />
+        <circle cx="83.5" cy="71" r="1.5" fill="var(--dark-blue)" />
+        <circle cx="61" cy="91.5" r="1.5" fill="var(--dark-blue)" />
     </svg>
 )
 
-export const TwoLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
+export const PieChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
     <svg
         width="169"
         height="158"
@@ -136,32 +148,28 @@ export const TwoLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>
         <rect x="16" y="91" width="137" height="1" />
         <rect x="16" y="114" width="137" height="1" />
         <rect x="23" y="132.5" width="15" height="1" />
-        <circle cx="18" cy="133" r="2" fill="#4496AA" />
+        <circle cx="18" cy="133" r="2" fill="var(--orange)" />
         <rect x="57" y="132.5" width="15" height="1" />
-        <circle cx="52" cy="133" r="2" fill="#3C7ED0" />
-        <circle cx="17.5" cy="85" r="1.5" fill="#4496AA" />
-        <circle cx="40" cy="84" r="1.5" fill="#4496AA" />
-        <circle cx="61.5" cy="72.5" r="1.5" fill="#4496AA" />
-        <circle cx="84" cy="67" r="1.5" fill="#4496AA" />
-        <circle cx="106" cy="50" r="1.5" fill="#4496AA" />
-        <circle cx="127.5" cy="31.7" r="1.5" fill="#4496AA" />
-        <circle cx="151" cy="113.7" r="1.5" fill="#3C7ED0" />
+        <circle cx="52" cy="133" r="2" fill="var(--pink)" />
+        <rect x="89" y="132.5" width="15" height="1" />
+        <circle cx="84" cy="133" r="2" fill="var(--dark-blue)" />
+        <rect x="123" y="132.5" width="15" height="1" />
+        <circle cx="118" cy="133" r="2" fill="var(--light-green)" />
+        <circle cx="84" cy="69" r="42" fill="var(--light-green)" stroke="var(--body-bg)" />
         <path
-            d="M18 85L40.2115 84L61.7885 72.28L84 67L105.577 50.8L127.154 31.8L150 22.8"
-            stroke="#4496AA"
-            strokeWidth="1.2"
+            d="M47.6269 48C43.9407 54.3848 42 61.6274 42 69L84 69L47.6269 48Z"
+            fill="var(--dark-blue)"
+            stroke="var(--body-bg)"
         />
         <path
-            d="M18 93L40.1498 96.1553L61.6667 104.981L83.8164 104.903L105.966 114.01L127.483 110.553L151 114"
-            stroke="#3C7ED0"
-            strokeWidth="1.2"
+            d="M84 27C89.5155 27 94.977 28.0864 100.073 30.1971C105.168 32.3078 109.798 35.4015 113.698 39.3015C117.599 43.2016 120.692 47.8316 122.803 52.9273C124.914 58.023 126 63.4845 126 69C126 74.5155 124.914 79.977 122.803 85.0727C120.692 90.1684 117.599 94.7984 113.698 98.6985C109.798 102.599 105.168 105.692 100.073 107.803C94.977 109.914 89.5155 111 84 111L84 69L84 27Z"
+            fill="var(--orange)"
+            stroke="var(--body-bg)"
         />
-        <circle cx="17.5" cy="93" r="1.5" fill="#3C7ED0" />
-        <circle cx="40" cy="96" r="1.5" fill="#3C7ED0" />
-        <circle cx="61.5" cy="105" r="1.5" fill="#3C7ED0" />
-        <circle cx="83.5" cy="105" r="1.5" fill="#3C7ED0" />
-        <circle cx="106" cy="114" r="1.5" fill="#3C7ED0" />
-        <circle cx="127.5" cy="110.5" r="1.5" fill="#3C7ED0" />
-        <circle cx="149.5" cy="23" r="1.5" fill="#4496AA" />
+        <path
+            d="M84 111C78.4845 111 73.023 109.914 67.9273 107.803C62.8316 105.692 58.2016 102.599 54.3015 98.6985C50.4014 94.7984 47.3078 90.1684 45.1971 85.0727C43.0864 79.977 42 74.5155 42 69L84 69L84 111Z"
+            fill="var(--pink)"
+            stroke="var(--body-bg)"
+        />
     </svg>
 )

--- a/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
+++ b/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
@@ -1,0 +1,167 @@
+import classname from 'classnames'
+import React from 'react'
+
+import styles from './MediaCharts.module.scss'
+
+export const ThreeLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
+    <svg
+        width="169"
+        height="158"
+        viewBox="0 0 169 158"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}
+        className={classname(styles.chart, props.className)}
+    >
+        <circle cx="60.5" cy="74" r="1.5" />
+        <rect x="16" y="45" width="137" height="1" />
+        <rect x="16" y="22" width="137" height="1" />
+        <rect x="16" y="68" width="137" height="1" />
+        <rect x="16" y="91" width="137" height="1" />
+        <rect x="16" y="114" width="137" height="1" />
+        <rect x="23" y="132.5" width="15" height="1" />
+        <circle cx="18" cy="133" r="2" fill="#DD4E47" />
+        <rect x="57" y="132.5" width="15" height="1" />
+        <circle cx="52" cy="133" r="2" fill="#3C7ED0" />
+        <rect x="91" y="132.5" width="15" height="1" />
+        <circle cx="86" cy="133" r="2" fill="#4496AA" />
+        <circle cx="17.5" cy="107" r="1.5" fill="#4496AA" />
+        <circle cx="40" cy="107" r="1.5" fill="#4496AA" />
+        <circle cx="61" cy="92.5" r="1.5" fill="#4496AA" />
+        <circle cx="84" cy="91" r="1.5" fill="#4496AA" />
+        <circle cx="105" cy="103.5" r="1.5" fill="#4496AA" />
+        <circle cx="127.5" cy="103.7" r="1.5" fill="#4496AA" />
+        <circle cx="149" cy="103.7" r="1.5" fill="#4496AA" />
+        <circle cx="40" cy="78" r="1.5" fill="#DD4E47" />
+        <circle cx="18.5" cy="95.5" r="1.5" fill="#DD4E47" />
+        <path
+            d="M18 96L40.1498 77.8824L61.6667 74L83.8164 70.7647H105.333H127.483L149 63"
+            stroke="#DD4E47"
+            strokeWidth="1.2"
+        />
+        <path d="M18 107H40.2115L61.7885 92.28L84 91L105.577 103.8H127.154H150" stroke="#4496AA" strokeWidth="1.2" />
+        <path
+            d="M18 93L40.1498 89.1553L61.6667 76.9806L83.8164 78.9029L105.966 68.0097L127.483 54.5534L149 27"
+            stroke="#3C7ED0"
+            strokeWidth="1.2"
+        />
+        <circle cx="17.5" cy="93" r="1.5" fill="#3C7ED0" />
+        <circle cx="40" cy="89" r="1.5" fill="#3C7ED0" />
+        <circle cx="61.5" cy="77" r="1.5" fill="#3C7ED0" />
+        <circle cx="83.5" cy="79" r="1.5" fill="#3C7ED0" />
+        <circle cx="106.5" cy="67.5" r="1.5" fill="#3C7ED0" />
+        <circle cx="127.5" cy="54.5" r="1.5" fill="#3C7ED0" />
+        <circle cx="148.5" cy="27.5" r="1.5" fill="#3C7ED0" />
+        <circle cx="127.5" cy="70.5" r="1.5" fill="#DD4E47" />
+        <circle cx="106.5" cy="71" r="1.5" fill="#DD4E47" />
+        <circle cx="148.5" cy="63" r="1.5" fill="#DD4E47" />
+        <circle cx="83.5" cy="71" r="1.5" fill="#DD4E47" />
+    </svg>
+)
+
+export const FourLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
+    <svg
+        width="169"
+        height="158"
+        viewBox="0 0 169 158"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}
+        className={classname(styles.chart, props.className)}
+    >
+        <rect x="16" y="45" width="137" height="1" />
+        <rect x="16" y="22" width="137" height="1" />
+        <rect x="16" y="68" width="137" height="1" />
+        <rect x="16" y="91" width="137" height="1" />
+        <rect x="16" y="114" width="137" height="1" />
+        <rect x="23" y="132.5" width="15" height="1" />
+        <circle cx="18" cy="133" r="2" fill="#E77334" />
+        <rect x="57" y="132.5" width="15" height="1" />
+        <circle cx="52" cy="133" r="2" fill="#C5436C" />
+        <rect x="89" y="132.5" width="15" height="1" />
+        <circle cx="84" cy="133" r="2" fill="#4865E3" />
+        <rect x="123" y="132.5" width="15" height="1" />
+        <circle cx="118" cy="133" r="2" fill="#4BA37B" />
+        <circle cx="17.5" cy="45.5" r="1.5" fill="#C5436C" />
+        <circle cx="40" cy="45.5" r="1.5" fill="#C5436C" />
+        <circle cx="61" cy="85" r="1.5" fill="#C5436C" />
+        <circle cx="84" cy="91" r="1.5" fill="#C5436C" />
+        <circle cx="105" cy="91" r="1.5" fill="#C5436C" />
+        <circle cx="126.5" cy="80.7" r="1.5" fill="#C5436C" />
+        <circle cx="149" cy="80.7" r="1.5" fill="#C5436C" />
+        <circle cx="39.5" cy="91.5" r="1.5" fill="#4865E3" />
+        <circle cx="17.5" cy="113.5" r="1.5" fill="#4865E3" />
+        <circle cx="17.5" cy="100.5" r="1.5" fill="#4BA37B" />
+        <circle cx="41.5" cy="100.5" r="1.5" fill="#4BA37B" />
+        <circle cx="62" cy="114.5" r="1.5" fill="#4BA37B" />
+        <circle cx="85" cy="105" r="1.5" fill="#4BA37B" />
+        <circle cx="106.5" cy="104.5" r="1.5" fill="#4BA37B" />
+        <circle cx="127" cy="68" r="1.5" fill="#4BA37B" />
+        <circle cx="150.5" cy="68" r="1.5" fill="#4BA37B" />
+        <path
+            d="M16.5 114.5L39.5 91.5H61.5L83.8164 70.7647H105.333L128 45.5H150.5"
+            stroke="#4865E3"
+            strokeWidth="1.2"
+        />
+        <path d="M17 45.5H40.2115L61 85.5L84 91H105.577L126 81H149.5" stroke="#C5436C" strokeWidth="1.2" />
+        <path d="M18 100.5H41.2115L62 114.5L85 105H106.577L127 68H150.5" stroke="#4BA37B" strokeWidth="1.2" />
+        <path d="M18 93L39 23.5L61.6667 46.5H83.8164L102 23.5H126.5L151.5 46.5" stroke="#E77334" strokeWidth="1.2" />
+        <circle cx="17.5" cy="93" r="1.5" fill="#E77334" />
+        <circle cx="39" cy="23.5" r="1.5" fill="#E77334" />
+        <circle cx="61.5" cy="46.5" r="1.5" fill="#E77334" />
+        <circle cx="83.5" cy="46.5" r="1.5" fill="#E77334" />
+        <circle cx="101.5" cy="24" r="1.5" fill="#E77334" />
+        <circle cx="126.5" cy="23.5" r="1.5" fill="#E77334" />
+        <circle cx="150.5" cy="45.5" r="1.5" fill="#E77334" />
+        <circle cx="128" cy="45.5" r="1.5" fill="#4865E3" />
+        <circle cx="105.5" cy="70.5" r="1.5" fill="#4865E3" />
+        <circle cx="83.5" cy="71" r="1.5" fill="#4865E3" />
+        <circle cx="61" cy="91.5" r="1.5" fill="#4865E3" />
+    </svg>
+)
+
+export const TwoLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
+    <svg
+        width="169"
+        height="158"
+        viewBox="0 0 169 158"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}
+        className={classname(styles.chart, props.className)}
+    >
+        <rect x="16" y="45" width="137" height="1" />
+        <rect x="16" y="22" width="137" height="1" />
+        <rect x="16" y="68" width="137" height="1" />
+        <rect x="16" y="91" width="137" height="1" />
+        <rect x="16" y="114" width="137" height="1" />
+        <rect x="23" y="132.5" width="15" height="1" />
+        <circle cx="18" cy="133" r="2" fill="#4496AA" />
+        <rect x="57" y="132.5" width="15" height="1" />
+        <circle cx="52" cy="133" r="2" fill="#3C7ED0" />
+        <circle cx="17.5" cy="85" r="1.5" fill="#4496AA" />
+        <circle cx="40" cy="84" r="1.5" fill="#4496AA" />
+        <circle cx="61.5" cy="72.5" r="1.5" fill="#4496AA" />
+        <circle cx="84" cy="67" r="1.5" fill="#4496AA" />
+        <circle cx="106" cy="50" r="1.5" fill="#4496AA" />
+        <circle cx="127.5" cy="31.7" r="1.5" fill="#4496AA" />
+        <circle cx="151" cy="113.7" r="1.5" fill="#3C7ED0" />
+        <path
+            d="M18 85L40.2115 84L61.7885 72.28L84 67L105.577 50.8L127.154 31.8L150 22.8"
+            stroke="#4496AA"
+            strokeWidth="1.2"
+        />
+        <path
+            d="M18 93L40.1498 96.1553L61.6667 104.981L83.8164 104.903L105.966 114.01L127.483 110.553L151 114"
+            stroke="#3C7ED0"
+            strokeWidth="1.2"
+        />
+        <circle cx="17.5" cy="93" r="1.5" fill="#3C7ED0" />
+        <circle cx="40" cy="96" r="1.5" fill="#3C7ED0" />
+        <circle cx="61.5" cy="105" r="1.5" fill="#3C7ED0" />
+        <circle cx="83.5" cy="105" r="1.5" fill="#3C7ED0" />
+        <circle cx="106" cy="114" r="1.5" fill="#3C7ED0" />
+        <circle cx="127.5" cy="110.5" r="1.5" fill="#3C7ED0" />
+        <circle cx="149.5" cy="23" r="1.5" fill="#4496AA" />
+    </svg>
+)

--- a/client/web/src/insights/utils/is-code-insights-enabled.ts
+++ b/client/web/src/insights/utils/is-code-insights-enabled.ts
@@ -30,7 +30,7 @@ export function isCodeInsightsEnabled(
     const viewsKeys = Object.keys(views) as (keyof CodeInsightsDisplayLocation)[]
     const experimentalFeatures: SettingsExperimentalFeatures = final?.experimentalFeatures ?? {}
 
-    if (!experimentalFeatures.codeInsights) {
+    if (experimentalFeatures.codeInsights === false) {
         return false
     }
 

--- a/client/web/src/integration/insights/utils/override-insights-graphql.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql.ts
@@ -48,6 +48,11 @@ export function overrideGraphQLExtensions(props: OverrideGraphQLExtensionsProps)
 
     testContext.overrideGraphQL({
         ...commonWebGraphQlResults,
+        // Mock temporary settings cause code insights beta modal UI relies on this handler to show/hide
+        // modal UI on all code insights related pages.
+        GetTemporarySettings: () => ({
+            temporarySettings: { contents: JSON.stringify({ 'insights.freeBetaAccepted': true }) },
+        }),
         Insights: () => ({ insights: { nodes: [] } }),
         CurrentAuthState: () => ({
             currentUser: {

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -31,6 +31,7 @@ import { CodeMonitoringProps } from '../code-monitoring'
 import { CodeMonitoringLogo } from '../code-monitoring/CodeMonitoringLogo'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { CodeInsightsProps } from '../insights/types'
+import { isCodeInsightsEnabled } from '../insights/utils/is-code-insights-enabled'
 import {
     KeyboardShortcutsProps,
     KEYBOARD_SHORTCUT_SHOW_COMMAND_PALETTE,
@@ -182,11 +183,9 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         props.showSearchContext,
     ])
 
-    const settings = !isErrorLike(props.settingsCascade.final) ? props.settingsCascade.final : null
-    const codeInsights =
-        codeInsightsEnabled &&
-        settings?.experimentalFeatures?.codeInsights &&
-        settings?.['insights.displayLocation.insightsPage'] !== false
+    // CodeInsightsEnabled props controls insights appearance over OSS and Enterprise version
+    // isCodeInsightsEnabled selector controls appearance based on user settings flags
+    const codeInsights = codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)
 
     const searchNavBar = (
         <SearchNavbarItem

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -185,7 +185,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
 
     // CodeInsightsEnabled props controls insights appearance over OSS and Enterprise version
     // isCodeInsightsEnabled selector controls appearance based on user settings flags
-    const codeInsights = codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)
+    const codeInsights = props.authenticatedUser && codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)
 
     const searchNavBar = (
         <SearchNavbarItem

--- a/client/web/src/search/home/LoggedOutHomepage.module.scss
+++ b/client/web/src/search/home/LoggedOutHomepage.module.scss
@@ -14,12 +14,10 @@
 
     :global(.theme-light) & {
         --homepage-card-color: var(--color-bg-1);
-        --marketing-gradient: linear-gradient(90.64deg, #e4d3fc 3.11%, #d7f0fd 83.64%);
     }
 
     :global(.theme-dark) & {
         --homepage-card-color: var(--color-bg-2);
-        --marketing-gradient: linear-gradient(90.64deg, rgba(108, 8, 223, 0.5) 3.11%, rgba(0, 165, 213, 0.5) 83.64%);
     }
 
     --home-marketing-drop: 0 4px 16px -6px rgba(46, 34, 119, 0.1);

--- a/client/web/src/settings/temporary/TemporarySettings.ts
+++ b/client/web/src/settings/temporary/TemporarySettings.ts
@@ -8,7 +8,7 @@ import { SectionID } from '../../search/results/sidebar/SearchSidebar'
 export interface TemporarySettingsSchema {
     'search.collapsedSidebarSections': { [key in SectionID]?: boolean }
     'search.sidebar.revisions.tab': number
-    'insights.acceptFreeBeta': boolean
+    'insights.freeBetaAccepted': boolean
 }
 
 /**

--- a/client/web/src/settings/temporary/TemporarySettings.ts
+++ b/client/web/src/settings/temporary/TemporarySettings.ts
@@ -8,6 +8,7 @@ import { SectionID } from '../../search/results/sidebar/SearchSidebar'
 export interface TemporarySettingsSchema {
     'search.collapsedSidebarSections': { [key in SectionID]?: boolean }
     'search.sidebar.revisions.tab': number
+    'insights.acceptFreeBeta': boolean
 }
 
 /**

--- a/client/web/src/settings/temporary/TemporarySettingsStorage.ts
+++ b/client/web/src/settings/temporary/TemporarySettingsStorage.ts
@@ -190,3 +190,17 @@ class ServersideSettingsBackend implements SettingsBackend {
         return of()
     }
 }
+
+/**
+ * Static in memory setting backend for testing purposes
+ */
+export class InMemoryMockSettingsBackend implements SettingsBackend {
+    constructor(private settings: TemporarySettings) {}
+    public load(): Observable<TemporarySettings> {
+        return of(this.settings)
+    }
+    public save(settings: TemporarySettings): Observable<void> {
+        this.settings = settings
+        return of()
+    }
+}

--- a/client/web/src/settings/temporary/useTemporarySetting.test.tsx
+++ b/client/web/src/settings/temporary/useTemporarySetting.test.tsx
@@ -2,25 +2,12 @@ import { gql } from '@apollo/client'
 import { createMockClient } from '@apollo/client/testing'
 import { renderHook, act } from '@testing-library/react-hooks'
 import React from 'react'
-import { Observable, of } from 'rxjs'
 
-import { TemporarySettings } from './TemporarySettings'
 import { TemporarySettingsContext } from './TemporarySettingsProvider'
-import { SettingsBackend, TemporarySettingsStorage } from './TemporarySettingsStorage'
+import { InMemoryMockSettingsBackend, TemporarySettingsStorage } from './TemporarySettingsStorage'
 import { useTemporarySetting } from './useTemporarySetting'
 
 describe('useTemporarySetting', () => {
-    class InMemoryMockSettingsBackend implements SettingsBackend {
-        constructor(private settings: TemporarySettings) {}
-        public load(): Observable<TemporarySettings> {
-            return of(this.settings)
-        }
-        public save(settings: TemporarySettings): Observable<void> {
-            this.settings = settings
-            return of()
-        }
-    }
-
     const mockClient = createMockClient(
         null,
         gql`


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/24298, https://github.com/sourcegraph/sourcegraph/issues/24538

### Context 

This PR adds a modal UI for the code insights pages. This modal appears for all users but only once if users accepted Free Beta rules by clicking the `Understood, let's try` button. Maybe later button always leads to the homepage. 

<table>
<tr><th>Light mode</th><th>Dark Mode</th></tr>
<tr>
<td>
<img width="538" alt="Screenshot 2021-09-14 at 20 19 36" src="https://user-images.githubusercontent.com/18492575/133304694-e65c0ff8-b065-499a-a8af-273fcec5b6c8.png">

</td>
<td>
<img width="535" alt="Screenshot 2021-09-14 at 20 19 48" src="https://user-images.githubusercontent.com/18492575/133304703-d12a9132-b380-4d81-919d-90142c5eb707.png">

</td>
</tr>
</table>

Also, this PR turns on by default the code insights functionality. With that PR change, you can disable code insights by setting 
```
"experimentalFeatures": {
 "codeInsights": false
}
```


### Tech details
Information to show/hide this modal UI is stored by Temporary Settings. This PR also introduces a new field in temporary settings for this code insights modal case `insights.acceptFreeBeta`.

### How to test
**- Code Insights Free beta modal UI**
1. Go to any code insights-related page. 
2. You should see this free beta modal UI
3. Maybe a later button should lead you to the homepage.
4. If you go back to any insights-related page you should see modal UI.
5. After click on the `Understood, let's try` button you should see no modal. Even if you reload the page or log in through a different browser. 

**- Code insights feature flag** 
1. Go to sourcegraph.com homepage as a logout user. See that no code insights things have appeared (insights navbar item, create insights button on the search page, All insights specific routes such as /insights, insights/dashboard/all are disabled)
2. Go to sourcegraph.com a sign-in user and see the insights nav bar, insights pages, insight creation UI, create insights button on the search page.
3. Turn off code insights by `"codeInsights": false` in the `experimentalFeatures` section. 
4. See no insights specific navbar, pages, buttons on the search page.

### Before merging this PR
- Check the latest copy for this modal here https://docs.google.com/document/d/1VaC3XN2K-cNiBKdJ_pSH61Mye6yozXhzhi5wP9ACShQ/edit# and change if needed
- Test modal UI appearance based on tests cases below from Joel and above about feature flag. 
- Update feedback link based on this PR https://github.com/sourcegraph/sourcegraph/pull/24979#pullrequestreview-755275161
