### PR TITLE
monitoring: remove redundant new lines in generated docs

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16,9 +16,7 @@ To see this dashboard, visit `/-/debug/grafana/d/frontend/frontend` on your Sour
 
 #### frontend: 99th_percentile_search_request_duration
 
-<p class="subtitle">99th percentile successful search request duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful search request duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-request-duration) for 1 alert related to this panel.
 
@@ -37,9 +35,7 @@ Query: `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_buck
 
 #### frontend: 90th_percentile_search_request_duration
 
-<p class="subtitle">90th percentile successful search request duration over 5m
-
-</p>
+<p class="subtitle">90th percentile successful search request duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-request-duration) for 1 alert related to this panel.
 
@@ -58,9 +54,7 @@ Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_buck
 
 #### frontend: hard_timeout_search_responses
 
-<p class="subtitle">Hard timeout search responses every 5m
-
-</p>
+<p class="subtitle">Hard timeout search responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses) for 2 alerts related to this panel.
 
@@ -79,9 +73,7 @@ Query: `(sum(increase(src_graphql_search_response{status="timeout",source="brows
 
 #### frontend: hard_error_search_responses
 
-<p class="subtitle">Hard error search responses every 5m
-
-</p>
+<p class="subtitle">Hard error search responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses) for 2 alerts related to this panel.
 
@@ -100,9 +92,7 @@ Query: `sum by (status)(increase(src_graphql_search_response{status=~"error",sou
 
 #### frontend: partial_timeout_search_responses
 
-<p class="subtitle">Partial timeout search responses every 5m
-
-</p>
+<p class="subtitle">Partial timeout search responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-responses) for 1 alert related to this panel.
 
@@ -121,9 +111,7 @@ Query: `sum by (status)(increase(src_graphql_search_response{status="partial_tim
 
 #### frontend: search_alert_user_suggestions
 
-<p class="subtitle">Search alert user suggestions shown every 5m
-
-</p>
+<p class="subtitle">Search alert user suggestions shown every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-alert-user-suggestions) for 1 alert related to this panel.
 
@@ -142,9 +130,7 @@ Query: `sum by (alert_type)(increase(src_graphql_search_response{status="alert",
 
 #### frontend: page_load_latency
 
-<p class="subtitle">90th percentile page load latency over all routes over 10m
-
-</p>
+<p class="subtitle">90th percentile page load latency over all routes over 10m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-page-load-latency) for 1 alert related to this panel.
 
@@ -163,9 +149,7 @@ Query: `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_secon
 
 #### frontend: blob_load_latency
 
-<p class="subtitle">90th percentile blob load latency over 10m
-
-</p>
+<p class="subtitle">90th percentile blob load latency over 10m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-blob-load-latency) for 1 alert related to this panel.
 
@@ -186,9 +170,7 @@ Query: `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_secon
 
 #### frontend: 99th_percentile_search_codeintel_request_duration
 
-<p class="subtitle">99th percentile code-intel successful search request duration over 5m
-
-</p>
+<p class="subtitle">99th percentile code-intel successful search request duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-codeintel-request-duration) for 1 alert related to this panel.
 
@@ -207,9 +189,7 @@ Query: `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_buck
 
 #### frontend: 90th_percentile_search_codeintel_request_duration
 
-<p class="subtitle">90th percentile code-intel successful search request duration over 5m
-
-</p>
+<p class="subtitle">90th percentile code-intel successful search request duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-codeintel-request-duration) for 1 alert related to this panel.
 
@@ -228,9 +208,7 @@ Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_buck
 
 #### frontend: hard_timeout_search_codeintel_responses
 
-<p class="subtitle">Hard timeout search code-intel responses every 5m
-
-</p>
+<p class="subtitle">Hard timeout search code-intel responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses) for 2 alerts related to this panel.
 
@@ -249,9 +227,7 @@ Query: `(sum(increase(src_graphql_search_response{status="timeout",source="brows
 
 #### frontend: hard_error_search_codeintel_responses
 
-<p class="subtitle">Hard error search code-intel responses every 5m
-
-</p>
+<p class="subtitle">Hard error search code-intel responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses) for 2 alerts related to this panel.
 
@@ -270,9 +246,7 @@ Query: `sum by (status)(increase(src_graphql_search_response{status=~"error",sou
 
 #### frontend: partial_timeout_search_codeintel_responses
 
-<p class="subtitle">Partial timeout search code-intel responses every 5m
-
-</p>
+<p class="subtitle">Partial timeout search code-intel responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-codeintel-responses) for 1 alert related to this panel.
 
@@ -291,9 +265,7 @@ Query: `sum by (status)(increase(src_graphql_search_response{status="partial_tim
 
 #### frontend: search_codeintel_alert_user_suggestions
 
-<p class="subtitle">Search code-intel alert user suggestions shown every 5m
-
-</p>
+<p class="subtitle">Search code-intel alert user suggestions shown every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-codeintel-alert-user-suggestions) for 1 alert related to this panel.
 
@@ -314,9 +286,7 @@ Query: `sum by (alert_type)(increase(src_graphql_search_response{status="alert",
 
 #### frontend: 99th_percentile_search_api_request_duration
 
-<p class="subtitle">99th percentile successful search API request duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful search API request duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-api-request-duration) for 1 alert related to this panel.
 
@@ -335,9 +305,7 @@ Query: `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_buck
 
 #### frontend: 90th_percentile_search_api_request_duration
 
-<p class="subtitle">90th percentile successful search API request duration over 5m
-
-</p>
+<p class="subtitle">90th percentile successful search API request duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-api-request-duration) for 1 alert related to this panel.
 
@@ -356,9 +324,7 @@ Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_buck
 
 #### frontend: hard_error_search_api_responses
 
-<p class="subtitle">Hard error search API responses every 5m
-
-</p>
+<p class="subtitle">Hard error search API responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses) for 2 alerts related to this panel.
 
@@ -377,9 +343,7 @@ Query: `sum by (status)(increase(src_graphql_search_response{status=~"error",sou
 
 #### frontend: partial_timeout_search_api_responses
 
-<p class="subtitle">Partial timeout search API responses every 5m
-
-</p>
+<p class="subtitle">Partial timeout search API responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-api-responses) for 1 alert related to this panel.
 
@@ -398,9 +362,7 @@ Query: `sum(increase(src_graphql_search_response{status="partial_timeout",source
 
 #### frontend: search_api_alert_user_suggestions
 
-<p class="subtitle">Search API alert user suggestions shown every 5m
-
-</p>
+<p class="subtitle">Search API alert user suggestions shown every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-api-alert-user-suggestions) for 1 alert related to this panel.
 
@@ -421,9 +383,7 @@ Query: `sum by (alert_type)(increase(src_graphql_search_response{status="alert",
 
 #### frontend: codeintel_resolvers_total
 
-<p class="subtitle">Aggregate graphql operations every 5m
-
-</p>
+<p class="subtitle">Aggregate graphql operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -442,9 +402,7 @@ Query: `sum(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-
 
 #### frontend: codeintel_resolvers_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate graphql operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate graphql operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -463,9 +421,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_resolvers_durat
 
 #### frontend: codeintel_resolvers_errors_total
 
-<p class="subtitle">Aggregate graphql operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate graphql operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -484,9 +440,7 @@ Query: `sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourc
 
 #### frontend: codeintel_resolvers_error_rate
 
-<p class="subtitle">Aggregate graphql operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate graphql operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -505,9 +459,7 @@ Query: `sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourc
 
 #### frontend: codeintel_resolvers_total
 
-<p class="subtitle">Graphql operations every 5m
-
-</p>
+<p class="subtitle">Graphql operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -526,9 +478,7 @@ Query: `sum by (op)(increase(src_codeintel_resolvers_total{job=~"^(frontend|sour
 
 #### frontend: codeintel_resolvers_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful graphql operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful graphql operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -547,9 +497,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_resolvers_du
 
 #### frontend: codeintel_resolvers_errors_total
 
-<p class="subtitle">Graphql operation errors every 5m
-
-</p>
+<p class="subtitle">Graphql operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -568,9 +516,7 @@ Query: `sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(fronte
 
 #### frontend: codeintel_resolvers_error_rate
 
-<p class="subtitle">Graphql operation error rate over 5m
-
-</p>
+<p class="subtitle">Graphql operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -591,9 +537,7 @@ Query: `sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(fronte
 
 #### frontend: codeintel_autoindex_enqueuer_total
 
-<p class="subtitle">Aggregate enqueuer operations every 5m
-
-</p>
+<p class="subtitle">Aggregate enqueuer operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -612,9 +556,7 @@ Query: `sum(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sou
 
 #### frontend: codeintel_autoindex_enqueuer_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate enqueuer operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate enqueuer operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -633,9 +575,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_autoindex_enque
 
 #### frontend: codeintel_autoindex_enqueuer_errors_total
 
-<p class="subtitle">Aggregate enqueuer operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate enqueuer operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -654,9 +594,7 @@ Query: `sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(front
 
 #### frontend: codeintel_autoindex_enqueuer_error_rate
 
-<p class="subtitle">Aggregate enqueuer operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate enqueuer operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -675,9 +613,7 @@ Query: `sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(front
 
 #### frontend: codeintel_autoindex_enqueuer_total
 
-<p class="subtitle">Enqueuer operations every 5m
-
-</p>
+<p class="subtitle">Enqueuer operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -696,9 +632,7 @@ Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(fron
 
 #### frontend: codeintel_autoindex_enqueuer_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful enqueuer operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful enqueuer operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -717,9 +651,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindex_en
 
 #### frontend: codeintel_autoindex_enqueuer_errors_total
 
-<p class="subtitle">Enqueuer operation errors every 5m
-
-</p>
+<p class="subtitle">Enqueuer operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -738,9 +670,7 @@ Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~
 
 #### frontend: codeintel_autoindex_enqueuer_error_rate
 
-<p class="subtitle">Enqueuer operation error rate over 5m
-
-</p>
+<p class="subtitle">Enqueuer operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -761,9 +691,7 @@ Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~
 
 #### frontend: codeintel_dbstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -782,9 +710,7 @@ Query: `sum(increase(src_codeintel_dbstore_total{job=~"^(frontend|sourcegraph-fr
 
 #### frontend: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -803,9 +729,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_dbstore_duratio
 
 #### frontend: codeintel_dbstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -824,9 +748,7 @@ Query: `sum(increase(src_codeintel_dbstore_errors_total{job=~"^(frontend|sourceg
 
 #### frontend: codeintel_dbstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -845,9 +767,7 @@ Query: `sum(increase(src_codeintel_dbstore_errors_total{job=~"^(frontend|sourceg
 
 #### frontend: codeintel_dbstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -866,9 +786,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_total{job=~"^(frontend|source
 
 #### frontend: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -887,9 +805,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dbstore_dura
 
 #### frontend: codeintel_dbstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -908,9 +824,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_errors_total{job=~"^(frontend
 
 #### frontend: codeintel_dbstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -931,9 +845,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_errors_total{job=~"^(frontend
 
 #### frontend: workerutil_dbworker_store_codeintel_index_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -952,9 +864,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_index_total{job=~"^
 
 #### frontend: workerutil_dbworker_store_codeintel_index_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -973,9 +883,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_workerutil_dbworker_store
 
 #### frontend: workerutil_dbworker_store_codeintel_index_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -994,9 +902,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{
 
 #### frontend: workerutil_dbworker_store_codeintel_index_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1017,9 +923,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{
 
 #### frontend: codeintel_lsifstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1038,9 +942,7 @@ Query: `sum(increase(src_codeintel_lsifstore_total{job=~"^(frontend|sourcegraph-
 
 #### frontend: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1059,9 +961,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_lsifstore_durat
 
 #### frontend: codeintel_lsifstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1080,9 +980,7 @@ Query: `sum(increase(src_codeintel_lsifstore_errors_total{job=~"^(frontend|sourc
 
 #### frontend: codeintel_lsifstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1101,9 +999,7 @@ Query: `sum(increase(src_codeintel_lsifstore_errors_total{job=~"^(frontend|sourc
 
 #### frontend: codeintel_lsifstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1122,9 +1018,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_total{job=~"^(frontend|sour
 
 #### frontend: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1143,9 +1037,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_lsifstore_du
 
 #### frontend: codeintel_lsifstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1164,9 +1056,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_errors_total{job=~"^(fronte
 
 #### frontend: codeintel_lsifstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1187,9 +1077,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_errors_total{job=~"^(fronte
 
 #### frontend: codeintel_gitserver_total
 
-<p class="subtitle">Aggregate client operations every 5m
-
-</p>
+<p class="subtitle">Aggregate client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1208,9 +1096,7 @@ Query: `sum(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-
 
 #### frontend: codeintel_gitserver_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1229,9 +1115,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_gitserver_durat
 
 #### frontend: codeintel_gitserver_errors_total
 
-<p class="subtitle">Aggregate client operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1250,9 +1134,7 @@ Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourc
 
 #### frontend: codeintel_gitserver_error_rate
 
-<p class="subtitle">Aggregate client operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1271,9 +1153,7 @@ Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourc
 
 #### frontend: codeintel_gitserver_total
 
-<p class="subtitle">Client operations every 5m
-
-</p>
+<p class="subtitle">Client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1292,9 +1172,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_total{job=~"^(frontend|sour
 
 #### frontend: codeintel_gitserver_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1313,9 +1191,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_du
 
 #### frontend: codeintel_gitserver_errors_total
 
-<p class="subtitle">Client operation errors every 5m
-
-</p>
+<p class="subtitle">Client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1334,9 +1210,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(fronte
 
 #### frontend: codeintel_gitserver_error_rate
 
-<p class="subtitle">Client operation error rate over 5m
-
-</p>
+<p class="subtitle">Client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1357,9 +1231,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(fronte
 
 #### frontend: codeintel_uploadstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1378,9 +1250,7 @@ Query: `sum(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegrap
 
 #### frontend: codeintel_uploadstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1399,9 +1269,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_uploadstore_dur
 
 #### frontend: codeintel_uploadstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1420,9 +1288,7 @@ Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sou
 
 #### frontend: codeintel_uploadstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1441,9 +1307,7 @@ Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sou
 
 #### frontend: codeintel_uploadstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1462,9 +1326,7 @@ Query: `sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^(frontend|so
 
 #### frontend: codeintel_uploadstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1483,9 +1345,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploadstore_
 
 #### frontend: codeintel_uploadstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1504,9 +1364,7 @@ Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(fron
 
 #### frontend: codeintel_uploadstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1527,9 +1385,7 @@ Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(fron
 
 #### frontend: batches_dbstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1548,9 +1404,7 @@ Query: `sum(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-fron
 
 #### frontend: batches_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1569,9 +1423,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_batches_dbstore_duration_
 
 #### frontend: batches_dbstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1590,9 +1442,7 @@ Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegra
 
 #### frontend: batches_dbstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1611,9 +1461,7 @@ Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegra
 
 #### frontend: batches_dbstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1632,9 +1480,7 @@ Query: `sum by (op)(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegr
 
 #### frontend: batches_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1653,9 +1499,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_durati
 
 #### frontend: batches_dbstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1674,9 +1518,7 @@ Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|s
 
 #### frontend: batches_dbstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1697,9 +1539,7 @@ Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|s
 
 #### frontend: oobmigration_total
 
-<p class="subtitle">Migration handler operations every 5m
-
-</p>
+<p class="subtitle">Migration handler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1718,9 +1558,7 @@ Query: `sum(increase(src_oobmigration_total{op="up",job=~"^(frontend|sourcegraph
 
 #### frontend: oobmigration_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful migration handler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful migration handler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1739,9 +1577,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_oobmigration_duration_sec
 
 #### frontend: oobmigration_errors_total
 
-<p class="subtitle">Migration handler operation errors every 5m
-
-</p>
+<p class="subtitle">Migration handler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1760,9 +1596,7 @@ Query: `sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sour
 
 #### frontend: oobmigration_error_rate
 
-<p class="subtitle">Migration handler operation error rate over 5m
-
-</p>
+<p class="subtitle">Migration handler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1783,9 +1617,7 @@ Query: `sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sour
 
 #### frontend: oobmigration_total
 
-<p class="subtitle">Migration handler operations every 5m
-
-</p>
+<p class="subtitle">Migration handler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -1804,9 +1636,7 @@ Query: `sum(increase(src_oobmigration_total{op="down",job=~"^(frontend|sourcegra
 
 #### frontend: oobmigration_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful migration handler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful migration handler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -1825,9 +1655,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_oobmigration_duration_sec
 
 #### frontend: oobmigration_errors_total
 
-<p class="subtitle">Migration handler operation errors every 5m
-
-</p>
+<p class="subtitle">Migration handler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -1846,9 +1674,7 @@ Query: `sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|so
 
 #### frontend: oobmigration_error_rate
 
-<p class="subtitle">Migration handler operation error rate over 5m
-
-</p>
+<p class="subtitle">Migration handler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -1869,9 +1695,7 @@ Query: `sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|so
 
 #### frontend: internal_indexed_search_error_responses
 
-<p class="subtitle">Internal indexed search error responses every 5m
-
-</p>
+<p class="subtitle">Internal indexed search error responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-indexed-search-error-responses) for 1 alert related to this panel.
 
@@ -1890,9 +1714,7 @@ Query: `sum by(code) (increase(src_zoekt_request_duration_seconds_count{code!~"2
 
 #### frontend: internal_unindexed_search_error_responses
 
-<p class="subtitle">Internal unindexed search error responses every 5m
-
-</p>
+<p class="subtitle">Internal unindexed search error responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-unindexed-search-error-responses) for 1 alert related to this panel.
 
@@ -1911,9 +1733,7 @@ Query: `sum by(code) (increase(searcher_service_request_total{code!~"2.."}[5m]))
 
 #### frontend: internal_api_error_responses
 
-<p class="subtitle">Internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -1932,9 +1752,7 @@ Query: `sum by(category) (increase(src_frontend_internal_request_duration_second
 
 #### frontend: 99th_percentile_gitserver_duration
 
-<p class="subtitle">99th percentile successful gitserver query duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful gitserver query duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-gitserver-duration) for 1 alert related to this panel.
 
@@ -1953,9 +1771,7 @@ Query: `histogram_quantile(0.99, sum by (le,category)(rate(src_gitserver_request
 
 #### frontend: gitserver_error_responses
 
-<p class="subtitle">Gitserver error responses every 5m
-
-</p>
+<p class="subtitle">Gitserver error responses every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-gitserver-error-responses) for 1 alert related to this panel.
 
@@ -1974,9 +1790,7 @@ Query: `sum by (category)(increase(src_gitserver_request_duration_seconds_count{
 
 #### frontend: observability_test_alert_warning
 
-<p class="subtitle">Warning test alert metric
-
-</p>
+<p class="subtitle">Warning test alert metric</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-warning) for 1 alert related to this panel.
 
@@ -1995,9 +1809,7 @@ Query: `max by(owner) (observability_test_metric_warning)`
 
 #### frontend: observability_test_alert_critical
 
-<p class="subtitle">Critical test alert metric
-
-</p>
+<p class="subtitle">Critical test alert metric</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical) for 1 alert related to this panel.
 
@@ -2018,9 +1830,7 @@ Query: `max by(owner) (observability_test_metric_critical)`
 
 #### frontend: max_open_conns
 
-<p class="subtitle">Maximum open
-
-</p>
+<p class="subtitle">Maximum open</p>
 
 This panel has no related alerts.
 
@@ -2039,9 +1849,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="frontend"
 
 #### frontend: open_conns
 
-<p class="subtitle">Established
-
-</p>
+<p class="subtitle">Established</p>
 
 This panel has no related alerts.
 
@@ -2060,9 +1868,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="frontend"})`
 
 #### frontend: in_use
 
-<p class="subtitle">Used
-
-</p>
+<p class="subtitle">Used</p>
 
 This panel has no related alerts.
 
@@ -2081,9 +1887,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="frontend"})
 
 #### frontend: idle
 
-<p class="subtitle">Idle
-
-</p>
+<p class="subtitle">Idle</p>
 
 This panel has no related alerts.
 
@@ -2102,9 +1906,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="frontend"})`
 
 #### frontend: mean_blocked_seconds_per_conn_request
 
-<p class="subtitle">Mean blocked seconds per conn request
-
-</p>
+<p class="subtitle">Mean blocked seconds per conn request</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-blocked-seconds-per-conn-request) for 2 alerts related to this panel.
 
@@ -2123,9 +1925,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app
 
 #### frontend: closed_max_idle
 
-<p class="subtitle">Closed by SetMaxIdleConns
-
-</p>
+<p class="subtitle">Closed by SetMaxIdleConns</p>
 
 This panel has no related alerts.
 
@@ -2144,9 +1944,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app
 
 #### frontend: closed_max_lifetime
 
-<p class="subtitle">Closed by SetConnMaxLifetime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxLifetime</p>
 
 This panel has no related alerts.
 
@@ -2165,9 +1963,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime
 
 #### frontend: closed_max_idle_time
 
-<p class="subtitle">Closed by SetConnMaxIdleTime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxIdleTime</p>
 
 This panel has no related alerts.
 
@@ -2188,9 +1984,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_tim
 
 #### frontend: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -2219,9 +2013,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^(frontend|sourcegr
 
 #### frontend: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-cpu-usage) for 1 alert related to this panel.
 
@@ -2240,9 +2032,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegr
 
 #### frontend: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-memory-usage) for 1 alert related to this panel.
 
@@ -2261,9 +2051,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourc
 
 #### frontend: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -2287,9 +2075,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^(frontend|sourcegrap
 
 #### frontend: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -2308,9 +2094,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### frontend: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -2329,9 +2113,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(
 
 #### frontend: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -2350,9 +2132,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(fro
 
 #### frontend: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -2373,9 +2153,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(
 
 #### frontend: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -2396,9 +2174,7 @@ Query: `max by(instance) (go_goroutines{job=~".*(frontend|sourcegraph-frontend)"
 
 #### frontend: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -2419,9 +2195,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*(frontend|sourcegraph-f
 
 #### frontend: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-pods-available-percentage) for 1 alert related to this panel.
 
@@ -2442,9 +2216,7 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 #### frontend: mean_successful_sentinel_duration_5m
 
-<p class="subtitle">Mean successful sentinel search duration over 5m
-
-</p>
+<p class="subtitle">Mean successful sentinel search duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-5m) for 2 alerts related to this panel.
 
@@ -2463,9 +2235,7 @@ Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*"
 
 #### frontend: mean_sentinel_stream_latency_5m
 
-<p class="subtitle">Mean sentinel stream latency over 5m
-
-</p>
+<p class="subtitle">Mean sentinel stream latency over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-5m) for 2 alerts related to this panel.
 
@@ -2484,9 +2254,7 @@ Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*
 
 #### frontend: 90th_percentile_successful_sentinel_duration_5m
 
-<p class="subtitle">90th percentile successful sentinel search duration over 5m
-
-</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-5m) for 2 alerts related to this panel.
 
@@ -2505,9 +2273,7 @@ Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_respo
 
 #### frontend: 90th_percentile_sentinel_stream_latency_5m
 
-<p class="subtitle">90th percentile sentinel stream latency over 5m
-
-</p>
+<p class="subtitle">90th percentile sentinel stream latency over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-5m) for 2 alerts related to this panel.
 
@@ -2526,9 +2292,7 @@ Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_strea
 
 #### frontend: mean_successful_sentinel_duration_by_query_5m
 
-<p class="subtitle">Mean successful sentinel search duration by query over 5m
-
-</p>
+<p class="subtitle">Mean successful sentinel search duration by query over 5m</p>
 
 - The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2549,9 +2313,7 @@ Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*"
 
 #### frontend: mean_sentinel_stream_latency_by_query_5m
 
-<p class="subtitle">Mean sentinel stream latency by query over 5m
-
-</p>
+<p class="subtitle">Mean sentinel stream latency by query over 5m</p>
 
 - The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2572,9 +2334,7 @@ Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*
 
 #### frontend: unsuccessful_status_rate_5m
 
-<p class="subtitle">Unsuccessful status rate per 5m
-
-</p>
+<p class="subtitle">Unsuccessful status rate per 5m</p>
 
 - The rate of unsuccessful sentinel query, broken down by failure type
 
@@ -2601,9 +2361,7 @@ To see this dashboard, visit `/-/debug/grafana/d/gitserver/gitserver` on your So
 
 #### gitserver: memory_working_set
 
-<p class="subtitle">Memory working set
-
-</p>
+<p class="subtitle">Memory working set</p>
 
 
 
@@ -2624,9 +2382,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (container_memory_workin
 
 #### gitserver: go_routines
 
-<p class="subtitle">Go routines
-
-</p>
+<p class="subtitle">Go routines</p>
 
 
 
@@ -2647,9 +2403,7 @@ Query: `go_goroutines{app="gitserver", instance=~"${shard:regex}"}`
 
 #### gitserver: cpu_throttling_time
 
-<p class="subtitle">Container CPU throttling time %
-
-</p>
+<p class="subtitle">Container CPU throttling time %</p>
 
 
 
@@ -2670,9 +2424,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) ((rate(container_cpu_cfs
 
 #### gitserver: cpu_usage_seconds
 
-<p class="subtitle">Cpu usage seconds
-
-</p>
+<p class="subtitle">Cpu usage seconds</p>
 
 
 
@@ -2693,9 +2445,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_cpu_usag
 
 #### gitserver: disk_space_remaining
 
-<p class="subtitle">Disk space remaining by instance
-
-</p>
+<p class="subtitle">Disk space remaining by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-disk-space-remaining) for 2 alerts related to this panel.
 
@@ -2714,9 +2464,7 @@ Query: `(src_gitserver_disk_space_available / src_gitserver_disk_space_total) * 
 
 #### gitserver: io_reads_total
 
-<p class="subtitle">I/o reads total
-
-</p>
+<p class="subtitle">I/o reads total</p>
 
 
 
@@ -2737,9 +2485,7 @@ Query: `sum by (container_label_io_kubernetes_container_name) (rate(container_fs
 
 #### gitserver: io_writes_total
 
-<p class="subtitle">I/o writes total
-
-</p>
+<p class="subtitle">I/o writes total</p>
 
 
 
@@ -2760,9 +2506,7 @@ Query: `sum by (container_label_io_kubernetes_container_name) (rate(container_fs
 
 #### gitserver: io_reads
 
-<p class="subtitle">I/o reads
-
-</p>
+<p class="subtitle">I/o reads</p>
 
 
 
@@ -2783,9 +2527,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_fs_reads
 
 #### gitserver: io_writes
 
-<p class="subtitle">I/o writes
-
-</p>
+<p class="subtitle">I/o writes</p>
 
 
 
@@ -2806,9 +2548,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_fs_write
 
 #### gitserver: io_read_througput
 
-<p class="subtitle">I/o read throughput
-
-</p>
+<p class="subtitle">I/o read throughput</p>
 
 
 
@@ -2829,9 +2569,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_fs_reads
 
 #### gitserver: io_write_throughput
 
-<p class="subtitle">I/o write throughput
-
-</p>
+<p class="subtitle">I/o write throughput</p>
 
 
 
@@ -2852,9 +2590,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_fs_write
 
 #### gitserver: running_git_commands
 
-<p class="subtitle">Git commands running on each gitserver instance
-
-</p>
+<p class="subtitle">Git commands running on each gitserver instance</p>
 
 A high value signals load.
 
@@ -2875,9 +2611,7 @@ Query: `sum by (instance, cmd) (src_gitserver_exec_running{instance=~"${shard:re
 
 #### gitserver: git_commands_received
 
-<p class="subtitle">Rate of git commands received across all instances
-
-</p>
+<p class="subtitle">Rate of git commands received across all instances</p>
 
 per second rate per command across all instances
 
@@ -2898,9 +2632,7 @@ Query: `sum by (cmd) (rate(src_gitserver_exec_duration_seconds_count[5m]))`
 
 #### gitserver: repository_clone_queue_size
 
-<p class="subtitle">Repository clone queue size
-
-</p>
+<p class="subtitle">Repository clone queue size</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-clone-queue-size) for 1 alert related to this panel.
 
@@ -2919,9 +2651,7 @@ Query: `sum(src_gitserver_clone_queue)`
 
 #### gitserver: repository_existence_check_queue_size
 
-<p class="subtitle">Repository existence check queue size
-
-</p>
+<p class="subtitle">Repository existence check queue size</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-existence-check-queue-size) for 1 alert related to this panel.
 
@@ -2940,9 +2670,7 @@ Query: `sum(src_gitserver_lsremote_queue)`
 
 #### gitserver: echo_command_duration_test
 
-<p class="subtitle">Echo test command duration
-
-</p>
+<p class="subtitle">Echo test command duration</p>
 
 A high value here likely indicates a problem, especially if consistently high.
 You can query for individual commands using `sum by (cmd)(src_gitserver_exec_running)` in Grafana (`/-/debug/grafana`) to see if a specific Git Server command might be spiking in frequency.
@@ -2969,9 +2697,7 @@ Query: `max(src_gitserver_echo_duration_seconds)`
 
 #### gitserver: frontend_internal_api_error_responses
 
-<p class="subtitle">Frontend-internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Frontend-internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -2992,9 +2718,7 @@ Query: `sum by (category)(increase(src_frontend_internal_request_duration_second
 
 #### gitserver: janitor_running
 
-<p class="subtitle">If the janitor process is running
-
-</p>
+<p class="subtitle">If the janitor process is running</p>
 
 1, if the janitor process is currently running
 
@@ -3015,9 +2739,7 @@ Query: `max by (instance) (src_gitserver_janitor_running)`
 
 #### gitserver: janitor_job_duration
 
-<p class="subtitle">95th percentile job run duration
-
-</p>
+<p class="subtitle">95th percentile job run duration</p>
 
 95th percentile job run duration
 
@@ -3038,9 +2760,7 @@ Query: `histogram_quantile(0.95, sum(rate(src_gitserver_janitor_job_duration_sec
 
 #### gitserver: repos_removed
 
-<p class="subtitle">Repositories removed due to disk pressure
-
-</p>
+<p class="subtitle">Repositories removed due to disk pressure</p>
 
 Repositories removed due to disk pressure
 
@@ -3063,9 +2783,7 @@ Query: `sum by (instance) (rate(src_gitserver_repos_removed_disk_pressure[5m]))`
 
 #### gitserver: codeintel_coursier_total
 
-<p class="subtitle">Aggregate invocations operations every 5m
-
-</p>
+<p class="subtitle">Aggregate invocations operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -3084,9 +2802,7 @@ Query: `sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitser
 
 #### gitserver: codeintel_coursier_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate invocations operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate invocations operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -3105,9 +2821,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_coursier_durati
 
 #### gitserver: codeintel_coursier_errors_total
 
-<p class="subtitle">Aggregate invocations operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate invocations operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -3126,9 +2840,7 @@ Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"
 
 #### gitserver: codeintel_coursier_error_rate
 
-<p class="subtitle">Aggregate invocations operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate invocations operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -3147,9 +2859,7 @@ Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"
 
 #### gitserver: codeintel_coursier_total
 
-<p class="subtitle">Invocations operations every 5m
-
-</p>
+<p class="subtitle">Invocations operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -3168,9 +2878,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~
 
 #### gitserver: codeintel_coursier_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful invocations operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful invocations operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -3189,9 +2897,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_coursier_dur
 
 #### gitserver: codeintel_coursier_errors_total
 
-<p class="subtitle">Invocations operation errors every 5m
-
-</p>
+<p class="subtitle">Invocations operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -3210,9 +2916,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand
 
 #### gitserver: codeintel_coursier_error_rate
 
-<p class="subtitle">Invocations operation error rate over 5m
-
-</p>
+<p class="subtitle">Invocations operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -3233,9 +2937,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand
 
 #### gitserver: max_open_conns
 
-<p class="subtitle">Maximum open
-
-</p>
+<p class="subtitle">Maximum open</p>
 
 This panel has no related alerts.
 
@@ -3254,9 +2956,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="gitserver
 
 #### gitserver: open_conns
 
-<p class="subtitle">Established
-
-</p>
+<p class="subtitle">Established</p>
 
 This panel has no related alerts.
 
@@ -3275,9 +2975,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="gitserver"})`
 
 #### gitserver: in_use
 
-<p class="subtitle">Used
-
-</p>
+<p class="subtitle">Used</p>
 
 This panel has no related alerts.
 
@@ -3296,9 +2994,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="gitserver"}
 
 #### gitserver: idle
 
-<p class="subtitle">Idle
-
-</p>
+<p class="subtitle">Idle</p>
 
 This panel has no related alerts.
 
@@ -3317,9 +3013,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="gitserver"})`
 
 #### gitserver: mean_blocked_seconds_per_conn_request
 
-<p class="subtitle">Mean blocked seconds per conn request
-
-</p>
+<p class="subtitle">Mean blocked seconds per conn request</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-mean-blocked-seconds-per-conn-request) for 2 alerts related to this panel.
 
@@ -3338,9 +3032,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app
 
 #### gitserver: closed_max_idle
 
-<p class="subtitle">Closed by SetMaxIdleConns
-
-</p>
+<p class="subtitle">Closed by SetMaxIdleConns</p>
 
 This panel has no related alerts.
 
@@ -3359,9 +3051,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app
 
 #### gitserver: closed_max_lifetime
 
-<p class="subtitle">Closed by SetConnMaxLifetime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxLifetime</p>
 
 This panel has no related alerts.
 
@@ -3380,9 +3070,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime
 
 #### gitserver: closed_max_idle_time
 
-<p class="subtitle">Closed by SetConnMaxIdleTime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxIdleTime</p>
 
 This panel has no related alerts.
 
@@ -3403,9 +3091,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_tim
 
 #### gitserver: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -3434,9 +3120,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^gitserver.*"}) > 6
 
 #### gitserver: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-cpu-usage) for 1 alert related to this panel.
 
@@ -3455,9 +3139,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}`
 
 #### gitserver: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage) for 1 alert related to this panel.
 
@@ -3476,9 +3158,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}`
 
 #### gitserver: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -3502,9 +3182,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^gitserver.*"}[1h]) +
 
 #### gitserver: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -3523,9 +3201,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### gitserver: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Git Server is expected to use up all the memory it is provided.
 
@@ -3546,9 +3222,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^g
 
 #### gitserver: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -3567,9 +3241,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^gits
 
 #### gitserver: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Git Server is expected to use up all the memory it is provided.
 
@@ -3592,9 +3264,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^g
 
 #### gitserver: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -3615,9 +3285,7 @@ Query: `max by(instance) (go_goroutines{job=~".*gitserver"})`
 
 #### gitserver: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -3638,9 +3306,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*gitserver"})`
 
 #### gitserver: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#gitserver-pods-available-percentage) for 1 alert related to this panel.
 
@@ -3667,9 +3333,7 @@ To see this dashboard, visit `/-/debug/grafana/d/github-proxy/github-proxy` on y
 
 #### github-proxy: github_proxy_waiting_requests
 
-<p class="subtitle">Number of requests waiting on the global mutex
-
-</p>
+<p class="subtitle">Number of requests waiting on the global mutex</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-github-proxy-waiting-requests) for 1 alert related to this panel.
 
@@ -3690,9 +3354,7 @@ Query: `max(github_proxy_waiting_requests)`
 
 #### github-proxy: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -3721,9 +3383,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^github-proxy.*"}) 
 
 #### github-proxy: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-cpu-usage) for 1 alert related to this panel.
 
@@ -3742,9 +3402,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^github-proxy.*"}`
 
 #### github-proxy: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-memory-usage) for 1 alert related to this panel.
 
@@ -3763,9 +3421,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^github-proxy.*"
 
 #### github-proxy: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -3789,9 +3445,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^github-proxy.*"}[1h]
 
 #### github-proxy: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -3810,9 +3464,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### github-proxy: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -3831,9 +3483,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^g
 
 #### github-proxy: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -3852,9 +3502,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^gith
 
 #### github-proxy: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -3875,9 +3523,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^g
 
 #### github-proxy: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -3898,9 +3544,7 @@ Query: `max by(instance) (go_goroutines{job=~".*github-proxy"})`
 
 #### github-proxy: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -3921,9 +3565,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*github-proxy"})`
 
 #### github-proxy: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-pods-available-percentage) for 1 alert related to this panel.
 
@@ -3948,9 +3590,7 @@ To see this dashboard, visit `/-/debug/grafana/d/postgres/postgres` on your Sour
 
 #### postgres: connections
 
-<p class="subtitle">Active connections
-
-</p>
+<p class="subtitle">Active connections</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-connections) for 1 alert related to this panel.
 
@@ -3969,9 +3609,7 @@ Query: `sum by (job) (pg_stat_activity_count{datname!~"template.*|postgres|cloud
 
 #### postgres: transaction_durations
 
-<p class="subtitle">Maximum transaction durations
-
-</p>
+<p class="subtitle">Maximum transaction durations</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for 2 alerts related to this panel.
 
@@ -3992,9 +3630,7 @@ Query: `sum by (datname) (pg_stat_activity_max_tx_duration{datname!~"template.*|
 
 #### postgres: postgres_up
 
-<p class="subtitle">Database availability
-
-</p>
+<p class="subtitle">Database availability</p>
 
 A non-zero value indicates the database is online.
 
@@ -4015,9 +3651,7 @@ Query: `pg_up`
 
 #### postgres: invalid_indexes
 
-<p class="subtitle">Invalid indexes (unusable by the query planner)
-
-</p>
+<p class="subtitle">Invalid indexes (unusable by the query planner)</p>
 
 A non-zero value indicates the that Postgres failed to build an index. Expect degraded performance until the index is manually rebuilt.
 
@@ -4038,9 +3672,7 @@ Query: `max by (relname)(pg_invalid_index_count)`
 
 #### postgres: pg_exporter_err
 
-<p class="subtitle">Errors scraping postgres exporter
-
-</p>
+<p class="subtitle">Errors scraping postgres exporter</p>
 
 This value indicates issues retrieving metrics from postgres_exporter.
 
@@ -4061,9 +3693,7 @@ Query: `pg_exporter_last_scrape_error`
 
 #### postgres: migration_in_progress
 
-<p class="subtitle">Active schema migration
-
-</p>
+<p class="subtitle">Active schema migration</p>
 
 A 0 value indicates that no migration is in progress.
 
@@ -4086,9 +3716,7 @@ Query: `pg_sg_migration_status`
 
 #### postgres: pg_table_size
 
-<p class="subtitle">Table size
-
-</p>
+<p class="subtitle">Table size</p>
 
 Total size of this table
 
@@ -4109,9 +3737,7 @@ Query: `max by (relname)(pg_table_bloat_size)`
 
 #### postgres: pg_table_bloat_ratio
 
-<p class="subtitle">Table bloat ratio
-
-</p>
+<p class="subtitle">Table bloat ratio</p>
 
 Estimated bloat ratio of this table (high bloat = high overhead)
 
@@ -4132,9 +3758,7 @@ Query: `max by (relname)(pg_table_bloat_ratio) * 100`
 
 #### postgres: pg_index_size
 
-<p class="subtitle">Index size
-
-</p>
+<p class="subtitle">Index size</p>
 
 Total size of this index
 
@@ -4155,9 +3779,7 @@ Query: `max by (relname)(pg_index_bloat_size)`
 
 #### postgres: pg_index_bloat_ratio
 
-<p class="subtitle">Index bloat ratio
-
-</p>
+<p class="subtitle">Index bloat ratio</p>
 
 Estimated bloat ratio of this index (high bloat = high overhead)
 
@@ -4180,9 +3802,7 @@ Query: `max by (relname)(pg_index_bloat_ratio) * 100`
 
 #### postgres: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -4201,9 +3821,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### postgres: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -4222,9 +3840,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(
 
 #### postgres: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -4243,9 +3859,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(pgs
 
 #### postgres: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -4266,9 +3880,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(
 
 #### postgres: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage) for 1 alert related to this panel.
 
@@ -4295,9 +3907,7 @@ To see this dashboard, visit `/-/debug/grafana/d/precise-code-intel-worker/preci
 
 #### precise-code-intel-worker: codeintel_upload_queue_size
 
-<p class="subtitle">Unprocessed upload record queue size
-
-</p>
+<p class="subtitle">Unprocessed upload record queue size</p>
 
 This panel has no related alerts.
 
@@ -4316,9 +3926,7 @@ Query: `max(src_codeintel_upload_total{job=~"^precise-code-intel-worker.*"})`
 
 #### precise-code-intel-worker: codeintel_upload_queue_growth_rate
 
-<p class="subtitle">Unprocessed upload record queue growth rate over 30m
-
-</p>
+<p class="subtitle">Unprocessed upload record queue growth rate over 30m</p>
 
 This value compares the rate of enqueues against the rate of finished jobs.
 
@@ -4345,9 +3953,7 @@ Query: `sum(increase(src_codeintel_upload_total{job=~"^precise-code-intel-worker
 
 #### precise-code-intel-worker: codeintel_upload_handlers
 
-<p class="subtitle">Handler active handlers
-
-</p>
+<p class="subtitle">Handler active handlers</p>
 
 This panel has no related alerts.
 
@@ -4366,9 +3972,7 @@ Query: `sum(src_codeintel_upload_processor_handlers{job=~"^precise-code-intel-wo
 
 #### precise-code-intel-worker: codeintel_upload_processor_total
 
-<p class="subtitle">Handler operations every 5m
-
-</p>
+<p class="subtitle">Handler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4387,9 +3991,7 @@ Query: `sum(increase(src_codeintel_upload_processor_total{job=~"^precise-code-in
 
 #### precise-code-intel-worker: codeintel_upload_processor_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful handler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful handler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -4408,9 +4010,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_upload_processo
 
 #### precise-code-intel-worker: codeintel_upload_processor_errors_total
 
-<p class="subtitle">Handler operation errors every 5m
-
-</p>
+<p class="subtitle">Handler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -4429,9 +4029,7 @@ Query: `sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-
 
 #### precise-code-intel-worker: codeintel_upload_processor_error_rate
 
-<p class="subtitle">Handler operation error rate over 5m
-
-</p>
+<p class="subtitle">Handler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -4452,9 +4050,7 @@ Query: `sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-
 
 #### precise-code-intel-worker: codeintel_dbstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4473,9 +4069,7 @@ Query: `sum(increase(src_codeintel_dbstore_total{job=~"^precise-code-intel-worke
 
 #### precise-code-intel-worker: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -4494,9 +4088,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_dbstore_duratio
 
 #### precise-code-intel-worker: codeintel_dbstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -4515,9 +4107,7 @@ Query: `sum(increase(src_codeintel_dbstore_errors_total{job=~"^precise-code-inte
 
 #### precise-code-intel-worker: codeintel_dbstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -4536,9 +4126,7 @@ Query: `sum(increase(src_codeintel_dbstore_errors_total{job=~"^precise-code-inte
 
 #### precise-code-intel-worker: codeintel_dbstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4557,9 +4145,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_total{job=~"^precise-code-int
 
 #### precise-code-intel-worker: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -4578,9 +4164,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dbstore_dura
 
 #### precise-code-intel-worker: codeintel_dbstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -4599,9 +4183,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_errors_total{job=~"^precise-c
 
 #### precise-code-intel-worker: codeintel_dbstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -4622,9 +4204,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_errors_total{job=~"^precise-c
 
 #### precise-code-intel-worker: codeintel_lsifstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4643,9 +4223,7 @@ Query: `sum(increase(src_codeintel_lsifstore_total{job=~"^precise-code-intel-wor
 
 #### precise-code-intel-worker: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -4664,9 +4242,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_lsifstore_durat
 
 #### precise-code-intel-worker: codeintel_lsifstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -4685,9 +4261,7 @@ Query: `sum(increase(src_codeintel_lsifstore_errors_total{job=~"^precise-code-in
 
 #### precise-code-intel-worker: codeintel_lsifstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -4706,9 +4280,7 @@ Query: `sum(increase(src_codeintel_lsifstore_errors_total{job=~"^precise-code-in
 
 #### precise-code-intel-worker: codeintel_lsifstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4727,9 +4299,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_total{job=~"^precise-code-i
 
 #### precise-code-intel-worker: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -4748,9 +4318,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_lsifstore_du
 
 #### precise-code-intel-worker: codeintel_lsifstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -4769,9 +4337,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_errors_total{job=~"^precise
 
 #### precise-code-intel-worker: codeintel_lsifstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -4792,9 +4358,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_errors_total{job=~"^precise
 
 #### precise-code-intel-worker: workerutil_dbworker_store_codeintel_upload_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4813,9 +4377,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_upload_total{job=~"
 
 #### precise-code-intel-worker: workerutil_dbworker_store_codeintel_upload_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -4834,9 +4396,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_workerutil_dbworker_store
 
 #### precise-code-intel-worker: workerutil_dbworker_store_codeintel_upload_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -4855,9 +4415,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total
 
 #### precise-code-intel-worker: workerutil_dbworker_store_codeintel_upload_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -4878,9 +4436,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total
 
 #### precise-code-intel-worker: codeintel_gitserver_total
 
-<p class="subtitle">Aggregate client operations every 5m
-
-</p>
+<p class="subtitle">Aggregate client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4899,9 +4455,7 @@ Query: `sum(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-wor
 
 #### precise-code-intel-worker: codeintel_gitserver_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -4920,9 +4474,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_gitserver_durat
 
 #### precise-code-intel-worker: codeintel_gitserver_errors_total
 
-<p class="subtitle">Aggregate client operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -4941,9 +4493,7 @@ Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-in
 
 #### precise-code-intel-worker: codeintel_gitserver_error_rate
 
-<p class="subtitle">Aggregate client operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -4962,9 +4512,7 @@ Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-in
 
 #### precise-code-intel-worker: codeintel_gitserver_total
 
-<p class="subtitle">Client operations every 5m
-
-</p>
+<p class="subtitle">Client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -4983,9 +4531,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_total{job=~"^precise-code-i
 
 #### precise-code-intel-worker: codeintel_gitserver_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -5004,9 +4550,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_du
 
 #### precise-code-intel-worker: codeintel_gitserver_errors_total
 
-<p class="subtitle">Client operation errors every 5m
-
-</p>
+<p class="subtitle">Client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -5025,9 +4569,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise
 
 #### precise-code-intel-worker: codeintel_gitserver_error_rate
 
-<p class="subtitle">Client operation error rate over 5m
-
-</p>
+<p class="subtitle">Client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -5048,9 +4590,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise
 
 #### precise-code-intel-worker: codeintel_uploadstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -5069,9 +4609,7 @@ Query: `sum(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-w
 
 #### precise-code-intel-worker: codeintel_uploadstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -5090,9 +4628,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_uploadstore_dur
 
 #### precise-code-intel-worker: codeintel_uploadstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -5111,9 +4647,7 @@ Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-
 
 #### precise-code-intel-worker: codeintel_uploadstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -5132,9 +4666,7 @@ Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-
 
 #### precise-code-intel-worker: codeintel_uploadstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -5153,9 +4685,7 @@ Query: `sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^precise-code
 
 #### precise-code-intel-worker: codeintel_uploadstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -5174,9 +4704,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploadstore_
 
 #### precise-code-intel-worker: codeintel_uploadstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -5195,9 +4723,7 @@ Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^preci
 
 #### precise-code-intel-worker: codeintel_uploadstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -5218,9 +4744,7 @@ Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^preci
 
 #### precise-code-intel-worker: frontend_internal_api_error_responses
 
-<p class="subtitle">Frontend-internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Frontend-internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -5241,9 +4765,7 @@ Query: `sum by (category)(increase(src_frontend_internal_request_duration_second
 
 #### precise-code-intel-worker: max_open_conns
 
-<p class="subtitle">Maximum open
-
-</p>
+<p class="subtitle">Maximum open</p>
 
 This panel has no related alerts.
 
@@ -5262,9 +4784,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="precise-c
 
 #### precise-code-intel-worker: open_conns
 
-<p class="subtitle">Established
-
-</p>
+<p class="subtitle">Established</p>
 
 This panel has no related alerts.
 
@@ -5283,9 +4803,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="precise-code-
 
 #### precise-code-intel-worker: in_use
 
-<p class="subtitle">Used
-
-</p>
+<p class="subtitle">Used</p>
 
 This panel has no related alerts.
 
@@ -5304,9 +4822,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="precise-cod
 
 #### precise-code-intel-worker: idle
 
-<p class="subtitle">Idle
-
-</p>
+<p class="subtitle">Idle</p>
 
 This panel has no related alerts.
 
@@ -5325,9 +4841,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="precise-code-
 
 #### precise-code-intel-worker: mean_blocked_seconds_per_conn_request
 
-<p class="subtitle">Mean blocked seconds per conn request
-
-</p>
+<p class="subtitle">Mean blocked seconds per conn request</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-mean-blocked-seconds-per-conn-request) for 2 alerts related to this panel.
 
@@ -5346,9 +4860,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app
 
 #### precise-code-intel-worker: closed_max_idle
 
-<p class="subtitle">Closed by SetMaxIdleConns
-
-</p>
+<p class="subtitle">Closed by SetMaxIdleConns</p>
 
 This panel has no related alerts.
 
@@ -5367,9 +4879,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app
 
 #### precise-code-intel-worker: closed_max_lifetime
 
-<p class="subtitle">Closed by SetConnMaxLifetime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxLifetime</p>
 
 This panel has no related alerts.
 
@@ -5388,9 +4898,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime
 
 #### precise-code-intel-worker: closed_max_idle_time
 
-<p class="subtitle">Closed by SetConnMaxIdleTime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxIdleTime</p>
 
 This panel has no related alerts.
 
@@ -5411,9 +4919,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_tim
 
 #### precise-code-intel-worker: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -5442,9 +4948,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^precise-code-intel
 
 #### precise-code-intel-worker: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-cpu-usage) for 1 alert related to this panel.
 
@@ -5463,9 +4967,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel
 
 #### precise-code-intel-worker: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-memory-usage) for 1 alert related to this panel.
 
@@ -5484,9 +4986,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-in
 
 #### precise-code-intel-worker: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -5510,9 +5010,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^precise-code-intel-w
 
 #### precise-code-intel-worker: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -5531,9 +5029,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### precise-code-intel-worker: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -5552,9 +5048,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^p
 
 #### precise-code-intel-worker: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -5573,9 +5067,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^prec
 
 #### precise-code-intel-worker: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -5596,9 +5088,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^p
 
 #### precise-code-intel-worker: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -5619,9 +5109,7 @@ Query: `max by(instance) (go_goroutines{job=~".*precise-code-intel-worker"})`
 
 #### precise-code-intel-worker: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -5642,9 +5130,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*precise-code-intel-work
 
 #### precise-code-intel-worker: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-pods-available-percentage) for 1 alert related to this panel.
 
@@ -5671,9 +5157,7 @@ To see this dashboard, visit `/-/debug/grafana/d/query-runner/query-runner` on y
 
 #### query-runner: frontend_internal_api_error_responses
 
-<p class="subtitle">Frontend-internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Frontend-internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -5694,9 +5178,7 @@ Query: `sum by (category)(increase(src_frontend_internal_request_duration_second
 
 #### query-runner: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -5725,9 +5207,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^query-runner.*"}) 
 
 #### query-runner: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage) for 1 alert related to this panel.
 
@@ -5746,9 +5226,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^query-runner.*"}`
 
 #### query-runner: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage) for 1 alert related to this panel.
 
@@ -5767,9 +5245,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^query-runner.*"
 
 #### query-runner: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -5793,9 +5269,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^query-runner.*"}[1h]
 
 #### query-runner: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -5814,9 +5288,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### query-runner: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -5835,9 +5307,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^q
 
 #### query-runner: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -5856,9 +5326,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^quer
 
 #### query-runner: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -5879,9 +5347,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^q
 
 #### query-runner: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -5902,9 +5368,7 @@ Query: `max by(instance) (go_goroutines{job=~".*query-runner"})`
 
 #### query-runner: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -5925,9 +5389,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*query-runner"})`
 
 #### query-runner: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#query-runner-pods-available-percentage) for 1 alert related to this panel.
 
@@ -5954,9 +5416,7 @@ To see this dashboard, visit `/-/debug/grafana/d/worker/worker` on your Sourcegr
 
 #### worker: worker_job_count
 
-<p class="subtitle">Number of worker instances running each job
-
-</p>
+<p class="subtitle">Number of worker instances running each job</p>
 
 The number of worker instances running each job type.
 It is necessary for each job type to be managed by at least one worker instance.
@@ -5977,9 +5437,7 @@ Query: `sum by (job_name) (src_worker_jobs{job="worker"})`
 
 #### worker: worker_job_codeintel-janitor_count
 
-<p class="subtitle">Number of worker instances running the codeintel-janitor job
-
-</p>
+<p class="subtitle">Number of worker instances running the codeintel-janitor job</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-worker-job-codeintel-janitor-count) for 2 alerts related to this panel.
 
@@ -5998,9 +5456,7 @@ Query: `sum (src_worker_jobs{job="worker", job_name="codeintel-janitor"})`
 
 #### worker: worker_job_codeintel-commitgraph_count
 
-<p class="subtitle">Number of worker instances running the codeintel-commitgraph job
-
-</p>
+<p class="subtitle">Number of worker instances running the codeintel-commitgraph job</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-worker-job-codeintel-commitgraph-count) for 2 alerts related to this panel.
 
@@ -6019,9 +5475,7 @@ Query: `sum (src_worker_jobs{job="worker", job_name="codeintel-commitgraph"})`
 
 #### worker: worker_job_codeintel-auto-indexing_count
 
-<p class="subtitle">Number of worker instances running the codeintel-auto-indexing job
-
-</p>
+<p class="subtitle">Number of worker instances running the codeintel-auto-indexing job</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-worker-job-codeintel-auto-indexing-count) for 2 alerts related to this panel.
 
@@ -6042,9 +5496,7 @@ Query: `sum (src_worker_jobs{job="worker", job_name="codeintel-auto-indexing"})`
 
 #### worker: codeintel_commit_graph_queue_size
 
-<p class="subtitle">Repository queue size
-
-</p>
+<p class="subtitle">Repository queue size</p>
 
 This panel has no related alerts.
 
@@ -6063,9 +5515,7 @@ Query: `max(src_codeintel_commit_graph_total{job=~"^worker.*"})`
 
 #### worker: codeintel_commit_graph_queue_growth_rate
 
-<p class="subtitle">Repository queue growth rate over 30m
-
-</p>
+<p class="subtitle">Repository queue growth rate over 30m</p>
 
 This value compares the rate of enqueues against the rate of finished jobs.
 
@@ -6092,9 +5542,7 @@ Query: `sum(increase(src_codeintel_commit_graph_total{job=~"^worker.*"}[30m])) /
 
 #### worker: codeintel_commit_graph_processor_total
 
-<p class="subtitle">Update operations every 5m
-
-</p>
+<p class="subtitle">Update operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6113,9 +5561,7 @@ Query: `sum(increase(src_codeintel_commit_graph_processor_total{job=~"^worker.*"
 
 #### worker: codeintel_commit_graph_processor_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful update operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful update operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6134,9 +5580,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_commit_graph_pr
 
 #### worker: codeintel_commit_graph_processor_errors_total
 
-<p class="subtitle">Update operation errors every 5m
-
-</p>
+<p class="subtitle">Update operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6155,9 +5599,7 @@ Query: `sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^wo
 
 #### worker: codeintel_commit_graph_processor_error_rate
 
-<p class="subtitle">Update operation error rate over 5m
-
-</p>
+<p class="subtitle">Update operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -6178,9 +5620,7 @@ Query: `sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^wo
 
 #### worker: codeintel_dependency_index_queue_size
 
-<p class="subtitle">Dependency index job queue size
-
-</p>
+<p class="subtitle">Dependency index job queue size</p>
 
 This panel has no related alerts.
 
@@ -6199,9 +5639,7 @@ Query: `max(src_codeintel_dependency_index_total{job=~"^worker.*"})`
 
 #### worker: codeintel_dependency_index_queue_growth_rate
 
-<p class="subtitle">Dependency index job queue growth rate over 30m
-
-</p>
+<p class="subtitle">Dependency index job queue growth rate over 30m</p>
 
 This value compares the rate of enqueues against the rate of finished jobs.
 
@@ -6228,9 +5666,7 @@ Query: `sum(increase(src_codeintel_dependency_index_total{job=~"^worker.*"}[30m]
 
 #### worker: codeintel_dependency_index_handlers
 
-<p class="subtitle">Handler active handlers
-
-</p>
+<p class="subtitle">Handler active handlers</p>
 
 This panel has no related alerts.
 
@@ -6249,9 +5685,7 @@ Query: `sum(src_codeintel_dependency_index_processor_handlers{job=~"^worker.*"})
 
 #### worker: codeintel_dependency_index_processor_total
 
-<p class="subtitle">Handler operations every 5m
-
-</p>
+<p class="subtitle">Handler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6270,9 +5704,7 @@ Query: `sum(increase(src_codeintel_dependency_index_processor_total{job=~"^worke
 
 #### worker: codeintel_dependency_index_processor_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful handler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful handler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6291,9 +5723,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_dependency_inde
 
 #### worker: codeintel_dependency_index_processor_errors_total
 
-<p class="subtitle">Handler operation errors every 5m
-
-</p>
+<p class="subtitle">Handler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6312,9 +5742,7 @@ Query: `sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~
 
 #### worker: codeintel_dependency_index_processor_error_rate
 
-<p class="subtitle">Handler operation error rate over 5m
-
-</p>
+<p class="subtitle">Handler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -6335,9 +5763,7 @@ Query: `sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~
 
 #### worker: codeintel_background_repositories_scanned_total
 
-<p class="subtitle">Repository records scanned every 5m
-
-</p>
+<p class="subtitle">Repository records scanned every 5m</p>
 
 Number of repositories considered for data retention scanning every 5m
 
@@ -6358,9 +5784,7 @@ Query: `sum(increase(src_codeintel_background_repositories_scanned_total{job=~"^
 
 #### worker: codeintel_background_upload_records_scanned_total
 
-<p class="subtitle">Lsif upload records scanned every 5m
-
-</p>
+<p class="subtitle">Lsif upload records scanned every 5m</p>
 
 Number of upload recrods considered for data retention scanning every 5m
 
@@ -6381,9 +5805,7 @@ Query: `sum(increase(src_codeintel_background_upload_records_scanned_total{job=~
 
 #### worker: codeintel_background_upload_records_expired_total
 
-<p class="subtitle">Lsif upload records expired every 5m
-
-</p>
+<p class="subtitle">Lsif upload records expired every 5m</p>
 
 Number of upload records found to be expired every 5m
 
@@ -6404,9 +5826,7 @@ Query: `sum(increase(src_codeintel_background_upload_records_expired_total{job=~
 
 #### worker: codeintel_background_upload_records_removed_total
 
-<p class="subtitle">Lsif upload records deleted every 5m
-
-</p>
+<p class="subtitle">Lsif upload records deleted every 5m</p>
 
 Number of LSIF upload records deleted due to expiration or unreachability every 5m
 
@@ -6427,9 +5847,7 @@ Query: `sum(increase(src_codeintel_background_upload_records_removed_total{job=~
 
 #### worker: codeintel_background_index_records_removed_total
 
-<p class="subtitle">Lsif index records deleted every 5m
-
-</p>
+<p class="subtitle">Lsif index records deleted every 5m</p>
 
 Number of LSIF index records deleted due to expiration or unreachability every 5m
 
@@ -6450,9 +5868,7 @@ Query: `sum(increase(src_codeintel_background_index_records_removed_total{job=~"
 
 #### worker: codeintel_background_uploads_purged_total
 
-<p class="subtitle">Lsif upload data bundles deleted every 5m
-
-</p>
+<p class="subtitle">Lsif upload data bundles deleted every 5m</p>
 
 Number of LSIF upload data bundles purged from the codeintel-db database every 5m
 
@@ -6473,9 +5889,7 @@ Query: `sum(increase(src_codeintel_background_uploads_purged_total{job=~"^worker
 
 #### worker: codeintel_background_errors_total
 
-<p class="subtitle">Janitor operation errors every 5m
-
-</p>
+<p class="subtitle">Janitor operation errors every 5m</p>
 
 Number of code intelligence janitor errors every 5m
 
@@ -6498,9 +5912,7 @@ Query: `sum(increase(src_codeintel_background_errors_total{job=~"^worker.*"}[5m]
 
 #### worker: codeintel_index_scheduler_total
 
-<p class="subtitle">Aggregate scheduler operations every 5m
-
-</p>
+<p class="subtitle">Aggregate scheduler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6519,9 +5931,7 @@ Query: `sum(increase(src_codeintel_index_scheduler_total{job=~"^worker.*"}[5m]))
 
 #### worker: codeintel_index_scheduler_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate scheduler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate scheduler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6540,9 +5950,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_index_scheduler
 
 #### worker: codeintel_index_scheduler_errors_total
 
-<p class="subtitle">Aggregate scheduler operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate scheduler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6561,9 +5969,7 @@ Query: `sum(increase(src_codeintel_index_scheduler_errors_total{job=~"^worker.*"
 
 #### worker: codeintel_index_scheduler_error_rate
 
-<p class="subtitle">Aggregate scheduler operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate scheduler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -6582,9 +5988,7 @@ Query: `sum(increase(src_codeintel_index_scheduler_errors_total{job=~"^worker.*"
 
 #### worker: codeintel_index_scheduler_total
 
-<p class="subtitle">Scheduler operations every 5m
-
-</p>
+<p class="subtitle">Scheduler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6603,9 +6007,7 @@ Query: `sum by (op)(increase(src_codeintel_index_scheduler_total{job=~"^worker.*
 
 #### worker: codeintel_index_scheduler_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful scheduler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful scheduler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6624,9 +6026,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_index_schedu
 
 #### worker: codeintel_index_scheduler_errors_total
 
-<p class="subtitle">Scheduler operation errors every 5m
-
-</p>
+<p class="subtitle">Scheduler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6645,9 +6045,7 @@ Query: `sum by (op)(increase(src_codeintel_index_scheduler_errors_total{job=~"^w
 
 #### worker: codeintel_index_scheduler_error_rate
 
-<p class="subtitle">Scheduler operation error rate over 5m
-
-</p>
+<p class="subtitle">Scheduler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -6668,9 +6066,7 @@ Query: `sum by (op)(increase(src_codeintel_index_scheduler_errors_total{job=~"^w
 
 #### worker: codeintel_autoindex_enqueuer_total
 
-<p class="subtitle">Aggregate enqueuer operations every 5m
-
-</p>
+<p class="subtitle">Aggregate enqueuer operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6689,9 +6085,7 @@ Query: `sum(increase(src_codeintel_autoindex_enqueuer_total{job=~"^worker.*"}[5m
 
 #### worker: codeintel_autoindex_enqueuer_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate enqueuer operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate enqueuer operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6710,9 +6104,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_autoindex_enque
 
 #### worker: codeintel_autoindex_enqueuer_errors_total
 
-<p class="subtitle">Aggregate enqueuer operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate enqueuer operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6731,9 +6123,7 @@ Query: `sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^worker
 
 #### worker: codeintel_autoindex_enqueuer_error_rate
 
-<p class="subtitle">Aggregate enqueuer operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate enqueuer operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -6752,9 +6142,7 @@ Query: `sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^worker
 
 #### worker: codeintel_autoindex_enqueuer_total
 
-<p class="subtitle">Enqueuer operations every 5m
-
-</p>
+<p class="subtitle">Enqueuer operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6773,9 +6161,7 @@ Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_total{job=~"^worke
 
 #### worker: codeintel_autoindex_enqueuer_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful enqueuer operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful enqueuer operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6794,9 +6180,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindex_en
 
 #### worker: codeintel_autoindex_enqueuer_errors_total
 
-<p class="subtitle">Enqueuer operation errors every 5m
-
-</p>
+<p class="subtitle">Enqueuer operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6815,9 +6199,7 @@ Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~
 
 #### worker: codeintel_autoindex_enqueuer_error_rate
 
-<p class="subtitle">Enqueuer operation error rate over 5m
-
-</p>
+<p class="subtitle">Enqueuer operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -6838,9 +6220,7 @@ Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~
 
 #### worker: codeintel_dbstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6859,9 +6239,7 @@ Query: `sum(increase(src_codeintel_dbstore_total{job=~"^worker.*"}[5m]))`
 
 #### worker: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6880,9 +6258,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_dbstore_duratio
 
 #### worker: codeintel_dbstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6901,9 +6277,7 @@ Query: `sum(increase(src_codeintel_dbstore_errors_total{job=~"^worker.*"}[5m]))`
 
 #### worker: codeintel_dbstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -6922,9 +6296,7 @@ Query: `sum(increase(src_codeintel_dbstore_errors_total{job=~"^worker.*"}[5m])) 
 
 #### worker: codeintel_dbstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -6943,9 +6315,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_total{job=~"^worker.*"}[5m]))
 
 #### worker: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -6964,9 +6334,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dbstore_dura
 
 #### worker: codeintel_dbstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -6985,9 +6353,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_errors_total{job=~"^worker.*"
 
 #### worker: codeintel_dbstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7008,9 +6374,7 @@ Query: `sum by (op)(increase(src_codeintel_dbstore_errors_total{job=~"^worker.*"
 
 #### worker: codeintel_lsifstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7029,9 +6393,7 @@ Query: `sum(increase(src_codeintel_lsifstore_total{job=~"^worker.*"}[5m]))`
 
 #### worker: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7050,9 +6412,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_lsifstore_durat
 
 #### worker: codeintel_lsifstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7071,9 +6431,7 @@ Query: `sum(increase(src_codeintel_lsifstore_errors_total{job=~"^worker.*"}[5m])
 
 #### worker: codeintel_lsifstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7092,9 +6450,7 @@ Query: `sum(increase(src_codeintel_lsifstore_errors_total{job=~"^worker.*"}[5m])
 
 #### worker: codeintel_lsifstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7113,9 +6469,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_total{job=~"^worker.*"}[5m]
 
 #### worker: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7134,9 +6488,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_lsifstore_du
 
 #### worker: codeintel_lsifstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7155,9 +6507,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_errors_total{job=~"^worker.
 
 #### worker: codeintel_lsifstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7178,9 +6528,7 @@ Query: `sum by (op)(increase(src_codeintel_lsifstore_errors_total{job=~"^worker.
 
 #### worker: workerutil_dbworker_store_codeintel_dependency_index_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7199,9 +6547,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_to
 
 #### worker: workerutil_dbworker_store_codeintel_dependency_index_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7220,9 +6566,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_workerutil_dbworker_store
 
 #### worker: workerutil_dbworker_store_codeintel_dependency_index_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7241,9 +6585,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_er
 
 #### worker: workerutil_dbworker_store_codeintel_dependency_index_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7264,9 +6606,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_er
 
 #### worker: codeintel_gitserver_total
 
-<p class="subtitle">Aggregate client operations every 5m
-
-</p>
+<p class="subtitle">Aggregate client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7285,9 +6625,7 @@ Query: `sum(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m]))`
 
 #### worker: codeintel_gitserver_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7306,9 +6644,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_gitserver_durat
 
 #### worker: codeintel_gitserver_errors_total
 
-<p class="subtitle">Aggregate client operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7327,9 +6663,7 @@ Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m])
 
 #### worker: codeintel_gitserver_error_rate
 
-<p class="subtitle">Aggregate client operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7348,9 +6682,7 @@ Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m])
 
 #### worker: codeintel_gitserver_total
 
-<p class="subtitle">Client operations every 5m
-
-</p>
+<p class="subtitle">Client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7369,9 +6701,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m]
 
 #### worker: codeintel_gitserver_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7390,9 +6720,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_du
 
 #### worker: codeintel_gitserver_errors_total
 
-<p class="subtitle">Client operation errors every 5m
-
-</p>
+<p class="subtitle">Client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7411,9 +6739,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.
 
 #### worker: codeintel_gitserver_error_rate
 
-<p class="subtitle">Client operation error rate over 5m
-
-</p>
+<p class="subtitle">Client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7434,9 +6760,7 @@ Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.
 
 #### worker: codeintel_dependency_repos_total
 
-<p class="subtitle">Aggregate insert operations every 5m
-
-</p>
+<p class="subtitle">Aggregate insert operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7455,9 +6779,7 @@ Query: `sum(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m])
 
 #### worker: codeintel_dependency_repos_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate insert operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate insert operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7476,9 +6798,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_dependency_repo
 
 #### worker: codeintel_dependency_repos_errors_total
 
-<p class="subtitle">Aggregate insert operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate insert operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7497,9 +6817,7 @@ Query: `sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*
 
 #### worker: codeintel_dependency_repos_error_rate
 
-<p class="subtitle">Aggregate insert operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate insert operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7518,9 +6836,7 @@ Query: `sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*
 
 #### worker: codeintel_dependency_repos_total
 
-<p class="subtitle">Insert operations every 5m
-
-</p>
+<p class="subtitle">Insert operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7539,9 +6855,7 @@ Query: `sum by (scheme,new)(increase(src_codeintel_dependency_repos_total{job=~"
 
 #### worker: codeintel_dependency_repos_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful insert operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful insert operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7560,9 +6874,7 @@ Query: `histogram_quantile(0.99, sum  by (le,scheme,new)(rate(src_codeintel_depe
 
 #### worker: codeintel_dependency_repos_errors_total
 
-<p class="subtitle">Insert operation errors every 5m
-
-</p>
+<p class="subtitle">Insert operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7581,9 +6893,7 @@ Query: `sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total
 
 #### worker: codeintel_dependency_repos_error_rate
 
-<p class="subtitle">Insert operation error rate over 5m
-
-</p>
+<p class="subtitle">Insert operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7604,9 +6914,7 @@ Query: `sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total
 
 #### worker: codeintel_background_upload_record_resets_total
 
-<p class="subtitle">Lsif upload records reset to queued state every 5m
-
-</p>
+<p class="subtitle">Lsif upload records reset to queued state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7625,9 +6933,7 @@ Query: `sum(increase(src_codeintel_background_upload_record_resets_total{job=~"^
 
 #### worker: codeintel_background_upload_record_reset_failures_total
 
-<p class="subtitle">Lsif upload records reset to errored state every 5m
-
-</p>
+<p class="subtitle">Lsif upload records reset to errored state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7646,9 +6952,7 @@ Query: `sum(increase(src_codeintel_background_upload_record_reset_failures_total
 
 #### worker: codeintel_background_upload_record_reset_errors_total
 
-<p class="subtitle">Lsif upload operation errors every 5m
-
-</p>
+<p class="subtitle">Lsif upload operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7669,9 +6973,7 @@ Query: `sum(increase(src_codeintel_background_upload_record_reset_errors_total{j
 
 #### worker: codeintel_background_index_record_resets_total
 
-<p class="subtitle">Lsif index records reset to queued state every 5m
-
-</p>
+<p class="subtitle">Lsif index records reset to queued state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7690,9 +6992,7 @@ Query: `sum(increase(src_codeintel_background_index_record_resets_total{job=~"^w
 
 #### worker: codeintel_background_index_record_reset_failures_total
 
-<p class="subtitle">Lsif index records reset to errored state every 5m
-
-</p>
+<p class="subtitle">Lsif index records reset to errored state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7711,9 +7011,7 @@ Query: `sum(increase(src_codeintel_background_index_record_reset_failures_total{
 
 #### worker: codeintel_background_index_record_reset_errors_total
 
-<p class="subtitle">Lsif index operation errors every 5m
-
-</p>
+<p class="subtitle">Lsif index operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7734,9 +7032,7 @@ Query: `sum(increase(src_codeintel_background_index_record_reset_errors_total{jo
 
 #### worker: codeintel_background_dependency_index_record_resets_total
 
-<p class="subtitle">Lsif dependency index records reset to queued state every 5m
-
-</p>
+<p class="subtitle">Lsif dependency index records reset to queued state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7755,9 +7051,7 @@ Query: `sum(increase(src_codeintel_background_dependency_index_record_resets_tot
 
 #### worker: codeintel_background_dependency_index_record_reset_failures_total
 
-<p class="subtitle">Lsif dependency index records reset to errored state every 5m
-
-</p>
+<p class="subtitle">Lsif dependency index records reset to errored state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7776,9 +7070,7 @@ Query: `sum(increase(src_codeintel_background_dependency_index_record_reset_fail
 
 #### worker: codeintel_background_dependency_index_record_reset_errors_total
 
-<p class="subtitle">Lsif dependency index operation errors every 5m
-
-</p>
+<p class="subtitle">Lsif dependency index operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7799,9 +7091,7 @@ Query: `sum(increase(src_codeintel_background_dependency_index_record_reset_erro
 
 #### worker: insights_search_queue_queue_size
 
-<p class="subtitle">Code insights search queue queue size
-
-</p>
+<p class="subtitle">Code insights search queue queue size</p>
 
 This panel has no related alerts.
 
@@ -7820,9 +7110,7 @@ Query: `max(src_insights_search_queue_total{job=~"^worker.*"})`
 
 #### worker: insights_search_queue_queue_growth_rate
 
-<p class="subtitle">Code insights search queue queue growth rate over 30m
-
-</p>
+<p class="subtitle">Code insights search queue queue growth rate over 30m</p>
 
 This value compares the rate of enqueues against the rate of finished jobs.
 
@@ -7849,9 +7137,7 @@ Query: `sum(increase(src_insights_search_queue_total{job=~"^worker.*"}[30m])) / 
 
 #### worker: insights_search_queue_handlers
 
-<p class="subtitle">Handler active handlers
-
-</p>
+<p class="subtitle">Handler active handlers</p>
 
 This panel has no related alerts.
 
@@ -7870,9 +7156,7 @@ Query: `sum(src_insights_search_queue_processor_handlers{job=~"^worker.*"})`
 
 #### worker: insights_search_queue_processor_total
 
-<p class="subtitle">Handler operations every 5m
-
-</p>
+<p class="subtitle">Handler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -7891,9 +7175,7 @@ Query: `sum(increase(src_insights_search_queue_processor_total{job=~"^worker.*"}
 
 #### worker: insights_search_queue_processor_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful handler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful handler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -7912,9 +7194,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_insights_search_queue_pro
 
 #### worker: insights_search_queue_processor_errors_total
 
-<p class="subtitle">Handler operation errors every 5m
-
-</p>
+<p class="subtitle">Handler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -7933,9 +7213,7 @@ Query: `sum(increase(src_insights_search_queue_processor_errors_total{job=~"^wor
 
 #### worker: insights_search_queue_processor_error_rate
 
-<p class="subtitle">Handler operation error rate over 5m
-
-</p>
+<p class="subtitle">Handler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -7956,9 +7234,7 @@ Query: `sum(increase(src_insights_search_queue_processor_errors_total{job=~"^wor
 
 #### worker: insights_search_queue_record_resets_total
 
-<p class="subtitle">Insights search queue records reset to queued state every 5m
-
-</p>
+<p class="subtitle">Insights search queue records reset to queued state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7977,9 +7253,7 @@ Query: `sum(increase(src_insights_search_queue_record_resets_total{job=~"^worker
 
 #### worker: insights_search_queue_record_reset_failures_total
 
-<p class="subtitle">Insights search queue records reset to errored state every 5m
-
-</p>
+<p class="subtitle">Insights search queue records reset to errored state every 5m</p>
 
 This panel has no related alerts.
 
@@ -7998,9 +7272,7 @@ Query: `sum(increase(src_insights_search_queue_record_reset_failures_total{job=~
 
 #### worker: insights_search_queue_record_reset_errors_total
 
-<p class="subtitle">Insights search queue operation errors every 5m
-
-</p>
+<p class="subtitle">Insights search queue operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -8021,9 +7293,7 @@ Query: `sum(increase(src_insights_search_queue_record_reset_errors_total{job=~"^
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -8042,9 +7312,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_st
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -8063,9 +7331,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_workerutil_dbworker_store
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -8084,9 +7350,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_st
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -8105,9 +7369,7 @@ Query: `sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_st
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -8126,9 +7388,7 @@ Query: `sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -8147,9 +7407,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_st
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -8168,9 +7426,7 @@ Query: `sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner
 
 #### worker: workerutil_dbworker_store_insights_query_runner_jobs_store_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -8191,9 +7447,7 @@ Query: `sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner
 
 #### worker: frontend_internal_api_error_responses
 
-<p class="subtitle">Frontend-internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Frontend-internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -8214,9 +7468,7 @@ Query: `sum by (category)(increase(src_frontend_internal_request_duration_second
 
 #### worker: max_open_conns
 
-<p class="subtitle">Maximum open
-
-</p>
+<p class="subtitle">Maximum open</p>
 
 This panel has no related alerts.
 
@@ -8235,9 +7487,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="worker"})
 
 #### worker: open_conns
 
-<p class="subtitle">Established
-
-</p>
+<p class="subtitle">Established</p>
 
 This panel has no related alerts.
 
@@ -8256,9 +7506,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="worker"})`
 
 #### worker: in_use
 
-<p class="subtitle">Used
-
-</p>
+<p class="subtitle">Used</p>
 
 This panel has no related alerts.
 
@@ -8277,9 +7525,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="worker"})`
 
 #### worker: idle
 
-<p class="subtitle">Idle
-
-</p>
+<p class="subtitle">Idle</p>
 
 This panel has no related alerts.
 
@@ -8298,9 +7544,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="worker"})`
 
 #### worker: mean_blocked_seconds_per_conn_request
 
-<p class="subtitle">Mean blocked seconds per conn request
-
-</p>
+<p class="subtitle">Mean blocked seconds per conn request</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-mean-blocked-seconds-per-conn-request) for 2 alerts related to this panel.
 
@@ -8319,9 +7563,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app
 
 #### worker: closed_max_idle
 
-<p class="subtitle">Closed by SetMaxIdleConns
-
-</p>
+<p class="subtitle">Closed by SetMaxIdleConns</p>
 
 This panel has no related alerts.
 
@@ -8340,9 +7582,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app
 
 #### worker: closed_max_lifetime
 
-<p class="subtitle">Closed by SetConnMaxLifetime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxLifetime</p>
 
 This panel has no related alerts.
 
@@ -8361,9 +7601,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime
 
 #### worker: closed_max_idle_time
 
-<p class="subtitle">Closed by SetConnMaxIdleTime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxIdleTime</p>
 
 This panel has no related alerts.
 
@@ -8384,9 +7622,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_tim
 
 #### worker: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -8415,9 +7651,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^worker.*"}) > 60)`
 
 #### worker: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-container-cpu-usage) for 1 alert related to this panel.
 
@@ -8436,9 +7670,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}`
 
 #### worker: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-container-memory-usage) for 1 alert related to this panel.
 
@@ -8457,9 +7689,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}`
 
 #### worker: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -8483,9 +7713,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^worker.*"}[1h]) + ra
 
 #### worker: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -8504,9 +7732,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### worker: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -8525,9 +7751,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^w
 
 #### worker: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -8546,9 +7770,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^work
 
 #### worker: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -8569,9 +7791,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^w
 
 #### worker: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -8592,9 +7812,7 @@ Query: `max by(instance) (go_goroutines{job=~".*worker"})`
 
 #### worker: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -8615,9 +7833,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*worker"})`
 
 #### worker: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#worker-pods-available-percentage) for 1 alert related to this panel.
 
@@ -8644,9 +7860,7 @@ To see this dashboard, visit `/-/debug/grafana/d/repo-updater/repo-updater` on y
 
 #### repo-updater: syncer_sync_last_time
 
-<p class="subtitle">Time since last sync
-
-</p>
+<p class="subtitle">Time since last sync</p>
 
 A high value here indicates issues synchronizing repo metadata.
 If the value is persistently high, make sure all external services have valid tokens.
@@ -8668,9 +7882,7 @@ Query: `max(timestamp(vector(time()))) - max(src_repoupdater_syncer_sync_last_ti
 
 #### repo-updater: src_repoupdater_max_sync_backoff
 
-<p class="subtitle">Time since oldest sync
-
-</p>
+<p class="subtitle">Time since oldest sync</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-max-sync-backoff) for 1 alert related to this panel.
 
@@ -8689,9 +7901,7 @@ Query: `max(src_repoupdater_max_sync_backoff)`
 
 #### repo-updater: src_repoupdater_syncer_sync_errors_total
 
-<p class="subtitle">Site level external service sync error rate
-
-</p>
+<p class="subtitle">Site level external service sync error rate</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total) for 2 alerts related to this panel.
 
@@ -8710,9 +7920,7 @@ Query: `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="u
 
 #### repo-updater: syncer_sync_start
 
-<p class="subtitle">Repo metadata sync was started
-
-</p>
+<p class="subtitle">Repo metadata sync was started</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start) for 1 alert related to this panel.
 
@@ -8731,9 +7939,7 @@ Query: `max by (family) (rate(src_repoupdater_syncer_start_sync{family="Syncer.S
 
 #### repo-updater: syncer_sync_duration
 
-<p class="subtitle">95th repositories sync duration
-
-</p>
+<p class="subtitle">95th repositories sync duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-duration) for 1 alert related to this panel.
 
@@ -8752,9 +7958,7 @@ Query: `histogram_quantile(0.95, max by (le, family, success) (rate(src_repoupda
 
 #### repo-updater: source_duration
 
-<p class="subtitle">95th repositories source duration
-
-</p>
+<p class="subtitle">95th repositories source duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-source-duration) for 1 alert related to this panel.
 
@@ -8773,9 +7977,7 @@ Query: `histogram_quantile(0.95, max by (le) (rate(src_repoupdater_source_durati
 
 #### repo-updater: syncer_synced_repos
 
-<p class="subtitle">Repositories synced
-
-</p>
+<p class="subtitle">Repositories synced</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos) for 1 alert related to this panel.
 
@@ -8794,9 +7996,7 @@ Query: `max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m]))`
 
 #### repo-updater: sourced_repos
 
-<p class="subtitle">Repositories sourced
-
-</p>
+<p class="subtitle">Repositories sourced</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos) for 1 alert related to this panel.
 
@@ -8815,9 +8015,7 @@ Query: `max(rate(src_repoupdater_source_repos_total[1m]))`
 
 #### repo-updater: user_added_repos
 
-<p class="subtitle">Total number of user added repos
-
-</p>
+<p class="subtitle">Total number of user added repos</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos) for 1 alert related to this panel.
 
@@ -8836,9 +8034,7 @@ Query: `max(src_repoupdater_user_repos_total)`
 
 #### repo-updater: purge_failed
 
-<p class="subtitle">Repositories purge failed
-
-</p>
+<p class="subtitle">Repositories purge failed</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-purge-failed) for 1 alert related to this panel.
 
@@ -8857,9 +8053,7 @@ Query: `max(rate(src_repoupdater_purge_failed[1m]))`
 
 #### repo-updater: sched_auto_fetch
 
-<p class="subtitle">Repositories scheduled due to hitting a deadline
-
-</p>
+<p class="subtitle">Repositories scheduled due to hitting a deadline</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-auto-fetch) for 1 alert related to this panel.
 
@@ -8878,9 +8072,7 @@ Query: `max(rate(src_repoupdater_sched_auto_fetch[1m]))`
 
 #### repo-updater: sched_manual_fetch
 
-<p class="subtitle">Repositories scheduled due to user traffic
-
-</p>
+<p class="subtitle">Repositories scheduled due to user traffic</p>
 
 Check repo-updater logs if this value is persistently high.
 This does not indicate anything if there are no user added code hosts.
@@ -8902,9 +8094,7 @@ Query: `max(rate(src_repoupdater_sched_manual_fetch[1m]))`
 
 #### repo-updater: sched_known_repos
 
-<p class="subtitle">Repositories managed by the scheduler
-
-</p>
+<p class="subtitle">Repositories managed by the scheduler</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-known-repos) for 1 alert related to this panel.
 
@@ -8923,9 +8113,7 @@ Query: `max(src_repoupdater_sched_known_repos)`
 
 #### repo-updater: sched_update_queue_length
 
-<p class="subtitle">Rate of growth of update queue length over 5 minutes
-
-</p>
+<p class="subtitle">Rate of growth of update queue length over 5 minutes</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-update-queue-length) for 1 alert related to this panel.
 
@@ -8944,9 +8132,7 @@ Query: `max(deriv(src_repoupdater_sched_update_queue_length[5m]))`
 
 #### repo-updater: sched_loops
 
-<p class="subtitle">Scheduler loops
-
-</p>
+<p class="subtitle">Scheduler loops</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-loops) for 1 alert related to this panel.
 
@@ -8965,9 +8151,7 @@ Query: `max(rate(src_repoupdater_sched_loops[1m]))`
 
 #### repo-updater: sched_error
 
-<p class="subtitle">Repositories schedule error rate
-
-</p>
+<p class="subtitle">Repositories schedule error rate</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-error) for 1 alert related to this panel.
 
@@ -8988,9 +8172,7 @@ Query: `max(rate(src_repoupdater_sched_error[1m]))`
 
 #### repo-updater: perms_syncer_perms
 
-<p class="subtitle">Time gap between least and most up to date permissions
-
-</p>
+<p class="subtitle">Time gap between least and most up to date permissions</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-perms) for 1 alert related to this panel.
 
@@ -9009,9 +8191,7 @@ Query: `max by (type) (src_repoupdater_perms_syncer_perms_gap_seconds)`
 
 #### repo-updater: perms_syncer_stale_perms
 
-<p class="subtitle">Number of entities with stale permissions
-
-</p>
+<p class="subtitle">Number of entities with stale permissions</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-stale-perms) for 1 alert related to this panel.
 
@@ -9030,9 +8210,7 @@ Query: `max by (type) (src_repoupdater_perms_syncer_stale_perms)`
 
 #### repo-updater: perms_syncer_no_perms
 
-<p class="subtitle">Number of entities with no permissions
-
-</p>
+<p class="subtitle">Number of entities with no permissions</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-no-perms) for 1 alert related to this panel.
 
@@ -9051,9 +8229,7 @@ Query: `max by (type) (src_repoupdater_perms_syncer_no_perms)`
 
 #### repo-updater: perms_syncer_sync_duration
 
-<p class="subtitle">95th permissions sync duration
-
-</p>
+<p class="subtitle">95th permissions sync duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-duration) for 1 alert related to this panel.
 
@@ -9072,9 +8248,7 @@ Query: `histogram_quantile(0.95, max by (le, type) (rate(src_repoupdater_perms_s
 
 #### repo-updater: perms_syncer_queue_size
 
-<p class="subtitle">Permissions sync queued items
-
-</p>
+<p class="subtitle">Permissions sync queued items</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-queue-size) for 1 alert related to this panel.
 
@@ -9093,9 +8267,7 @@ Query: `max(src_repoupdater_perms_syncer_queue_size)`
 
 #### repo-updater: perms_syncer_sync_errors
 
-<p class="subtitle">Permissions sync error rate
-
-</p>
+<p class="subtitle">Permissions sync error rate</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-errors) for 1 alert related to this panel.
 
@@ -9116,9 +8288,7 @@ Query: `max by (type) (ceil(rate(src_repoupdater_perms_syncer_sync_errors_total[
 
 #### repo-updater: src_repoupdater_external_services_total
 
-<p class="subtitle">The total number of external services
-
-</p>
+<p class="subtitle">The total number of external services</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-external-services-total) for 1 alert related to this panel.
 
@@ -9137,9 +8307,7 @@ Query: `max(src_repoupdater_external_services_total)`
 
 #### repo-updater: src_repoupdater_user_external_services_total
 
-<p class="subtitle">The total number of user added external services
-
-</p>
+<p class="subtitle">The total number of user added external services</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-user-external-services-total) for 1 alert related to this panel.
 
@@ -9158,9 +8326,7 @@ Query: `max(src_repoupdater_user_external_services_total)`
 
 #### repo-updater: repoupdater_queued_sync_jobs_total
 
-<p class="subtitle">The total number of queued sync jobs
-
-</p>
+<p class="subtitle">The total number of queued sync jobs</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-queued-sync-jobs-total) for 1 alert related to this panel.
 
@@ -9179,9 +8345,7 @@ Query: `max(src_repoupdater_queued_sync_jobs_total)`
 
 #### repo-updater: repoupdater_completed_sync_jobs_total
 
-<p class="subtitle">The total number of completed sync jobs
-
-</p>
+<p class="subtitle">The total number of completed sync jobs</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-completed-sync-jobs-total) for 1 alert related to this panel.
 
@@ -9200,9 +8364,7 @@ Query: `max(src_repoupdater_completed_sync_jobs_total)`
 
 #### repo-updater: repoupdater_errored_sync_jobs_percentage
 
-<p class="subtitle">The percentage of external services that have failed their most recent sync
-
-</p>
+<p class="subtitle">The percentage of external services that have failed their most recent sync</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-errored-sync-jobs-percentage) for 1 alert related to this panel.
 
@@ -9221,9 +8383,7 @@ Query: `max(src_repoupdater_errored_sync_jobs_percentage)`
 
 #### repo-updater: github_graphql_rate_limit_remaining
 
-<p class="subtitle">Remaining calls to GitHub graphql API before hitting the rate limit
-
-</p>
+<p class="subtitle">Remaining calls to GitHub graphql API before hitting the rate limit</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-graphql-rate-limit-remaining) for 1 alert related to this panel.
 
@@ -9242,9 +8402,7 @@ Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="graphql"})`
 
 #### repo-updater: github_rest_rate_limit_remaining
 
-<p class="subtitle">Remaining calls to GitHub rest API before hitting the rate limit
-
-</p>
+<p class="subtitle">Remaining calls to GitHub rest API before hitting the rate limit</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-rest-rate-limit-remaining) for 1 alert related to this panel.
 
@@ -9263,9 +8421,7 @@ Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="rest"})`
 
 #### repo-updater: github_search_rate_limit_remaining
 
-<p class="subtitle">Remaining calls to GitHub search API before hitting the rate limit
-
-</p>
+<p class="subtitle">Remaining calls to GitHub search API before hitting the rate limit</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-search-rate-limit-remaining) for 1 alert related to this panel.
 
@@ -9284,9 +8440,7 @@ Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="search"})`
 
 #### repo-updater: github_graphql_rate_limit_wait_duration
 
-<p class="subtitle">Time spent waiting for the GitHub graphql API rate limiter
-
-</p>
+<p class="subtitle">Time spent waiting for the GitHub graphql API rate limiter</p>
 
 Indicates how long we`re waiting on the rate limit once it has been exceeded
 
@@ -9307,9 +8461,7 @@ Query: `max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource=
 
 #### repo-updater: github_rest_rate_limit_wait_duration
 
-<p class="subtitle">Time spent waiting for the GitHub rest API rate limiter
-
-</p>
+<p class="subtitle">Time spent waiting for the GitHub rest API rate limiter</p>
 
 Indicates how long we`re waiting on the rate limit once it has been exceeded
 
@@ -9330,9 +8482,7 @@ Query: `max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource=
 
 #### repo-updater: github_search_rate_limit_wait_duration
 
-<p class="subtitle">Time spent waiting for the GitHub search API rate limiter
-
-</p>
+<p class="subtitle">Time spent waiting for the GitHub search API rate limiter</p>
 
 Indicates how long we`re waiting on the rate limit once it has been exceeded
 
@@ -9353,9 +8503,7 @@ Query: `max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource=
 
 #### repo-updater: gitlab_rest_rate_limit_remaining
 
-<p class="subtitle">Remaining calls to GitLab rest API before hitting the rate limit
-
-</p>
+<p class="subtitle">Remaining calls to GitLab rest API before hitting the rate limit</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-gitlab-rest-rate-limit-remaining) for 1 alert related to this panel.
 
@@ -9374,9 +8522,7 @@ Query: `max by (name) (src_gitlab_rate_limit_remaining{resource="rest"})`
 
 #### repo-updater: gitlab_rest_rate_limit_wait_duration
 
-<p class="subtitle">Time spent waiting for the GitLab rest API rate limiter
-
-</p>
+<p class="subtitle">Time spent waiting for the GitLab rest API rate limiter</p>
 
 Indicates how long we`re waiting on the rate limit once it has been exceeded
 
@@ -9399,9 +8545,7 @@ Query: `max by(name) (rate(src_gitlab_rate_limit_wait_duration_seconds{resource=
 
 #### repo-updater: batches_dbstore_total
 
-<p class="subtitle">Aggregate store operations every 5m
-
-</p>
+<p class="subtitle">Aggregate store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -9420,9 +8564,7 @@ Query: `sum(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m]))`
 
 #### repo-updater: batches_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -9441,9 +8583,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_batches_dbstore_duration_
 
 #### repo-updater: batches_dbstore_errors_total
 
-<p class="subtitle">Aggregate store operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -9462,9 +8602,7 @@ Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m
 
 #### repo-updater: batches_dbstore_error_rate
 
-<p class="subtitle">Aggregate store operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -9483,9 +8621,7 @@ Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m
 
 #### repo-updater: batches_dbstore_total
 
-<p class="subtitle">Store operations every 5m
-
-</p>
+<p class="subtitle">Store operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -9504,9 +8640,7 @@ Query: `sum by (op)(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5
 
 #### repo-updater: batches_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful store operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful store operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -9525,9 +8659,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_durati
 
 #### repo-updater: batches_dbstore_errors_total
 
-<p class="subtitle">Store operation errors every 5m
-
-</p>
+<p class="subtitle">Store operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -9546,9 +8678,7 @@ Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-update
 
 #### repo-updater: batches_dbstore_error_rate
 
-<p class="subtitle">Store operation error rate over 5m
-
-</p>
+<p class="subtitle">Store operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -9569,9 +8699,7 @@ Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-update
 
 #### repo-updater: codeintel_coursier_total
 
-<p class="subtitle">Aggregate invocations operations every 5m
-
-</p>
+<p class="subtitle">Aggregate invocations operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -9590,9 +8718,7 @@ Query: `sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-u
 
 #### repo-updater: codeintel_coursier_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate invocations operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate invocations operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -9611,9 +8737,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_codeintel_coursier_durati
 
 #### repo-updater: codeintel_coursier_errors_total
 
-<p class="subtitle">Aggregate invocations operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate invocations operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -9632,9 +8756,7 @@ Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"
 
 #### repo-updater: codeintel_coursier_error_rate
 
-<p class="subtitle">Aggregate invocations operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate invocations operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -9653,9 +8775,7 @@ Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"
 
 #### repo-updater: codeintel_coursier_total
 
-<p class="subtitle">Invocations operations every 5m
-
-</p>
+<p class="subtitle">Invocations operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -9674,9 +8794,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~
 
 #### repo-updater: codeintel_coursier_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful invocations operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful invocations operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -9695,9 +8813,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_coursier_dur
 
 #### repo-updater: codeintel_coursier_errors_total
 
-<p class="subtitle">Invocations operation errors every 5m
-
-</p>
+<p class="subtitle">Invocations operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -9716,9 +8832,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand
 
 #### repo-updater: codeintel_coursier_error_rate
 
-<p class="subtitle">Invocations operation error rate over 5m
-
-</p>
+<p class="subtitle">Invocations operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -9739,9 +8853,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand
 
 #### repo-updater: frontend_internal_api_error_responses
 
-<p class="subtitle">Frontend-internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Frontend-internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -9762,9 +8874,7 @@ Query: `sum by (category)(increase(src_frontend_internal_request_duration_second
 
 #### repo-updater: max_open_conns
 
-<p class="subtitle">Maximum open
-
-</p>
+<p class="subtitle">Maximum open</p>
 
 This panel has no related alerts.
 
@@ -9783,9 +8893,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="repo-upda
 
 #### repo-updater: open_conns
 
-<p class="subtitle">Established
-
-</p>
+<p class="subtitle">Established</p>
 
 This panel has no related alerts.
 
@@ -9804,9 +8912,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="repo-updater"
 
 #### repo-updater: in_use
 
-<p class="subtitle">Used
-
-</p>
+<p class="subtitle">Used</p>
 
 This panel has no related alerts.
 
@@ -9825,9 +8931,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="repo-update
 
 #### repo-updater: idle
 
-<p class="subtitle">Idle
-
-</p>
+<p class="subtitle">Idle</p>
 
 This panel has no related alerts.
 
@@ -9846,9 +8950,7 @@ Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="repo-updater"
 
 #### repo-updater: mean_blocked_seconds_per_conn_request
 
-<p class="subtitle">Mean blocked seconds per conn request
-
-</p>
+<p class="subtitle">Mean blocked seconds per conn request</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-mean-blocked-seconds-per-conn-request) for 2 alerts related to this panel.
 
@@ -9867,9 +8969,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app
 
 #### repo-updater: closed_max_idle
 
-<p class="subtitle">Closed by SetMaxIdleConns
-
-</p>
+<p class="subtitle">Closed by SetMaxIdleConns</p>
 
 This panel has no related alerts.
 
@@ -9888,9 +8988,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app
 
 #### repo-updater: closed_max_lifetime
 
-<p class="subtitle">Closed by SetConnMaxLifetime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxLifetime</p>
 
 This panel has no related alerts.
 
@@ -9909,9 +9007,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime
 
 #### repo-updater: closed_max_idle_time
 
-<p class="subtitle">Closed by SetConnMaxIdleTime
-
-</p>
+<p class="subtitle">Closed by SetConnMaxIdleTime</p>
 
 This panel has no related alerts.
 
@@ -9932,9 +9028,7 @@ Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_tim
 
 #### repo-updater: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -9963,9 +9057,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^repo-updater.*"}) 
 
 #### repo-updater: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-cpu-usage) for 1 alert related to this panel.
 
@@ -9984,9 +9076,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}`
 
 #### repo-updater: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-memory-usage) for 1 alert related to this panel.
 
@@ -10005,9 +9095,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"
 
 #### repo-updater: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -10031,9 +9119,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^repo-updater.*"}[1h]
 
 #### repo-updater: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -10052,9 +9138,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### repo-updater: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -10073,9 +9157,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^r
 
 #### repo-updater: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -10094,9 +9176,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^repo
 
 #### repo-updater: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -10117,9 +9197,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^r
 
 #### repo-updater: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -10140,9 +9218,7 @@ Query: `max by(instance) (go_goroutines{job=~".*repo-updater"})`
 
 #### repo-updater: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -10163,9 +9239,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*repo-updater"})`
 
 #### repo-updater: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-pods-available-percentage) for 1 alert related to this panel.
 
@@ -10190,9 +9264,7 @@ To see this dashboard, visit `/-/debug/grafana/d/searcher/searcher` on your Sour
 
 #### searcher: unindexed_search_request_errors
 
-<p class="subtitle">Unindexed search request errors every 5m by code
-
-</p>
+<p class="subtitle">Unindexed search request errors every 5m by code</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-unindexed-search-request-errors) for 1 alert related to this panel.
 
@@ -10211,9 +9283,7 @@ Query: `sum by (code)(increase(searcher_service_request_total{code!="200",code!=
 
 #### searcher: replica_traffic
 
-<p class="subtitle">Requests per second over 10m
-
-</p>
+<p class="subtitle">Requests per second over 10m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-replica-traffic) for 1 alert related to this panel.
 
@@ -10234,9 +9304,7 @@ Query: `sum by(instance) (rate(searcher_service_request_total[10m]))`
 
 #### searcher: frontend_internal_api_error_responses
 
-<p class="subtitle">Frontend-internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Frontend-internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -10257,9 +9325,7 @@ Query: `sum by (category)(increase(src_frontend_internal_request_duration_second
 
 #### searcher: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -10288,9 +9354,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^searcher.*"}) > 60
 
 #### searcher: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage) for 1 alert related to this panel.
 
@@ -10309,9 +9373,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}`
 
 #### searcher: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage) for 1 alert related to this panel.
 
@@ -10330,9 +9392,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}`
 
 #### searcher: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -10356,9 +9416,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^searcher.*"}[1h]) + 
 
 #### searcher: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -10377,9 +9435,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### searcher: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -10398,9 +9454,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^s
 
 #### searcher: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -10419,9 +9473,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^sear
 
 #### searcher: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -10442,9 +9494,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^s
 
 #### searcher: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -10465,9 +9515,7 @@ Query: `max by(instance) (go_goroutines{job=~".*searcher"})`
 
 #### searcher: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -10488,9 +9536,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*searcher"})`
 
 #### searcher: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage) for 1 alert related to this panel.
 
@@ -10515,9 +9561,7 @@ To see this dashboard, visit `/-/debug/grafana/d/symbols/symbols` on your Source
 
 #### symbols: store_fetch_failures
 
-<p class="subtitle">Store fetch failures every 5m
-
-</p>
+<p class="subtitle">Store fetch failures every 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-store-fetch-failures) for 1 alert related to this panel.
 
@@ -10536,9 +9580,7 @@ Query: `sum(increase(symbols_store_fetch_failed[5m]))`
 
 #### symbols: current_fetch_queue_size
 
-<p class="subtitle">Current fetch queue size
-
-</p>
+<p class="subtitle">Current fetch queue size</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-current-fetch-queue-size) for 1 alert related to this panel.
 
@@ -10559,9 +9601,7 @@ Query: `sum(symbols_store_fetch_queue_size)`
 
 #### symbols: frontend_internal_api_error_responses
 
-<p class="subtitle">Frontend-internal API error responses every 5m by route
-
-</p>
+<p class="subtitle">Frontend-internal API error responses every 5m by route</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
@@ -10582,9 +9622,7 @@ Query: `sum by (category)(increase(src_frontend_internal_request_duration_second
 
 #### symbols: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -10613,9 +9651,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^symbols.*"}) > 60)
 
 #### symbols: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-cpu-usage) for 1 alert related to this panel.
 
@@ -10634,9 +9670,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}`
 
 #### symbols: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-memory-usage) for 1 alert related to this panel.
 
@@ -10655,9 +9689,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}`
 
 #### symbols: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -10681,9 +9713,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^symbols.*"}[1h]) + r
 
 #### symbols: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -10702,9 +9732,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### symbols: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -10723,9 +9751,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^s
 
 #### symbols: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -10744,9 +9770,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^symb
 
 #### symbols: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -10767,9 +9791,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^s
 
 #### symbols: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -10790,9 +9812,7 @@ Query: `max by(instance) (go_goroutines{job=~".*symbols"})`
 
 #### symbols: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -10813,9 +9833,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*symbols"})`
 
 #### symbols: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#symbols-pods-available-percentage) for 1 alert related to this panel.
 
@@ -10840,9 +9858,7 @@ To see this dashboard, visit `/-/debug/grafana/d/syntect-server/syntect-server` 
 
 #### syntect-server: syntax_highlighting_errors
 
-<p class="subtitle">Syntax highlighting errors every 5m
-
-</p>
+<p class="subtitle">Syntax highlighting errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -10861,9 +9877,7 @@ Query: `sum(increase(src_syntax_highlighting_requests{status="error"}[5m])) / su
 
 #### syntect-server: syntax_highlighting_timeouts
 
-<p class="subtitle">Syntax highlighting timeouts every 5m
-
-</p>
+<p class="subtitle">Syntax highlighting timeouts every 5m</p>
 
 This panel has no related alerts.
 
@@ -10882,9 +9896,7 @@ Query: `sum(increase(src_syntax_highlighting_requests{status="timeout"}[5m])) / 
 
 #### syntect-server: syntax_highlighting_panics
 
-<p class="subtitle">Syntax highlighting panics every 5m
-
-</p>
+<p class="subtitle">Syntax highlighting panics every 5m</p>
 
 This panel has no related alerts.
 
@@ -10903,9 +9915,7 @@ Query: `sum(increase(src_syntax_highlighting_requests{status="panic"}[5m]))`
 
 #### syntect-server: syntax_highlighting_worker_deaths
 
-<p class="subtitle">Syntax highlighter worker deaths every 5m
-
-</p>
+<p class="subtitle">Syntax highlighter worker deaths every 5m</p>
 
 This panel has no related alerts.
 
@@ -10926,9 +9936,7 @@ Query: `sum(increase(src_syntax_highlighting_requests{status="hss_worker_timeout
 
 #### syntect-server: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -10957,9 +9965,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^syntect-server.*"}
 
 #### syntect-server: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-cpu-usage) for 1 alert related to this panel.
 
@@ -10978,9 +9984,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}
 
 #### syntect-server: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-memory-usage) for 1 alert related to this panel.
 
@@ -10999,9 +10003,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.
 
 #### syntect-server: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -11025,9 +10027,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^syntect-server.*"}[1
 
 #### syntect-server: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -11046,9 +10046,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### syntect-server: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -11067,9 +10065,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^s
 
 #### syntect-server: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -11088,9 +10084,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^synt
 
 #### syntect-server: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -11111,9 +10105,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^s
 
 #### syntect-server: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pods-available-percentage) for 1 alert related to this panel.
 
@@ -11138,9 +10130,7 @@ To see this dashboard, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexse
 
 #### zoekt-indexserver: repos_assigned
 
-<p class="subtitle">Total number of repos
-
-</p>
+<p class="subtitle">Total number of repos</p>
 
 Sudden changes should be caused by indexing configuration changes.
 
@@ -11161,9 +10151,7 @@ Query: `sum(index_num_assigned)`
 
 #### zoekt-indexserver: repo_index_state
 
-<p class="subtitle">Indexing results over 5m (noop=no changes, empty=no branches to index)
-
-</p>
+<p class="subtitle">Indexing results over 5m (noop=no changes, empty=no branches to index)</p>
 
 A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
 
@@ -11184,9 +10172,7 @@ Query: `sum by (state) (increase(index_repo_seconds_count[5m]))`
 
 #### zoekt-indexserver: repo_index_success_speed
 
-<p class="subtitle">Successful indexing durations
-
-</p>
+<p class="subtitle">Successful indexing durations</p>
 
 Latency increases can indicate bottlenecks in the indexserver.
 
@@ -11207,9 +10193,7 @@ Query: `sum by (le, state) (increase(index_repo_seconds_bucket{state="success"}[
 
 #### zoekt-indexserver: repo_index_fail_speed
 
-<p class="subtitle">Failed indexing durations
-
-</p>
+<p class="subtitle">Failed indexing durations</p>
 
 Failures happening after a long time indicates timeouts.
 
@@ -11230,9 +10214,7 @@ Query: `sum by (le, state) (increase(index_repo_seconds_bucket{state="fail"}[$__
 
 #### zoekt-indexserver: average_resolve_revision_duration
 
-<p class="subtitle">Average resolve revision duration over 5m
-
-</p>
+<p class="subtitle">Average resolve revision duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-average-resolve-revision-duration) for 2 alerts related to this panel.
 
@@ -11251,9 +10233,7 @@ Query: `sum(rate(resolve_revision_seconds_sum[5m])) / sum(rate(resolve_revision_
 
 #### zoekt-indexserver: get_index_options_error_increase
 
-<p class="subtitle">The number of repositories we failed to get indexing options over 5m
-
-</p>
+<p class="subtitle">The number of repositories we failed to get indexing options over 5m</p>
 
 When considering indexing a repository we ask for the index configuration
 from frontend per repository. The most likely reason this would fail is
@@ -11282,9 +10262,7 @@ Query: `sum(increase(get_index_options_error_total[5m]))`
 
 #### zoekt-indexserver: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -11313,9 +10291,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-indexserver.
 
 #### zoekt-indexserver: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage) for 1 alert related to this panel.
 
@@ -11334,9 +10310,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.
 
 #### zoekt-indexserver: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage) for 1 alert related to this panel.
 
@@ -11355,9 +10329,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserv
 
 #### zoekt-indexserver: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -11381,9 +10353,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-indexserver.*"
 
 #### zoekt-indexserver: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -11402,9 +10372,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### zoekt-indexserver: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -11423,9 +10391,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 #### zoekt-indexserver: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -11444,9 +10410,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoek
 
 #### zoekt-indexserver: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -11467,9 +10431,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 #### zoekt-indexserver: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage) for 1 alert related to this panel.
 
@@ -11494,9 +10456,7 @@ To see this dashboard, visit `/-/debug/grafana/d/zoekt-webserver/zoekt-webserver
 
 #### zoekt-webserver: indexed_search_request_errors
 
-<p class="subtitle">Indexed search request errors every 5m by code
-
-</p>
+<p class="subtitle">Indexed search request errors every 5m by code</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-indexed-search-request-errors) for 1 alert related to this panel.
 
@@ -11517,9 +10477,7 @@ Query: `sum by (code)(increase(src_zoekt_request_duration_seconds_count{code!~"2
 
 #### zoekt-webserver: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -11548,9 +10506,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-webserver.*"
 
 #### zoekt-webserver: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-cpu-usage) for 1 alert related to this panel.
 
@@ -11569,9 +10525,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"
 
 #### zoekt-webserver: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage) for 1 alert related to this panel.
 
@@ -11590,9 +10544,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver
 
 #### zoekt-webserver: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -11616,9 +10568,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-webserver.*"}[
 
 #### zoekt-webserver: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -11637,9 +10587,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### zoekt-webserver: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -11658,9 +10606,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 #### zoekt-webserver: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -11679,9 +10625,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoek
 
 #### zoekt-webserver: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -11708,9 +10652,7 @@ To see this dashboard, visit `/-/debug/grafana/d/prometheus/prometheus` on your 
 
 #### prometheus: prometheus_rule_eval_duration
 
-<p class="subtitle">Average prometheus rule group evaluation duration over 10m by rule group
-
-</p>
+<p class="subtitle">Average prometheus rule group evaluation duration over 10m by rule group</p>
 
 A high value here indicates Prometheus rule evaluation is taking longer than expected.
 It might indicate that certain rule groups are taking too long to evaluate, or Prometheus is underprovisioned.
@@ -11734,9 +10676,7 @@ Query: `sum by(rule_group) (avg_over_time(prometheus_rule_group_last_duration_se
 
 #### prometheus: prometheus_rule_eval_failures
 
-<p class="subtitle">Failed prometheus rule evaluations over 5m by rule group
-
-</p>
+<p class="subtitle">Failed prometheus rule evaluations over 5m by rule group</p>
 
 Rules that Sourcegraph ships with are grouped under `/sg_config_prometheus`. [Custom rules are grouped under `/sg_prometheus_addons`](https://docs.sourcegraph.com/admin/observability/metrics#prometheus-configuration).
 
@@ -11759,9 +10699,7 @@ Query: `sum by(rule_group) (rate(prometheus_rule_evaluation_failures_total[5m]))
 
 #### prometheus: alertmanager_notification_latency
 
-<p class="subtitle">Alertmanager notification latency over 1m by integration
-
-</p>
+<p class="subtitle">Alertmanager notification latency over 1m by integration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notification-latency) for 1 alert related to this panel.
 
@@ -11780,9 +10718,7 @@ Query: `sum by(integration) (rate(alertmanager_notification_latency_seconds_sum[
 
 #### prometheus: alertmanager_notification_failures
 
-<p class="subtitle">Failed alertmanager notifications over 1m by integration
-
-</p>
+<p class="subtitle">Failed alertmanager notifications over 1m by integration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notification-failures) for 1 alert related to this panel.
 
@@ -11803,9 +10739,7 @@ Query: `sum by(integration) (rate(alertmanager_notifications_failed_total[1m]))`
 
 #### prometheus: prometheus_config_status
 
-<p class="subtitle">Prometheus configuration reload status
-
-</p>
+<p class="subtitle">Prometheus configuration reload status</p>
 
 A `1` indicates Prometheus reloaded its configuration successfully.
 
@@ -11826,9 +10760,7 @@ Query: `prometheus_config_last_reload_successful`
 
 #### prometheus: alertmanager_config_status
 
-<p class="subtitle">Alertmanager configuration reload status
-
-</p>
+<p class="subtitle">Alertmanager configuration reload status</p>
 
 A `1` indicates Alertmanager reloaded its configuration successfully.
 
@@ -11849,9 +10781,7 @@ Query: `alertmanager_config_last_reload_successful`
 
 #### prometheus: prometheus_tsdb_op_failure
 
-<p class="subtitle">Prometheus tsdb failures by operation over 1m by operation
-
-</p>
+<p class="subtitle">Prometheus tsdb failures by operation over 1m by operation</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-tsdb-op-failure) for 1 alert related to this panel.
 
@@ -11870,9 +10800,7 @@ Query: `increase(label_replace({__name__=~"prometheus_tsdb_(.*)_failed_total"}, 
 
 #### prometheus: prometheus_target_sample_exceeded
 
-<p class="subtitle">Prometheus scrapes that exceed the sample limit over 10m
-
-</p>
+<p class="subtitle">Prometheus scrapes that exceed the sample limit over 10m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-exceeded) for 1 alert related to this panel.
 
@@ -11891,9 +10819,7 @@ Query: `increase(prometheus_target_scrapes_exceeded_sample_limit_total[10m])`
 
 #### prometheus: prometheus_target_sample_duplicate
 
-<p class="subtitle">Prometheus scrapes rejected due to duplicate timestamps over 10m
-
-</p>
+<p class="subtitle">Prometheus scrapes rejected due to duplicate timestamps over 10m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-duplicate) for 1 alert related to this panel.
 
@@ -11914,9 +10840,7 @@ Query: `increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[10m]
 
 #### prometheus: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -11945,9 +10869,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^prometheus.*"}) > 
 
 #### prometheus: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-cpu-usage) for 1 alert related to this panel.
 
@@ -11966,9 +10888,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}`
 
 #### prometheus: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-memory-usage) for 1 alert related to this panel.
 
@@ -11987,9 +10907,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}`
 
 #### prometheus: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -12013,9 +10931,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^prometheus.*"}[1h]) 
 
 #### prometheus: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -12034,9 +10950,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### prometheus: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -12055,9 +10969,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^p
 
 #### prometheus: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -12076,9 +10988,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^prom
 
 #### prometheus: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -12099,9 +11009,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^p
 
 #### prometheus: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#prometheus-pods-available-percentage) for 1 alert related to this panel.
 
@@ -12128,9 +11036,7 @@ To see this dashboard, visit `/-/debug/grafana/d/executor/executor` on your Sour
 
 #### executor: executor_queue_size
 
-<p class="subtitle">Unprocessed executor job queue size
-
-</p>
+<p class="subtitle">Unprocessed executor job queue size</p>
 
 This panel has no related alerts.
 
@@ -12149,9 +11055,7 @@ Query: `max by (queue)(src_executor_total{job=~"^(executor|sourcegraph-code-inte
 
 #### executor: executor_queue_growth_rate
 
-<p class="subtitle">Unprocessed executor job queue growth rate over 30m
-
-</p>
+<p class="subtitle">Unprocessed executor job queue growth rate over 30m</p>
 
 This value compares the rate of enqueues against the rate of finished jobs for the selected queue.
 
@@ -12178,9 +11082,7 @@ Query: `sum by (queue)(increase(src_executor_total{job=~"^(executor|sourcegraph-
 
 #### executor: executor_handlers
 
-<p class="subtitle">Handler active handlers
-
-</p>
+<p class="subtitle">Handler active handlers</p>
 
 This panel has no related alerts.
 
@@ -12199,9 +11101,7 @@ Query: `sum(src_executor_processor_handlers{queue=~"${queue:regex}",job=~"^(exec
 
 #### executor: executor_processor_total
 
-<p class="subtitle">Handler operations every 5m
-
-</p>
+<p class="subtitle">Handler operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12220,9 +11120,7 @@ Query: `sum(increase(src_executor_processor_total{queue=~"${queue:regex}",job=~"
 
 #### executor: executor_processor_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful handler operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful handler operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12241,9 +11139,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_executor_processor_durati
 
 #### executor: executor_processor_errors_total
 
-<p class="subtitle">Handler operation errors every 5m
-
-</p>
+<p class="subtitle">Handler operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12262,9 +11158,7 @@ Query: `sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}"
 
 #### executor: executor_processor_error_rate
 
-<p class="subtitle">Handler operation error rate over 5m
-
-</p>
+<p class="subtitle">Handler operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12285,9 +11179,7 @@ Query: `sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}"
 
 #### executor: apiworker_apiclient_total
 
-<p class="subtitle">Aggregate client operations every 5m
-
-</p>
+<p class="subtitle">Aggregate client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12306,9 +11198,7 @@ Query: `sum(increase(src_apiworker_apiclient_total{job=~"^(executor|sourcegraph-
 
 #### executor: apiworker_apiclient_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12327,9 +11217,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_apiworker_apiclient_durat
 
 #### executor: apiworker_apiclient_errors_total
 
-<p class="subtitle">Aggregate client operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12348,9 +11236,7 @@ Query: `sum(increase(src_apiworker_apiclient_errors_total{job=~"^(executor|sourc
 
 #### executor: apiworker_apiclient_error_rate
 
-<p class="subtitle">Aggregate client operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12369,9 +11255,7 @@ Query: `sum(increase(src_apiworker_apiclient_errors_total{job=~"^(executor|sourc
 
 #### executor: apiworker_apiclient_total
 
-<p class="subtitle">Client operations every 5m
-
-</p>
+<p class="subtitle">Client operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12390,9 +11274,7 @@ Query: `sum by (op)(increase(src_apiworker_apiclient_total{job=~"^(executor|sour
 
 #### executor: apiworker_apiclient_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful client operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful client operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12411,9 +11293,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_apiclient_du
 
 #### executor: apiworker_apiclient_errors_total
 
-<p class="subtitle">Client operation errors every 5m
-
-</p>
+<p class="subtitle">Client operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12432,9 +11312,7 @@ Query: `sum by (op)(increase(src_apiworker_apiclient_errors_total{job=~"^(execut
 
 #### executor: apiworker_apiclient_error_rate
 
-<p class="subtitle">Client operation error rate over 5m
-
-</p>
+<p class="subtitle">Client operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12455,9 +11333,7 @@ Query: `sum by (op)(increase(src_apiworker_apiclient_errors_total{job=~"^(execut
 
 #### executor: apiworker_command_total
 
-<p class="subtitle">Aggregate command operations every 5m
-
-</p>
+<p class="subtitle">Aggregate command operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12476,9 +11352,7 @@ Query: `sum(increase(src_apiworker_command_total{op=~"setup.*",job=~"^(executor|
 
 #### executor: apiworker_command_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate command operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate command operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12497,9 +11371,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_apiworker_command_duratio
 
 #### executor: apiworker_command_errors_total
 
-<p class="subtitle">Aggregate command operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate command operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12518,9 +11390,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"setup.*",job=~"^(ex
 
 #### executor: apiworker_command_error_rate
 
-<p class="subtitle">Aggregate command operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate command operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12539,9 +11409,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"setup.*",job=~"^(ex
 
 #### executor: apiworker_command_total
 
-<p class="subtitle">Command operations every 5m
-
-</p>
+<p class="subtitle">Command operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12560,9 +11428,7 @@ Query: `sum by (op)(increase(src_apiworker_command_total{op=~"setup.*",job=~"^(e
 
 #### executor: apiworker_command_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful command operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful command operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12581,9 +11447,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_dura
 
 #### executor: apiworker_command_errors_total
 
-<p class="subtitle">Command operation errors every 5m
-
-</p>
+<p class="subtitle">Command operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12602,9 +11466,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",jo
 
 #### executor: apiworker_command_error_rate
 
-<p class="subtitle">Command operation error rate over 5m
-
-</p>
+<p class="subtitle">Command operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12625,9 +11487,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",jo
 
 #### executor: apiworker_command_total
 
-<p class="subtitle">Aggregate command operations every 5m
-
-</p>
+<p class="subtitle">Aggregate command operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12646,9 +11506,7 @@ Query: `sum(increase(src_apiworker_command_total{op=~"exec.*",job=~"^(executor|s
 
 #### executor: apiworker_command_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate command operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate command operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12667,9 +11525,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_apiworker_command_duratio
 
 #### executor: apiworker_command_errors_total
 
-<p class="subtitle">Aggregate command operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate command operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12688,9 +11544,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"exec.*",job=~"^(exe
 
 #### executor: apiworker_command_error_rate
 
-<p class="subtitle">Aggregate command operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate command operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12709,9 +11563,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"exec.*",job=~"^(exe
 
 #### executor: apiworker_command_total
 
-<p class="subtitle">Command operations every 5m
-
-</p>
+<p class="subtitle">Command operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12730,9 +11582,7 @@ Query: `sum by (op)(increase(src_apiworker_command_total{op=~"exec.*",job=~"^(ex
 
 #### executor: apiworker_command_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful command operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful command operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12751,9 +11601,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_dura
 
 #### executor: apiworker_command_errors_total
 
-<p class="subtitle">Command operation errors every 5m
-
-</p>
+<p class="subtitle">Command operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12772,9 +11620,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",job
 
 #### executor: apiworker_command_error_rate
 
-<p class="subtitle">Command operation error rate over 5m
-
-</p>
+<p class="subtitle">Command operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12795,9 +11641,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",job
 
 #### executor: apiworker_command_total
 
-<p class="subtitle">Aggregate command operations every 5m
-
-</p>
+<p class="subtitle">Aggregate command operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12816,9 +11660,7 @@ Query: `sum(increase(src_apiworker_command_total{op=~"teardown.*",job=~"^(execut
 
 #### executor: apiworker_command_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful aggregate command operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful aggregate command operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12837,9 +11679,7 @@ Query: `histogram_quantile(0.99, sum  by (le)(rate(src_apiworker_command_duratio
 
 #### executor: apiworker_command_errors_total
 
-<p class="subtitle">Aggregate command operation errors every 5m
-
-</p>
+<p class="subtitle">Aggregate command operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12858,9 +11698,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",job=~"^
 
 #### executor: apiworker_command_error_rate
 
-<p class="subtitle">Aggregate command operation error rate over 5m
-
-</p>
+<p class="subtitle">Aggregate command operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12879,9 +11717,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",job=~"^
 
 #### executor: apiworker_command_total
 
-<p class="subtitle">Command operations every 5m
-
-</p>
+<p class="subtitle">Command operations every 5m</p>
 
 This panel has no related alerts.
 
@@ -12900,9 +11736,7 @@ Query: `sum by (op)(increase(src_apiworker_command_total{op=~"teardown.*",job=~"
 
 #### executor: apiworker_command_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful command operation duration over 5m
-
-</p>
+<p class="subtitle">99th percentile successful command operation duration over 5m</p>
 
 This panel has no related alerts.
 
@@ -12921,9 +11755,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_dura
 
 #### executor: apiworker_command_errors_total
 
-<p class="subtitle">Command operation errors every 5m
-
-</p>
+<p class="subtitle">Command operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -12942,9 +11774,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*"
 
 #### executor: apiworker_command_error_rate
 
-<p class="subtitle">Command operation error rate over 5m
-
-</p>
+<p class="subtitle">Command operation error rate over 5m</p>
 
 This panel has no related alerts.
 
@@ -12965,9 +11795,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*"
 
 #### executor: container_missing
 
-<p class="subtitle">Container missing
-
-</p>
+<p class="subtitle">Container missing</p>
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -12996,9 +11824,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^(executor|sourcegr
 
 #### executor: container_cpu_usage
 
-<p class="subtitle">Container cpu usage total (1m average) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (1m average) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-container-cpu-usage) for 1 alert related to this panel.
 
@@ -13017,9 +11843,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^(executor|sourcegr
 
 #### executor: container_memory_usage
 
-<p class="subtitle">Container memory usage by instance
-
-</p>
+<p class="subtitle">Container memory usage by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-container-memory-usage) for 1 alert related to this panel.
 
@@ -13038,9 +11862,7 @@ Query: `cadvisor_container_memory_usage_percentage_total{name=~"^(executor|sourc
 
 #### executor: fs_io_operations
 
-<p class="subtitle">Filesystem reads and writes rate by instance over 1h
-
-</p>
+<p class="subtitle">Filesystem reads and writes rate by instance over 1h</p>
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
@@ -13064,9 +11886,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^(executor|sourcegrap
 
 #### executor: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
@@ -13085,9 +11905,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 #### executor: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">Container memory usage (1d maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (1d maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
@@ -13106,9 +11924,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(
 
 #### executor: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance
-
-</p>
+<p class="subtitle">Container cpu usage total (5m maximum) across all cores by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
@@ -13127,9 +11943,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(exe
 
 #### executor: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">Container memory usage (5m maximum) by instance
-
-</p>
+<p class="subtitle">Container memory usage (5m maximum) by instance</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
@@ -13150,9 +11964,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(
 
 #### executor: go_goroutines
 
-<p class="subtitle">Maximum active goroutines
-
-</p>
+<p class="subtitle">Maximum active goroutines</p>
 
 A high value here indicates a possible goroutine leak.
 
@@ -13173,9 +11985,7 @@ Query: `max by(instance) (go_goroutines{job=~".*(executor|sourcegraph-code-intel
 
 #### executor: go_gc_duration_seconds
 
-<p class="subtitle">Maximum go garbage collection duration
-
-</p>
+<p class="subtitle">Maximum go garbage collection duration</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-go-gc-duration-seconds) for 1 alert related to this panel.
 
@@ -13196,9 +12006,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*(executor|sourcegraph-c
 
 #### executor: pods_available_percentage
 
-<p class="subtitle">Percentage pods available
-
-</p>
+<p class="subtitle">Percentage pods available</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#executor-pods-available-percentage) for 1 alert related to this panel.
 

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -166,7 +166,7 @@ func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) err
 
 func (d *documentation) renderDashboardPanelEntry(c *Container, g Group, o Observable, panelID uint) error {
 	fprintObservableHeader(&d.dashboards, c, &o, 4)
-	fprintSubtitle(&d.dashboards, fmt.Sprintf("%s\n\n", upperFirst(o.Description)))
+	fprintSubtitle(&d.dashboards, upperFirst(o.Description))
 
 	// render interpretation reference if available
 	if o.Interpretation != "" && o.Interpretation != "none" {


### PR DESCRIPTION
Noticed some weirdness in the generated docs

Massive diff is just a bunch of these:

![image](https://user-images.githubusercontent.com/23356519/133532274-faed9ef9-b16b-4432-a24a-ed68db7f37d6.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
