### PR TITLE
search: Add repo: filter if necessary when a revision filter is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A search regression in 3.32.0 which caused instances with search indexing _disabled_ (very rare) via `"search.index.enabled": false,` in their site config to crash with a panic. [#25321](https://github.com/sourcegraph/sourcegraph/pull/25321)
 - An issue where the default `search.index.enabled` value on single-container Docker instances would incorrectly be computed as `false` in some situations. [#25321](https://github.com/sourcegraph/sourcegraph/pull/25321)
 - StatefulSet service discovery in Kubernetes correctly constructs pod hostnames in the case where the ServiceName is different from the StatefulSet name. [#25146](https://github.com/sourcegraph/sourcegraph/pull/25146)
+- An issue where clicking on a link in the 'Revisions' search sidebar section would result in an invalid query if the query didn't already contain a 'repo:' filter. [#25076](https://github.com/sourcegraph/sourcegraph/pull/25076)
 
 ### Removed
 

--- a/client/web/src/search/helpers.test.tsx
+++ b/client/web/src/search/helpers.test.tsx
@@ -2,7 +2,7 @@ import * as H from 'history'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql/schema'
 
-import { getSearchTypeFromQuery, toggleSearchType, toggleSearchFilter, submitSearch } from './helpers'
+import { getSearchTypeFromQuery, toggleSearchType, toggleSubquery, submitSearch } from './helpers'
 import { SearchType } from './results/StreamingSearchResults'
 
 describe('search/helpers', () => {
@@ -111,15 +111,15 @@ describe('search/helpers', () => {
 
     describe('toggleSearchFilter', () => {
         it('adds filter if it is not already in query', () => {
-            expect(toggleSearchFilter('repo:test ', 'lang:c++')).toStrictEqual('repo:test lang:c++ ')
+            expect(toggleSubquery('repo:test ', 'lang:c++')).toStrictEqual('repo:test lang:c++ ')
         })
 
         it('adds filter if it is not already in query, even if it matches substring for an existing filter', () => {
-            expect(toggleSearchFilter('repo:test lang:c++ ', 'lang:c')).toStrictEqual('repo:test lang:c++ lang:c ')
+            expect(toggleSubquery('repo:test lang:c++ ', 'lang:c')).toStrictEqual('repo:test lang:c++ lang:c ')
         })
 
         it('removes filter from query it it exists', () => {
-            expect(toggleSearchFilter('repo:test lang:c++ lang:c ', 'lang:c')).toStrictEqual('repo:test lang:c++')
+            expect(toggleSubquery('repo:test lang:c++ lang:c ', 'lang:c')).toStrictEqual('repo:test lang:c++')
         })
     })
 })

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -119,7 +119,7 @@ export function queryIndexOfScope(query: string, scope: string): number {
  * @param searchFilter The search scope (sub query) or dynamic filter to toggle (add/remove) from the current user query.
  * @returns The new query.
  */
-export function toggleSearchFilter(query: string, searchFilter: string): string {
+export function toggleSubquery(query: string, searchFilter: string): string {
     const index = queryIndexOfScope(query, searchFilter)
     if (index === -1) {
         // Scope doesn't exist in search query, so add it now.

--- a/client/web/src/search/navbarSearchQueryState.ts
+++ b/client/web/src/search/navbarSearchQueryState.ts
@@ -5,9 +5,55 @@
 // (see https://github.com/sourcegraph/sourcegraph/issues/21200).
 import create from 'zustand'
 
-import { QueryState, SubmitSearchParameters, submitSearch } from './helpers'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
+import { appendFilter, updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
+import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
+
+import { QueryState, SubmitSearchParameters, submitSearch, toggleSearchFilter } from './helpers'
 
 type QueryStateUpdate = QueryState | ((queryState: QueryState) => QueryState)
+
+export type QueryUpdate =
+    | {
+          type: 'appendFilter'
+          field: FilterType
+          value: string
+          /**
+           * If true, the filter will only be appended a filter with the same name
+           * doesn't already exist in the query.
+           */
+          unique?: true
+      }
+    | {
+          type: 'updateOrAppendFilter'
+          field: FilterType
+          value: string
+      }
+    // Only exists for the filters from the serach sidebar since they come in
+    // filter:value form. Should not be used elsewhere.
+    | {
+          type: 'toggleSubstring'
+          value: string
+      }
+
+function updateQuery(query: string, updates: QueryUpdate[]): string {
+    for (const update of updates) {
+        switch (update.type) {
+            case 'appendFilter':
+                if (!update.unique || !filterExists(query, update.field)) {
+                    query = appendFilter(query, update.field, update.value)
+                }
+                break
+            case 'updateOrAppendFilter':
+                query = updateFilter(query, update.field, update.value)
+                break
+            case 'toggleSubstring':
+                query = toggleSearchFilter(query, update.value)
+                break
+        }
+    }
+    return query
+}
 
 export interface NavbarQueryState {
     queryState: QueryState
@@ -16,10 +62,7 @@ export interface NavbarQueryState {
      * submitSearch makes it possible to submit a new search query by updating
      * the current query via the callback.
      */
-    submitSearch: (
-        updateQuery: (currentQuery: string) => string,
-        parameters: Omit<SubmitSearchParameters, 'query'>
-    ) => void
+    submitSearch: (updates: QueryUpdate[], parameters: Omit<SubmitSearchParameters, 'query'>) => void
 }
 export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
     queryState: { query: '' },
@@ -30,7 +73,7 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
             set({ queryState: queryStateUpdate })
         }
     },
-    submitSearch: (updateQuery, parameters) => {
-        submitSearch({ ...parameters, query: updateQuery(get().queryState.query) })
+    submitSearch: (updates, parameters) => {
+        submitSearch({ ...parameters, query: updateQuery(get().queryState.query, updates) })
     },
 }))

--- a/client/web/src/search/navbarSearchQueryState.ts
+++ b/client/web/src/search/navbarSearchQueryState.ts
@@ -37,22 +37,20 @@ export type QueryUpdate =
       }
 
 function updateQuery(query: string, updates: QueryUpdate[]): string {
-    for (const update of updates) {
+    return updates.reduce((query, update) => {
         switch (update.type) {
             case 'appendFilter':
                 if (!update.unique || !filterExists(query, update.field)) {
-                    query = appendFilter(query, update.field, update.value)
+                    return appendFilter(query, update.field, update.value)
                 }
                 break
             case 'updateOrAppendFilter':
-                query = updateFilter(query, update.field, update.value)
-                break
+                return updateFilter(query, update.field, update.value)
             case 'toggleSubquery':
-                query = toggleSubquery(query, update.value)
-                break
+                return toggleSubquery(query, update.value)
         }
-    }
-    return query
+        return query
+    }, query)
 }
 
 export interface NavbarQueryState {

--- a/client/web/src/search/navbarSearchQueryState.ts
+++ b/client/web/src/search/navbarSearchQueryState.ts
@@ -9,7 +9,7 @@ import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { appendFilter, updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 
-import { QueryState, SubmitSearchParameters, submitSearch, toggleSearchFilter } from './helpers'
+import { QueryState, SubmitSearchParameters, submitSearch, toggleSubquery } from './helpers'
 
 type QueryStateUpdate = QueryState | ((queryState: QueryState) => QueryState)
 
@@ -32,7 +32,7 @@ export type QueryUpdate =
     // Only exists for the filters from the serach sidebar since they come in
     // filter:value form. Should not be used elsewhere.
     | {
-          type: 'toggleSubstring'
+          type: 'toggleSubquery'
           value: string
       }
 
@@ -47,8 +47,8 @@ function updateQuery(query: string, updates: QueryUpdate[]): string {
             case 'updateOrAppendFilter':
                 query = updateFilter(query, update.field, update.value)
                 break
-            case 'toggleSubstring':
-                query = toggleSearchFilter(query, update.value)
+            case 'toggleSubquery':
+                query = toggleSubquery(query, update.value)
                 break
         }
     }

--- a/client/web/src/search/results/sidebar/Revisions.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { GitRefType } from '@sourcegraph/shared/src/graphql/schema'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 
 import { useConnection } from '../../../components/FilteredConnection/hooks/useConnection'
 import { SyntaxHighlightedSearchQuery } from '../../../components/SyntaxHighlightedSearchQuery'
@@ -14,6 +15,7 @@ import {
     SearchSidebarGitRefFields,
 } from '../../../graphql-operations'
 import { useTemporarySetting } from '../../../settings/temporary/useTemporarySetting'
+import { QueryUpdate } from '../../navbarSearchQueryState'
 
 import { FilterLink } from './FilterLink'
 import styles from './SearchSidebarSection.module.scss'
@@ -151,7 +153,7 @@ export enum TabIndex {
 
 export interface RevisionsProps {
     repoName: string
-    onFilterClick: (filter: string, value: string) => void
+    onFilterClick: (updates: QueryUpdate[]) => void
     query: string
     /**
      * This property is only exposed for storybook tests.
@@ -162,7 +164,11 @@ export interface RevisionsProps {
 export const Revisions: React.FunctionComponent<RevisionsProps> = React.memo(
     ({ repoName, onFilterClick, query, _initialTab }) => {
         const [selectedTab, setSelectedTab] = useTemporarySetting('search.sidebar.revisions.tab')
-        const onRevisionFilterClick = (value: string): void => onFilterClick('rev', value)
+        const onRevisionFilterClick = (value: string): void =>
+            onFilterClick([
+                { type: 'updateOrAppendFilter', field: FilterType.rev, value },
+                { type: 'appendFilter', field: FilterType.repo, value: `^${repoName}$`, unique: true },
+            ])
         return (
             <Tabs index={_initialTab ?? selectedTab ?? 0} onChange={setSelectedTab}>
                 <TabList className={styles.sidebarSectionTabsHeader}>

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -72,7 +72,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                 search_filter: { value },
             })
 
-            submitQueryWithProps([{ type: 'toggleSubstring', value }])
+            submitQueryWithProps([{ type: 'toggleSubquery', value }])
         },
         [submitQueryWithProps, props.telemetryService]
     )
@@ -80,7 +80,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     const onSnippetClicked = useCallback(
         (value: string) => {
             props.telemetryService.log('SearchSnippetClicked')
-            submitQueryWithProps([{ type: 'toggleSubstring', value }])
+            submitQueryWithProps([{ type: 'toggleSubquery', value }])
         },
         [submitQueryWithProps, props.telemetryService]
     )


### PR DESCRIPTION
Fixes #24841

This PR builds on top of #24996 and changes the `submitQuery` action to accept multiple modifications instead. This is certainly not the final structure of the API, but it shows the direction this could go.

https://user-images.githubusercontent.com/179026/133821911-7bb551f8-352f-4efc-bdab-3c51357d4116.mp4

