### PR TITLE
temporary settings: allow editing without overwriting everything

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -740,6 +740,19 @@ type Mutation {
         """
         contents: String!
     ): EmptyResponse!
+
+    """
+    Merges the given settings edit with the current temporary settings for the current user.
+    Keys in the given edit take priority over key in the temporary settings. The merge is
+    not recursive.
+    If temporary settings for the user do not exist, they are created.
+    """
+    editTemporarySettings(
+        """
+        The settings to merge with the current temporary settings for the current user, as a JSON string.
+        """
+        settingsToEdit: String!
+    ): EmptyResponse!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/temporary_settings.go
+++ b/cmd/frontend/graphqlbackend/temporary_settings.go
@@ -39,5 +39,14 @@ func (r *schemaResolver) OverwriteTemporarySettings(ctx context.Context, args st
 		return nil, errors.New("not authenticated")
 	}
 
-	return &EmptyResponse{}, database.TemporarySettings(r.db).UpsertTemporarySettings(ctx, a.UID, args.Contents)
+	return &EmptyResponse{}, database.TemporarySettings(r.db).OverwriteTemporarySettings(ctx, a.UID, args.Contents)
+}
+
+func (r *schemaResolver) EditTemporarySettings(ctx context.Context, args struct{ SettingsToEdit string }) (*EmptyResponse, error) {
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return nil, errors.New("not authenticated")
+	}
+
+	return &EmptyResponse{}, database.TemporarySettings(r.db).EditTemporarySettings(ctx, a.UID, args.SettingsToEdit)
 }

--- a/cmd/frontend/graphqlbackend/temporary_settings_test.go
+++ b/cmd/frontend/graphqlbackend/temporary_settings_test.go
@@ -94,9 +94,9 @@ func TestTemporarySettings(t *testing.T) {
 func TestOverwriteTemporarySettingsNotSignedIn(t *testing.T) {
 	resetMocks()
 
-	calledUpsertTemporarySettings := false
-	database.Mocks.TemporarySettings.UpsertTemporarySettings = func(ctx context.Context, userID int32, contents string) error {
-		calledUpsertTemporarySettings = true
+	calledOverwriteTemporarySettings := false
+	database.Mocks.TemporarySettings.OverwriteTemporarySettings = func(ctx context.Context, userID int32, contents string) error {
+		calledOverwriteTemporarySettings = true
 		return nil
 	}
 
@@ -127,19 +127,19 @@ func TestOverwriteTemporarySettingsNotSignedIn(t *testing.T) {
 		},
 	})
 
-	if calledUpsertTemporarySettings {
-		t.Fatal("should not call UpsertTemporarySettings")
+	if calledOverwriteTemporarySettings {
+		t.Fatal("should not call OverwriteTemporarySettings")
 	}
 }
 
 func TestOverwriteTemporarySettings(t *testing.T) {
 	resetMocks()
 
-	calledUpsertTemporarySettings := false
-	var calledUpsertTemporarySettingsUserID int32
-	database.Mocks.TemporarySettings.UpsertTemporarySettings = func(ctx context.Context, userID int32, contents string) error {
-		calledUpsertTemporarySettingsUserID = userID
-		calledUpsertTemporarySettings = true
+	calledOverwriteTemporarySettings := false
+	var calledOverwriteTemporarySettingsUserID int32
+	database.Mocks.TemporarySettings.OverwriteTemporarySettings = func(ctx context.Context, userID int32, contents string) error {
+		calledOverwriteTemporarySettingsUserID = userID
+		calledOverwriteTemporarySettings = true
 		return nil
 	}
 
@@ -148,7 +148,7 @@ func TestOverwriteTemporarySettings(t *testing.T) {
 			Context: actor.WithActor(context.Background(), actor.FromUser(1)),
 			Schema:  mustParseGraphQLSchema(t),
 			Query: `
-				mutation ModifyTemporarySettings {
+				mutation OverwriteTemporarySettings {
 					overwriteTemporarySettings(
 						contents: "{\"search.collapsedSidebarSections\": []}"
 					) {
@@ -160,10 +160,46 @@ func TestOverwriteTemporarySettings(t *testing.T) {
 		},
 	})
 
-	if !calledUpsertTemporarySettings {
-		t.Fatal("should call UpsertTemporarySettings")
+	if !calledOverwriteTemporarySettings {
+		t.Fatal("should call OverwriteTemporarySettings")
 	}
-	if calledUpsertTemporarySettingsUserID != 1 {
-		t.Fatalf("should call UpsertTemporarySettings with userID=1, got=%d", calledUpsertTemporarySettingsUserID)
+	if calledOverwriteTemporarySettingsUserID != 1 {
+		t.Fatalf("should call OverwriteTemporarySettings with userID=1, got=%d", calledOverwriteTemporarySettingsUserID)
+	}
+}
+
+func TestEditTemporarySettings(t *testing.T) {
+	resetMocks()
+
+	calledEditTemporarySettings := false
+	var calledEditTemporarySettingsUserID int32
+	database.Mocks.TemporarySettings.EditTemporarySettings = func(ctx context.Context, userID int32, settingsToEdit string) error {
+		calledEditTemporarySettingsUserID = userID
+		calledEditTemporarySettings = true
+		return nil
+	}
+
+	RunTests(t, []*Test{
+		{
+			Context: actor.WithActor(context.Background(), actor.FromUser(1)),
+			Schema:  mustParseGraphQLSchema(t),
+			Query: `
+				mutation EditTemporarySettings {
+					editTemporarySettings(
+						settingsToEdit: "{\"search.collapsedSidebarSections\": []}"
+					) {
+						alwaysNil
+					}
+				}
+			`,
+			ExpectedResult: "{\"editTemporarySettings\":{\"alwaysNil\":null}}",
+		},
+	})
+
+	if !calledEditTemporarySettings {
+		t.Fatal("should call EditTemporarySettings")
+	}
+	if calledEditTemporarySettingsUserID != 1 {
+		t.Fatalf("should call EditTemporarySettings with userID=1, got=%d", calledEditTemporarySettingsUserID)
 	}
 }

--- a/internal/database/temporary_settings_mock.go
+++ b/internal/database/temporary_settings_mock.go
@@ -7,6 +7,7 @@ import (
 )
 
 type MockTemporarySettings struct {
-	GetTemporarySettings    func(ctx context.Context, userID int32) (*ts.TemporarySettings, error)
-	UpsertTemporarySettings func(ctx context.Context, userID int32, contents string) error
+	GetTemporarySettings       func(ctx context.Context, userID int32) (*ts.TemporarySettings, error)
+	OverwriteTemporarySettings func(ctx context.Context, userID int32, contents string) error
+	EditTemporarySettings      func(ctx context.Context, userID int32, settingsToEdit string) error
 }


### PR DESCRIPTION
Currently, the only way to update temporary settings for authenticated users is to overwrite the whole settings object. This can cause changing some settings to delete or revert unrelated settings if the settings have not been completely synced between two different devices/browsers. 

With this change, editing settings can be done by merging the desired changes with the existing settings in the database, thus making temporary settings more robust.