### PR TITLE
Add Code Insights GitHub Beta Project issue status automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -49,6 +49,11 @@ jobs:
                 $pr = $github.event.pull_request
                 $repo = $github.repository
 
+                # Ignore merged and closed PRs
+                if ($pr.state -ne 'open') {
+                  return
+                }
+
                 $status = if ($pr.draft) { 'In Progress' } else { 'In Review' }
 
                 # Get fixed issues from the PR description

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -16,9 +16,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
         with:
           script: |
-            Install-Module PSGitHub -Force -ErrorAction Stop
+            $global:InformationPreference = 'Continue'
 
-            $VerbosePreference = 'Continue'
+            Install-Module PSGitHub -Force -ErrorAction Stop
 
             if (!$env:GITHUB_TOKEN) {
               throw "No GITHUB_TOKEN env var provided"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,4 +1,4 @@
-name: Update issue status in Code Insights GitHub Beta project
+name: Code Insights GitHub project automation
 
 on:
   issues:
@@ -17,6 +17,8 @@ jobs:
         with:
           script: |
             Install-Module PSGitHub -Force -ErrorAction Stop
+
+            $VerbosePreference = 'Continue'
 
             if (!$env:GITHUB_TOKEN) {
               throw "No GITHUB_TOKEN env var provided"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           script: |
             $global:InformationPreference = 'Continue'
+            $global:ProgressPreference = 'SilentlyContinue'
 
             Install-Module PSGitHub -Force -ErrorAction Stop
 
@@ -72,7 +73,7 @@ jobs:
                   Where-Object { $_.labels | Where-Object { $_.name -eq 'team/code-insights' } }
 
                 if (!$fixedIssues) {
-                  Write-Information "No fixed issues with team/code-insights label referenced from PR description"
+                  Write-Information "No fixed issues with team/code-insights label referenced from PR description, exiting."
                   return
                 }
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -38,6 +38,7 @@ jobs:
                 # which means we can hope the issue is usually found in the first page(s).
 
                 if (-not ($github.event.issue.labels | Where-Object { $_.name -eq 'team/code-insights' })) {
+                  Write-Information "Issue does not have team/code-insights label, exiting."
                   return
                 }
 
@@ -71,6 +72,7 @@ jobs:
                   Where-Object { $_.labels | Where-Object { $_.name -eq 'team/code-insights' } }
 
                 if (!$fixedIssues) {
+                  Write-Information "No fixed issues with team/code-insights label referenced from PR description"
                   return
                 }
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -27,7 +27,7 @@ jobs:
             $PSDefaultParameterValues['*GitHub*:Token'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
             $PSDefaultParameterValues['*GitHubBetaProject*:ProjectNodeId'] = 'MDExOlByb2plY3ROZXh0MzI3Ng==' # https://github.com/orgs/sourcegraph/projects/200
 
-            $fixIssuePattern = "(?:close|fixe?|resolve)(?:[sd])? (?:#|(?<repo>[^/]+/[^/]+)|https://github\.com/(?<repo>[^/]+/[^/]+)/issues/)(?<number>\d+)"
+            $fixIssuePattern = "(?:close|fixe?|resolve)(?:[sd])? (?:#|(?<owner>[^/]+)/(?<repo>[^/]+)|https://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/issues/)(?<number>\d+)"
 
             switch ($github.event_name) {
 
@@ -36,6 +36,10 @@ jobs:
                 # THIS DOES NOT SCALE AS THE PROJECT GETS LARGE, but it's the only way possible afaict.
                 # One way this is mitigated is that this request is streamed/paginated in order of most-recent-first,
                 # which means we can hope the issue is usually found in the first page(s).
+
+                if (-not ($github.event.issue.labels | Where-Object { $_.name -eq 'team/code-insights' })) {
+                  return
+                }
 
                 $status = if ($github.event.action -eq 'closed') { 'Done' } else { 'In Progress' }
 
@@ -56,18 +60,31 @@ jobs:
 
                 $status = if ($pr.draft) { 'In Progress' } else { 'In Review' }
 
-                # Get fixed issues from the PR description
-                $fixedIssues = [regex]::Matches($pr.body, $fixIssuePattern, [Text.RegularExpressions.RegexOptions]::IgnoreCase) | ForEach-Object { $_.Groups['number'].Value }
+                # Get fixed team/code-insights issues from the PR description
+                $fixedIssues = [regex]::Matches($pr.body, $fixIssuePattern, [Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+                  ForEach-Object {
+                    $owner = if ($_.Groups.owner.Success) { $_.Groups.owner.Value } else { $pr.repository.owner.login }
+                    $repo = if ($_.Groups.repo.Success) { $_.Groups.repo.Value } else { $pr.repository.name }
+                    $number = $_.Groups.number.Value
+                    Get-GitHubIssue -Owner $owner -Repository $repo -Number $number
+                  } |
+                  Where-Object { $_.labels | Where-Object { $_.name -eq 'team/code-insights' } }
+
+                if (!$fixedIssues) {
+                  return
+                }
+
+                Write-Information "Fixed issues:"
+                $fixedIssues | ForEach-Object HtmlUrl | Write-Information
 
                 # Find project items for the issues the PR references
                 Get-GitHubBetaProjectItem |
                   Where-Object {
                     $item = $_
                     $fixedIssues | Where-Object {
-                      # Check issue number is the same
-                      $_.Groups['number'].Value -eq $item.content.number -and
-                      # Check repo is same
-                      ($_.Groups['repo'].Value -eq $item.content.repository.nameWithOwner -or (!$_.Groups['repo'].Success -and $repo -eq $item.content.repository.nameWithOwner))
+                      $_.Number -eq $item.content.number -and
+                      $_.Owner -eq $item.content.repository.owner.login -and
+                      $_.RepositoryName -eq $item.content.repository.name
                     }
                   } |
                   Select-Object -First $fixedIssues.Count |

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,69 @@
+name: Update issue status in Code Insights GitHub Beta project
+
+on:
+  issues:
+    types: [closed, reopened]
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+jobs:
+  update-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update status
+        uses: Amadevus/pwsh-script@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
+        with:
+          script: |
+            Install-Module PSGitHub -Force -ErrorAction Stop
+
+            if (!$env:GITHUB_TOKEN) {
+              throw "No GITHUB_TOKEN env var provided"
+            }
+
+            $PSDefaultParameterValues['*GitHub*:Token'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
+            $PSDefaultParameterValues['*GitHubBetaProject*:ProjectNodeId'] = 'MDExOlByb2plY3ROZXh0MzI3Ng==' # https://github.com/orgs/sourcegraph/projects/200
+
+            $fixIssuePattern = "(?:close|fixe?|resolve)(?:[sd])? (?:#|(?<repo>[^/]+/[^/]+)|https://github\.com/(?<repo>[^/]+/[^/]+)/issues/)(?<number>\d+)"
+
+            switch ($github.event_name) {
+
+              'issues' {
+                # Find project item for the issue
+                # THIS DOES NOT SCALE AS THE PROJECT GETS LARGE, but it's the only way possible afaict.
+                # One way this is mitigated is that this request is streamed/paginated in order of most-recent-first,
+                # which means we can hope the issue is usually found in the first page(s).
+
+                $status = if ($github.event.action -eq 'closed') { 'Done' } else { 'In Progress' }
+
+                Get-GitHubBetaProjectItem |
+                  Where-Object { $_.content.number -eq $github.event.issue.number } |
+                  Select-Object -First 1 |
+                  Set-GitHubBetaProjectItemField -FieldName 'Status' -Value $status
+              }
+
+              'pull_request' {
+                $pr = $github.event.pull_request
+                $repo = $github.repository
+
+                $status = if ($pr.draft) { 'In Progress' } else { 'In Review' }
+
+                # Get fixed issues from the PR description
+                $fixedIssues = [regex]::Matches($pr.body, $fixIssuePattern, [Text.RegularExpressions.RegexOptions]::IgnoreCase) | ForEach-Object { $_.Groups['number'].Value }
+
+                # Find project items for the issues the PR references
+                Get-GitHubBetaProjectItem |
+                  Where-Object {
+                    $item = $_
+                    $fixedIssues | Where-Object {
+                      # Check issue number is the same
+                      $_.Groups['number'].Value -eq $item.content.number -and
+                      # Check repo is same
+                      ($_.Groups['repo'].Value -eq $item.content.repository.nameWithOwner -or (!$_.Groups['repo'].Success -and $repo -eq $item.content.repository.nameWithOwner))
+                    }
+                  } |
+                  Select-Object -First $fixedIssues.Count |
+                  Set-GitHubBetaProjectItemField -FieldName 'Status' -Value $status
+              }
+            }


### PR DESCRIPTION
Experiment to see if I can quickly automate issue statuses in the new Beta GitHub project boards. This is intended to be supported in the next months, but currently, the only way is through some extremely clunky GraphQL APIs. For example, the only way to get the associated project item for an issue is to go through all project items, there is no reverse-lookup. This is implemented using streaming in most-recently-added-items-first order (aborting once the matching item is found) to make this somewhat better than fetching the whole list into memory.

This is hard to test locally, so I expect more follow-up fix and debug PRs...