### PR TITLE
internal/repos: Wrap error from Store.Transact for context

### DIFF
--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -241,7 +241,7 @@ func (s *Store) DeleteExternalServiceRepo(ctx context.Context, svc *types.Extern
 	if !s.InTransaction() {
 		s, err = s.Transact(ctx)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "DeleteExternalServiceRepo")
 		}
 		defer func() { s.Done(err) }()
 	}
@@ -402,7 +402,7 @@ func (s *Store) CreateExternalServiceRepo(ctx context.Context, svc *types.Extern
 	if !s.InTransaction() {
 		s, err = s.Transact(ctx)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "CreateExternalServiceRepo")
 		}
 		defer func() { s.Done(err) }()
 	}
@@ -511,7 +511,7 @@ func (s *Store) UpdateExternalServiceRepo(ctx context.Context, svc *types.Extern
 	if !s.InTransaction() {
 		s, err = s.Transact(ctx)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "UpdateExternalServiceRep")
 		}
 		defer func() { s.Done(err) }()
 	}

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -511,7 +511,7 @@ func (s *Store) UpdateExternalServiceRepo(ctx context.Context, svc *types.Extern
 	if !s.InTransaction() {
 		s, err = s.Transact(ctx)
 		if err != nil {
-			return errors.Wrap(err, "UpdateExternalServiceRep")
+			return errors.Wrap(err, "UpdateExternalServiceRepo")
 		}
 		defer func() { s.Done(err) }()
 	}


### PR DESCRIPTION
We're seeing frequent "starting transaction: context deadline
exceeded" errors  on production. Wrapping the errors to add more
context could help narrowing down the cause.

Link to logs: https://sourcegraph.grafana.net/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22grafanacloud-sourcegraph-logs%22,%7B%22expr%22:%22%7Bapp%3D%5C%22repo-updater%5C%22,%20namespace%3D%5C%22prod%5C%22%7D%20%7C%3D%20%5C%22context%20deadline%20exceeded%5C%22%22%7D%5D



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
