### PR TITLE
Fix `owner/repo#number` reference in issue automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -29,7 +29,7 @@ jobs:
             $PSDefaultParameterValues['*GitHub*:Token'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
             $PSDefaultParameterValues['*GitHubBetaProject*:ProjectNodeId'] = 'MDExOlByb2plY3ROZXh0MzI3Ng==' # https://github.com/orgs/sourcegraph/projects/200
 
-            $fixIssuePattern = "(?:close|fixe?|resolve)(?:[sd])? (?:#|(?<owner>[^/]+)/(?<repo>[^/]+)|https://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/issues/)(?<number>\d+)"
+            $fixIssuePattern = "(?:close|fixe?|resolve)(?:[sd])? (?:#|(?<owner>[^/]+)/(?<repo>[^/]+)#|https://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/issues/)(?<number>\d+)"
 
             switch ($github.event_name) {
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/runs/3732326921?check_suite_focus=true

Reported by @valerybugakov