### PR TITLE
eventLogger: update connect code hosts clicked log name

### DIFF
--- a/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
+++ b/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
@@ -66,7 +66,7 @@ export const UserCodeHosts: React.FunctionComponent<UserCodeHosts> = ({
 
             if (authProvider) {
                 onNavigation?.(true)
-                eventLogger.log('UserAttemptConnectCodeHost', { kind }, { kind })
+                eventLogger.log('ConnectUserCodeHostClicked', { kind }, { kind })
                 window.location.assign(
                     `${authProvider.authenticationURL as string}&redirect=${
                         window.location.href


### PR DESCRIPTION
This updates an instance of `UserAttemptConnectCodeHost` to `ConnectUserCodeHostClicked`. This was [updated for another instance of this event in the past](https://sourcegraph.com/search?q=context:global+r:%5Egithub.com/sourcegraph/sourcegraph+UserAttemptConnectCodeHost+type:diff&patternType=literal), to match our naming conventions, but it seems this one was missed.  

@artemruts this event also occurs in the post-signup flow, and it [seems this is the same event](https://sourcegraph.com/search?q=context:global+r:%5Egithub.com/sourcegraph/sourcegraph+UserAttemptConnectCodeHost%7CConnectUserCodeHostClicked&patternType=regexp) as the other instance of ConnectUserCodeHost, so it should be the same event name. Could you confirm? Thanks! 

Closes https://github.com/sourcegraph/analytics/issues/293 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
