### PR TITLE
search: Avoid excessive rerendering of search sidebar sections

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -55,8 +55,6 @@ const defaultProps: StreamingSearchResultsProps = {
     } as AuthenticatedUser,
     isLightTheme: true,
 
-    isSourcegraphDotCom: false,
-
     settingsCascade: {
         subjects: null,
         final: null,

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -52,8 +52,6 @@ describe('StreamingSearchResults', () => {
         location: history.location,
         authenticatedUser: null,
 
-        isSourcegraphDotCom: false,
-
         settingsCascade: {
             subjects: null,
             final: null,

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -3,6 +3,7 @@ import * as H from 'history'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Observable } from 'rxjs'
 
+import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -23,6 +24,7 @@ import {
     resolveVersionContext,
     ParsedSearchQueryProps,
     MutableVersionContextProps,
+    SearchContextProps,
 } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { CodeMonitoringProps } from '../../code-monitoring'
@@ -45,10 +47,12 @@ import { VersionContextWarning } from './VersionContextWarning'
 
 export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
+        Pick<ActivationProps, 'activation'>,
         Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
         Pick<PatternTypeProps, 'patternType'>,
         Pick<MutableVersionContextProps, 'versionContext' | 'availableVersionContexts' | 'previousVersionContext'>,
         Pick<CaseSensitivityProps, 'caseSensitive'>,
+        Pick<SearchContextProps, 'selectedSearchContextSpec'>,
         SettingsCascadeProps,
         ExtensionsControllerProps<'executeCommand' | 'extHostAPI'>,
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
@@ -60,7 +64,6 @@ export interface StreamingSearchResultsProps
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
-    isSourcegraphDotCom: boolean
 
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
@@ -237,7 +240,13 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
             <PageTitle key="page-title" title={query} />
 
             <SearchSidebar
-                {...props}
+                activation={props.activation}
+                caseSensitive={props.caseSensitive}
+                patternType={props.patternType}
+                settingsCascade={props.settingsCascade}
+                telemetryService={props.telemetryService}
+                versionContext={props.versionContext}
+                selectedSearchContextSpec={props.selectedSearchContextSpec}
                 className={classNames(
                     styles.streamingSearchResultsSidebar,
                     showSidebar && styles.streamingSearchResultsSidebarShow

--- a/client/web/src/search/results/sidebar/Revisions.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.tsx
@@ -159,38 +159,40 @@ export interface RevisionsProps {
     _initialTab?: TabIndex
 }
 
-export const Revisions: React.FunctionComponent<RevisionsProps> = ({ repoName, onFilterClick, query, _initialTab }) => {
-    const [selectedTab, setSelectedTab] = useTemporarySetting('search.sidebar.revisions.tab')
-    const onRevisionFilterClick = (value: string): void => onFilterClick('rev', value)
-    return (
-        <Tabs index={_initialTab ?? selectedTab ?? 0} onChange={setSelectedTab}>
-            <TabList className={styles.sidebarSectionTabsHeader}>
-                <Tab index={TabIndex.BRANCHES}>Branches</Tab>
-                <Tab index={TabIndex.TAGS}>Tags</Tab>
-            </TabList>
-            <TabPanels>
-                <TabPanel>
-                    <RevisionList
-                        pluralNoun="branches"
-                        repoName={repoName}
-                        type={GitRefType.GIT_BRANCH}
-                        onFilterClick={onRevisionFilterClick}
-                        query={query}
-                    />
-                </TabPanel>
-                <TabPanel>
-                    <RevisionList
-                        pluralNoun="tags"
-                        repoName={repoName}
-                        type={GitRefType.GIT_TAG}
-                        onFilterClick={onRevisionFilterClick}
-                        query={query}
-                    />
-                </TabPanel>
-            </TabPanels>
-        </Tabs>
-    )
-}
+export const Revisions: React.FunctionComponent<RevisionsProps> = React.memo(
+    ({ repoName, onFilterClick, query, _initialTab }) => {
+        const [selectedTab, setSelectedTab] = useTemporarySetting('search.sidebar.revisions.tab')
+        const onRevisionFilterClick = (value: string): void => onFilterClick('rev', value)
+        return (
+            <Tabs index={_initialTab ?? selectedTab ?? 0} onChange={setSelectedTab}>
+                <TabList className={styles.sidebarSectionTabsHeader}>
+                    <Tab index={TabIndex.BRANCHES}>Branches</Tab>
+                    <Tab index={TabIndex.TAGS}>Tags</Tab>
+                </TabList>
+                <TabPanels>
+                    <TabPanel>
+                        <RevisionList
+                            pluralNoun="branches"
+                            repoName={repoName}
+                            type={GitRefType.GIT_BRANCH}
+                            onFilterClick={onRevisionFilterClick}
+                            query={query}
+                        />
+                    </TabPanel>
+                    <TabPanel>
+                        <RevisionList
+                            pluralNoun="tags"
+                            repoName={repoName}
+                            type={GitRefType.GIT_TAG}
+                            onFilterClick={onRevisionFilterClick}
+                            query={query}
+                        />
+                    </TabPanel>
+                </TabPanels>
+            </Tabs>
+        )
+    }
+)
 
 export const getRevisions = (props: Omit<RevisionsProps, 'query'>) => (query: string) => (
     <Revisions {...props} query={query} />

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -12,14 +12,13 @@ import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { FILTERS, FilterType, isNegatableFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
-import { CaseSensitivityProps, PatternTypeProps, SearchContextProps } from '../..'
-import { QueryChangeSource, QueryState } from '../../helpers'
+import { QueryChangeSource } from '../../helpers'
 import { createQueryExampleFromString, updateQueryWithFilterAndExample, QueryExample } from '../../helpers/queryExample'
+import { NavbarQueryState } from '../..//navbarSearchQueryState'
 
 import styles from './SearchReference.module.scss'
 import sidebarStyles from './SearchSidebarSection.module.scss'
@@ -475,115 +474,114 @@ const FilterInfoList = ({ filters, onClick, onExampleClick }: FilterInfoListProp
     </ul>
 )
 
-export interface SearchReferenceProps
-    extends Omit<PatternTypeProps, 'setPatternType'>,
-        Omit<CaseSensitivityProps, 'setCaseSensitivity'>,
-        VersionContextProps,
-        TelemetryProps,
-        Pick<SearchContextProps, 'selectedSearchContextSpec'> {
-    query: string
+export interface SearchReferenceProps extends TelemetryProps, Pick<NavbarQueryState, 'setQueryState'> {
     filter: string
-    onNavbarQueryChange: (queryState: QueryState) => void
-    isSourcegraphDotCom: boolean
 }
 
-const SearchReference = (props: SearchReferenceProps): ReactElement => {
-    const [selectedTab, setSelectedTab] = useLocalStorage(SEARCH_REFERENCE_TAB_KEY, 0)
+const SearchReference = React.memo(
+    (props: SearchReferenceProps): ReactElement => {
+        const [selectedTab, setSelectedTab] = useLocalStorage(SEARCH_REFERENCE_TAB_KEY, 0)
 
-    const { onNavbarQueryChange, query, telemetryService } = props
-    const filter = props.filter.trim()
-    const hasFilter = filter.length > 0
+        const { setQueryState, telemetryService } = props
+        const filter = props.filter.trim()
+        const hasFilter = filter.length > 0
 
-    const selectedFilters = useMemo(() => {
-        if (!hasFilter) {
-            return filterInfos
-        }
-        const searchTerms = parseSearchInput(filter)
-        return filterInfos.filter(info => matches(searchTerms, info))
-    }, [filter, hasFilter])
+        const selectedFilters = useMemo(() => {
+            if (!hasFilter) {
+                return filterInfos
+            }
+            const searchTerms = parseSearchInput(filter)
+            return filterInfos.filter(info => matches(searchTerms, info))
+        }, [filter, hasFilter])
 
-    const updateQuery = useCallback(
-        (searchReference: FilterInfo, negate: boolean) => {
-            const updatedQuery = updateQueryWithFilterAndExample(query, searchReference.field, searchReference, {
-                singular: Boolean(FILTERS[searchReference.field].singular),
-                negate: negate && isNegatableFilter(searchReference.field),
-                emptyValue: shouldShowSuggestions(searchReference),
-            })
-            onNavbarQueryChange({
-                changeSource: QueryChangeSource.searchReference,
-                query: updatedQuery.query,
-                selectionRange: updatedQuery.placeholderRange,
-                revealRange: updatedQuery.filterRange,
-                showSuggestions: shouldShowSuggestions(searchReference),
-            })
-        },
-        [onNavbarQueryChange, query]
-    )
-    const updateQueryWithOperator = useCallback(
-        (info: OperatorInfo) => {
-            onNavbarQueryChange({
-                query: query + ` ${info.operator} `,
-            })
-        },
-        [onNavbarQueryChange, query]
-    )
-    const updateQueryWithExample = useCallback(
-        (example: string) => {
-            telemetryService.log(hasFilter ? 'SearchReferenceSearchedAndClicked' : 'SearchReferenceFilterClicked')
-            onNavbarQueryChange({ query: query.trimEnd() + ' ' + example })
-        },
-        [onNavbarQueryChange, query, hasFilter, telemetryService]
-    )
+        const updateQuery = useCallback(
+            (searchReference: FilterInfo, negate: boolean) => {
+                setQueryState(({ query }) => {
+                    const updatedQuery = updateQueryWithFilterAndExample(
+                        query,
+                        searchReference.field,
+                        searchReference,
+                        {
+                            singular: Boolean(FILTERS[searchReference.field].singular),
+                            negate: negate && isNegatableFilter(searchReference.field),
+                            emptyValue: shouldShowSuggestions(searchReference),
+                        }
+                    )
+                    return {
+                        changeSource: QueryChangeSource.searchReference,
+                        query: updatedQuery.query,
+                        selectionRange: updatedQuery.placeholderRange,
+                        revealRange: updatedQuery.filterRange,
+                        showSuggestions: shouldShowSuggestions(searchReference),
+                    }
+                })
+            },
+            [setQueryState]
+        )
+        const updateQueryWithOperator = useCallback(
+            (info: OperatorInfo) => {
+                setQueryState(({ query }) => ({ query: query + ` ${info.operator} ` }))
+            },
+            [setQueryState]
+        )
+        const updateQueryWithExample = useCallback(
+            (example: string) => {
+                telemetryService.log(hasFilter ? 'SearchReferenceSearchedAndClicked' : 'SearchReferenceFilterClicked')
+                setQueryState(({ query }) => ({ query: query.trimEnd() + ' ' + example }))
+            },
+            [setQueryState, hasFilter, telemetryService]
+        )
 
-    const filterList = (
-        <FilterInfoList filters={selectedFilters} onClick={updateQuery} onExampleClick={updateQueryWithExample} />
-    )
+        const filterList = (
+            <FilterInfoList filters={selectedFilters} onClick={updateQuery} onExampleClick={updateQueryWithExample} />
+        )
 
-    return (
-        <div>
-            {hasFilter ? (
-                filterList
-            ) : (
-                <Tabs index={selectedTab} onChange={setSelectedTab}>
-                    <TabList className={styles.tablist}>
-                        <Tab>Common</Tab>
-                        <Tab>All filters</Tab>
-                        <Tab>Operators</Tab>
-                    </TabList>
-                    <TabPanels>
-                        <TabPanel>
-                            <FilterInfoList
-                                filters={commonFilters}
-                                onClick={updateQuery}
-                                onExampleClick={updateQueryWithExample}
-                            />
-                        </TabPanel>
-                        <TabPanel>{filterList}</TabPanel>
-                        <TabPanel>
-                            <ul className={styles.list}>
-                                {operatorInfo.map(operatorInfo => (
-                                    <SearchReferenceEntry
-                                        searchReference={operatorInfo}
-                                        key={operatorInfo.operator + operatorInfo.value}
-                                        onClick={updateQueryWithOperator}
-                                        onExampleClick={updateQueryWithExample}
-                                    />
-                                ))}
-                            </ul>
-                        </TabPanel>
-                    </TabPanels>
-                </Tabs>
-            )}
-            <p className={sidebarStyles.sidebarSectionFooter}>
-                <small>
-                    <Link target="blank" to="https://docs.sourcegraph.com/code_search/reference/queries">
-                        Search syntax <ExternalLinkIcon className="icon-inline" />
-                    </Link>
-                </small>
-            </p>
-        </div>
-    )
-}
+        return (
+            <div>
+                {hasFilter ? (
+                    filterList
+                ) : (
+                    <Tabs index={selectedTab} onChange={setSelectedTab}>
+                        <TabList className={styles.tablist}>
+                            <Tab>Common</Tab>
+                            <Tab>All filters</Tab>
+                            <Tab>Operators</Tab>
+                        </TabList>
+                        <TabPanels>
+                            <TabPanel>
+                                <FilterInfoList
+                                    filters={commonFilters}
+                                    onClick={updateQuery}
+                                    onExampleClick={updateQueryWithExample}
+                                />
+                            </TabPanel>
+                            <TabPanel>{filterList}</TabPanel>
+                            <TabPanel>
+                                <ul className={styles.list}>
+                                    {operatorInfo.map(operatorInfo => (
+                                        <SearchReferenceEntry
+                                            searchReference={operatorInfo}
+                                            key={operatorInfo.operator + operatorInfo.value}
+                                            onClick={updateQueryWithOperator}
+                                            onExampleClick={updateQueryWithExample}
+                                        />
+                                    ))}
+                                </ul>
+                            </TabPanel>
+                        </TabPanels>
+                    </Tabs>
+                )}
+                <p className={sidebarStyles.sidebarSectionFooter}>
+                    <small>
+                        <Link target="blank" to="https://docs.sourcegraph.com/code_search/reference/queries">
+                            Search syntax <ExternalLinkIcon className="icon-inline" />
+                        </Link>
+                    </small>
+                </p>
+            </div>
+        )
+    }
+)
 
 export function getSearchReferenceFactory(
     props: Omit<SearchReferenceProps, 'filter'>

--- a/client/web/src/search/results/sidebar/SearchReference.tsx
+++ b/client/web/src/search/results/sidebar/SearchReference.tsx
@@ -18,7 +18,7 @@ import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
 import { QueryChangeSource } from '../../helpers'
 import { createQueryExampleFromString, updateQueryWithFilterAndExample, QueryExample } from '../../helpers/queryExample'
-import { NavbarQueryState } from '../..//navbarSearchQueryState'
+import { NavbarQueryState } from '../../navbarSearchQueryState'
 
 import styles from './SearchReference.module.scss'
 import sidebarStyles from './SearchSidebarSection.module.scss'

--- a/client/web/src/search/results/sidebar/SearchSidebar.story.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.story.tsx
@@ -5,9 +5,7 @@ import { Filter } from '@sourcegraph/shared/src/search/stream'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
-import { AuthenticatedUser } from '../../../auth'
 import { WebStory } from '../../../components/WebStory'
-import { EMPTY_FEATURE_FLAGS } from '../../../featureFlags/featureFlags'
 import { SearchPatternType } from '../../../graphql-operations'
 import { QuickLink, SearchScope } from '../../../schema/settings.schema'
 
@@ -21,35 +19,13 @@ const { add } = storiesOf('web/search/results/sidebar/SearchSidebar', module).ad
     chromatic: { viewports: [544, 577, 993] },
 })
 
-const authenticatedUser: AuthenticatedUser = {
-    __typename: 'User',
-    id: '0',
-    email: 'alice@sourcegraph.com',
-    username: 'alice',
-    avatarURL: null,
-    session: { canSignOut: true },
-    displayName: null,
-    url: '',
-    settingsURL: '#',
-    siteAdmin: true,
-    organizations: {
-        nodes: [],
-    },
-    tags: [],
-    viewerCanAdminister: true,
-    databaseID: 0,
-}
-
 const defaultProps: SearchSidebarProps = {
-    authenticatedUser,
     caseSensitive: false,
     patternType: SearchPatternType.literal,
     versionContext: undefined,
     selectedSearchContextSpec: 'global',
     settingsCascade: EMPTY_SETTINGS_CASCADE,
     telemetryService: NOOP_TELEMETRY_SERVICE,
-    featureFlags: EMPTY_FEATURE_FLAGS,
-    isSourcegraphDotCom: false,
 }
 
 const quicklinks: QuickLink[] = [

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -42,7 +42,15 @@ export enum SectionID {
     REVISIONS = 'revisions',
 }
 
-const selectFromQueryState = ({ queryState: { query }, setQueryState, submitSearch }: NavbarQueryState) => ({
+const selectFromQueryState = ({
+    queryState: { query },
+    setQueryState,
+    submitSearch,
+}: NavbarQueryState): {
+    query: string
+    setQueryState: NavbarQueryState['setQueryState']
+    submitSearch: NavbarQueryState['submitSearch']
+} => ({
     query,
     setQueryState,
     submitSearch,
@@ -56,14 +64,14 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     const toggleFilter = useCallback(
         (value: string) =>
             submitSearch(query => toggleSearchFilter(query, value), { ...props, source: 'filter', history }),
-        [history, props]
+        [history, props, submitSearch]
     )
 
     // Unlike onFilterClicked, this function will always append or update a filter
     const updateOrAppendFilter = useCallback(
         (filter: string, value: string) =>
             submitSearch(query => updateFilter(query, filter, value), { ...props, source: 'filter', history }),
-        [history, props]
+        [history, props, submitSearch]
     )
 
     const onDynamicFilterClicked = useCallback(
@@ -136,7 +144,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                         caseSensitive: props.caseSensitive,
                         onNavbarQueryChange: setQueryState,
                         patternType: props.patternType,
-                        query: query,
+                        query,
                         versionContext: props.versionContext,
                         selectedSearchContextSpec: props.selectedSearchContextSpec,
                     })}

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -134,7 +134,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         body = (
             <StickyBox className={styles.searchSidebarStickyBox}>
                 <SearchSidebarSection
-                    id={SectionID.SEARCH_TYPES}
+                    sectionId={SectionID.SEARCH_TYPES}
                     className={styles.searchSidebarItem}
                     header="Search Types"
                     startCollapsed={collapsedSections?.[SectionID.SEARCH_TYPES]}
@@ -150,7 +150,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     })}
                 </SearchSidebarSection>
                 <SearchSidebarSection
-                    id={SectionID.DYNAMIC_FILTERS}
+                    sectionId={SectionID.DYNAMIC_FILTERS}
                     className={styles.searchSidebarItem}
                     header="Dynamic filters"
                     startCollapsed={collapsedSections?.[SectionID.DYNAMIC_FILTERS]}
@@ -160,7 +160,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                 </SearchSidebarSection>
                 {showReposSection ? (
                     <SearchSidebarSection
-                        id={SectionID.REPOSITORIES}
+                        sectionId={SectionID.REPOSITORIES}
                         className={styles.searchSidebarItem}
                         header="Repositories"
                         startCollapsed={collapsedSections?.[SectionID.REPOSITORIES]}
@@ -178,7 +178,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                 ) : null}
                 {repoName ? (
                     <SearchSidebarSection
-                        id={SectionID.REVISIONS}
+                        sectionId={SectionID.REVISIONS}
                         className={styles.searchSidebarItem}
                         header="Revisions"
                         startCollapsed={collapsedSections?.[SectionID.REVISIONS]}
@@ -190,7 +190,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     </SearchSidebarSection>
                 ) : null}
                 <SearchSidebarSection
-                    id={SectionID.SEARCH_REFERENCE}
+                    sectionId={SectionID.SEARCH_REFERENCE}
                     className={styles.searchSidebarItem}
                     header="Search reference"
                     showSearch={true}
@@ -206,7 +206,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     })}
                 </SearchSidebarSection>
                 <SearchSidebarSection
-                    id={SectionID.SEARCH_SNIPPETS}
+                    sectionId={SectionID.SEARCH_SNIPPETS}
                     className={styles.searchSidebarItem}
                     header="Search snippets"
                     startCollapsed={collapsedSections?.[SectionID.SEARCH_SNIPPETS]}
@@ -215,7 +215,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     {getSearchSnippetLinks(props.settingsCascade, onSnippetClicked)}
                 </SearchSidebarSection>
                 <SearchSidebarSection
-                    id={SectionID.QUICK_LINKS}
+                    sectionId={SectionID.QUICK_LINKS}
                     className={styles.searchSidebarItem}
                     header="Quicklinks"
                     startCollapsed={collapsedSections?.[SectionID.QUICK_LINKS]}

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.test.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.test.tsx
@@ -22,7 +22,7 @@ describe('SearchSidebarSection', () => {
 
     it('should render all items initially', () => {
         const element = mount(
-            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -36,7 +36,7 @@ describe('SearchSidebarSection', () => {
 
     it('should filter items based on search', () => {
         const element = mount(
-            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -51,7 +51,7 @@ describe('SearchSidebarSection', () => {
 
     it('should clear search when items change', () => {
         const element = mount(
-            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -73,7 +73,7 @@ describe('SearchSidebarSection', () => {
 
     it('should not show search if only one item in list', () => {
         const element = mount(
-            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks([filters[2]], onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -87,7 +87,7 @@ describe('SearchSidebarSection', () => {
 
     it('should not show search if showSearch is false', () => {
         const element = mount(
-            <SearchSidebarSection id="id" header="Dynamic filters">
+            <SearchSidebarSection sectionId="id" header="Dynamic filters">
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.test.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.test.tsx
@@ -22,7 +22,7 @@ describe('SearchSidebarSection', () => {
 
     it('should render all items initially', () => {
         const element = mount(
-            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -36,7 +36,7 @@ describe('SearchSidebarSection', () => {
 
     it('should filter items based on search', () => {
         const element = mount(
-            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -51,7 +51,7 @@ describe('SearchSidebarSection', () => {
 
     it('should clear search when items change', () => {
         const element = mount(
-            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -73,7 +73,7 @@ describe('SearchSidebarSection', () => {
 
     it('should not show search if only one item in list', () => {
         const element = mount(
-            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection id="id" header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks([filters[2]], onFilterChosen)}
             </SearchSidebarSection>
         )
@@ -87,7 +87,7 @@ describe('SearchSidebarSection', () => {
 
     it('should not show search if showSearch is false', () => {
         const element = mount(
-            <SearchSidebarSection header="Dynamic filters">
+            <SearchSidebarSection id="id" header="Dynamic filters">
                 {getDynamicFilterLinks(filters, onFilterChosen)}
             </SearchSidebarSection>
         )

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
@@ -8,7 +8,7 @@ import { FilterLink, FilterLinkProps } from './FilterLink'
 import styles from './SearchSidebarSection.module.scss'
 
 export const SearchSidebarSection: React.FunctionComponent<{
-    id: string
+    sectionId: string
     header: string
     children?: React.ReactElement | React.ReactElement[] | ((filter: string) => React.ReactElement)
     className?: string
@@ -28,7 +28,7 @@ export const SearchSidebarSection: React.FunctionComponent<{
     clearSearchOnChange?: {}
 }> = React.memo(
     ({
-        id,
+        sectionId,
         header,
         children = [],
         className,
@@ -97,7 +97,7 @@ export const SearchSidebarSection: React.FunctionComponent<{
                     onClick={() =>
                         setCollapsed(collapsed => {
                             if (onToggle) {
-                                onToggle(id, !collapsed)
+                                onToggle(sectionId, !collapsed)
                             }
                             return !collapsed
                         })

--- a/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebarSection.tsx
@@ -8,11 +8,12 @@ import { FilterLink, FilterLinkProps } from './FilterLink'
 import styles from './SearchSidebarSection.module.scss'
 
 export const SearchSidebarSection: React.FunctionComponent<{
+    id: string
     header: string
     children?: React.ReactElement | React.ReactElement[] | ((filter: string) => React.ReactElement)
     className?: string
     showSearch?: boolean // Search only works if children are FilterLink
-    onToggle?: (open: boolean) => void
+    onToggle?: (id: string, open: boolean) => void
     startCollapsed?: boolean
     /**
      * Shown when the built-in search doesn't find any results.
@@ -25,106 +26,109 @@ export const SearchSidebarSection: React.FunctionComponent<{
      * Defaults to the component's children.
      */
     clearSearchOnChange?: {}
-}> = ({
-    header,
-    children = [],
-    className,
-    showSearch = false,
-    onToggle,
-    startCollapsed,
-    noResultText = 'No results',
-    clearSearchOnChange = children,
-}) => {
-    const [filter, setFilter] = useState('')
+}> = React.memo(
+    ({
+        id,
+        header,
+        children = [],
+        className,
+        showSearch = false,
+        onToggle,
+        startCollapsed,
+        noResultText = 'No results',
+        clearSearchOnChange = children,
+    }) => {
+        const [filter, setFilter] = useState('')
 
-    // Clears the filter whenever clearSearchOnChange changes (defaults to the
-    // component's children)
-    useEffect(() => setFilter(''), [clearSearchOnChange])
+        // Clears the filter whenever clearSearchOnChange changes (defaults to the
+        // component's children)
+        useEffect(() => setFilter(''), [clearSearchOnChange])
 
-    let body
-    let searchVisible = showSearch
-    let visible = false
+        let body
+        let searchVisible = showSearch
+        let visible = false
 
-    if (typeof children === 'function') {
-        visible = true
-        body = children(filter)
-    } else if (Array.isArray(children)) {
-        visible = children.length > 0
-        searchVisible = searchVisible && children.length > 1
-        const childrenList = children as React.ReactElement[]
+        if (typeof children === 'function') {
+            visible = true
+            body = children(filter)
+        } else if (Array.isArray(children)) {
+            visible = children.length > 0
+            searchVisible = searchVisible && children.length > 1
+            const childrenList = children as React.ReactElement[]
 
-        const filteredChildren = searchVisible
-            ? childrenList.filter(child => {
-                  if (child.type === FilterLink) {
-                      const props: FilterLinkProps = child.props as FilterLinkProps
-                      return (
-                          (props?.label).toLowerCase().includes(filter.toLowerCase()) ||
-                          (props?.value).toLowerCase().includes(filter.toLowerCase())
-                      )
-                  }
-                  return true
-              })
-            : childrenList
+            const filteredChildren = searchVisible
+                ? childrenList.filter(child => {
+                      if (child.type === FilterLink) {
+                          const props: FilterLinkProps = child.props as FilterLinkProps
+                          return (
+                              (props?.label).toLowerCase().includes(filter.toLowerCase()) ||
+                              (props?.value).toLowerCase().includes(filter.toLowerCase())
+                          )
+                      }
+                      return true
+                  })
+                : childrenList
 
-        body = (
-            <>
-                <ul className={styles.sidebarSectionList}>
-                    {filteredChildren.map((child, index) => (
-                        <li key={child.key || index}>{child}</li>
-                    ))}
-                    {filteredChildren.length === 0 && (
-                        <li className={classNames('text-muted', styles.sidebarSectionNoResults)}>{noResultText}</li>
+            body = (
+                <>
+                    <ul className={styles.sidebarSectionList}>
+                        {filteredChildren.map((child, index) => (
+                            <li key={child.key || index}>{child}</li>
+                        ))}
+                        {filteredChildren.length === 0 && (
+                            <li className={classNames('text-muted', styles.sidebarSectionNoResults)}>{noResultText}</li>
+                        )}
+                    </ul>
+                </>
+            )
+        } else {
+            visible = true
+            body = children
+        }
+
+        const [collapsed, setCollapsed] = useState(startCollapsed)
+        useEffect(() => setCollapsed(startCollapsed), [startCollapsed])
+
+        return visible ? (
+            <div className={classNames(styles.sidebarSection, className)}>
+                <button
+                    type="button"
+                    className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
+                    onClick={() =>
+                        setCollapsed(collapsed => {
+                            if (onToggle) {
+                                onToggle(id, !collapsed)
+                            }
+                            return !collapsed
+                        })
+                    }
+                    aria-label={collapsed ? 'Expand' : 'Collapse'}
+                >
+                    <h5 className="flex-grow-1">{header}</h5>
+                    {collapsed ? (
+                        <ChevronLeftIcon className="icon-inline mr-1" />
+                    ) : (
+                        <ChevronDownIcon className="icon-inline mr-1" />
                     )}
-                </ul>
-            </>
-        )
-    } else {
-        visible = true
-        body = children
+                </button>
+
+                <Collapse isOpen={!collapsed}>
+                    <div className={classNames('pb-4', !searchVisible && 'border-top')}>
+                        {searchVisible && (
+                            <input
+                                type="search"
+                                placeholder="Find..."
+                                aria-label="Find filters"
+                                value={filter}
+                                onChange={event => setFilter(event.currentTarget.value)}
+                                data-testid="sidebar-section-search-box"
+                                className={classNames('form-control form-control-sm', styles.sidebarSectionSearchBox)}
+                            />
+                        )}
+                        {body}
+                    </div>
+                </Collapse>
+            </div>
+        ) : null
     }
-
-    const [collapsed, setCollapsed] = useState(startCollapsed)
-    useEffect(() => setCollapsed(startCollapsed), [startCollapsed])
-
-    return visible ? (
-        <div className={classNames(styles.sidebarSection, className)}>
-            <button
-                type="button"
-                className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
-                onClick={() =>
-                    setCollapsed(collapsed => {
-                        if (onToggle) {
-                            onToggle(!collapsed)
-                        }
-                        return !collapsed
-                    })
-                }
-                aria-label={collapsed ? 'Expand' : 'Collapse'}
-            >
-                <h5 className="flex-grow-1">{header}</h5>
-                {collapsed ? (
-                    <ChevronLeftIcon className="icon-inline mr-1" />
-                ) : (
-                    <ChevronDownIcon className="icon-inline mr-1" />
-                )}
-            </button>
-
-            <Collapse isOpen={!collapsed}>
-                <div className={classNames('pb-4', !searchVisible && 'border-top')}>
-                    {searchVisible && (
-                        <input
-                            type="search"
-                            placeholder="Find..."
-                            aria-label="Find filters"
-                            value={filter}
-                            onChange={event => setFilter(event.currentTarget.value)}
-                            data-testid="sidebar-section-search-box"
-                            className={classNames('form-control form-control-sm', styles.sidebarSectionSearchBox)}
-                        />
-                    )}
-                    {body}
-                </div>
-            </Collapse>
-        </div>
-    ) : null
-}
+)


### PR DESCRIPTION
Resolves #24996

tl;dr: Sidebar renders now 20x faster on every keypress

(note: enable "hide whitespace changes")

This PR does a couple of things:

- Adds a new method (action) to `NavbarQueryState` which makes it possible to submit a new search query without needing a reference to the current query. This means that components don't need to receive the current query as props, which means they don't need to rerender on every query update.
- A couple of things have been memoized, especially `SearchReference` because it contributes the most to sidebar render time (maybe there is room for improvement there as well). The general advice is to apply memoization carefully. I think it in this case it is necessary because the search results page is one of the most important pages and typing into the search input is the main action one does on that page. Some of the memoization might not be necessary if we move more query related state out of the root component state (such as `patternType`).
- Cleaned up props so that really only what is needed is passed to the search sidebar (also I added a bunch of unnecessary things to `SearchReference` because I didn't know what I was doing.

Especially the changes to `NavbarQueryState` shows how we can consolidate query related logic into one place. There are more opportunities to improve this.

Before: 

<img width="376" alt="2021-09-16_15-03" src="https://user-images.githubusercontent.com/179026/133619670-4a43ec51-ec8f-49a6-a63e-1835ed2d169c.png">

https://user-images.githubusercontent.com/179026/133619581-d4a7d766-801f-4100-b468-fce09b05c909.mp4

After:

<img width="456" alt="2021-09-16_14-59" src="https://user-images.githubusercontent.com/179026/133619718-40a5355d-bc4a-4d9a-aa92-4eaf12ddbf0b.png">


https://user-images.githubusercontent.com/179026/133619625-b0055ce9-11b0-4ff2-a956-b311b48f8692.mp4

