### PR TITLE
Add support for `importChangesets` to `createBatchSpecFromRaw` mutation

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1460,22 +1460,17 @@ func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlback
 	}
 
 	svc := service.New(r.store)
-	batchSpec, err := svc.CreateBatchSpec(ctx, service.CreateBatchSpecOpts{
-		NamespaceUserID: actor.FromContext(ctx).UID,
-		RawSpec:         args.BatchSpec,
-	})
-	if err != nil {
-		return nil, err
-	}
-	err = svc.EnqueueBatchSpecResolution(ctx, service.EnqueueBatchSpecResolutionOpts{
-		BatchSpecID:      batchSpec.ID,
+	batchSpec, err := svc.CreateBatchSpecFromRaw(ctx, service.CreateBatchSpecFromRawOpts{
+		NamespaceUserID:  actor.FromContext(ctx).UID,
+		RawSpec:          args.BatchSpec,
 		AllowIgnored:     args.AllowIgnored,
 		AllowUnsupported: args.AllowUnsupported,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return r.batchSpecByID(ctx, marshalBatchSpecRandID(batchSpec.RandID))
+
+	return &batchSpecResolver{store: r.store, batchSpec: batchSpec}, nil
 }
 
 func (r *Resolver) DeleteBatchSpec(ctx context.Context, args *graphqlbackend.DeleteBatchSpecArgs) (*graphqlbackend.EmptyResponse, error) {

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1217,7 +1217,8 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("ReplaceBatchSpecInput", func(t *testing.T) {
-		t.Run("success", func(t *testing.T) {
+		createBatchSpecWithWorkspaces := func(t *testing.T) *btypes.BatchSpec {
+			t.Helper()
 			spec := testBatchSpec(admin.ID)
 			if err := s.CreateBatchSpec(ctx, spec); err != nil {
 				t.Fatal(err)
@@ -1238,6 +1239,11 @@ func TestService(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
+			return spec
+		}
+
+		t.Run("success", func(t *testing.T) {
+			spec := createBatchSpecWithWorkspaces(t)
 
 			newSpec, err := svc.ReplaceBatchSpecInput(ctx, ReplaceBatchSpecInputOpts{
 				BatchSpecRandID: spec.RandID,
@@ -1280,6 +1286,48 @@ func TestService(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 		})
+
+		t.Run("success with importChangesets", func(t *testing.T) {
+			spec := createBatchSpecWithWorkspaces(t)
+
+			newSpec, err := svc.ReplaceBatchSpecInput(ctx, ReplaceBatchSpecInputOpts{
+				BatchSpecRandID: spec.RandID,
+				RawSpec: ct.BuildRawBatchSpecWithImportChangesets(t, []batcheslib.ImportChangeset{
+					{Repository: string(rs[0].Name), ExternalIDs: []interface{}{"#123", 456}},
+					{Repository: string(rs[1].Name), ExternalIDs: []interface{}{"789"}},
+				}),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resolutionJob, err := s.GetBatchSpecResolutionJob(ctx, store.GetBatchSpecResolutionJobOpts{
+				BatchSpecID: newSpec.ID,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want, have := btypes.BatchSpecResolutionJobStateQueued, resolutionJob.State; have != want {
+				t.Fatalf("resolution job has wrong state. want=%s, have=%s", want, have)
+			}
+
+			changesetSpecs, _, err := s.ListChangesetSpecs(ctx, store.ListChangesetSpecsOpts{BatchSpecID: newSpec.ID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Assert that the number of changeset specs is correct. More
+			// extensive assertions are in the tests for
+			// CreateBatchSpecFromRaw.
+			if len(changesetSpecs) != 3 {
+				t.Fatalf("wrong number of changeset specs: %d", len(changesetSpecs))
+			}
+
+			// Assert that old batch spec is deleted
+			_, err = s.GetBatchSpec(ctx, store.GetBatchSpecOpts{ID: spec.ID})
+			if err != store.ErrNoResults {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
 	})
 
 	t.Run("CreateBatchSpecFromRaw", func(t *testing.T) {
@@ -1304,22 +1352,13 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("success with importChangesets", func(t *testing.T) {
-			rawSpec := batcheslib.BatchSpec{
-				Name:        "test-batch-change",
-				Description: "only importing",
-				ImportChangesets: []batcheslib.ImportChangeset{
-					{Repository: string(rs[0].Name), ExternalIDs: []interface{}{"#123", 456}},
-					{Repository: string(rs[1].Name), ExternalIDs: []interface{}{"789"}},
-				},
-			}
-
-			marshaledRawSpec, err := json.Marshal(rawSpec)
-			if err != nil {
-				t.Fatal(err)
-			}
+			rawSpec := ct.BuildRawBatchSpecWithImportChangesets(t, []batcheslib.ImportChangeset{
+				{Repository: string(rs[0].Name), ExternalIDs: []interface{}{"#123", 456}},
+				{Repository: string(rs[1].Name), ExternalIDs: []interface{}{"789"}},
+			})
 
 			newSpec, err := svc.CreateBatchSpecFromRaw(ctx, CreateBatchSpecFromRawOpts{
-				RawSpec:         string(marshaledRawSpec),
+				RawSpec:         rawSpec,
 				NamespaceUserID: admin.ID,
 			})
 			if err != nil {

--- a/enterprise/internal/batches/testing/specs.go
+++ b/enterprise/internal/batches/testing/specs.go
@@ -58,6 +58,23 @@ changesetTemplate:
   published: false
 `
 
+func BuildRawBatchSpecWithImportChangesets(t *testing.T, imports []batcheslib.ImportChangeset) string {
+	t.Helper()
+
+	spec := batcheslib.BatchSpec{
+		Name:             "test-batch-change",
+		Description:      "only importing",
+		ImportChangesets: imports,
+	}
+
+	marshaledRawSpec, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("failed to marshal BatchSpec: %s", err)
+	}
+
+	return string(marshaledRawSpec)
+}
+
 var ChangesetSpecDiffStat = &diff.Stat{Added: 1, Changed: 2, Deleted: 1}
 
 const ChangesetSpecAuthorEmail = "mary@example.com"

--- a/lib/batches/changeset_spec.go
+++ b/lib/batches/changeset_spec.go
@@ -1,6 +1,9 @@
 package batches
 
 import (
+	"reflect"
+	"strconv"
+
 	"github.com/cockroachdb/errors"
 
 	jsonutil "github.com/sourcegraph/sourcegraph/lib/batches/json"
@@ -28,6 +31,29 @@ func ParseChangesetSpec(rawSpec []byte) (*ChangesetSpec, error) {
 	}
 
 	return spec, nil
+}
+
+// ParseChangesetSpecExternalID attempts to parse the ID of a changeset in the
+// batch spec that should be imported.
+func ParseChangesetSpecExternalID(id interface{}) (string, error) {
+	var sid string
+
+	switch tid := id.(type) {
+	case string:
+		sid = tid
+	case int, int8, int16, int32, int64:
+		sid = strconv.FormatInt(reflect.ValueOf(id).Int(), 10)
+	case uint, uint8, uint16, uint32, uint64:
+		sid = strconv.FormatUint(reflect.ValueOf(id).Uint(), 10)
+	case float32:
+		sid = strconv.FormatFloat(float64(tid), 'f', -1, 32)
+	case float64:
+		sid = strconv.FormatFloat(tid, 'f', -1, 64)
+	default:
+		return "", errors.Errorf("cannot convert value of type %T into a valid external ID: expected string or int", id)
+	}
+
+	return sid, nil
 }
 
 type ChangesetSpec struct {


### PR DESCRIPTION
This is stacked on top of https://github.com/sourcegraph/sourcegraph/pull/25182 and adds support for `importChangesets` to `createBatchSpecFromRaw`.