### PR TITLE
[CLOUD-18] event_log: validate URL upon responding to client

### DIFF
--- a/cmd/frontend/graphqlbackend/event_log_test.go
+++ b/cmd/frontend/graphqlbackend/event_log_test.go
@@ -1,0 +1,54 @@
+package graphqlbackend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestUserEventLogResolver_URL(t *testing.T) {
+	conf.Mock(
+		&conf.Unified{
+			SiteConfiguration: schema.SiteConfiguration{
+				ExternalURL: "https://sourcegraph.test:3443",
+			},
+		},
+	)
+	defer conf.Mock(nil)
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "valid URL",
+			url:  "https://sourcegraph.test:3443/search",
+			want: "https://sourcegraph.test:3443/search",
+		},
+		{
+			name: "invalid URL",
+			url:  "https://localhost:3080/search",
+			want: "",
+		},
+		{
+			name: "not a URL",
+			url:  `javascript:alert("HIJACKED")`,
+			want: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := (&userEventLogResolver{
+				event: &types.Event{
+					URL: test.url,
+				},
+			}).URL()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Instead of going with the proposed solution in https://sourcegraph.atlassian.net/browse/VUL-6 (which involves a little bit hack), I found a simpler way to sanitize/validate the `event_log.url` field since it has to be an URL within the site.

---

Jira: https://sourcegraph.atlassian.net/browse/CLOUD-18

CLOUD-18 #done