### PR TITLE
sg: set `SITE_CONFIG_ESCAPE_HATCH_PATH` to not be under home root

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -139,6 +139,7 @@ commands:
       ENTERPRISE: 1
       SITE_CONFIG_FILE: '../dev-private/enterprise/dev/site-config.json'
       EXTSVC_CONFIG_FILE: '../dev-private/enterprise/dev/external-services-config.json'
+      SITE_CONFIG_ESCAPE_HATCH_PATH: '$HOME/.sourcegraph/site-config.json'
       # frontend processes need this to be so that the paths to the assets are rendered correctly
       WEBPACK_DEV_SERVER: 1
     watch:


### PR DESCRIPTION
By default, `SITE_CONFIG_ESCAPE_HATCH_PATH` points to `$HOME/site-config.json`, which feels isolated because we store everything else under `$HOME/.sourcegraph/`.
