### PR TITLE
[SG-29452] Do not skip `__typename` generation `graphql-codegen`

### DIFF
--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -53,7 +53,6 @@ async function generateGraphQlOperations() {
         preResolveTypes: true,
         operationResultSuffix: 'Result',
         omitOperationSuffix: true,
-        skipTypename: true,
         namingConvention: {
           typeNames: 'keep',
           enumValues: 'keep',

--- a/client/web/src/auth/useSelectedRepos.tsx
+++ b/client/web/src/auth/useSelectedRepos.tsx
@@ -25,7 +25,9 @@ const SelectedReposInitialValue: SelectedRepos = undefined
 export const selectedReposVar = makeVar<SelectedRepos>(SelectedReposInitialValue)
 
 interface UseSelectedReposResult {
-    selectedRepos: NonNullable<UserRepositoriesResult['node']>['repositories']['nodes'] | undefined
+    selectedRepos:
+        | (NonNullable<UserRepositoriesResult['node']> & { __typename: 'User' })['repositories']['nodes']
+        | undefined
     loadingSelectedRepos: boolean
     errorSelectedRepos: ApolloError | undefined
     refetchSelectedRepos:
@@ -85,6 +87,7 @@ export const SELECTED_REPOS = gql`
     ) {
         node(id: $id) {
             ... on User {
+                __typename
                 repositories(
                     first: $first
                     query: $query
@@ -140,7 +143,7 @@ export const useSelectedRepos = (userId: string, first?: number): UseSelectedRep
     )
 
     return {
-        selectedRepos: data?.node?.repositories.nodes,
+        selectedRepos: (data?.node?.__typename === 'User' && data.node.repositories.nodes) || undefined,
         loadingSelectedRepos: loading,
         errorSelectedRepos: error,
         refetchSelectedRepos: refetch,

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -541,6 +541,7 @@ const changesetDiffFragment = gql`
         currentSpec {
             description {
                 ... on GitBranchChangesetDescription {
+                    __typename
                     commits {
                         diff
                     }
@@ -575,7 +576,9 @@ export async function getChangesetDiff(changeset: Scalars['ID']): Promise<string
                     throw new Error(`The given ID is a ${node.__typename}, not an ExternalChangeset`)
                 }
 
-                const commits = node.currentSpec?.description.commits
+                const commits =
+                    node.currentSpec?.description?.__typename === 'GitBranchChangesetDescription' &&
+                    node.currentSpec?.description.commits
                 if (!commits) {
                     throw new Error(`No commit available for changeset ID ${changeset}`)
                 } else if (commits.length !== 1) {

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -3,11 +3,7 @@ import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 
-import {
-    ExternalChangesetFields,
-    GitBranchChangesetDescriptionFields,
-    ChangesetState,
-} from '../../../../graphql-operations'
+import { ExternalChangesetFields, ChangesetState } from '../../../../graphql-operations'
 
 import { ChangesetLabel } from './ChangesetLabel'
 import { ChangesetLastSynced } from './ChangesetLastSynced'
@@ -85,7 +81,7 @@ function importingFailed(node: ExternalChangesetFields): boolean {
 
 function headReference(node: ExternalChangesetFields): string | undefined {
     if (hasHeadReference(node)) {
-        return node.currentSpec?.description.headRef
+        return node.currentSpec.description.headRef
     }
     return undefined
 }
@@ -93,7 +89,9 @@ function headReference(node: ExternalChangesetFields): string | undefined {
 function hasHeadReference(
     node: ExternalChangesetFields
 ): node is ExternalChangesetFields & {
-    currentSpec: ExternalChangesetFields & { description: GitBranchChangesetDescriptionFields }
+    currentSpec: typeof node.currentSpec & {
+        description: { __typename: 'GitBranchChangesetDescription' }
+    }
 } {
     return node.currentSpec?.description.__typename === 'GitBranchChangesetDescription'
 }

--- a/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import sinon from 'sinon'
 
 import { CodeMonitorNode } from './CodeMonitoringNode'
-import { mockCodeMonitor } from './testing/util'
+import { mockCodeMonitorFields } from './testing/util'
 
 describe('CreateCodeMonitorPage', () => {
     const history = H.createMemoryHistory()
@@ -14,7 +14,7 @@ describe('CreateCodeMonitorPage', () => {
             <CodeMonitorNode
                 toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
-                node={mockCodeMonitor.node}
+                node={mockCodeMonitorFields}
                 isSiteAdminUser={true}
                 showCodeMonitoringTestEmailButton={false}
             />
@@ -27,7 +27,7 @@ describe('CreateCodeMonitorPage', () => {
             <CodeMonitorNode
                 toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
-                node={mockCodeMonitor.node}
+                node={mockCodeMonitorFields}
                 isSiteAdminUser={true}
                 showCodeMonitoringTestEmailButton={true}
             />
@@ -36,11 +36,15 @@ describe('CreateCodeMonitorPage', () => {
     })
 
     test('Does not show "Send test email" option when code monitor is disabled', () => {
+        const disabledCodeMonitor = {
+            ...mockCodeMonitorFields,
+            enabled: false,
+        }
         const component = mount(
             <CodeMonitorNode
                 toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
-                node={{ ...mockCodeMonitor.node, enabled: false }}
+                node={disabledCodeMonitor}
                 isSiteAdminUser={true}
                 showCodeMonitoringTestEmailButton={true}
             />
@@ -53,7 +57,7 @@ describe('CreateCodeMonitorPage', () => {
             <CodeMonitorNode
                 toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
-                node={mockCodeMonitor.node}
+                node={mockCodeMonitorFields}
                 isSiteAdminUser={false}
                 showCodeMonitoringTestEmailButton={true}
             />

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
@@ -4,11 +4,10 @@ import React from 'react'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 
-import { AuthenticatedUser } from '../../auth'
 import { EnterpriseWebStory } from '../components/EnterpriseWebStory'
 
 import { ManageCodeMonitorPage } from './ManageCodeMonitorPage'
-import { mockCodeMonitor } from './testing/util'
+import { mockCodeMonitor, mockUser } from './testing/util'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/ManageCodeMonitorPage', module).addParameters({
     design: {
@@ -23,7 +22,7 @@ add('Example', () => (
         {props => (
             <ManageCodeMonitorPage
                 {...props}
-                authenticatedUser={{ id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser}
+                authenticatedUser={{ ...mockUser, id: 'foobar', username: 'alice', email: 'alice@alice.com' }}
                 updateCodeMonitor={sinon.fake()}
                 fetchCodeMonitor={sinon.fake((id: string) => of(mockCodeMonitor))}
                 deleteCodeMonitor={sinon.fake((id: string) => NEVER)}
@@ -43,9 +42,7 @@ add('Disabled toggles', () => {
             {props => (
                 <ManageCodeMonitorPage
                     {...props}
-                    authenticatedUser={
-                        { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser
-                    }
+                    authenticatedUser={{ ...mockUser, id: 'foobar', username: 'alice', email: 'alice@alice.com' }}
                     updateCodeMonitor={sinon.fake()}
                     fetchCodeMonitor={sinon.fake((id: string) => of(monitor))}
                     deleteCodeMonitor={sinon.fake((id: string) => NEVER)}

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -12,19 +12,12 @@ import {
     MonitorEmailPriority,
 } from '@sourcegraph/shared/src/graphql-operations'
 
-import { AuthenticatedUser } from '../../auth'
+import { FetchCodeMonitorResult } from '../../graphql-operations'
 
 import { ManageCodeMonitorPage } from './ManageCodeMonitorPage'
-import { mockCodeMonitor } from './testing/util'
+import { mockCodeMonitor, mockCodeMonitorFields, mockUser } from './testing/util'
 
 describe('ManageCodeMonitorPage', () => {
-    const mockUser = {
-        id: 'userID',
-        username: 'username',
-        email: 'user@me.com',
-        siteAdmin: true,
-    } as AuthenticatedUser
-
     const history = H.createMemoryHistory()
     history.location.pathname = '/code-monitoring/test-monitor-id'
     const props = {
@@ -40,9 +33,9 @@ describe('ManageCodeMonitorPage', () => {
                 monitorEditInput: MonitorEditInput,
                 triggerEditInput: MonitorEditTriggerInput,
                 actionEditInput: MonitorEditActionInput[]
-            ) => of(mockCodeMonitor.node)
+            ) => of(mockCodeMonitorFields)
         ),
-        fetchCodeMonitor: sinon.spy((id: string) => of(mockCodeMonitor)),
+        fetchCodeMonitor: sinon.spy((id: string) => of(mockCodeMonitor as FetchCodeMonitorResult)),
         match: {
             params: { id: 'test-id' },
             isExact: true,

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -60,7 +60,7 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<ManageCodeMoni
             () =>
                 fetchCodeMonitor(match.params.id).pipe(
                     tap(monitor => {
-                        if (monitor.node !== null) {
+                        if (monitor.node !== null && monitor.node.__typename === 'Monitor') {
                             setCodeMonitorState(monitor.node)
                         }
                     }),

--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -166,6 +166,7 @@ export const fetchCodeMonitor = (id: string): Observable<FetchCodeMonitorResult>
         query FetchCodeMonitor($id: ID!) {
             node(id: $id) {
                 ... on Monitor {
+                    __typename
                     id
                     description
                     owner {

--- a/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { NEVER } from 'rxjs'
 import sinon from 'sinon'
 
+import { CodeMonitorFields } from '../../../graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 import { mockCodeMonitor } from '../testing/util'
 
@@ -18,7 +19,7 @@ add(
                 <DeleteMonitorModal
                     {...props}
                     isOpen={true}
-                    codeMonitor={mockCodeMonitor.node}
+                    codeMonitor={mockCodeMonitor.node as CodeMonitorFields}
                     toggleDeleteModal={sinon.fake()}
                     deleteCodeMonitor={sinon.fake(() => NEVER)}
                 />

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -1,5 +1,40 @@
+import { AuthenticatedUser } from '../../../auth'
+import { CodeMonitorFields } from '../../../graphql-operations'
+
+export const mockUser: AuthenticatedUser = {
+    __typename: 'User',
+    id: 'userID',
+    username: 'username',
+    email: 'user@me.com',
+    siteAdmin: true,
+    databaseID: 0,
+    tags: [],
+    url: '',
+    avatarURL: '',
+    displayName: 'display name',
+    settingsURL: '',
+    viewerCanAdminister: true,
+    organizations: {
+        __typename: 'OrgConnection',
+        nodes: [],
+    },
+    session: { __typename: 'Session', canSignOut: true },
+}
+
+export const mockCodeMonitorFields: CodeMonitorFields = {
+    __typename: 'Monitor',
+    id: 'foo0',
+    description: 'Test code monitor',
+    enabled: true,
+    trigger: { id: 'test-0', query: 'test' },
+    actions: {
+        nodes: [{ id: 'test-action-0', enabled: true, recipients: { nodes: [{ id: 'baz-0' }] } }],
+    },
+}
+
 export const mockCodeMonitor = {
     node: {
+        __typename: 'Monitor',
         id: 'foo0',
         description: 'Test code monitor',
         enabled: true,

--- a/client/web/src/enterprise/codeintel/configuration/usePoliciesConfigurations.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/usePoliciesConfigurations.tsx
@@ -87,7 +87,7 @@ export const useRepositoryConfig = (id: string): UseRepositoryConfigResult => {
         variables: { id },
     })
 
-    const configuration = data?.node?.indexConfiguration?.configuration || ''
+    const configuration = (data?.node?.__typename === 'Repository' && data.node.indexConfiguration?.configuration) || ''
 
     return {
         configuration,
@@ -122,7 +122,8 @@ export const useInferredConfig = (id: string): UseInferredConfigResult => {
         variables: { id },
     })
 
-    const inferredConfiguration = data?.node?.indexConfiguration?.inferredConfiguration || ''
+    const inferredConfiguration =
+        (data?.node?.__typename === 'Repository' && data.node.indexConfiguration?.inferredConfiguration) || ''
 
     return {
         inferredConfiguration,
@@ -168,7 +169,7 @@ export const usePolicyConfigurationByID = (id: string): UsePolicyConfigResult =>
         skip: id === 'new',
     })
 
-    const response = data?.node || undefined
+    const response = (data?.node?.__typename === 'CodeIntelligenceConfigurationPolicy' && data.node) || undefined
     const isNew = id === 'new'
 
     return {

--- a/client/web/src/enterprise/codeintel/detail/backend.ts
+++ b/client/web/src/enterprise/codeintel/detail/backend.ts
@@ -36,7 +36,7 @@ export function fetchLsifUpload({ id }: { id: string }): Observable<LsifUploadFi
     return requestGraphQL<LsifUploadResult, LsifUploadVariables>(query, { id }).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {
-            if (!node) {
+            if (!node || node.__typename !== 'LSIFUpload') {
                 throw new Error('No such LSIFUpload')
             }
             return node
@@ -58,7 +58,7 @@ export function fetchLsifIndex({ id }: { id: string }): Observable<LsifIndexFiel
     return requestGraphQL<LsifIndexResult, LsifIndexVariables>(query, { id }).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {
-            if (!node) {
+            if (!node || node.__typename !== 'LSIFIndex') {
                 throw new Error('No such LSIFIndex')
             }
             return node

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import React from 'react'
 import { of } from 'rxjs'
 
-import { LsifUploadFields, LSIFUploadState } from '../../../graphql-operations'
+import { LsifUploadConnectionFields, LsifUploadFields, LSIFUploadState } from '../../../graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 
 import { CodeIntelUploadsPage, CodeIntelUploadsPageProps } from './CodeIntelUploadsPage'
@@ -84,7 +84,8 @@ const testUploads: LsifUploadFields[] = [
 
 const now = () => new Date('2020-06-15T15:25:00+00:00')
 
-const makeResponse = (uploads: LsifUploadFields[]) => ({
+const makeResponse = (uploads: LsifUploadFields[]): LsifUploadConnectionFields => ({
+    __typename: 'LSIFUploadConnection',
     nodes: uploads,
     totalCount: uploads.length,
     pageInfo: {

--- a/client/web/src/enterprise/insights/core/backend/api/get-search-insight-content/get-search-insight-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/api/get-search-insight-content/get-search-insight-content.ts
@@ -189,13 +189,14 @@ async function determineCommitsToSearch(dates: Date[], repo: string): Promise<Se
             throw new Error(`Expected field ${name} to be at index ${index_} of object keys`)
         }
 
-        if (search.results.results.length === 0) {
+        const firstCommit = search.results.results[0]
+        if (search.results.results.length === 0 || firstCommit?.__typename !== 'CommitSearchResult') {
             console.warn(`No result for ${commitQueries[index_]}`)
 
             return { commit: null, date }
         }
 
-        const commit = (search?.results.results[0]).commit
+        const commit = firstCommit.commit
 
         // Sanity check
         const commitDate = commit.committer && new Date(commit.committer.date)

--- a/client/web/src/enterprise/insights/core/backend/requests/fetch-search-insight.ts
+++ b/client/web/src/enterprise/insights/core/backend/requests/fetch-search-insight.ts
@@ -45,6 +45,7 @@ const bulkSearchCommitsFragment = gql`
         results {
             results {
                 ... on CommitSearchResult {
+                    __typename
                     commit {
                         oid
                         committer {

--- a/client/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
+++ b/client/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
@@ -76,6 +76,7 @@ export class UserSettingsExternalAccountsPage extends React.Component<Props> {
                 query UserExternalAccounts($user: ID!, $first: Int) {
                     node(id: $user) {
                         ... on User {
+                            __typename
                             externalAccounts(first: $first) {
                                 ...ExternalAccountsConnectionFields
                             }
@@ -91,7 +92,7 @@ export class UserSettingsExternalAccountsPage extends React.Component<Props> {
                     throw createAggregateError(errors)
                 }
                 const user = data.node
-                if (!user.externalAccounts) {
+                if (user.__typename !== 'User' || !user.externalAccounts) {
                     throw createAggregateError(errors)
                 }
                 return user.externalAccounts

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -124,6 +124,11 @@ const mockDiff: NonNullable<ExternalChangesetFileDiffsFields['diff']> = {
     },
 }
 
+const mockChangesetSpecFileDiffs: NonNullable<ExternalChangesetFileDiffsFields['diff']> = {
+    __typename: 'PreviewRepositoryComparison',
+    fileDiffs: mockDiff.fileDiffs,
+}
+
 const ChangesetCountsOverTime: (variables: ChangesetCountsOverTimeVariables) => ChangesetCountsOverTimeResult = () => ({
     node: {
         __typename: 'BatchChange',
@@ -664,7 +669,7 @@ describe('Batches', () => {
                             __typename: 'VisibleChangesetSpec',
                             description: {
                                 __typename: 'GitBranchChangesetDescription',
-                                diff: mockDiff,
+                                diff: mockChangesetSpecFileDiffs,
                             },
                         },
                     }),

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -127,6 +127,7 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
     }),
     EventLogsData: () => ({
         node: {
+            __typename: 'User',
             eventLogs: {
                 nodes: [],
                 totalCount: 0,
@@ -196,6 +197,7 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
     }),
     UserRepositories: () => ({
         node: {
+            __typename: 'User',
             repositories: {
                 totalCount: 0,
                 nodes: [],

--- a/client/web/src/integration/insights/utils/insight-mock-data.ts
+++ b/client/web/src/integration/insights/utils/insight-mock-data.ts
@@ -5,6 +5,7 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '0b81b624c24f5fc4d53fd10651eb84d67072e74e',
                         committer: {
@@ -19,6 +20,7 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '03956c5dde9dcb22a53e7d3f259a0e98dd50704b',
                         committer: {
@@ -33,6 +35,7 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '948698c42a2a05b1ebebf3cda5945b0764426f57',
                         committer: {
@@ -47,6 +50,7 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: 'db37595dc3a4ceb7953dd89b2122a974ff70b311',
                         committer: {
@@ -61,6 +65,7 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '4472874fb5fddb44d402f4fdf064149b68dce68c',
                         committer: {
@@ -75,6 +80,7 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '6f34ec9377091a1665d554a54bc58812813c7c1a',
                         committer: {
@@ -89,6 +95,7 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '6f34ec9377091a1665d554a54bc58812813c7c1a',
                         committer: {
@@ -199,11 +206,12 @@ export const BACKEND_INSIGHTS = [LINEAR_BACKEND_INSIGHT]
  * Mock gql api for live preview chart of `INSIGHT_VIEW_TYPES_MIGRATION` insight.
  * {@link INSIGHT_VIEW_TYPES_MIGRATION}
  */
-export const INSIGHT_TYPES_MIGRATION_COMMITS = {
+export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> = {
     search0: {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '2a1cd8a30c72780ad884159161d0ec828cfe69a3',
                         committer: {
@@ -218,6 +226,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '68afed3a2812a197096720c80df928eba0ea0703',
                         committer: {
@@ -232,6 +241,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: 'f62cb0864d367cfd09fb6f755807e6c25b44e6dd',
                         committer: {
@@ -246,6 +256,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: 'ccede06037725365c3391e36b9d90c85eb00b71a',
                         committer: {
@@ -260,6 +271,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: 'b29a72431e10adac2267cd4e5097f11d517e9139',
                         committer: {
@@ -274,6 +286,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '4e565e36dc880f75c12982e2aba41f2445eeb4e1',
                         committer: {
@@ -288,6 +301,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS = {
         results: {
             results: [
                 {
+                    __typename: 'CommitSearchResult',
                     commit: {
                         oid: '1c2601a76662f6a0700b614a4a68406335075c29',
                         committer: {

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -106,6 +106,7 @@ describe('Search contexts', () => {
         ...viewerSettingsWithSearchContexts,
         UserRepositories: () => ({
             node: {
+                __typename: 'User',
                 repositories: {
                     totalCount: 1,
                     nodes: [

--- a/client/web/src/search/backend.tsx
+++ b/client/web/src/search/backend.tsx
@@ -579,6 +579,7 @@ function fetchEvents(userId: Scalars['ID'], first: number, eventName: string): O
             query EventLogsData($userId: ID!, $first: Int, $eventName: String!) {
                 node(id: $userId) {
                     ... on User {
+                        __typename
                         eventLogs(first: $first, eventName: $eventName) {
                             nodes {
                                 argument
@@ -601,7 +602,7 @@ function fetchEvents(userId: Scalars['ID'], first: number, eventName: string): O
         map(dataOrThrowErrors),
         map(
             (data: EventLogsDataResult): EventLogResult => {
-                if (!data.node) {
+                if (!data.node || data.node.__typename !== 'User') {
                     throw new Error('User not found')
                 }
                 return data.node.eventLogs

--- a/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
+++ b/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
@@ -11,7 +11,7 @@ import { LoaderButton } from '../../../components/LoaderButton'
 import { SetUserEmailPrimaryResult, SetUserEmailPrimaryVariables, UserEmailsResult } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 
-type UserEmail = NonNullable<UserEmailsResult['node']>['emails'][number]
+type UserEmail = (NonNullable<UserEmailsResult['node']> & { __typename: 'User' })['emails'][number]
 
 interface Props {
     user: string

--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -17,7 +17,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 
 interface Props {
     user: string
-    email: NonNullable<UserEmailsResult['node']>['emails'][number]
+    email: (NonNullable<UserEmailsResult['node']> & { __typename: 'User' })['emails'][number]
     onError: (error: ErrorLike) => void
 
     onDidRemove?: (email: string) => void

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -21,7 +21,7 @@ interface Props {
     user: UserAreaUserFields
 }
 
-type UserEmail = NonNullable<UserEmailsResult['node']>['emails'][number]
+type UserEmail = (NonNullable<UserEmailsResult['node']> & { __typename: 'User' })['emails'][number]
 type Status = undefined | 'loading' | 'loaded' | ErrorLike
 type EmailActionError = undefined | ErrorLike
 
@@ -47,7 +47,7 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user }) => {
         // always cleanup email action errors when re-fetching emails
         setEmailActionError(undefined)
 
-        if (fetchedEmails?.node?.emails) {
+        if (fetchedEmails?.node?.__typename === 'User' && fetchedEmails.node.emails) {
             setEmails(fetchedEmails.node.emails)
             setStatusOrError('loaded')
         } else {
@@ -128,6 +128,7 @@ async function fetchUserEmails(userID: Scalars['ID']): Promise<UserEmailsResult>
                 query UserEmails($user: ID!) {
                     node(id: $user) {
                         ... on User {
+                            __typename
                             emails {
                                 email
                                 isPrimary

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -208,7 +208,9 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
     )
 
     const fetchSelectedRepositories = useCallback(
-        async (): Promise<NonNullable<UserRepositoriesResult['node']>['repositories']['nodes']> =>
+        async (): Promise<
+            (NonNullable<UserRepositoriesResult['node']> & { __typename: 'User' })['repositories']['nodes']
+        > =>
             listUserRepositories({ id: authenticatedUser.id, first: 2000 })
                 .toPromise()
                 .then(({ nodes }) => nodes),


### PR DESCRIPTION
### Description

- Because of bringing back `__typename` for every types, so CodeGen is using `union` types with `__typename: "..."`, so there are a lot of "empty" type since it contains only `{ __typename?: '...' }` together with only one type contains the query result we expected (See the screenshot for diffs between old vs new code-gen results)

![image](https://user-images.githubusercontent.com/51897872/133716131-19f2bbee-0933-40c6-be38-f6e6068c5904.png)

To fix TS build issue, we can add `__typename` checks, Typescript would automatically refine types

But in the end, keeping using `union types` like that is not a good idea at all

### Refs
- sourcegraph/sourcegraph#24644