### PR TITLE
new commit/diff search: fix an issue where the last line in a diff would not be highlighted

### DIFF
--- a/internal/gitserver/search/diff_format.go
+++ b/internal/gitserver/search/diff_format.go
@@ -180,6 +180,9 @@ func splitHunkMatches(hunks []*diff.Hunk, hunkHighlights map[int]HunkHighlight, 
 		if cur != nil {
 			addExtraHunkMatchesSection(cur, extraHunkMatches)
 			cur.Body = bytes.Join(curLines, nil)
+			if len(curHighlights) > 0 {
+				newHighlights[len(results)] = HunkHighlight{LineHighlights: curHighlights}
+			}
 			results = append(results, cur)
 		}
 	}

--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/go-diff/diff"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+)
+
+func TestDiffFormat(t *testing.T) {
+	t.Run("last line matches", func(t *testing.T) {
+		rawDiff := `diff --git a/.mailmap b/.mailmap
+index dbace57d5f..53357b4971 100644
+--- .mailmap
++++ .mailmap
+@@ -59,3 +59,4 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>
+ Renovate Bot <bot@renovateapp.com> renovate[bot] <renovate[bot]@users.noreply.github.com>
+ Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>
++Camden Cheek <camden@sourcegraph.com> Camden Cheek <camden@ccheek.com>
+`
+		parsedDiff, err := diff.NewMultiFileDiffReader(strings.NewReader(rawDiff)).ReadAllFiles()
+		require.NoError(t, err)
+
+		highlights := map[int]FileDiffHighlight{
+			0: {HunkHighlights: map[int]HunkHighlight{
+				0: {LineHighlights: map[int]protocol.Ranges{
+					2: {{
+						Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
+						End:   protocol.Location{Offset: 6, Line: 0, Column: 6},
+					}},
+				}},
+			}},
+		}
+
+		formatted, ranges := FormatDiff(parsedDiff, highlights)
+		expectedFormatted := `.mailmap .mailmap
+@@ -60,1 +60,2 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>
+ Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>
++Camden Cheek <camden@sourcegraph.com> Camden Cheek <camden@ccheek.com>
+`
+		require.Equal(t, expectedFormatted, formatted)
+
+		expectedRanges := protocol.Ranges{{
+			Start: protocol.Location{Offset: 142, Line: 3, Column: 1},
+			End:   protocol.Location{Offset: 148, Line: 3, Column: 7},
+		}}
+		require.Equal(t, expectedRanges, ranges)
+
+	})
+}


### PR DESCRIPTION
See test for an example of what would be affected. 

Stacked on #25006 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
