### PR TITLE
web: wait for auth redirects to fix e2e tests

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -210,7 +210,17 @@ export class Driver {
             localStorage.setItem('has-dismissed-integrations-toast', 'true')
             localStorage.setItem('has-dismissed-survey-toast', 'true')
         })
+
+        /**
+         * Wait for redirects to complete to avoid using an outdated page URL.
+         *
+         * In case a user is not authenticated, and site-init is required, two redirects happen:
+         * 1. Redirect to /sign-in?returnTo=%2F
+         * 2. Redirect to /site-admin/init
+         */
+        await delay(1000)
         const url = new URL(this.page.url())
+
         if (url.pathname === '/site-admin/init') {
             await this.page.waitForSelector('.test-signup-form')
             if (email) {

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -204,13 +204,6 @@ export class Driver {
         password: string
         email?: string
     }): Promise<void> {
-        await this.page.goto(this.sourcegraphBaseUrl)
-        await this.page.evaluate(() => {
-            localStorage.setItem('has-dismissed-browser-ext-toast', 'true')
-            localStorage.setItem('has-dismissed-integrations-toast', 'true')
-            localStorage.setItem('has-dismissed-survey-toast', 'true')
-        })
-
         /**
          * Wait for redirects to complete to avoid using an outdated page URL.
          *
@@ -218,7 +211,13 @@ export class Driver {
          * 1. Redirect to /sign-in?returnTo=%2F
          * 2. Redirect to /site-admin/init
          */
-        await delay(1000)
+        await this.page.goto(this.sourcegraphBaseUrl, { waitUntil: 'networkidle0' })
+        await this.page.evaluate(() => {
+            localStorage.setItem('has-dismissed-browser-ext-toast', 'true')
+            localStorage.setItem('has-dismissed-integrations-toast', 'true')
+            localStorage.setItem('has-dismissed-survey-toast', 'true')
+        })
+
         const url = new URL(this.page.url())
 
         if (url.pathname === '/site-admin/init') {

--- a/client/web/src/components/HeroPage.tsx
+++ b/client/web/src/components/HeroPage.tsx
@@ -38,7 +38,11 @@ export const HeroPage: React.FunctionComponent<HeroPageProps> = props => (
             </div>
         )}
         {props.title && <div className={styles.title}>{props.title}</div>}
-        {props.subtitle && <div className={styles.subtitle}>{props.subtitle}</div>}
+        {props.subtitle && (
+            <div data-testid="hero-page-subtitle" className={styles.subtitle}>
+                {props.subtitle}
+            </div>
+        )}
         {props.detail && <div>{props.detail}</div>}
         {props.body}
         {props.cta && <div className={styles.cta}>{props.cta}</div>}

--- a/client/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/client/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`ErrorBoundary passes through if non-error 1`] = `
   </div>
   <div
     className="subtitle"
+    data-testid="hero-page-subtitle"
   >
     <div
       className="container"
@@ -57,6 +58,7 @@ exports[`ErrorBoundary renders reload page if chunk error 1`] = `
   </div>
   <div
     className="subtitle"
+    data-testid="hero-page-subtitle"
   >
     <div
       className="container"

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -904,10 +904,14 @@ describe('e2e test suite', () => {
         describe('revision resolution', () => {
             test('shows clone in progress interstitial page', async () => {
                 await driver.page.goto(sourcegraphBaseUrl + '/github.com/sourcegraphtest/AlwaysCloningTest')
-                await driver.page.waitForSelector('.hero-page__subtitle', { visible: true })
+                await driver.page.waitForSelector('[data-testid="hero-page-subtitle"]', {
+                    visible: true,
+                })
                 await retry(async () =>
                     expect(
-                        await driver.page.evaluate(() => document.querySelector('.hero-page__subtitle')?.textContent)
+                        await driver.page.evaluate(
+                            () => document.querySelector('[data-testid="hero-page-subtitle"]')?.textContent
+                        )
                     ).toEqual('Cloning in progress')
                 )
             })


### PR DESCRIPTION
## Context

End-to-end tests [started failing](https://buildkite.com/sourcegraph/e2e/builds/16318#cd73f8da-93bf-4272-a14c-d428e6f7cc1f) recently because of the auth redirects race condition. We relied on the outdated URL in the e2e test logic to perform authentication. 

## Changes

- This PR adds a small delay that ensures that redirects are completed.