### PR TITLE
search: fix TestCachedSearcher flakiness

### DIFF
--- a/internal/search/backend/cached_test.go
+++ b/internal/search/backend/cached_test.go
@@ -19,7 +19,7 @@ func TestCachedSearcher(t *testing.T) {
 		}},
 	}
 
-	ttl := time.Second
+	ttl := 30 * time.Second
 	s := NewCachedSearcher(ttl, ms)
 
 	now := time.Now()


### PR DESCRIPTION
We had a ttl of 1 second in the test. However, we did a jitter sleep of
5s. This meant depending on the jitter, the test would fail. Note: we
don't actually sleep for 30s now, we mock time.