### PR TITLE
new diff/commit search: improve performance for case-insensitive search

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -979,8 +979,13 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 		defer close(resultChan)
 		done := ctx.Done()
 
+		mt, err := search.ToMatchTree(args.Query)
+		if err != nil {
+			return err
+		}
+
 		var conversionErr error
-		err := search.Search(ctx, dir.Path(), args.Revisions, search.ToMatchTree(args.Query), func(match *search.LazyCommit, highlights *search.CommitHighlights) bool {
+		err = search.Search(ctx, dir.Path(), args.Revisions, mt, func(match *search.LazyCommit, highlights *search.CommitHighlights) bool {
 			res, err := search.CreateCommitMatch(match, highlights, args.IncludeDiff)
 			if err != nil {
 				conversionErr = err

--- a/cmd/searcher/search/lower_amd64.go
+++ b/cmd/searcher/search/lower_amd64.go
@@ -1,4 +1,0 @@
-package search
-
-// implemented in assembly, see lower_amd64.s
-func bytesToLowerASCII(dst, src []byte)

--- a/cmd/searcher/search/lower_other.go
+++ b/cmd/searcher/search/lower_other.go
@@ -1,6 +1,0 @@
-//go:build !amd64
-// +build !amd64
-
-package search
-
-var bytesToLowerASCII = bytesToLowerASCIIgeneric

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/errors"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/pathmatch"
+	"github.com/sourcegraph/sourcegraph/internal/search/casetransform"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
@@ -91,7 +91,7 @@ func compile(p *protocol.PatternInfo) (*readerGrep, error) {
 			if err != nil {
 				return nil, err
 			}
-			lowerRegexpASCII(re)
+			casetransform.LowerRegexpASCII(re)
 			expr = re.String()
 		}
 
@@ -172,7 +172,7 @@ func (rg *readerGrep) Find(zf *store.ZipFile, f *store.SrcFile, limit int) (matc
 			rg.transformBuf = make([]byte, zf.MaxLen)
 		}
 		fileMatchBuf = rg.transformBuf[:len(fileBuf)]
-		bytesToLowerASCII(fileMatchBuf, fileBuf)
+		casetransform.BytesToLowerASCII(fileMatchBuf, fileBuf)
 	}
 
 	// Most files will not have a match and we bound the number of matched
@@ -418,149 +418,6 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, limit i
 	)
 
 	return err
-}
-
-// lowerRegexpASCII lowers rune literals and expands char classes to include
-// lowercase. It does it inplace. We can't just use strings.ToLower since it
-// will change the meaning of regex shorthands like \S or \B.
-func lowerRegexpASCII(re *syntax.Regexp) {
-	for _, c := range re.Sub {
-		if c != nil {
-			lowerRegexpASCII(c)
-		}
-	}
-	switch re.Op {
-	case syntax.OpLiteral:
-		// For literal strings we can simplify lower each character.
-		for i := range re.Rune {
-			re.Rune[i] = unicode.ToLower(re.Rune[i])
-		}
-	case syntax.OpCharClass:
-		l := len(re.Rune)
-
-		// An exclusion class is something like [^A-Z]. We need to specially
-		// handle it since the user intention of [^A-Z] should map to
-		// [^a-z]. If we use the normal mapping logic, we will do nothing
-		// since [a-z] is in [^A-Z]. We assume we have an exclusion class if
-		// our inclusive range starts at 0 and ends at the end of the unicode
-		// range. Note this means we don't support unusual ranges like
-		// [^\x00-B] or [^B-\x{10ffff}].
-		isExclusion := l >= 4 && re.Rune[0] == 0 && re.Rune[l-1] == utf8.MaxRune
-		if isExclusion {
-			// Algorithm:
-			// Assume re.Rune is sorted (it is!)
-			// 1. Build a list of inclusive ranges in a-z that are excluded in A-Z (excluded)
-			// 2. Copy across classes, ensuring all ranges are outside of ranges in excluded.
-			//
-			// In our comments we use the mathematical notation [x, y] and (a,
-			// b). [ and ] are range inclusive, ( and ) are range
-			// exclusive. So x is in [x, y], but not in (x, y).
-
-			// excluded is a list of _exclusive_ ranges in ['a', 'z'] that need
-			// to be removed.
-			excluded := []rune{}
-
-			// Note i starts at 1, so we are inspecting the gaps between
-			// ranges. So [re.Rune[0], re.Rune[1]] and [re.Rune[2],
-			// re.Rune[3]] impiles we have an excluded range of (re.Rune[1],
-			// re.Rune[2]).
-			for i := 1; i < l-1; i += 2 {
-				// (a, b) is a range that is excluded
-				a, b := re.Rune[i], re.Rune[i+1]
-				// This range doesn't exclude [A-Z], so skip (does not
-				// intersect with ['A', 'Z']).
-				if a > 'Z' || b < 'A' {
-					continue
-				}
-				// We know (a, b) intersects with ['A', 'Z']. So clamp such
-				// that we have the intersection (a, b) ^ [A, Z]
-				if a < 'A' {
-					a = 'A' - 1
-				}
-				if b > 'Z' {
-					b = 'Z' + 1
-				}
-				// (a, b) is now a range contained in ['A', 'Z'] that needs to
-				// be excluded. So we map it to the lower case version and add
-				// it to the excluded list.
-				excluded = append(excluded, a+'a'-'A', b+'b'-'B')
-			}
-
-			// Adjust re.Rune to exclude excluded. This may require shrinking
-			// or growing the list, so we do it to a copy.
-			copy := make([]rune, 0, len(re.Rune))
-			for i := 0; i < l; i += 2 {
-				// [a, b] is a range that is included
-				a, b := re.Rune[i], re.Rune[i+1]
-
-				// Remove exclusions ranges that occur before a. They would of
-				// been previously processed.
-				for len(excluded) > 0 && a >= excluded[1] {
-					excluded = excluded[2:]
-				}
-
-				// If our exclusion range happens after b, that means we
-				// should only consider it later.
-				if len(excluded) == 0 || b <= excluded[0] {
-					copy = append(copy, a, b)
-					continue
-				}
-
-				// We now know that the current exclusion range intersects
-				// with [a, b]. Break it into two parts, the range before a
-				// and the range after b.
-				if a <= excluded[0] {
-					copy = append(copy, a, excluded[0])
-				}
-				if b >= excluded[1] {
-					copy = append(copy, excluded[1], b)
-				}
-			}
-			re.Rune = copy
-		} else {
-			for i := 0; i < l; i += 2 {
-				// We found a char class that includes a-z. No need to
-				// modify.
-				if re.Rune[i] <= 'a' && re.Rune[i+1] >= 'z' {
-					return
-				}
-			}
-			for i := 0; i < l; i += 2 {
-				a, b := re.Rune[i], re.Rune[i+1]
-				// This range doesn't include A-Z, so skip
-				if a > 'Z' || b < 'A' {
-					continue
-				}
-				simple := true
-				if a < 'A' {
-					simple = false
-					a = 'A'
-				}
-				if b > 'Z' {
-					simple = false
-					b = 'Z'
-				}
-				a, b = unicode.ToLower(a), unicode.ToLower(b)
-				if simple {
-					// The char range is within A-Z, so we can
-					// just modify it to be the equivalent in a-z.
-					re.Rune[i], re.Rune[i+1] = a, b
-				} else {
-					// The char range includes characters outside
-					// of A-Z. To be safe we just append a new
-					// lowered range which is the intersection
-					// with A-Z.
-					re.Rune = append(re.Rune, a, b)
-				}
-			}
-		}
-	default:
-		return
-	}
-	// Copy to small storage if necessary
-	for i := 0; i < 2 && i < len(re.Rune); i++ {
-		re.Rune0[i] = re.Rune[i]
-	}
 }
 
 // longestLiteral finds the longest substring that is guaranteed to appear in

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -16,21 +16,23 @@ type SearchQuery interface {
 // AuthorMatches is a predicate that matches if the author's name or email address
 // matches the regex pattern.
 type AuthorMatches struct {
-	Regexp
+	Expr       string
+	IgnoreCase bool
 }
 
 func (a AuthorMatches) String() string {
-	return fmt.Sprintf("%T(%s)", a, a.Regexp.String())
+	return fmt.Sprintf("%T(%s)", a, a.Expr)
 }
 
 // CommitterMatches is a predicate that matches if the author's name or email address
 // matches the regex pattern.
 type CommitterMatches struct {
-	Regexp
+	Expr       string
+	IgnoreCase bool
 }
 
 func (c CommitterMatches) String() string {
-	return fmt.Sprintf("%T(%s)", c, c.Regexp.String())
+	return fmt.Sprintf("%T(%s)", c, c.Expr)
 }
 
 // CommitBefore is a predicate that matches if the commit is before the given date
@@ -54,31 +56,34 @@ func (c CommitAfter) String() string {
 // MessageMatches is a predicate that matches if the commit message matches
 // the provided regex pattern.
 type MessageMatches struct {
-	Regexp
+	Expr       string
+	IgnoreCase bool
 }
 
 func (m MessageMatches) String() string {
-	return fmt.Sprintf("%T(%s)", m, m.Regexp.String())
+	return fmt.Sprintf("%T(%s)", m, m.Expr)
 }
 
 // DiffMatches is a a predicate that matches if any of the lines changed by
 // the commit match the given regex pattern.
 type DiffMatches struct {
-	Regexp
+	Expr       string
+	IgnoreCase bool
 }
 
 func (d DiffMatches) String() string {
-	return fmt.Sprintf("%T(%s)", d, d.Regexp.String())
+	return fmt.Sprintf("%T(%s)", d, d.Expr)
 }
 
 // DiffModifiesFile is a predicate that matches if the commit modifies any files
 // that match the given regex pattern.
 type DiffModifiesFile struct {
-	Regexp
+	Expr       string
+	IgnoreCase bool
 }
 
 func (d DiffModifiesFile) String() string {
-	return fmt.Sprintf("%T(%s)", d, d.Regexp.String())
+	return fmt.Sprintf("%T(%s)", d, d.Expr)
 }
 
 // And is a predicate that matches if all of its children predicates match

--- a/internal/gitserver/search/diff_test.go
+++ b/internal/gitserver/search/diff_test.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 
@@ -39,8 +38,9 @@ index 2f71392b2f..d874527291 100644
 	fileDiffs, err := r.ReadAllFiles()
 	require.NoError(t, err)
 
-	query := &protocol.DiffMatches{protocol.Regexp{regexp.MustCompile("(?i)polly")}}
-	matchTree := ToMatchTree(query)
+	query := &protocol.DiffMatches{Expr: "(?i)polly"}
+	matchTree, err := ToMatchTree(query)
+	require.NoError(t, err)
 
 	matched, highlights, err := matchTree.Match(&LazyCommit{diff: fileDiffs})
 	require.NoError(t, err)

--- a/internal/gitserver/search/diff_test.go
+++ b/internal/gitserver/search/diff_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	_ "embed"
 	"strings"
 	"testing"
 
@@ -10,31 +11,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
 
+var (
+	//go:embed testdata/small_diff.txt
+	smallDiff string
+
+	//go:embed testdata/large_diff.txt
+	largeDiff string
+)
+
 func TestDiffSearch(t *testing.T) {
-	rawDiff := `diff --git a/web/src/integration/gqlresponses/user_settings_bla_response_1.ts b/web/src/integration/gqlresponses/user_settings_bla_response_1.ts
-new file mode 100644
-index 0000000000..4f6e758628
---- /dev/null
-+++ web/src/integration/gqlresponses/user_settings_bla_response_1.ts
-@@ -0,0 +1,4 @@
-+export const overrideSettingsResponse: OverrideSettingsResponseShape = {
-+    foo: 1,
-+    bar: {},
-+}
-diff --git a/web/src/integration/helpers.ts b/web/src/integration/helpers.ts
-index 2f71392b2f..d874527291 100644
---- web/src/integration/helpers.ts
-+++ web/src/integration/helpers.ts
-@@ -5,7 +5,7 @@ import { createDriverForTest, Driver } from '../../../shared/src/testing/driver'
- import * as path from 'path'
- import mkdirp from 'mkdirp-promise'
- import express from 'express'
--import { Polly } from '@pollyjs/core'
-+import { Polly, Request, Response } from '@pollyjs/core'
- import { PuppeteerAdapter } from './polly/PuppeteerAdapter'
- import FSPersister from '@pollyjs/persister-fs'
-`
-	r := diff.NewMultiFileDiffReader(strings.NewReader(rawDiff))
+	r := diff.NewMultiFileDiffReader(strings.NewReader(smallDiff))
 	fileDiffs, err := r.ReadAllFiles()
 	require.NoError(t, err)
 
@@ -100,4 +86,88 @@ index 2f71392b2f..d874527291 100644
 	require.Equal(t, expectedFormatted, formatted)
 	require.Equal(t, expectedRanges, ranges)
 
+}
+
+func BenchmarkDiffSearchCaseInsensitiveOptimization(b *testing.B) {
+	b.Run("small diff", func(b *testing.B) {
+		r := diff.NewMultiFileDiffReader(strings.NewReader(smallDiff))
+		fileDiffs, err := r.ReadAllFiles()
+		require.NoError(b, err)
+
+		b.Run("with optimization", func(b *testing.B) {
+			query := &protocol.DiffMatches{Expr: "polly", IgnoreCase: true}
+			matchTree, err := ToMatchTree(query)
+			require.NoError(b, err)
+
+			for i := 0; i < b.N; i++ {
+				matched, _, _ := matchTree.Match(&LazyCommit{diff: fileDiffs})
+				require.True(b, matched)
+			}
+		})
+
+		b.Run("without optimization", func(b *testing.B) {
+			query := &protocol.DiffMatches{Expr: "(?i)polly", IgnoreCase: false}
+			matchTree, err := ToMatchTree(query)
+			require.NoError(b, err)
+
+			for i := 0; i < b.N; i++ {
+				matched, _, _ := matchTree.Match(&LazyCommit{diff: fileDiffs})
+				require.True(b, matched)
+			}
+		})
+	})
+
+	b.Run("large diff", func(b *testing.B) {
+		r := diff.NewMultiFileDiffReader(strings.NewReader(largeDiff))
+		fileDiffs, err := r.ReadAllFiles()
+		require.NoError(b, err)
+
+		b.Run("many matches", func(b *testing.B) {
+			b.Run("with optimization", func(b *testing.B) {
+				query := &protocol.DiffMatches{Expr: "suggestion", IgnoreCase: true}
+				matchTree, err := ToMatchTree(query)
+				require.NoError(b, err)
+
+				for i := 0; i < b.N; i++ {
+					matched, _, _ := matchTree.Match(&LazyCommit{diff: fileDiffs})
+					require.True(b, matched)
+				}
+			})
+
+			b.Run("without optimization", func(b *testing.B) {
+				query := &protocol.DiffMatches{Expr: "(?i)suggestion", IgnoreCase: false}
+				matchTree, err := ToMatchTree(query)
+				require.NoError(b, err)
+
+				for i := 0; i < b.N; i++ {
+					matched, _, _ := matchTree.Match(&LazyCommit{diff: fileDiffs})
+					require.True(b, matched)
+				}
+			})
+		})
+
+		b.Run("few matches", func(b *testing.B) {
+			b.Run("with optimization", func(b *testing.B) {
+				query := &protocol.DiffMatches{Expr: "limitoffset", IgnoreCase: true}
+				matchTree, err := ToMatchTree(query)
+				require.NoError(b, err)
+
+				for i := 0; i < b.N; i++ {
+					matched, _, _ := matchTree.Match(&LazyCommit{diff: fileDiffs})
+					require.True(b, matched)
+				}
+			})
+
+			b.Run("without optimization", func(b *testing.B) {
+				query := &protocol.DiffMatches{Expr: "(?i)limitoffset", IgnoreCase: false}
+				matchTree, err := ToMatchTree(query)
+				require.NoError(b, err)
+
+				for i := 0; i < b.N; i++ {
+					matched, _, _ := matchTree.Match(&LazyCommit{diff: fileDiffs})
+					require.True(b, matched)
+				}
+			})
+		})
+	})
 }

--- a/internal/gitserver/search/lazy_commit.go
+++ b/internal/gitserver/search/lazy_commit.go
@@ -19,6 +19,9 @@ type LazyCommit struct {
 	// diff is the parsed output from the diff fetcher, cached here for performance
 	diff        []*diff.FileDiff
 	diffFetcher *DiffFetcher
+
+	// LowerBuf is a re-usable buffer for doing case-transformations on the fields of LazyCommit
+	LowerBuf []byte
 }
 
 func (l *LazyCommit) AuthorDate() (time.Time, error) {

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"bytes"
-	"unicode/utf8"
 
 	"github.com/cockroachdb/errors"
 

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"bytes"
+	"unicode/utf8"
 
 	"github.com/cockroachdb/errors"
 

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -172,6 +172,8 @@ func Search(ctx context.Context, dir string, revs []protocol.RevisionSpecifier, 
 			}
 			defer diffFetcher.Stop()
 
+			startBuf := make([]byte, 1024)
+
 			runJob := func(j job) error {
 				defer close(j.resultChan)
 				if ctx.Err() != nil {
@@ -183,6 +185,7 @@ func Search(ctx context.Context, dir string, revs []protocol.RevisionSpecifier, 
 					lc := &LazyCommit{
 						RawCommit:   cv,
 						diffFetcher: diffFetcher,
+						LowerBuf:    startBuf,
 					}
 					commitMatches, highlights, err := p.Match(lc)
 					if err != nil {

--- a/internal/gitserver/search/testdata/large_diff.txt
+++ b/internal/gitserver/search/testdata/large_diff.txt
@@ -1,0 +1,618 @@
+diff --git cmd/frontend/graphqlbackend/search_suggestions.go cmd/frontend/graphqlbackend/search_suggestions.go
+index de6ee08821..d19b72e222 100644
+--- cmd/frontend/graphqlbackend/search_suggestions.go
++++ cmd/frontend/graphqlbackend/search_suggestions.go
+@@ -211,294 +211,264 @@ var (
+ 	mockShowSymbolMatches   showSearchSuggestionResolvers
+ )
+ 
+-func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestionsArgs) ([]SearchSuggestionResolver, error) {
+-
+-	// If globbing is activated, convert regex patterns of repo, file, and repohasfile
+-	// from "field:^foo$" to "field:^foo".
+-	globbing := false
+-	if getBoolPtr(r.UserSettings.SearchGlobbing, false) {
+-		globbing = true
+-	}
+-	if globbing {
+-		r.Query = query.FuzzifyRegexPatterns(r.Query)
++func (r *searchResolver) showRepoSuggestions(ctx context.Context) ([]SearchSuggestionResolver, error) {
++	if mockShowRepoSuggestions != nil {
++		return mockShowRepoSuggestions()
+ 	}
+ 
+-	args.applyDefaultsAndConstraints()
+-
+-	if len(r.Query) == 0 {
+-		return nil, nil
++	// * If query contains only a single term (or 1 repogroup: token and a single term), treat it as a repo field here and ignore the other repo queries.
++	// * If only repo fields (except 1 term in query), show repo suggestions.
++
++	hasSingleField := len(r.Query.Fields()) == 1
++	hasTwoFields := len(r.Query.Fields()) == 2
++	hasSingleContextField := len(r.Query.Values(query.FieldContext)) == 1
++	hasSingleRepoGroupField := len(r.Query.Values(query.FieldRepoGroup)) == 1
++	var effectiveRepoFieldValues []string
++	if len(r.Query.Values(query.FieldDefault)) == 1 && (hasSingleField || (hasTwoFields && (hasSingleRepoGroupField || hasSingleContextField))) {
++		effectiveRepoFieldValues = append(effectiveRepoFieldValues, r.Query.Values(query.FieldDefault)[0].ToString())
++	} else if len(r.Query.Values(query.FieldRepo)) > 0 && ((len(r.Query.Values(query.FieldRepoGroup)) > 0 && hasTwoFields) || (len(r.Query.Values(query.FieldRepoGroup)) == 0 && hasSingleField)) {
++		effectiveRepoFieldValues, _ = r.Query.Repositories()
+ 	}
+ 
+-	// Only suggest for type:file.
+-	typeValues, _ := r.Query.StringValues(query.FieldType)
+-	for _, resultType := range typeValues {
+-		if resultType != "file" {
+-			return nil, nil
++	// If we have a query which is not valid, just ignore it since this is for a suggestion.
++	i := 0
++	for _, v := range effectiveRepoFieldValues {
++		if _, err := regexp.Compile(v); err == nil {
++			effectiveRepoFieldValues[i] = v
++			i++
+ 		}
+ 	}
++	effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
+ 
+-	var suggesters []func(ctx context.Context) ([]SearchSuggestionResolver, error)
++	if len(effectiveRepoFieldValues) > 0 || hasSingleContextField {
++		repoOptions := r.toRepoOptions(r.Query,
++			resolveRepositoriesOpts{
++				effectiveRepoFieldValues: effectiveRepoFieldValues,
++				limit:                    maxSearchSuggestions,
++			})
+ 
+-	showRepoSuggestions := func(ctx context.Context) ([]SearchSuggestionResolver, error) {
+-		if mockShowRepoSuggestions != nil {
+-			return mockShowRepoSuggestions()
++		resolved, err := r.resolveRepositories(ctx, repoOptions)
++		resolvers := make([]SearchSuggestionResolver, 0, len(resolved.RepoRevs))
++		for i, rev := range resolved.RepoRevs {
++			resolvers = append(resolvers, repositorySuggestionResolver{
++				repo: NewRepositoryResolver(r.db, rev.Repo.ToRepo()),
++				// Encode the returned order in score.
++				score: math.MaxInt32 - i,
++			})
+ 		}
+ 
+-		// * If query contains only a single term (or 1 repogroup: token and a single term), treat it as a repo field here and ignore the other repo queries.
+-		// * If only repo fields (except 1 term in query), show repo suggestions.
+-
+-		hasSingleField := len(r.Query.Fields()) == 1
+-		hasTwoFields := len(r.Query.Fields()) == 2
+-		hasSingleContextField := len(r.Query.Values(query.FieldContext)) == 1
+-		hasSingleRepoGroupField := len(r.Query.Values(query.FieldRepoGroup)) == 1
+-		var effectiveRepoFieldValues []string
+-		if len(r.Query.Values(query.FieldDefault)) == 1 && (hasSingleField || (hasTwoFields && (hasSingleRepoGroupField || hasSingleContextField))) {
+-			effectiveRepoFieldValues = append(effectiveRepoFieldValues, r.Query.Values(query.FieldDefault)[0].ToString())
+-		} else if len(r.Query.Values(query.FieldRepo)) > 0 && ((len(r.Query.Values(query.FieldRepoGroup)) > 0 && hasTwoFields) || (len(r.Query.Values(query.FieldRepoGroup)) == 0 && hasSingleField)) {
+-			effectiveRepoFieldValues, _ = r.Query.Repositories()
+-		}
++		return resolvers, err
++	}
++	return nil, nil
++}
+ 
+-		// If we have a query which is not valid, just ignore it since this is for a suggestion.
+-		i := 0
+-		for _, v := range effectiveRepoFieldValues {
+-			if _, err := regexp.Compile(v); err == nil {
+-				effectiveRepoFieldValues[i] = v
+-				i++
+-			}
+-		}
+-		effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
+-
+-		if len(effectiveRepoFieldValues) > 0 || hasSingleContextField {
+-			repoOptions := r.toRepoOptions(r.Query,
+-				resolveRepositoriesOpts{
+-					effectiveRepoFieldValues: effectiveRepoFieldValues,
+-					limit:                    maxSearchSuggestions,
+-				})
+-
+-			resolved, err := r.resolveRepositories(ctx, repoOptions)
+-			resolvers := make([]SearchSuggestionResolver, 0, len(resolved.RepoRevs))
+-			for i, rev := range resolved.RepoRevs {
+-				resolvers = append(resolvers, repositorySuggestionResolver{
+-					repo: NewRepositoryResolver(r.db, rev.Repo.ToRepo()),
+-					// Encode the returned order in score.
+-					score: math.MaxInt32 - i,
+-				})
+-			}
++func (r *searchResolver) showFileSuggestions(ctx context.Context) ([]SearchSuggestionResolver, error) {
++	if mockShowFileSuggestions != nil {
++		return mockShowFileSuggestions()
++	}
+ 
+-			return resolvers, err
+-		}
++	// If only repos/repogroups and files are specified (and at most 1 term), then show file
++	// suggestions.  If the query has a single term, then consider it to be a `file:` filter (to
++	// make it easy to jump to files by just typing in their name, not `file:<their name>`).
++	hasOnlyEmptyRepoField := len(r.Query.Values(query.FieldRepo)) > 0 && allEmptyStrings(r.Query.RegexpPatterns(query.FieldRepo)) && len(r.Query.Fields()) == 1
++	hasRepoOrFileFields := len(r.Query.Values(query.FieldRepoGroup)) > 0 || len(r.Query.Values(query.FieldRepo)) > 0 || len(r.Query.Values(query.FieldFile)) > 0
++	if !hasOnlyEmptyRepoField && hasRepoOrFileFields && len(r.Query.Values(query.FieldDefault)) <= 1 {
++		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
++		defer cancel()
++		return r.suggestFilePaths(ctx, maxSearchSuggestions)
++	}
++	return nil, nil
++}
++
++func (r *searchResolver) showLangSuggestions(ctx context.Context) ([]SearchSuggestionResolver, error) {
++	if mockShowLangSuggestions != nil {
++		return mockShowLangSuggestions()
++	}
++
++	// The "repo:" field must be specified for showing language suggestions.
++	// For performance reasons, only try to get languages of the first repository found
++	// within the scope of the "repo:" field value.
++	if len(r.Query.Values(query.FieldRepo)) == 0 {
+ 		return nil, nil
+ 	}
+-	suggesters = append(suggesters, showRepoSuggestions)
++	effectiveRepoFieldValues, _ := r.Query.Repositories()
+ 
+-	showFileSuggestions := func(ctx context.Context) ([]SearchSuggestionResolver, error) {
+-		if mockShowFileSuggestions != nil {
+-			return mockShowFileSuggestions()
++	validValues := effectiveRepoFieldValues[:0]
++	for _, v := range effectiveRepoFieldValues {
++		if i := strings.LastIndexByte(v, '@'); i > -1 {
++			// Strip off the @revision suffix so that we can use
++			// the trigram index on the name column in Postgres.
++			v = v[:i]
+ 		}
+ 
+-		// If only repos/repogroups and files are specified (and at most 1 term), then show file
+-		// suggestions.  If the query has a single term, then consider it to be a `file:` filter (to
+-		// make it easy to jump to files by just typing in their name, not `file:<their name>`).
+-		hasOnlyEmptyRepoField := len(r.Query.Values(query.FieldRepo)) > 0 && allEmptyStrings(r.Query.RegexpPatterns(query.FieldRepo)) && len(r.Query.Fields()) == 1
+-		hasRepoOrFileFields := len(r.Query.Values(query.FieldRepoGroup)) > 0 || len(r.Query.Values(query.FieldRepo)) > 0 || len(r.Query.Values(query.FieldFile)) > 0
+-		if !hasOnlyEmptyRepoField && hasRepoOrFileFields && len(r.Query.Values(query.FieldDefault)) <= 1 {
+-			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+-			defer cancel()
+-			return r.suggestFilePaths(ctx, maxSearchSuggestions)
++		if _, err := regexp.Compile(v); err == nil {
++			validValues = append(validValues, v)
+ 		}
++	}
++	if len(validValues) == 0 {
+ 		return nil, nil
+ 	}
+-	suggesters = append(suggesters, showFileSuggestions)
+ 
+-	showLangSuggestions := func(ctx context.Context) ([]SearchSuggestionResolver, error) {
+-		if mockShowLangSuggestions != nil {
+-			return mockShowLangSuggestions()
+-		}
++	// Only care about the first found repository.
++	repos, err := backend.Repos.List(ctx, database.ReposListOptions{
++		IncludePatterns: validValues,
++		LimitOffset: &database.LimitOffset{
++			Limit: 1,
++		},
++	})
++	if err != nil || len(repos) == 0 {
++		return nil, err
++	}
++	repo := repos[0]
+ 
+-		// The "repo:" field must be specified for showing language suggestions.
+-		// For performance reasons, only try to get languages of the first repository found
+-		// within the scope of the "repo:" field value.
+-		if len(r.Query.Values(query.FieldRepo)) == 0 {
+-			return nil, nil
+-		}
+-		effectiveRepoFieldValues, _ := r.Query.Repositories()
+-
+-		validValues := effectiveRepoFieldValues[:0]
+-		for _, v := range effectiveRepoFieldValues {
+-			if i := strings.LastIndexByte(v, '@'); i > -1 {
+-				// Strip off the @revision suffix so that we can use
+-				// the trigram index on the name column in Postgres.
+-				v = v[:i]
+-			}
++	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
++	defer cancel()
+ 
+-			if _, err := regexp.Compile(v); err == nil {
+-				validValues = append(validValues, v)
+-			}
+-		}
+-		if len(validValues) == 0 {
+-			return nil, nil
+-		}
++	commitID, err := backend.Repos.ResolveRev(ctx, repo, "")
++	if err != nil {
++		return nil, err
++	}
++
++	inventory, err := backend.Repos.GetInventory(ctx, repo, commitID, false)
++	if err != nil {
++		return nil, err
++	}
+ 
+-		// Only care about the first found repository.
+-		repos, err := backend.Repos.List(ctx, database.ReposListOptions{
+-			IncludePatterns: validValues,
+-			LimitOffset: &database.LimitOffset{
+-				Limit: 1,
+-			},
++	resolvers := make([]SearchSuggestionResolver, 0, len(inventory.Languages))
++	for _, l := range inventory.Languages {
++		resolvers = append(resolvers, languageSuggestionResolver{
++			lang:  &languageResolver{name: strings.ToLower(l.Name)},
++			score: math.MaxInt32,
+ 		})
+-		if err != nil || len(repos) == 0 {
+-			return nil, err
+-		}
+-		repo := repos[0]
++	}
+ 
+-		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+-		defer cancel()
++	return resolvers, err
++}
+ 
+-		commitID, err := backend.Repos.ResolveRev(ctx, repo, "")
++func (r *searchResolver) showSymbolMatches(ctx context.Context) ([]SearchSuggestionResolver, error) {
++	if mockShowSymbolMatches != nil {
++		return mockShowSymbolMatches()
++	}
++
++	b, err := query.ToBasicQuery(r.Query)
++	if err != nil {
++		return nil, err
++	}
++	if !query.IsPatternAtom(b) {
++		// Not an atomic pattern, can't guarantee it will behave well.
++		return nil, nil
++	}
++
++	var fileMatches []result.Match
++	if featureflag.FromContext(ctx).GetBoolOr("sh_search_suggestions_symbols", false) {
++		args, jobs, err := r.toSearchInputs(r.Query)
+ 		if err != nil {
+ 			return nil, err
+ 		}
++		args.ResultTypes = result.TypeSymbol
+ 
+-		inventory, err := backend.Repos.GetInventory(ctx, repo, commitID, false)
++		results, err := r.doResults(ctx, args, jobs)
++		if errors.Is(err, context.DeadlineExceeded) {
++			err = nil
++		}
+ 		if err != nil {
+ 			return nil, err
+ 		}
+-
+-		resolvers := make([]SearchSuggestionResolver, 0, len(inventory.Languages))
+-		for _, l := range inventory.Languages {
+-			resolvers = append(resolvers, languageSuggestionResolver{
+-				lang:  &languageResolver{name: strings.ToLower(l.Name)},
+-				score: math.MaxInt32,
+-			})
++		if results != nil {
++			fileMatches = results.Matches
+ 		}
+-
+-		return resolvers, err
+-	}
+-	suggesters = append(suggesters, showLangSuggestions)
+-
+-	showSymbolMatches := func(ctx context.Context) ([]SearchSuggestionResolver, error) {
+-		if mockShowSymbolMatches != nil {
+-			return mockShowSymbolMatches()
+-		}
+-
+-		b, err := query.ToBasicQuery(r.Query)
++	} else {
++		repoOptions := r.toRepoOptions(r.Query, resolveRepositoriesOpts{})
++		resolved, err := r.resolveRepositories(ctx, repoOptions)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+-		if !query.IsPatternAtom(b) {
+-			// Not an atomic pattern, can't guarantee it will behave well.
++
++		p := search.ToTextPatternInfo(b, search.Batch, query.Identity)
++		if p.Pattern == "" {
+ 			return nil, nil
+ 		}
+ 
+-		var fileMatches []result.Match
+-		if featureflag.FromContext(ctx).GetBoolOr("sh_search_suggestions_symbols", false) {
+-			args, jobs, err := r.toSearchInputs(r.Query)
+-			if err != nil {
+-				return nil, err
+-			}
+-			args.ResultTypes = result.TypeSymbol
++		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
++		defer cancel()
+ 
+-			results, err := r.doResults(ctx, args, jobs)
+-			if errors.Is(err, context.DeadlineExceeded) {
+-				err = nil
+-			}
+-			if err != nil {
+-				return nil, err
+-			}
+-			if results != nil {
+-				fileMatches = results.Matches
+-			}
+-		} else {
+-			repoOptions := r.toRepoOptions(r.Query, resolveRepositoriesOpts{})
+-			resolved, err := r.resolveRepositories(ctx, repoOptions)
+-			if err != nil {
+-				return nil, err
+-			}
++		fileMatches, _, err = streaming.CollectStream(func(stream streaming.Sender) error {
++			return symbol.Search(ctx, &search.TextParameters{
++				PatternInfo:  p,
++				Repos:        resolved.RepoRevs,
++				Query:        r.Query,
++				Zoekt:        r.zoekt,
++				SearcherURLs: r.searcherURLs,
++			}, 7, stream)
++		})
++		if err != nil {
++			return nil, err
++		}
++	}
+ 
+-			p := search.ToTextPatternInfo(b, search.Batch, query.Identity)
+-			if p.Pattern == "" {
+-				return nil, nil
++	suggestions := make([]SearchSuggestionResolver, 0)
++	for _, match := range fileMatches {
++		fileMatch, ok := match.(*result.FileMatch)
++		if !ok {
++			continue
++		}
++		for _, sm := range fileMatch.Symbols {
++			score := 20
++			if sm.Symbol.Parent == "" {
++				score++
+ 			}
+-
+-			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+-			defer cancel()
+-
+-			fileMatches, _, err = streaming.CollectStream(func(stream streaming.Sender) error {
+-				return symbol.Search(ctx, &search.TextParameters{
+-					PatternInfo:  p,
+-					Repos:        resolved.RepoRevs,
+-					Query:        r.Query,
+-					Zoekt:        r.zoekt,
+-					SearcherURLs: r.searcherURLs,
+-				}, 7, stream)
+-			})
+-			if err != nil {
+-				return nil, err
++			if len(sm.Symbol.Name) < 12 {
++				score++
+ 			}
+-		}
+-
+-		suggestions := make([]SearchSuggestionResolver, 0)
+-		for _, match := range fileMatches {
+-			fileMatch, ok := match.(*result.FileMatch)
+-			if !ok {
+-				continue
++			switch sm.Symbol.LSPKind() {
++			case lsp.SKFunction, lsp.SKMethod:
++				score += 2
++			case lsp.SKClass:
++				score += 3
+ 			}
+-			for _, sm := range fileMatch.Symbols {
+-				score := 20
+-				if sm.Symbol.Parent == "" {
+-					score++
+-				}
+-				if len(sm.Symbol.Name) < 12 {
+-					score++
+-				}
+-				switch sm.Symbol.LSPKind() {
+-				case lsp.SKFunction, lsp.SKMethod:
+-					score += 2
+-				case lsp.SKClass:
+-					score += 3
+-				}
+-				repoName := strings.ToLower(string(sm.File.Repo.Name))
+-				fileName := strings.ToLower(sm.File.Path)
+-				symbolName := strings.ToLower(sm.Symbol.Name)
+-				if len(sm.Symbol.Name) >= 4 && strings.Contains(repoName+fileName, symbolName) {
+-					score++
+-				}
+-				suggestions = append(suggestions, symbolSuggestionResolver{
+-					symbol: symbolResolver{
+-						db: r.db,
+-						commit: toGitCommitResolver(
+-							NewRepositoryResolver(r.db, fileMatch.Repo.ToRepo()),
+-							r.db,
+-							fileMatch.CommitID,
+-							nil,
+-						),
+-						SymbolMatch: sm,
+-					},
+-					score: score,
+-				})
++			repoName := strings.ToLower(string(sm.File.Repo.Name))
++			fileName := strings.ToLower(sm.File.Path)
++			symbolName := strings.ToLower(sm.Symbol.Name)
++			if len(sm.Symbol.Name) >= 4 && strings.Contains(repoName+fileName, symbolName) {
++				score++
+ 			}
++			suggestions = append(suggestions, symbolSuggestionResolver{
++				symbol: symbolResolver{
++					db: r.db,
++					commit: toGitCommitResolver(
++						NewRepositoryResolver(r.db, fileMatch.Repo.ToRepo()),
++						r.db,
++						fileMatch.CommitID,
++						nil,
++					),
++					SymbolMatch: sm,
++				},
++				score: score,
++			})
+ 		}
++	}
+ 
+-		sortSearchSuggestions(suggestions)
+-		const maxBoostedSymbolResults = 3
+-		boost := maxBoostedSymbolResults
+-		if len(suggestions) < boost {
+-			boost = len(suggestions)
+-		}
+-		if boost > 0 {
+-			for i := 0; i < boost; i++ {
+-				if res, ok := suggestions[i].(symbolSuggestionResolver); ok {
+-					res.score += 200
+-					suggestions[i] = res
+-				}
++	sortSearchSuggestions(suggestions)
++	const maxBoostedSymbolResults = 3
++	boost := maxBoostedSymbolResults
++	if len(suggestions) < boost {
++		boost = len(suggestions)
++	}
++	if boost > 0 {
++		for i := 0; i < boost; i++ {
++			if res, ok := suggestions[i].(symbolSuggestionResolver); ok {
++				res.score += 200
++				suggestions[i] = res
+ 			}
+ 		}
+-
+-		return suggestions, nil
+ 	}
+-	suggesters = append(suggesters, showSymbolMatches)
+ 
+-	showFilesWithTextMatches := func(ctx context.Context) ([]SearchSuggestionResolver, error) {
++	return suggestions, nil
++}
++
++// showFilesWithTextMatches returns a suggester bounded by `first`.
++func (r *searchResolver) showFilesWithTextMatches(first int32) suggester {
++	return func(ctx context.Context) ([]SearchSuggestionResolver, error) {
+ 		// If terms are specified, then show files that have text matches. Set an aggressive timeout
+ 		// to avoid delaying repo and file suggestions for too long.
+ 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+@@ -515,8 +485,8 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
+ 			}
+ 			var suggestions []SearchSuggestionResolver
+ 			if results != nil {
+-				if len(results.Matches) > int(*args.First) {
+-					results.Matches = results.Matches[:*args.First]
++				if len(results.Matches) > int(first) {
++					results.Matches = results.Matches[:first]
+ 				}
+ 				suggestions = make([]SearchSuggestionResolver, 0, len(results.Matches))
+ 				for i, res := range results.Matches {
+@@ -536,38 +506,74 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
+ 		}
+ 		return nil, nil
+ 	}
+-	suggesters = append(suggesters, showFilesWithTextMatches)
++}
++
++func (r *searchResolver) showSearchContextSuggestions(ctx context.Context) ([]SearchSuggestionResolver, error) {
++	hasSingleContextField := len(r.Query.Values(query.FieldContext)) == 1
++	if !hasSingleContextField {
++		return nil, nil
++	}
++	searchContextSpec, _ := r.Query.StringValue(query.FieldContext)
++	parsedSearchContextSpec := searchcontexts.ParseSearchContextSpec(searchContextSpec)
++	searchContexts, err := database.SearchContexts(r.db).ListSearchContexts(
++		ctx,
++		database.ListSearchContextsPageOptions{First: maxSearchSuggestions},
++		database.ListSearchContextsOptions{
++			Name:              parsedSearchContextSpec.SearchContextName,
++			NamespaceName:     parsedSearchContextSpec.NamespaceName,
++			OrderBy:           database.SearchContextsOrderBySpec,
++			OrderByDescending: true,
++		},
++	)
++	if err != nil {
++		return nil, err
++	}
++	suggestions := make([]SearchSuggestionResolver, 0, len(searchContexts))
++	for i, searchContext := range searchContexts {
++		suggestions = append(suggestions, &searchContextSuggestionResolver{
++			searchContext: &searchContextResolver{searchContext, r.db},
++			score:         len(searchContexts) - i,
++		})
++	}
++	return suggestions, nil
++}
++
++type suggester func(ctx context.Context) ([]SearchSuggestionResolver, error)
++
++func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestionsArgs) ([]SearchSuggestionResolver, error) {
++
++	// If globbing is activated, convert regex patterns of repo, file, and repohasfile
++	// from "field:^foo$" to "field:^foo".
++	globbing := false
++	if getBoolPtr(r.UserSettings.SearchGlobbing, false) {
++		globbing = true
++	}
++	if globbing {
++		r.Query = query.FuzzifyRegexPatterns(r.Query)
++	}
++
++	args.applyDefaultsAndConstraints()
++
++	if len(r.Query) == 0 {
++		return nil, nil
++	}
+ 
+-	showSearchContextSuggestions := func(ctx context.Context) ([]SearchSuggestionResolver, error) {
+-		hasSingleContextField := len(r.Query.Values(query.FieldContext)) == 1
+-		if !hasSingleContextField {
++	// Only suggest for type:file.
++	typeValues, _ := r.Query.StringValues(query.FieldType)
++	for _, resultType := range typeValues {
++		if resultType != "file" {
+ 			return nil, nil
+ 		}
+-		searchContextSpec, _ := r.Query.StringValue(query.FieldContext)
+-		parsedSearchContextSpec := searchcontexts.ParseSearchContextSpec(searchContextSpec)
+-		searchContexts, err := database.SearchContexts(r.db).ListSearchContexts(
+-			ctx,
+-			database.ListSearchContextsPageOptions{First: maxSearchSuggestions},
+-			database.ListSearchContextsOptions{
+-				Name:              parsedSearchContextSpec.SearchContextName,
+-				NamespaceName:     parsedSearchContextSpec.NamespaceName,
+-				OrderBy:           database.SearchContextsOrderBySpec,
+-				OrderByDescending: true,
+-			},
+-		)
+-		if err != nil {
+-			return nil, err
+-		}
+-		suggestions := make([]SearchSuggestionResolver, 0, len(searchContexts))
+-		for i, searchContext := range searchContexts {
+-			suggestions = append(suggestions, &searchContextSuggestionResolver{
+-				searchContext: &searchContextResolver{searchContext, r.db},
+-				score:         len(searchContexts) - i,
+-			})
+-		}
+-		return suggestions, nil
+ 	}
+-	suggesters = append(suggesters, showSearchContextSuggestions)
++
++	suggesters := []suggester{
++		r.showRepoSuggestions,
++		r.showFileSuggestions,
++		r.showLangSuggestions,
++		r.showSymbolMatches,
++		r.showFilesWithTextMatches(*args.First),
++		r.showSearchContextSuggestions,
++	}
+ 
+ 	// Run suggesters.
+ 	var (

--- a/internal/gitserver/search/testdata/small_diff.txt
+++ b/internal/gitserver/search/testdata/small_diff.txt
@@ -1,0 +1,23 @@
+diff --git a/web/src/integration/gqlresponses/user_settings_bla_response_1.ts b/web/src/integration/gqlresponses/user_settings_bla_response_1.ts
+new file mode 100644
+index 0000000000..4f6e758628
+--- /dev/null
++++ web/src/integration/gqlresponses/user_settings_bla_response_1.ts
+@@ -0,0 +1,4 @@
++export const overrideSettingsResponse: OverrideSettingsResponseShape = {
++    foo: 1,
++    bar: {},
++}
+diff --git a/web/src/integration/helpers.ts b/web/src/integration/helpers.ts
+index 2f71392b2f..d874527291 100644
+--- web/src/integration/helpers.ts
++++ web/src/integration/helpers.ts
+@@ -5,7 +5,7 @@ import { createDriverForTest, Driver } from '../../../shared/src/testing/driver'
+ import * as path from 'path'
+ import mkdirp from 'mkdirp-promise'
+ import express from 'express'
+-import { Polly } from '@pollyjs/core'
++import { Polly, Request, Response } from '@pollyjs/core'
+ import { PuppeteerAdapter } from './polly/PuppeteerAdapter'
+ import FSPersister from '@pollyjs/persister-fs'
+

--- a/internal/search/casetransform/lower.go
+++ b/internal/search/casetransform/lower.go
@@ -1,4 +1,4 @@
-package search
+package casetransform
 
 // python to generate ', '.join(hex(ord(chr(i).lower())) for i in range(256))
 var lowerTable = [256]uint8{

--- a/internal/search/casetransform/lower_amd64.go
+++ b/internal/search/casetransform/lower_amd64.go
@@ -1,0 +1,4 @@
+package casetransform
+
+// implemented in assembly, see lower_amd64.s
+func BytesToLowerASCII(dst, src []byte)

--- a/internal/search/casetransform/lower_amd64.s
+++ b/internal/search/casetransform/lower_amd64.s
@@ -1,6 +1,6 @@
 #include "textflag.h"
 
-TEXT ·bytesToLowerASCII(SB),NOSPLIT,$0
+TEXT ·BytesToLowerASCII(SB),NOSPLIT,$0
 	// use the smaller of the two lengths to avoid out-of-bounds writes
 	MOVQ	dst_len+8(FP), BX
 	MOVQ	src_len+32(FP), DX

--- a/internal/search/casetransform/lower_other.go
+++ b/internal/search/casetransform/lower_other.go
@@ -1,0 +1,6 @@
+//go:build !amd64
+// +build !amd64
+
+package casetransform
+
+var BytesToLowerASCII = bytesToLowerASCIIgeneric

--- a/internal/search/casetransform/lower_regexp.go
+++ b/internal/search/casetransform/lower_regexp.go
@@ -1,0 +1,150 @@
+package casetransform
+
+import (
+	"regexp/syntax"
+	"unicode"
+	"unicode/utf8"
+)
+
+// LowerRegexpASCII lowers rune literals and expands char classes to include
+// lowercase. It does it inplace. We can't just use strings.ToLower since it
+// will change the meaning of regex shorthands like \S or \B.
+func LowerRegexpASCII(re *syntax.Regexp) {
+	for _, c := range re.Sub {
+		if c != nil {
+			LowerRegexpASCII(c)
+		}
+	}
+	switch re.Op {
+	case syntax.OpLiteral:
+		// For literal strings we can simplify lower each character.
+		for i := range re.Rune {
+			re.Rune[i] = unicode.ToLower(re.Rune[i])
+		}
+	case syntax.OpCharClass:
+		l := len(re.Rune)
+
+		// An exclusion class is something like [^A-Z]. We need to specially
+		// handle it since the user intention of [^A-Z] should map to
+		// [^a-z]. If we use the normal mapping logic, we will do nothing
+		// since [a-z] is in [^A-Z]. We assume we have an exclusion class if
+		// our inclusive range starts at 0 and ends at the end of the unicode
+		// range. Note this means we don't support unusual ranges like
+		// [^\x00-B] or [^B-\x{10ffff}].
+		isExclusion := l >= 4 && re.Rune[0] == 0 && re.Rune[l-1] == utf8.MaxRune
+		if isExclusion {
+			// Algorithm:
+			// Assume re.Rune is sorted (it is!)
+			// 1. Build a list of inclusive ranges in a-z that are excluded in A-Z (excluded)
+			// 2. Copy across classes, ensuring all ranges are outside of ranges in excluded.
+			//
+			// In our comments we use the mathematical notation [x, y] and (a,
+			// b). [ and ] are range inclusive, ( and ) are range
+			// exclusive. So x is in [x, y], but not in (x, y).
+
+			// excluded is a list of _exclusive_ ranges in ['a', 'z'] that need
+			// to be removed.
+			excluded := []rune{}
+
+			// Note i starts at 1, so we are inspecting the gaps between
+			// ranges. So [re.Rune[0], re.Rune[1]] and [re.Rune[2],
+			// re.Rune[3]] impiles we have an excluded range of (re.Rune[1],
+			// re.Rune[2]).
+			for i := 1; i < l-1; i += 2 {
+				// (a, b) is a range that is excluded
+				a, b := re.Rune[i], re.Rune[i+1]
+				// This range doesn't exclude [A-Z], so skip (does not
+				// intersect with ['A', 'Z']).
+				if a > 'Z' || b < 'A' {
+					continue
+				}
+				// We know (a, b) intersects with ['A', 'Z']. So clamp such
+				// that we have the intersection (a, b) ^ [A, Z]
+				if a < 'A' {
+					a = 'A' - 1
+				}
+				if b > 'Z' {
+					b = 'Z' + 1
+				}
+				// (a, b) is now a range contained in ['A', 'Z'] that needs to
+				// be excluded. So we map it to the lower case version and add
+				// it to the excluded list.
+				excluded = append(excluded, a+'a'-'A', b+'b'-'B')
+			}
+
+			// Adjust re.Rune to exclude excluded. This may require shrinking
+			// or growing the list, so we do it to a copy.
+			copy := make([]rune, 0, len(re.Rune))
+			for i := 0; i < l; i += 2 {
+				// [a, b] is a range that is included
+				a, b := re.Rune[i], re.Rune[i+1]
+
+				// Remove exclusions ranges that occur before a. They would of
+				// been previously processed.
+				for len(excluded) > 0 && a >= excluded[1] {
+					excluded = excluded[2:]
+				}
+
+				// If our exclusion range happens after b, that means we
+				// should only consider it later.
+				if len(excluded) == 0 || b <= excluded[0] {
+					copy = append(copy, a, b)
+					continue
+				}
+
+				// We now know that the current exclusion range intersects
+				// with [a, b]. Break it into two parts, the range before a
+				// and the range after b.
+				if a <= excluded[0] {
+					copy = append(copy, a, excluded[0])
+				}
+				if b >= excluded[1] {
+					copy = append(copy, excluded[1], b)
+				}
+			}
+			re.Rune = copy
+		} else {
+			for i := 0; i < l; i += 2 {
+				// We found a char class that includes a-z. No need to
+				// modify.
+				if re.Rune[i] <= 'a' && re.Rune[i+1] >= 'z' {
+					return
+				}
+			}
+			for i := 0; i < l; i += 2 {
+				a, b := re.Rune[i], re.Rune[i+1]
+				// This range doesn't include A-Z, so skip
+				if a > 'Z' || b < 'A' {
+					continue
+				}
+				simple := true
+				if a < 'A' {
+					simple = false
+					a = 'A'
+				}
+				if b > 'Z' {
+					simple = false
+					b = 'Z'
+				}
+				a, b = unicode.ToLower(a), unicode.ToLower(b)
+				if simple {
+					// The char range is within A-Z, so we can
+					// just modify it to be the equivalent in a-z.
+					re.Rune[i], re.Rune[i+1] = a, b
+				} else {
+					// The char range includes characters outside
+					// of A-Z. To be safe we just append a new
+					// lowered range which is the intersection
+					// with A-Z.
+					re.Rune = append(re.Rune, a, b)
+				}
+			}
+		}
+	default:
+		return
+	}
+	// Copy to small storage if necessary
+	for i := 0; i < 2 && i < len(re.Rune); i++ {
+		re.Rune0[i] = re.Rune[i]
+	}
+}

--- a/internal/search/casetransform/lower_regexp_test.go
+++ b/internal/search/casetransform/lower_regexp_test.go
@@ -1,0 +1,65 @@
+package casetransform
+
+import (
+	"regexp/syntax"
+	"testing"
+)
+
+func TestLowerRegexpASCII(t *testing.T) {
+	// The expected values are a bit volatile, since they come from
+	// syntex.Regexp.String. So they may change between go versions. Just
+	// ensure they make sense.
+	cases := map[string]string{
+		"foo":       "foo",
+		"FoO":       "foo",
+		"(?m:^foo)": "(?m:^)foo", // regex parse simplifies to this
+		"(?m:^FoO)": "(?m:^)foo",
+
+		// Ranges for the characters can be tricky. So we include many
+		// cases. Importantly user intention when they write [^A-Z] is would
+		// expect [^a-z] to apply when ignoring case.
+		"[A-Z]":  "[a-z]",
+		"[^A-Z]": "[^A-Za-z]",
+		"[A-M]":  "[a-m]",
+		"[^A-M]": "[^A-Ma-m]",
+		"[A]":    "a",
+		"[^A]":   "[^Aa]",
+		"[M]":    "m",
+		"[^M]":   "[^Mm]",
+		"[Z]":    "z",
+		"[^Z]":   "[^Zz]",
+		"[a-z]":  "[a-z]",
+		"[^a-z]": "[^a-z]",
+		"[a-m]":  "[a-m]",
+		"[^a-m]": "[^a-m]",
+		"[a]":    "a",
+		"[^a]":   "[^a]",
+		"[m]":    "m",
+		"[^m]":   "[^m]",
+		"[z]":    "z",
+		"[^z]":   "[^z]",
+
+		// @ is tricky since it is 1 value less than A
+		"[^A-Z@]": "[^@-Za-z]",
+
+		// full unicode range should just be a .
+		"[\\x00-\\x{10ffff}]": "(?s:.)",
+
+		"[abB-Z]":       "[b-za-b]",
+		"([abB-Z]|FoO)": "([b-za-b]|foo)",
+		`[@-\[]`:        `[@-\[a-z]`,      // original range includes A-Z but excludes a-z
+		`\S`:            `[^\t-\n\f-\r ]`, // \S is shorthand for the expected
+	}
+
+	for expr, want := range cases {
+		re, err := syntax.Parse(expr, syntax.Perl)
+		if err != nil {
+			t.Fatal(expr, err)
+		}
+		LowerRegexpASCII(re)
+		got := re.String()
+		if want != got {
+			t.Errorf("LowerRegexpASCII(%q) == %q != %q", expr, got, want)
+		}
+	}
+}

--- a/internal/search/casetransform/lower_test.go
+++ b/internal/search/casetransform/lower_test.go
@@ -1,0 +1,82 @@
+package casetransform
+
+import (
+	"bytes"
+	"testing"
+	"testing/quick"
+)
+
+func benchBytesToLower(b *testing.B, src []byte) {
+	dst := make([]byte, len(src))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		BytesToLowerASCII(dst, src)
+	}
+}
+
+func BenchmarkBytesToLowerASCII(b *testing.B) {
+	b.Run("short", func(b *testing.B) { benchBytesToLower(b, []byte("a-z@[A-Z")) })
+	b.Run("pangram", func(b *testing.B) { benchBytesToLower(b, []byte("\tThe Quick Brown Fox juMPs over the LAZY dog!?")) })
+	long := bytes.Repeat([]byte{'A'}, 8*1024)
+	b.Run("8k", func(b *testing.B) { benchBytesToLower(b, long) })
+	b.Run("8k-misaligned", func(b *testing.B) { benchBytesToLower(b, long[1:]) })
+}
+
+func checkBytesToLower(t *testing.T, b []byte) {
+	t.Helper()
+	want := make([]byte, len(b))
+	bytesToLowerASCIIgeneric(want, b)
+	got := make([]byte, len(b))
+	BytesToLowerASCII(got, b)
+	if !bytes.Equal(want, got) {
+		t.Errorf("BytesToLowerASCII(%q)=%q want %q", b, got, want)
+	}
+}
+
+func TestBytesToLowerASCII(t *testing.T) {
+	// @ and [ are special: '@'+1=='A' and 'Z'+1=='['
+	t.Run("pangram", func(t *testing.T) {
+		checkBytesToLower(t, []byte("\t[The Quick Brown Fox juMPs over the LAZY dog!?@"))
+	})
+	t.Run("short", func(t *testing.T) {
+		checkBytesToLower(t, []byte("a-z@[A-Z"))
+	})
+	t.Run("quick", func(t *testing.T) {
+		f := func(b []byte) bool {
+			x := make([]byte, len(b))
+			bytesToLowerASCIIgeneric(x, b)
+			y := make([]byte, len(b))
+			BytesToLowerASCII(y, b)
+			return bytes.Equal(x, y)
+		}
+		if err := quick.Check(f, nil); err != nil {
+			t.Error(err)
+		}
+	})
+	t.Run("alignment", func(t *testing.T) {
+		// The goal of this test is to make sure we don't write to any bytes
+		// that don't belong to us.
+		b := make([]byte, 96)
+		c := make([]byte, 96)
+		for i := 0; i < len(b); i++ {
+			for j := i; j < len(b); j++ {
+				// fill b with Ms and c with xs
+				for k := range b {
+					b[k] = 'M'
+					c[k] = 'x'
+				}
+				// process a subslice of b
+				BytesToLowerASCII(c[i:j], b[i:j])
+				for k := range b {
+					want := byte('m')
+					if k < i || k >= j {
+						want = 'x'
+					}
+					if want != c[k] {
+						t.Errorf("BytesToLowerASCII bad byte using bounds [%d:%d] (len %d) at index %d, have %c want %c", i, j, len(c[i:j]), k, c[k], want)
+					}
+				}
+			}
+		}
+	})
+}

--- a/internal/search/casetransform/regexp.go
+++ b/internal/search/casetransform/regexp.go
@@ -5,6 +5,18 @@ import (
 	"regexp/syntax"
 )
 
+// Regexp is a light wrapper over *regexp.Regexp that optimizes for case-insensitive search.
+//
+// Case-insensitive search using *regexp.Regexp and `(?i)` meta tags is quite
+// slow. To mitigate the performance cost of case-insensitive search, we
+// transform regexp patterns to their lower-case equivalent (LowerRegexpASCII),
+// and transform the search content to its lower-case equivalent (BytesToLowerASCII)
+// before matching the pattern to the content.
+//
+// This type encodes the requirements that, if ignoreCase is set:
+// 1) The regexp pattern is transformed into its lower-case equivalent
+// 2) The content to be searched is transformed into its lower-case equivalent
+// 3) A re-usable buffer is passed in to the match methods to encourage buffer re-use
 type Regexp struct {
 	re         *regexp.Regexp
 	ignoreCase bool

--- a/internal/search/casetransform/regexp.go
+++ b/internal/search/casetransform/regexp.go
@@ -1,0 +1,57 @@
+package casetransform
+
+import (
+	"regexp"
+	"regexp/syntax"
+)
+
+type Regexp struct {
+	re         *regexp.Regexp
+	ignoreCase bool
+}
+
+func CompileRegexp(expr string, ignoreCase bool) (*Regexp, error) {
+	if ignoreCase {
+		syn, err := syntax.Parse(expr, syntax.Perl)
+		if err != nil {
+			return nil, err
+		}
+		LowerRegexpASCII(syn)
+		expr = syn.String()
+	}
+
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	return &Regexp{
+		re:         re,
+		ignoreCase: ignoreCase,
+	}, nil
+}
+
+func (r *Regexp) FindAllIndex(b []byte, n int, lowerBuf *[]byte) [][]int {
+	if !r.ignoreCase {
+		return r.re.FindAllIndex(b, n)
+	}
+
+	if len(*lowerBuf) < len(b) {
+		*lowerBuf = make([]byte, len(b)*2)
+	}
+	transformBuf := (*lowerBuf)[:len(b)]
+	BytesToLowerASCII(transformBuf, b)
+	return r.re.FindAllIndex(transformBuf, n)
+}
+
+func (r *Regexp) Match(b []byte, lowerBuf *[]byte) bool {
+	if !r.ignoreCase {
+		return r.re.Match(b)
+	}
+
+	if len(*lowerBuf) < len(b) {
+		*lowerBuf = make([]byte, len(b)*2)
+	}
+	transformBuf := (*lowerBuf)[:len(b)]
+	BytesToLowerASCII(transformBuf, b)
+	return r.re.Match(transformBuf)
+}

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -160,13 +160,6 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	return newPred
 }
 
-func wrapCaseSensitive(pattern string, caseSensitive bool) string {
-	if caseSensitive {
-		return pattern
-	}
-	return "(?i:" + pattern + ")"
-}
-
 func protocolMatchToCommitMatch(repo types.RepoName, diff bool, in protocol.CommitMatch) *result.CommitMatch {
 	var (
 		matchBody       string

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -37,7 +37,7 @@ func searchInReposNew(ctx context.Context, db dbutil.DB, textParams *search.Text
 		args := &protocol.SearchRequest{
 			Repo:        rr.Repo.Name,
 			Revisions:   searchRevsToGitserverRevs(rr.Revs),
-			Query:       &gitprotocol.And{queryNodesToPredicates(query, query.IsCaseSensitive(), diff)},
+			Query:       &gitprotocol.And{Children: queryNodesToPredicates(query, query.IsCaseSensitive(), diff)},
 			IncludeDiff: diff,
 			Limit:       limit,
 		}
@@ -100,9 +100,9 @@ func queryNodesToPredicates(nodes []query.Node, caseSensitive, diff bool) []gitp
 func queryOperatorToPredicate(op query.Operator, caseSensitive, diff bool) gitprotocol.SearchQuery {
 	switch op.Kind {
 	case query.And:
-		return &gitprotocol.And{queryNodesToPredicates(op.Operands, caseSensitive, diff)}
+		return &gitprotocol.And{Children: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
 	case query.Or:
-		return &gitprotocol.Or{queryNodesToPredicates(op.Operands, caseSensitive, diff)}
+		return &gitprotocol.Or{Children: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
 	default:
 		// I don't think we should have concats at this point, but ignore it if we do
 		return nil
@@ -117,13 +117,13 @@ func queryPatternToPredicate(pattern query.Pattern, caseSensitive, diff bool) gi
 
 	var newPred gitprotocol.SearchQuery
 	if diff {
-		newPred = &gitprotocol.DiffMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(patString, caseSensitive))}}
+		newPred = &gitprotocol.DiffMatches{Expr: patString, IgnoreCase: !caseSensitive}
 	} else {
-		newPred = &gitprotocol.MessageMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(patString, caseSensitive))}}
+		newPred = &gitprotocol.MessageMatches{Expr: patString, IgnoreCase: !caseSensitive}
 	}
 
 	if pattern.Negated {
-		return &gitprotocol.Not{newPred}
+		return &gitprotocol.Not{Child: newPred}
 	}
 	return newPred
 }
@@ -133,29 +133,29 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	switch parameter.Field {
 	case query.FieldAuthor:
 		// TODO(@camdencheek) look up emails (issue #25180)
-		newPred = &gitprotocol.AuthorMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
+		newPred = &gitprotocol.AuthorMatches{Expr: parameter.Value, IgnoreCase: !caseSensitive}
 	case query.FieldCommitter:
-		newPred = &gitprotocol.CommitterMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
+		newPred = &gitprotocol.CommitterMatches{Expr: parameter.Value, IgnoreCase: !caseSensitive}
 	case query.FieldBefore:
-		newPred = &gitprotocol.CommitBefore{time.Now()} // TODO(@camdencheek) parse the time in with go-naturaldate (issue #25357)
+		newPred = &gitprotocol.CommitBefore{Time: time.Now()} // TODO(@camdencheek) parse the time in with go-naturaldate (issue #25357)
 	case query.FieldAfter:
-		newPred = &gitprotocol.CommitAfter{time.Now()}
+		newPred = &gitprotocol.CommitAfter{Time: time.Now()}
 	case query.FieldMessage:
-		newPred = &gitprotocol.MessageMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
+		newPred = &gitprotocol.MessageMatches{Expr: parameter.Value, IgnoreCase: !caseSensitive}
 	case query.FieldContent:
 		if diff {
-			newPred = &gitprotocol.DiffMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
+			newPred = &gitprotocol.DiffMatches{Expr: parameter.Value, IgnoreCase: !caseSensitive}
 		} else {
-			newPred = &gitprotocol.MessageMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
+			newPred = &gitprotocol.MessageMatches{Expr: parameter.Value, IgnoreCase: !caseSensitive}
 		}
 	case query.FieldFile:
-		newPred = &gitprotocol.DiffModifiesFile{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
+		newPred = &gitprotocol.DiffModifiesFile{Expr: parameter.Value, IgnoreCase: !caseSensitive}
 	case query.FieldLang:
-		newPred = &gitprotocol.DiffModifiesFile{gitprotocol.Regexp{regexp.MustCompile(search.LangToFileRegexp(parameter.Value))}}
+		newPred = &gitprotocol.DiffModifiesFile{Expr: search.LangToFileRegexp(parameter.Value), IgnoreCase: true}
 	}
 
 	if parameter.Negated {
-		return &gitprotocol.Not{newPred}
+		return &gitprotocol.Not{Child: newPred}
 	}
 	return newPred
 }


### PR DESCRIPTION
Go's implementation of case-insensitive search is quite slow. In searcher, we transform both the [regexp pattern](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/searcher/search/search_regex.go?L423:4) and the [text to be searched](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/searcher/search/lower_amd64.go?L4:6) (using an optimized implementation in assembly) before doing the search. The same performance issue affects diff/commit search. 

Fixes #25177 

This PR: 
- Moves `bytesToLowerASCII` and `lowerRegexpASCII` into a new, shared `internal/search/casetransform` package
- Modifies the gitserver protocol regex matchers to take an expression and a case-sensitive toggle, allowing gitserver to use the optimized version of case-insensitive search
- Mints a `casetransform.Regexp` type that is a light wrapper around `regexp.Regexp` that encodes the requirements of the optimization into its method calls (no need to remember whether the regex pattern has already been lower-cased, or whether we need to lower-case the input before matching with the compiled regex)
- Creates some benchmarks to test that the optimization works similarly well for diff/commit search as it does for searcher

Anecdotal real-life results: 
`type:diff repo:github.com/sourcegraph/sourcegraph$ camden` takes 10 seconds with the optimization on my machine vs 16 seconds without

Benchmark results (more significant because generating/parsing the diff is not included):
```❯ go test -bench=DiffSearch ./internal/gitserver/search
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/internal/gitserver/search
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkDiffSearchCaseInsensitiveOptimization/small_diff/with_optimization-16            340771              3358 ns/op
BenchmarkDiffSearchCaseInsensitiveOptimization/small_diff/without_optimization-16         157194              7487 ns/op
BenchmarkDiffSearchCaseInsensitiveOptimization/large_diff/many_matches/with_optimization-16                 9270            120307 ns/op
BenchmarkDiffSearchCaseInsensitiveOptimization/large_diff/many_matches/without_optimization-16              1674            716881 ns/op
BenchmarkDiffSearchCaseInsensitiveOptimization/large_diff/few_matches/with_optimization-16                 19105             59558 ns/op
BenchmarkDiffSearchCaseInsensitiveOptimization/large_diff/few_matches/without_optimization-16               2677            428236 ns/op
PASS
ok      github.com/sourcegraph/sourcegraph/internal/gitserver/search    9.006s
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
