### PR TITLE
search: honeycomb for debugging poison queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,7 @@ require (
 	github.com/prometheus/common v0.30.0
 	github.com/qustavo/sqlhooks/v2 v2.1.0
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be
+	github.com/rs/xid v1.3.0
 	github.com/russellhaering/gosaml2 v0.6.0
 	github.com/russellhaering/goxmldsig v1.1.1-0.20201210191726-3541f5e554ee
 	github.com/schollz/progressbar/v3 v3.5.0
@@ -271,7 +272,6 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
-	github.com/rs/xid v1.3.0 // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17 // indirect
 	github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480 // indirect


### PR DESCRIPTION
We add a special dataset to try and catch poison queries in production.
It will log both before and after a search query against zoekt. We plan
on using honeycomb to find all queries where grouping by xid only has 1
row.