### PR TITLE
Post-refresh: Update text-disabled/muted colors for improved contrast

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -96,7 +96,7 @@ $theme-colors: (
     --line-number-color: var(--gray-06);
     --header-icon-color: var(--gray-05);
     --tooltip-bg: var(--gray-08);
-    --text-disabled: var(gray-06);
+    --text-disabled: var(--gray-06);
 }
 
 .theme-light {

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -96,6 +96,7 @@ $theme-colors: (
     --line-number-color: var(--gray-06);
     --header-icon-color: var(--gray-05);
     --tooltip-bg: var(--gray-08);
+    --text-disabled: var(gray-06);
 }
 
 .theme-light {
@@ -128,7 +129,6 @@ $theme-colors: (
     --mark-bg: #f8e688;
     --merged-4: #eee9fd;
     --text-muted: var(--gray-07);
-    --text-disabled: var(--gray-05);
     --link-color: var(--primary);
     --link-color-2: #0766cc;
     --link-active-color: #0c7bf0;
@@ -182,8 +182,7 @@ $theme-colors: (
     --color-bg-3: var(--gray-08);
     --mark-bg: #7a341e;
     --merged-4: #1f0a5c;
-    --text-muted: var(--gray-05);
-    --text-disabled: var(--gray-07);
+    --text-muted: var(--gray-06);
     --link-color: #4393e7;
     --link-color-2: #70b0f3;
     --link-active-color: #489ffa;


### PR DESCRIPTION
- Set `text-disabled` to `gray-06` on both themes
- Set `text-muted` to `gray-06` in dark theme

This PR should be reviewed with https://github.com/sourcegraph/sourcegraph/pull/25030. They are separated to make the Chromatic/Percy diffs more manageable

fixes https://github.com/sourcegraph/sourcegraph/issues/21601