### PR TITLE
Minor docs fix?

### DIFF
--- a/doc/extensions/authoring/activation.md
+++ b/doc/extensions/authoring/activation.md
@@ -11,7 +11,7 @@ For simplicity, the extension creator sets `activationEvents` to `["*"]`. Adjust
 
 ## Determining the correct language value
 
-Search this [list of languages](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml) to find the value assigned to the `codemirror_mode` key for that language. For example, Typescript
+Search this [list of languages](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml) to find the value assigned to the `codemirror_mode` key for that language.
 
 ## Deactivation
 

--- a/doc/extensions/authoring/activation.md
+++ b/doc/extensions/authoring/activation.md
@@ -5,13 +5,13 @@ Sourcegraph selectively activates each extension based on the `activationEvents`
 There are two types of activation events:
 
 - `["*"]`: always activate
-- `["onLanguage:typescript"]`: activate for files of a language (multiple languages supported)
+- `["onLanguage:javascript"]`: activate for files of a language (multiple languages supported)
 
 For simplicity, the extension creator sets `activationEvents` to `["*"]`. Adjust this if your extension is language-specific.
 
 ## Determining the correct language value
 
-Search this [list of languages](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml) to find the value assigned to the `codemirror_mode` key for that language.
+Search this [list of languages](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml) to find the value assigned to the `codemirror_mode` key for that language. For example, Typescript
 
 ## Deactivation
 


### PR DESCRIPTION
Make it clearer what language to use – typescript, per our own guide, is not the `codemirror_mode`? https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L6184



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
