### PR TITLE
no windows support for batch changes

### DIFF
--- a/doc/batch_changes/references/requirements.md
+++ b/doc/batch_changes/references/requirements.md
@@ -35,7 +35,7 @@ Batch Changes makes it possible to create changesets in tens, hundreds, or thous
 
 * Latest version of the [Sourcegraph CLI `src`](../../cli/index.md)
   * `src` is supported on Linux or Intel macOS
-  * <span class="badge badge-experimental">Experimental</span> Windows and ARM (eg. M1) macOS support are experimental
+  * <span class="badge badge-experimental">Experimental</span> ARM (eg. M1) macOS support is experimental
 * Docker
   * MacOS:
       * If using Docker 3.x, ensure your version is at least 3.0.1


### PR DESCRIPTION
Clarify windows running the src-cli to create batch changes is not supported in windows environment.
Support was previously tagged as experimental, but that was creating confusion.