### PR TITLE
add issue numbers to new TODOs

### DIFF
--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -69,7 +69,7 @@ var (
 		"--no-merges",
 	}
 
-	// TODO support adding refs
+	// TODO(@camdencheek) support adding refs (issue #25356)
 	// logArgsWithRefs    = append(baseLogArgs, "--format=format:"+strings.Join(formatWithRefs, "%x00")+"%x00")
 	logArgsWithoutRefs = append(baseLogArgs, "--format=format:"+strings.Join(formatWithoutRefs, "%x00")+"%x00")
 	sep                = []byte{0x0}

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -132,12 +132,12 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	var newPred gitprotocol.SearchQuery
 	switch parameter.Field {
 	case query.FieldAuthor:
-		// TODO look up emails
+		// TODO(@camdencheek) look up emails (issue #25180)
 		newPred = &gitprotocol.AuthorMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
 	case query.FieldCommitter:
 		newPred = &gitprotocol.CommitterMatches{gitprotocol.Regexp{regexp.MustCompile(wrapCaseSensitive(parameter.Value, caseSensitive))}}
 	case query.FieldBefore:
-		newPred = &gitprotocol.CommitBefore{time.Now()} // TODO parse the time in with go-naturaldate
+		newPred = &gitprotocol.CommitBefore{time.Now()} // TODO(@camdencheek) parse the time in with go-naturaldate (issue #25357)
 	case query.FieldAfter:
 		newPred = &gitprotocol.CommitAfter{time.Now()}
 	case query.FieldMessage:


### PR DESCRIPTION
Merging the new commit/diff search path added a few TODOs, and this adds issue numbers to them. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
