### PR TITLE
convert unnecessary panic to error

### DIFF
--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -64,7 +66,7 @@ func (a *Actor) User(ctx context.Context, fetcher userFetcher) (*types.User, err
 		a.user, a.userErr = fetcher.GetByID(ctx, a.UID)
 	})
 	if a.user.ID != a.UID {
-		panic(fmt.Sprintf("actor UID (%d) and the ID of the cached User (%d) do not match", a.UID, a.user.ID))
+		return nil, errors.Errorf("actor UID (%d) and the ID of the cached User (%d) do not match", a.UID, a.user.ID)
 	}
 	return a.user, a.userErr
 }


### PR DESCRIPTION
Panic is not needed since this method already returns an error. 

https://github.com/sourcegraph/sourcegraph/pull/25091#discussion_r712763316
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
