### PR TITLE
honey: add HONEYCOMB_SUFFIX and HONEYCOMB_DISABLE

### DIFF
--- a/internal/honey/honey.go
+++ b/internal/honey/honey.go
@@ -11,18 +11,22 @@ import (
 	"github.com/honeycombio/libhoney-go"
 )
 
-var apiKey = env.Get("HONEYCOMB_TEAM", "", "The key used for Honeycomb event tracking.")
+var (
+	apiKey  = env.Get("HONEYCOMB_TEAM", "", "The key used for Honeycomb event tracking.")
+	suffix  = env.Get("HONEYCOMB_SUFFIX", "", "Suffix to append to honeycomb datasets. Used to differentiate between prod/dogfood/dev/etc.")
+	disable = env.Get("HONEYCOMB_DISABLE", "", "Ignore that HONEYCOMB_TEAM is set and return false for Enabled. Used by specific instrumentation which ignores what Enabled returns and will log based on other criteria.")
+)
 
 // Enabled returns true if honeycomb has been configured to run.
 func Enabled() bool {
-	return apiKey != ""
+	return apiKey != "" && disable == ""
 }
 
 // Event creates an event for logging to dataset. Event.Send will only work if
 // Enabled() returns true.
 func Event(dataset string) *libhoney.Event {
 	ev := libhoney.NewEvent()
-	ev.Dataset = dataset
+	ev.Dataset = dataset + suffix
 	return ev
 }
 
@@ -35,13 +39,6 @@ func EventWithFields(dataset string, fields map[string]interface{}) *libhoney.Ev
 	}
 
 	return ev
-}
-
-// Builder creates a builder for logging to a dataset.
-func Builder(dataset string) *libhoney.Builder {
-	b := libhoney.NewBuilder()
-	b.Dataset = dataset
-	return b
 }
 
 func init() {


### PR DESCRIPTION
I want to enable honeycomb on dogfood. Honeycomb's official
documentation recommends creating a new dataset rather than adding a
column for to match against. In particular they give examples of "-dev"
suffix. So this commit adds support for a suffix for each dataset name
via the envvar HONEYCOMB_SUFFIX.

In particular I want to log our search core debug dataset. This doesn't
respect honey.Enabled, but rather its own envvar. So rather than
enabling everything, we add HONEYCOMB_DISABLE so Enabled returns
false. This way at first we will just get our debug data.

This commit also removes the unused "honey.Builder".
