### PR TITLE
insights: add site configuration value for commit indexer interval

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [closed, reopened]
   pull_request:
-    types: [opened, edited, synchronize, ready_for_review]
+    types: [opened, edited, synchronize, ready_for_review, converted_to_draft]
 
 jobs:
   update-status:

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 
 	"github.com/inconshreveable/log15"
@@ -79,8 +80,11 @@ func NewCommitIndexerWorker(ctx context.Context, base dbutil.DB, insights dbutil
 }
 
 func (i *CommitIndexer) Handler(ctx context.Context) goroutine.BackgroundRoutine {
-	//TODO(insights) consider adding setting for index interval
-	interval := time.Hour * 1
+	intervalMinutes := conf.Get().InsightsCommitIndexerInterval
+	if intervalMinutes <= 0 {
+		intervalMinutes = 1
+	}
+	interval := time.Minute * time.Duration(intervalMinutes)
 
 	//TODO(insights) convert this to a metrics generating goroutine
 	return goroutine.NewPeriodicGoroutine(ctx, interval,

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -82,7 +82,7 @@ func NewCommitIndexerWorker(ctx context.Context, base dbutil.DB, insights dbutil
 func (i *CommitIndexer) Handler(ctx context.Context) goroutine.BackgroundRoutine {
 	intervalMinutes := conf.Get().InsightsCommitIndexerInterval
 	if intervalMinutes <= 0 {
-		intervalMinutes = 1
+		intervalMinutes = 60
 	}
 	interval := time.Minute * time.Duration(intervalMinutes)
 

--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -58,6 +58,7 @@ var requireRestart = []string{
 	"externalURL",
 	"update.channel",
 	"insights.query.worker.concurrency",
+	"insights.commit.indexer.interval",
 }
 
 // NeedRestartToApply determines if a restart is needed to apply the changes

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1540,6 +1540,8 @@ type SiteConfiguration struct {
 	HtmlHeadBottom string `json:"htmlHeadBottom,omitempty"`
 	// HtmlHeadTop description: HTML to inject at the top of the `<head>` element on each page, for analytics scripts
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
+	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the commit indexer will check for new commits.
+	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
 	// InsightsHistoricalFrameLength description: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
 	InsightsHistoricalFrameLength string `json:"insights.historical.frameLength,omitempty"`
 	// InsightsHistoricalFrames description: (debug) number of historical insights timeframes to populate

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1540,7 +1540,7 @@ type SiteConfiguration struct {
 	HtmlHeadBottom string `json:"htmlHeadBottom,omitempty"`
 	// HtmlHeadTop description: HTML to inject at the top of the `<head>` element on each page, for analytics scripts
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
-	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the commit indexer will check for new commits.
+	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the insights commit indexer will check for new commits.
 	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
 	// InsightsHistoricalFrameLength description: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
 	InsightsHistoricalFrameLength string `json:"insights.historical.frameLength,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -920,6 +920,13 @@
       "examples": [50.0, 0.5],
       "!go": { "pointer": true }
     },
+    "insights.commit.indexer.interval": {
+      "description": "The interval (in minutes) at which the commit indexer will check for new commits.",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 60,
+      "examples": [120]
+    },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",
       "type": "string",


### PR DESCRIPTION
Closes #22038

### Description

This adds a site configuration value for the commit indexer interval, (in minutes,) and reads the value in when setting the interval in the commit indexer.

### Testing Steps

This was a little tricky to test; it doesn't seem like the site configuration settings get saved through the UI. (Is that expected?) But I did verify:
- Saving an `insights.commit.indexer.interval` value warns that the service will need to be restarted in order for it to take effect.
- If I modify the site config in `dev-private` to include this value, the commit indexer interval is picked up and set appropriately.

Let me know if this sounds reasonable, or if I'm misunderstanding how to test it!

