### PR TITLE
Insights/user permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The search sidebar shows a revisions section if all search results are from a single repository. This makes it easier to search in and switch between different revisions. [#23835](https://github.com/sourcegraph/sourcegraph/pull/23835)
 - Added a `Documentation` tab to the Site Admin Maintenance panel that links to the official Sourcegraph documentation. [#24917](https://github.com/sourcegraph/sourcegraph/pull/24917)
 - Code Insights that run over all repositories now generate a moving daily snapshot between time points. [#24804](https://github.com/sourcegraph/sourcegraph/pull/24804)
+- The Code Insights GraphQL API now restricts the results to user, org, and globally scoped insights. Insights will be synced to the database with access associated to the user or org setting containing the insight definition. [#25017](https://github.com/sourcegraph/sourcegraph/pull/25017)
 
 ### Changed
 

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -52,7 +52,6 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 
 	// Create database just for this test.
 	dbname := "insights_test_" + strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_"))
-	log15.Info("dbname", "name", dbname)
 	_, err = initConn.Exec(ctx, "DROP DATABASE IF EXISTS "+dbname+";")
 	if err != nil {
 		t.Fatal("dropping test database", err)

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/inconshreveable/log15"
+
 	"github.com/jackc/pgx/v4"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
@@ -50,6 +52,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 
 	// Create database just for this test.
 	dbname := "insights_test_" + strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_"))
+	log15.Info("dbname", "name", dbname)
 	_, err = initConn.Exec(ctx, "DROP DATABASE IF EXISTS "+dbname+";")
 	if err != nil {
 		t.Fatal("dropping test database", err)

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/jackc/pgx/v4"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -162,18 +162,6 @@ func (m *settingMigrator) migrate(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		// results, err := insightStore.Get(ctx, store.InsightQueryArgs{
-		// 	UniqueID: d.ID,
-		// })
-		// if err != nil {
-		// 	return err
-		// }
-		// if len(results) != 0 {
-		// 	// this insight has already been ingested, so let's skip it. Technically this insight could have been edited
-		// 	// but for now we are going to ignore any edits to display settings.
-		// 	skipped++
-		// 	continue
-		// }
 		err := insightStore.DeleteViewByUniqueID(ctx, d.ID)
 		log15.Info("insights migration: deleting insight view", "unique_id", d.ID)
 		if err != nil {

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -155,22 +155,29 @@ func (m *settingMigrator) migrate(ctx context.Context) error {
 		return err
 	}
 
-	var count, skipped, errors int
+	var count, skipped, errorCount int
 	for _, d := range discovered {
 		if d.ID == "" {
 			// we need a unique ID, and if for some reason this insight doesn't have one, it can't be migrated.
 			skipped++
 			continue
 		}
-		results, err := insightStore.Get(ctx, store.InsightQueryArgs{
-			UniqueID: d.ID,
-		})
+		// results, err := insightStore.Get(ctx, store.InsightQueryArgs{
+		// 	UniqueID: d.ID,
+		// })
+		// if err != nil {
+		// 	return err
+		// }
+		// if len(results) != 0 {
+		// 	// this insight has already been ingested, so let's skip it. Technically this insight could have been edited
+		// 	// but for now we are going to ignore any edits to display settings.
+		// 	skipped++
+		// 	continue
+		// }
+		err := insightStore.DeleteViewByUniqueID(ctx, d.ID)
+		log15.Info("insights migration: deleting insight view", "unique_id", d.ID)
 		if err != nil {
-			return err
-		}
-		if len(results) != 0 {
-			// this insight has already been ingested, so let's skip it. Technically this insight could have been edited
-			// but for now we are going to ignore any edits to display settings.
+			// if we fail here there isn't much we can do in this migration, so continue
 			skipped++
 			continue
 		}
@@ -178,12 +185,12 @@ func (m *settingMigrator) migrate(ctx context.Context) error {
 		err = migrateSeries(ctx, insightStore, d)
 		if err != nil {
 			// we can't do anything about errors, so we will just skip it and log it
-			errors++
-			log15.Error("error while migrating insight", "error", err)
+			errorCount++
+			log15.Error("insights migraiton: error while migrating insight", "error", err)
 		}
 		count++
 	}
-	log15.Info("insights settings migration complete", "count", count, "skipped", skipped, "errors", errors)
+	log15.Info("insights settings migration complete", "count", count, "skipped", skipped, "errors", errorCount)
 	return nil
 }
 
@@ -195,7 +202,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 	}
 	defer func() { err = tx.Store.Done(err) }()
 
-	log15.Info("attempting to migrate insight", "unique_id", from.ID)
+	log15.Info("insights migration: attempting to migrate insight", "unique_id", from.ID)
 	dataSeries := make([]types.InsightSeries, len(from.Series))
 	metadata := make([]types.InsightViewSeriesMetadata, len(from.Series))
 
@@ -214,7 +221,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 			return errors.Wrapf(err, "unable to migrate insight unique_id: %s series_id: %s", from.ID, temp.SeriesID)
 		} else if len(existing) > 0 {
 			series = existing[0]
-			log15.Info("existing data series identified, attempting to construct and attach new view", "series_id", series.SeriesID, "unique_id", from.ID)
+			log15.Info("insights migration: existing data series identified, attempting to construct and attach new view", "series_id", series.SeriesID, "unique_id", from.ID)
 		} else {
 			series, err = tx.CreateSeries(ctx, temp)
 			if err != nil {
@@ -235,7 +242,16 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 		UniqueID:    from.ID,
 	}
 
-	view, err = tx.CreateView(ctx, view, nil)
+	var grants []store.InsightViewGrant
+	if from.UserID != nil {
+		grants = []store.InsightViewGrant{store.UserGrant(int(*from.UserID))}
+	} else if from.OrgID != nil {
+		grants = []store.InsightViewGrant{store.OrgGrant(int(*from.OrgID))}
+	} else {
+		grants = []store.InsightViewGrant{store.GlobalGrant()}
+	}
+
+	view, err = tx.CreateView(ctx, view, grants)
 	if err != nil {
 		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
 	}

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -235,7 +235,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 		UniqueID:    from.ID,
 	}
 
-	view, err = tx.CreateView(ctx, view)
+	view, err = tx.CreateView(ctx, view, nil)
 	if err != nil {
 		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
 	}

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -174,7 +174,7 @@ func (m *settingMigrator) migrate(ctx context.Context) error {
 		if err != nil {
 			// we can't do anything about errors, so we will just skip it and log it
 			errorCount++
-			log15.Error("insights migraiton: error while migrating insight", "error", err)
+			log15.Error("insights migration: error while migrating insight", "error", err)
 		}
 		count++
 	}

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -76,7 +76,8 @@ func (r *insightConnectionResolver) compute(ctx context.Context) ([]types.Insigh
 		uid := actor.FromContext(ctx).UID
 		if uid != 0 {
 			// 🚨 SECURITY
-			// only filter user if the actor is not anonymous so that internal users of the API have super-admin like behavior
+			// only add users / orgs if the user is non-anonymous. This will restrict anonymous users to only see
+			// insights with a global grant.
 			args.UserID = []int{int(uid)}
 			orgs, err := r.orgStore.GetByUserID(ctx, uid)
 			if err != nil {

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
+
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -51,6 +53,7 @@ func (r *Resolver) Insights(ctx context.Context, args *graphqlbackend.InsightsAr
 		workerBaseStore:      r.workerBaseStore,
 		insightMetadataStore: r.insightMetadataStore,
 		ids:                  idList,
+		orgStore:             database.Orgs(r.workerBaseStore.Handle().DB()),
 	}, nil
 }
 

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -366,6 +366,8 @@ INSERT INTO insight_view_grants (insight_view_id, org_id, user_id, global)
 VALUES %s;
 `
 
+// DeleteViewByUniqueID deletes an insight view (cascading to dependent child tables) given a unique ID. This operation
+// is idempotent and can be executed many times with only one effect or error.
 func (s *InsightStore) DeleteViewByUniqueID(ctx context.Context, uniqueID string) error {
 	if len(uniqueID) == 0 {
 		return errors.New("unable to delete view invalid view ID")

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/insights"
 
 	"github.com/cockroachdb/errors"
@@ -47,11 +49,13 @@ func (s *InsightStore) Transact(ctx context.Context) (*InsightStore, error) {
 type InsightQueryArgs struct {
 	UniqueIDs []string
 	UniqueID  string
+	UserID    []int
+	OrgID     []int
 }
 
 // Get returns all matching viewable insight series.
 func (s *InsightStore) Get(ctx context.Context, args InsightQueryArgs) ([]types.InsightViewSeries, error) {
-	preds := make([]*sqlf.Query, 0, 2)
+	preds := make([]*sqlf.Query, 0, 4)
 
 	if len(args.UniqueIDs) > 0 {
 		elems := make([]*sqlf.Query, 0, len(args.UniqueIDs))
@@ -63,13 +67,38 @@ func (s *InsightStore) Get(ctx context.Context, args InsightQueryArgs) ([]types.
 	if len(args.UniqueID) > 0 {
 		preds = append(preds, sqlf.Sprintf("iv.unique_id = %s", args.UniqueID))
 	}
+	preds = append(preds, viewPermissionsQuery(args))
 
 	if len(preds) == 0 {
 		preds = append(preds, sqlf.Sprintf("%s", "TRUE"))
 	}
 
 	q := sqlf.Sprintf(getInsightByViewSql, sqlf.Join(preds, "\n AND"))
+	log15.Info("testing query", "query", q.Query(sqlf.PostgresBindVar), "args", q.Args())
+
 	return scanInsightViewSeries(s.Query(ctx, q))
+}
+
+// viewPermissionsQuery generates the SQL query for selecting insight views based on granted permissions.
+func viewPermissionsQuery(args InsightQueryArgs) *sqlf.Query {
+	permsPreds := make([]*sqlf.Query, 0, 2)
+	if len(args.OrgID) > 0 {
+		elems := make([]*sqlf.Query, 0, len(args.OrgID))
+		for _, id := range args.OrgID {
+			elems = append(elems, sqlf.Sprintf("%s", id))
+		}
+		permsPreds = append(permsPreds, sqlf.Sprintf("ivg.org_id IN (%s)", sqlf.Join(elems, ",")))
+	}
+	if len(args.UserID) > 0 {
+		elems := make([]*sqlf.Query, 0, len(args.UserID))
+		for _, id := range args.UserID {
+			elems = append(elems, sqlf.Sprintf("%s", id))
+		}
+		permsPreds = append(permsPreds, sqlf.Sprintf("ivg.user_id IN (%s)", sqlf.Join(elems, ",")))
+	}
+	permsPreds = append(permsPreds, sqlf.Sprintf("ivg.global is true"))
+
+	return sqlf.Sprintf("(%s)", sqlf.Join(permsPreds, " OR "))
 }
 
 func (s *InsightStore) GetMapped(ctx context.Context, args InsightQueryArgs) ([]types.Insight, error) {
@@ -288,8 +317,14 @@ func (s *InsightStore) AttachSeriesToView(ctx context.Context,
 }
 
 // CreateView will create a new insight view with no associated data series. This view must have a unique identifier.
-func (s *InsightStore) CreateView(ctx context.Context, view types.InsightView) (types.InsightView, error) {
-	row := s.QueryRow(ctx, sqlf.Sprintf(createInsightViewSql,
+func (s *InsightStore) CreateView(ctx context.Context, view types.InsightView, grants []InsightViewGrant) (_ types.InsightView, err error) {
+	tx, err := s.Transact(ctx)
+	if err != nil {
+		return types.InsightView{}, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	row := tx.QueryRow(ctx, sqlf.Sprintf(createInsightViewSql,
 		view.Title,
 		view.Description,
 		view.UniqueID,
@@ -298,13 +333,43 @@ func (s *InsightStore) CreateView(ctx context.Context, view types.InsightView) (
 		return types.InsightView{}, row.Err()
 	}
 	var id int
-	err := row.Scan(&id)
+	err = row.Scan(&id)
 	if err != nil {
-		return types.InsightView{}, err
+		return types.InsightView{}, errors.Wrap(err, "failed to insert insight view")
 	}
 	view.ID = id
+	err = tx.AddViewGrants(ctx, view, grants)
+	if err != nil {
+		return types.InsightView{}, errors.Wrap(err, "failed to attach view grants")
+	}
 	return view, nil
 }
+
+func (s *InsightStore) AddViewGrants(ctx context.Context, view types.InsightView, grants []InsightViewGrant) error {
+	if view.ID == 0 {
+		return errors.New("unable to grant view permissions invalid insight view id")
+	} else if len(grants) == 0 {
+		return nil
+	}
+
+	values := make([]*sqlf.Query, 0, len(grants))
+	for _, grant := range grants {
+		values = append(values, grant.toQuery(view.ID))
+	}
+	q := sqlf.Sprintf(AddViewGrantsSql, sqlf.Join(values, ",\n"))
+	log15.Info("add_insight_view_grant_query", "query", q.Query(sqlf.PostgresBindVar), "args", q.Args())
+	err := s.Exec(ctx, q)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+const AddViewGrantsSql = `
+-- source: enterprise/internal/insights/store/insight_store.go:AddViewGrants
+INSERT INTO insight_view_grants (insight_view_id, org_id, user_id, global)
+VALUES %s;
+`
 
 // CreateSeries will create a new insight data series. This series must be uniquely identified by the series ID.
 func (s *InsightStore) CreateSeries(ctx context.Context, series types.InsightSeries) (types.InsightSeries, error) {
@@ -438,6 +503,7 @@ i.next_recording_after, i.backfill_queued_at, i.recording_interval_days, i.last_
 FROM insight_view iv
          JOIN insight_view_series ivs ON iv.id = ivs.insight_view_id
          JOIN insight_series i ON ivs.insight_series_id = i.id
+         JOIN insight_view_grants ivg ON iv.id = ivg.insight_view_id
 WHERE %s
 ORDER BY iv.unique_id, i.series_id
 `

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -53,7 +53,7 @@ type InsightQueryArgs struct {
 
 // Get returns all matching viewable insight series.
 func (s *InsightStore) Get(ctx context.Context, args InsightQueryArgs) ([]types.InsightViewSeries, error) {
-	preds := make([]*sqlf.Query, 0, 4)
+	preds := make([]*sqlf.Query, 0, 3)
 
 	if len(args.UniqueIDs) > 0 {
 		elems := make([]*sqlf.Query, 0, len(args.UniqueIDs))

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -352,7 +352,7 @@ func (s *InsightStore) AddViewGrants(ctx context.Context, view types.InsightView
 	for _, grant := range grants {
 		values = append(values, grant.toQuery(view.ID))
 	}
-	q := sqlf.Sprintf(AddViewGrantsSql, sqlf.Join(values, ",\n"))
+	q := sqlf.Sprintf(addViewGrantsSql, sqlf.Join(values, ",\n"))
 	err := s.Exec(ctx, q)
 	if err != nil {
 		return err
@@ -360,7 +360,7 @@ func (s *InsightStore) AddViewGrants(ctx context.Context, view types.InsightView
 	return nil
 }
 
-const AddViewGrantsSql = `
+const addViewGrantsSql = `
 -- source: enterprise/internal/insights/store/insight_store.go:AddViewGrants
 INSERT INTO insight_view_grants (insight_view_id, org_id, user_id, global)
 VALUES %s;
@@ -373,7 +373,7 @@ func (s *InsightStore) DeleteViewByUniqueID(ctx context.Context, uniqueID string
 		return errors.New("unable to delete view invalid view ID")
 	}
 	conds := sqlf.Sprintf("unique_id = %s", uniqueID)
-	q := sqlf.Sprintf(DeleteViewSql, conds)
+	q := sqlf.Sprintf(deleteViewSql, conds)
 	err := s.Exec(ctx, q)
 	if err != nil {
 		return err
@@ -381,7 +381,7 @@ func (s *InsightStore) DeleteViewByUniqueID(ctx context.Context, uniqueID string
 	return nil
 }
 
-const DeleteViewSql = `
+const deleteViewSql = `
 -- source: enterprise/internal/insights/store/insight_store.go:DeleteView
 delete from insight_view where %s;
 `

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -94,7 +94,7 @@ func viewPermissionsQuery(args InsightQueryArgs) *sqlf.Query {
 	}
 	permsPreds = append(permsPreds, sqlf.Sprintf("ivg.global is true"))
 
-	return sqlf.Sprintf("(%s)", sqlf.Join(permsPreds, " OR "))
+	return sqlf.Sprintf("(%s)", sqlf.Join(permsPreds, "OR"))
 }
 
 func (s *InsightStore) GetMapped(ctx context.Context, args InsightQueryArgs) ([]types.Insight, error) {

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -23,7 +23,15 @@ func TestGet(t *testing.T) {
 
 	_, err := timescale.Exec(`INSERT INTO insight_view (title, description, unique_id)
 									VALUES ('test title', 'test description', 'unique-1'),
-									       ('test title 2', 'test description 2', 'unique-2');`)
+									       ('test title 2', 'test description 2', 'unique-2')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assign some global grants just so the test can immediately fetch the created views
+	_, err = timescale.Exec(`INSERT INTO insight_view_grants (insight_view_id, global)
+									VALUES (1, true),
+									       (2, true)`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +281,7 @@ func TestCreateView(t *testing.T) {
 			UniqueID:    "1234567",
 		}
 
-		got, err := store.CreateView(ctx, view)
+		got, err := store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -288,6 +296,91 @@ func TestCreateView(t *testing.T) {
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("unexpected result from create insight view (want/got): %s", diff)
 		}
+	})
+}
+
+func TestCreateGetView_WithGrants(t *testing.T) {
+	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+	defer cleanup()
+	now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond).Round(0)
+	ctx := context.Background()
+
+	store := NewInsightStore(timescale)
+	store.Now = func() time.Time {
+		return now
+	}
+
+	uniqueID := "user1viewonly"
+	view, err := store.CreateView(ctx, types.InsightView{
+		Title:       "user 1 view only",
+		Description: "user 1 should see this only",
+		UniqueID:    uniqueID,
+	}, []InsightViewGrant{UserGrant(1), OrgGrant(5)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	series, err := store.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:              "series1",
+		Query:                 "query1",
+		CreatedAt:             now,
+		OldestHistoricalAt:    now,
+		LastRecordedAt:        now,
+		NextRecordingAfter:    now,
+		LastSnapshotAt:        now,
+		NextSnapshotAfter:     now,
+		BackfillQueuedAt:      now,
+		RecordingIntervalDays: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.AttachSeriesToView(ctx, series, view, types.InsightViewSeriesMetadata{
+		Label:  "label1",
+		Stroke: "blue",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("user 1 can see this view", func(t *testing.T) {
+		got, err := store.Get(ctx, InsightQueryArgs{UniqueID: uniqueID, UserID: []int{1}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 0 {
+			t.Errorf("unexpected count for user 1 insight views")
+		}
+		autogold.Equal(t, got, autogold.ExportedOnly())
+	})
+
+	t.Run("user 2 cannot see the view", func(t *testing.T) {
+		got, err := store.Get(ctx, InsightQueryArgs{UniqueID: uniqueID, UserID: []int{2}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Errorf("unexpected count for user 2 insight views")
+		}
+	})
+
+	t.Run("org 1 cannot see the view", func(t *testing.T) {
+		got, err := store.Get(ctx, InsightQueryArgs{UniqueID: uniqueID, UserID: []int{3}, OrgID: []int{1}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Errorf("unexpected count for org 1 insight views")
+		}
+	})
+	t.Run("org 5 can see the view", func(t *testing.T) {
+		got, err := store.Get(ctx, InsightQueryArgs{UniqueID: uniqueID, UserID: []int{3}, OrgID: []int{5}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 0 {
+			t.Errorf("unexpected count for org 5 insight views")
+		}
+		autogold.Equal(t, got, autogold.ExportedOnly())
 	})
 }
 
@@ -322,7 +415,7 @@ func TestAttachSeriesView(t *testing.T) {
 			Description: "my view description",
 			UniqueID:    "1234567",
 		}
-		view, err = store.CreateView(ctx, view)
+		view, err = store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -382,6 +382,48 @@ func TestCreateGetView_WithGrants(t *testing.T) {
 		}
 		autogold.Equal(t, got, autogold.ExportedOnly())
 	})
+	t.Run("no users or orgs provided should only return global", func(t *testing.T) {
+		uniqueID := "globalonly"
+		view, err := store.CreateView(ctx, types.InsightView{
+			Title:       "global only",
+			Description: "global only",
+			UniqueID:    uniqueID,
+		}, []InsightViewGrant{GlobalGrant()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		series, err := store.CreateSeries(ctx, types.InsightSeries{
+			SeriesID:              "globalseries",
+			Query:                 "global",
+			CreatedAt:             now,
+			OldestHistoricalAt:    now,
+			LastRecordedAt:        now,
+			NextRecordingAfter:    now,
+			LastSnapshotAt:        now,
+			NextSnapshotAfter:     now,
+			BackfillQueuedAt:      now,
+			RecordingIntervalDays: 0,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.AttachSeriesToView(ctx, series, view, types.InsightViewSeriesMetadata{
+			Label:  "label2",
+			Stroke: "red",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := store.Get(ctx, InsightQueryArgs{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 {
+			t.Errorf("unexpected count for global only insights")
+		}
+		autogold.Equal(t, got, autogold.ExportedOnly())
+	})
 }
 
 func TestDeleteView(t *testing.T) {

--- a/enterprise/internal/insights/store/permissions.go
+++ b/enterprise/internal/insights/store/permissions.go
@@ -61,3 +61,28 @@ func NewInsightPermissionStore(db dbutil.DB) *InsightPermStore {
 type InsightPermissionStore interface {
 	GetUnauthorizedRepoIDs(ctx context.Context) (results []api.RepoID, err error)
 }
+
+type InsightViewGrant struct {
+	UserID *int
+	OrgID  *int
+	Global *bool
+}
+
+func (i InsightViewGrant) toQuery(insightViewID int) *sqlf.Query {
+	// insight_view_id, org_id, user_id, global
+	valuesFmt := "(%s, %s, %s, %s)"
+	return sqlf.Sprintf(valuesFmt, insightViewID, i.OrgID, i.UserID, i.Global)
+}
+
+func UserGrant(userID int) InsightViewGrant {
+	return InsightViewGrant{UserID: &userID}
+}
+
+func OrgGrant(orgID int) InsightViewGrant {
+	return InsightViewGrant{OrgID: &orgID}
+}
+
+func GlobalGrant() InsightViewGrant {
+	b := true
+	return InsightViewGrant{Global: &b}
+}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/no_users_or_orgs_provided_should_only_return_global.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/no_users_or_orgs_provided_should_only_return_global.golden
@@ -1,0 +1,15 @@
+[]types.InsightViewSeries{types.InsightViewSeries{
+	UniqueID:           "globalonly",
+	SeriesID:           "globalseries",
+	Title:              "global only",
+	Description:        "global only",
+	Query:              "global",
+	CreatedAt:          time.Time{ext: 63713433600},
+	OldestHistoricalAt: time.Time{ext: 63713433600},
+	LastRecordedAt:     time.Time{ext: 63713433600},
+	NextRecordingAfter: time.Time{ext: 63713433600},
+	LastSnapshotAt:     time.Time{ext: 63713433600},
+	NextSnapshotAfter:  time.Time{ext: 63713433600},
+	Label:              "label2",
+	Stroke:             "red",
+}}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/org_5_can_see_the_view.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/org_5_can_see_the_view.golden
@@ -1,0 +1,15 @@
+[]types.InsightViewSeries{types.InsightViewSeries{
+	UniqueID:           "user1viewonly",
+	SeriesID:           "series1",
+	Title:              "user 1 view only",
+	Description:        "user 1 should see this only",
+	Query:              "query1",
+	CreatedAt:          time.Time{ext: 63713433600},
+	OldestHistoricalAt: time.Time{ext: 63713433600},
+	LastRecordedAt:     time.Time{ext: 63713433600},
+	NextRecordingAfter: time.Time{ext: 63713433600},
+	LastSnapshotAt:     time.Time{ext: 63713433600},
+	NextSnapshotAfter:  time.Time{ext: 63713433600},
+	Label:              "label1",
+	Stroke:             "blue",
+}}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/user_1_can_see_this_view.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/user_1_can_see_this_view.golden
@@ -1,0 +1,15 @@
+[]types.InsightViewSeries{types.InsightViewSeries{
+	UniqueID:           "user1viewonly",
+	SeriesID:           "series1",
+	Title:              "user 1 view only",
+	Description:        "user 1 should see this only",
+	Query:              "query1",
+	CreatedAt:          time.Time{ext: 63713433600},
+	OldestHistoricalAt: time.Time{ext: 63713433600},
+	LastRecordedAt:     time.Time{ext: 63713433600},
+	NextRecordingAfter: time.Time{ext: 63713433600},
+	LastSnapshotAt:     time.Time{ext: 63713433600},
+	NextSnapshotAfter:  time.Time{ext: 63713433600},
+	Label:              "label1",
+	Stroke:             "blue",
+}}

--- a/internal/insights/insights_test.go
+++ b/internal/insights/insights_test.go
@@ -89,6 +89,7 @@ func TestGetIntegrationInsights(t *testing.T) {
 
 	weeks := 2
 
+	wantOrg := int32(1)
 	want := []SearchInsight{
 		{
 			ID:           "unique-id1",
@@ -102,6 +103,7 @@ func TestGetIntegrationInsights(t *testing.T) {
 			Step: Interval{
 				Weeks: &weeks,
 			},
+			OrgID: &wantOrg,
 		},
 		{
 			ID:           "unique-id2",
@@ -115,6 +117,7 @@ func TestGetIntegrationInsights(t *testing.T) {
 			Step: Interval{
 				Weeks: &weeks,
 			},
+			OrgID: &wantOrg,
 		},
 	}
 

--- a/migrations/codeinsights/1000000013_insights_view_grants.down.sql
+++ b/migrations/codeinsights/1000000013_insights_view_grants.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS insight_view_grants;
+
+COMMIT;

--- a/migrations/codeinsights/1000000013_insights_view_grants.down.sql
+++ b/migrations/codeinsights/1000000013_insights_view_grants.down.sql
@@ -2,4 +2,11 @@ BEGIN;
 
 DROP TABLE IF EXISTS insight_view_grants;
 
+ALTER TABLE insight_view_series
+    DROP CONSTRAINT IF EXISTS insight_view_series_insight_view_id_fkey;
+
+ALTER TABLE insight_view_series
+    ADD CONSTRAINT insight_view_series_insight_view_id_fkey
+        FOREIGN KEY (insight_view_id) REFERENCES insight_view;
+
 COMMIT;

--- a/migrations/codeinsights/1000000013_insights_view_grants.up.sql
+++ b/migrations/codeinsights/1000000013_insights_view_grants.up.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS insight_view_grants
+(
+    id              SERIAL
+        CONSTRAINT insight_view_grants_pk
+            PRIMARY KEY,
+    insight_view_id INTEGER NOT NULL
+        CONSTRAINT insight_view_grants_insight_view_id_fk
+            REFERENCES insight_view
+            ON DELETE CASCADE,
+    user_id         INTEGER,
+    org_id          INTEGER,
+    global          BOOLEAN
+);
+
+COMMENT ON TABLE insight_view_grants IS 'Permission grants for insight views. Each row should represent a unique principal (user, org, etc).';
+COMMENT ON COLUMN insight_view_grants.user_id IS 'User ID that that receives this grant.';
+COMMENT ON COLUMN insight_view_grants.org_id IS 'Org ID that that receives this grant.';
+COMMENT ON COLUMN insight_view_grants.global IS 'Grant that does not belong to any specific principal and is granted to all users.';
+
+CREATE INDEX IF NOT EXISTS insight_view_grants_insight_view_id_index
+    ON insight_view_grants (insight_view_id);
+
+CREATE INDEX IF NOT EXISTS insight_view_grants_user_id_idx
+    ON insight_view_grants (user_id);
+
+CREATE INDEX IF NOT EXISTS insight_view_grants_org_id_idx
+    ON insight_view_grants (org_id);
+
+CREATE INDEX IF NOT EXISTS insight_view_grants_global_idx
+    ON insight_view_grants (global) WHERE global IS TRUE;
+
+COMMIT;

--- a/migrations/codeinsights/1000000013_insights_view_grants.up.sql
+++ b/migrations/codeinsights/1000000013_insights_view_grants.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS insight_view_grants
     insight_view_id INTEGER NOT NULL
         CONSTRAINT insight_view_grants_insight_view_id_fk
             REFERENCES insight_view
-            ON DELETE CASCADE,
+            ON DELETE CASCADE, -- These grants only have meaning in the context of a parent view.
     user_id         INTEGER,
     org_id          INTEGER,
     global          BOOLEAN
@@ -30,5 +30,16 @@ CREATE INDEX IF NOT EXISTS insight_view_grants_org_id_idx
 
 CREATE INDEX IF NOT EXISTS insight_view_grants_global_idx
     ON insight_view_grants (global) WHERE global IS TRUE;
+
+
+-- This series join table is completely dependent on the existence of a parent view. So to simplify db operations
+-- and avoid dangling rows, adding cascade deletes to the insight view FK.
+ALTER TABLE insight_view_series
+    DROP CONSTRAINT IF EXISTS insight_view_series_insight_view_id_fkey;
+
+ALTER TABLE insight_view_series
+    ADD CONSTRAINT insight_view_series_insight_view_id_fkey
+        FOREIGN KEY (insight_view_id) REFERENCES insight_view
+            ON DELETE CASCADE;
 
 COMMIT;


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/24438

To summarize this PR, previously any backend insights were unrestricted based on user / org permissions, and the GraphQL API would return all insights to all users. In preparation for building an API for insights and dashboards, we obviously had to solve this problem.

1. Permission grant associations for insight views to user, org, and global
    1. Eventually this will get partitioned into more granular permission levels, but for now everyone is assumed to have read / write to match feature parity of frontend insights.
    2. Insights defined in a users private settings will get associated with that user ID
    3. Insights defined in an org will get associated with that org ID, and any user in that org can view them
2. The sync job from settings -> the database had to be updated to capture permissions updates as insights move between dashboards.
    1. The sync job will now just optimistically delete and replace any insight view that is defined in settings. This will still leave dangling insights that have been removed from the dashboard, but that's okay for the interm without an API.

New DDL looks like this:
<img width="887" alt="CleanShot 2021-09-15 at 15 38 39@2x" src="https://user-images.githubusercontent.com/5090588/133519129-00616284-b9b7-4fb1-80af-4d338acfa1cd.png">

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
