### PR TITLE
repos: Switch to in memory semaphore

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -299,6 +299,9 @@ func (s *Syncer) syncRepo(
 	defer func() { save(svc, err) }()
 
 	s.SyncSemaphoreMu.Lock()
+	if s.SyncSemaphore == nil {
+		s.SyncSemaphore = make(map[api.RepoName]*semaphore.Weighted)
+	}
 	sem := s.SyncSemaphore[name]
 	if sem == nil {
 		sem = semaphore.NewWeighted(1)

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -51,10 +51,10 @@ type Syncer struct {
 	// If zero, we'll read from config instead.
 	UserReposMaxPerSite int
 
-	// SyncSemaphoreMu protects SyncSemaphore
+	// SyncSemaphoreMu protects SyncSemaphores
 	SyncSemaphoreMu sync.Mutex
-	// SyncSemaphore allows us to limit the number of concurrent syncs per repo to 1
-	SyncSemaphore map[api.RepoName]*semaphore.Weighted
+	// SyncSemaphores allows us to limit the number of concurrent syncs per repo to 1
+	SyncSemaphores map[api.RepoName]*semaphore.Weighted
 }
 
 // RunOptions contains options customizing Run behaviour.
@@ -299,13 +299,13 @@ func (s *Syncer) syncRepo(
 	defer func() { save(svc, err) }()
 
 	s.SyncSemaphoreMu.Lock()
-	if s.SyncSemaphore == nil {
-		s.SyncSemaphore = make(map[api.RepoName]*semaphore.Weighted)
+	if s.SyncSemaphores == nil {
+		s.SyncSemaphores = make(map[api.RepoName]*semaphore.Weighted)
 	}
-	sem := s.SyncSemaphore[name]
+	sem := s.SyncSemaphores[name]
 	if sem == nil {
 		sem = semaphore.NewWeighted(1)
-		s.SyncSemaphore[name] = sem
+		s.SyncSemaphores[name] = sem
 	}
 	s.SyncSemaphoreMu.Unlock()
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -51,7 +51,7 @@ type Syncer struct {
 	// If zero, we'll read from config instead.
 	UserReposMaxPerSite int
 
-	// SyncSemaphoreMu protects   SyncSemaphore
+	// SyncSemaphoreMu protects SyncSemaphore
 	SyncSemaphoreMu sync.Mutex
 	// SyncSemaphore allows us to limit the number of concurrent syncs per repo to 1
 	SyncSemaphore map[api.RepoName]*semaphore.Weighted


### PR DESCRIPTION
Instead of using pg advisory locks. We only support a single instance of
repo-updater at the moment and we're seeing contention on the database
which this change will hopefully avoid.
