### PR TITLE
make new commit/diff search unicode-aware

### DIFF
--- a/internal/gitserver/search/match_tree_test.go
+++ b/internal/gitserver/search/match_tree_test.go
@@ -72,6 +72,14 @@ func Test_matchesToRanges(t *testing.T) {
 				End:   protocol.Location{Offset: 7, Line: 1, Column: 3},
 			}},
 		},
+		5: {
+			input:   "›a", // three-byte unicode character
+			matches: [][]int{{3, 4}},
+			expectedRanges: protocol.Ranges{{
+				Start: protocol.Location{Offset: 1, Line: 0, Column: 1},
+				End:   protocol.Location{Offset: 2, Line: 0, Column: 2},
+			}},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This PR modifies commit/diff search to make highlight ranges use rune offsets rather than byte offsets.

Fixes #25308 
Stacked on #25006 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
