### PR TITLE
Code Insights: Fix funky colors of insight data-series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed a number of issues where repository permissions sync may fail for instances with very large numbers of repositories. [#24852](https://github.com/sourcegraph/sourcegraph/pull/24852), [#24972](https://github.com/sourcegraph/sourcegraph/pull/24972)
 - Fixed excessive re-rendering of the whole web application on every keypress in the search query input. [#24844](https://github.com/sourcegraph/sourcegraph/pull/24844)
+- Code Insights line chart now supports different timelines for each data series (lines). [#25005](https://github.com/sourcegraph/sourcegraph/pull/25005)
 
 ### Removed
 

--- a/client/extension-api/src/sourcegraph.d.ts
+++ b/client/extension-api/src/sourcegraph.d.ts
@@ -787,24 +787,26 @@ declare module 'sourcegraph' {
         data: D[]
 
         /** The series (lines) of the chart. */
-        series: {
-            /** The key in each data object for the values this line should be calculated from. */
-            dataKey: keyof D
-
-            /** The name of the line shown in the legend and tooltip. */
-            name?: string
-
-            /**
-             * The link URLs for each data point.
-             * A link URL should take the user to more details about the specific data point.
-             */
-            linkURLs?: string[]
-
-            /** The CSS color of the line. */
-            stroke?: string
-        }[]
+        series: LineChartSeries<D>[]
 
         xAxis: ChartAxis<XK, D>
+    }
+
+    export interface LineChartSeries<D> {
+        /** The key in each data object for the values this line should be calculated from. */
+        dataKey: keyof D
+
+        /** The name of the line shown in the legend and tooltip. */
+        name?: string
+
+        /**
+         * The link URLs for each data point.
+         * A link URL should take the user to more details about the specific data point.
+         */
+        linkURLs?: string[]
+
+        /** The CSS color of the line. */
+        stroke?: string
     }
 
     export interface BarChartContent<D extends object, XK extends keyof D> {

--- a/client/web/src/views/components/content/view-content/chart-view-content/ChartViewContent.story.tsx
+++ b/client/web/src/views/components/content/view-content/chart-view-content/ChartViewContent.story.tsx
@@ -34,6 +34,8 @@ add('Line chart with missing data', () => (
                 { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: null, b: null },
                 { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, a: null, b: null },
                 { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 94, b: 200 },
+                { x: 1588965700286 - 1.5 * 24 * 60 * 60 * 1000, a: 134, b: null },
+                { x: 1588965700286 - 1.3 * 24 * 60 * 60 * 1000, a: null, b: 150 },
                 { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 134, b: 190 },
                 { x: 1588965700286, a: 123, b: 170 },
             ],
@@ -41,7 +43,7 @@ add('Line chart with missing data', () => (
                 {
                     dataKey: 'a',
                     name: 'A metric',
-                    stroke: 'var(--warning)',
+                    stroke: 'var(--blue)',
                     linkURLs: [
                         '#A:1st_data_point',
                         '#A:2nd_data_point',

--- a/client/web/src/views/components/content/view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/views/components/content/view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -215,7 +215,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
     const rootClasses = classnames('line-chart__content', { 'line-chart__content--with-cursor': !!hoveredDatumLink })
 
     return (
-        <div className={rootClasses} data-testid="line-chart__content">
+        <div className={classnames(rootClasses, 'percy-inactive-element')} data-testid="line-chart__content">
             {/*
                 Because XYChart wraps itself with context providers in case if consumer didn't add them
                 But this recursive wrapping leads to problem with event emitter context - double subscription all event

--- a/client/web/src/views/components/content/view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/views/components/content/view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -13,10 +13,11 @@ import { LineChartContent as LineChartContentType } from 'sourcegraph'
 
 import { DEFAULT_LINE_STROKE } from '../constants'
 import { generateAccessors } from '../helpers/generate-accessors'
+import { getProcessedChartData } from '../helpers/get-processed-chart-data'
 import { getYAxisWidth } from '../helpers/get-y-axis-width'
 import { usePointerEventEmitters } from '../helpers/use-event-emitters'
 import { useScalesConfiguration, useXScale, useYScale } from '../helpers/use-scales'
-import { onDatumZoneClick } from '../types'
+import { onDatumZoneClick, Point } from '../types'
 
 import { ActiveDatum, GlyphContent } from './GlyphContent'
 import { NonActiveBackground } from './NonActiveBackground'
@@ -97,15 +98,11 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
 
     const dynamicMargin = { ...MARGIN, left: MARGIN.left + yAxisWidth }
 
-    // In case if we've got unsorted by x (time) axis dataset we have to sort that by ourselves
-    // otherwise we will get an error in calculation of position for the tooltip
-    // Details: bisector from d3-array package expects sorted data otherwise he can't calculate
-    // right index for nearest point on the XYChart.
-    // See https://github.com/airbnb/visx/blob/master/packages/visx-xychart/src/utils/findNearestDatumSingleDimension.ts#L30
-    const sortedData = useMemo(
-        () => data.sort((firstDatum, secondDatum) => +firstDatum[xAxis.dataKey] - +secondDatum[xAxis.dataKey]),
-        [data, xAxis]
-    )
+    const { sortedData, seriesWithData } = useMemo(() => getProcessedChartData({ accessors, data, series }), [
+        data,
+        accessors,
+        series,
+    ])
 
     // state
     const [hoveredDatum, setHoveredDatum] = useState<ActiveDatum<Datum> | null>(null)
@@ -113,19 +110,14 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
 
     // callbacks
     const renderTooltip = useCallback(
-        (renderProps: RenderTooltipParams<Datum>) => (
-            <TooltipContent
-                {...renderProps}
-                accessors={accessors}
-                series={series}
-                className="line-chart__tooltip-content"
-            />
+        (renderProps: RenderTooltipParams<Point>) => (
+            <TooltipContent {...renderProps} series={seriesWithData} className="line-chart__tooltip-content" />
         ),
-        [accessors, series]
+        [seriesWithData]
     )
 
     const handlePointerMove = useCallback(
-        (event: EventHandlerParams<Datum>) => {
+        (event: EventHandlerParams<Point>) => {
             // If active point hasn't been change we shouldn't call setActiveDatum again
             if (hoveredDatum?.index === event.index && hoveredDatum?.key === event.key) {
                 return
@@ -147,7 +139,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
     )
 
     const handlePointerUp = useCallback(
-        (info: EventHandlerParams<Datum>) => {
+        (info: EventHandlerParams<Point>) => {
             info.event?.persist()
 
             // According to types from visx/xychart index can be undefined
@@ -309,7 +301,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                 fill="transparent"
                             />
 
-                            {series.map((line, index) => (
+                            {seriesWithData.map((line, index) => (
                                 <Group
                                     key={line.dataKey as string}
                                     // eslint-disable-next-line jsx-a11y/aria-role
@@ -320,12 +312,12 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                 >
                                     <LineSeries
                                         dataKey={line.dataKey as string}
-                                        data={sortedData}
+                                        data={line.data}
                                         strokeWidth={2}
                                         /* eslint-disable-next-line jsx-a11y/aria-role */
                                         role="graphics-dataline"
-                                        xAccessor={accessors.x}
-                                        yAccessor={accessors.y[line.dataKey]}
+                                        xAccessor={point => point?.x}
+                                        yAccessor={point => point?.y}
                                         stroke={getLineStroke(line)}
                                         curve={curveLinear}
                                         aria-hidden={true}
@@ -333,10 +325,10 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
 
                                     <GlyphSeries
                                         dataKey={line.dataKey as string}
-                                        data={sortedData}
+                                        data={line.data}
                                         enableEvents={false}
-                                        xAccessor={accessors.x}
-                                        yAccessor={accessors.y[line.dataKey]}
+                                        xAccessor={point => point?.x}
+                                        yAccessor={point => point?.y}
                                         // Don't have info about line in props. @visx/xychart doesn't expose this information
                                         // Move this arrow function in separate component when API of GlyphSeries will be fixed.
                                         renderGlyph={glyphProps => (
@@ -345,7 +337,6 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                                 index={glyphProps.key}
                                                 hoveredDatum={hoveredDatum}
                                                 focusedDatum={focusedDatum}
-                                                accessors={accessors}
                                                 line={line}
                                                 lineIndex={index}
                                                 totalNumberOfLines={series.length}

--- a/client/web/src/views/components/content/view-content/chart-view-content/charts/line/helpers/get-processed-chart-data.ts
+++ b/client/web/src/views/components/content/view-content/chart-view-content/charts/line/helpers/get-processed-chart-data.ts
@@ -70,6 +70,7 @@ export function getProcessedChartData<Datum extends object>(
  * Filters series data list, preserves null value at the beginning of the series data list
  * and removes null value between the points.
  *
+ * ```
  * Null value ▽   Real point ■                  Null value ▽   Real point ■
  * ┌────────────────────────────────────┐       ┌────────────────────────────────────┐
  * │░░░░░░░░░░░░░░░                     │       │░░░░░░░░░░░░░░░                     │
@@ -82,6 +83,7 @@ export function getProcessedChartData<Datum extends object>(
  * │░░░▽░░░░░░░░░░░                     │       │░░░▽░░░░░░░░░░░                     │
  * │░░░░░░░░░░░░░░░             ▽       │       │░░░░░░░░░░░░░░░                     │
  * └────────────────────────────────────┘       └────────────────────────────────────┘
+ *```
  *
  * @param data - Series data list
  */

--- a/client/web/src/views/components/content/view-content/chart-view-content/charts/line/helpers/get-processed-chart-data.ts
+++ b/client/web/src/views/components/content/view-content/chart-view-content/charts/line/helpers/get-processed-chart-data.ts
@@ -1,0 +1,78 @@
+import { LineChartSeries } from 'sourcegraph'
+
+import { Accessors, Point, LineChartSeriesWithData } from '../types'
+
+interface GetProcessedChartDataProps<Datum extends object> {
+    data: Datum[]
+
+    /**
+     * Accessors map to get (x, y) value from datum objects
+     */
+    accessors: Accessors<Datum, keyof Datum>
+
+    series: LineChartSeries<Datum>[]
+}
+
+interface ProcessedChartData<Datum extends object> {
+    /**
+     * List of processed data series data for each data series line.
+     */
+    seriesWithData: LineChartSeriesWithData<Datum>[]
+
+    sortedData: Datum[]
+}
+
+/**
+ * Processes data list (sort it) and extracts data from the datum object and merge it with
+ * series (line) data.
+ */
+export function getProcessedChartData<Datum extends object>(
+    props: GetProcessedChartDataProps<Datum>
+): ProcessedChartData<Datum> {
+    const { data, series, accessors } = props
+
+    // In case if we've got unsorted by x (time) axis dataset we have to sort that by ourselves
+    // otherwise we will get an error in calculation of position for the tooltip
+    // Details: bisector from d3-array package expects sorted data otherwise he can't calculate
+    // right index for nearest point on the XYChart.
+    // See https://github.com/airbnb/visx/blob/master/packages/visx-xychart/src/utils/findNearestDatumSingleDimension.ts#L30
+    const sortedData = data.sort((firstDatum, secondDatum) => +accessors.x(firstDatum) - +accessors.x(secondDatum))
+
+    const seriesWithData = series
+        // Separate datum object by series lines
+        .map<LineChartSeriesWithData<Datum>>(line => ({
+            ...line,
+            // Filter select series data from the datum object and process this points array
+            data: getFilteredSeriesData(
+                sortedData.map(datum => ({
+                    x: accessors.x(datum),
+                    y: accessors.y[line.dataKey](datum),
+                }))
+            ),
+        }))
+
+    return { sortedData, seriesWithData }
+}
+
+/**
+ * Filters series data list, preserves null value at the beginning of the series data list
+ * and removes null value between the points.
+ *
+ * @param data - Series data list
+ */
+function getFilteredSeriesData<Datum>(data: Point[]): Point[] {
+    const firstNonNullablePointIndex = Math.max(
+        data.findIndex(datum => datum.y !== null),
+        0
+    )
+
+    // Preserve null values at the beginning of the series data list
+    // but remove null holes between the points further.
+    const nullBeginningValues = data.slice(0, firstNonNullablePointIndex)
+    const pointsWithoutHoles = data
+        // Get values after null area
+        .slice(firstNonNullablePointIndex)
+        .filter(point => point.y !== null)
+
+    return [...nullBeginningValues, ...pointsWithoutHoles]
+}

--- a/client/web/src/views/components/content/view-content/chart-view-content/charts/line/helpers/get-processed-chart-data.ts
+++ b/client/web/src/views/components/content/view-content/chart-view-content/charts/line/helpers/get-processed-chart-data.ts
@@ -25,6 +25,18 @@ interface ProcessedChartData<Datum extends object> {
 /**
  * Processes data list (sort it) and extracts data from the datum object and merge it with
  * series (line) data.
+ *
+ * Example:
+ * ```
+ * data: [
+ *   { a: 2, b: 3, x: 2},
+ *   { a: 4, b: 5, x: 3},
+ *   { a: null, b: 6, x: 4}
+ * ] → series: [
+ *     { name: a, data: [{ y: 2, x: 2 }, { y: 4, x: 3 }],
+ *     { name: b, data: [{ y: 3, x: 2 }, { y: 5, x: 3 }, { y: 6, x: 4 }]
+ *   ]
+ * ```
  */
 export function getProcessedChartData<Datum extends object>(
     props: GetProcessedChartDataProps<Datum>
@@ -57,6 +69,19 @@ export function getProcessedChartData<Datum extends object>(
 /**
  * Filters series data list, preserves null value at the beginning of the series data list
  * and removes null value between the points.
+ *
+ * Null value ▽   Real point ■                  Null value ▽   Real point ■
+ * ┌────────────────────────────────────┐       ┌────────────────────────────────────┐
+ * │░░░░░░░░░░░░░░░                     │       │░░░░░░░░░░░░░░░                     │
+ * │░░░░░░░░░░░░░░░                     │       │░░░░░░░░░░░░░░░                     │
+ * │░░░░░░░░░░░░░░░                ■    │       │░░░░░░░░░░░░░░░                ■    │
+ * │░░░░░░░░░░░░▽░░    ■                │       │░░░░░░░░░░░░▽░░    ■                │
+ * │░░░░░░░░░░░░░░░          ▽          │──────▶│░░░░░░░░░░░░░░░                     │
+ * │░░░░░░▽░░░░░░░░ ■                   │       │░░░░░░▽░░░░░░░░ ■                   │
+ * │░░░░░░░░░░░░░░░       ■             │       │░░░░░░░░░░░░░░░       ■             │
+ * │░░░▽░░░░░░░░░░░                     │       │░░░▽░░░░░░░░░░░                     │
+ * │░░░░░░░░░░░░░░░             ▽       │       │░░░░░░░░░░░░░░░                     │
+ * └────────────────────────────────────┘       └────────────────────────────────────┘
  *
  * @param data - Series data list
  */

--- a/client/web/src/views/components/content/view-content/chart-view-content/charts/line/types.ts
+++ b/client/web/src/views/components/content/view-content/chart-view-content/charts/line/types.ts
@@ -1,6 +1,16 @@
 import { MouseEvent } from 'react'
+import { LineChartSeries } from 'sourcegraph'
 
 export type YAccessor<Datum> = (data: Datum) => any
+
+export interface LineChartSeriesWithData<Datum> extends LineChartSeries<Datum> {
+    data: Point[]
+}
+
+export interface Point {
+    x: Date | number
+    y: number | null
+}
 
 /** Accessors map for getting values for x and y axes from datum object */
 export interface Accessors<Datum, Key extends keyof Datum> {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/24683

## Context

On main at the moment we have a problem with chart when two or more points don't have values for some time-x value when other point/points have values at this x point

```
[
  { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: null, b: null },
  { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 94, b: 200 },
  // Datum below doesn't have b value but have a value  
  { x: 1588965700286 - 1.5 * 24 * 60 * 60 * 1000, a: 134, b: null },
    // Datum below doesn't have a value but have b value 
  { x: 1588965700286 - 1.3 * 24 * 60 * 60 * 1000, a: null, b: 150 },
  { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 134, b: 190 },
]
```

So because our assumption about this case was wrong in the line chart code base (initially we thought that all points will have some values at some point at the time X-axis or neither of points has that value and therefore we don't have this point on the x-axis in the datum array at all).

But it turned out that this is the case cause for BE insights it's possible to have some values for one series and doesn't have value for other series at one particular point on the x-axis. 

As a result, we have this visual behavior 

<img width="549" alt="image" src="https://user-images.githubusercontent.com/18492575/133472726-faee41a7-7f79-4920-8213-32b0a7ea6585.png">

## Solution

This Pr adds the preparation step for the line chart data (datum list) and series configs. 
We convert this data
```
[
  { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: null, b: null },
  { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 94, b: 200 },
  // Datum below doesn't have b value but have a value  
  { x: 1588965700286 - 1.5 * 24 * 60 * 60 * 1000, a: 134, b: null },
    // Datum below doesn't have a value but have b value 
  { x: 1588965700286 - 1.3 * 24 * 60 * 60 * 1000, a: null, b: 150 },
  { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 134, b: 190 },
],
series: [
 { dataKey: 'a', name: 'A metric' },
 { dataKey: 'b', name: 'B metric' },
],
```

into this
```
series: [
  { dataKey: 'a', name: 'A metric', points: [ {x, y}, {x,y} ... ] },
  { dataKey: 'b', name: 'B metric', points: [ {x, y}, {x,y} ... ] },
]
```

Each series now has its own datum list (points array) we process this array and remove null/undefined gaps between points but preserve nullish data at the beginning for the non-existent points patter (line background)
Also because in this case, not all series may have all points at some x-axis value it's possible to not have some chart value in tooltip info. See screenshots below

<table>
 <tr><th>With a and b series values</th><th>With one series missing value</th></tr>
 <tr><td>
 
<img width="575" alt="Screenshot 2021-09-15 at 19 22 17" src="https://user-images.githubusercontent.com/18492575/133473767-85017f3e-c736-41b8-956f-d5a18e3e66f7.png">

 </td>
 <td>
 
<img width="547" alt="image" src="https://user-images.githubusercontent.com/18492575/133473974-6f2e22d4-a2ee-458e-ba5c-2f7974834e76.png">

 </td>
 </tr>
</table>


## Work in progress
- Add unit tests to the `getProcessedChartData` function
- Probably change other logic for data preparation and move away from datum reach list to the series datum instead.
- Create a separate story for this case
