### PR TITLE
search: use FakeSearcher instead of custom mock

### DIFF
--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
@@ -10,28 +11,47 @@ import (
 
 // FakeSearcher is a zoekt.Searcher that returns a predefined search Result.
 type FakeSearcher struct {
-	Result *zoekt.SearchResult
+	Result      *zoekt.SearchResult
+	SearchError error
 
-	Repos []*zoekt.RepoListEntry
+	Repos     []*zoekt.RepoListEntry
+	ListError error
 
 	// Default all unimplemented zoekt.Searcher methods to panic.
 	zoekt.Searcher
 }
 
 func (ss *FakeSearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
-	if ss.Result == nil {
-		return &zoekt.SearchResult{}, nil
+	if ss.SearchError != nil {
+		return nil, ss.SearchError
 	}
-	return ss.Result, nil
+	res := ss.Result
+	if res == nil {
+		res = &zoekt.SearchResult{}
+	}
+
+	// Copy since downstream could mutate
+	sr := *res
+	sr.Files = append([]zoekt.FileMatch{}, sr.Files...)
+	res = &sr
+
+	return res, nil
 }
 
 func (ss *FakeSearcher) StreamSearch(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions, z zoekt.Sender) error {
-	sr, _ := ss.Search(ctx, q, opts)
+	sr, err := ss.Search(ctx, q, opts)
+	if err != nil {
+		return err
+	}
 	z.Send(sr)
 	return nil
 }
 
 func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q, opt *zoekt.ListOptions) (*zoekt.RepoList, error) {
+	if ss.ListError != nil {
+		return nil, ss.ListError
+	}
+
 	list := &zoekt.RepoList{}
 	if opt != nil && opt.Minimal {
 		list.Minimal = make(map[uint32]*zoekt.MinimalRepoListEntry, len(ss.Repos))
@@ -48,6 +68,21 @@ func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q, opt *zoekt.Lis
 	return list, nil
 }
 
+func (ss *FakeSearcher) Close() {}
+
 func (ss *FakeSearcher) String() string {
-	return fmt.Sprintf("FakeSearcher(Result = %v, Repos = %v)", ss.Result, ss.Repos)
+	var parts []string
+	if ss.Result != nil {
+		parts = append(parts, fmt.Sprintf("Result = %v", ss.Result))
+	}
+	if ss.Repos != nil {
+		parts = append(parts, fmt.Sprintf("Repos = %v", ss.Repos))
+	}
+	if ss.SearchError != nil {
+		parts = append(parts, fmt.Sprintf("SearchError = %v", ss.SearchError))
+	}
+	if ss.ListError != nil {
+		parts = append(parts, fmt.Sprintf("ListError = %v", ss.ListError))
+	}
+	return fmt.Sprintf("FakeSearcher(%s)", strings.Join(parts, ", "))
 }

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
-	"github.com/google/zoekt/query"
 )
 
 func TestHorizontalSearcher(t *testing.T) {
@@ -24,23 +23,20 @@ func TestHorizontalSearcher(t *testing.T) {
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
 		Dial: func(endpoint string) zoekt.Streamer {
+			repoID, _ := strconv.Atoi(endpoint)
 			var rle zoekt.RepoListEntry
 			rle.Repository.Name = endpoint
-			repoID, _ := strconv.Atoi(endpoint)
-			client := &mockSearcher{
-				searchResult: &zoekt.SearchResult{
+			rle.Repository.ID = uint32(repoID)
+			client := &FakeSearcher{
+				Result: &zoekt.SearchResult{
 					Files: []zoekt.FileMatch{{
 						Repository: endpoint,
 					}},
 				},
-				listResult: &zoekt.RepoList{
-					Repos:   []*zoekt.RepoListEntry{&rle},
-					Crashes: 0,
-					Minimal: map[uint32]*zoekt.MinimalRepoListEntry{uint32(repoID): {}},
-				},
+				Repos: []*zoekt.RepoListEntry{&rle},
 			}
 			// Return metered searcher to test that codepath
-			return NewMeteredSearcher(endpoint, &StreamSearchAdapter{client})
+			return NewMeteredSearcher(endpoint, client)
 		},
 	}
 	defer searcher.Close()
@@ -107,13 +103,17 @@ func TestHorizontalSearcher(t *testing.T) {
 			t.Errorf("list mismatch (-want +got):\n%s", cmp.Diff(want, got))
 		}
 
+		rle, err = searcher.List(context.Background(), nil, &zoekt.ListOptions{Minimal: true})
+		if err != nil {
+			t.Fatal(err)
+		}
 		got = []string{}
 		for r := range rle.Minimal {
 			got = append(got, strconv.Itoa(int(r)))
 		}
 		sort.Strings(got)
 		if !cmp.Equal(want, got, cmpopts.EquateEmpty()) {
-			t.Errorf("list mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			t.Fatalf("list mismatch (-want +got):\n%s", cmp.Diff(want, got))
 		}
 	}
 
@@ -127,12 +127,11 @@ func TestDoStreamSearch(t *testing.T) {
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
 		Dial: func(endpoint string) zoekt.Streamer {
-			client := &mockSearcher{
-				searchResult: nil,
-				searchError:  errors.Errorf("test error"),
+			client := &FakeSearcher{
+				SearchError: errors.Errorf("test error"),
 			}
 			// Return metered searcher to test that codepath
-			return NewMeteredSearcher(endpoint, &StreamSearchAdapter{client})
+			return NewMeteredSearcher(endpoint, client)
 		},
 	}
 	defer searcher.Close()
@@ -159,7 +158,7 @@ func TestSyncSearchers(t *testing.T) {
 	endpoints.Store(prefixMap{"a"})
 
 	type mock struct {
-		mockSearcher
+		FakeSearcher
 		dialNum int
 	}
 
@@ -199,7 +198,7 @@ func TestIgnoreDownEndpoints(t *testing.T) {
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
 		Dial: func(endpoint string) zoekt.Streamer {
-			var client zoekt.Searcher
+			var client *FakeSearcher
 			switch endpoint {
 			case "down":
 				err := &net.DNSError{
@@ -207,32 +206,30 @@ func TestIgnoreDownEndpoints(t *testing.T) {
 					Name:       "down",
 					IsNotFound: true,
 				}
-				client = &mockSearcher{
-					searchError: err,
-					listError:   err,
+				client = &FakeSearcher{
+					SearchError: err,
+					ListError:   err,
 				}
 			case "up":
 				var rle zoekt.RepoListEntry
 				rle.Repository.Name = "repo"
 
-				client = &mockSearcher{
-					searchResult: &zoekt.SearchResult{
+				client = &FakeSearcher{
+					Result: &zoekt.SearchResult{
 						Files: []zoekt.FileMatch{{
 							Repository: "repo",
 						}},
 					},
-					listResult: &zoekt.RepoList{
-						Repos: []*zoekt.RepoListEntry{&rle},
-					},
+					Repos: []*zoekt.RepoListEntry{&rle},
 				}
 			case "error":
-				client = &mockSearcher{
-					searchError: errors.New("boom"),
-					listError:   errors.New("boom"),
+				client = &FakeSearcher{
+					SearchError: errors.New("boom"),
+					ListError:   errors.New("boom"),
 				}
 			}
 
-			return NewMeteredSearcher(endpoint, &StreamSearchAdapter{client})
+			return NewMeteredSearcher(endpoint, client)
 		},
 	}
 	defer searcher.Close()
@@ -419,38 +416,6 @@ func backgroundSearch(searcher zoekt.Searcher) func(t *testing.T) {
 			t.Error("concurrent search failed: ", err)
 		}
 	}
-}
-
-type mockSearcher struct {
-	searchResult *zoekt.SearchResult
-	searchError  error
-	listResult   *zoekt.RepoList
-	listError    error
-}
-
-func (s *mockSearcher) Search(context.Context, query.Q, *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
-	res := s.searchResult
-	if s.searchResult != nil {
-		// Copy since we mutate the File slice
-		sr := *res
-		sr.Files = append([]zoekt.FileMatch{}, sr.Files...)
-		res = &sr
-	}
-	return res, s.searchError
-}
-
-func (s *mockSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoekt.Sender) error {
-	return (&StreamSearchAdapter{s}).StreamSearch(ctx, q, opts, streamer)
-}
-
-func (s *mockSearcher) List(context.Context, query.Q, *zoekt.ListOptions) (*zoekt.RepoList, error) {
-	return s.listResult, s.listError
-}
-
-func (*mockSearcher) Close() {}
-
-func (*mockSearcher) String() string {
-	return "mockSearcher"
 }
 
 type atomicMap struct {

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -1,11 +1,9 @@
 package backend
 
 import (
-	"context"
 	"sync"
 
 	"github.com/google/zoekt"
-	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/rpc"
 	zoektstream "github.com/google/zoekt/stream"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -29,30 +27,6 @@ type StreamSearchEvent struct {
 	// SearchResult is non-nil if this event is a search result. These should be
 	// combined with previous and later SearchResults.
 	SearchResult *zoekt.SearchResult
-}
-
-// StreamSearchAdapter adapts a zoekt.Searcher to conform to the StreamSearch
-// interface by calling zoekt.Searcher.Search.
-type StreamSearchAdapter struct {
-	zoekt.Searcher
-}
-
-func (s *StreamSearchAdapter) StreamSearch(
-	ctx context.Context,
-	q query.Q,
-	opts *zoekt.SearchOptions,
-	c zoekt.Sender,
-) error {
-	sr, err := s.Search(ctx, q, opts)
-	if err != nil {
-		return err
-	}
-	c.Send(sr)
-	return nil
-}
-
-func (s *StreamSearchAdapter) String() string {
-	return "streamSearchAdapter{" + s.Searcher.String() + "}"
 }
 
 // ZoektDialer is a function that returns a zoekt.Streamer for the given endpoint.


### PR DESCRIPTION
This also removes the final use of StreamSearchAdapter, so we remove
that as well.