### PR TITLE
monitoring: Relax alerts for blocked connections

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -657,8 +657,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> frontend: 0.1s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-warning">warning</span> frontend: 0.05s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-critical">critical</span> frontend: 0.1s+ mean blocked seconds per conn request for 15m0s
 
 **Possible solutions**
 
@@ -1150,8 +1150,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> gitserver: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> gitserver: 0.1s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-warning">warning</span> gitserver: 0.05s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-critical">critical</span> gitserver: 0.1s+ mean blocked seconds per conn request for 15m0s
 
 **Possible solutions**
 
@@ -1886,8 +1886,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> precise-code-intel-worker: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> precise-code-intel-worker: 0.1s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-warning">warning</span> precise-code-intel-worker: 0.05s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-critical">critical</span> precise-code-intel-worker: 0.1s+ mean blocked seconds per conn request for 15m0s
 
 **Possible solutions**
 
@@ -2498,8 +2498,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> worker: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> worker: 0.1s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-warning">warning</span> worker: 0.05s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-critical">critical</span> worker: 0.1s+ mean blocked seconds per conn request for 15m0s
 
 **Possible solutions**
 
@@ -3488,8 +3488,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> repo-updater: 0.05s+ mean blocked seconds per conn request for 5m0s
-- <span class="badge badge-critical">critical</span> repo-updater: 0.1s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-warning">warning</span> repo-updater: 0.05s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 0.1s+ mean blocked seconds per conn request for 15m0s
 
 **Possible solutions**
 

--- a/monitoring/definitions/shared/dbconns.go
+++ b/monitoring/definitions/shared/dbconns.go
@@ -63,8 +63,8 @@ func DatabaseConnectionsMonitoring(app string) []monitoring.Row {
 				Query: fmt.Sprintf(`sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name=%q}[5m])) / `+
 					`sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name=%q}[5m]))`, app, app),
 				Panel:    monitoring.Panel().LegendFormat("dbname={{db_name}}").Unit(monitoring.Seconds),
-				Warning:  monitoring.Alert().GreaterOrEqual(0.05, nil).For(5 * time.Minute),
-				Critical: monitoring.Alert().GreaterOrEqual(0.10, nil).For(10 * time.Minute),
+				Warning:  monitoring.Alert().GreaterOrEqual(0.05, nil).For(10 * time.Minute),
+				Critical: monitoring.Alert().GreaterOrEqual(0.10, nil).For(15 * time.Minute),
 				Owner:    monitoring.ObservableOwnerCoreApplication,
 				PossibleSolutions: `
 					- Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed


### PR DESCRIPTION
These have fired a few times in production recently and then resolved
themselves. It appears to be related to deployments so it should be safe
to relax them a little.
