### PR TITLE
Fix browser extension toggle button styles

### DIFF
--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -29,7 +29,12 @@
   },
   "optional_permissions": ["tabs", "http://*/*", "https://*/*"],
   "content_security_policy": "script-src 'self' blob:; object-src 'self'",
-  "web_accessible_resources": ["img/*", "css/style.bundle.css", "css/branded-style.bundle.css"],
+  "web_accessible_resources": [
+    "img/*",
+    "css/style.bundle.css",
+    "css/branded-style.bundle.css",
+    "css/options.bundle.scss"
+  ],
   "omnibox": {
     "keyword": "src"
   },

--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -29,12 +29,7 @@
   },
   "optional_permissions": ["tabs", "http://*/*", "https://*/*"],
   "content_security_policy": "script-src 'self' blob:; object-src 'self'",
-  "web_accessible_resources": [
-    "img/*",
-    "css/style.bundle.css",
-    "css/branded-style.bundle.css",
-    "css/options.bundle.scss"
-  ],
+  "web_accessible_resources": ["img/*", "css/*"],
   "omnibox": {
     "keyword": "src"
   },

--- a/client/browser/src/browser-extension/pages/options.html
+++ b/client/browser/src/browser-extension/pages/options.html
@@ -5,6 +5,7 @@
         <title>Sourcegraph extension</title>
         <meta name="color-scheme" content="light dark" />
         <link href="./css/branded-style.bundle.css" rel="stylesheet" type="text/css" />
+        <link href="./css/options.bundle.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
         <script type="text/javascript" src="./js/options.bundle.js"></script>


### PR DESCRIPTION
Seems like after converting `Toggle.scss` to `Toggle.module.scss` it got broken.

| Before | After|
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/134310053-ed145c61-1989-4789-8cfb-a575d910f964.png) | ![image](https://user-images.githubusercontent.com/6717049/134309964-2297e966-9fbc-496e-8c2c-fd1350dab341.png) |

