### PR TITLE
ci: run puppeteer tests with more concurrent jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook",
-    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=2 \"./client/web/src/integration/**/*.test.ts\"",
+    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=${CI_INTEGRATION_MOCHA_JOBS:-2} \"./client/web/src/integration/**/*.test.ts\"",
     "test-browser-integration": "yarn --cwd client/browser run test-integration",
     "cover-integration": "nyc --hook-require=false yarn test-integration",
     "cover-browser-integration": "nyc --hook-require=false yarn --cwd client/browser test-integration",


### PR DESCRIPTION
ℹ️  See Testing branch/pr at #25130
**TL;DR**: shave off 6 minutes from the Pupetteer build step.

--- 

Our Puppeteers tests are run concurrently but with a very low job count. The job usually takes [about 16 minutes](https://buildkite.com/sourcegraph/sourcegraph/builds/108877#d693e64c-30a8-436c-9b66-8bb786f3d93d) to complete. 

Because our Buildkite agents are really beefy ([13-15 CPUs and 13-15Gb of memory](https://sourcegraph.com/github.com/sourcegraph/infrastructure/-/blob/buildkite/kubernetes/buildkite-agent/buildkite-agent.Deployment.yaml?L226-231)) their size allow for running more jobs than just two. 

With a job count of 8, the above job is now down to 9 to 10 minutes. This number was achieved empirically, the default is to have `core count - 1` jobs, but as we are running Chromium in those tests, that results in failures and potential flakiness. 

You can find an example failure documented here, with instructions on how to fix it, in case it's preventing to ship critical changes: https://gist.github.com/jhchabran/0a6e3dd73299400fdec983e07fbbac20 

A note about this has been added to the step, so people can find the solution next to the problem and immediately report to us if they see something. 

I propose that we observe for a couple of days how the builds are performing, which will lead to maybe increase or decrease that number, if we see random failures happening. Once we're pretty confident this isn't messing with the pipeline robustness, we can remove the PSA. 

<img width="904" alt="image" src="https://user-images.githubusercontent.com/10151/134162129-da81e260-af51-4404-87e5-31fcfd1970bd.png">

