### PR TITLE
web: prevent layout flash for logged-in user

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -323,7 +323,10 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
             })
 
         this.subscriptions.add(
-            combineLatest([from(this.platformContext.settings), authenticatedUser.pipe(startWith(null))]).subscribe(
+            combineLatest([
+                from(this.platformContext.settings),
+                authenticatedUser.pipe(startWith(undefined)),
+            ]).subscribe(
                 ([settingsCascade, authenticatedUser]) => {
                     this.setState(state => ({
                         settingsCascade,

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -131,7 +131,12 @@ export interface SourcegraphWebAppProps
 interface SourcegraphWebAppState extends SettingsCascadeProps {
     error?: Error
 
-    /** The currently authenticated user (or null if the viewer is anonymous). */
+    /**
+     * The currently authenticated user:
+     * - `undefined` until `CurrentAuthState` query completion.
+     * - `AuthenticatedUser` if the viewer is authenticated.
+     * - `null` if the viewer is anonymous.
+     */
     authenticatedUser?: AuthenticatedUser | null
 
     /** GraphQL client initialized asynchronously to restore persisted cache. */
@@ -325,6 +330,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
         this.subscriptions.add(
             combineLatest([
                 from(this.platformContext.settings),
+                // Start with `undefined` while we don't know if the viewer is authenticated or not.
                 authenticatedUser.pipe(startWith(undefined)),
             ]).subscribe(
                 ([settingsCascade, authenticatedUser]) => {

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -16,7 +16,7 @@ export const SITE_SUBJECT_NO_ADMIN: Pick<GQL.ISettingsSubject, 'id' | 'viewerCan
 
 export function viewerSubjectFromSettings(
     cascade: SettingsCascadeOrError,
-    authenticatedUser: AuthenticatedUser | null
+    authenticatedUser?: AuthenticatedUser | null
 ): LayoutProps['viewerSubject'] {
     if (authenticatedUser) {
         return authenticatedUser


### PR DESCRIPTION
## Context

Layout flashes on page load from non-logged-in variant to logged-in variant. 

https://user-images.githubusercontent.com/3846380/134764071-ce9498b4-c93b-4bf4-85c9-f80f8fee6493.mov


### The root cause of the issue 

After enabling persistent cache for the `viewerSettings` query, it's loaded faster than the `CurrentAuthState` query. This causes [the update](https://github.com/sourcegraph/sourcegraph/blob/9d3fa0602733e0b497c54bdf0620931353d6b013/client/web/src/SourcegraphWebApp.tsx#L326-L330) of the  `authenticatedUser` state to `null` which [enables](https://github.com/sourcegraph/sourcegraph/blob/9d3fa0602733e0b497c54bdf0620931353d6b013/client/web/src/SourcegraphWebApp.tsx#L464-L470) content rendering despite the fact that the `CurrentAuthState` request is not completed. The correct value for `authenticatedUser` is `undefined` till the `CurrentAuthState` query completion. It prevents the render function from going past [the condition](https://github.com/sourcegraph/sourcegraph/blob/9d3fa0602733e0b497c54bdf0620931353d6b013/client/web/src/SourcegraphWebApp.tsx#L464-L466):

```tsx
if (authenticatedUser === undefined || graphqlClient === undefined) {
      return null
}
```