### PR TITLE
endpoint: use serviceName when constructing StatefulSet pod names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- StatefulSet service discovery in Kubernetes correctly constructs pod hostnames in the case where the ServiceName is different from the StatefulSet name. [#25146](https://github.com/sourcegraph/sourcegraph/pull/25146)
 
 ### Removed
 


### PR DESCRIPTION
We incorrectly assumed the serviceName was always the same as the
StatefulSet name. We now correctly construct the pod name as described
by the kubernetes documentation.