### PR TITLE
bump libgcrypt package

### DIFF
--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql
 
-RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r0 apk-tools=2.12.7-r0
+RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r1 apk-tools=2.12.7-r0
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \


### PR DESCRIPTION
fixes
```
#7 1.043 ERROR: unable to select packages:
#7 1.073   libgcrypt-1.8.8-r1:
#7 1.073     breaks: world[libgcrypt=1.8.8-r0]
#7 1.073     satisfies: libxslt-1.1.34-r0[so:libgcrypt.so.20]
```