### PR TITLE
search: do not panic / use Zoekt code path if indexed search is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- A search regression in 3.32.0 which caused instances with search indexing _disabled_ (very rare) via `"search.index.enabled": false,` in their site config to crash with a panic. [#25321](https://github.com/sourcegraph/sourcegraph/pull/25321)
+- An issue where the default `search.index.enabled` value on single-container Docker instances would incorrectly be computed as `false` in some situations. [#25321](https://github.com/sourcegraph/sourcegraph/pull/25321)
 - StatefulSet service discovery in Kubernetes correctly constructs pod hostnames in the case where the ServiceName is different from the StatefulSet name. [#25146](https://github.com/sourcegraph/sourcegraph/pull/25146)
 
 ### Removed

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -204,19 +203,12 @@ func UpdateChannel() string {
 }
 
 // SearchIndexEnabled returns true if sourcegraph should index all
-// repositories for text search. If the configuration is unset, it returns
-// false for the docker server image (due to resource usage) but true
-// elsewhere. Additionally it also checks for the outdated environment
-// variable INDEXED_SEARCH.
+// repositories for text search.
 func SearchIndexEnabled() bool {
 	if v := Get().SearchIndexEnabled; v != nil {
 		return *v
 	}
-	if v := os.Getenv("INDEXED_SEARCH"); v != "" {
-		enabled, _ := strconv.ParseBool(v)
-		return enabled
-	}
-	return DeployType() != DeploySingleDocker
+	return true // always on by default in all deployment types, see confdefaults.go
 }
 
 func BatchChangesEnabled() bool {

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -38,16 +38,6 @@ func TestSearchIndexEnabled(t *testing.T) {
 		sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{SearchIndexEnabled: boolPtr(false)}},
 		env:  []string{"DEPLOY_TYPE=docker-container"},
 		want: false,
-	}, {
-		name: "SearchIndex INDEXED_SEARCH=f",
-		sc:   &Unified{},
-		env:  []string{"DEPLOY_TYPE=docker-container", "INDEXED_SEARCH=f"},
-		want: false,
-	}, {
-		name: "SearchIndex INDEXED_SEARCH=t",
-		sc:   &Unified{},
-		env:  []string{"DEPLOY_TYPE=docker-container", "INDEXED_SEARCH=t"},
-		want: true,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -19,10 +19,10 @@ func TestSearchIndexEnabled(t *testing.T) {
 		env  []string
 		want interface{}
 	}{{
-		name: "SearchIndex defaults to false in docker",
+		name: "SearchIndex defaults to true in docker",
 		sc:   &Unified{},
 		env:  []string{"DEPLOY_TYPE=docker-container"},
-		want: false,
+		want: true,
 	}, {
 		name: "SearchIndex defaults to true in k8s",
 		sc:   &Unified{},

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -149,7 +149,7 @@ type IndexedSearchRequest interface {
 }
 
 func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ search.IndexedRequestType, onMissing OnMissingRepoRevs) (IndexedSearchRequest, error) {
-	if args.Mode == search.ZoektGlobalSearch {
+	if args.Zoekt != nil && args.Mode == search.ZoektGlobalSearch {
 		// performance: optimize global searches where Zoekt searches
 		// all shards anyway.
 		return NewIndexedUniverseSearchRequest(ctx, args, typ, args.RepoOptions, args.UserPrivateRepos)


### PR DESCRIPTION
This PR fixes an issue where disabling indexed search via the site config would result in a nil pointer panic reported in #25269

This PR also fixes an issue where the default value of `search.index.enabled` was incorrectly computed as `false` on some Docker instances (older ones), while newer ones would always start with `"search.index.enabled": true,`.

This regression was released in 3.32.0, but having indexed search disabled is rare, this would generally only affect single-container Docker instances, and anyone can easily workaround the issue by adding `"search.index.enabled": true,` to their site configuration.

Fixes #25269

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>