### PR TITLE
Code Insights: Add fix for bad sizing of insights grid layout items

### DIFF
--- a/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
@@ -84,7 +84,7 @@ export const ExtensionViewsDirectorySection: React.FunctionComponent<ExtensionVi
 
     const allViewIds = useMemo(() => [...extensionViews, ...insights].map(view => view.id), [extensionViews, insights])
 
-    if (!showCodeInsights) {
+    if (!showCodeInsights || !directoryPageContext) {
         return null
     }
 
@@ -96,19 +96,17 @@ export const ExtensionViewsDirectorySection: React.FunctionComponent<ExtensionVi
             ))}
 
             {/* Render all code insights with proper directory page context */}
-            {directoryPageContext
-                ? insights.map(insight => (
-                      <SmartInsight
-                          key={insight.id}
-                          insight={insight}
-                          telemetryService={props.telemetryService}
-                          platformContext={props.platformContext}
-                          settingsCascade={settingsCascade}
-                          where="directory"
-                          context={directoryPageContext}
-                      />
-                  ))
-                : []}
+            {insights.map(insight => (
+                <SmartInsight
+                    key={insight.id}
+                    insight={insight}
+                    telemetryService={props.telemetryService}
+                    platformContext={props.platformContext}
+                    settingsCascade={settingsCascade}
+                    where="directory"
+                    context={directoryPageContext}
+                />
+            ))}
         </ViewGrid>
     )
 }


### PR DESCRIPTION
This PR adds a fix for the bad code insights item sizing at the home and search pages. It turned out that react-grid-layout lib behaves very odd when we don't have all items and therefore we don't know how many elements we have. React grid layout can't count them dynamically (by iteration over child array) and requires a number of ids to generate the right grid layout media queries. So, this PR just adds rendering conditions and now the component does not render grid component if it doesn't have all the needed information. 

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="1088" alt="Screenshot 2021-09-16 at 22 05 58" src="https://user-images.githubusercontent.com/18492575/133670591-b964882b-81f1-407c-8e6b-814335502964.png">
</td><td>
<img width="1092" alt="Screenshot 2021-09-16 at 22 04 39" src="https://user-images.githubusercontent.com/18492575/133670455-193076e9-aeab-4d93-b41c-6fed4efe0f94.png">

</td></tr>
</table>


## How to test
1. Turn off codecov extension or any other external code insights like an extension (like snyk)
2. Go to any directory page and see correct-sized items.

Note: you need to run the enterprise version of sourcegraph since code insights is part of the enterprise now
`sg run enterprise-web-standalone`

Also to be able to see insights on the directory page you have to turn on `"insights.displayLocation.directory": true,` flag in your settings
