### PR TITLE
[SG-24591] Add in product CTAs to the Cloud app

### DIFF
--- a/client/web/src/components/MarketingBlock/MarketingBlock.module.scss
+++ b/client/web/src/components/MarketingBlock/MarketingBlock.module.scss
@@ -1,0 +1,15 @@
+.wrapper {
+    background: var(--marketing-gradient);
+    border-radius: var(--border-radius);
+    padding: 0.25rem;
+}
+
+.content {
+    white-space: normal;
+    word-break: break-word;
+    display: block;
+    background-color: var(--body-bg);
+    color: var(--body-color);
+    border-radius: var(--border-radius);
+    padding: 0.5rem;
+}

--- a/client/web/src/components/MarketingBlock/MarketingBlock.story.tsx
+++ b/client/web/src/components/MarketingBlock/MarketingBlock.story.tsx
@@ -1,0 +1,29 @@
+import { DecoratorFn, Meta } from '@storybook/react'
+import ArrowRightIcon from 'mdi-react/ArrowRightIcon'
+import React from 'react'
+
+import { WebStory } from '../WebStory'
+
+import { MarketingBlock } from './MarketingBlock'
+
+const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+
+const config: Meta = {
+    title: 'web/markering/MarketingBlock',
+    decorators: [decorator],
+}
+
+export default config
+
+export const Basic = (): JSX.Element => (
+    <MarketingBlock>
+        <h3 className="pr-3">Need help getting started?</h3>
+
+        <div>
+            <a href="https://sourcegraph.com/search">
+                Speak to an engineer
+                <ArrowRightIcon className="icon-inline ml-2" />
+            </a>
+        </div>
+    </MarketingBlock>
+)

--- a/client/web/src/components/MarketingBlock/MarketingBlock.tsx
+++ b/client/web/src/components/MarketingBlock/MarketingBlock.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import styles from './MarketingBlock.module.scss'
+
+interface MarketingBlockProps {
+    wrapperClassName?: string
+    contentClassName?: string
+}
+
+export const MarketingBlock: React.FunctionComponent<MarketingBlockProps> = ({
+    wrapperClassName,
+    contentClassName,
+    children,
+}) => (
+    <div className={classNames(styles.wrapper, wrapperClassName)}>
+        <div className={classNames(styles.content, contentClassName)}>{children}</div>
+    </div>
+)

--- a/client/web/src/components/MarketingBlock/index.ts
+++ b/client/web/src/components/MarketingBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './MarketingBlock'

--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.story.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.story.tsx
@@ -1,0 +1,33 @@
+import { DecoratorFn, Meta } from '@storybook/react'
+import React from 'react'
+
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { WebStory } from '../WebStory'
+
+import { SelfHostedCta, SelfHostedCtaProps } from './SelfHostedCta'
+
+const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+
+const config: Meta = {
+    title: 'web/markering/SelfHostedCta',
+    decorators: [decorator],
+}
+
+export default config
+
+export const Basic: React.FunctionComponent<Partial<SelfHostedCtaProps>> = (props): JSX.Element => (
+    <SelfHostedCta telemetryService={NOOP_TELEMETRY_SERVICE} page="storybook" {...props}>
+        <p className="mb-2">
+            <strong>Run Sourcegraph self-hosted for more enterprise features</strong>
+        </p>
+        <p className="mb-2">
+            For team oriented functionality, additional code hosts and enterprise only features, install Sourcegraph
+            self-hosted.
+        </p>
+    </SelfHostedCta>
+)
+
+export const CustomDisplay = (): JSX.Element => (
+    <Basic contentClassName="font-italic" className="p-2 container border rounded" />
+)

--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
@@ -1,0 +1,83 @@
+import classNames from 'classnames'
+import ArrowRightIcon from 'mdi-react/ArrowRightIcon'
+import React from 'react'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MarketingBlock } from '@sourcegraph/web/src/components/MarketingBlock'
+
+export interface SelfHostedCtaProps extends TelemetryProps {
+    className?: string
+    contentClassName?: string
+    page: string
+}
+
+export const SelfHostedCta: React.FunctionComponent<SelfHostedCtaProps> = ({
+    className,
+    contentClassName,
+    telemetryService,
+    page,
+    children,
+}) => {
+    const linkProps = { rel: 'noopener noreferrer' }
+
+    const gettingStartedCTAOnClick = (): void => {
+        telemetryService.log('InstallSourcegraphCTAClicked', { page })
+    }
+
+    const selfVsCloudDocumentsLinkOnClick = (): void => {
+        telemetryService.log('SelfVsCloudDocsLink', { page })
+    }
+
+    const helpGettingStartedCTAOnClick = (): void => {
+        telemetryService.log('HelpGettingStartedCTA', { page })
+    }
+
+    return (
+        <div
+            className={classNames(
+                'd-flex flex-md-row align-items-md-start justify-content-md-between flex-column',
+                className
+            )}
+        >
+            <div className={classNames('mr-md-4 mr-0', contentClassName)}>
+                {children}
+
+                <ul>
+                    <li>
+                        <a
+                            onClick={gettingStartedCTAOnClick}
+                            href="https://docs.sourcegraph.com/admin/install"
+                            {...linkProps}
+                        >
+                            Learn how to install
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            onClick={selfVsCloudDocumentsLinkOnClick}
+                            href="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud#who-is-sourcegraph-cloud-for-why-should-i-use-this-over-sourcegraph-self-hosted"
+                            {...linkProps}
+                        >
+                            Self-hosted vs. cloud features
+                        </a>
+                    </li>
+                </ul>
+            </div>
+
+            <MarketingBlock wrapperClassName="flex-md-shrink-0 mt-md-0 mt-sm-2 w-sm-100">
+                <h3 className="pr-3">Need help getting started?</h3>
+
+                <div>
+                    <a
+                        onClick={helpGettingStartedCTAOnClick}
+                        href="https://info.sourcegraph.com/talk-to-a-developer?_ga=2.257481099.1451692402.1630329056-789994471.1629391417"
+                        {...linkProps}
+                    >
+                        Speak to an engineer
+                        <ArrowRightIcon className="icon-inline ml-2" />
+                    </a>
+                </div>
+            </MarketingBlock>
+        </div>
+    )
+}

--- a/client/web/src/components/SelfHostedCta/index.ts
+++ b/client/web/src/components/SelfHostedCta/index.ts
@@ -1,0 +1,1 @@
+export * from './SelfHostedCta'

--- a/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.module.scss
+++ b/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.module.scss
@@ -1,0 +1,7 @@
+.container {
+    padding: 0.75rem;
+    background-color: var(--color-bg-1);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    display: inline-block;
+}

--- a/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.story.tsx
+++ b/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.story.tsx
@@ -1,0 +1,19 @@
+import { DecoratorFn, Meta } from '@storybook/react'
+import React from 'react'
+
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { WebStory } from '../WebStory'
+
+import { SelfHostedCtaLink } from './SelfHostedCtaLink'
+
+const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+
+const config: Meta = {
+    title: 'web/markering/SelfHostedCtaLink',
+    decorators: [decorator],
+}
+
+export default config
+
+export const Basic = (): JSX.Element => <SelfHostedCtaLink telemetryService={NOOP_TELEMETRY_SERVICE} page="storybook" />

--- a/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.tsx
+++ b/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.tsx
@@ -1,0 +1,37 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import styles from './SelfHostedCtaLink.module.scss'
+
+interface SelfHostedCtaLinkProps extends TelemetryProps {
+    className?: string
+    contentClassName?: string
+    page: string
+}
+
+export const SelfHostedCtaLink: React.FunctionComponent<SelfHostedCtaLinkProps> = ({
+    className,
+    contentClassName,
+    telemetryService,
+    page,
+}) => {
+    const linkProps = { rel: 'noopener noreferrer' }
+
+    const gettingStartedCTAOnClick = (): void => {
+        telemetryService.log('InstallSourcegraphCTAClicked', { page })
+    }
+
+    return (
+        <div className={classNames(styles.container, className)}>
+            <span className={contentClassName}>
+                Get Sourcegraph for teams via our{' '}
+                <a onClick={gettingStartedCTAOnClick} href="https://docs.sourcegraph.com/admin/install" {...linkProps}>
+                    self-hosted installation
+                </a>
+                .
+            </span>
+        </div>
+    )
+}

--- a/client/web/src/components/SelfHostedCtaLink/index.ts
+++ b/client/web/src/components/SelfHostedCtaLink/index.ts
@@ -1,0 +1,1 @@
+export * from './SelfHostedCtaLink'

--- a/client/web/src/search/home/SelfHostInstructions.module.scss
+++ b/client/web/src/search/home/SelfHostInstructions.module.scss
@@ -31,24 +31,23 @@
 }
 
 .code-wrapper {
-    background: var(--marketing-gradient);
-    border-radius: var(--border-radius);
-    padding: 0.25rem;
     margin: 0.625rem 0;
 }
 
-.code {
+.code-content {
+    background-color: var(--code-bg);
+}
+
+.code-block {
     white-space: normal;
     word-break: break-word;
     display: block;
-    background-color: var(--code-bg);
-    border-radius: var(--border-radius);
-    padding: 0.5rem;
 }
 
 .copy-button {
     float: right;
     padding: 0.5rem;
+    margin: -0.5rem -0.5rem 0 0;
 }
 
 .contact-link {

--- a/client/web/src/search/home/SelfHostInstructions.tsx
+++ b/client/web/src/search/home/SelfHostInstructions.tsx
@@ -6,6 +6,7 @@ import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import React, { useState } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MarketingBlock } from '@sourcegraph/web/src/components/MarketingBlock'
 
 import styles from './SelfHostInstructions.module.scss'
 
@@ -61,7 +62,7 @@ export const SelfHostInstructions: React.FunctionComponent<TelemetryProps> = ({ 
                 <div>
                     <strong>Quickstart:</strong> launch Sourcegraph at http://localhost:3370
                 </div>
-                <div className={styles.codeWrapper}>
+                <MarketingBlock wrapperClassName={styles.codeWrapper} contentClassName={styles.codeContent}>
                     <button
                         type="button"
                         className={classNames('btn btn-link', styles.copyButton)}
@@ -72,8 +73,8 @@ export const SelfHostInstructions: React.FunctionComponent<TelemetryProps> = ({ 
                     >
                         <ContentCopyIcon className="icon-inline" />
                     </button>
-                    <code className={styles.code}>{dockerCommand}</code>
-                </div>
+                    <code className={styles.codeBlock}>{dockerCommand}</code>
+                </MarketingBlock>
                 <div className="d-flex justify-content-between">
                     <a
                         href="https://docs.sourcegraph.com/admin/install"

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -1,5 +1,4 @@
 import AddIcon from 'mdi-react/AddIcon'
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import * as React from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
 
@@ -83,23 +82,18 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                             <OrgAvatar org={org.name} className="d-inline-flex mr-1" /> {org.name}
                         </SidebarNavItem>
                     ))}
-                    {!siteAdminViewingOtherUser && (
-                        <div className="user-settings-sidebar__new-org-btn-wrapper">
-                            {!window.context.sourcegraphDotComMode ? (
+                    {!siteAdminViewingOtherUser &&
+                        (window.context.sourcegraphDotComMode ? (
+                            <SidebarNavItem to={`${props.match.path}/about-organizations`}>
+                                About organizations
+                            </SidebarNavItem>
+                        ) : (
+                            <div className="user-settings-sidebar__new-org-btn-wrapper">
                                 <Link to="/organizations/new" className="btn btn-outline-secondary btn-sm">
                                     <AddIcon className="icon-inline" /> New organization
                                 </Link>
-                            ) : (
-                                <a
-                                    href="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    Learn More <ExternalLinkIcon className="icon-inline" />
-                                </a>
-                            )}
-                        </div>
-                    )}
+                            </div>
+                        ))}
                 </SidebarGroup>
             )}
             <SidebarGroup>

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.module.scss
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.module.scss
@@ -1,0 +1,3 @@
+.self-hosted-cta-content {
+    font-size: 1rem;
+}

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
@@ -1,0 +1,18 @@
+import { DecoratorFn, Meta } from '@storybook/react'
+import React from 'react'
+
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { WebStory } from '@sourcegraph/web/src/components/WebStory'
+
+import { AboutOrganizationPage } from './AboutOrganizationPage'
+
+const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+
+const config: Meta = {
+    title: 'web/Organizations/AboutOrganizationPage',
+    decorators: [decorator],
+}
+
+export default config
+
+export const Basic = (): JSX.Element => <AboutOrganizationPage telemetryService={NOOP_TELEMETRY_SERVICE} />

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from 'react'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
+import { SelfHostedCta } from '@sourcegraph/web/src/components/SelfHostedCta'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
+
+import styles from './AboutOrganizationPage.module.scss'
+
+interface AboutOrganizationPageProps extends TelemetryProps {}
+
+export const AboutOrganizationPage: React.FunctionComponent<AboutOrganizationPageProps> = ({ telemetryService }) => {
+    useEffect(() => {
+        telemetryService.logViewEvent('AboutOrg')
+    }, [telemetryService])
+
+    return (
+        <>
+            <PageTitle title="Organizations" />
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'Organizations' }]}
+                description="Support for organizations is not currently available on Sourcegraph cloud."
+                className="mb-3"
+            />
+            <Container>
+                <SelfHostedCta
+                    contentClassName={styles.selfHostedCtaContent}
+                    page="organizations"
+                    telemetryService={telemetryService}
+                >
+                    <p className="mb-2">
+                        <strong>Run Sourcegraph self-hosted for more enterprise features</strong>
+                    </p>
+                    <p className="mb-2">
+                        For team oriented functionality, additional code hosts and enterprise only features, install
+                        Sourcegraph self-hosted.
+                    </p>
+                </SelfHostedCta>
+            </Container>
+        </>
+    )
+}

--- a/client/web/src/user/settings/aboutOrganization/index.ts
+++ b/client/web/src/user/settings/aboutOrganization/index.ts
@@ -1,0 +1,1 @@
+export * from './AboutOrganizationPage'

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -2,8 +2,10 @@ import React, { useCallback, useState, useEffect } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isDefined, keyExistsIn } from '@sourcegraph/shared/src/util/types'
+import { SelfHostedCta } from '@sourcegraph/web/src/components/SelfHostedCta'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../../components/alerts'
@@ -23,7 +25,8 @@ type AuthProvider = SourcegraphContext['authProviders'][0]
 type AuthProvidersByKind = Partial<Record<ExternalServiceKind, AuthProvider>>
 
 export interface UserAddCodeHostsPageProps
-    extends Pick<UserExternalServicesOrRepositoriesUpdateProps, 'onUserExternalServicesOrRepositoriesUpdate'> {
+    extends Pick<UserExternalServicesOrRepositoriesUpdateProps, 'onUserExternalServicesOrRepositoriesUpdate'>,
+        TelemetryProps {
     user: { id: Scalars['ID']; tags: string[] }
     codeHostExternalServices: Record<string, AddExternalServiceOptions>
     routingPrefix: string
@@ -64,6 +67,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
     routingPrefix,
     context,
     onUserExternalServicesOrRepositoriesUpdate,
+    telemetryService,
 }) => {
     const [statusOrError, setStatusOrError] = useState<Status>()
     const { scopes, setScope } = useCodeHostScopeContext()
@@ -264,7 +268,6 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                 }
                 className="mb-3"
             />
-
             {/* display external service errors and success banners */}
             {getErrorAndSuccessBanners(statusOrError)}
             {/* display other errors, e.g. network errors */}
@@ -298,6 +301,13 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                     <LoadingSpinner className="icon-inline" />
                 </div>
             )}
+
+            <SelfHostedCta className="mt-5" page="settings/code-hosts" telemetryService={telemetryService}>
+                <p className="mb-2">
+                    <strong>Require support for Bitbucket, or nearly any other code host?</strong>
+                </p>
+                <p className="mb-2">You may need our self-hosted installation.</p>
+            </SelfHostedCta>
         </div>
     )
 }

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
@@ -2,13 +2,16 @@
     --gradient: linear-gradient(to right, var(--color-bg-2) 4%, var(--color-bg-1) 25%, var(--color-bg-2) 36%);
     --animation: shimmer 2s infinite linear;
     margin-bottom: 5rem;
+    position: relative;
 
     &__gitlab {
         fill: #ff5900 !important;
     }
+
     &__github {
         fill: var(--body-color) !important;
     }
+
     &__check {
         fill: var(--color-bg-3) !important;
     }
@@ -41,9 +44,11 @@
         border-color: var(--border-color-2) !important;
         border: 0;
         padding: 0;
+
         &:not(:last-child) {
             margin-bottom: 1.5rem;
         }
+
         + .user-settings-repos__container {
             border-top: 1px solid var(--border-color);
             padding-top: 1.5rem;
@@ -65,12 +70,19 @@
     &__text-disabled {
         color: var(--text-disabled);
     }
+
+    &__self-hosted-cta {
+        position: absolute;
+        top: -5rem;
+        right: 0;
+    }
 }
 
 @keyframes shimmer {
     0% {
         background-position: -1000px 0;
     }
+
     100% {
         background-position: 1000px 0;
     }

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -12,6 +12,7 @@ import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/er
 import { repeatUntil } from '@sourcegraph/shared/src/util/rxjs/repeatUntil'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { Badge } from '@sourcegraph/web/src/components/Badge'
+import { SelfHostedCtaLink } from '@sourcegraph/web/src/components/SelfHostedCtaLink'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
@@ -392,6 +393,11 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
 
     return (
         <div className="user-settings-repos">
+            <SelfHostedCtaLink
+                className="user-settings-repos__self-hosted-cta"
+                telemetryService={telemetryService}
+                page="settings/repositories"
+            />
             {status === 'scheduled' && (
                 <div className="alert alert-info">
                     <span className="font-weight-bold">{getCodeHostsSyncMessage()}</span> Repositories list may not be

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -130,6 +130,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
                 context={window.context}
                 routingPrefix={props.user.url + '/settings'}
                 onUserExternalServicesOrRepositoriesUpdate={props.onUserExternalServicesOrRepositoriesUpdate}
+                telemetryService={props.telemetryService}
             />
         ),
         exact: true,
@@ -152,5 +153,10 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
         exact: true,
         render: lazyComponent(() => import('./research/ProductResearch'), 'ProductResearchPage'),
         condition: () => window.context.productResearchPageEnabled,
+    },
+    {
+        path: '/about-organizations',
+        exact: true,
+        render: lazyComponent(() => import('./aboutOrganization/AboutOrganizationPage'), 'AboutOrganizationPage'),
     },
 ]


### PR DESCRIPTION
### Description
- Add new components `MarketingBlock` and `SelfHostedCta`, use them to add in product CTAs to the Cloud app

### Refs
- https://github.com/sourcegraph/sourcegraph/issues/24591


