### PR TITLE
Add pricing note to topline docs page directly

### DIFF
--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -2,7 +2,7 @@
 Code Insights are the analytics tool that tells you things about your codebase at a high level based on how your code changes over time.
 
 Code Insights are based on our universal code search, making them incredibly accurate and extremely configurable. Track anything that can be expressed with Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories.
-> NOTE: While in Beta, Code Insights is free for enterprise customers. Once Code Insights is generally available and no sooner than January 1, 2022, it may cost an additional amount. 
+> NOTE: While in Beta, Code Insights is free for enterprise customers. Once Code Insights is generally available and no sooner than January 1, 2022, to continue using Code Insights may require a separate paid plan.
 
 Code Insights are currently in Private [Beta](../admin/beta_and_experimental_features.md). If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).
 

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,7 +1,7 @@
 # Code Insights <a href="../admin/beta_and_experimental_features"><sup><span class="badge badge-beta">Beta</span></sup></a>
 Code Insights tells you things about your codebase at a high level, based on both how your code changes over time and its current state.
 
-Code Insights are based on our universal code search, making them incredibly accurate and extremely configurable. Track anything that can be expressed with Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories.
+Code Insights is based on our universal code search, making it incredibly precise and extremely configurable. Track anything that can be expressed with Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories.
 > NOTE: While in Beta, Code Insights is free for enterprise customers. Once Code Insights is generally available and no sooner than January 1, 2022, to continue using Code Insights may require a separate paid plan.
 
 Code Insights are currently in Private [Beta](../admin/beta_and_experimental_features.md). If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,5 +1,7 @@
 # Code Insights <a href="../admin/beta_and_experimental_features"><sup><span class="badge badge-beta">Beta</span></sup></a>
+Code Insights are the analytics tool that tells you things about your codebase at a high level based on how your code changes over time.
 
+Code Insights are based on our universal code search, making them incredibly accurate and extremely configurable. Track anything that can be expressed with Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories.
 > NOTE: While in Beta, Code Insights is free for enterprise customers. Once Code Insights is generally available and no sooner than January 1, 2022, it may cost an additional amount. 
 
 Code Insights are currently in Private [Beta](../admin/beta_and_experimental_features.md). If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,5 +1,5 @@
 # Code Insights <a href="../admin/beta_and_experimental_features"><sup><span class="badge badge-beta">Beta</span></sup></a>
-Code Insights are the analytics tool that tells you things about your codebase at a high level based on how your code changes over time.
+Code Insights tells you things about your codebase at a high level, based on both how your code changes over time and its current state.
 
 Code Insights are based on our universal code search, making them incredibly accurate and extremely configurable. Track anything that can be expressed with Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories.
 > NOTE: While in Beta, Code Insights is free for enterprise customers. Once Code Insights is generally available and no sooner than January 1, 2022, to continue using Code Insights may require a separate paid plan.

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,10 +1,10 @@
 # Code Insights <a href="../admin/beta_and_experimental_features"><sup><span class="badge badge-beta">Beta</span></sup></a>
 
-Code Insights are currently in Private [Beta](../admin/beta_and_experimental_features.md).
+> NOTE: While in Beta, Code Insights is free for enterprise customers. Once Code Insights is generally available and no sooner than January 1, 2022, it may cost an additional amount. 
 
-If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).
+Code Insights are currently in Private [Beta](../admin/beta_and_experimental_features.md). If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).
 
-> NOTE: Code insights docs are actively in progress.
+Code insights docs are actively in progress during the beta.
 
 Table of contents:
 

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -7,7 +7,7 @@ Code Insights are based on our universal code search, making them incredibly acc
 Code Insights are currently in Private [Beta](../admin/beta_and_experimental_features.md). If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).
 
 Code insights docs are actively in progress during the beta.
-It means that we're still polishing Insights and you might find bugs while we’re in beta. Please, do [share any bugs 🐛 or feedback](mailto:feedback@sourcegraph.com) to help us make Code Insights better.
+We're still polishing Code Insights and you might find bugs while we’re in beta. Please [share any bugs 🐛 or feedback](mailto:feedback@sourcegraph.com) you have to help us make Code Insights better.
 Table of contents:
 
 - [Quickstart](quickstart.md)

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -7,7 +7,7 @@ Code Insights are based on our universal code search, making them incredibly acc
 Code Insights are currently in Private [Beta](../admin/beta_and_experimental_features.md). If you're a customer who wants early access or needs support, please [send us an email](mailto:feedback@sourcegraph.com).
 
 Code insights docs are actively in progress during the beta.
-
+It means that we're still polishing Insights and you might find bugs while we’re in beta. Please, do [share any bugs 🐛 or feedback](mailto:feedback@sourcegraph.com) to help us make Code Insights better.
 Table of contents:
 
 - [Quickstart](quickstart.md)


### PR DESCRIPTION
This was already on the linked page but moving it up for visibility

