### PR TITLE
[cloud] Add org namespace to codehost connections in postgres

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -716,6 +716,7 @@ func (e *ExternalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 			&svcs[i].Unrestricted,
 			&svcs[i].CloudDefault,
 			&keyID,
+			&dbutil.NullInt32{N: &svcs[i].NamespaceOrgID},
 		)
 		if err != nil {
 			return err

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -695,14 +695,18 @@ Foreign-key constraints:
  unrestricted      | boolean                  |           | not null | false
  cloud_default     | boolean                  |           | not null | false
  encryption_key_id | text                     |           | not null | ''::text
+ namespace_org_id  | integer                  |           |          | 
 Indexes:
     "external_services_pkey" PRIMARY KEY, btree (id)
     "kind_cloud_default" UNIQUE, btree (kind, cloud_default) WHERE cloud_default = true AND deleted_at IS NULL
+    "external_services_namespace_org_id_idx" btree (namespace_org_id)
     "external_services_namespace_user_id_idx" btree (namespace_user_id)
 Check constraints:
     "check_non_empty_config" CHECK (btrim(config) <> ''::text)
+    "external_services_max_1_namespace" CHECK (namespace_user_id IS NULL AND namespace_org_id IS NULL OR (namespace_user_id IS NULL) <> (namespace_org_id IS NULL))
 Foreign-key constraints:
     "external_services_namepspace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
+    "external_services_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
 Referenced by:
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_external_service_id_fkey" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE DEFERRABLE
     TABLE "external_service_sync_jobs" CONSTRAINT "external_services_id_fk" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE
@@ -1405,6 +1409,7 @@ Referenced by:
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     TABLE "cm_monitors" CONSTRAINT "cm_monitors_org_id_fk" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
     TABLE "cm_recipients" CONSTRAINT "cm_recipients_org_id_fk" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
+    TABLE "external_services" CONSTRAINT "external_services_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     TABLE "feature_flag_overrides" CONSTRAINT "feature_flag_overrides_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
     TABLE "names" CONSTRAINT "names_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id) ON UPDATE CASCADE ON DELETE CASCADE
     TABLE "org_invitations" CONSTRAINT "org_invitations_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -472,6 +472,7 @@ type ExternalService struct {
 	LastSyncAt      time.Time
 	NextSyncAt      time.Time
 	NamespaceUserID int32
+	NamespaceOrgID  int32
 	Unrestricted    bool // Whether access to repositories belong to this external service is unrestricted.
 	CloudDefault    bool // Whether this external service is our default public service on Cloud
 }

--- a/migrations/frontend/1528395895_codehost_connection_owned_by_org.down.sql
+++ b/migrations/frontend/1528395895_codehost_connection_owned_by_org.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS external_services DROP COLUMN IF EXISTS namespace_org_id;

--- a/migrations/frontend/1528395895_codehost_connection_owned_by_org.up.sql
+++ b/migrations/frontend/1528395895_codehost_connection_owned_by_org.up.sql
@@ -1,0 +1,8 @@
+-- Adds support for organization owning a codehost connection
+BEGIN;
+
+ALTER TABLE IF EXISTS external_services ADD COLUMN IF NOT EXISTS namespace_org_id integer REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE;
+ALTER TABLE IF EXISTS external_services ADD CONSTRAINT external_services_max_1_namespace CHECK ((namespace_user_id IS NULL AND namespace_org_id IS NULL) OR ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL)));
+CREATE INDEX external_services_namespace_org_id_idx ON external_services USING btree (namespace_org_id);
+
+END;


### PR DESCRIPTION
# Description
Add a DB migration so that we can attach ownership of codehost connections to organizations.

# Related
https://sourcegraph.atlassian.net/browse/CLOUD-23
https://sourcegraph.atlassian.net/browse/CLOUD-69

# Testing
Tested locally by following the [migration guide](../blob/main/migrations/README.md#migrating-up-and-down)