### PR TITLE
Compute GitMaxConcurrentClones and use it everywhere

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -236,17 +236,11 @@ func (s *Server) Handler() http.Handler {
 	// The new repo-updater scheduler enforces the rate limit across all gitserver,
 	// so ideally this logic could be removed here; however, ensureRevision can also
 	// cause an update to happen and it is called on every exec command.
-	maxConcurrentClones := conf.Get().GitMaxConcurrentClones
-	if maxConcurrentClones == 0 {
-		maxConcurrentClones = 5
-	}
+	maxConcurrentClones := conf.GitMaxConcurrentClones()
 	s.cloneLimiter = mutablelimiter.New(maxConcurrentClones)
 	s.cloneableLimiter = mutablelimiter.New(maxConcurrentClones)
 	conf.Watch(func() {
-		limit := conf.Get().GitMaxConcurrentClones
-		if limit == 0 {
-			limit = 5
-		}
+		limit := conf.GitMaxConcurrentClones()
 		s.cloneLimiter.SetLimit(limit)
 		s.cloneableLimiter.SetLimit(limit)
 	})

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -398,6 +398,14 @@ func GitMaxCodehostRequestsPerSecond() int {
 	return *val
 }
 
+func GitMaxConcurrentClones() int {
+	v := Get().GitMaxConcurrentClones
+	if v <= 0 {
+		return 5
+	}
+	return v
+}
+
 func UserReposMaxPerUser() int {
 	v := Get().UserReposMaxPerUser
 	if v == 0 {

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -151,6 +151,47 @@ func TestGitMaxCodehostRequestsPerSecond(t *testing.T) {
 	}
 }
 
+func TestGitMaxConcurrentClones(t *testing.T) {
+	tests := []struct {
+		name string
+		sc   *Unified
+		want int
+	}{
+		{
+			name: "not set should return default",
+			sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{}},
+			want: 5,
+		},
+		{
+			name: "bad value should return default",
+			sc: &Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					GitMaxConcurrentClones: -100,
+				},
+			},
+			want: 5,
+		},
+		{
+			name: "set non-zero should return non-zero",
+			sc: &Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					GitMaxConcurrentClones: 100,
+				},
+			},
+			want: 100,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Mock(test.sc)
+			if got, want := GitMaxConcurrentClones(), test.want; got != want {
+				t.Fatalf("GitMaxConcurrentClones() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func setenv(t *testing.T, keyval string) func() {
 	t.Helper()
 

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -249,11 +249,7 @@ var requestRepoUpdate = func(ctx context.Context, repo configuredRepo, since tim
 var configuredLimiter = func() *mutablelimiter.Limiter {
 	limiter := mutablelimiter.New(1)
 	conf.Watch(func() {
-		limit := conf.Get().GitMaxConcurrentClones
-		if limit == 0 {
-			limit = 5
-		}
-		limiter.SetLimit(limit)
+		limiter.SetLimit(conf.GitMaxConcurrentClones())
 	})
 	return limiter
 }


### PR DESCRIPTION
Inspiration came from this review thread: https://github.com/sourcegraph/sourcegraph/pull/24892/files/f0c22b71cd40ffaf44030977c840b4c1e47564c5#r708614129

Link to Sourcegraph search results for `GitMaxConcurrentClones` in `Go` files in this tree to ensure I didn't miss anything: https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%404a4e075+GitMaxConcurrentClones+lang:Go+&patternType=literal&case=yes

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
