### PR TITLE
[SG-21696] Checkboxes are not well aligned with labels

### DIFF
--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -11,7 +11,7 @@
     --input-focus-box-shadow: var(--focus-box-shadow);
 
     // Checkbox margins
-    --form-check-input-margin-y: 0.3rem;
+    --form-check-input-margin-y: 0.2rem;
 }
 
 .theme-dark {
@@ -27,7 +27,7 @@
     --input-focus-box-shadow: var(--focus-box-shadow);
 
     // Checkbox margins
-    --form-check-input-margin-y: 0.3rem;
+    --form-check-input-margin-y: 0.2rem;
 }
 
 // Prevent Firefox's default red outline for inputs


### PR DESCRIPTION
## Description

- Update `--form-check-input-margin-y` value to fix the issue

## Screenshots
<img width="1679" alt="Screenshot at Sep 16 22-37-21" src="https://user-images.githubusercontent.com/51897872/133645702-981eb49a-2017-44c7-a885-1597be30b388.png">
<img width="1679" alt="Screenshot at Sep 16 22-38-44" src="https://user-images.githubusercontent.com/51897872/133645844-4a92f546-12f1-49b4-8caf-1eadc44afea3.png">


## Refs
- sourcegraph/sourcegraph#21696
