### PR TITLE
SG: Add the teammate time|handbook commands 

### DIFF
--- a/dev/sg/go.mod
+++ b/dev/sg/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.8.1 // indirect
@@ -47,6 +48,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/slack-go/slack v0.9.5 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect

--- a/dev/sg/go.sum
+++ b/dev/sg/go.sum
@@ -212,6 +212,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
@@ -325,6 +326,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -646,6 +649,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/slack-go/slack v0.9.5 h1:j7uOUDowybWf9eSgZg/AbGx6J1OPJB6SE8Z5dNl6Mtw=
+github.com/slack-go/slack v0.9.5/go.mod h1:wWL//kk0ho+FcQXcBTmEafUI5dz4qz5f4mMk8oIkioQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowflakedb/glog v0.0.0-20180824191149-f5055e6f21ce/go.mod h1:EB/w24pR5VKI60ecFnKqXzxX3dOorz1rnVicQTQrGM0=

--- a/dev/sg/internal/slack/slack.go
+++ b/dev/sg/internal/slack/slack.go
@@ -125,10 +125,22 @@ func queryUserHandbook(token, nick string) (string, error) {
 // a list of possible matches.
 func findUserByNickname(users []slack.User, nickname string) *slack.User {
 	nickname = strings.ToLower(nickname)
+	nickname = strings.TrimPrefix(nickname, "@")
 	for _, u := range users {
 		if strings.ToLower(u.Profile.DisplayName) == nickname || strings.ToLower(u.Profile.RealName) == nickname {
 			return &u
 		}
 	}
-	return nil
+
+	// No user found, try to guess now
+	candidates := []*slack.User{}
+	for _, u := range users {
+		if strings.HasPrefix(strings.ToLower(u.Profile.RealName), nickname) {
+			candidates = append(candidates, &u)
+		}
+	}
+	if len(candidates) > 1 {
+		return nil
+	}
+	return candidates[0]
 }

--- a/dev/sg/internal/slack/slack.go
+++ b/dev/sg/internal/slack/slack.go
@@ -78,7 +78,11 @@ func queryUserCurrentTime(token, nick string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	str := fmt.Sprintf("%s's current time is %s", nick, time.Now().In(loc).Format(time.RFC822))
+	t := time.Now().In(loc)
+	t2 := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
+	diff := t2.Sub(t) / time.Hour
+
+	str := fmt.Sprintf("%s's current time is %s (%dh from your local time)", nick, t.Format(time.RFC822), diff)
 	return str, nil
 }
 

--- a/dev/sg/internal/slack/slack.go
+++ b/dev/sg/internal/slack/slack.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	ErrUserNotFound                = errors.New("User not found")
-	out             *output.Output = stdout.Out
+	out *output.Output = stdout.Out
 )
 
 type slackToken struct {
@@ -72,7 +71,7 @@ func queryUserCurrentTime(token, nick string) (string, error) {
 	}
 	u := findUserByNickname(users, nick)
 	if u == nil {
-		return "", errors.Wrapf(err, "cannot find nickname '%s'", nick)
+		return "", fmt.Errorf("cannot find user with nickname '%s'", nick)
 	}
 	loc, err := time.LoadLocation(u.TZ)
 	if err != nil {
@@ -104,21 +103,21 @@ func queryUserHandbook(token, nick string) (string, error) {
 	}
 	u := findUserByNickname(users, nick)
 	if u == nil {
-		return "", errors.Wrapf(err, "cannot find nickname '%s'", nick)
+		return "", fmt.Errorf("cannot find user with nickname '%s'", nick)
 	}
 	p, err := api.GetUserProfile(&slack.GetUserProfileParameters{
 		UserID:        u.ID,
 		IncludeLabels: true,
 	})
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	for _, v := range p.FieldsMap() {
 		if v.Label == "Handbook link" {
 			return v.Value, nil
 		}
 	}
-	return "", ErrUserNotFound
+	return "", fmt.Errorf("no handbook link found for %s", nick)
 }
 
 // findUserByNickname searches for a user by its nickname, e.g. what we type in Slack after a '@' character.

--- a/dev/sg/internal/slack/slack.go
+++ b/dev/sg/internal/slack/slack.go
@@ -1,0 +1,131 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/slack-go/slack"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var (
+	ErrUserNotFound                = errors.New("User not found")
+	out             *output.Output = stdout.Out
+)
+
+type slackToken struct {
+	Token string `json:"token"`
+}
+
+// retrieveToken obtains a token either from the cached configuration or by asking the user for it.
+func retrieveToken(ctx context.Context) (string, error) {
+	sec := secrets.FromContext(ctx)
+	tok := slackToken{}
+	err := sec.Get("slack", &tok)
+	if errors.Is(err, secrets.ErrSecretNotFound) {
+		str, err := getTokenFromUser()
+		if err != nil {
+			return "", nil
+		}
+		if err := sec.PutAndSave("slack", slackToken{Token: str}); err != nil {
+			return "", err
+		}
+		return str, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return tok.Token, nil
+}
+
+// getTokenFromUser prompts the user for a slack OAuth token.
+func getTokenFromUser() (string, error) {
+	out.WriteLine(output.Linef("", output.StyleWarning, "Please find the Slack OAuth Token in the 1Password vault named 'TODO'"))
+	fmt.Printf("Paste it here: ")
+	var token string
+	if _, err := fmt.Scan(&token); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// QueryUserCurrentTime returns a given sourcegrapher current time, in its own timezone.
+func QueryUserCurrentTime(ctx context.Context, nick string) (string, error) {
+	token, err := retrieveToken(ctx)
+	if err != nil {
+		return "", err
+	}
+	return queryUserCurrentTime(token, nick)
+}
+
+func queryUserCurrentTime(token, nick string) (string, error) {
+	// api := slack.New(token, slack.OptionDebug(true))
+	api := slack.New(token)
+	users, err := api.GetUsers()
+	if err != nil {
+		return "", err
+	}
+	u := findUserByNickname(users, nick)
+	if u == nil {
+		return "", errors.Wrapf(err, "cannot find nickname '%s'", nick)
+	}
+	loc, err := time.LoadLocation(u.TZ)
+	if err != nil {
+		return "", err
+	}
+	str := fmt.Sprintf("%s's current time is %s", nick, time.Now().In(loc).Format(time.RFC822))
+	return str, nil
+}
+
+// QueryUserHandbook returns a link to a given sourcegrapher handbook profile.
+func QueryUserHandbook(ctx context.Context, nick string) (string, error) {
+	token, err := retrieveToken(ctx)
+	if err != nil {
+		return "", err
+	}
+	return queryUserHandbook(token, nick)
+}
+
+func queryUserHandbook(token, nick string) (string, error) {
+	// api := slack.New(token, slack.OptionDebug(true))
+	api := slack.New(token)
+	users, err := api.GetUsers()
+	if err != nil {
+		return "", err
+	}
+	u := findUserByNickname(users, nick)
+	if u == nil {
+		return "", errors.Wrapf(err, "cannot find nickname '%s'", nick)
+	}
+	p, err := api.GetUserProfile(&slack.GetUserProfileParameters{
+		UserID:        u.ID,
+		IncludeLabels: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	for _, v := range p.FieldsMap() {
+		if v.Label == "Handbook link" {
+			return v.Value, nil
+		}
+	}
+	return "", ErrUserNotFound
+}
+
+// findUserByNickname searches for a user by its nickname, e.g. what we type in Slack after a '@' character.
+// TODO would be great to have some "did you mean" and use Levenshtein distance or something else to return
+// a list of possible matches.
+func findUserByNickname(users []slack.User, nickname string) *slack.User {
+	nickname = strings.ToLower(nickname)
+	for _, u := range users {
+		if strings.ToLower(u.Profile.DisplayName) == nickname || strings.ToLower(u.Profile.RealName) == nickname {
+			return &u
+		}
+	}
+	return nil
+}

--- a/dev/sg/internal/slack/slack.go
+++ b/dev/sg/internal/slack/slack.go
@@ -81,7 +81,7 @@ func queryUserCurrentTime(token, nick string) (string, error) {
 	t2 := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
 	diff := t2.Sub(t) / time.Hour
 
-	str := fmt.Sprintf("%s's current time is %s (%dh from your local time)", nick, t.Format(time.RFC822), diff)
+	str := fmt.Sprintf("%s's current time is %s (%dh from your local time)", u.Profile.RealName, t.Format(time.RFC822), diff)
 	return str, nil
 }
 
@@ -121,8 +121,6 @@ func queryUserHandbook(token, nick string) (string, error) {
 }
 
 // findUserByNickname searches for a user by its nickname, e.g. what we type in Slack after a '@' character.
-// TODO would be great to have some "did you mean" and use Levenshtein distance or something else to return
-// a list of possible matches.
 func findUserByNickname(users []slack.User, nickname string) *slack.User {
 	nickname = strings.ToLower(nickname)
 	nickname = strings.TrimPrefix(nickname, "@")
@@ -133,14 +131,14 @@ func findUserByNickname(users []slack.User, nickname string) *slack.User {
 	}
 
 	// No user found, try to guess now
-	candidates := []*slack.User{}
+	candidates := []slack.User{}
 	for _, u := range users {
 		if strings.HasPrefix(strings.ToLower(u.Profile.RealName), nickname) {
-			candidates = append(candidates, &u)
+			candidates = append(candidates, u)
 		}
 	}
-	if len(candidates) > 1 {
-		return nil
+	if len(candidates) == 1 {
+		return &candidates[0]
 	}
-	return candidates[0]
+	return nil
 }

--- a/dev/sg/internal/slack/slack.go
+++ b/dev/sg/internal/slack/slack.go
@@ -45,7 +45,7 @@ func retrieveToken(ctx context.Context) (string, error) {
 
 // getTokenFromUser prompts the user for a slack OAuth token.
 func getTokenFromUser() (string, error) {
-	out.WriteLine(output.Linef("", output.StyleWarning, "Please find the Slack OAuth Token in the 1Password vault named 'TODO'"))
+	out.WriteLine(output.Linef("", output.StyleWarning, `Please copy the content of "SG Slack Integration" from the "Shared" 1Password vault`))
 	fmt.Printf("Paste it here: ")
 	var token string
 	if _, err := fmt.Scan(&token); err != nil {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -56,7 +56,7 @@ var (
 			migrationCommand,
 			rfcCommand,
 			funkLogoCommand,
-			teammatesCommand,
+			teammateCommand,
 		},
 	}
 )

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -56,6 +56,7 @@ var (
 			migrationCommand,
 			rfcCommand,
 			funkLogoCommand,
+			teammatesCommand,
 		},
 	}
 )

--- a/dev/sg/sg_team.go
+++ b/dev/sg/sg_team.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"flag"
+
+	"github.com/cockroachdb/errors"
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/slack"
+)
+
+var (
+	teammatesFlagSet = flag.NewFlagSet("sg teammates", flag.ExitOnError)
+	teammatesCommand = &ffcli.Command{
+		Name:       "teammates",
+		ShortUsage: "sg teammates [time|handbook]",
+		ShortHelp:  "Run the given teammates command show informations about teammates",
+		LongHelp:   `Display current time, handbook link of sourcegraphers`,
+		FlagSet:    teammatesFlagSet,
+		Exec:       teammatesExec,
+	}
+)
+
+func teammatesExec(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("no teammates command given")
+	}
+	switch args[0] {
+	case "time":
+		if len(args) != 2 {
+			return errors.New("no nickname given")
+		}
+		str, err := slack.QueryUserCurrentTime(ctx, args[1])
+		if err != nil {
+			return err
+		}
+		out.Writef(str)
+		return nil
+	case "handbook":
+		if len(args) != 2 {
+			return errors.New("no nickname given")
+		}
+		str, err := slack.QueryUserHandbook(ctx, args[1])
+		if err != nil {
+			return err
+		}
+		open.URL(str)
+		return nil
+	default:
+		return nil
+	}
+}

--- a/dev/sg/sg_team.go
+++ b/dev/sg/sg_team.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -48,6 +49,6 @@ func teammateExec(ctx context.Context, args []string) error {
 		open.URL(str)
 		return nil
 	default:
-		return errors.New("unknown teammate command")
+		return fmt.Errorf("unknown teammate command: %s", args[0])
 	}
 }

--- a/dev/sg/sg_team.go
+++ b/dev/sg/sg_team.go
@@ -11,20 +11,20 @@ import (
 )
 
 var (
-	teammatesFlagSet = flag.NewFlagSet("sg teammates", flag.ExitOnError)
-	teammatesCommand = &ffcli.Command{
-		Name:       "teammates",
-		ShortUsage: "sg teammates [time|handbook]",
+	teammateFlagSet = flag.NewFlagSet("sg teammate", flag.ExitOnError)
+	teammateCommand = &ffcli.Command{
+		Name:       "teammate",
+		ShortUsage: "sg teammate [time|handbook]",
 		ShortHelp:  "Run the given teammates command show informations about teammates",
 		LongHelp:   `Display current time, handbook link of sourcegraphers`,
-		FlagSet:    teammatesFlagSet,
-		Exec:       teammatesExec,
+		FlagSet:    teammateFlagSet,
+		Exec:       teammateExec,
 	}
 )
 
-func teammatesExec(ctx context.Context, args []string) error {
+func teammateExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return errors.New("no teammates command given")
+		return errors.New("no teammate command given")
 	}
 	switch args[0] {
 	case "time":
@@ -48,6 +48,6 @@ func teammatesExec(ctx context.Context, args []string) error {
 		open.URL(str)
 		return nil
 	default:
-		return nil
+		return errors.New("unknown teammate command")
 	}
 }

--- a/dev/sg/sg_team.go
+++ b/dev/sg/sg_team.go
@@ -16,9 +16,9 @@ var (
 	teammateFlagSet = flag.NewFlagSet("sg teammate", flag.ExitOnError)
 	teammateCommand = &ffcli.Command{
 		Name:       "teammate",
-		ShortUsage: "sg teammate [time|handbook]",
-		ShortHelp:  "Run the given teammates command show informations about teammates",
-		LongHelp:   `Display current time, handbook link of sourcegraphers`,
+		ShortUsage: "sg teammate [time|handbook] nickname",
+		ShortHelp:  "Run the given teammates command show infos about your teammates.",
+		LongHelp:   `Display current time, handbook link of sourcegraphers.`,
 		FlagSet:    teammateFlagSet,
 		Exec:       teammateExec,
 	}

--- a/dev/sg/sg_team.go
+++ b/dev/sg/sg_team.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -26,7 +25,7 @@ var (
 
 func teammateExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return errors.New("no teammate command given")
+		return flag.ErrHelp
 	}
 	switch args[0] {
 	case "time":
@@ -50,6 +49,6 @@ func teammateExec(ctx context.Context, args []string) error {
 		open.URL(str)
 		return nil
 	default:
-		return fmt.Errorf("unknown teammate command: %s", args[0])
+		return flag.ErrHelp
 	}
 }

--- a/dev/sg/sg_team.go
+++ b/dev/sg/sg_team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -29,20 +30,20 @@ func teammateExec(ctx context.Context, args []string) error {
 	}
 	switch args[0] {
 	case "time":
-		if len(args) != 2 {
+		if len(args) < 2 {
 			return errors.New("no nickname given")
 		}
-		str, err := slack.QueryUserCurrentTime(ctx, args[1])
+		str, err := slack.QueryUserCurrentTime(ctx, strings.Join(args[1:], " "))
 		if err != nil {
 			return err
 		}
 		out.Writef(str)
 		return nil
 	case "handbook":
-		if len(args) != 2 {
+		if len(args) < 2 {
 			return errors.New("no nickname given")
 		}
-		str, err := slack.QueryUserHandbook(ctx, args[1])
+		str, err := slack.QueryUserHandbook(ctx, strings.Join(args[1:], " "))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds the `people time` and `people handbook` commands to `sg`. 

TODO:
- [x] Display errors instead of silently failing when a user is not found
- [x] Try to guess usernames, for example I should be able to type `sg people time thorsten` instead of `sg people time "thorsten ball"` 

While the code querying the Slack API is pretty straightforward, obtaining the token isn't. For the RFCs, this content is already public so we don't care (I think?) if we publish the `appID` and `appSecret` to query our google docs. 

When it comes to Slack, that resource is technically internal to SG, so that would be an issue to publish those AFAIU (1).  So I took the route of assuming that we have the token stored in our 1Password vault (search for _SG Slack Integration_, I was able to create one already).

Unless I am mistaken regarding how to handle access, I think that's a fair trade-off for now. If you have a better idea, please tell me! 

---

```
$ sg people time "Thorsten Ball"
Thorsten Ball's current time is 19 Sep 21 15:42 CEST
```
 
```
$ sg people time "Thorsten Ball"
# open a browser on handbook profile
```

(1) Also, Slack's OAuth does not support `urn:ietf:wg:oauth:2.0:oob` as a redirect URI to display the code, we could use `https://postmane-echo.com/get` for example but that's a bit meh as well.  All of that to say, that yeah the 1Password token seems to be the shortest route to this up and running. 