### PR TITLE
only fetch full user data once

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
-	golang.org/x/tools v0.1.5
+	golang.org/x/tools v0.1.6
 	google.golang.org/api v0.54.0
 	google.golang.org/genproto v0.0.0-20210824181836-a4879c3d0e89
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -1548,6 +1548,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/zenazn/goji v0.9.1-0.20160507202103-64eb34159fe5/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/zenazn/goji v1.0.1 h1:4lbD8Mx2h7IvloP7r2C0D6ltZP6Ufip8Hn0wmSK5LR8=
@@ -1739,6 +1740,7 @@ golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20170517211232-f52d1811a629/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1852,6 +1854,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1974,8 +1977,9 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.6 h1:SIasE1FVIQOWz2GEAHFOmoW7xchJcqlucjSULTL0Ag4=
+golang.org/x/tools v0.1.6/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -63,6 +63,9 @@ func (a *Actor) User(ctx context.Context, fetcher userFetcher) (*types.User, err
 	a.userOnce.Do(func() {
 		a.user, a.userErr = fetcher.GetByID(ctx, a.UID)
 	})
+	if a.user.ID != a.UID {
+		panic(fmt.Sprintf("actor UID (%d) and the ID of the cached User (%d) do not match", a.UID, a.user.ID))
+	}
 	return a.user, a.userErr
 }
 

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // Actor represents an agent that accesses resources. It can represent an anonymous user, an
@@ -24,6 +26,11 @@ type Actor struct {
 	// to selectively display a logout link. (If the actor wasn't authenticated with a session
 	// cookie, logout would be ineffective.)
 	FromSessionCookie bool `json:"-"`
+
+	// user is populated lazily by (*Actor).User()
+	user     *types.User
+	userErr  error
+	userOnce sync.Once
 }
 
 // FromUser returns an actor corresponding to a user
@@ -44,6 +51,19 @@ func (a *Actor) IsAuthenticated() bool {
 // IsInternal returns true if the Actor is an internal actor.
 func (a *Actor) IsInternal() bool {
 	return a != nil && a.Internal
+}
+
+type userFetcher interface {
+	GetByID(context.Context, int32) (*types.User, error)
+}
+
+// User returns the expanded types.User for the actor's ID. The ID is expanded to a full
+// types.User using the fetcher, which is likely a *database.UserStore.
+func (a *Actor) User(ctx context.Context, fetcher userFetcher) (*types.User, error) {
+	a.userOnce.Do(func() {
+		a.user, a.userErr = fetcher.GetByID(ctx, a.UID)
+	})
+	return a.user, a.userErr
 }
 
 type key int

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -738,7 +738,7 @@ func (u *UserStore) GetByCurrentAuthUser(ctx context.Context) (*types.User, erro
 		return nil, ErrNoCurrentUser
 	}
 
-	return u.getOneBySQL(ctx, sqlf.Sprintf("WHERE id=%s AND deleted_at IS NULL LIMIT 1", a.UID))
+	return a.User(ctx, u)
 }
 
 func (u *UserStore) InvalidateSessionsByID(ctx context.Context, id int32) (err error) {

--- a/internal/honey/search.go
+++ b/internal/honey/search.go
@@ -21,18 +21,20 @@ type SearchEventArgs struct {
 
 // SearchEvent returns a honey event for the dataset "search".
 func SearchEvent(ctx context.Context, args SearchEventArgs) *libhoney.Event {
+	act := &actor.Actor{}
+	if a := actor.FromContext(ctx); a != nil {
+		act = a
+	}
 	ev := Event("search")
 	ev.AddField("query", args.OriginalQuery)
+	ev.AddField("actor_uid", act.UID)
+	ev.AddField("actor_internal", act.Internal)
 	ev.AddField("type", args.Typ)
 	ev.AddField("source", args.Source)
 	ev.AddField("status", args.Status)
 	ev.AddField("alert_type", args.AlertType)
 	ev.AddField("duration_ms", args.DurationMs)
 	ev.AddField("result_size", args.ResultSize)
-	if a := actor.FromContext(ctx); a != nil {
-		ev.AddField("actor_uid", a.UID)
-		ev.AddField("actor_internal", a.Internal)
-	}
 	if args.Error != nil {
 		ev.AddField("error", args.Error.Error())
 	}

--- a/internal/honey/search.go
+++ b/internal/honey/search.go
@@ -21,20 +21,18 @@ type SearchEventArgs struct {
 
 // SearchEvent returns a honey event for the dataset "search".
 func SearchEvent(ctx context.Context, args SearchEventArgs) *libhoney.Event {
-	var act actor.Actor
-	if a := actor.FromContext(ctx); a != nil {
-		act = *a
-	}
 	ev := Event("search")
 	ev.AddField("query", args.OriginalQuery)
-	ev.AddField("actor_uid", act.UID)
-	ev.AddField("actor_internal", act.Internal)
 	ev.AddField("type", args.Typ)
 	ev.AddField("source", args.Source)
 	ev.AddField("status", args.Status)
 	ev.AddField("alert_type", args.AlertType)
 	ev.AddField("duration_ms", args.DurationMs)
 	ev.AddField("result_size", args.ResultSize)
+	if a := actor.FromContext(ctx); a != nil {
+		ev.AddField("actor_uid", a.UID)
+		ev.AddField("actor_internal", a.Internal)
+	}
 	if args.Error != nil {
 		ev.AddField("error", args.Error.Error())
 	}


### PR DESCRIPTION
We are currently fetching user metadata many times over the course of 
a request (search `u.id` in the find bar in [this trace](https://sourcegraph.grafana.net/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22grafanacloud-sourcegraph-traces%22,%7B%22query%22:%224330561d42f12c22%22,%22queryType%22:%22traceId%22%7D%5D)).
According to Query Insights, it is the 5th most-executed query
on sourcegraph.com.

At least three of these (often more) are on the critical path
for streaming search latency, so even though they're cheap (<1ms), that
adds up to a few additional milliseconds of latency for every request.

This PR modifies the Actor to store the result of a user fetch so this
only needs to be done once per request. This felt like the least invasive 
way to do this since it doesn't require changing any consumers of 
`GetByCurrentAuthUser`, but I'm always open to alternatives. 