### PR TITLE
chore: correct PROJECT_ID var, rename other issue mover

### DIFF
--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -3,7 +3,7 @@ on:
   issues:
     types: [labeled]
 jobs:
-  Move_Labeled_Issue_On_Project_Board:
+  move-labeled-or-milestoned-issue:
     runs-on: ubuntu-latest
     steps:
     - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
@@ -32,7 +32,7 @@ jobs:
   distribution-board:
     runs-on: ubuntu-latest
     env:
-      PROJECT: MDExOlByb2plY3ROZXh0MzIxNw== # https://github.com/orgs/sourcegraph/projects/197
+      PROJECT_ID: MDExOlByb2plY3ROZXh0MzIxNw== # https://github.com/orgs/sourcegraph/projects/197
       GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
     steps:
     - name: Get issue if relevant


### PR DESCRIPTION
Of course it's a typo! Rename `PROJECT` to `PROJECT_ID`. Also renames the other job to something that's a little more sane to read 😋 

Related to https://github.com/sourcegraph/sourcegraph/issues/24704

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
