### PR TITLE
batches: refetch batch change after performing bulk action

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -57,11 +57,17 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
     // Query bulk operations created after this time.
     const createdAfter = useMemo(() => subDays(startOfDay(new Date()), 3).toISOString(), [])
 
-    const { data, error, loading } = useQuery<BatchChangeByNamespaceResult, BatchChangeByNamespaceVariables>(
+    const { data, error, loading, refetch } = useQuery<BatchChangeByNamespaceResult, BatchChangeByNamespaceVariables>(
         BATCH_CHANGE_BY_NAMESPACE,
         {
             variables: { namespaceID, batchChange: batchChangeName, createdAfter },
+            // Cache this data but always re-request it in the background when we revisit
+            // this page to pick up newer changes.
             fetchPolicy: 'cache-and-network',
+            // For subsequent requests while this page is open, make additional network
+            // requests; this is necessary for `refetch` to actually use the network. (see
+            // https://github.com/apollographql/apollo-client/issues/5515)
+            nextFetchPolicy: 'network-only',
             // TODO: Why do we need to poll this every 5 seconds??
             // pollInterval: 5000,
         }
@@ -127,7 +133,10 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                 className="mb-3"
             />
             <Description description={batchChange.description} />
-            <BatchChangeDetailsTabs batchChange={batchChange} {...props} />
+            <button className="btn btn-outline-secondary btn-sm" onClick={() => refetch()} type="button">
+                Refetch
+            </button>
+            <BatchChangeDetailsTabs batchChange={batchChange} refetchBatchChange={refetch} {...props} />
         </>
     )
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -61,6 +61,7 @@ export interface BatchChangeDetailsProps
 
 interface BatchChangeDetailsTabsProps extends BatchChangeDetailsProps {
     batchChange: BatchChangeFields
+    refetchBatchChange: () => void
 }
 
 export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsTabsProps> = ({
@@ -74,6 +75,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
     queryChangesets,
     queryExternalChangesetWithFileDiffs,
     queryAllChangesetIDs,
+    refetchBatchChange,
     telemetryService,
 }) => (
     <BatchChangeTabs history={history} location={location}>
@@ -133,6 +135,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                 <BatchChangeChangesets
                     batchChangeID={batchChange.id}
                     viewerCanAdminister={batchChange.viewerCanAdminister}
+                    refetchBatchChange={refetchBatchChange}
                     history={history}
                     location={location}
                     isLightTheme={isLightTheme}
@@ -181,6 +184,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                     queryChangesets={queryChangesets}
                     queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
                     onlyArchived={true}
+                    refetchBatchChange={refetchBatchChange}
                 />
             </BatchChangeTabPanel>
             <BatchChangeTabPanel index={4}>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -45,6 +45,7 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
 
     hideFilters?: boolean
     onlyArchived?: boolean
+    refetchBatchChange: () => void
 
     /** For testing only. */
     queryChangesets?: typeof _queryChangesets
@@ -80,6 +81,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
     queryExternalChangesetWithFileDiffs,
     expandByDefault,
     onlyArchived,
+    refetchBatchChange,
 }) => {
     // You might look at this destructuring statement and wonder why this isn't
     // just a single context consumer object. The reason is because making it a
@@ -110,6 +112,13 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
         },
         [deselectAll, setChangesetFilters]
     )
+
+    // After selecting and performing a bulk action, deselect all changesets and refetch
+    // the batch change to get the actively-running bulk operations.
+    const onSubmitBulkAction = useCallback(() => {
+        deselectAll()
+        refetchBatchChange()
+    }, [deselectAll, refetchBatchChange])
 
     const [queryArguments, setQueryArguments] = useState<Omit<AllChangesetIDsVariables, 'after'>>()
 
@@ -220,7 +229,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
             {showSelectRow && queryArguments && (
                 <ChangesetSelectRow
                     batchChangeID={batchChangeID}
-                    onSubmit={deselectAll}
+                    onSubmit={onSubmitBulkAction}
                     queryAllChangesetIDs={queryAllChangesetIDs}
                     queryArguments={queryArguments}
                 />


### PR DESCRIPTION
Another small improvement for #24417.

I think this was the main reason for originally polling this query; when a user performs a bulk operation, we want to refetch the batch change details so that we have the updated active bulk operations handy to display the alert and update the count on the tab. Technically, we don't care about refetching all the other details of the batch change, but this is still a performance improvement over continuously polling every 5 seconds, and it's almost instant when the bulk operation begins, whereas before it might have taken up to 5 seconds to see that update.

Based on #25379 because it was easier.