### PR TITLE
dev/ci: make PR pipeline construction purely additive

### DIFF
--- a/enterprise/dev/ci/internal/ci/changed.go
+++ b/enterprise/dev/ci/internal/ci/changed.go
@@ -7,34 +7,44 @@ import (
 
 type ChangedFiles []string
 
-// onlyDocs returns whether the ChangedFiles are only documentation.
-func (c ChangedFiles) onlyDocs() bool {
+// affectsDocs returns whether the ChangedFiles affects documentation.
+func (c ChangedFiles) affectsDocs() bool {
 	for _, p := range c {
-		if !strings.HasPrefix(p, "doc/") && p != "CHANGELOG.md" {
-			return false
+		if strings.HasPrefix(p, "doc/") && p != "CHANGELOG.md" {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
-// onlySg returns whether the ChangedFiles are only in the ./dev/sg folder.
-func (c ChangedFiles) onlySg() bool {
+// affectsSg returns whether the ChangedFiles affects the ./dev/sg folder.
+func (c ChangedFiles) affectsSg() bool {
 	for _, p := range c {
-		if !strings.HasPrefix(p, "dev/sg/") {
-			return false
+		if strings.HasPrefix(p, "dev/sg/") {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
-// onlyGo returns whether the ChangedFiles are only go files.
-func (c ChangedFiles) onlyGo() bool {
+// affectsGo returns whether the ChangedFiles affects go files.
+func (c ChangedFiles) affectsGo() bool {
 	for _, p := range c {
-		if !strings.HasSuffix(p, ".go") && p != "go.sum" && p != "go.mod" {
-			return false
+		if strings.HasSuffix(p, ".go") || p == "go.sum" || p == "go.mod" {
+			return true
 		}
 	}
-	return true
+	return false
+}
+
+// affectsDockerfiles whether the ChangedFiles affects Dockerfiles.
+func (c ChangedFiles) affectsDockerfiles() bool {
+	for _, p := range c {
+		if strings.HasPrefix(p, "Dockerfile") || strings.HasSuffix(p, "Dockerfile") {
+			return true
+		}
+	}
+	return false
 }
 
 // Check if files that affect client code were changed. Used to detect if we need to run Puppeteer or Chromatic tests.


### PR DESCRIPTION
Right now, if we make a PR that only affects Go files, we get the Go-only pipeline. However, if we then write some docs in the same PR, you get the entire test suite because you are no longer "go-only".

This starts work on deconstructing the core tests pipeline so that we start with a bare-minimum pipeline and add steps only if affected parts of the codebase are changed. Special-case branches (e.g. main) should still run the full set.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
