### PR TITLE
search: check for wrapped errors in isContextError

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1667,7 +1667,7 @@ func (r *searchResolver) toSearchResults(ctx context.Context, agg *run.Aggregato
 // isContextError returns true if ctx.Err() is not nil or if err
 // is an error caused by context cancelation or timeout.
 func isContextError(ctx context.Context, err error) bool {
-	return ctx.Err() != nil || err == context.Canceled || err == context.DeadlineExceeded
+	return ctx.Err() != nil || errors.IsAny(err, context.Canceled, context.DeadlineExceeded)
 }
 
 // SearchResultResolver is a resolver for the GraphQL union type `SearchResult`.


### PR DESCRIPTION
isContextError did not check for wrapped context errors and therefore
didn't handle context errors returned by Zoekt properly.

This should make our frontend logs less chatty. 