### PR TITLE
fix result streaming on dev environment

### DIFF
--- a/client/web/gulpfile.js
+++ b/client/web/gulpfile.js
@@ -106,6 +106,7 @@ async function webpackDevelopmentServer() {
     hot: !process.env.NO_HOT,
     host: DEV_SERVER_LISTEN_ADDR.host,
     port: DEV_SERVER_LISTEN_ADDR.port,
+    compress: false,
     client: {
       overlay: false,
       webSocketTransport: 'ws',

--- a/client/web/gulpfile.js
+++ b/client/web/gulpfile.js
@@ -106,6 +106,8 @@ async function webpackDevelopmentServer() {
     hot: !process.env.NO_HOT,
     host: DEV_SERVER_LISTEN_ADDR.host,
     port: DEV_SERVER_LISTEN_ADDR.port,
+    // Disable compression on the dev server because gzip buffers the full
+    // response before sending it, which makes streaming search not stream.
     compress: false,
     client: {
       overlay: false,


### PR DESCRIPTION
Streaming search hasn't been working on the dev environment for a little
while. The issue is the webpack dev server compresses requests with gzip
by default, but gzip buffers the full response before sending it. This
commit disables compression on the dev server so requests to the
`/stream` endpoint are actually streamed back to the client.

Fixes issue in #24618

I wasn't able to find a simple way to disable compression for only
that endpoint, so this disables it for every request on the dev server.
I'm open to alternatives if anyone has better ideas. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
