### PR TITLE
extensions: enable apex by default, update language detection

### DIFF
--- a/client/shared/src/languages.ts
+++ b/client/shared/src/languages.ts
@@ -45,6 +45,12 @@ function getModeFromExtension(extension: string): string | undefined {
         case 'ads':
             return 'ada'
 
+        // Apex
+        case 'cls':
+        case 'apex':
+        case 'trigger':
+            return 'apex'
+
         // Actionscript
         case 'as':
             return 'actionscript'

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -12,6 +12,7 @@ import (
 )
 
 var builtinExtensions = map[string]bool{
+	"sourcegraph/apex":       true,
 	"sourcegraph/clojure":    true,
 	"sourcegraph/cobol":      true,
 	"sourcegraph/cpp":        true,


### PR DESCRIPTION
Continuation of https://github.com/sourcegraph/sourcegraph/pull/25268

We forgot that extension activation works differently when sideloading during development vs not sideloading.