### PR TITLE
ci: disable prettier on markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "^1.22.4"
   },
   "scripts": {
-    "prettier": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --write --list-different --config prettier.config.js",
+    "prettier": "prettier '**/{*.{js?(on),ts?(x),graphql,scss},.*.js?(on)}' --write --list-different --config prettier.config.js",
     "prettier-check": "yarn -s run prettier --write=false",
     "all:eslint": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" dev/foreach-ts-project.sh yarn -s run eslint --quiet",
     "all:stylelint": "yarn --cwd client/web run stylelint && yarn --cwd client/shared run stylelint && yarn --cwd client/branded run stylelint && yarn --cwd client/browser run stylelint && yarn --cwd client/wildcard run stylelint",


### PR DESCRIPTION
Prettier running on markdown files is not very good in terms of cost/benefit and lead to failing builds: https://buildkite.com/sourcegraph/sourcegraph/builds/109763 

It trims longs lines, indent code in snippets. The former has no incidence on the output and the latter is something that should be done on your own anyway. Because it gets in the way of builds, I really don't feel that's worse it. 