### PR TITLE
db: Remove repo.cloned column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - The `PRECISE_CODE_INTEL_DATA_TTL` environment variable is no longer read by the worker service. Instead, global and repository-specific data retention policies configurable in the UI by site-admins will control the length of time LSIF uploads are considered _fresh_. [#24793](https://github.com/sourcegraph/sourcegraph/pull/24793)
+- The `repo.cloned` column was removed as it was deprecated in 3.26. [#25066](https://github.com/sourcegraph/sourcegraph/pull/25066)
 
 ## 3.31.2
 

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -151,11 +151,11 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 	// 2 & 3) public repos
 	_, err = postgres.Exec(`
 		INSERT INTO repo (id, name, description, fork, created_at, updated_at, external_id, external_service_type,
-					  external_service_id, archived, uri, deleted_at, metadata, private, cloned, stars)
+					  external_service_id, archived, uri, deleted_at, metadata, private, stars)
 		VALUES
-			(1, 'test-repo1', 'description', false, current_timestamp, current_timestamp, 1, 'github', 1, false, 'github.com/test-repo/test-repo1', null, '{}', true, true, 1),
-			(2, 'test-repo2', 'description', false, current_timestamp, current_timestamp, 2, 'github', 1, false, 'github.com/test-repo/test-repo2', null, '{}', false, true, 1),
-			(3, 'test-repo3', 'description', false, current_timestamp, current_timestamp, 3, 'github', 1, false, 'github.com/test-repo/test-repo3', null, '{}', false, true, 1);
+			(1, 'test-repo1', 'description', false, current_timestamp, current_timestamp, 1, 'github', 1, false, 'github.com/test-repo/test-repo1', null, '{}', true, 1),
+			(2, 'test-repo2', 'description', false, current_timestamp, current_timestamp, 2, 'github', 1, false, 'github.com/test-repo/test-repo2', null, '{}', false, 1),
+			(3, 'test-repo3', 'description', false, current_timestamp, current_timestamp, 3, 'github', 1, false, 'github.com/test-repo/test-repo3', null, '{}', false, 1);
 
 		INSERT INTO user_permissions (user_id, permission, object_type, object_ids, updated_at, synced_at, object_ids_ints)
 		VALUES

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -106,7 +106,6 @@ type InsertRepoOp struct {
 	Description  string
 	Fork         bool
 	Archived     bool
-	Cloned       bool
 	Private      bool
 	ExternalRepo api.ExternalRepoSpec
 }
@@ -122,8 +121,7 @@ WITH upsert AS (
     external_service_type = NULLIF(BTRIM($5), ''),
     external_service_id   = NULLIF(BTRIM($6), ''),
     archived              = $7,
-    cloned                = $8,
-    private               = $9
+    private               = $8
   WHERE name = $1 OR (
     external_id IS NOT NULL
     AND external_service_type IS NOT NULL
@@ -146,7 +144,6 @@ INSERT INTO repo (
   external_service_type,
   external_service_id,
   archived,
-  cloned,
   private
 ) (
   SELECT
@@ -157,8 +154,7 @@ INSERT INTO repo (
     NULLIF(BTRIM($5), '') AS external_service_type,
     NULLIF(BTRIM($6), '') AS external_service_id,
     $7 AS archived,
-    $8 AS cloned,
-    $9 AS private
+    $8 AS private
   WHERE NOT EXISTS (SELECT 1 FROM upsert)
 )`
 
@@ -201,7 +197,6 @@ func (s *RepoStore) Upsert(ctx context.Context, op InsertRepoOp) error {
 		op.ExternalRepo.ServiceType,
 		op.ExternalRepo.ServiceID,
 		op.Archived,
-		op.Cloned,
 		op.Private,
 	)
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1644,7 +1644,6 @@ Referenced by:
  deleted_at            | timestamp with time zone |           |          | 
  metadata              | jsonb                    |           | not null | '{}'::jsonb
  private               | boolean                  |           | not null | false
- cloned                | boolean                  |           | not null | false
  stars                 | integer                  |           |          | 
  blocked               | jsonb                    |           |          | 
 Indexes:
@@ -1653,7 +1652,6 @@ Indexes:
     "repo_name_unique" UNIQUE CONSTRAINT, btree (name) DEFERRABLE
     "repo_archived" btree (archived)
     "repo_blocked_idx" btree ((blocked IS NOT NULL))
-    "repo_cloned" btree (cloned)
     "repo_created_at" btree (created_at)
     "repo_fork" btree (fork)
     "repo_is_not_blocked_idx" btree ((blocked IS NULL))

--- a/migrations/frontend/1528395890_drop_repo_cloned.down.sql
+++ b/migrations/frontend/1528395890_drop_repo_cloned.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- This migration is destructive since the column has been
+-- deprecated since 3.26
+ALTER TABLE
+    repo
+ADD COLUMN IF NOT EXISTS
+    cloned bool NOT NULL DEFAULT false;
+
+COMMIT;

--- a/migrations/frontend/1528395890_drop_repo_cloned.up.sql
+++ b/migrations/frontend/1528395890_drop_repo_cloned.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE
+    repo
+DROP COLUMN IF EXISTS cloned;
+
+COMMIT;


### PR DESCRIPTION
It has been deprecated since 3.26 so can be safely removed.

Fixes https://github.com/sourcegraph/sourcegraph/issues/19160