### PR TITLE
[on-prem] Add terms of service checkbox to sign up forms

### DIFF
--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -101,7 +101,7 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
                 body={
                     <div className={classNames('pb-5', signInSignUpCommonStyles.signupPageContainer)}>
                         {context.sourcegraphDotComMode && <p className="pt-1 pb-2">Start searching public code now</p>}
-                        <SignUpForm context={context} onSignUp={handleSignUp} />
+                        <SignUpForm context={context} onSignUp={handleSignUp} signupTermsCheckbox={true} />
                         <p className="mt-3">
                             Already have an account? <Link to={`/sign-in${location.search}`}>Sign in</Link>
                         </p>

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -89,6 +89,7 @@ export const SiteInitPage: React.FunctionComponent<Props> = ({
                                 className="w-100"
                                 buttonLabel="Create admin account & continue"
                                 onSignUp={initSite}
+                                signupTermsCheckbox={true}
                                 context={context}
                             />
                         </>


### PR DESCRIPTION
This is needed from legal perspective. A user signing up
should provide active consent to privacy policy.

Related issue:
https://sourcegraph.atlassian.net/browse/CLOUD-34

<img width="373" alt="Screenshot 2021-09-22 at 17 42 07" src="https://user-images.githubusercontent.com/9974711/134517147-bb2a28b9-c0ed-485c-8406-4517ccfd8637.png">

