### PR TITLE
add commit and diff search to sentinel queries

### DIFF
--- a/internal/cmd/search-blitz/config.yaml
+++ b/internal/cmd/search-blitz/config.yaml
@@ -93,3 +93,19 @@ groups:
           - name: symbol_small # ~72 results
             query: >
                 type:symbol IndexFormatVersion
+
+          # Diff search
+          - name: diff_small # ~42 results
+            query: >
+                type:diff 
+                repo:^github\.com/sourcegraph/sourcegraph$ 
+                author:camden 
+                before:"february 1 2021"
+
+          # Commit search
+          - name: commit_small # ~42 results
+            query: >
+                type:commit
+                repo:^github\.com/sourcegraph/sourcegraph$ 
+                author:camden 
+                before:"february 1 2021"


### PR DESCRIPTION
Our sentinel queries don't currently track diff and commit search timing and latency, so these two additions should help improve how representative our sentinel queries are. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
