### PR TITLE
database: Codify deleted_at index on repo table

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1650,6 +1650,7 @@ Indexes:
     "repo_metadata_gin_idx" gin (metadata)
     "repo_name_idx" btree (lower(name::text) COLLATE "C")
     "repo_name_trgm" gin (lower(name::text) gin_trgm_ops)
+    "repo_non_deleted_id_name_idx" btree (id, name) WHERE deleted_at IS NULL
     "repo_private" btree (private)
     "repo_stars_idx" btree (stars DESC NULLS LAST)
     "repo_uri_idx" btree (uri)

--- a/migrations/frontend/1528395893_fix_repo_index_part_one.down.sql
+++ b/migrations/frontend/1528395893_fix_repo_index_part_one.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS repo_non_deleted_id_name_idx;
+COMMIT;

--- a/migrations/frontend/1528395893_fix_repo_index_part_one.up.sql
+++ b/migrations/frontend/1528395893_fix_repo_index_part_one.up.sql
@@ -1,0 +1,9 @@
+-- We have a hand-created but non-codified index in our Cloud environment
+-- called repo_deleted_at_idx which is a partial btree index over deleted_at
+-- where deleted_at is null. This effectively creates a btree index whose only
+-- value is NULL.
+--
+-- Instead, we'll make a partial index on useful fields that can at least help
+-- cover queries that select only/filter by id and/or name.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS repo_non_deleted_id_name_idx ON repo(id, name) WHERE deleted_at IS NULL;


### PR DESCRIPTION
Replace the rogue `repo_deleted_at_idx` index in Cloud with one that can be more applicably used by other queries that need to require id and/or name values.

Here's a candid photograph of the old index structure (let's all take a second to laugh at it).

<img width="1008" alt="Screen Shot 2021-09-24 at 3 16 24 PM" src="https://user-images.githubusercontent.com/103087/134734765-6097859b-565a-434d-98f1-04b57d4498c3.png">