### PR TITLE
Revert "monitoring: remove repo-updater: syncer_synced_repos (#24678)"

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2896,6 +2896,30 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
+## repo-updater: syncer_synced_repos
+
+<p class="subtitle">repositories synced</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> repo-updater: less than 0 repositories synced for 9h0m0s
+
+**Possible solutions**
+
+- Check network connectivity to code hosts
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#repo-updater-syncer-synced-repos).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_repo-updater_syncer_synced_repos"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 ## repo-updater: sourced_repos
 
 <p class="subtitle">repositories sourced</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -7998,13 +7998,32 @@ Query: `histogram_quantile(0.95, max by (le) (rate(src_repoupdater_source_durati
 
 <br />
 
+#### repo-updater: syncer_synced_repos
+
+<p class="subtitle">Repositories synced</p>
+
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100020` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m]))`
+
+</details>
+
+<br />
+
 #### repo-updater: sourced_repos
 
 <p class="subtitle">Repositories sourced</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100020` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100021` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 
@@ -8023,7 +8042,7 @@ Query: `max(rate(src_repoupdater_source_repos_total[1m]))`
 
 Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100021` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100022` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -110,6 +110,15 @@ func RepoUpdater() *monitoring.Container {
 					},
 					{
 						{
+							Name:              "syncer_synced_repos",
+							Description:       "repositories synced",
+							Query:             `max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m]))`,
+							Warning:           monitoring.Alert().LessOrEqual(0, monitoring.StringPtr("max")).For(syncDurationThreshold),
+							Panel:             monitoring.Panel().LegendFormat("{{state}}").Unit(monitoring.Number),
+							Owner:             monitoring.ObservableOwnerCoreApplication,
+							PossibleSolutions: "Check network connectivity to code hosts",
+						},
+						{
 							Name:              "sourced_repos",
 							Description:       "repositories sourced",
 							Query:             `max(rate(src_repoupdater_source_repos_total[1m]))`,


### PR DESCRIPTION
This reverts commit c19529bbd64bd48e6e7b2f5bea535b692bcf59f4.

The panel was removed based on an old thread that wasn't aware the metric had been fixed.