### PR TITLE
database: instrument counters on sql requests

### DIFF
--- a/internal/database/dbconn/dbconn.go
+++ b/internal/database/dbconn/dbconn.go
@@ -272,7 +272,14 @@ func open(cfg *pgx.ConnConfig) (*sql.DB, error) {
 	cfgKey := stdlib.RegisterConnConfig(cfg)
 
 	registerOnce.Do(func() {
-		sql.Register("postgres-proxy", sqlhooks.Wrap(stdlib.GetDefaultDriver(), &hook{}))
+		m := promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "src_pgsql_request_total",
+			Help: "Total number of SQL requests to the database.",
+		}, []string{"type"})
+		sql.Register("postgres-proxy", sqlhooks.Wrap(stdlib.GetDefaultDriver(), &hook{
+			metricSQLSuccessTotal: m.WithLabelValues("success"),
+			metricSQLErrorTotal:   m.WithLabelValues("error"),
+		}))
 	})
 	db, err := sql.Open("postgres-proxy", cfgKey)
 	if err != nil {
@@ -313,7 +320,10 @@ func WithBulkInsertion(ctx context.Context, bulkInsertion bool) context.Context 
 	return context.WithValue(ctx, bulkInsertionKey, bulkInsertion)
 }
 
-type hook struct{}
+type hook struct {
+	metricSQLSuccessTotal prometheus.Counter
+	metricSQLErrorTotal   prometheus.Counter
+}
 
 // postgresBulkInsertRowsPattern matches `($1, $2, $3), ($4, $5, $6), ...` which
 // we use to cut out the row payloads from bulk insertion tracing data. We don't
@@ -366,7 +376,7 @@ func (h *hook) After(ctx context.Context, query string, args ...interface{}) (co
 	if tr := trace.TraceFromContext(ctx); tr != nil {
 		tr.Finish()
 	}
-	metricSQLSuccessTotal.Inc()
+	h.metricSQLSuccessTotal.Inc()
 	return ctx, nil
 }
 
@@ -376,7 +386,7 @@ func (h *hook) OnError(ctx context.Context, err error, query string, args ...int
 		tr.SetError(err)
 		tr.Finish()
 	}
-	metricSQLErrorTotal.Inc()
+	h.metricSQLErrorTotal.Inc()
 	return err
 }
 
@@ -395,15 +405,4 @@ func configureConnectionPool(db *sql.DB) {
 	db.SetMaxOpenConns(maxOpen)
 	db.SetMaxIdleConns(maxOpen)
 	db.SetConnMaxIdleTime(time.Minute)
-}
-
-var metricSQLSuccessTotal, metricSQLErrorTotal prometheus.Counter
-
-func init() {
-	m := promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "src_pgsql_request_total",
-		Help: "Total number of SQL requests to the database.",
-	}, []string{"type"})
-	metricSQLSuccessTotal = m.WithLabelValues("success")
-	metricSQLErrorTotal = m.WithLabelValues("error")
 }


### PR DESCRIPTION
We were missing metrics around the number of requests we do against
postgresql. This is using the existing sql hook we have for
instrumentating tracing.

In the hook layer we don't know which DB we are accessing, so we have a
single metric for all request and request errors. We use a labeled
metric so it is easy to calculate percentage error.

There is other SQL instrumentation, but that is on the connection /
connection pool.