### PR TITLE
search: only debug log for aggregate operations

### DIFF
--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -72,7 +72,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		evBefore.AddField(key, value)
 		evAfter.AddField(key, value)
 	}
-	if searchCoreOOMDebug {
+	if searchCoreOOMDebug && cat == "SearchAll" {
 		evBefore = honey.Event("search-core-oom-debug")
 		evAfter = honey.Event("search-core-oom-debug")
 		debugAdd("category", cat)
@@ -253,7 +253,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 		evBefore.AddField(key, value)
 		evAfter.AddField(key, value)
 	}
-	if searchCoreOOMDebug {
+	if searchCoreOOMDebug && cat == "ListAll" {
 		evBefore = honey.Event("search-core-oom-debug")
 		evAfter = honey.Event("search-core-oom-debug")
 		debugAdd("category", cat)


### PR DESCRIPTION
In 5min we sent 150k events to honeycomb. This is too many, so we reduce
the events sent by 40x by only instrumenting the aggregation layer.