### PR TITLE
codeintel: Add stencil graphql endpoint

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -147,6 +147,7 @@ type GitBlobLSIFDataResolver interface {
 	ToGitTreeLSIFData() (GitTreeLSIFDataResolver, bool)
 	ToGitBlobLSIFData() (GitBlobLSIFDataResolver, bool)
 
+	Stencil(ctx context.Context) ([]RangeResolver, error)
 	Ranges(ctx context.Context, args *LSIFRangesArgs) (CodeIntelligenceRangeConnectionResolver, error)
 	Definitions(ctx context.Context, args *LSIFQueryPositionArgs) (LocationConnectionResolver, error)
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -530,6 +530,11 @@ null, no LSIF data is available for the git blob in question.
 """
 type GitBlobLSIFData implements TreeEntryLSIFData {
     """
+    Return a flat list of all ranges in the document that have code intelligence.
+    """
+    stencil: [Range!]!
+
+    """
     Get aggregated local code intelligence for all ranges that fall in the window
     indicated by the given zero-based start (inclusive) and end (exclusive) lines.
     The associated data for each range is "local", in that the locations and hover

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
@@ -43,6 +43,20 @@ func NewQueryResolver(resolver resolvers.QueryResolver, locationResolver *Cached
 func (r *QueryResolver) ToGitTreeLSIFData() (gql.GitTreeLSIFDataResolver, bool) { return r, true }
 func (r *QueryResolver) ToGitBlobLSIFData() (gql.GitBlobLSIFDataResolver, bool) { return r, true }
 
+func (r *QueryResolver) Stencil(ctx context.Context) ([]gql.RangeResolver, error) {
+	ranges, err := r.resolver.Stencil(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers := make([]gql.RangeResolver, 0, len(ranges))
+	for _, r := range ranges {
+		resolvers = append(resolvers, gql.NewRangeResolver(convertRange(r)))
+	}
+
+	return resolvers, nil
+}
+
 func (r *QueryResolver) Ranges(ctx context.Context, args *gql.LSIFRangesArgs) (gql.CodeIntelligenceRangeConnectionResolver, error) {
 	if args.StartLine < 0 || args.EndLine < args.StartLine {
 		return nil, ErrIllegalBounds

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -49,6 +49,7 @@ type DBStore interface {
 
 type LSIFStore interface {
 	Exists(ctx context.Context, bundleID int, path string) (bool, error)
+	Stencil(ctx context.Context, bundelID int, path string) ([]lsifstore.Range, error)
 	Ranges(ctx context.Context, bundleID int, path string, startLine, endLine int) ([]lsifstore.CodeIntelligenceRange, error)
 	Definitions(ctx context.Context, bundleID int, path string, line, character, limit, offset int) ([]lsifstore.Location, int, error)
 	References(ctx context.Context, bundleID int, path string, line, character, limit, offset int) ([]lsifstore.Location, int, error)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -15,17 +15,18 @@ import (
 )
 
 type operations struct {
-	queryResolver             *observation.Operation
 	definitions               *observation.Operation
 	diagnostics               *observation.Operation
-	hover                     *observation.Operation
-	ranges                    *observation.Operation
-	references                *observation.Operation
+	documentation             *observation.Operation
+	documentationIDsToPathIDs *observation.Operation
 	documentationPage         *observation.Operation
 	documentationPathInfo     *observation.Operation
-	documentationIDsToPathIDs *observation.Operation
 	documentationReferences   *observation.Operation
-	documentation             *observation.Operation
+	hover                     *observation.Operation
+	queryResolver             *observation.Operation
+	ranges                    *observation.Operation
+	references                *observation.Operation
+	stencil                   *observation.Operation
 
 	findClosestDumps *observation.Operation
 }
@@ -56,17 +57,18 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		queryResolver:             op("QueryResolver"),
 		definitions:               op("Definitions"),
 		diagnostics:               op("Diagnostics"),
-		hover:                     op("Hover"),
-		ranges:                    op("Ranges"),
-		references:                op("References"),
+		documentation:             op("Documentation"),
+		documentationIDsToPathIDs: op("DocumentationIDsToPathIDs"),
 		documentationPage:         op("DocumentationPage"),
 		documentationPathInfo:     op("DocumentationPathInfo"),
-		documentationIDsToPathIDs: op("DocumentationIDsToPathIDs"),
 		documentationReferences:   op("DocumentationReferences"),
-		documentation:             op("Documentation"),
+		hover:                     op("Hover"),
+		queryResolver:             op("QueryResolver"),
+		ranges:                    op("Ranges"),
+		references:                op("References"),
+		stencil:                   op("Stencil"),
 
 		findClosestDumps: subOp("findClosestDumps"),
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -49,6 +49,7 @@ func (a *AdjustedCodeIntelligenceRange) ToDocumentation() *Documentation {
 // specifics (auth, validation, marshaling, etc.). This resolver is wrapped by a symmetrics resolver
 // in this package's graphql subpackage, which is exposed directly by the API.
 type QueryResolver interface {
+	Stencil(ctx context.Context) ([]lsifstore.Range, error)
 	Ranges(ctx context.Context, startLine, endLine int) ([]AdjustedCodeIntelligenceRange, error)
 	Definitions(ctx context.Context, line, character int) ([]AdjustedLocation, error)
 	References(ctx context.Context, line, character, limit int, rawCursor string) ([]AdjustedLocation, string, error)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil.go
@@ -1,0 +1,56 @@
+package resolvers
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+const slowStencilRequestThreshold = time.Second
+
+// TODO - test
+func (r *queryResolver) Stencil(ctx context.Context) (adjustedRanges []lsifstore.Range, err error) {
+	ctx, traceLog, endObservation := observeResolver(ctx, &err, "Stencil", r.operations.stencil, slowStencilRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.Int("numUploads", len(r.uploads)),
+			log.String("uploads", uploadIDsToString(r.uploads)),
+		},
+	})
+	defer endObservation()
+
+	adjustedUploads, err := r.adjustUploadPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range adjustedUploads {
+		traceLog(log.Int("uploadID", adjustedUploads[i].Upload.ID))
+
+		// TODO
+		ranges, err := r.lsifStore.Stencil(
+			ctx,
+			adjustedUploads[i].Upload.ID,
+			adjustedUploads[i].AdjustedPathInBundle,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "lsifStore.Stencil")
+		}
+
+		for _, rn := range ranges {
+			// TODO - adjust range
+			// TODO - keep sorted
+			adjustedRanges = append(adjustedRanges, rn)
+		}
+	}
+	traceLog(log.Int("numRanges", len(adjustedRanges)))
+
+	return adjustedRanges, nil
+}

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -12,6 +12,14 @@ type operations struct {
 	clear                         *observation.Operation
 	definitions                   *observation.Operation
 	diagnostics                   *observation.Operation
+	documentationAtPosition       *observation.Operation
+	documentationDefinitions      *observation.Operation
+	documentationIDsToPathIDs     *observation.Operation
+	documentationPage             *observation.Operation
+	documentationPathIDToFilePath *observation.Operation
+	documentationPathIDToID       *observation.Operation
+	documentationPathInfo         *observation.Operation
+	documentationReferences       *observation.Operation
 	exists                        *observation.Operation
 	hover                         *observation.Operation
 	monikerResults                *observation.Operation
@@ -19,21 +27,14 @@ type operations struct {
 	packageInformation            *observation.Operation
 	ranges                        *observation.Operation
 	references                    *observation.Operation
-	documentationPage             *observation.Operation
-	documentationPathInfo         *observation.Operation
-	documentationIDsToPathIDs     *observation.Operation
-	documentationPathIDToID       *observation.Operation
-	documentationPathIDToFilePath *observation.Operation
-	documentationDefinitions      *observation.Operation
-	documentationReferences       *observation.Operation
-	documentationAtPosition       *observation.Operation
+	stencil                       *observation.Operation
 	writeDefinitions              *observation.Operation
+	writeDocumentationPages       *observation.Operation
+	writeDocumentationPathInfo    *observation.Operation
 	writeDocuments                *observation.Operation
 	writeMeta                     *observation.Operation
 	writeReferences               *observation.Operation
 	writeResultChunks             *observation.Operation
-	writeDocumentationPages       *observation.Operation
-	writeDocumentationPathInfo    *observation.Operation
 	writeDocumentationMappings    *observation.Operation
 
 	locations           *observation.Operation
@@ -70,6 +71,14 @@ func newOperations(observationContext *observation.Context) *operations {
 		clear:                         op("Clear"),
 		definitions:                   op("Definitions"),
 		diagnostics:                   op("Diagnostics"),
+		documentationAtPosition:       op("DocumentationAtPosition"),
+		documentationDefinitions:      op("DocumentationDefinitions"),
+		documentationIDsToPathIDs:     op("DocumentationIDsToPathIDs"),
+		documentationPage:             op("DocumentationPage"),
+		documentationPathIDToFilePath: op("DocumentationPathIDToFilePath"),
+		documentationPathIDToID:       op("DocumentationPathIDToID"),
+		documentationPathInfo:         op("DocumentationPathInfo"),
+		documentationReferences:       op("DocumentationReferences"),
 		exists:                        op("Exists"),
 		hover:                         op("Hover"),
 		monikerResults:                op("MonikerResults"),
@@ -77,22 +86,15 @@ func newOperations(observationContext *observation.Context) *operations {
 		packageInformation:            op("PackageInformation"),
 		ranges:                        op("Ranges"),
 		references:                    op("References"),
-		documentationPage:             op("DocumentationPage"),
-		documentationPathInfo:         op("DocumentationPathInfo"),
-		documentationIDsToPathIDs:     op("DocumentationIDsToPathIDs"),
-		documentationPathIDToID:       op("DocumentationPathIDToID"),
-		documentationPathIDToFilePath: op("DocumentationPathIDToFilePath"),
-		documentationDefinitions:      op("DocumentationDefinitions"),
-		documentationReferences:       op("DocumentationReferences"),
-		documentationAtPosition:       op("DocumentationAtPosition"),
+		stencil:                       op("Stencil"),
 		writeDefinitions:              op("WriteDefinitions"),
+		writeDocumentationMappings:    op("WriteDocumentationMappings"),
+		writeDocumentationPages:       op("WriteDocumentationPages"),
+		writeDocumentationPathInfo:    op("WriteDocumentationPathInfo"),
 		writeDocuments:                op("WriteDocuments"),
 		writeMeta:                     op("WriteMeta"),
 		writeReferences:               op("WriteReferences"),
 		writeResultChunks:             op("WriteResultChunks"),
-		writeDocumentationPages:       op("WriteDocumentationPages"),
-		writeDocumentationPathInfo:    op("WriteDocumentationPathInfo"),
-		writeDocumentationMappings:    op("WriteDocumentationMappings"),
 
 		locations:           subOp("locations"),
 		locationsWithinFile: subOp("locationsWithinFile"),

--- a/enterprise/internal/codeintel/stores/lsifstore/stencil.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/stencil.go
@@ -1,0 +1,33 @@
+package lsifstore
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// TODO - test
+func (s *Store) Stencil(ctx context.Context, bundleID int, path string) (_ []Range, err error) {
+	ctx, traceLog, endObservation := s.operations.stencil.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("bundleID", bundleID),
+		log.String("path", path),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	documentData, exists, err := s.scanFirstDocumentData(s.Store.Query(ctx, sqlf.Sprintf(rangesDocumentQuery, bundleID, path)))
+	if err != nil || !exists {
+		return nil, err
+	}
+
+	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+
+	ranges := make([]Range, 0, len(documentData.Document.Ranges))
+	for _, r := range documentData.Document.Ranges {
+		ranges = append(ranges, newRange(r.StartLine, r.StartCharacter, r.EndLine, r.EndCharacter))
+	}
+
+	return ranges, nil
+}


### PR DESCRIPTION
We'll eventually want to underline all actionable ranges in the code view, and also use this information to prevent sending requests for whitespace and docs (we tend to be overly chatty with network requests).

This PR adds a `stencil` endpoint on the blob view to return all range for a document with known precise code intelligence.