### PR TITLE
New cloud sign-up page redirect to post-sign-up flow

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.story.tsx
+++ b/client/web/src/auth/CloudSignUpPage.story.tsx
@@ -11,7 +11,7 @@ import { CloudSignUpPage } from './CloudSignUpPage'
 
 const { add } = storiesOf('web/auth/CloudSignUpPage', module)
 
-const context: Pick<SourcegraphContext, 'authProviders'> = {
+const context: Pick<SourcegraphContext, 'authProviders' | 'experimentalFeatures'> = {
     authProviders: [
         {
             serviceType: 'github',
@@ -26,6 +26,7 @@ const context: Pick<SourcegraphContext, 'authProviders'> = {
             authenticationURL: '/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F',
         },
     ],
+    experimentalFeatures: {},
 }
 
 add('default', () => (

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -56,10 +56,11 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
     }
 
     const assetsRoot = window.context?.assetsRoot || ''
+    const isPostSignUpEnabled = window.context.experimentalFeatures.enablePostSignupFlow
 
-    // Since this page is only intented for use on Sourcegraph.com, it's OK to hardcode
+    // Since this page is only intended for use on Sourcegraph.com, it's OK to hardcode
     // GitHub and GitLab auth providers here as they are the only ones used on Sourcegraph.com.
-    // In the future if this page is intented for use in Sourcegraph Sever, this would need to be generisized
+    // In the future if this page is intended for use in Sourcegraph Sever, this would need to be generalized
     // for other auth providers such SAML, OpenID, Okta, Azure AD, etc.
     const githubProvider = context.authProviders.find(provider =>
         provider.authenticationURL?.startsWith('/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F')
@@ -124,7 +125,9 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                         <>
                             {githubProvider && (
                                 <a
-                                    href={githubProvider.authenticationURL}
+                                    href={`${githubProvider.authenticationURL || ''}${
+                                        isPostSignUpEnabled ? '&redirect=/welcome' : ''
+                                    }`}
                                     className={classNames(styles.signUpButton, styles.githubButton)}
                                     onClick={logEvent}
                                 >
@@ -133,7 +136,9 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                             )}
                             {gitlabProvider && (
                                 <a
-                                    href={gitlabProvider.authenticationURL}
+                                    href={`${gitlabProvider.authenticationURL || ''}${
+                                        isPostSignUpEnabled ? '&redirect=/welcome' : ''
+                                    }`}
                                     className={classNames(styles.signUpButton, styles.gitlabButton)}
                                     onClick={logEvent}
                                 >

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -69,6 +69,9 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
         provider.authenticationURL?.startsWith('/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F')
     )
 
+    const maybeRedirectToWelcome = (url?: string): string =>
+        url ? `${url}${isPostSignUpEnabled ? '&redirect=/welcome' : ''}` : ''
+
     const sourceIsValid = source && Object.keys(SourceToTitleMap).includes(source)
     const title = sourceIsValid ? SourceToTitleMap[source as CloudSignUpSource] : SourceToTitleMap.Context // Use Context as default
 
@@ -125,9 +128,7 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                         <>
                             {githubProvider && (
                                 <a
-                                    href={`${githubProvider.authenticationURL || ''}${
-                                        isPostSignUpEnabled ? '&redirect=/welcome' : ''
-                                    }`}
+                                    href={maybeRedirectToWelcome(githubProvider.authenticationURL)}
                                     className={classNames(styles.signUpButton, styles.githubButton)}
                                     onClick={logEvent}
                                 >
@@ -136,9 +137,7 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                             )}
                             {gitlabProvider && (
                                 <a
-                                    href={`${gitlabProvider.authenticationURL || ''}${
-                                        isPostSignUpEnabled ? '&redirect=/welcome' : ''
-                                    }`}
+                                    href={maybeRedirectToWelcome(gitlabProvider.authenticationURL)}
                                     className={classNames(styles.signUpButton, styles.gitlabButton)}
                                     onClick={logEvent}
                                 >

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -56,7 +56,6 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
     }
 
     const assetsRoot = window.context?.assetsRoot || ''
-    const isPostSignUpEnabled = window.context.experimentalFeatures.enablePostSignupFlow
 
     // Since this page is only intended for use on Sourcegraph.com, it's OK to hardcode
     // GitHub and GitLab auth providers here as they are the only ones used on Sourcegraph.com.
@@ -70,7 +69,7 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
     )
 
     const maybeRedirectToWelcome = (url?: string): string =>
-        url ? `${url}${isPostSignUpEnabled ? '&redirect=/welcome' : ''}` : ''
+        url ? `${url}${window.context.experimentalFeatures.enablePostSignupFlow ? '&redirect=/welcome' : ''}` : ''
 
     const sourceIsValid = source && Object.keys(SourceToTitleMap).includes(source)
     const title = sourceIsValid ? SourceToTitleMap[source as CloudSignUpSource] : SourceToTitleMap.Context // Use Context as default

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -18,7 +18,7 @@ interface Props extends ThemeProps, TelemetryProps {
     showEmailForm: boolean
     /** Called to perform the signup on the server. */
     onSignUp: (args: SignUpArguments) => Promise<void>
-    context: Pick<SourcegraphContext, 'authProviders'>
+    context: Pick<SourcegraphContext, 'authProviders' | 'experimentalFeatures'>
 }
 
 const SourceToTitleMap = {
@@ -69,7 +69,7 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
     )
 
     const maybeRedirectToWelcome = (url?: string): string =>
-        url ? `${url}${window.context.experimentalFeatures.enablePostSignupFlow ? '&redirect=/welcome' : ''}` : ''
+        url ? `${url}${context.experimentalFeatures.enablePostSignupFlow ? '&redirect=/welcome' : ''}` : ''
 
     const sourceIsValid = source && Object.keys(SourceToTitleMap).includes(source)
     const title = sourceIsValid ? SourceToTitleMap[source as CloudSignUpSource] : SourceToTitleMap.Context // Use Context as default


### PR DESCRIPTION
### Description

if the post-sign-up flow experimental features is `ON` - redirect users to the `/welcome` route (post-sign-up flow)

Tested on the local instance.