### PR TITLE
sg: switch from syntect_server to syntax-highlighter in dev

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -329,7 +329,7 @@ commands:
     cmd: |
       docker run --name=syntect_server --rm -p9238:9238 \
       -e WORKERS=1 -e ROCKET_ADDRESS=0.0.0.0 \
-      sourcegraph/syntect_server:32d880d@sha256:899661691c3a6f8d587186bed73c3224b065d1e1c3485aff2ea208c261c010f6
+      sourcegraph/syntax-highlighter@sha256:92a5c181dbf2d8aead5171c985139bf38c496bef2ac98afbd64c3612967fe5cc
     install: docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server || true
     env:
       # This is not needed actually


### PR DESCRIPTION
Previously, in local development, we were still using the old https://hub.docker.com/r/sourcegraph/syntect_server (from before migrating https://github.com/sourcegraph/syntect_server to https://github.com/sourcegraph/sourcegraph).

After this change, we will use https://hub.docker.com/r/sourcegraph/syntax-highlighter in local development.