### PR TITLE
web: Add custom concurrent Apollo link

### DIFF
--- a/client/shared/src/graphql/links/concurrent-requests-link.ts
+++ b/client/shared/src/graphql/links/concurrent-requests-link.ts
@@ -1,0 +1,137 @@
+import { ApolloLink, FetchResult, NextLink, Operation, Observable, Observer } from '@apollo/client'
+
+import { ApolloContext } from '../types'
+
+interface OperationQueueEntry {
+    operation: Operation
+    forward: NextLink
+
+    groupKey: string
+    observable: Observable<FetchResult>
+    observers: Observer<unknown>[]
+    currentSubscription?: ZenObservable.Subscription
+}
+
+interface RequestGroupQueues {
+    queue: OperationQueueEntry[]
+    activeQueue: OperationQueueEntry[]
+}
+
+export class ConcurrentRequestsLink extends ApolloLink {
+    private requests: Record<string, RequestGroupQueues> = {}
+
+    public request(operation: Operation, forward: NextLink): Observable<FetchResult> {
+        const context = (operation.getContext() ?? {}) as ApolloContext
+
+        // Ignore and pass further all operations that don't required being run
+        // in concurrent mode.
+        if (!context.concurrent) {
+            return forward(operation)
+        }
+
+        const event: OperationQueueEntry = {
+            operation,
+            forward,
+            observers: [],
+            groupKey: context.concurrentKey ?? '',
+            observable: new Observable<FetchResult>(observer => {
+                // Called for each subscriber, so need to save all listeners(next, error, complete)
+                event.observers.push(observer)
+
+                return () => {
+                    this.cancelOperation(event)
+                }
+            }),
+        }
+
+        this.addOperations(event)
+
+        return event.observable
+    }
+
+    private addOperations(operation: OperationQueueEntry): void {
+        if (!this.requests[operation.groupKey]) {
+            this.requests[operation.groupKey] = {
+                queue: [],
+                activeQueue: [],
+            }
+        }
+
+        this.requests[operation.groupKey].queue.push(operation)
+        this.scheduleOperations(operation.groupKey)
+    }
+
+    private cancelOperation(event: OperationQueueEntry): void {
+        const { queue, activeQueue } = this.requests[event.groupKey]
+        const possibleQueuedEventIndex = queue.indexOf(event)
+
+        if (possibleQueuedEventIndex !== -1) {
+            this.requests[event.groupKey].queue = queue.filter(queuedEvent => queuedEvent !== event)
+            event.currentSubscription?.unsubscribe()
+
+            return
+        }
+
+        const possibleOnGoingEventIndex = activeQueue.indexOf(event)
+
+        if (possibleOnGoingEventIndex !== -1) {
+            this.requests[event.groupKey].activeQueue = activeQueue.filter(operation => operation !== event)
+            event.currentSubscription?.unsubscribe()
+
+            this.scheduleOperations(event.groupKey)
+        }
+    }
+
+    private scheduleOperations(groupKey: string): void {
+        const { activeQueue, queue } = this.requests[groupKey]
+
+        while (activeQueue.length < 2 && queue.length > 0) {
+            const event = queue.shift()
+
+            if (event) {
+                activeQueue.push(event)
+
+                event.currentSubscription = event.forward(event.operation).subscribe({
+                    next: value => this.onNext(value, event),
+                    error: error => this.onErrorLink(error, event),
+                    complete: () => this.onComplete(event),
+                })
+            }
+        }
+    }
+
+    private onNext(value: unknown, event: OperationQueueEntry): void {
+        for (const observer of event.observers) {
+            observer.next?.(value)
+        }
+    }
+
+    private onErrorLink(error: unknown, event: OperationQueueEntry): void {
+        for (const observer of event.observers) {
+            observer.error?.(error)
+        }
+
+        const { activeQueue } = this.requests[event.groupKey]
+        // Delete errored event from the active queue in order to run other
+        // queued events.
+        this.requests[event.groupKey].activeQueue = activeQueue.filter(operation => operation !== event)
+
+        // Run queued events.
+        this.scheduleOperations(event.groupKey)
+    }
+
+    private onComplete(event: OperationQueueEntry): void {
+        const { activeQueue } = this.requests[event.groupKey]
+
+        // Delete completed event from the active queue in order to run other
+        // queued events.
+        this.requests[event.groupKey].activeQueue = activeQueue.filter(operation => operation !== event)
+
+        for (const observer of event.observers) {
+            observer.complete?.()
+        }
+
+        // Run queued events
+        this.scheduleOperations(event.groupKey)
+    }
+}

--- a/client/shared/src/graphql/types.ts
+++ b/client/shared/src/graphql/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared global Apollo context is used in hooks to specify some context properties
+ * and read in apollo links to turn on/off some internal apollo request logic.
+ */
+export interface ApolloContext {
+    /**
+     * Turns on/off concurrent/parallel requests apollo link.
+     * See `./links/concurrent-requests-link.ts` for more details.
+     */
+    concurrent?: boolean
+
+    /**
+     * Group requests by this key and run them concurrently/in parallel.
+     */
+    concurrentKey?: string
+}

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "yarn-deduplicate": "^3.1.0"
   },
   "dependencies": {
-    "@apollo/client": "^3.3.20",
+    "@apollo/client": "^3.4.13",
     "@reach/accordion": "^0.10.2",
     "@reach/combobox": "^0.15.2",
     "@reach/dialog": "^0.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,24 +38,23 @@
     call-me-maybe "^1.0.1"
     js-yaml "^3.13.1"
 
-"@apollo/client@^3.3.20":
-  version "3.3.20"
-  resolved "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz#8f0935fa991857e9cf2e73c9bd378ad7ec97caf8"
-  integrity sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==
+"@apollo/client@^3.4.13":
+  version "3.4.13"
+  resolved "https://registry.npmjs.org/@apollo/client/-/client-3.4.13.tgz#81670c27b376e80e3845ecf6468e534d908fa5b5"
+  integrity sha512-/nH8z/0X6WJ+wtUREHTlKQGX4lo6u3XkF1hy+k4eCxLZzT5+VRw1rm92iIkj1H85vep/eE/KV3DdRq1x3t9NnQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
-    "@types/zen-observable" "^0.8.0"
     "@wry/context" "^0.6.0"
     "@wry/equality" "^0.5.0"
-    fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.12.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
     hoist-non-react-statics "^3.3.2"
-    optimism "^0.16.0"
+    optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.7.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.14"
+    ts-invariant "^0.9.0"
+    tslib "^2.3.0"
+    zen-observable-ts "~1.1.0"
 
 "@ardatan/aggregate-error@0.0.1":
   version "0.0.1"
@@ -4749,9 +4748,9 @@
   integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
 
 "@types/d3-random@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.0.tgz#fc44cabb966917459490b758f31f5359adeabe5b"
-  integrity sha512-Hjfj9m68NmYZzushzEG7etPvKH/nj9b9s9+qtkNG3/dbRBjQZQg1XS6nRuHJcCASTjxXlyXZnKu2gDxyQIIu9A==
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.1.tgz#551edbb71cb317dea2cf9c76ebe059d311eefacb"
+  integrity sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA==
 
 "@types/d3-scale@2.2.0":
   version "2.2.0"
@@ -4766,6 +4765,13 @@
   integrity sha512-qpQe8G02tzUwt9sdWX1h8A/W0Q1+N48wMnYXVOkrzeLUkCfvzJYV9Ee3aORCS4dN4ONRLFmMvaXdziQ29XGLjQ==
   dependencies:
     "@types/d3-time" "*"
+
+"@types/d3-scale@^3.3.0":
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz#18c94e90f4f1c6b1ee14a70f14bfca2bd1c61d06"
+  integrity sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==
+  dependencies:
+    "@types/d3-time" "^2"
 
 "@types/d3-selection@*", "@types/d3-selection@1.4.1":
   version "1.4.1"
@@ -4788,6 +4794,11 @@
   version "1.1.1"
   resolved "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz#6cf3a4242c3bbac00440dfb8ba7884f16bedfcbf"
   integrity sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw==
+
+"@types/d3-time@^2", "@types/d3-time@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz#743fdc821c81f86537cbfece07093ac39b4bc342"
+  integrity sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==
 
 "@types/d3-voronoi@^1.1.9":
   version "1.1.9"
@@ -5699,10 +5710,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/zen-observable@^0.8.0":
-  version "0.8.2"
-  resolved "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
-  integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
+"@types/zen-observable@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
+  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
 "@typescript-eslint/eslint-plugin@^4.28.3":
   version "4.28.3"
@@ -5794,7 +5805,7 @@
     prop-types "^15.5.10"
     react-use-measure "^2.0.4"
 
-"@visx/axis@1.7.0", "@visx/axis@^1.7.0":
+"@visx/axis@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/axis/-/axis-1.7.0.tgz#ae3bf46bb508eca9cd61cd7dcf6a32a1facdeeef"
   integrity sha512-C9XCszH+lMyA73lMalrdloDFI3P8E301KZqfmybU+OpwLtClqsEQmzWWpRmw5xPElgtSLztemsx8SczHFGLKuw==
@@ -5807,6 +5818,20 @@
     "@visx/shape" "1.7.0"
     "@visx/text" "1.7.0"
     classnames "^2.2.5"
+    prop-types "^15.6.0"
+
+"@visx/axis@^1.7.0":
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@visx/axis/-/axis-1.17.1.tgz#3241ea00c8d9ca522238282617c9ecbd7b9c8eee"
+  integrity sha512-3JdAY8xwA4xVnzkbXdIzCOWYCknCgw3L185lOJTXWNGO7kIgzbQ2YrLXnet37BFgD83MfxmlP6LhiHLkKVI6OQ==
+  dependencies:
+    "@types/react" "*"
+    "@visx/group" "1.17.1"
+    "@visx/point" "1.7.0"
+    "@visx/scale" "1.14.0"
+    "@visx/shape" "1.17.1"
+    "@visx/text" "1.17.1"
+    classnames "^2.3.1"
     prop-types "^15.6.0"
 
 "@visx/bounds@1.7.0":
@@ -5843,7 +5868,7 @@
     "@types/react" "*"
     "@visx/point" "1.7.0"
 
-"@visx/glyph@1.7.0", "@visx/glyph@^1.7.0":
+"@visx/glyph@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/glyph/-/glyph-1.7.0.tgz#baa38f6974e7da73a8a5f851b5a7f6abcf3991a0"
   integrity sha512-fejF4c/t2psZ600RwuF29g2rjD2RHgieQNdW6jW1nupfbBgItii6+65wlk9J2rp9qLlorValf4o7A4DG5bXDEQ==
@@ -5856,7 +5881,19 @@
     d3-shape "^1.2.0"
     prop-types "^15.6.2"
 
-"@visx/grid@1.7.0", "@visx/grid@^1.7.0":
+"@visx/glyph@^1.7.0":
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@visx/glyph/-/glyph-1.17.1.tgz#9b98b1fddaf91075026acfa9caaa04145ec0f552"
+  integrity sha512-9KAPmO7DsH1Iq+2kZs8oTgirgYWRq7EacNyEtsq78uuHqw0gFqmOuyYV6+iHelLbulNCAzHKVAZ7Aebfy7G8ZA==
+  dependencies:
+    "@types/d3-shape" "^1.3.1"
+    "@types/react" "*"
+    "@visx/group" "1.17.1"
+    classnames "^2.3.1"
+    d3-shape "^1.2.0"
+    prop-types "^15.6.2"
+
+"@visx/grid@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/grid/-/grid-1.7.0.tgz#b447b09d9b409a5b41ca7e04707e08d015c18dba"
   integrity sha512-mJQjg67JogLNh5ta8RmOgilX0TPiEJWZ0O0VggFS2onThj1Ild0xZgZxCiGEFLqM8vpfuIQxb4qR2vTe16uPQQ==
@@ -5871,7 +5908,30 @@
     classnames "^2.2.5"
     prop-types "^15.6.2"
 
-"@visx/group@1.7.0", "@visx/group@^1.7.0":
+"@visx/grid@^1.7.0":
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@visx/grid/-/grid-1.17.1.tgz#625e69dc99f9b0a5bac04bc8ad7c6fa2352d99ab"
+  integrity sha512-dse9q3weDqPNmeXK0lGKKPRgGiDuUjJ7Mt7NNonPUyXPctNmv6lJEWZu9HJrXEGiCAVNa8PHJ7Qkns/z+mH88Q==
+  dependencies:
+    "@types/react" "*"
+    "@visx/curve" "1.7.0"
+    "@visx/group" "1.17.1"
+    "@visx/point" "1.7.0"
+    "@visx/scale" "1.14.0"
+    "@visx/shape" "1.17.1"
+    classnames "^2.3.1"
+    prop-types "^15.6.2"
+
+"@visx/group@1.17.1", "@visx/group@^1.7.0":
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@visx/group/-/group-1.17.1.tgz#23818d3233511dc2360de4febc2a3ecd43c3c9d0"
+  integrity sha512-g8pSqy8TXAisiOzypnVycDynEGlBhfxtVlwDmsbYB+XSFGEjnOheQSDohDI+ia7ek54Mw9uYe05tx5kP1hRMYw==
+  dependencies:
+    "@types/react" "*"
+    classnames "^2.3.1"
+    prop-types "^15.6.2"
+
+"@visx/group@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/group/-/group-1.7.0.tgz#e0ef2efbe00ef05326215d65b3d8a2b114df4f35"
   integrity sha512-rzSXtV0+MHUyK+rwhVSV4qaHdzGi3Me3PRFXJSIAKVfoJIZczOkudUOLy34WvSrRlVyoFvGL7k9U5g8wHyY3nw==
@@ -5890,13 +5950,12 @@
     d3-random "^2.2.2"
 
 "@visx/pattern@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/@visx/pattern/-/pattern-1.7.0.tgz#4b4392b976f57592d836b2055dc606aa7b0192d9"
-  integrity sha512-uIrGDtm7NqDfZZneRZ/DRdZA0nli/13sIUcxQ0oRL70b6ul+epNGiBVR8pvrgMhZ+SW3b05xhfEDnfnl2CqFQw==
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@visx/pattern/-/pattern-1.17.1.tgz#2be0b35584eaedfa0e4cdbf7fd7ae036480805ac"
+  integrity sha512-lPlkSHr9a/+3je6D35mIq6tNZ0BBWU5FExX0EroNRYPl9KxKtQv4C8PlAiTdmMuAXwYLnxls04y5iHwDRXH6Cw==
   dependencies:
-    "@types/classnames" "^2.2.9"
     "@types/react" "*"
-    classnames "^2.2.5"
+    classnames "^2.3.1"
     prop-types "^15.5.10"
 
 "@visx/point@1.7.0":
@@ -5929,7 +5988,19 @@
     prop-types "^15.6.1"
     resize-observer-polyfill "1.5.1"
 
-"@visx/scale@1.7.0", "@visx/scale@^1.7.0":
+"@visx/scale@1.14.0", "@visx/scale@^1.7.0":
+  version "1.14.0"
+  resolved "https://registry.npmjs.org/@visx/scale/-/scale-1.14.0.tgz#622d274ec4f5e608de29d06cd6071892bb1e7587"
+  integrity sha512-ovbtEOF/d76uGMJ5UZlxdS3t2T8I6md+aIwOXBaq0HdjaCLbe7HLlMyHJKjak/sqBxLAiCGVnechTUpSkfgSQw==
+  dependencies:
+    "@types/d3-interpolate" "^1.3.1"
+    "@types/d3-scale" "^3.3.0"
+    "@types/d3-time" "^2.0.0"
+    d3-interpolate "^1.4.0"
+    d3-scale "^3.3.0"
+    d3-time "^2.1.1"
+
+"@visx/scale@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/scale/-/scale-1.7.0.tgz#c46daade4492edb9eaec36fd3c87dc776960d6af"
   integrity sha512-JjAAaUPaFT6aCYTN7ILhZHk/ECg1CQ2zJZKGBbsW/HFor0mEfT/H8eSOFqI3f/DGA3eSvgmxHHBbJxyD6dB/sg==
@@ -5940,6 +6011,24 @@
     d3-interpolate "^1.4.0"
     d3-scale "^3.2.3"
     d3-time "^1.1.0"
+
+"@visx/shape@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@visx/shape/-/shape-1.17.1.tgz#c5d83b955d2e94f39002ff986550944e24ff660a"
+  integrity sha512-rVYFpytPCnV4s5U0za+jQ2jqFzKnmB3c8RP6fuOfF6kKosFPJcOYg9ikvewojARyMBTr1u3XvWV960Da+xyUdQ==
+  dependencies:
+    "@types/d3-path" "^1.0.8"
+    "@types/d3-shape" "^1.3.1"
+    "@types/lodash" "^4.14.146"
+    "@types/react" "*"
+    "@visx/curve" "1.7.0"
+    "@visx/group" "1.17.1"
+    "@visx/scale" "1.14.0"
+    classnames "^2.3.1"
+    d3-path "^1.0.5"
+    d3-shape "^1.2.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.10"
 
 "@visx/shape@1.7.0":
   version "1.7.0"
@@ -5959,6 +6048,18 @@
     d3-shape "^1.2.0"
     lodash "^4.17.15"
     prop-types "^15.5.10"
+
+"@visx/text@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@visx/text/-/text-1.17.1.tgz#e9ba06ab58bf4c347c9f25ecb29f78f296132045"
+  integrity sha512-Cx6iH0kVq3YqCfFj7U6bMiKwa/bz4Z3q0vPdxmnVGcPjGZM1ac/y61KFH263e164LJ5jFaTYpPrrFmbZoy8+Vg==
+  dependencies:
+    "@types/lodash" "^4.14.160"
+    "@types/react" "*"
+    classnames "^2.3.1"
+    lodash "^4.17.20"
+    prop-types "^15.7.2"
+    reduce-css-calc "^1.3.0"
 
 "@visx/text@1.7.0":
   version "1.7.0"
@@ -8345,6 +8446,11 @@ classnames@2.x, classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6:
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
@@ -9400,17 +9506,17 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d3-array@^1.2.0:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
-  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
-
-d3-array@^2.3.0, d3-array@^2.6.0:
+d3-array@2, d3-array@^2.3.0, d3-array@^2.6.0:
   version "2.12.1"
   resolved "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
   integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
   dependencies:
     internmap "^1.0.0"
+
+d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
 d3-axis@^1.0.12:
   version "1.0.12"
@@ -9482,6 +9588,17 @@ d3-scale@^3.2.1, d3-scale@^3.2.3:
     d3-time "1 - 2"
     d3-time-format "2 - 3"
 
+d3-scale@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz#28c600b29f47e5b9cd2df9749c206727966203f3"
+  integrity sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==
+  dependencies:
+    d3-array "^2.3.0"
+    d3-format "1 - 2"
+    d3-interpolate "1.2.0 - 2"
+    d3-time "^2.1.1"
+    d3-time-format "2 - 3"
+
 d3-selection@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz#98eedbbe085fbda5bafa2f9e3f3a2f4d7d622a98"
@@ -9519,6 +9636,13 @@ d3-time@1, "d3-time@1 - 2", d3-time@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+
+d3-time@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz#e9d8a8a88691f4548e68ca085e5ff956724a6682"
+  integrity sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==
+  dependencies:
+    d3-array "2"
 
 d3-voronoi@^1.1.2:
   version "1.1.4"
@@ -12882,10 +13006,17 @@ graphql-schema-linter@^2.0.1:
     glob "^7.1.2"
     graphql "^15.0.0"
 
-graphql-tag@^2.11.0, graphql-tag@^2.12.0:
+graphql-tag@^2.11.0:
   version "2.12.4"
   resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz#d34066688a4f09e72d6f4663c74211e9b4b7c4bf"
   integrity sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==
+  dependencies:
+    tslib "^2.1.0"
+
+graphql-tag@^2.12.3:
+  version "2.12.5"
+  resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz#5cff974a67b417747d05c8d9f5f3cb4495d0db8f"
+  integrity sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -17497,7 +17628,7 @@ openurl@^1.1.1:
   resolved "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
   integrity sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=
 
-optimism@^0.16.0:
+optimism@^0.16.1:
   version "0.16.1"
   resolved "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
   integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
@@ -22563,10 +22694,10 @@ ts-essentials@^7.0.3:
   resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
   integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
-ts-invariant@^0.7.0:
-  version "0.7.5"
-  resolved "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.5.tgz#f9658719f9a7737b117d09820d952aacf6263f9c"
-  integrity sha512-qfVyqTYWEqADMtncLqwpUdMjMSXnsqOeqGtj1LeJNFDjz8oqZ1YxLEp29YCOq65z0LgEiERqQ8ThVjnfibJNpg==
+ts-invariant@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
+  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
   dependencies:
     tslib "^2.1.0"
 
@@ -24383,7 +24514,15 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zen-observable@^0.8.14:
+zen-observable-ts@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
+  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+  dependencies:
+    "@types/zen-observable" "0.8.3"
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
   version "0.8.15"
   resolved "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Closes part of https://github.com/sourcegraph/sourcegraph/issues/24236

## Context

This PR adds a custom Apollo link that implements concurrency request logic. Previously we used our own custom hook to load BE insights in parallel by two insights at the time - [useParallelRequest](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/insights/hooks/use-parallel-requests/use-parallel-request.ts?L136:36&subtree=true). With this PR we will load them via this custom Apollo link which allows us to use Apollo cache for the dashboard, directory, and homepage pages.

<img width="1011" alt="Screenshot 2021-09-22 at 19 20 36" src="https://user-images.githubusercontent.com/18492575/134382867-4fc92d7a-f58b-416d-b965-9bbda611e46c.png">


## How it works
Now `useQuery` and `useMutation` hooks have a typed context.

```ts
interface ApolloContext {
    concurrent?: boolean;
    concurrentKey?: string;
}
```

With `concurrent:true` query will be intercepted by `ConcurrentRequestsLink`. This link intercepts all hooks with `concurrent:true` and runs them sequentially and in parallel by two. You also can specify `concurrentKey: someKey`
to group your requests. For example, you want to run 10 requests for one component and 8 requests for the other component and you don't want that request from the second component will be blocked by requests for the first component. You need to specify different `concurrentKey` for these components queries and they will be run independently but still sequentially and in parallel by two.

At the moment this is in PR we don't use this link for any request by in the next PR for code insights we will adopt this link for code insights BE loading.



