### PR TITLE
search: remove most uses of StreamSearchAdapter

### DIFF
--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -26,7 +26,9 @@ func (ss *FakeSearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoekt.
 }
 
 func (ss *FakeSearcher) StreamSearch(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions, z zoekt.Sender) error {
-	return (&StreamSearchAdapter{ss}).StreamSearch(ctx, q, opts, z)
+	sr, _ := ss.Search(ctx, q, opts)
+	z.Send(sr)
+	return nil
 }
 
 func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q, opt *zoekt.ListOptions) (*zoekt.RepoList, error) {


### PR DESCRIPTION
The adapter was added during the transition to streaming search. It still is being used, however in most cases it is easy to move to proper streaming search. This removes most of the uses.

There is one more tricky one which I'll do in a follow-up PR.