### PR TITLE
Remove unnecessary and misleading link to image diagram

### DIFF
--- a/doc/admin/config/settings.md
+++ b/doc/admin/config/settings.md
@@ -8,10 +8,6 @@ Settings can be set at the global level (by site admins), the organization level
   <object data="settings-cascade.svg" type="image/svg+xml" style="width:80%;"></object>
 </div>
 
-<div class="text-center small">
-  Non-sighted users can view a <a href="settings-cascade">text-representation of this diagram.</a>
-</div>
-
 ## Editing global settings (for site admins)
 
 Global settings are found in **Site admin > Global settings** while links to organization and user settings are found in the user dropdown menu.


### PR DESCRIPTION
As referenced in [this Slack thread](https://sourcegraph.slack.com/archives/C0190QFK49X/p1631661825006400).