### PR TITLE
Revert "Wait for firstConsumer"

### DIFF
--- a/dev/ci/test/cluster/storageClass.yaml
+++ b/dev/ci/test/cluster/storageClass.yaml
@@ -5,10 +5,9 @@ metadata:
     name: sourcegraph
     labels:
         deploy: sourcegraph
-provisioner: pd.csi.storage.gke.io
+provisioner: kubernetes.io/gce-pd
 parameters:
-    type: pd-balanced
+    type: pd-ssd # This configures SSDs (recommended).
     fsType: ext4
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
-allowVolumeExpansion: true


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#25343

Looks like the pipeline failed when this was merged: https://buildkite.com/sourcegraph/qa/builds/5663
I've raised this issue as follow-up: https://github.com/sourcegraph/sourcegraph/issues/25354