### PR TITLE
search: gob encode zoekt queries once

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -83,6 +83,11 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 		endpointMaxPendingPriority[endpoint] = math.Inf(1)
 	}
 
+	// GobCache exists so we only pay the cost of marshalling a query once
+	// when we aggregate it out over all the replicas. Zoekt's RPC layers
+	// unwrap this before passing it on to the Zoekt evaluation layers.
+	q = &query.GobCache{Q: q}
+
 	ch := make(chan error, len(clients))
 	for endpoint, c := range clients {
 		go func(endpoint string, c zoekt.Streamer) {


### PR DESCRIPTION
We currently marshal Q for each replica, which is 49 times for
sourcegraph.com. If you have a large Q this cost can add up to GB of
memory use.

We need to remove most of our large querys we generate, but for now it
is better behaviour to not potentially OOM if we miss something.
