### PR TITLE
migrations: clear the dirty flag in each migration

### DIFF
--- a/dev/db/add_migration.sh
+++ b/dev/db/add_migration.sh
@@ -30,6 +30,18 @@ EOF
 files=$(find . -type f -name '[0-9]*.sql' | sort | awk -v name="$2" "$awkcmd")
 
 for f in $files; do
+  case "$1" in
+    frontend)
+      table="schema_migrations"
+      ;;
+    codeintel)
+      table="codeintel_schema_migrations"
+      ;;
+    codeinsights)
+      table="codeinsights_schema_migrations"
+      ;;
+  esac
+
   cat >"$f" <<EOF
 BEGIN;
 
@@ -40,6 +52,8 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE $table SET dirty = 'f';
 COMMIT;
 EOF
 

--- a/doc/admin/how-to/dirty_database.md
+++ b/doc/admin/how-to/dirty_database.md
@@ -29,8 +29,8 @@ ERROR: Failed to migrate the DB. Please contact support@sourcegraph.com for furt
   * The `dirty` column indicates whether a migration is in-process, and
   * The `version` column indicates the version of the migration the database is on or converting to.
   * On startup, frontend will abort if the `dirty` column is set to true. (The table has only one row.)
-* If frontend fails at startup with a complaint about a dirty migration, a migration was started but not recorded as completing.
-  * It’s possible that one or more commands from the migration ran successfully.
+* If frontend fails at startup with a complaint about a dirty migration, a migration failed to complete.
+  * Each migration is wrapped in a transaction, so either all the changes that a migration makes are committed or none are.
 * Do not mark the migration table as clean if you have not verified that the migration was successfully completed.
 * To check the state of the migration table:
   * `SELECT * FROM schema_migrations;`

--- a/migrations/codeinsights/1000000001_initial_schema.down.sql
+++ b/migrations/codeinsights/1000000001_initial_schema.down.sql
@@ -4,4 +4,6 @@ DROP TABLE IF EXISTS series_points;
 DROP TABLE IF EXISTS repo_names;
 DROP TABLE IF EXISTS metadata;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000001_initial_schema.up.sql
+++ b/migrations/codeinsights/1000000001_initial_schema.up.sql
@@ -106,4 +106,6 @@ CREATE INDEX series_points_repo_id_btree ON series_points USING btree (repo_id);
 CREATE INDEX series_points_repo_name_id_btree ON series_points USING btree (repo_name_id);
 CREATE INDEX series_points_original_repo_name_id_btree ON series_points USING btree (original_repo_name_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000002_comments.down.sql
+++ b/migrations/codeinsights/1000000002_comments.down.sql
@@ -7,4 +7,6 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000002_comments.up.sql
+++ b/migrations/codeinsights/1000000002_comments.up.sql
@@ -21,4 +21,6 @@ COMMENT ON COLUMN series_points.repo_id IS 'The repository ID (from the main app
 COMMENT ON COLUMN series_points.repo_name_id IS 'The most recently known name for the repository, updated periodically to account for e.g. repository renames. If the repository was deleted, this is still the most recently known name.  null if the event was not for a single repository (i.e. a global gauge).';
 COMMENT ON COLUMN series_points.original_repo_name_id IS 'The repository name as it was known at the time the event was created. It may have been renamed since.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000003_insights_series_id.down.sql
+++ b/migrations/codeinsights/1000000003_insights_series_id.down.sql
@@ -1,3 +1,5 @@
 BEGIN;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000003_insights_series_id.up.sql
+++ b/migrations/codeinsights/1000000003_insights_series_id.up.sql
@@ -7,4 +7,6 @@ ALTER TABLE series_points ALTER COLUMN series_id SET NOT NULL;
 -- Give series_id a btree index since we'll be filtering on it very frequently.
 CREATE INDEX series_points_series_id_btree ON series_points USING btree (series_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000004_no_telemetry.down.sql
+++ b/migrations/codeinsights/1000000004_no_telemetry.down.sql
@@ -7,4 +7,6 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000005_wipe_data.down.sql
+++ b/migrations/codeinsights/1000000005_wipe_data.down.sql
@@ -7,4 +7,6 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000005_wipe_data.up.sql
+++ b/migrations/codeinsights/1000000005_wipe_data.up.sql
@@ -12,4 +12,6 @@ BEGIN;
 -- needed in general when making this change, but is useful in this specific situation.
 DELETE FROM series_points;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000006_commit_index.down.sql
+++ b/migrations/codeinsights/1000000006_commit_index.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 DROP TABLE IF EXISTS commit_index;
 DROP TABLE IF EXISTS commit_index_metadata;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000006_commit_index.up.sql
+++ b/migrations/codeinsights/1000000006_commit_index.up.sql
@@ -18,4 +18,6 @@ CREATE TABLE commit_index_metadata
     last_indexed_at TIMESTAMPTZ NOT NULL DEFAULT '1900-01-01'
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000007_series_points_index.down.sql
+++ b/migrations/codeinsights/1000000007_series_points_index.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS series_points_series_id_repo_id_time_idx;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000007_series_points_index.up.sql
+++ b/migrations/codeinsights/1000000007_series_points_index.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 CREATE INDEX IF NOT EXISTS series_points_series_id_repo_id_time_idx ON series_points (series_id, repo_id, time);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000008_insights_views_series.down.sql
+++ b/migrations/codeinsights/1000000008_insights_views_series.down.sql
@@ -4,4 +4,6 @@ DROP TABLE IF EXISTS insight_view_series;
 DROP TABLE IF EXISTS insight_view;
 DROP TABLE IF EXISTS insight_series;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000008_insights_views_series.up.sql
+++ b/migrations/codeinsights/1000000008_insights_views_series.up.sql
@@ -67,4 +67,6 @@ ALTER TABLE insight_view_series
 ALTER TABLE insight_view_series
     ADD FOREIGN KEY (insight_series_id) REFERENCES insight_series (id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000009_backfiller_state.down.sql
+++ b/migrations/codeinsights/1000000009_backfiller_state.down.sql
@@ -10,4 +10,6 @@ BEGIN;
 
 ALTER TABLE insight_series DROP COLUMN IF EXISTS backfill_queued_at;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000009_backfiller_state.up.sql
+++ b/migrations/codeinsights/1000000009_backfiller_state.up.sql
@@ -12,4 +12,6 @@ ALTER TABLE insight_series ADD COLUMN backfill_queued_at TIMESTAMP;
 COMMENT ON COLUMN insight_series.series_id IS
     'Timestamp that this series completed a full repository iteration for backfill. This flag has limited semantic value, and only means it tried to queue up queries for each repository. It does not guarantee success on those queries.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000010_series_points_reset.down.sql
+++ b/migrations/codeinsights/1000000010_series_points_reset.down.sql
@@ -8,4 +8,6 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000010_series_points_reset.up.sql
+++ b/migrations/codeinsights/1000000010_series_points_reset.up.sql
@@ -28,4 +28,6 @@ TRUNCATE commit_index_metadata;
 
 -- Update all of the underlying insights that may have been synced to reset metadata and rebuild their data.
 update insight_series set created_at = current_timestamp, backfill_queued_at = null, next_recording_after = date_trunc('month', current_date) + interval '1 month';
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000011_insights_dirty_queries.down.sql
+++ b/migrations/codeinsights/1000000011_insights_dirty_queries.down.sql
@@ -8,4 +8,6 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 DROP TABLE IF EXISTS insight_dirty_queries;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000011_insights_dirty_queries.up.sql
+++ b/migrations/codeinsights/1000000011_insights_dirty_queries.up.sql
@@ -29,4 +29,6 @@ COMMENT ON COLUMN insight_dirty_queries.dirty_at IS 'Timestamp when this query w
 COMMENT ON COLUMN insight_dirty_queries.reason IS 'Human readable string indicating the reason the query was marked dirty.';
 COMMENT ON COLUMN insight_dirty_queries.for_time IS 'Timestamp for which the original data point was recorded or intended to be recorded.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000012_insights_snapshots.down.sql
+++ b/migrations/codeinsights/1000000012_insights_snapshots.down.sql
@@ -9,4 +9,6 @@ BEGIN;
 --    migrate library handled it. However, it does not! /facepalm
 
 DROP TABLE series_points_snapshots;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000012_insights_snapshots.up.sql
+++ b/migrations/codeinsights/1000000012_insights_snapshots.up.sql
@@ -21,4 +21,6 @@ alter table insight_series
 alter table insight_series
     add next_snapshot_after timestamp default CURRENT_TIMESTAMP;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000013_insights_view_grants.down.sql
+++ b/migrations/codeinsights/1000000013_insights_view_grants.down.sql
@@ -9,4 +9,6 @@ ALTER TABLE insight_view_series
     ADD CONSTRAINT insight_view_series_insight_view_id_fkey
         FOREIGN KEY (insight_view_id) REFERENCES insight_view;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeinsights/1000000013_insights_view_grants.up.sql
+++ b/migrations/codeinsights/1000000013_insights_view_grants.up.sql
@@ -42,4 +42,6 @@ ALTER TABLE insight_view_series
         FOREIGN KEY (insight_view_id) REFERENCES insight_view
             ON DELETE CASCADE;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeinsights_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000005_squashed_migrations.up.sql
+++ b/migrations/codeintel/1000000005_squashed_migrations.up.sql
@@ -98,4 +98,6 @@ ALTER TABLE ONLY lsif_data_references
 ALTER TABLE ONLY lsif_data_result_chunks
     ADD CONSTRAINT lsif_data_result_chunks_pkey PRIMARY KEY (dump_id, idx);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000006_document_versions.down.sql
+++ b/migrations/codeintel/1000000006_document_versions.down.sql
@@ -4,4 +4,6 @@ DROP TABLE lsif_data_documents_schema_versions;
 DROP TRIGGER lsif_data_documents_schema_versions_insert ON lsif_data_documents;
 DROP FUNCTION update_lsif_data_documents_schema_versions_insert;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000006_document_versions.up.sql
+++ b/migrations/codeintel/1000000006_document_versions.up.sql
@@ -65,4 +65,6 @@ CREATE TRIGGER lsif_data_documents_schema_versions_insert
 AFTER INSERT ON lsif_data_documents REFERENCING NEW TABLE AS newtab
 FOR EACH STATEMENT EXECUTE PROCEDURE update_lsif_data_documents_schema_versions_insert();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000007_definitions_locations_counts.down.sql
+++ b/migrations/codeintel/1000000007_definitions_locations_counts.down.sql
@@ -7,4 +7,6 @@ DROP FUNCTION update_lsif_data_definitions_schema_versions_insert;
 ALTER TABLE lsif_data_definitions DROP COLUMN IF EXISTS schema_version;
 ALTER TABLE lsif_data_definitions DROP COLUMN IF EXISTS num_locations;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000007_definitions_locations_counts.up.sql
+++ b/migrations/codeintel/1000000007_definitions_locations_counts.up.sql
@@ -72,4 +72,6 @@ CREATE TRIGGER lsif_data_definitions_schema_versions_insert
 AFTER INSERT ON lsif_data_definitions REFERENCING NEW TABLE AS newtab
 FOR EACH STATEMENT EXECUTE PROCEDURE update_lsif_data_definitions_schema_versions_insert();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000008_references_locations_counts.down.sql
+++ b/migrations/codeintel/1000000008_references_locations_counts.down.sql
@@ -7,4 +7,6 @@ DROP FUNCTION update_lsif_data_references_schema_versions_insert;
 ALTER TABLE lsif_data_references DROP COLUMN IF EXISTS schema_version;
 ALTER TABLE lsif_data_references DROP COLUMN IF EXISTS num_locations;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000008_references_locations_counts.up.sql
+++ b/migrations/codeintel/1000000008_references_locations_counts.up.sql
@@ -72,4 +72,6 @@ CREATE TRIGGER lsif_data_references_schema_versions_insert
 AFTER INSERT ON lsif_data_references REFERENCING NEW TABLE AS newtab
 FOR EACH STATEMENT EXECUTE PROCEDURE update_lsif_data_references_schema_versions_insert();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000009_documents_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000009_documents_schema_version_index.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS lsif_data_documents_dump_id_schema_version;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000010_definitions_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000010_definitions_schema_version_index.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS lsif_data_definitions_dump_id_schema_version;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000011_references_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000011_references_schema_version_index.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS lsif_data_references_dump_id_schema_version;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000012_delete_missing_schema_versions.up.sql
+++ b/migrations/codeintel/1000000012_delete_missing_schema_versions.up.sql
@@ -8,4 +8,6 @@ DELETE FROM lsif_data_documents_schema_versions sv WHERE NOT EXISTS (SELECT 1 FR
 DELETE FROM lsif_data_definitions_schema_versions sv WHERE NOT EXISTS (SELECT 1 FROM lsif_data_definitions d WHERE d.dump_id = sv.dump_id);
 DELETE FROM lsif_data_references_schema_versions sv WHERE NOT EXISTS (SELECT 1 FROM lsif_data_references r WHERE r.dump_id = sv.dump_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000013_split_document_payload.down.sql
+++ b/migrations/codeintel/1000000013_split_document_payload.down.sql
@@ -6,4 +6,6 @@ ALTER TABLE lsif_data_documents DROP COLUMN monikers;
 ALTER TABLE lsif_data_documents DROP COLUMN packages;
 ALTER TABLE lsif_data_documents DROP COLUMN diagnostics;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000013_split_document_payload.up.sql
+++ b/migrations/codeintel/1000000013_split_document_payload.up.sql
@@ -20,4 +20,6 @@ COMMENT ON COLUMN lsif_data_result_chunks.data IS 'A gob-encoded payload conform
 COMMENT ON COLUMN lsif_data_definitions.data IS 'A gob-encoded payload conforming to an array of [LocationData](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@3.26/-/blob/enterprise/lib/codeintel/semantic/types.go#L106:6) types.';
 COMMENT ON COLUMN lsif_data_references.data IS 'A gob-encoded payload conforming to an array of [LocationData](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@3.26/-/blob/enterprise/lib/codeintel/semantic/types.go#L106:6) types.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000014_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000014_schema_version_index.down.sql
@@ -4,4 +4,6 @@ DROP INDEX IF EXISTS lsif_data_documents_schema_versions_dump_id_schema_version_
 DROP INDEX IF EXISTS lsif_data_definitions_schema_versions_dump_id_schema_version_bounds;
 DROP INDEX IF EXISTS lsif_data_references_schema_versions_dump_id_schema_version_bounds;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000014_schema_version_index.up.sql
+++ b/migrations/codeintel/1000000014_schema_version_index.up.sql
@@ -4,4 +4,6 @@ CREATE INDEX IF NOT EXISTS lsif_data_documents_schema_versions_dump_id_schema_ve
 CREATE INDEX IF NOT EXISTS lsif_data_definitions_schema_versions_dump_id_schema_version_bounds ON lsif_data_definitions_schema_versions (dump_id, min_schema_version, max_schema_version);
 CREATE INDEX IF NOT EXISTS lsif_data_references_schema_versions_dump_id_schema_version_bounds ON lsif_data_references_schema_versions (dump_id, min_schema_version, max_schema_version);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000015_lsif_documentation.down.sql
+++ b/migrations/codeintel/1000000015_lsif_documentation.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS lsif_data_documentation_pages;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000015_lsif_documentation.up.sql
+++ b/migrations/codeintel/1000000015_lsif_documentation.up.sql
@@ -13,4 +13,6 @@ COMMENT ON COLUMN lsif_data_documentation_pages.dump_id IS 'The identifier of th
 COMMENT ON COLUMN lsif_data_documentation_pages.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';
 COMMENT ON COLUMN lsif_data_documentation_pages.data IS 'A gob-encoded payload conforming to a `type DocumentationPageData struct` pointer (lib/codeintel/semantic/types.go)';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000016_apidocs_clean.down.sql
+++ b/migrations/codeintel/1000000016_apidocs_clean.down.sql
@@ -7,4 +7,6 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000016_apidocs_clean.up.sql
+++ b/migrations/codeintel/1000000016_apidocs_clean.up.sql
@@ -6,4 +6,6 @@ BEGIN;
 -- anyway.)
 TRUNCATE lsif_data_documentation_pages;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000017_lsif_documentation_path_info.down.sql
+++ b/migrations/codeintel/1000000017_lsif_documentation_path_info.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS lsif_data_documentation_path_info;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000017_lsif_documentation_path_info.up.sql
+++ b/migrations/codeintel/1000000017_lsif_documentation_path_info.up.sql
@@ -13,4 +13,6 @@ COMMENT ON COLUMN lsif_data_documentation_path_info.dump_id IS 'The identifier o
 COMMENT ON COLUMN lsif_data_documentation_path_info.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';
 COMMENT ON COLUMN lsif_data_documentation_path_info.data IS 'A gob-encoded payload conforming to a `type DocumentationPathInoData struct` pointer (lib/codeintel/semantic/types.go)';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000018_lsif_documentation_mappings.down.sql
+++ b/migrations/codeintel/1000000018_lsif_documentation_mappings.down.sql
@@ -1,1 +1,7 @@
+BEGIN;
+
 DROP TABLE IF EXISTS lsif_data_documentation_mappings;
+
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
+COMMIT;

--- a/migrations/codeintel/1000000018_lsif_documentation_mappings.up.sql
+++ b/migrations/codeintel/1000000018_lsif_documentation_mappings.up.sql
@@ -15,4 +15,6 @@ COMMENT ON COLUMN lsif_data_documentation_mappings.dump_id IS 'The identifier of
 COMMENT ON COLUMN lsif_data_documentation_mappings.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';
 COMMENT ON COLUMN lsif_data_documentation_mappings.result_id IS 'The documentationResult vertex ID.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000019_documentation_path_mapping.down.sql
+++ b/migrations/codeintel/1000000019_documentation_path_mapping.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE lsif_data_documentation_mappings DROP COLUMN file_path;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/codeintel/1000000019_documentation_path_mapping.up.sql
+++ b/migrations/codeintel/1000000019_documentation_path_mapping.up.sql
@@ -4,4 +4,6 @@ BEGIN;
 ALTER TABLE lsif_data_documentation_mappings ADD COLUMN file_path text;
 COMMENT ON COLUMN lsif_data_documentation_mappings.file_path IS 'The document file path for the documentationResult, if any. e.g. the path to the file where the symbol described by this documentationResult is located, if it is a symbol.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE codeintel_schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395787_squashed_migrations.up.sql
+++ b/migrations/frontend/1528395787_squashed_migrations.up.sql
@@ -2212,4 +2212,6 @@ INSERT INTO out_of_band_migrations VALUES (1, 'code-intelligence', 'codeintel-db
 
 SELECT pg_catalog.setval('out_of_band_migrations_id_seq', 1, false);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395788_campaigns_ssh_key_migration.up.sql
+++ b/migrations/frontend/1528395788_campaigns_ssh_key_migration.up.sql
@@ -4,4 +4,6 @@ INSERT INTO out_of_band_migrations (id, team, component, description, introduced
 VALUES (2, 'campaigns', 'frontend-db.authenticators', 'Prepare for SSH pushes to code hosts', '3.26.0', '3.27.0', true)
 ON CONFLICT DO NOTHING;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395789_add_encryption_key_ident.down.sql
+++ b/migrations/frontend/1528395789_add_encryption_key_ident.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE external_services DROP COLUMN IF EXISTS encryption_key_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395789_add_encryption_key_ident.up.sql
+++ b/migrations/frontend/1528395789_add_encryption_key_ident.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE external_services ADD COLUMN IF NOT EXISTS encryption_key_id text NOT NULL DEFAULT '';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395790_create_gitserver_repos.down.sql
+++ b/migrations/frontend/1528395790_create_gitserver_repos.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS gitserver_repos;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395790_create_gitserver_repos.up.sql
+++ b/migrations/frontend/1528395790_create_gitserver_repos.up.sql
@@ -10,4 +10,6 @@ CREATE TABLE IF NOT EXISTS gitserver_repos
     updated_at timestamp WITH TIME ZONE default now() not null
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395791_insights_query_runner_jobs_record_time.down.sql
+++ b/migrations/frontend/1528395791_insights_query_runner_jobs_record_time.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE insights_query_runner_jobs DROP COLUMN record_time;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395791_insights_query_runner_jobs_record_time.up.sql
+++ b/migrations/frontend/1528395791_insights_query_runner_jobs_record_time.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE insights_query_runner_jobs ADD COLUMN record_time timestamptz;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395792_add_user_public_repos.down.sql
+++ b/migrations/frontend/1528395792_add_user_public_repos.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS user_public_repos;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395792_add_user_public_repos.up.sql
+++ b/migrations/frontend/1528395792_add_user_public_repos.up.sql
@@ -9,4 +9,6 @@ CREATE TABLE IF NOT EXISTS user_public_repos (
     FOREIGN KEY (repo_id) REFERENCES repo (id) ON DELETE CASCADE
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395793_fix_invalid_changeset_reconciler_states.down.sql
+++ b/migrations/frontend/1528395793_fix_invalid_changeset_reconciler_states.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 UPDATE changesets SET reconciler_state = 'QUEUED' WHERE reconciler_state = 'queued';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395793_fix_invalid_changeset_reconciler_states.up.sql
+++ b/migrations/frontend/1528395793_fix_invalid_changeset_reconciler_states.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 UPDATE changesets SET reconciler_state = 'queued' WHERE reconciler_state = 'QUEUED';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395794_campaigns_rename.down.sql
+++ b/migrations/frontend/1528395794_campaigns_rename.down.sql
@@ -127,4 +127,6 @@ ALTER TABLE changeset_specs RENAME CONSTRAINT "changeset_specs_batch_spec_id_fke
 ALTER TABLE changesets RENAME CONSTRAINT "changesets_owned_by_batch_spec_id_fkey" TO "changesets_owned_by_campaign_id_fkey";
 ALTER TABLE changesets RENAME CONSTRAINT "changesets_batch_change_ids_check" TO "changesets_campaign_ids_check";
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395794_campaigns_rename.up.sql
+++ b/migrations/frontend/1528395794_campaigns_rename.up.sql
@@ -127,4 +127,6 @@ ALTER TABLE changeset_specs RENAME CONSTRAINT "changeset_specs_campaign_spec_id_
 ALTER TABLE changesets RENAME CONSTRAINT "changesets_owned_by_campaign_id_fkey" TO "changesets_owned_by_batch_spec_id_fkey";
 ALTER TABLE changesets RENAME CONSTRAINT "changesets_campaign_ids_check" TO "changesets_batch_change_ids_check";
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395795_add_clone_status_index_to_gitserver_repos.down.sql
+++ b/migrations/frontend/1528395795_add_clone_status_index_to_gitserver_repos.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS gitserver_repos_clone_status_idx;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395795_add_clone_status_index_to_gitserver_repos.up.sql
+++ b/migrations/frontend/1528395795_add_clone_status_index_to_gitserver_repos.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 CREATE INDEX IF NOT EXISTS gitserver_repos_clone_status_idx ON gitserver_repos (clone_status);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395796_alter_cloud_default_constraint.down.sql
+++ b/migrations/frontend/1528395796_alter_cloud_default_constraint.down.sql
@@ -4,4 +4,6 @@ DROP INDEX IF EXISTS kind_cloud_default;
 CREATE UNIQUE INDEX IF NOT EXISTS kind_cloud_default ON external_services (kind, cloud_default)
     WHERE cloud_default = true;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395796_alter_cloud_default_constraint.up.sql
+++ b/migrations/frontend/1528395796_alter_cloud_default_constraint.up.sql
@@ -4,4 +4,6 @@ DROP INDEX IF EXISTS kind_cloud_default;
 CREATE UNIQUE INDEX IF NOT EXISTS kind_cloud_default ON external_services (kind, cloud_default)
     WHERE cloud_default = true AND deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395797_faster_changeset_lookups.down.sql
+++ b/migrations/frontend/1528395797_faster_changeset_lookups.down.sql
@@ -1,1 +1,7 @@
+BEGIN;
+
 DROP INDEX IF EXISTS changesets_batch_change_ids;
+
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
+COMMIT;

--- a/migrations/frontend/1528395798_changeset_title.down.sql
+++ b/migrations/frontend/1528395798_changeset_title.down.sql
@@ -25,4 +25,6 @@ CREATE VIEW reconciler_changesets AS
         )
 ;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395798_changeset_title.up.sql
+++ b/migrations/frontend/1528395798_changeset_title.up.sql
@@ -29,4 +29,6 @@ CREATE VIEW reconciler_changesets AS
         )
 ;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395799_add_clone_status_conditional_indexes.down.sql
+++ b/migrations/frontend/1528395799_add_clone_status_conditional_indexes.down.sql
@@ -5,4 +5,6 @@ DROP INDEX IF EXISTS gitserver_repos_not_cloned_status_idx;
 DROP INDEX IF EXISTS gitserver_repos_cloning_status_idx;
 CREATE INDEX IF NOT EXISTS gitserver_repos_clone_status_idx ON gitserver_repos (repo_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395799_add_clone_status_conditional_indexes.up.sql
+++ b/migrations/frontend/1528395799_add_clone_status_conditional_indexes.up.sql
@@ -8,4 +8,6 @@ CREATE INDEX IF NOT EXISTS gitserver_repos_cloning_status_idx ON gitserver_repos
 
 DROP INDEX IF EXISTS gitserver_repos_clone_status_idx;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395800_add_external_service_repos_index.down.sql
+++ b/migrations/frontend/1528395800_add_external_service_repos_index.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS external_service_repos_idx;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395800_add_external_service_repos_index.up.sql
+++ b/migrations/frontend/1528395800_add_external_service_repos_index.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 CREATE INDEX external_service_repos_idx ON external_service_repos(external_service_id, repo_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395801_search_contexts.down.sql
+++ b/migrations/frontend/1528395801_search_contexts.down.sql
@@ -4,4 +4,6 @@ DROP TABLE IF EXISTS search_context_repos;
 
 DROP TABLE IF EXISTS search_contexts;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395801_search_contexts.up.sql
+++ b/migrations/frontend/1528395801_search_contexts.up.sql
@@ -54,4 +54,6 @@ CREATE TABLE IF NOT EXISTS search_context_repos (
     CONSTRAINT search_context_repos_search_context_id_repo_id_revision_unique UNIQUE (search_context_id, repo_id, revision)
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395802_external_service_config_migration.up.sql
+++ b/migrations/frontend/1528395802_external_service_config_migration.up.sql
@@ -4,4 +4,6 @@ INSERT INTO out_of_band_migrations (id, team, component, description, introduced
 VALUES (3, 'core-application', 'frontend-db.external-services', 'Encrypt configuration', '3.26.0', '3.27.0', true)
 ON CONFLICT DO NOTHING;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.down.sql
+++ b/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.down.sql
@@ -27,4 +27,6 @@ CREATE TRIGGER trig_soft_delete_orphan_repo_by_external_service_repo
     AFTER DELETE ON external_service_repos
     FOR EACH STATEMENT EXECUTE PROCEDURE soft_delete_orphan_repo_by_external_service_repos();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.up.sql
+++ b/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.up.sql
@@ -24,4 +24,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395804_batch_changes_site_credentials.down.sql
+++ b/migrations/frontend/1528395804_batch_changes_site_credentials.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS batch_changes_site_credentials;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395804_batch_changes_site_credentials.up.sql
+++ b/migrations/frontend/1528395804_batch_changes_site_credentials.up.sql
@@ -11,4 +11,6 @@ CREATE TABLE IF NOT EXISTS batch_changes_site_credentials (
 
 CREATE UNIQUE INDEX batch_changes_site_credentials_unique ON batch_changes_site_credentials(external_service_type, external_service_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395805_delete_external_service_trigger.down.sql
+++ b/migrations/frontend/1528395805_delete_external_service_trigger.down.sql
@@ -19,4 +19,6 @@ $$;
 CREATE TRIGGER trig_delete_external_service_ref_on_external_service_repos
     AFTER UPDATE OF deleted_at ON external_services FOR EACH ROW EXECUTE PROCEDURE delete_external_service_ref_on_external_service_repos();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395805_delete_external_service_trigger.up.sql
+++ b/migrations/frontend/1528395805_delete_external_service_trigger.up.sql
@@ -5,4 +5,6 @@ ON external_services;
 
 DROP FUNCTION IF EXISTS delete_external_service_ref_on_external_service_repos();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395806_add_encryption_key_ident.down.sql
+++ b/migrations/frontend/1528395806_add_encryption_key_ident.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE user_external_accounts DROP COLUMN IF EXISTS encryption_key_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395806_add_encryption_key_ident.up.sql
+++ b/migrations/frontend/1528395806_add_encryption_key_ident.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE user_external_accounts ADD COLUMN IF NOT EXISTS encryption_key_id text NOT NULL DEFAULT '';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395807_lsif_locations_migration.up.sql
+++ b/migrations/frontend/1528395807_lsif_locations_migration.up.sql
@@ -8,4 +8,6 @@ INSERT INTO out_of_band_migrations (id, team, component, description, introduced
 VALUES (5, 'code-intelligence', 'codeintel-db.lsif_data_references', 'Populate num_locations from gob-encoded payload', '3.26.0', true)
 ON CONFLICT DO NOTHING;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395808_add_user_id_column_to_external_service_repos.down.sql
+++ b/migrations/frontend/1528395808_add_user_id_column_to_external_service_repos.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 DROP INDEX external_service_user_repos_idx;
 ALTER TABLE external_service_repos DROP COLUMN user_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395808_add_user_id_column_to_external_service_repos.up.sql
+++ b/migrations/frontend/1528395808_add_user_id_column_to_external_service_repos.up.sql
@@ -9,4 +9,6 @@ WHERE es.id = external_service_id AND es.namespace_user_id IS NOT NULL;
 
 CREATE INDEX external_service_user_repos_idx ON external_service_repos(user_id, repo_id) WHERE user_id IS NOT NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395809_external_account_migration.up.sql
+++ b/migrations/frontend/1528395809_external_account_migration.up.sql
@@ -4,4 +4,6 @@ INSERT INTO out_of_band_migrations (id, team, component, description, introduced
 VALUES (6, 'core-application', 'frontend-db.external-accounts', 'Encrypt auth data', '3.26.0', true)
 ON CONFLICT DO NOTHING;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395810_split_document_payload.up.sql
+++ b/migrations/frontend/1528395810_split_document_payload.up.sql
@@ -4,4 +4,6 @@ INSERT INTO out_of_band_migrations (id, team, component, description, introduced
 VALUES (7, 'code-intelligence', 'codeintel-db.lsif_data_documents', 'Split payload into multiple columns', '3.27.0', false)
 ON CONFLICT DO NOTHING;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395811_add_gitserver_repos_last_error_idx.down.sql
+++ b/migrations/frontend/1528395811_add_gitserver_repos_last_error_idx.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS gitserver_repos_last_error_idx;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395811_add_gitserver_repos_last_error_idx.up.sql
+++ b/migrations/frontend/1528395811_add_gitserver_repos_last_error_idx.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 CREATE INDEX IF NOT EXISTS
     gitserver_repos_last_error_idx ON gitserver_repos(last_error) WHERE last_error IS NOT NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.down.sql
+++ b/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.down.sql
@@ -4,4 +4,6 @@ ALTER TABLE global_state
 ADD COLUMN IF NOT EXISTS mgmt_password_plaintext TEXT NOT NULL DEFAULT '',
 ADD COLUMN IF NOT EXISTS mgmt_password_bcrypt TEXT NOT NULL DEFAULT '';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.up.sql
+++ b/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.up.sql
@@ -4,4 +4,6 @@ ALTER TABLE global_state
 DROP COLUMN IF EXISTS mgmt_password_plaintext,
 DROP COLUMN IF EXISTS mgmt_password_bcrypt;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395813_gitserver_repos_add_cascade_delete.down.sql
+++ b/migrations/frontend/1528395813_gitserver_repos_add_cascade_delete.down.sql
@@ -8,4 +8,6 @@ ALTER TABLE gitserver_repos
         FOREIGN KEY (repo_id)
             REFERENCES repo (id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395813_gitserver_repos_add_cascade_delete.up.sql
+++ b/migrations/frontend/1528395813_gitserver_repos_add_cascade_delete.up.sql
@@ -9,4 +9,6 @@ ALTER TABLE gitserver_repos
             REFERENCES repo (id)
             ON DELETE CASCADE;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.down.sql
+++ b/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.down.sql
@@ -8,4 +8,6 @@ ALTER TABLE external_service_sync_jobs
         FOREIGN KEY (external_service_id)
             REFERENCES external_services (id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.up.sql
+++ b/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.up.sql
@@ -9,4 +9,6 @@ ALTER TABLE external_service_sync_jobs
             REFERENCES external_services (id)
             ON DELETE CASCADE;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395815_undeprecate_oob_migrations.up.sql
+++ b/migrations/frontend/1528395815_undeprecate_oob_migrations.up.sql
@@ -6,4 +6,6 @@ BEGIN;
 
 UPDATE out_of_band_migrations SET deprecated = NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395816_changeset_bulk_jobs_table.down.sql
+++ b/migrations/frontend/1528395816_changeset_bulk_jobs_table.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS changeset_jobs;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395816_changeset_bulk_jobs_table.up.sql
+++ b/migrations/frontend/1528395816_changeset_bulk_jobs_table.up.sql
@@ -23,4 +23,6 @@ CREATE TABLE IF NOT EXISTS changeset_jobs (
     updated_at timestamp with time zone NOT NULL DEFAULT now()
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395817_lsif_uploads_committed_at.down.sql
+++ b/migrations/frontend/1528395817_lsif_uploads_committed_at.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 DROP INDEX lsif_uploads_committed_at;
 ALTER TABLE lsif_uploads DROP COLUMN committed_at;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395817_lsif_uploads_committed_at.up.sql
+++ b/migrations/frontend/1528395817_lsif_uploads_committed_at.up.sql
@@ -7,4 +7,6 @@ INSERT INTO out_of_band_migrations (id, team, component, description, introduced
 VALUES (8, 'code-intelligence', 'frontend-db.lsif_uploads', 'Backfill committed_at', '3.28.0', true)
 ON CONFLICT DO NOTHING;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395818_commit_last_checked_at.down.sql
+++ b/migrations/frontend/1528395818_commit_last_checked_at.down.sql
@@ -5,4 +5,6 @@ ALTER TABLE lsif_uploads DROP COLUMN commit_last_checked_at;
 DROP INDEX lsif_indexes_commit_last_checked_at;
 ALTER TABLE lsif_indexes DROP COLUMN commit_last_checked_at;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395818_commit_last_checked_at.up.sql
+++ b/migrations/frontend/1528395818_commit_last_checked_at.up.sql
@@ -5,4 +5,6 @@ CREATE INDEX lsif_uploads_commit_last_checked_at ON lsif_uploads (commit_last_ch
 ALTER TABLE lsif_indexes ADD COLUMN commit_last_checked_at timestamp with time zone;
 CREATE INDEX lsif_indexes_commit_last_checked_at ON lsif_indexes (commit_last_checked_at) WHERE state != 'deleted';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395819_oob_credential_encryption.down.sql
+++ b/migrations/frontend/1528395819_oob_credential_encryption.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 -- We need to leave the new column in place here for the OOB down migration, so
 -- no changes here.
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395819_oob_credential_encryption.up.sql
+++ b/migrations/frontend/1528395819_oob_credential_encryption.up.sql
@@ -49,4 +49,6 @@ CREATE INDEX IF NOT EXISTS
 ON
     user_credentials ((credential_enc IS NULL));
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395820_changeset_job_indexes.down.sql
+++ b/migrations/frontend/1528395820_changeset_job_indexes.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 DROP INDEX IF EXISTS changeset_jobs_state_idx;
 DROP INDEX IF EXISTS changeset_jobs_bulk_group_idx;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395820_changeset_job_indexes.up.sql
+++ b/migrations/frontend/1528395820_changeset_job_indexes.up.sql
@@ -6,4 +6,6 @@ CREATE INDEX IF NOT EXISTS changeset_jobs_state_idx ON changeset_jobs USING BTRE
 -- primary key, because the bulk_group entity doesn't really exist.
 CREATE INDEX IF NOT EXISTS changeset_jobs_bulk_group_idx ON changeset_jobs USING BTREE(bulk_group);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395821_oob_site_credential_encryption.down.sql
+++ b/migrations/frontend/1528395821_oob_site_credential_encryption.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 -- We need to leave the new column in place here for the OOB down migration, so
 -- no changes here.
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395821_oob_site_credential_encryption.up.sql
+++ b/migrations/frontend/1528395821_oob_site_credential_encryption.up.sql
@@ -33,4 +33,6 @@ CREATE INDEX IF NOT EXISTS
 ON
     batch_changes_site_credentials ((credential_enc IS NULL));
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395822_track_encryption_key.down.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.down.sql
@@ -86,4 +86,6 @@ ALTER TABLE
 DROP COLUMN IF EXISTS
     encryption_key_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395822_track_encryption_key.up.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.up.sql
@@ -111,4 +111,6 @@ CREATE INDEX IF NOT EXISTS
 ON
     user_credentials ((encryption_key_id IN ('', 'previously-migrated')));
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395823_feature_flags.down.sql
+++ b/migrations/frontend/1528395823_feature_flags.down.sql
@@ -6,4 +6,6 @@ DROP TABLE IF EXISTS feature_flags;
 
 DROP TYPE feature_flag_type;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395823_feature_flags.up.sql
+++ b/migrations/frontend/1528395823_feature_flags.up.sql
@@ -61,4 +61,6 @@ CREATE INDEX feature_flag_overrides_user_id
 	ON feature_flag_overrides (namespace_user_id)
 	WHERE namespace_user_id IS NOT NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395824_fix_lsif_upload_state_casing.up.sql
+++ b/migrations/frontend/1528395824_fix_lsif_upload_state_casing.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 UPDATE lsif_uploads SET state = 'deleted' WHERE state = 'DELETED';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395825_add_upload_dependency_indexing_jobs.down.sql
+++ b/migrations/frontend/1528395825_add_upload_dependency_indexing_jobs.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE lsif_dependency_indexing_jobs;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395825_add_upload_dependency_indexing_jobs.up.sql
+++ b/migrations/frontend/1528395825_add_upload_dependency_indexing_jobs.up.sql
@@ -17,4 +17,6 @@ CREATE TABLE lsif_dependency_indexing_jobs (
 COMMENT ON TABLE lsif_dependency_indexing_jobs IS 'Tracks jobs that scan imports of indexes to schedule auto-index jobs.';
 COMMENT ON COLUMN lsif_dependency_indexing_jobs.upload_id IS 'The identifier of the triggering upload record.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395826_track_first_version.down.sql
+++ b/migrations/frontend/1528395826_track_first_version.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE versions DROP COLUMN first_version;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395826_track_first_version.up.sql
+++ b/migrations/frontend/1528395826_track_first_version.up.sql
@@ -4,4 +4,6 @@ ALTER TABLE versions ADD COLUMN first_version text;
 UPDATE versions set first_version = version;
 ALTER TABLE versions ALTER COLUMN first_version SET NOT NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395827_oob_enterprise_flag.down.sql
+++ b/migrations/frontend/1528395827_oob_enterprise_flag.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE out_of_band_migrations DROP COLUMN is_enterprise;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395827_oob_enterprise_flag.up.sql
+++ b/migrations/frontend/1528395827_oob_enterprise_flag.up.sql
@@ -10,4 +10,6 @@ ALTER TABLE out_of_band_migrations ALTER COLUMN is_enterprise SET NOT NULL;
 
 COMMENT ON COLUMN out_of_band_migrations.is_enterprise IS 'When true, these migrations are invisible to OSS mode.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395828_split_oob_version_columns.down.sql
+++ b/migrations/frontend/1528395828_split_oob_version_columns.down.sql
@@ -11,4 +11,6 @@ UPDATE out_of_band_migrations SET deprecated = concat(deprecated_version_major, 
 ALTER TABLE out_of_band_migrations DROP COLUMN deprecated_version_major;
 ALTER TABLE out_of_band_migrations DROP COLUMN deprecated_version_minor;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395828_split_oob_version_columns.up.sql
+++ b/migrations/frontend/1528395828_split_oob_version_columns.up.sql
@@ -34,4 +34,6 @@ COMMENT ON COLUMN out_of_band_migrations.introduced_version_minor IS 'The Source
 COMMENT ON COLUMN out_of_band_migrations.deprecated_version_major IS 'The lowest Sourcegraph version (major component) that assumes the migration has completed.';
 COMMENT ON COLUMN out_of_band_migrations.deprecated_version_minor IS 'The lowest Sourcegraph version (minor component) that assumes the migration has completed.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395829_first_version_trigger.down.sql
+++ b/migrations/frontend/1528395829_first_version_trigger.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 DROP TRIGGER versions_insert ON versions;
 DROP FUNCTION versions_insert_row_trigger;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395829_first_version_trigger.up.sql
+++ b/migrations/frontend/1528395829_first_version_trigger.up.sql
@@ -8,4 +8,6 @@ END $lang$;
 
 CREATE TRIGGER versions_insert BEFORE INSERT ON versions FOR EACH ROW EXECUTE PROCEDURE versions_insert_row_trigger();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395830_index_associated_index_id.down.sql
+++ b/migrations/frontend/1528395830_index_associated_index_id.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX lsif_uploads_associated_index_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395830_index_associated_index_id.up.sql
+++ b/migrations/frontend/1528395830_index_associated_index_id.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 CREATE INDEX lsif_uploads_associated_index_id ON lsif_uploads(associated_index_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395831_add_stars_column_to_repo.down.sql
+++ b/migrations/frontend/1528395831_add_stars_column_to_repo.down.sql
@@ -4,4 +4,6 @@ DROP INDEX IF EXISTS repo_stars_idx;
 
 ALTER TABLE repo DROP COLUMN IF EXISTS stars;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395831_add_stars_column_to_repo.up.sql
+++ b/migrations/frontend/1528395831_add_stars_column_to_repo.up.sql
@@ -9,4 +9,6 @@ AND metadata ? 'StargazerCount';
 
 CREATE INDEX IF NOT EXISTS repo_stars_idx ON repo USING BTREE (stars DESC NULLS LAST);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395832_create_security_event_logs_sql.down.sql
+++ b/migrations/frontend/1528395832_create_security_event_logs_sql.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS security_event_logs;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395832_create_security_event_logs_sql.up.sql
+++ b/migrations/frontend/1528395832_create_security_event_logs_sql.up.sql
@@ -33,4 +33,6 @@ COMMENT ON COLUMN security_event_logs.source            IS 'The site section (WE
 COMMENT ON COLUMN security_event_logs.argument          IS 'An arbitrary JSON blob containing event data.';
 COMMENT ON COLUMN security_event_logs.version           IS 'The version of Sourcegraph which generated the event.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395833_feature_flag_events.down.sql
+++ b/migrations/frontend/1528395833_feature_flag_events.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 ALTER TABLE event_logs
 DROP COLUMN feature_flags;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395833_feature_flag_events.up.sql
+++ b/migrations/frontend/1528395833_feature_flag_events.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 ALTER TABLE event_logs
 ADD COLUMN feature_flags jsonb;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395834_add_autoindex_enable.down.sql
+++ b/migrations/frontend/1528395834_add_autoindex_enable.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 ALTER TABLE lsif_index_configuration
   DROP COLUMN IF EXISTS "autoindex_enabled";
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395834_add_autoindex_enable.up.sql
+++ b/migrations/frontend/1528395834_add_autoindex_enable.up.sql
@@ -5,4 +5,6 @@ ALTER TABLE lsif_index_configuration
 
 COMMENT ON COLUMN lsif_index_configuration.autoindex_enabled IS 'Whether or not auto-indexing should be attempted on this repo. Index jobs may be inferred from the repository contents if data is empty.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395835_cohort_id.down.sql
+++ b/migrations/frontend/1528395835_cohort_id.down.sql
@@ -4,4 +4,6 @@ BEGIN;
 ALTER TABLE event_logs
 DROP COLUMN cohort_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395835_cohort_id.up.sql
+++ b/migrations/frontend/1528395835_cohort_id.up.sql
@@ -4,4 +4,6 @@ BEGIN;
 ALTER TABLE event_logs
 ADD COLUMN cohort_id date;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395836_dbworkers_worker_hostname.down.sql
+++ b/migrations/frontend/1528395836_dbworkers_worker_hostname.down.sql
@@ -33,4 +33,6 @@ ALTER TABLE lsif_dependency_indexing_jobs DROP COLUMN IF EXISTS worker_hostname;
 ALTER TABLE lsif_indexes DROP COLUMN IF EXISTS worker_hostname;
 ALTER TABLE lsif_uploads DROP COLUMN IF EXISTS worker_hostname;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395836_dbworkers_worker_hostname.up.sql
+++ b/migrations/frontend/1528395836_dbworkers_worker_hostname.up.sql
@@ -33,4 +33,6 @@ ALTER TABLE lsif_dependency_indexing_jobs ADD COLUMN IF NOT EXISTS worker_hostna
 ALTER TABLE lsif_indexes ADD COLUMN IF NOT EXISTS worker_hostname text NOT NULL DEFAULT '';
 ALTER TABLE lsif_uploads ADD COLUMN IF NOT EXISTS worker_hostname text NOT NULL DEFAULT '';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395837_mark_unmigrated_credentials.down.sql
+++ b/migrations/frontend/1528395837_mark_unmigrated_credentials.down.sql
@@ -14,4 +14,6 @@ SET
 WHERE
     encryption_key_id = 'unmigrated';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395837_mark_unmigrated_credentials.up.sql
+++ b/migrations/frontend/1528395837_mark_unmigrated_credentials.up.sql
@@ -19,4 +19,6 @@ SET
 WHERE
     encryption_key_id = '';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395838_add_blocked_column_to_repo_table.down.sql
+++ b/migrations/frontend/1528395838_add_blocked_column_to_repo_table.down.sql
@@ -7,4 +7,6 @@ DROP FUNCTION IF EXISTS repo_block;
 
 ALTER TABLE IF EXISTS repo DROP COLUMN IF EXISTS blocked;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
+++ b/migrations/frontend/1528395838_add_blocked_column_to_repo_table.up.sql
@@ -13,4 +13,6 @@ $$ LANGUAGE SQL STRICT IMMUTABLE;
 CREATE INDEX repo_blocked_idx ON repo USING BTREE ((blocked IS NOT NULL));
 CREATE INDEX repo_is_not_blocked_idx ON repo USING BTREE ((blocked IS NULL));
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395839_ui_publish_state.down.sql
+++ b/migrations/frontend/1528395839_ui_publish_state.down.sql
@@ -30,4 +30,6 @@ CREATE VIEW reconciler_changesets AS
         )
 ;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395839_ui_publish_state.up.sql
+++ b/migrations/frontend/1528395839_ui_publish_state.up.sql
@@ -35,4 +35,6 @@ CREATE VIEW reconciler_changesets AS
         )
 ;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395840_create_sg_service_role.down.sql
+++ b/migrations/frontend/1528395840_create_sg_service_role.down.sql
@@ -8,4 +8,6 @@ BEGIN;
 -- ref migrations/frontend/1528395861_remove_sg_service_grants.up.sql
 -- ref migrations/frontend/1528395862_remove_sg_service_role.up.sql
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395840_create_sg_service_role.up.sql
+++ b/migrations/frontend/1528395840_create_sg_service_role.up.sql
@@ -8,4 +8,6 @@ BEGIN;
 -- ref migrations/frontend/1528395861_remove_sg_service_grants.up.sql
 -- ref migrations/frontend/1528395862_remove_sg_service_role.up.sql
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395841_add_repo_table_policy.down.sql
+++ b/migrations/frontend/1528395841_add_repo_table_policy.down.sql
@@ -8,4 +8,6 @@ BEGIN;
 -- ref migrations/frontend/1528395861_remove_sg_service_grants.up.sql
 -- ref migrations/frontend/1528395862_remove_sg_service_role.up.sql
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395841_add_repo_table_policy.up.sql
+++ b/migrations/frontend/1528395841_add_repo_table_policy.up.sql
@@ -8,4 +8,6 @@ BEGIN;
 -- ref migrations/frontend/1528395861_remove_sg_service_grants.up.sql
 -- ref migrations/frontend/1528395862_remove_sg_service_role.up.sql
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395842_add_settings_user_id_index.down.sql
+++ b/migrations/frontend/1528395842_add_settings_user_id_index.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS settings_user_id_idx;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395842_add_settings_user_id_index.up.sql
+++ b/migrations/frontend/1528395842_add_settings_user_id_index.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 CREATE INDEX IF NOT EXISTS settings_user_id_idx ON settings USING BTREE (user_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395843_batch_spec_executions_table.down.sql
+++ b/migrations/frontend/1528395843_batch_spec_executions_table.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS batch_spec_executions;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395843_batch_spec_executions_table.up.sql
+++ b/migrations/frontend/1528395843_batch_spec_executions_table.up.sql
@@ -19,4 +19,6 @@ CREATE TABLE IF NOT EXISTS batch_spec_executions (
   batch_spec_id integer REFERENCES batch_specs(id)
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.down.sql
+++ b/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS user_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.up.sql
+++ b/migrations/frontend/1528395844_add_user_id_to_bach_spec_executions.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions ADD COLUMN IF NOT EXISTS user_id int REFERENCES users(id) DEFERRABLE;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395845_batch_spec_execution_namespace.down.sql
+++ b/migrations/frontend/1528395845_batch_spec_execution_namespace.down.sql
@@ -4,4 +4,6 @@ ALTER TABLE IF EXISTS batch_spec_executions DROP CONSTRAINT batch_spec_execution
 ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS namespace_user_id;
 ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS namespace_org_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395845_batch_spec_execution_namespace.up.sql
+++ b/migrations/frontend/1528395845_batch_spec_execution_namespace.up.sql
@@ -5,4 +5,6 @@ ALTER TABLE IF EXISTS batch_spec_executions ADD COLUMN IF NOT EXISTS namespace_o
 UPDATE batch_spec_executions SET namespace_user_id = user_id;
 ALTER TABLE IF EXISTS batch_spec_executions ADD CONSTRAINT batch_spec_executions_has_1_namespace CHECK ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL));
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395846_expand_visible_lsif_uploads.down.sql
+++ b/migrations/frontend/1528395846_expand_visible_lsif_uploads.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 ALTER TABLE lsif_uploads_visible_at_tip DROP COLUMN branch_or_tag_name;
 ALTER TABLE lsif_uploads_visible_at_tip DROP COLUMN is_default_branch;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395846_expand_visible_lsif_uploads.up.sql
+++ b/migrations/frontend/1528395846_expand_visible_lsif_uploads.up.sql
@@ -15,4 +15,6 @@ UPDATE lsif_uploads_visible_at_tip SET is_default_branch = true;
 -- boots up.
 UPDATE lsif_dirty_repositories SET dirty_token = dirty_token + 1;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395847_codeintel_eviction_ages.down.sql
+++ b/migrations/frontend/1528395847_codeintel_eviction_ages.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE lsif_retention_configuration;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395847_codeintel_eviction_ages.up.sql
+++ b/migrations/frontend/1528395847_codeintel_eviction_ages.up.sql
@@ -11,4 +11,6 @@ COMMENT ON TABLE lsif_retention_configuration IS 'Stores the retention policy of
 COMMENT ON COLUMN lsif_retention_configuration.max_age_for_non_stale_branches_seconds IS 'The number of seconds since the last modification of a branch until it is considered stale.';
 COMMENT ON COLUMN lsif_retention_configuration.max_age_for_non_stale_tags_seconds IS 'The nujmber of seconds since the commit date of a tagged commit until it is considered stale.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395848_drop_default_repos.down.sql
+++ b/migrations/frontend/1528395848_drop_default_repos.down.sql
@@ -4,4 +4,6 @@ CREATE TABLE default_repos (
     repo_id integer NOT NULL
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395848_drop_default_repos.up.sql
+++ b/migrations/frontend/1528395848_drop_default_repos.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS default_repos;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395849_drop_unused_indexes.down.sql
+++ b/migrations/frontend/1528395849_drop_unused_indexes.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 CREATE INDEX external_service_repos_external_service_id ON external_service_repos USING btree (external_service_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395849_drop_unused_indexes.up.sql
+++ b/migrations/frontend/1528395849_drop_unused_indexes.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 -- Covered by external_service_repos_idx (external_service_id, repo_id)
 DROP INDEX IF EXISTS external_service_repos_external_service_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395850_add_rand_id_to_batch_spec_executions.down.sql
+++ b/migrations/frontend/1528395850_add_rand_id_to_batch_spec_executions.down.sql
@@ -4,4 +4,6 @@ DROP INDEX IF EXISTS batch_spec_executions_rand_id;
 
 ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS rand_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395850_add_rand_id_to_batch_spec_executions.up.sql
+++ b/migrations/frontend/1528395850_add_rand_id_to_batch_spec_executions.up.sql
@@ -4,4 +4,6 @@ ALTER TABLE IF EXISTS batch_spec_executions ADD COLUMN IF NOT EXISTS rand_id tex
 
 CREATE INDEX batch_spec_executions_rand_id ON batch_spec_executions USING btree (rand_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395851_workerutil_last_updated_at.down.sql
+++ b/migrations/frontend/1528395851_workerutil_last_updated_at.down.sql
@@ -11,4 +11,6 @@ ALTER TABLE lsif_dependency_indexing_jobs DROP COLUMN last_heartbeat_at;
 ALTER TABLE lsif_indexes DROP COLUMN last_heartbeat_at;
 ALTER TABLE lsif_uploads DROP COLUMN last_heartbeat_at;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395851_workerutil_last_updated_at.up.sql
+++ b/migrations/frontend/1528395851_workerutil_last_updated_at.up.sql
@@ -11,4 +11,6 @@ ALTER TABLE lsif_dependency_indexing_jobs ADD COLUMN last_heartbeat_at timestamp
 ALTER TABLE lsif_indexes ADD COLUMN last_heartbeat_at timestamp with time zone;
 ALTER TABLE lsif_uploads ADD COLUMN last_heartbeat_at timestamp with time zone;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395852_lsif_add_covering_index.down.sql
+++ b/migrations/frontend/1528395852_lsif_add_covering_index.down.sql
@@ -6,4 +6,6 @@ DROP INDEX lsif_packages_scheme_name_version_dump_id;
 CREATE INDEX lsif_references_package ON lsif_references(scheme, name, version);
 DROP INDEX lsif_references_scheme_name_version_dump_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395852_lsif_add_covering_index.up.sql
+++ b/migrations/frontend/1528395852_lsif_add_covering_index.up.sql
@@ -6,4 +6,6 @@ DROP INDEX lsif_packages_scheme_name_version;
 CREATE INDEX lsif_references_scheme_name_version_dump_id ON lsif_references(scheme, name, version, dump_id);
 DROP INDEX lsif_references_package;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395853_add_deleting_state.down.sql
+++ b/migrations/frontend/1528395853_add_deleting_state.down.sql
@@ -44,4 +44,6 @@ CREATE VIEW lsif_dumps_with_repository_name AS SELECT u.id,
     r.name AS repository_name
 FROM lsif_dumps u JOIN repo r ON r.id = u.repository_id WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395853_add_deleting_state.up.sql
+++ b/migrations/frontend/1528395853_add_deleting_state.up.sql
@@ -47,4 +47,6 @@ FROM lsif_dumps u
 JOIN repo r ON r.id = u.repository_id
 WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395854_add_priority_insights_queryrunner.down.sql
+++ b/migrations/frontend/1528395854_add_priority_insights_queryrunner.down.sql
@@ -4,4 +4,6 @@ ALTER TABLE insights_query_runner_jobs
 
 ALTER TABLE insights_query_runner_jobs
     DROP COLUMN cost;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395854_add_priority_insights_queryrunner.up.sql
+++ b/migrations/frontend/1528395854_add_priority_insights_queryrunner.up.sql
@@ -11,5 +11,7 @@ COMMENT ON COLUMN insights_query_runner_jobs.cost IS 'Integer representing a cos
 CREATE INDEX insights_query_runner_jobs_priority_idx on insights_query_runner_jobs(priority);
 CREATE INDEX insights_query_runner_jobs_cost_idx on insights_query_runner_jobs(cost);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;
 

--- a/migrations/frontend/1528395855_add-missing-execution-logs-cols.down.sql
+++ b/migrations/frontend/1528395855_add-missing-execution-logs-cols.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 ALTER TABLE IF EXISTS cm_trigger_jobs DROP COLUMN IF EXISTS execution_logs;
 ALTER TABLE IF EXISTS cm_action_jobs  DROP COLUMN IF EXISTS execution_logs;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395855_add-missing-execution-logs-cols.up.sql
+++ b/migrations/frontend/1528395855_add-missing-execution-logs-cols.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 ALTER TABLE IF EXISTS cm_trigger_jobs ADD COLUMN IF NOT EXISTS execution_logs JSON[];
 ALTER TABLE IF EXISTS cm_action_jobs  ADD COLUMN IF NOT EXISTS execution_logs JSON[];
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395856_add_missing_execution_logs_cols_for_real.down.sql
+++ b/migrations/frontend/1528395856_add_missing_execution_logs_cols_for_real.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS lsif_uploads DROP COLUMN IF EXISTS execution_logs;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395856_add_missing_execution_logs_cols_for_real.up.sql
+++ b/migrations/frontend/1528395856_add_missing_execution_logs_cols_for_real.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS lsif_uploads ADD COLUMN IF NOT EXISTS execution_logs JSON[];
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395857_last_fetched.down.sql
+++ b/migrations/frontend/1528395857_last_fetched.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 
 ALTER TABLE gitserver_repos DROP COLUMN last_fetched;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395857_last_fetched.up.sql
+++ b/migrations/frontend/1528395857_last_fetched.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 
 ALTER TABLE gitserver_repos ADD COLUMN last_fetched TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395858_drop_lsif_indexable_repositories.down.sql
+++ b/migrations/frontend/1528395858_drop_lsif_indexable_repositories.down.sql
@@ -13,4 +13,6 @@ CREATE TABLE lsif_indexable_repositories (
 
 CREATE UNIQUE INDEX lsif_indexable_repositories_repository_id_key ON lsif_indexable_repositories (repository_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395858_drop_lsif_indexable_repositories.up.sql
+++ b/migrations/frontend/1528395858_drop_lsif_indexable_repositories.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS lsif_indexable_repositories;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.down.sql
+++ b/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions ALTER CONSTRAINT batch_spec_executions_batch_spec_id_fkey NOT DEFERRABLE;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.up.sql
+++ b/migrations/frontend/1528395859_make_batch_spec_executions_batch_spec_id_deferrable.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions ALTER CONSTRAINT batch_spec_executions_batch_spec_id_fkey DEFERRABLE;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395860_remove_repo_table_policy.down.sql
+++ b/migrations/frontend/1528395860_remove_repo_table_policy.down.sql
@@ -4,4 +4,6 @@ BEGIN;
 -- level security to application-level code. Prior migrations that created the
 -- policy have also been removed.
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395860_remove_repo_table_policy.up.sql
+++ b/migrations/frontend/1528395860_remove_repo_table_policy.up.sql
@@ -5,4 +5,6 @@ BEGIN;
 DROP POLICY IF EXISTS sg_repo_access_policy ON repo;
 ALTER TABLE repo DISABLE ROW LEVEL SECURITY;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395861_remove_sg_service_grants.down.sql
+++ b/migrations/frontend/1528395861_remove_sg_service_grants.down.sql
@@ -4,4 +4,6 @@ BEGIN;
 -- level security to application-level code. Prior migrations that created the
 -- grants have also been removed.
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395861_remove_sg_service_grants.up.sql
+++ b/migrations/frontend/1528395861_remove_sg_service_grants.up.sql
@@ -14,4 +14,6 @@ EXCEPTION WHEN undefined_object THEN
 END;
 $$;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395862_remove_sg_service_role.down.sql
+++ b/migrations/frontend/1528395862_remove_sg_service_role.down.sql
@@ -4,4 +4,6 @@ BEGIN;
 -- level security to application-level code. Prior migrations that created the
 -- role have also been removed.
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395862_remove_sg_service_role.up.sql
+++ b/migrations/frontend/1528395862_remove_sg_service_role.up.sql
@@ -11,4 +11,6 @@ EXCEPTION WHEN dependent_objects_still_exist THEN
 END;
 $$;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395863_event_logs_public_properties_column.down.sql
+++ b/migrations/frontend/1528395863_event_logs_public_properties_column.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS event_logs DROP COLUMN IF EXISTS public_argument;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395863_event_logs_public_properties_column.up.sql
+++ b/migrations/frontend/1528395863_event_logs_public_properties_column.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS event_logs ADD COLUMN IF NOT EXISTS public_argument JSONB DEFAULT '{}'::jsonb NOT NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395864_create_temporary_settings.down.sql
+++ b/migrations/frontend/1528395864_create_temporary_settings.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS temporary_settings;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395864_create_temporary_settings.up.sql
+++ b/migrations/frontend/1528395864_create_temporary_settings.up.sql
@@ -14,4 +14,6 @@ COMMENT ON TABLE temporary_settings IS 'Stores per-user temporary settings used 
 COMMENT ON COLUMN temporary_settings.user_id IS 'The ID of the user the settings will be saved for.';
 COMMENT ON COLUMN temporary_settings.contents IS 'JSON-encoded temporary settings.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395865_insights_job_dependencies.down.sql
+++ b/migrations/frontend/1528395865_insights_job_dependencies.down.sql
@@ -10,4 +10,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS insights_query_runner_jobs_dependencies;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395865_insights_job_dependencies.up.sql
+++ b/migrations/frontend/1528395865_insights_job_dependencies.up.sql
@@ -22,4 +22,6 @@ COMMENT ON TABLE insights_query_runner_jobs_dependencies IS 'Stores data points 
 COMMENT ON COLUMN insights_query_runner_jobs_dependencies.job_id IS 'Foreign key to the job that owns this record.';
 COMMENT ON COLUMN insights_query_runner_jobs_dependencies.recording_time IS 'The time for which this dependency should be recorded at using the parents value.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395866_insights_queue_reset.down.sql
+++ b/migrations/frontend/1528395866_insights_queue_reset.down.sql
@@ -8,4 +8,6 @@ BEGIN;
 --  * Historically we advised against transactions since we thought the
 --    migrate library handled it. However, it does not! /facepalm
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395866_insights_queue_reset.up.sql
+++ b/migrations/frontend/1528395866_insights_queue_reset.up.sql
@@ -16,4 +16,6 @@ BEGIN;
 -- Note: This data is by design ephemeral, so there is no risk of permanent data loss here.
 
 TRUNCATE insights_query_runner_jobs CASCADE;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395867_batch-spec-executions-cancel.down.sql
+++ b/migrations/frontend/1528395867_batch-spec-executions-cancel.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions DROP COLUMN IF EXISTS cancel;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395867_batch-spec-executions-cancel.up.sql
+++ b/migrations/frontend/1528395867_batch-spec-executions-cancel.up.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE IF EXISTS batch_spec_executions ADD COLUMN IF NOT EXISTS cancel BOOL DEFAULT FALSE;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395868_insights_queue_dependencies_index.down.sql
+++ b/migrations/frontend/1528395868_insights_queue_dependencies_index.down.sql
@@ -9,4 +9,6 @@ BEGIN;
 --    migrate library handled it. However, it does not! /facepalm
 
 DROP INDEX IF EXISTS insights_query_runner_jobs_dependencies_job_id_fk_idx;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395868_insights_queue_dependencies_index.up.sql
+++ b/migrations/frontend/1528395868_insights_queue_dependencies_index.up.sql
@@ -10,4 +10,6 @@ BEGIN;
 
 CREATE INDEX insights_query_runner_jobs_dependencies_job_id_fk_idx ON insights_query_runner_jobs_dependencies(job_id);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395869_add_lsif_configuration_policy.down.sql
+++ b/migrations/frontend/1528395869_add_lsif_configuration_policy.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS lsif_configuration_policies;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395869_add_lsif_configuration_policy.up.sql
+++ b/migrations/frontend/1528395869_add_lsif_configuration_policy.up.sql
@@ -26,4 +26,6 @@ COMMENT ON COLUMN lsif_configuration_policies.indexing_enabled IS 'Whether or no
 COMMENT ON COLUMN lsif_configuration_policies.index_commit_max_age_hours IS 'The max age of commits indexed by this configuration policy. If null, the age is unbounded.';
 COMMENT ON COLUMN lsif_configuration_policies.index_intermediate_commits IS 'If the matching Git object is a branch, setting this value to true will also index all commits on the matching branches. Setting this value to false will only consider the tip of the branch.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395870_codeintel_dependency_repos.down.sql
+++ b/migrations/frontend/1528395870_codeintel_dependency_repos.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE IF EXISTS lsif_dependency_repos;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395870_codeintel_dependency_repos.up.sql
+++ b/migrations/frontend/1528395870_codeintel_dependency_repos.up.sql
@@ -9,4 +9,6 @@ CREATE TABLE IF NOT EXISTS lsif_dependency_repos (
         UNIQUE (scheme, name, version)
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395871_insights_queue_state_index.down.sql
+++ b/migrations/frontend/1528395871_insights_queue_state_index.down.sql
@@ -9,4 +9,6 @@ BEGIN;
 --    migrate library handled it. However, it does not! /facepalm
 
 drop index if exists insights_query_runner_jobs_processable_priority_id;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395871_insights_queue_state_index.up.sql
+++ b/migrations/frontend/1528395871_insights_queue_state_index.up.sql
@@ -8,4 +8,6 @@ BEGIN;
 --    migrate library handled it. However, it does not! /facepalm
 CREATE INDEX IF NOT EXISTS insights_query_runner_jobs_processable_priority_id ON insights_query_runner_jobs (priority, id) WHERE state = 'queued' OR state = 'errored';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395872_lsif_upload_reference_counts.down.sql
+++ b/migrations/frontend/1528395872_lsif_upload_reference_counts.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE lsif_uploads DROP COLUMN num_references;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395872_lsif_upload_reference_counts.up.sql
+++ b/migrations/frontend/1528395872_lsif_upload_reference_counts.up.sql
@@ -3,4 +3,6 @@ BEGIN;
 ALTER TABLE lsif_uploads ADD COLUMN num_references int;
 COMMENT ON COLUMN lsif_uploads.num_references IS 'The number of references to this upload data from other upload records (via lsif_references).';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395873_lsif_upload_reference_counts_oob_migration.down.sql
+++ b/migrations/frontend/1528395873_lsif_upload_reference_counts_oob_migration.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 -- Do not remove oob migration when downgrading
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395873_lsif_upload_reference_counts_oob_migration.up.sql
+++ b/migrations/frontend/1528395873_lsif_upload_reference_counts_oob_migration.up.sql
@@ -4,4 +4,6 @@ INSERT INTO out_of_band_migrations (id, team, component, description, introduced
 VALUES (11, 'code-intelligence', 'lsif_uploads.num_references', 'Backfill LSIF upload reference counts', 3, 22, true)
 ON CONFLICT DO NOTHING;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395874_lsif_nearest_uploads_indexes.down.sql
+++ b/migrations/frontend/1528395874_lsif_nearest_uploads_indexes.down.sql
@@ -3,4 +3,6 @@ BEGIN;
 DROP INDEX lsif_nearest_uploads_uploads;
 DROP INDEX lsif_nearest_uploads_links_repository_id_ancestor_commit_bytea;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395874_lsif_nearest_uploads_indexes.up.sql
+++ b/migrations/frontend/1528395874_lsif_nearest_uploads_indexes.up.sql
@@ -6,4 +6,6 @@ CREATE INDEX lsif_nearest_uploads_uploads ON lsif_nearest_uploads USING GIN(uplo
 -- Allow for lookup from commit to the set of commits that have analogous nearest uploads.
 CREATE INDEX lsif_nearest_uploads_links_repository_id_ancestor_commit_bytea ON lsif_nearest_uploads_links(repository_id, ancestor_commit_bytea);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395875_lsif_upload_expired_flag.down.sql
+++ b/migrations/frontend/1528395875_lsif_upload_expired_flag.down.sql
@@ -78,4 +78,6 @@ CREATE VIEW lsif_dumps_with_repository_name AS
     JOIN repo r ON r.id = u.repository_id
     WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395875_lsif_upload_expired_flag.up.sql
+++ b/migrations/frontend/1528395875_lsif_upload_expired_flag.up.sql
@@ -82,4 +82,6 @@ CREATE VIEW lsif_dumps_with_repository_name AS
     JOIN repo r ON r.id = u.repository_id
     WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395876_lsif_last_retention_scan.down.sql
+++ b/migrations/frontend/1528395876_lsif_last_retention_scan.down.sql
@@ -79,4 +79,6 @@ CREATE VIEW lsif_dumps_with_repository_name AS
     JOIN repo r ON r.id = u.repository_id
     WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395876_lsif_last_retention_scan.up.sql
+++ b/migrations/frontend/1528395876_lsif_last_retention_scan.up.sql
@@ -92,4 +92,6 @@ CREATE VIEW lsif_dumps_with_repository_name AS
     JOIN repo r ON r.id = u.repository_id
     WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395877_index-lsif-uploads-repo.down.sql
+++ b/migrations/frontend/1528395877_index-lsif-uploads-repo.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS lsif_uploads_repository_id;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395878_index-lsif-indexes-repo.down.sql
+++ b/migrations/frontend/1528395878_index-lsif-indexes-repo.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP INDEX IF EXISTS lsif_indexes_repository_id_commit;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395879_repair_lsif_configuration_policies.down.sql
+++ b/migrations/frontend/1528395879_repair_lsif_configuration_policies.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 -- Nothing on down
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395879_repair_lsif_configuration_policies.up.sql
+++ b/migrations/frontend/1528395879_repair_lsif_configuration_policies.up.sql
@@ -28,4 +28,6 @@ COMMENT ON COLUMN lsif_configuration_policies.indexing_enabled IS 'Whether or no
 COMMENT ON COLUMN lsif_configuration_policies.index_commit_max_age_hours IS 'The max age of commits indexed by this configuration policy. If null, the age is unbounded.';
 COMMENT ON COLUMN lsif_configuration_policies.index_intermediate_commits IS 'If the matching Git object is a branch, setting this value to true will also index all commits on the matching branches. Setting this value to false will only consider the tip of the branch.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395880_insights_queue_persist_mode.down.sql
+++ b/migrations/frontend/1528395880_insights_queue_persist_mode.down.sql
@@ -11,4 +11,6 @@ BEGIN;
 ALTER TABLE insights_query_runner_jobs
     DROP COLUMN persist_mode;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395880_insights_queue_persist_mode.up.sql
+++ b/migrations/frontend/1528395880_insights_queue_persist_mode.up.sql
@@ -13,4 +13,6 @@ ALTER TABLE insights_query_runner_jobs
     ADD persist_mode PersistMode DEFAULT 'record' NOT NULL;
 
 COMMENT ON COLUMN insights_query_runner_jobs.persist_mode IS 'The persistence level for this query. This value will determine the lifecycle of the resulting value.';
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395881_add_batch_spec_workspaces.down.sql
+++ b/migrations/frontend/1528395881_add_batch_spec_workspaces.down.sql
@@ -4,4 +4,6 @@ DROP TABLE IF EXISTS batch_spec_workspace_execution_jobs;
 DROP TABLE IF EXISTS batch_spec_workspaces;
 DROP TABLE IF EXISTS batch_spec_resolution_jobs;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395881_add_batch_spec_workspaces.up.sql
+++ b/migrations/frontend/1528395881_add_batch_spec_workspaces.up.sql
@@ -60,4 +60,6 @@ CREATE TABLE IF NOT EXISTS batch_spec_workspace_execution_jobs (
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395882_lsif_configuration_protected_policies.down.sql
+++ b/migrations/frontend/1528395882_lsif_configuration_protected_policies.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 ALTER TABLE lsif_configuration_policies DROP COLUMN protected;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395882_lsif_configuration_protected_policies.up.sql
+++ b/migrations/frontend/1528395882_lsif_configuration_protected_policies.up.sql
@@ -6,4 +6,6 @@ ALTER TABLE lsif_configuration_policies ALTER COLUMN protected SET NOT NULL;
 
 COMMENT ON COLUMN lsif_configuration_policies.protected IS 'Whether or not this configuration policy is protected from modification of its data retention behavior (except for duration).';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395883_default_lsif_configuration_policies.down.sql
+++ b/migrations/frontend/1528395883_default_lsif_configuration_policies.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 -- Nothing on down
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395883_default_lsif_configuration_policies.up.sql
+++ b/migrations/frontend/1528395883_default_lsif_configuration_policies.up.sql
@@ -20,4 +20,6 @@ VALUES
         false, false, 0
     );
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395884_add_cancel_to_batch_spec_workspace_execution_jobs.down.sql
+++ b/migrations/frontend/1528395884_add_cancel_to_batch_spec_workspace_execution_jobs.down.sql
@@ -5,4 +5,6 @@ DROP INDEX IF EXISTS batch_spec_workspace_execution_jobs_cancel;
 ALTER TABLE IF EXISTS batch_spec_workspace_execution_jobs
   DROP COLUMN IF EXISTS cancel;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395884_add_cancel_to_batch_spec_workspace_execution_jobs.up.sql
+++ b/migrations/frontend/1528395884_add_cancel_to_batch_spec_workspace_execution_jobs.up.sql
@@ -6,4 +6,6 @@ ALTER TABLE IF EXISTS batch_spec_workspace_execution_jobs
 CREATE INDEX IF NOT EXISTS batch_spec_workspace_execution_jobs_cancel
   ON batch_spec_workspace_execution_jobs (cancel);
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395885_lsif_last_retention_scan_views.down.sql
+++ b/migrations/frontend/1528395885_lsif_last_retention_scan_views.down.sql
@@ -76,4 +76,6 @@ CREATE VIEW lsif_dumps_with_repository_name AS
     JOIN repo r ON r.id = u.repository_id
     WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395885_lsif_last_retention_scan_views.up.sql
+++ b/migrations/frontend/1528395885_lsif_last_retention_scan_views.up.sql
@@ -79,4 +79,6 @@ CREATE VIEW lsif_dumps_with_repository_name AS
     JOIN repo r ON r.id = u.repository_id
     WHERE r.deleted_at IS NULL;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395886_add_missing_fk_indexes1.down.sql
+++ b/migrations/frontend/1528395886_add_missing_fk_indexes1.down.sql
@@ -1,3 +1,5 @@
 BEGIN;
 DROP INDEX IF EXISTS lsif_dependency_indexing_jobs_upload_id;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395887_add_missing_fk_indexes2.down.sql
+++ b/migrations/frontend/1528395887_add_missing_fk_indexes2.down.sql
@@ -1,3 +1,5 @@
 BEGIN;
 DROP INDEX IF EXISTS lsif_packages_dump_id;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395888_add_missing_fk_indexes3.down.sql
+++ b/migrations/frontend/1528395888_add_missing_fk_indexes3.down.sql
@@ -1,3 +1,5 @@
 BEGIN;
 DROP INDEX IF EXISTS lsif_references_dump_id;
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.down.sql
+++ b/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.down.sql
@@ -4,4 +4,6 @@ ALTER TABLE
     out_of_band_migrations
 DROP COLUMN IF EXISTS metadata;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.up.sql
+++ b/migrations/frontend/1528395889_add_metadata_column_to_oobmigration.up.sql
@@ -5,4 +5,6 @@ ALTER TABLE
 ADD COLUMN IF NOT EXISTS
     metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395890_drop_repo_cloned.down.sql
+++ b/migrations/frontend/1528395890_drop_repo_cloned.down.sql
@@ -7,4 +7,6 @@ ALTER TABLE
 ADD COLUMN IF NOT EXISTS
     cloned bool NOT NULL DEFAULT false;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395890_drop_repo_cloned.up.sql
+++ b/migrations/frontend/1528395890_drop_repo_cloned.up.sql
@@ -4,4 +4,6 @@ ALTER TABLE
     repo
 DROP COLUMN IF EXISTS cloned;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395891_lsif_dependency_indexing_queueing.down.sql
+++ b/migrations/frontend/1528395891_lsif_dependency_indexing_queueing.down.sql
@@ -6,4 +6,6 @@ DROP TABLE IF EXISTS lsif_dependency_indexing_jobs;
 ALTER TABLE lsif_dependency_syncing_jobs
 RENAME TO lsif_dependency_indexing_jobs;
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;

--- a/migrations/frontend/1528395891_lsif_dependency_indexing_queueing.up.sql
+++ b/migrations/frontend/1528395891_lsif_dependency_indexing_queueing.up.sql
@@ -25,4 +25,6 @@ CREATE TABLE IF NOT EXISTS lsif_dependency_indexing_jobs (
 COMMENT ON COLUMN lsif_dependency_indexing_jobs.external_service_kind IS 'Filter the external services for this kind to wait to have synced. If empty, external_service_sync is ignored and no external services are polled for their last sync time.';
 COMMENT ON COLUMN lsif_dependency_indexing_jobs.external_service_sync IS 'The sync time after which external services of the given kind will have synced/created any repositories referenced by the LSIF upload that are resolvable.';
 
+-- Clear the dirty flag in case the operator timed out and isn't around to clear it.
+UPDATE schema_migrations SET dirty = 'f'
 COMMIT;


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/25089 (this PR will remain a draft unless and until we decide to move forward with this approach).

**Prior to this change**, it was possible for a migration to complete successfully but leave the dirty flag set to true.

**After this change**, each migration will set the dirty flag to false within the transaction, so that the dirty flag is cleared even if the frontend disconnects halfway through ✨ 

Script I used to update all the migrations: https://gist.github.com/chrismwendt/80c8f68ce12bc9c9e6638bd22971d581#file-clear-dirty-flag-py