### PR TITLE
Handle draft issues in project automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -85,6 +85,7 @@ jobs:
                   Where-Object {
                     $item = $_
                     $fixedIssues | Where-Object {
+                      $item.content -and
                       $_.Number -eq $item.content.number -and
                       $_.Owner -eq $item.content.repository.owner.login -and
                       $_.RepositoryName -eq $item.content.repository.name


### PR DESCRIPTION
When the issue is a "draft issue" (item on the project board without associated issue/PR), `item.content` is `null`.