### PR TITLE
oobmigrations: Add metadata column

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1441,6 +1441,7 @@ Referenced by:
  introduced_version_minor | integer                  |           | not null | 
  deprecated_version_major | integer                  |           |          | 
  deprecated_version_minor | integer                  |           |          | 
+ metadata                 | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
     "out_of_band_migrations_pkey" PRIMARY KEY, btree (id)
 Check constraints:

--- a/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.down.sql
+++ b/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE
+    out_of_band_migrations
+DROP COLUMN IF EXISTS metadata;
+
+COMMIT;

--- a/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.up.sql
+++ b/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE
+    out_of_band_migrations
+ADD COLUMN IF NOT EXISTS
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMIT;


### PR DESCRIPTION
Add a metadata column so that extra information can be stored with migrations
marshalled as JSON.