### PR TITLE
sg: include commit for dev builds

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -6,10 +6,11 @@ pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 # The BUILD_COMMIT is baked into the binary (see `go install` below) and
 # contains the latest commit in the `dev/sg` folder. If the directory is
 # "dirty", though, we mark the build as a dev build.
+commit=$(git rev-list -1 HEAD .)
 if [[ $(git diff --stat .) != '' ]]; then
-  BUILD_COMMIT="dev"
+  BUILD_COMMIT="dev-$commit"
 else
-  BUILD_COMMIT=$(git rev-list -1 HEAD .)
+  BUILD_COMMIT="$commit"
 fi
 export BUILD_COMMIT
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -260,9 +260,15 @@ func checkSgVersion() {
 		return
 	}
 
-	out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..HEAD", BuildCommit), "./dev/sg")
+	rev := BuildCommit
+	if strings.HasPrefix(BuildCommit, "dev-") {
+		rev = BuildCommit[len("dev-"):]
+	}
+
+	out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..HEAD", rev), "./dev/sg")
 	if err != nil {
-		fmt.Printf("error getting new commits in ./dev/sg: %s\n", err)
+		fmt.Printf("error getting new commits since %s in ./dev/sg: %s\n", rev, err)
+		fmt.Println("try reinstalling sg with `./dev/sg/install.sh`.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This allows us to warn even if the user's working copy is dirty at time
of installation. We prefix "dev-" to BuildCommit.

Additionally we give advice to users on how to resolve "has changed"
detection failing. This can fail if the user installed sg on a feature
branch whose commits have been GCed.

I noticed this footgun while reading the install.sh script.
