### PR TITLE
git: Instrument calls to ResolveRevision

### DIFF
--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -5,10 +5,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -49,12 +49,10 @@ type ResolveRevisionOptions struct {
 	NoEnsureRevision bool // do not try to fetch from remote if revision doesn't exist locally
 }
 
-const labelEnsureRevision = "ensure_revision"
-
 var resolveRevisionCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "src_resolve_revision_total",
 	Help: "The number of times we call internal/vcs/git/ResolveRevision",
-}, []string{labelEnsureRevision})
+}, []string{"ensure_revision"})
 
 // ResolveRevision will return the absolute commit for a commit-ish spec. If spec is empty, HEAD is
 // used.


### PR DESCRIPTION
We see a huge number of `rev-parse` commands being sent to gitserver and
we have a hunch that this is the main culprit.
