### PR TITLE
Fix executor image release: use correct IMAGE_NAME

### DIFF
--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -7,4 +7,4 @@ IMAGE_NAME="executor-$(git log -n1 --pretty=format:%h)-${BUILD_TIMESTAMP}"
 gcloud compute images add-labels --project=sourcegraph-ci "${IMAGE_NAME}" --labels='released=true'
 
 # Make image publicly accessible
-gcloud compute images add-iam-policy-binding "${IMAGE}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+gcloud compute images add-iam-policy-binding "${IMAGE_NAME}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'


### PR DESCRIPTION
Should fix the build failing: https://buildkite.com/sourcegraph/sourcegraph/builds/109262#73250311-5b8b-424b-a47d-eb3c272d5b5e