### PR TITLE
web: Add aria-labels to menu buttons

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-action/DrillDownFiltersPanel.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-action/DrillDownFiltersPanel.tsx
@@ -51,7 +51,7 @@ export const DrillDownFiltersAction: React.FunctionComponent<DrillDownFiltersPro
                     [styles.filterButtonWithOpenPanel]: isOpen,
                     [styles.filterButtonActive]: isFiltered,
                 })}
-                aria-label={isFiltered ? 'Active filters button' : 'Filters button'}
+                aria-label={isFiltered ? 'Active filters' : 'Filters'}
                 // To prevent grid layout position change animation. Attempts to drag
                 // the filter panel should not trigger react-grid-layout events.
                 onMouseDown={event => event.stopPropagation()}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -1,7 +1,6 @@
 import { Menu, MenuButton, MenuItem, MenuItems, MenuLink, MenuPopover } from '@reach/menu-button'
 import classnames from 'classnames'
 import { noop } from 'lodash'
-import CheckIcon from 'mdi-react/CheckIcon'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'
 import React, { useContext } from 'react'
 import { Link } from 'react-router-dom'
@@ -73,14 +72,7 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                                     onSelect={onToggleZeroYAxisMin}
                                     aria-checked={zeroYAxisMin}
                                 >
-                                    <input
-                                        type="checkbox"
-                                        className="sr-only"
-                                        aria-hidden="true"
-                                        checked={zeroYAxisMin}
-                                        onChange={noop}
-                                    />
-                                    <CheckIcon size={16} className={classnames('mr-2', { invisible: !zeroYAxisMin })} />{' '}
+                                    <input type="checkbox" aria-hidden="true" checked={zeroYAxisMin} onChange={noop} />
                                     <span>Start Y Axis at 0</span>
                                 </MenuItem>
                             )}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -55,7 +55,7 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                             <MenuLink
                                 as={Link}
                                 data-testid="InsightContextMenuEditLink"
-                                className={classnames('btn btn-outline', styles.item)}
+                                className={styles.item}
                                 to={editUrl}
                             >
                                 Edit
@@ -72,7 +72,13 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                                     onSelect={onToggleZeroYAxisMin}
                                     aria-checked={zeroYAxisMin}
                                 >
-                                    <input type="checkbox" aria-hidden="true" checked={zeroYAxisMin} onChange={noop} tabIndex={-1} />
+                                    <input
+                                        type="checkbox"
+                                        aria-hidden="true"
+                                        checked={zeroYAxisMin}
+                                        onChange={noop}
+                                        tabIndex={-1}
+                                    />
                                     <span>Start Y Axis at 0</span>
                                 </MenuItem>
                             )}
@@ -80,7 +86,7 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                             <MenuItem
                                 data-testid="insight-context-menu-delete-button"
                                 onSelect={() => onDelete(insightID)}
-                                className={classnames('btn btn-outline-', styles.item)}
+                                className={styles.item}
                             >
                                 Delete
                             </MenuItem>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuButton, MenuItem, MenuItems, MenuLink, MenuPopover } from '@reach/menu-button'
 import classnames from 'classnames'
+import { noop } from 'lodash'
 import CheckIcon from 'mdi-react/CheckIcon'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'
 import React, { useContext } from 'react'
@@ -40,7 +41,7 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                     <MenuButton
                         data-testid="InsightContextMenuButton"
                         className={classnames(menuButtonClassName, 'btn btn-outline p-1', styles.button)}
-                        aria-label="Insight context menu"
+                        aria-label="Insight options"
                     >
                         <DotsVerticalIcon
                             className={classnames(styles.buttonIcon, { [styles.buttonIconActive]: isOpen })}
@@ -62,15 +63,26 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                             </MenuLink>
 
                             {showYAxisToggleMenu && (
-                                <MenuLink
+                                <MenuItem
+                                    role="menuitemcheckbox"
                                     data-testid="InsightContextMenuEditLink"
-                                    className={classnames('btn btn-outline border-bottom', styles.item)}
-                                    onClick={onToggleZeroYAxisMin}
+                                    className={classnames(
+                                        'd-flex align-items-center justify-content-between',
+                                        styles.item
+                                    )}
+                                    onSelect={onToggleZeroYAxisMin}
+                                    aria-checked={zeroYAxisMin}
                                 >
-                                    <CheckIcon size={16} className={classnames('mr-2', { 'd-none': !zeroYAxisMin })} />{' '}
-                                    Start Y Axis at 0
-                                    <span className="sr-only">{zeroYAxisMin ? 'enabled' : 'disabled'}</span>
-                                </MenuLink>
+                                    <input
+                                        type="checkbox"
+                                        className="sr-only"
+                                        aria-hidden="true"
+                                        checked={zeroYAxisMin}
+                                        onChange={noop}
+                                    />
+                                    <CheckIcon size={16} className={classnames('mr-2', { invisible: !zeroYAxisMin })} />{' '}
+                                    <span>Start Y Axis at 0</span>
+                                </MenuItem>
                             )}
 
                             <MenuItem

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -40,6 +40,7 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                     <MenuButton
                         data-testid="InsightContextMenuButton"
                         className={classnames(menuButtonClassName, 'btn btn-outline p-1', styles.button)}
+                        aria-label="Insight context menu"
                     >
                         <DotsVerticalIcon
                             className={classnames(styles.buttonIcon, { [styles.buttonIconActive]: isOpen })}
@@ -68,6 +69,7 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                                 >
                                     <CheckIcon size={16} className={classnames('mr-2', { 'd-none': !zeroYAxisMin })} />{' '}
                                     Start Y Axis at 0
+                                    <span className="sr-only">{zeroYAxisMin ? 'enabled' : 'disabled'}</span>
                                 </MenuLink>
                             )}
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -72,7 +72,7 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
                                     onSelect={onToggleZeroYAxisMin}
                                     aria-checked={zeroYAxisMin}
                                 >
-                                    <input type="checkbox" aria-hidden="true" checked={zeroYAxisMin} onChange={noop} />
+                                    <input type="checkbox" aria-hidden="true" checked={zeroYAxisMin} onChange={noop} tabIndex={-1} />
                                     <span>Start Y Axis at 0</span>
                                 </MenuItem>
                             )}

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -67,7 +67,7 @@ describe('Backend insight drill down filters', () => {
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
 
-        await driver.page.click('button[aria-label="Filters button"]')
+        await driver.page.click('button[aria-label="Filters"]')
         await driver.page.waitForSelector('[role="dialog"][aria-label="Drill-down filters panel"]')
         await driver.page.type('[name="excludeRepoRegexp"]', 'github.com/sourcegraph/sourcegraph')
 
@@ -78,7 +78,7 @@ describe('Backend insight drill down filters', () => {
         })
 
         // In this time we should see active button state (filter dot should appear if we've got some filters)
-        await driver.page.click('button[aria-label="Active filters button"]')
+        await driver.page.click('button[aria-label="Active filters"]')
 
         const variables = await testContext.waitForGraphQLRequest(async () => {
             await driver.page.click('[role="dialog"][aria-label="Drill-down filters panel"] button[type="submit"]')
@@ -140,7 +140,7 @@ describe('Backend insight drill down filters', () => {
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
 
-        await driver.page.click('button[aria-label="Active filters button"]')
+        await driver.page.click('button[aria-label="Active filters"]')
         await driver.page.waitForSelector('[role="dialog"][aria-label="Drill-down filters panel"]')
 
         await driver.page.click(


### PR DESCRIPTION
Refers to the insight card menu buttons:

![Screen Shot 2021-09-21 at 9 33 05 PM](https://user-images.githubusercontent.com/1855233/134274597-075e535a-7e92-4857-ae03-f550ea0fa1ed.png)

| Before | After |
| --- | --- |
| ![Screen Shot 2021-09-21 at 9 34 21 PM](https://user-images.githubusercontent.com/1855233/134274644-6a3fdf61-2c04-4d37-a912-9ed26682d1f3.png) | ![Screen Shot 2021-09-21 at 9 34 50 PM](https://user-images.githubusercontent.com/1855233/134274671-ac94f4f7-f52e-4ffc-9813-1073e4ec2c9a.png) |

## To test

The simplest way is to run Storybook and go to the `BackendInsight` component. Turn on voice-over then tab over the buttons.

Closes https://github.com/sourcegraph/sourcegraph/issues/24078
Closes https://github.com/sourcegraph/sourcegraph/issues/24079