### PR TITLE
insights: fix bug where historical records are missing persist mode

### DIFF
--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -182,6 +182,7 @@ func (q *QueryExecution) ToQueueJob(seriesID string, query string, cost priority
 		Priority:        int(jobPriority),
 		DependentFrames: q.SharedRecordings,
 		State:           "queued",
+		PersistMode:     string(store.RecordMode),
 	}
 }
 

--- a/enterprise/internal/insights/compression/testdata/TestQueryExecution_ToQueueJob/test_to_job_with_dependents.golden
+++ b/enterprise/internal/insights/compression/testdata/TestQueryExecution_ToQueueJob/test_to_job_with_dependents.golden
@@ -5,6 +5,7 @@
 	},
 	Cost:            500,
 	Priority:        1000,
+	PersistMode:     "record",
 	DependentFrames: []time.Time{time.Time{ext: 63713520000}},
 	State:           "queued",
 }

--- a/enterprise/internal/insights/compression/testdata/TestQueryExecution_ToQueueJob/test_to_job_without_dependents.golden
+++ b/enterprise/internal/insights/compression/testdata/TestQueryExecution_ToQueueJob/test_to_job_without_dependents.golden
@@ -3,7 +3,8 @@
 	RecordTime: &time.Time{
 		ext: 63713433600,
 	},
-	Cost:     500,
-	Priority: 1000,
-	State:    "queued",
+	Cost:        500,
+	Priority:    1000,
+	PersistMode: "record",
+	State:       "queued",
 }


### PR DESCRIPTION
This either got missed or dropped in a bad merge, but historical records cannot queue up because they don't have a persist mode set.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
