### PR TITLE
Remove unnecessary extra puppeteer download

### DIFF
--- a/client/web/package.json
+++ b/client/web/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest --testPathIgnorePatterns end-to-end --testPathIgnorePatterns regression integration",
-    "task:mocha": "yarn --cwd ../.. download-puppeteer-browser && cross-env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha",
+    "task:mocha": "cross-env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha",
     "test:regression": "yarn task:mocha './src/regression/**/*.test.ts' --exit",
     "test:regression:codeintel": "yarn task:mocha ./src/regression/codeintel.test.ts",
     "test:regression:config-settings": "yarn task:mocha ./src/regression/config-settings.test.ts",


### PR DESCRIPTION
Shouldn't be necessary, as it is also being downloaded [here](https://github.com/sourcegraph/sourcegraph/pull/25329/commits/a854f211b99f19b1e8e2fe94f0d53ab22d0e5659). I didn't realize that commit had been pushed when I pushed my fix.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
