### PR TITLE
Clean up `sg` README, add VISION.md document, make quickstart quick, link to tickets, ...

### DIFF
--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -37,14 +37,7 @@
   - [`sg migration` - Run or manipulate database migrations](#sg-migration---run-or-manipulate-database-migrations)
   - [`sg rfc` - List, open, or search Sourcegraph RFCs](#sg-rfc---list-or-open-sourcegraph-rfcs)
 - [Configuration](#configuration)
-- [TODOs](#todos)
-- [Hacking](#hacking)
-- [Principles](#principles)
-- [Inspiration](#inspiration)
-- [Ideas](#ideas)
-  - [Generators](#generators)
-  - [Edit configuration files](#edit-configuration-files)
-  - [Tail logs](#tail-logs)
+- [Contributing to sg](#contributing-to-sg)
 
 ## Quickstart
 
@@ -112,30 +105,37 @@ Then make sure that `~/my/path` is in your `$PATH`.
 
 ## Usage
 
-### `sg [start,run,run-set]` - Start dev environment
+### `sg start` - Start dev environments
 
 ```bash
-# Run default environment (this starts the 'default' command set defined in `sg.config.yaml`):
+# Run default environment, Sourcegraph enterprise:
 sg start
 
-# Run the enterprise environment:
-sg run-set enterprise
+# List available environments (defined under `commandSets` in `sg.config.yaml`):
+sg start -help
+
+# Run the enterprise environment with code-intel enabled:
+sg start enterprise-codeintel
+
+# Run the environment for Batch Changes development:
+sg start batches
 
 # Override the logger levels for specific services
-sg run-set --debug=gitserver --error=enterprise-worker,enterprise-frontend enterprise
+sg start --debug=gitserver --error=enterprise-worker,enterprise-frontend enterprise
+```
 
+### `sg run` - Run single commands
+
+```bash
 # Run specific commands:
 sg run gitserver
 sg run frontend
 
-# Run multiple commands:
-sg run gitserver frontend repo-updater
-
-# List available commands:
+# List available commands (defined under `commands:` in `sg.config.yaml`):
 sg run -help
 
-# List available command sets:
-sg run-set -help
+# Run multiple commands:
+sg run gitserver frontend repo-updater
 ```
 
 ### `sg test` - Running test suites
@@ -214,121 +214,64 @@ sg rfc open 420
 
 ## Configuration
 
-`sg` is configured through the `sg.config.yaml` file in the root of the `sourcegraph/sourcegraph` repository:
+`sg` is configured through the [`sg.config.yaml` file in the root of the `sourcegraph/sourcegraph` repository](https://github.com/sourcegraph/sourcegraph/blob/main/sg.config.yaml). Take a look at that file to see which commands are run in which environment, how these commands set setup, what environment variables they use, and more.
 
-```yaml
-commands:
-  gitserver:
-    cmd: .bin/gitserver
-    install: go install github.com/sourcegraph/sourcegraph/cmd/gitserver -o .bin/gitserver
-    env:
-      HOSTNAME: $SRC_GIT_SERVER_1
+To modify your configuration locally, you can overwrite chunks of configuration by creating a `sg.config.overwrite.yaml` file in the root of the repository. It's `.gitignore`d so you won't accidentally commit those changes.
 
-  enterprise-gitserver:
-    cmd: .bin/gitserver
-    install: go install github.com/sourcegraph/sourcegraph/enterprise/cmd/gitserver -o .bin/gitserver
-    env:
-      HOSTNAME: $SRC_GIT_SERVER_1
-
-  query-runner:
-    cmd: .bin/query-runner
-    install: go install github.com/sourcegraph/sourcegraph/cmd/query-runner -o .bin/gitserver
-
-  searcher:
-    cmd: .bin/searcher
-    install: go install github.com/sourcegraph/sourcegraph/cmd/searcher -o .bin/gitserver
-
-  caddy:
-    installDoc.darwin: 'use brew install'
-    installDoc.linux: 'use apt install'
-
-  web:
-    cmd: ./node_modules/.bin/gulp --silent --color dev
-    install: yarn install
-
-  # [...]
-
-commandsets:
-  # This is the set that will be used when `sg start` is run:
-  default:
-    - gitserver
-    - query-runner
-    - repo-updater
-    - searcher
-    - symbols
-    - github-proxy
-    - frontend
-    - watch
-    - caddy
-    - web
-    - syntax-highlighter
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
-  # Another set that can be run with `sg run-set monitoring`:
-  monitoring:
-    - jaeger
-    - docsite
-    - prometheus
-    - grafana
-    - postgres_exporter
-  enterprise:
-    - enterprise-gitserver
-    - enterprise-query-runner
-    - enterprise-repo-updater
-    - enterprise-frontend
-    - searcher
-    - symbols
-    - github-proxy
-    - watch
-    - caddy
-    - web
-    - syntax-highlighter
-    - zoekt-indexserver-0
-    - zoekt-indexserver-1
-    - zoekt-webserver-0
-    - zoekt-webserver-1
-
-tests:
-  # These can be run with `sg test [name]`
-  backend:
-    cmd: go test ./...
-  backend-integration:
-    cmd: go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD
-    env:
-      # These are defaults. They can be overwritten by setting the env vars when
-      # running the command.
-      BASE_URL: 'http://localhost:3080'
-      EMAIL: 'joe@sourcegraph.com'
-      PASSWORD: '12345'
-  frontend:
-    cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook
-  frontend-e2e:
-    cmd: yarn run mocha ./client/web/src/end-to-end/end-to-end.test.ts
-    env:
-      TS_NODE_PROJECT: client/web/src/end-to-end/tsconfig.json
-```
-
-To modify your configuration locally without accidentally committing the changes, you can overwrite
-chunks of configuration with a `sg.config.overwrite.yaml` file in the root of the repository. If it exists,
-the contents of this file will be merged into the contents of the default configuration file, overwriting
-where there are conflicts. This is useful for running custom command sets or adding environment variables
+If an `sg.config.overwrite.yaml` file exists, its contents will be merged with the content of `sg.config.yaml`, overwriting where there are conflicts. This is useful for running custom command sets or adding environment variables
 specific to your work.
 
-## TODOs
+### Examples
+#### Changing database configuration
 
-- [ ] Rename `install` in the config files to `build` because it's clearer
-- [ ] Add the remaining processes from `<root>/dev/Procfile` to `<root>/sg.config.yaml`
-- [ ] All of the [ideas](#ideas) below
-  - [ ] Rebuild and restart a command (if it has `build` defined, see Configuration): `sg build gitserver`
-  - [ ] Implement the `sg generate` command
-  - [ ] Implement `sg edit site-config` and `sg edit external-services`
-  - [ ] Implement `sg tail-log`
-- [ ] Add built-in support for "download binary" so that the `caddy` command, for example, would be 3 lines instead of 20. That would allow us to get rid of the bash code.
-- [ ] Add a `sg rfc create` command
+In order to change the default database configuration, the username and the database, for example, create an `sg.config.overwrite.yaml` file that looks like this:
 
-## Hacking
+```yaml
+env:
+  PGUSER: 'mrnugget'
+  PGDATABASE: 'my-database'
+```
+
+That works for all the other `env` variables in `sg.config.yaml` too.
+
+#### Defining a custom environment by setting a `commandset`
+
+You can customize what boots up in your development environment by defining a `commandSet` in your `sg.config.overwrite.yaml`.
+
+For example, the following defines a commandset called `minimal-batches` that boots up a minimal environment to work on Batch Changes:
+
+```yaml
+commandsets:
+  minimal-batches:
+    checks:
+      - docker
+      - redis
+      - postgres
+    commands:
+      - enterprise-frontend
+      - enterprise-worker
+      - enterprise-repo-updater
+      - enterprise-web
+      - gitserver
+      - searcher
+      - symbols
+      - caddy
+      - github-proxy
+      - zoekt-indexserver-0
+      - zoekt-indexserver-1
+      - zoekt-webserver-0
+      - zoekt-webserver-1
+      - batches-executor-firecracker
+```
+
+With that in `sg.config.overwrite.yaml` you can now run `sg start minimal-batches`.
+
+## Contributing to `sg`
+
+Want to hack on `sg`? Great! Here's how:
+
+1. Read through the [`sg` Vision](./VISION.md) to get an idea of what `sg` should be in the long term.
+2. Look at the open [`sg` issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Asg)
 
 When you want to hack on `sg` it's best to be in the `dev/sg` directory and run it from there:
 
@@ -338,56 +281,3 @@ go run . -config ../../sg.config.yaml start
 ```
 
 The `-config` can be anything you want, of course.
-
-## Principles
-
-- `sg` should be fun to use.
-- If you think "it would be cool if `sg` could do X": add it! Let's go :)
-- `sg` should make Sourcegraph developers productive and happy.
-- `sg` is not and should not be a build system.
-- `sg` is not and should not be a container orchestrator.
-- Try to fix [a lot of the problems in this RFC](https://docs.google.com/document/d/18hrRIN0pUBRwUFF7vkcVmstJccqWeHiecNF2t1GAZfU/edit) by encoding conventions in executable code.
-- No bash. `sg` was built to get rid of all the bash scripts in `./dev/`. If you have a chance to build something into `sg` to avoid another bash script: do it. Try to keep shell scripts to easy-to-understand one liners if you must. Replicating something in Go code that could be done in 4 lines of bash is probably a good idea.
-- Duplicated data is fine as long as it's dumb data. Copying some lines in `sg.config.yaml` to get something working is often (but not always) better than trying to be clever.
-
-You can also watch [this video](https://drive.google.com/file/d/1DXjjf1YXr8Od8vG4R74Ko-soLOx_tXa6/view?usp=sharing) to get an overview of the original thinking that lead to `sg`.
-
-## Inspiration
-
-- [GitLab Developer Kit (GDK)](https://gitlab.com/gitlab-org/gitlab-development-kit)
-- Stripe's `pay` command, [described here](https://buttondown.email/nelhage/archive/papers-i-love-gg/)
-- [Stack Exchange Local Environment Setup](https://twitter.com/nick_craver/status/1375871107773956103?s=21) command
-
-## Ideas
-
-The following are ideas for what could/should be built into `sg`:
-
-#### Generators
-
-```bash
-# Generate code, equivalent to current `./dev/generate.sh`
-sg generate
-
-# Generate only specific things
-sg generate mocks ./internal/enterprise/batches
-```
-
-#### Edit configuration files
-
-```bash
-# Edit the site configuration
-sg edit site-config # opens site-config in $EDITOR
-# Edit external service configuration
-sg edit external-services # opens external-services.json in $EDITOR
-```
-
-#### Tail logs
-
-```bash
-# Tail the SQL logs
-sg tail-log sql
-# Tail the http logs
-sg tail-log http
-# Tail all logs
-sg tail-log all
-```

--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -28,6 +28,7 @@
 `sg` is the CLI tool that Sourcegraph developers can use to develop Sourcegraph.
 
 - [Quickstart](#quickstart)
+- [Installation](#quickstart)
 - [Usage](#usage)
   - [`sg [start,run,run-set]` - Start dev environment](#sg-startrunrun-set---start-dev-environment)
   - [`sg test` - Running test suites](#sg-test---running-test-suites)
@@ -47,30 +48,12 @@
 
 ## Quickstart
 
+**`sg` requires the [Sourcegraph development dependencies](https://docs.sourcegraph.com/dev/getting-started/quickstart_1_install_dependencies) to be installed.**
+
 Run the following to install `sg` from inside `sourcegraph/sourcegraph`:
 
 ```
 ./dev/sg/install.sh
-```
-
-Make sure that `$HOME/go/bin` is in your `$PATH`. (If you use `$GOPATH` then `$GOPATH/bin` needs to be in the `$PATH`)
-
-**Note for Linux users:** A command called [sg](https://www.man7.org/linux/man-pages/man1/sg.1.html) is already available at `/usr/bin/sg`. To use the Sourcegraph `sg` CLI, you need to make sure that its location comes first in `PATH`. For example, by prepending `$GOPATH/bin`:
-
-```
-export PATH=$GOPATH/bin:$PATH
-```
-
-Instead of the more conventional:
-
-```
-export PATH=$PATH:$GOPATH/bin
-```
-
-Or you may add an alias to your `.bashrc`:
-
-```
-alias sg=$HOME/go/bin/sg
 ```
 
 Then, in the root of `sourcegraph/sourcegraph`, run:
@@ -79,17 +62,57 @@ Then, in the root of `sourcegraph/sourcegraph`, run:
 sg start
 ```
 
-This will boot the `default` commands in `sg.config.yaml` in the root of the repository.
+This will start the default Sourcegraph development environment.
 
-**Alternative install method** (if you want to move the binary to a custom location):
+Once the `web` process has finished compilation, open [`https://sourcegraph.test:3443`](https://sourcegraph.test:3443/) in your browser.
 
-In the root of `sourcegraph/sourcegraph`, run the following:
+## Installation
+
+**`sg` requires the [Sourcegraph development dependencies](https://docs.sourcegraph.com/dev/getting-started/quickstart_1_install_dependencies) to be installed.**
+
+### Using install script (recommended)
+
+Run the following in the root of `sourcegraph/sourcegraph`:
+
+```
+./dev/sg/install.sh
+```
+
+That builds the `sg` binary and moves it to the standard installation location for Go binaries.
+
+If you don't have a `$GOPATH` set (or don't know what that is), that location is `$HOME/go/bin`. If you do use `$GOPATH` the location is `$GOPATH/bin`.
+
+Make sure that location is in your `$PATH`. (If you use `$GOPATH` then `$GOPATH/bin` needs to be in the `$PATH`)
+
+> **Note for Linux users:** A command called [sg](https://www.man7.org/linux/man-pages/man1/sg.1.html) is already available at `/usr/bin/sg`. To use the Sourcegraph `sg` CLI, you need to make sure that its location comes first in `PATH`. For example, by prepending `$GOPATH/bin`:
+>
+> ```
+> export PATH=$GOPATH/bin:$PATH
+> ```
+>
+> Instead of the more conventional:
+>
+> ```
+> export PATH=$PATH:$GOPATH/bin
+> ```
+>
+> Or you may add an alias to your `.bashrc`:
+>
+> ```
+> alias sg=$HOME/go/bin/sg
+> ```
+
+### Manually building the binary
+
+If you want full control over where the `sg` binary ends up, use this option.
+
+In the root of `sourcegraph/sourcegraph`, run:
 
 ```
 go build -o ~/my/path/sg ./dev/sg
 ```
 
-Make sure that `~/my/path` is in your `$PATH` then.
+Then make sure that `~/my/path` is in your `$PATH`.
 
 ## Usage
 

--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -48,23 +48,19 @@
 
 ## Quickstart
 
-**`sg` requires the [Sourcegraph development dependencies](https://docs.sourcegraph.com/dev/getting-started/quickstart_1_install_dependencies) to be installed.**
+1. Install the [Sourcegraph development dependencies](https://docs.sourcegraph.com/dev/getting-started/quickstart_1_install_dependencies).
+2. In your clone of [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph), run:
 
-Run the following to install `sg` from inside `sourcegraph/sourcegraph`:
+    ```
+    ./dev/sg/install.sh
+    ```
+3. Start the default Sourcegraph environment:
 
-```
-./dev/sg/install.sh
-```
+    ```
+    sg start
+    ```
 
-Then, in the root of `sourcegraph/sourcegraph`, run:
-
-```
-sg start
-```
-
-This will start the default Sourcegraph development environment.
-
-Once the `web` process has finished compilation, open [`https://sourcegraph.test:3443`](https://sourcegraph.test:3443/) in your browser.
+    Once the `web` process has finished compilation, open [`https://sourcegraph.test:3443`](https://sourcegraph.test:3443/) in your browser.
 
 ## Installation
 

--- a/dev/sg/VISION.md
+++ b/dev/sg/VISION.md
@@ -23,6 +23,7 @@ You can also watch [this video](https://drive.google.com/file/d/1DXjjf1YXr8Od8vG
 
 The following are ideas for what could/should be built into `sg`:
 
+- Create `sg setup` command that sets up local environment, including dependencies https://github.com/sourcegraph/sourcegraph/issues/24900
 - Replace every shell script in `./dev` with an `sg` command
   - Replace `./dev/generate.sh` with an `sg generate` command https://github.com/sourcegraph/sourcegraph/issues/25441
   - Replace `./dev/drop-entire-local-database-and-redis.sh` with an `sg` command
@@ -30,3 +31,5 @@ The following are ideas for what could/should be built into `sg`:
 - Get rid of the `dev-private` repository and handle shared site-configuration, credentials, and licenses in `sg`.
 - Build log handling into `sg` so it's easier to debug what's happening in a local environment. https://github.com/sourcegraph/sourcegraph/issues/25442
 - Add `sg generate-graphql-resolver-and-stub-methods` command that has a better name but creates all the boilerplate needed to create new GraphQL resolvers in Go
+
+See all [`sg` tickets](https://github.com/sourcegraph/sourcegraph/labels/sg).

--- a/dev/sg/VISION.md
+++ b/dev/sg/VISION.md
@@ -1,0 +1,32 @@
+# `sg` Vision
+
+## Principles
+
+- `sg` should be fun to use.
+- If you think "it would be cool if `sg` could do X": add it! Let's go :)
+- `sg` should make Sourcegraph developers productive and happy.
+- `sg` is not and should not be a build system.
+- `sg` is not and should not be a container orchestrator.
+- Try to fix [a lot of the problems in this RFC](https://docs.google.com/document/d/18hrRIN0pUBRwUFF7vkcVmstJccqWeHiecNF2t1GAZfU/edit) by encoding conventions in executable code.
+- No bash. `sg` was built to get rid of all the bash scripts in `./dev/`. If you have a chance to build something into `sg` to avoid another bash script: do it. Try to keep shell scripts to easy-to-understand one liners if you must. Replicating something in Go code that could be done in 4 lines of bash is probably a good idea.
+- Duplicated data is fine as long as it's dumb data. Copying some lines in `sg.config.yaml` to get something working is often (but not always) better than trying to be clever.
+
+You can also watch [this video](https://drive.google.com/file/d/1DXjjf1YXr8Od8vG4R74Ko-soLOx_tXa6/view?usp=sharing) to get an overview of the original thinking that lead to `sg`.
+
+## Inspiration
+
+- [GitLab Developer Kit (GDK)](https://gitlab.com/gitlab-org/gitlab-development-kit)
+- Stripe's `pay` command, [described here](https://buttondown.email/nelhage/archive/papers-i-love-gg/)
+- [Stack Exchange Local Environment Setup](https://twitter.com/nick_craver/status/1375871107773956103?s=21) command
+
+## Long term
+
+The following are ideas for what could/should be built into `sg`:
+
+- Replace every shell script in `./dev` with an `sg` command
+  - Replace `./dev/generate.sh` with an `sg generate` command https://github.com/sourcegraph/sourcegraph/issues/25441
+  - Replace `./dev/drop-entire-local-database-and-redis.sh` with an `sg` command
+  - ...
+- Get rid of the `dev-private` repository and handle shared site-configuration, credentials, and licenses in `sg`.
+- Build log handling into `sg` so it's easier to debug what's happening in a local environment. https://github.com/sourcegraph/sourcegraph/issues/25442
+- Add `sg generate-graphql-resolver-and-stub-methods` command that has a better name but creates all the boilerplate needed to create new GraphQL resolvers in Go


### PR DESCRIPTION
This does a lot of things, most importantly, though: it removes outdated information and makes the README.md easier to digest for newcomers.

I converted most of the TODOs/ideas in there into tickets: [`sg` tickets](https://github.com/sourcegraph/sourcegraph/labels/sg)