### PR TITLE
doc/admin: 3.32 update notes

### DIFF
--- a/doc/admin/install/docker/operations.md
+++ b/doc/admin/install/docker/operations.md
@@ -4,6 +4,18 @@ Operations guides specific to managing [single-container Soucegraph with Docker]
 
 Trying to deploy single-container Soucegraph with Docker? Refer to our [installation guide](./index.md#installation).
 
+## Upgrade
+
+Before upgrading, refer to the [update notes for single-container Soucegraph with Docker](../../updates/pure_docker.md).
+
+To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
+
+You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
+
+- As a precaution, before updating, we recommend backing up the contents of the Docker volumes used by Sourcegraph.
+- If you need a HA deployment, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
+- There is currently no automated way to downgrade to an older version after you have updated. [Contact support](https://about.sourcegraph.com/contact) for help.
+
 ## Configure exposed Sourcegraph port
 
 Change the `docker` `--publish` argument to make it listen on the specific interface and port on your host machine. For example, `docker run ... --publish 0.0.0.0:80:7080 ...` would make it accessible on port 80 of your machine. For more information, see "[Publish or expose port](https://docs.docker.com/engine/reference/commandline/run/#publish-or-expose-port--p---expose)" in the Docker documentation.

--- a/doc/admin/install/kubernetes/azure.md
+++ b/doc/admin/install/kubernetes/azure.md
@@ -1,4 +1,4 @@
-# Kubernetes on Azure
+# Sourcegraph with Kubernetes on Azure
 
 Install the [Azure CLI tool](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) and log in:
 

--- a/doc/admin/install/kubernetes/eks.md
+++ b/doc/admin/install/kubernetes/eks.md
@@ -1,4 +1,4 @@
-# Kubernetes on Amazon EKS
+# Sourcegraph with Kubernetes on Amazon EKS
 
 [Amazon EKS](https://aws.amazon.com/eks/) is Amazon's managed Kubernetes offering, similar to how Google Cloud offers managed Kubernetes clusters (GKE).
 

--- a/doc/admin/install/kubernetes/scale.md
+++ b/doc/admin/install/kubernetes/scale.md
@@ -1,4 +1,4 @@
-# Scaling
+# Scaling Sourcegraph with Kubernetes
 
 Sourcegraph can be configured to scale to very large codebases and large numbers of
 users. If you notice latency for search or code intelligence is higher than desired, changing these

--- a/doc/admin/install/kubernetes/update.md
+++ b/doc/admin/install/kubernetes/update.md
@@ -1,4 +1,4 @@
-# Updating Sourcegraph
+# Updating Sourcegraph with Kubernetes
 
 A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) for release announcements.
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -12,7 +12,7 @@ Each section comprehensively describes the steps needed to upgrade, and any manu
 
 ## 3.31 -> 3.32
 
-TODO
+No manual migration is required - follow the [standard upgrade procedure](../install/docker-compose/operations.md#upgrade) to upgrade your deployment.
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.31).*
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -18,7 +18,11 @@ TODO
 
 ## 3.30.3 -> 3.31
 
-See upgrade notes around alpine below
+The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database.
+
+If you have already upgraded to 3.30.3, which uses the new alpine-based Docker images, all users that use our bundled (built-in) database instances should have already performed [the necessary re-indexing](../migration/3_31.md).
+
+> NOTE: The above does not apply to users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.).
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.30).*
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -18,7 +18,11 @@ TODO
 
 ## 3.30.3 -> 3.31
 
-See upgrade notes around alpine below
+The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database.
+
+If you have already upgraded to 3.30.3, which uses the new alpine-based Docker images, all users that use our bundled (built-in) database instances should have already performed [the necessary re-indexing](../migration/3_31.md).
+
+> NOTE: The above does not apply to users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.).
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.30).*
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -12,7 +12,7 @@ and any manual migration steps you must perform.
 
 ## 3.31 -> 3.32
 
-TODO
+No manual migration is required - follow the [standard upgrade procedure](../install/kubernetes/update.md) to upgrade your deployment.
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.31).*
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -10,25 +10,18 @@ Each section comprehensively describes the changes needed in Docker images, envi
 
 ## 3.31 -> 3.32
 
-TODO
-
-*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.31).*
-
-
-
-## 3.31 -> 3.32.0
-
 To upgrade, please perform the changes in the following diff:
 [https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/2c4c283ae9f89fa48232f0b99ed1982008034fee]https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/2c4c283ae9f89fa48232f0b99ed1982008034fee)
 
-
-
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.32).*
-
 
 ## 3.30.3 -> 3.31
 
-See upgrade notes around alpine below
+The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database.
+
+If you have already upgraded to 3.30.3, which uses the new alpine-based Docker images, all users that use our bundled (built-in) database instances should have already performed [the necessary re-indexing](../migration/3_31.md).
+
+> NOTE: The above does not apply to users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.).
 
 ## 3.30.x -> 3.31
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -5,7 +5,11 @@ This document describes the exact changes needed to update a single-node Sourceg
 
 1. Read our [update policy](index.md#update-policy) to learn about Sourcegraph updates.
 2. Find the relevant entry for your update in the update notes on this page.
-3. After checking the relevant update notes, refer to the [standard upgrade procedure](../install/docker-compose/operations.md#standard-upgrade-procedure) to upgrade your instance.
+3. After checking the relevant update notes, refer to the [standard upgrade procedure](../install/docker/operations.md#upgrade) to upgrade your instance.
+
+## 3.31 -> 3.32
+
+Follow the [standard upgrade procedure](../install/docker/operations.md#upgrade).
 
 ## 3.30 -> 3.31
 
@@ -15,12 +19,9 @@ All users that use our bundled (built-in) database instances **must** read throu
 
 > NOTE: The above does not apply to users that use external databases (e.x: Amazon RDS, Google Cloud SQL, etc.).
 
-
 ## 3.29 -> 3.30.3
 
 > WARNING: **Users on 3.29.x are advised to upgrade directly to 3.30.3**. If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2 please follow [this migration guide](../migration/3_30.md).
-
-## Standard upgrade procedure
 
 To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
 
@@ -28,19 +29,11 @@ You can always find the version number of the latest release at [docs.sourcegrap
 
 ## 3.28 -> 3.29
 
-## Standard upgrade procedure
-
-To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
-
-You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
+Follow the [standard upgrade procedure](../install/docker/operations.md#upgrade).
 
 ## 3.27 -> 3.28
 
-## Standard upgrade procedure
-
-To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
-
-You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
+Follow the [standard upgrade procedure](../install/docker/operations.md#upgrade).
 
 ## 3.26 -> 3.27
 
@@ -50,15 +43,7 @@ If you are using an external database, [upgrade your database](https://docs.sour
 
 ## 3.25 -> 3.26
 
-## Standard upgrade procedure
-
-To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
-
-You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
-
-- As a precaution, before updating, we recommend backing up the contents of the Docker volumes used by Sourcegraph.
-- If you need a HA deployment, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
-- There is currently no automated way to downgrade to an older version after you have updated. [Contact support](https://about.sourcegraph.com/contact) for help.
+Follow the [standard upgrade procedure](../install/docker/operations.md#upgrade).
 
 > NOTE: ⚠️ From **3.27** onwards we will only support PostgreSQL versions **starting from 12**.
 
@@ -91,14 +76,4 @@ In Sourcegraph version 3.20, we would automatically generate a secret key file (
 
 ## 3.16 -> 3.17
 
-- There was [a bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in release that caused the version displayed on the `site-admin/update` page to be `0.0.0+dev` instead of `3.17.0`. This issue [was fixed](https://github.com/sourcegraph/sourcegraph/pull/11633) in the `3.17.2` release. We recommend that you avoid this issue by upgrading past `3.17.0` to `3.17.2` using the [Standard upgrade procedure](#Standard-upgrade-procedure) listed below.
-
-## Standard upgrade procedure
-
-To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
-
-You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
-
-- As a precaution, before updating, we recommend backing up the contents of the Docker volumes used by Sourcegraph.
-- If you need a HA deployment, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
-- There is currently no automated way to downgrade to an older version after you have updated. [Contact support](https://about.sourcegraph.com/contact) for help.
+- There was [a bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in release that caused the version displayed on the `site-admin/update` page to be `0.0.0+dev` instead of `3.17.0`. This issue [was fixed](https://github.com/sourcegraph/sourcegraph/pull/11633) in the `3.17.2` release. We recommend that you avoid this issue by upgrading past `3.17.0` to `3.17.2` using the [Standard upgrade procedure](../install/docker/operations.md#upgrade) listed below.


### PR DESCRIPTION
part of https://github.com/sourcegraph/sourcegraph/issues/25002 , looks like this was missed in https://github.com/sourcegraph/sourcegraph/pull/25160

- remove TODOs for 3.32
- clearer wording for 3.30.3 -> 3.31 notes
- clean up pure-docker update notes
- improve titles for kubernetes-specific pages

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
