### PR TITLE
codeintel: Never expire upload providing intelligence for tip of default branch

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_gitserver_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_gitserver_test.go
@@ -20,8 +20,9 @@ func testUploadExpirerMockGitserverClient(branchMap map[string]map[string]string
 				}
 
 				refDescriptions[commit] = append(refDescriptions[commit], gitserver.RefDescription{
-					Name: branch,
-					Type: gitserver.RefTypeBranch,
+					Name:            branch,
+					Type:            gitserver.RefTypeBranch,
+					IsDefaultBranch: branch == "main",
 				})
 			}
 		}

--- a/enterprise/cmd/worker/internal/codeintel/janitor/policy_matcher.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/policy_matcher.go
@@ -27,6 +27,14 @@ func isUploadCommitProtectedByPolicy(
 			return true, nil
 		}
 
+		// Never expire tip of the default branch
+		for _, refDescription := range refDescriptions[commit] {
+			if refDescription.IsDefaultBranch {
+				repositoryState.MarkProtected(commit)
+				return true, nil
+			}
+		}
+
 		// See if this commit was shown to be unprotected through this upload's timeframe. We may have
 		// previously been able to tell that a commit cannot be protected by any upload after a certain
 		// date, which can potentially short-circuit a large number of both policy comparisons and calls


### PR DESCRIPTION
Ensure that we always protect uploads that provide intelligence to the tip of each repository's default branch from data retention.