### PR TITLE
Add `use-resize-observer` mock

### DIFF
--- a/client/shared/dev/mockResizeObserver.ts
+++ b/client/shared/dev/mockResizeObserver.ts
@@ -1,0 +1,11 @@
+import ResizeObserver from 'resize-observer-polyfill'
+
+if ('ResizeObserver' in window === false) {
+    window.ResizeObserver = ResizeObserver
+}
+
+jest.mock('use-resize-observer', () => ({
+    __esModule: true,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    default: jest.requireActual('use-resize-observer/polyfilled'),
+}))

--- a/client/shared/src/util/searchTestHelpers.ts
+++ b/client/shared/src/util/searchTestHelpers.ts
@@ -237,6 +237,7 @@ export const extensionsController: Controller = {
         pretendRemote<FlatExtensionHostAPI>({
             getContributions: () => pretendProxySubscribable(NEVER),
             registerContributions: () => pretendProxySubscribable(EMPTY).subscribe(noop as any),
+            haveInitialExtensionsLoaded: () => pretendProxySubscribable(of(true)),
         })
     ),
     commandErrors: EMPTY,

--- a/client/wildcard/src/components/PageSelector/PageSelector.test.tsx
+++ b/client/wildcard/src/components/PageSelector/PageSelector.test.tsx
@@ -4,11 +4,6 @@ import sinon from 'sinon'
 
 import { PageSelector, PageSelectorProps } from './PageSelector'
 
-jest.mock('use-resize-observer', () => ({
-    __esModule: true,
-    default: jest.requireActual('use-resize-observer/polyfilled'),
-}))
-
 describe('PageSelector', () => {
     let queries: RenderResult
     const renderWithProps = (props: PageSelectorProps): RenderResult => render(<PageSelector {...props} />)

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -57,6 +57,7 @@ const config = {
     require.resolve('abort-controller/polyfill'),
     path.join(__dirname, 'client/shared/dev/fetch'),
     path.join(__dirname, 'client/shared/dev/setLinkComponentForTest.ts'),
+    path.join(__dirname, 'client/shared/dev/mockResizeObserver.ts'),
     path.join(__dirname, 'client/shared/dev/mockUniqueId.ts'),
     // Enzyme setup file
     path.join(__dirname, 'client/shared/dev/enzymeSetup.js'),


### PR DESCRIPTION
### Description
- Add mock for `use-resize-observer` which causes `yarn test` failed on Github CI Action (ubuntu-latest, node 16.7.0)
- Fix errors on log during testing `StatusBar.test.tsx`

![image](https://user-images.githubusercontent.com/51897872/134725306-0dc51889-fa9c-4692-a4ec-d11a2df8b40d.png)

```bash
 ~/Pr/client-sourcegraph  main *1 !1  yarn test -i client/web/src/extensions/components/StatusBar.test.tsx            ✔  1.22.4 yarn  1.17 Go  16.8.0 Node  2.6.3 Ruby 
yarn run v1.22.11
$ jest --testPathIgnorePatterns end-to-end regression integration storybook -i client/web/src/extensions/components/StatusBar.test.tsx
 PASS   web  client/web/src/extensions/components/StatusBar.test.tsx
  StatusBar
    ✓ renders correctly (103ms)

  console.error
    Warning: An update to StatusBar inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in StatusBar

      at printWarning (../../node_modules/react-dom/cjs/react-dom.development.js:88:30)
      at error (../../node_modules/react-dom/cjs/react-dom.development.js:60:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (../../node_modules/react-dom/cjs/react-dom.development.js:23284:7)
      at dispatchAction (../../node_modules/react-dom/cjs/react-dom.development.js:15656:9)
      at SafeSubscriber.Object.<anonymous>.SafeSubscriber.__tryOrUnsub (../../node_modules/rxjs/src/internal/Subscriber.ts:265:10)
      at SafeSubscriber.Object.<anonymous>.SafeSubscriber.error (../../node_modules/rxjs/src/internal/Subscriber.ts:220:16)
      at Subscriber.Object.<anonymous>.Subscriber._error (../../node_modules/rxjs/src/internal/Subscriber.ts:143:22)

  console.error
    Error: Uncaught [Error: unspecified property in the stub: "haveInitialExtensionsLoaded"]
        at reportException (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:62:24)
        at innerInvokeEventListeners (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:332:9)
        at invokeEventListeners (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:267:3)
        at HTMLUnknownElementImpl._dispatch (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:214:9)
        at HTMLUnknownElementImpl.dispatchEvent (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:87:17)
        at HTMLUnknownElement.dispatchEvent (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:144:23)
        at Object.invokeGuardedCallbackDev (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/react-dom/cjs/react-dom.development.js:237:16)
        at invokeGuardedCallback (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/react-dom/cjs/react-dom.development.js:292:31)
        at beginWork$1 (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/react-dom/cjs/react-dom.development.js:23203:7)
        at performUnitOfWork (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/react-dom/cjs/react-dom.development.js:22157:12) Error: unspecified property in the stub: "haveInitialExtensionsLoaded"
        at Object.haveInitialExtensionsLoaded [as get] (/Users/kentnguyen/Projects/client-sourcegraph/client/shared/src/api/util.ts:152:19)
        at SwitchMapSubscriber.project (/Users/kentnguyen/Projects/client-sourcegraph/client/shared/src/api/features.ts:16:75)
        at SwitchMapSubscriber.Object.<anonymous>.SwitchMapSubscriber._next (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/rxjs/src/internal/operators/switchMap.ts:121:21)
        at SwitchMapSubscriber.Object.<anonymous>.Subscriber.next (/Users/kentnguyen/Projects/client-sourcegraph/node_modules/rxjs/src/internal/Subscriber.ts:99:12)
        at /Users/kentnguyen/Projects/client-sourcegraph/node_modules/rxjs/src/internal/util/subscribeToPromise.ts:8:20
        at processTicksAndRejections (node:internal/process/task_queues:96:5)

      at VirtualConsole.<anonymous> (../../node_modules/jsdom/lib/jsdom/virtual-console.js:29:45)
      at VirtualConsole.emit (../../node:events:394:28)
      at reportException (../../node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:28)
      at innerInvokeEventListeners (../../node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:332:9)
      at invokeEventListeners (../../node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:267:3)
      at HTMLUnknownElementImpl._dispatch (../../node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:214:9)
      at HTMLUnknownElementImpl.dispatchEvent (../../node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:87:17)

  console.error
    The above error occurred in the <StatusBar> component:
        in StatusBar
    
    Consider adding an error boundary to your tree to customize error handling behavior.
    Visit https://fb.me/react-error-boundaries to learn more about error boundaries.

      at logCapturedError (../../node_modules/react-dom/cjs/react-dom.development.js:19527:21)
      at logError (../../node_modules/react-dom/cjs/react-dom.development.js:19564:5)
      at update.callback (../../node_modules/react-dom/cjs/react-dom.development.js:20708:5)
      at callCallback (../../node_modules/react-dom/cjs/react-dom.development.js:12490:12)
      at commitUpdateQueue (../../node_modules/react-dom/cjs/react-dom.development.js:12511:9)
      at commitLifeCycles (../../node_modules/react-dom/cjs/react-dom.development.js:19883:11)
      at commitLayoutEffects (../../node_modules/react-dom/cjs/react-dom.development.js:22803:7)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        5.014s
Ran all test suites matching /client\/web\/src\/extensions\/components\/StatusBar.test.tsx/i.
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
