### PR TITLE
Fix .gitignore for img assets

### DIFF
--- a/ui/assets/.gitignore
+++ b/ui/assets/.gitignore
@@ -3,8 +3,8 @@
 *.svg
 !fonts/*.css
 *.map
-*.DS_Store
 *.ttf
 *.woff2
 *.png
 !img/**
+*.DS_Store

--- a/ui/assets/.gitignore
+++ b/ui/assets/.gitignore
@@ -3,8 +3,8 @@
 *.svg
 !fonts/*.css
 *.map
-!img/**
 *.DS_Store
 *.ttf
 *.woff2
 *.png
+!img/**


### PR DESCRIPTION
Currently there are a few assets checked in which are gitignored at the same time. This is caused by the specific order in which they were defined in the gitignore

This would fix the redundant files nuked in the following 2 PRs:
- https://github.com/sourcegraph/sourcegraph/pull/25087
- https://github.com/sourcegraph/sourcegraph/pull/25079


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
