### PR TITLE
web: clear `localStorage` on Puppeteer driver creation

### DIFF
--- a/client/shared/src/testing/integration/context.ts
+++ b/client/shared/src/testing/integration/context.ts
@@ -101,6 +101,9 @@ export const createSharedIntegrationTestContext = async <
     directory,
 }: IntegrationTestOptions): Promise<IntegrationTestContext<TGraphQlOperations, TGraphQlOperationNames>> => {
     await driver.newPage()
+    // Create every new document with empty `localStorage`: https://github.com/puppeteer/puppeteer/issues/1607
+    await driver.page.evaluateOnNewDocument(() => localStorage.clear())
+
     const recordingsDirectory = path.join(directory, '__fixtures__', snakeCase(currentTest.fullTitle()))
     if (record) {
         await mkdir(recordingsDirectory, { recursive: true })
@@ -265,11 +268,6 @@ export const createSharedIntegrationTestContext = async <
                 recordCoverage(driver.browser),
                 DISPOSE_ACTION_TIMEOUT,
                 new Error('Recording coverage timed out')
-            )
-            await pTimeout(
-                driver.page.evaluate(() => localStorage.clear()),
-                DISPOSE_ACTION_TIMEOUT * 5, // localStorage reset needs more time.
-                () => console.warn('Failed to clear localStorage!')
             )
             await pTimeout(driver.page.close(), DISPOSE_ACTION_TIMEOUT, new Error('Closing Puppeteer page timed out'))
             await pTimeout(polly.stop(), DISPOSE_ACTION_TIMEOUT, new Error('Stopping Polly timed out'))


### PR DESCRIPTION
## Context

It should fix `localStorage.clear()` [errors](https://buildkite.com/sourcegraph/sourcegraph/builds/109758#0e64c87e-2053-4379-a395-9b43fd3550aa) in web integration tests. See related issue: https://github.com/puppeteer/puppeteer/issues/1607#issuecomment-428263737

## Changes

- Moved `localStorage.clear()` to the driver init step.