### PR TITLE
search: factor out Zoekt params for both global/non-global paths

### DIFF
--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -267,7 +267,15 @@ func TestIndexedSearch(t *testing.T) {
 				},
 			}
 
-			indexed, err := newIndexedSubsetSearchRequest(context.Background(), args, search.TextRequest, MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})))
+			zoektArgs := &search.ZoektParameters{
+				Query:          q,
+				Typ:            search.TextRequest,
+				FileMatchLimit: tt.args.patternInfo.FileMatchLimit,
+				Select:         tt.args.patternInfo.Select,
+				Zoekt:          args.Zoekt,
+			}
+
+			indexed, err := newIndexedSubsetSearchRequest(context.Background(), args, zoektArgs, MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Semantics preserving. Stacked on https://github.com/sourcegraph/sourcegraph/pull/25418.

- Factors out the common parts where we convert `PatternInfo` into a `ZoektQuery` along two paths: non-global and global searches. We can do this once now. 

```go
q, err := search.QueryToZoektQuery(...)
```

- Factors out the common state for both these paths:

```go
	zoektArgs := &search.ZoektParameters{
		Query:          q,
		Typ:            typ,
		FileMatchLimit: args.PatternInfo.FileMatchLimit,
		Select:         args.PatternInfo.Select,
		Zoekt:          args.Zoekt,
	}
```

Both of the above items are app state that we know statically up front from queries, and will trickle up for optimized Zoekt query construction/validation. (Strictly speaking `args.Zoekt` client is not static, but a runtime value. But, we know it's state early and, the static parts here don't depend on this runtime value, so we can basically treat it as static since it exists at the earliest point of our app. Note that an example of a true runtime value that we cannot depend on in Zoekt query construction/validation, is the set of resolved repos).

- Factors out the common state for both these paths:

```go
	zoektArgs := &search.ZoektParameters{
		Query:          q,
		Typ:            typ,
		FileMatchLimit: args.PatternInfo.FileMatchLimit,
		Select:         args.PatternInfo.Select,
		Zoekt:          args.Zoekt,
	}
```

Both of the above items are app state that we know statically up front from queries, and will trickle up for optimized Zoekt query construction/validation. (Strictly speaking `args.Zoekt` client is not static, but a runtime value. But, we know it's state early and, the static parts here don't depend on this runtime value, so we can basically treat it as static since it exists at the earliest point of our app. Note that an example of a true runtime value that we cannot depend on in Zoekt query construction/validation, is the set of resolved repos).