### PR TITLE
Don't run Buildkite CI on .github config changes

### DIFF
--- a/enterprise/dev/ci/internal/ci/changed.go
+++ b/enterprise/dev/ci/internal/ci/changed.go
@@ -17,6 +17,16 @@ func (c ChangedFiles) onlyDocs() bool {
 	return true
 }
 
+// onlyConfig returns whether the ChangedFiles are only config file changes that don't need to run CI.
+func (c ChangedFiles) onlyConfig() bool {
+	for _, p := range c {
+		if !strings.HasPrefix(p, ".github/") {
+			return false
+		}
+	}
+	return true
+}
+
 // onlySg returns whether the ChangedFiles are only in the ./dev/sg folder.
 func (c ChangedFiles) onlySg() bool {
 	for _, p := range c {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -45,6 +45,10 @@ func CoreTestOperations(changedFiles ChangedFiles, buildOptions bk.BuildOptions)
 
 	// Build special pipelines for changes that only touch a subset of code.
 	switch {
+	case changedFiles.onlyConfig():
+		// If this PR only affects e.g. .github config files, no steps are necessary to run.
+		operations = []Operation{}
+
 	case changedFiles.onlyDocs():
 		// If this is a docs-only PR, run only the steps necessary to verify the docs.
 		operations = []Operation{


### PR DESCRIPTION
Adds the same logic we have for changes to only the docs for changes to config and markdown files under `.github`, to not run long and potentially flaky CI tests for changes to these files.