### PR TITLE
insights: don't return series that have been deleted

### DIFF
--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -53,7 +53,7 @@ type InsightQueryArgs struct {
 
 // Get returns all matching viewable insight series.
 func (s *InsightStore) Get(ctx context.Context, args InsightQueryArgs) ([]types.InsightViewSeries, error) {
-	preds := make([]*sqlf.Query, 0, 3)
+	preds := make([]*sqlf.Query, 0, 4)
 
 	if len(args.UniqueIDs) > 0 {
 		elems := make([]*sqlf.Query, 0, len(args.UniqueIDs))
@@ -66,10 +66,7 @@ func (s *InsightStore) Get(ctx context.Context, args InsightQueryArgs) ([]types.
 		preds = append(preds, sqlf.Sprintf("iv.unique_id = %s", args.UniqueID))
 	}
 	preds = append(preds, viewPermissionsQuery(args))
-
-	if len(preds) == 0 {
-		preds = append(preds, sqlf.Sprintf("%s", "TRUE"))
-	}
+	preds = append(preds, sqlf.Sprintf("i.deleted_at IS NULL"))
 
 	q := sqlf.Sprintf(getInsightByViewSql, sqlf.Join(preds, "\n AND"))
 	return scanInsightViewSeries(s.Query(ctx, q))

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -37,15 +37,19 @@ func TestGet(t *testing.T) {
 	}
 
 	_, err = timescale.Exec(`INSERT INTO insight_series (series_id, query, created_at, oldest_historical_at, last_recorded_at,
-                            next_recording_after, last_snapshot_at, next_snapshot_after, recording_interval_days)
-                            VALUES ('series-id-1', 'query-1', $1, $1, $1, $1, $1, $1, 5),
-									('series-id-2', 'query-2', $1, $1, $1, $1, $1, $1, 6);`, now)
+                            next_recording_after, last_snapshot_at, next_snapshot_after, recording_interval_days, deleted_at)
+                            VALUES ('series-id-1', 'query-1', $1, $1, $1, $1, $1, $1, 5, null),
+									('series-id-2', 'query-2', $1, $1, $1, $1, $1, $1, 6, null),
+									('series-id-3', 'query-3-deleted', $1, $1, $1, $1, $1, $1, 6, $1);`, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	_, err = timescale.Exec(`INSERT INTO insight_view_series (insight_view_id, insight_series_id, label, stroke)
-									VALUES (1, 1, 'label1', 'color1'), (1, 2, 'label2', 'color2'), (2, 2, 'second-label-2', 'second-color-2');`)
+									VALUES (1, 1, 'label1', 'color1'),
+											(1, 2, 'label2', 'color2'),
+											(2, 2, 'second-label-2', 'second-color-2'),
+											(2, 3, 'label3', 'color-2');`)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Note: I'll leave this as a draft PR until after the hackathon. :) 

Closes #24333

<!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
### Overview

The `insight_series` table has a `deleted_at` column that allows for a soft delete of insight series. This PR makes sure that deleted series won't be returned when fetching insights.

### Testing Steps

I see a "Remove" button in the UI on series when editing an insight, but it's grayed out. Let me know if I'm missing something there. I tested it by editing the db rows directly.

I saw two cases here:
1. An insight with only one series: adding a value for `deleted_at` will result in "Your insight is being processed." I imagine we might not let a user delete the last series from an insight anyway?
2. An insight with multiple series: adding a value for `deleted_at` for one of the series will remove the series from the chart. Making that value `null` again will add it back to the chart. 
