### PR TITLE
dev/ci: partial revert of root_dir change for cluster ci

### DIFF
--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -6,7 +6,6 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)""
 # cd to repo root
 root_dir="$(dirname "${BASH_SOURCE[0]}")/../../../.."
 cd "$root_dir"
-root_dir=$(pwd)
 
 export NAMESPACE="cluster-ci-$BUILDKITE_BUILD_NUMBER"
 


### PR DESCRIPTION
We want those frontend logs for these tests, it seems like this stopped?

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
