### PR TITLE
docs: adding code host connections on local dev env

### DIFF
--- a/doc/dev/background-information/code-host.md
+++ b/doc/dev/background-information/code-host.md
@@ -19,13 +19,16 @@ site config JSON file:
 
 ## Enabling for specific users
 
-To enable code host connections for a user, two flags need to be set:
+To enable code host connections for a user, one of two flags need to be set:
 `AllowUserExternalServicePublic` and `AllowUserExternalServicePrivate`.
-These flags may not be set when testing locally. You can run the following
-SQL command to set the flags for all users in your local test instance:
+The former allows users to add public repositories, while the latter allows
+users to add both public and private repositories.
+These flags may not already be set when testing locally. You can run the following
+SQL command to set the flags for a user in your local test instance
+(replace `{USER ID HERE}` with the user ID):
 
 ```sql
-update users 
-set tags = '{AllowUserExternalServicePublic,AllowUserExternalServicePrivate}'
-where id={USER ID HERE};
+update users
+set tags = array_append(tags, 'AllowUserExternalServicePrivate')
+where not ('AllowUserExternalServicePrivate'=any(tags)) and id = {USER ID HERE};
 ```

--- a/doc/dev/background-information/code-host.md
+++ b/doc/dev/background-information/code-host.md
@@ -5,11 +5,27 @@ Connecting to a code host is required to develop and test certain features, incl
 - Adding public and private repositories
 - Creating and modifying search contexts
 
-To enable code host connections, two flags need to be set for a user:
+To enable code host connections, there are two options: enabling site-wide or
+enabling for a specific user.
+
+## Enabling site-wide (enabled by default on local dev environment)
+
+Code host connections can be enabled site-wide by adding the following to the
+site config JSON file:
+
+```json
+"externalService.userMode": "all"
+```
+
+## Enabling for specific users
+
+To enable code host connections for a user, two flags need to be set:
 `AllowUserExternalServicePublic` and `AllowUserExternalServicePrivate`.
 These flags may not be set when testing locally. You can run the following
 SQL command to set the flags for all users in your local test instance:
 
 ```sql
-update users set tags = '{AllowUserExternalServicePublic,AllowUserExternalServicePrivate}';
+update users 
+set tags = '{AllowUserExternalServicePublic,AllowUserExternalServicePrivate}'
+where id={USER ID HERE};
 ```

--- a/doc/dev/background-information/code-host.md
+++ b/doc/dev/background-information/code-host.md
@@ -1,0 +1,15 @@
+# Code host connections on local dev environment
+
+Connecting to a code host is required to develop and test certain features, including:
+
+- Adding public and private repositories
+- Creating and modifying search contexts
+
+To enable code host connections, two flags need to be set for a user:
+`AllowUserExternalServicePublic` and `AllowUserExternalServicePrivate`.
+These flags may not be set when testing locally. You can run the following
+SQL command to set the flags for all users in your local test instance:
+
+```sql
+update users set tags = '{AllowUserExternalServicePublic,AllowUserExternalServicePrivate}';
+```

--- a/doc/dev/background-information/index.md
+++ b/doc/dev/background-information/index.md
@@ -37,6 +37,7 @@
 - [Developing an out-of-band migration](oobmigrations.md)
 - [Developing a background routine](backgroundroutine.md)
 - [High-performance SQL](sql.md)
+- [Code host connections on local dev environment](code-host.md)
 
 ## [Languages](languages/index.md)
 

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -103,6 +103,8 @@ Clarification and discussion about key concepts, architecture, and development s
 - [Developing a worker](background-information/workers.md)
 - [Developing an out-of-band migration](background-information/oobmigrations.md)
 - [Developing a background routine](background-information/backgroundroutine.md)
+- [High-performance SQL](background-information/sql.md)
+- [Code host connections on local dev environment](background-information/code-host.md)
 
 ### [Languages](background-information/languages/index.md)
 


### PR DESCRIPTION
There are currently no docs on how to enable code host connections on local dev environment, so adding it here.