### PR TITLE
Insights/sg docs

### DIFF
--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -93,17 +93,17 @@ Make sure that `~/my/path` is in your `$PATH` then.
 
 ## Usage
 
-### `sg [start,run,run-set]` - Start dev environment
+### `sg [start,run]` - Start dev environment
 
 ```bash
 # Run default environment (this starts the 'default' command set defined in `sg.config.yaml`):
 sg start
 
 # Run the enterprise environment:
-sg run-set enterprise
+sg start enterprise
 
 # Override the logger levels for specific services
-sg run-set --debug=gitserver --error=enterprise-worker,enterprise-frontend enterprise
+sg start --debug=gitserver --error=enterprise-worker,enterprise-frontend enterprise
 
 # Run specific commands:
 sg run gitserver
@@ -116,7 +116,7 @@ sg run gitserver frontend repo-updater
 sg run -help
 
 # List available command sets:
-sg run-set -help
+sg start -help
 ```
 
 ### `sg test` - Running test suites
@@ -191,6 +191,14 @@ sg rfc search "search terms"
 
 # Open a specific RFC
 sg rfc open 420
+```
+
+## Useful commands by feature
+### Code Insights
+```bash
+sg start --info=enterprise-worker enterprise-codeinsights # start the local environment with Code Insights running at a useful log level
+sg start monitoring # start the monitoring stack if needed
+sg run enterprise-web-standalone # connect to k8s-dogfood with just the web client 
 ```
 
 ## Configuration

--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -196,9 +196,14 @@ sg rfc open 420
 ## Useful commands by feature
 ### Code Insights
 ```bash
-sg start --info=enterprise-worker enterprise-codeinsights # start the local environment with Code Insights running at a useful log level
-sg start monitoring # start the monitoring stack if needed
-sg run enterprise-web-standalone # connect to k8s-dogfood with just the web client 
+# start the local environment with Code Insights running at a useful log level
+sg start --info=enterprise-worker enterprise-codeinsights
+
+# start the monitoring stack if needed
+sg start monitoring 
+
+# connect to k8s-dogfood with just the web client 
+sg run enterprise-web-standalone 
 ```
 
 ## Configuration


### PR DESCRIPTION
1. Removed references to `run-set` from the README.
2. Added a useful commands section for teams to place useful commands for their feature. Context in [this](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1632348940158400) thread

 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
