### PR TITLE
generate/mockgen.sh: use pinned version of goimports instead of installing latest version on the fly

### DIFF
--- a/dev/generate.sh
+++ b/dev/generate.sh
@@ -6,5 +6,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 # We'll exclude generating the CLI reference documentation by default due to the
 # relatively high cost of fetching and building src-cli.
 go list ./... | grep -v 'doc/cli/references' | xargs go generate -x
-GOBIN="$PWD/.bin" go install golang.org/x/tools/cmd/goimports@latest && ./.bin/goimports -w .
+GOBIN="$PWD/.bin" go install golang.org/x/tools/cmd/goimports && ./.bin/goimports -w .
 go mod tidy

--- a/dev/mockgen.sh
+++ b/dev/mockgen.sh
@@ -17,9 +17,8 @@ set -o pipefail
 if [[ "${INSTALLED_VERSION}" != "${REQUIRED_VERSION}" ]]; then
   echo "Updating local installation of go-mockgen"
 
-  go get \
-    "github.com/derision-test/go-mockgen/cmd/go-mockgen@v${REQUIRED_VERSION}" \
-    golang.org/x/tools/cmd/goimports
+  go get "github.com/derision-test/go-mockgen/cmd/go-mockgen@v${REQUIRED_VERSION}"
+  go install "golang.org/x/tools/cmd/goimports"
 fi
 
 go-mockgen -f "$@"

--- a/dev/mockgen.sh
+++ b/dev/mockgen.sh
@@ -17,7 +17,7 @@ set -o pipefail
 if [[ "${INSTALLED_VERSION}" != "${REQUIRED_VERSION}" ]]; then
   echo "Updating local installation of go-mockgen"
 
-  go get "github.com/derision-test/go-mockgen/cmd/go-mockgen@v${REQUIRED_VERSION}"
+  go install "github.com/derision-test/go-mockgen/cmd/go-mockgen@v${REQUIRED_VERSION}"
   go install "golang.org/x/tools/cmd/goimports"
 fi
 

--- a/dev/tools.go
+++ b/dev/tools.go
@@ -17,5 +17,6 @@ import (
 	_ "github.com/sourcegraph/go-jsonschema/cmd/go-jsonschema-compiler"
 
 	// used in many places
+	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/tools/cmd/stringer"
 )

--- a/dev/tools.go
+++ b/dev/tools.go
@@ -16,7 +16,7 @@ import (
 	// used in schema pkg
 	_ "github.com/sourcegraph/go-jsonschema/cmd/go-jsonschema-compiler"
 
-	// used in many places
 	_ "golang.org/x/tools/cmd/goimports"
+	// used in many places
 	_ "golang.org/x/tools/cmd/stringer"
 )


### PR DESCRIPTION
Following https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module

Using an unpinned version can cause an unintended package upgrade whenever `golang.org/x/tools` publishes a new version. 