### PR TITLE
rename Highlighted* to Matched*

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -980,7 +980,7 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 		}
 
 		var conversionErr error
-		err = search.Search(ctx, dir.Path(), args.Revisions, mt, func(match *search.LazyCommit, highlights *search.CommitHighlights) bool {
+		err = search.Search(ctx, dir.Path(), args.Revisions, mt, func(match *search.LazyCommit, highlights *search.MatchedCommit) bool {
 			res, err := search.CreateCommitMatch(match, highlights, args.IncludeDiff)
 			if err != nil {
 				conversionErr = err
@@ -1049,11 +1049,11 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 // 2) the number of messsage matches if there are any
 // 3) one, to represent matching the commit, but nothing inside it
 func matchCount(cm *protocol.CommitMatch) int {
-	if len(cm.Diff.Highlights) > 0 {
-		return len(cm.Diff.Highlights)
+	if len(cm.Diff.MatchedRanges) > 0 {
+		return len(cm.Diff.MatchedRanges)
 	}
-	if len(cm.Message.Highlights) > 0 {
-		return len(cm.Message.Highlights)
+	if len(cm.Message.MatchedRanges) > 0 {
+		return len(cm.Message.MatchedRanges)
 	}
 	return 1
 }

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -62,8 +62,8 @@ type CommitMatch struct {
 	Refs       []string       `json:",omitempty"`
 	SourceRefs []string       `json:",omitempty"`
 
-	Message HighlightedString `json:",omitempty"`
-	Diff    HighlightedString `json:",omitempty"`
+	Message MatchedString `json:",omitempty"`
+	Diff    MatchedString `json:",omitempty"`
 }
 
 type Signature struct {

--- a/internal/gitserver/protocol/highlight.go
+++ b/internal/gitserver/protocol/highlight.go
@@ -5,17 +5,17 @@ import (
 	"sort"
 )
 
-type HighlightedString struct {
-	Content    string `json:"content"`
-	Highlights Ranges `json:"highlights"`
+type MatchedString struct {
+	Content       string `json:"content"`
+	MatchedRanges Ranges `json:"matched_ranges"`
 }
 
-func (h *HighlightedString) Merge(other HighlightedString) {
+func (h *MatchedString) Merge(other MatchedString) {
 	if h.Content == "" {
 		h.Content = other.Content
 	}
-	h.Highlights = append(h.Highlights, other.Highlights...)
-	sort.Sort(h.Highlights)
+	h.MatchedRanges = append(h.MatchedRanges, other.MatchedRanges...)
+	sort.Sort(h.MatchedRanges)
 }
 
 type Location struct {

--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -24,9 +24,9 @@ index dbace57d5f..53357b4971 100644
 		parsedDiff, err := diff.NewMultiFileDiffReader(strings.NewReader(rawDiff)).ReadAllFiles()
 		require.NoError(t, err)
 
-		highlights := map[int]FileDiffHighlight{
-			0: {HunkHighlights: map[int]HunkHighlight{
-				0: {LineHighlights: map[int]protocol.Ranges{
+		highlights := map[int]MatchedFileDiff{
+			0: {MatchedHunks: map[int]MatchedHunk{
+				0: {MatchedLines: map[int]protocol.Ranges{
 					2: {{
 						Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
 						End:   protocol.Location{Offset: 6, Line: 0, Column: 6},

--- a/internal/gitserver/search/diff_test.go
+++ b/internal/gitserver/search/diff_test.go
@@ -32,12 +32,12 @@ func TestDiffSearch(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, matched)
 
-	expectedHighlights := &CommitHighlights{
-		Diff: map[int]FileDiffHighlight{
+	expectedHighlights := &MatchedCommit{
+		Diff: map[int]MatchedFileDiff{
 			1: {
-				HunkHighlights: map[int]HunkHighlight{
+				MatchedHunks: map[int]MatchedHunk{
 					0: {
-						LineHighlights: map[int]protocol.Ranges{
+						MatchedLines: map[int]protocol.Ranges{
 							3: {{
 								Start: protocol.Location{Offset: 9, Column: 9},
 								End:   protocol.Location{Offset: 14, Column: 14},

--- a/internal/gitserver/search/highlight.go
+++ b/internal/gitserver/search/highlight.go
@@ -6,18 +6,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
 
-// CommitHighlights are the portions of a commit that match a query
-type CommitHighlights struct {
+// MatchedCommit are the portions of a commit that match a query
+type MatchedCommit struct {
 	// Message is the set of ranges of the commit message that were matched
 	Message protocol.Ranges
 
 	// Diff is the set of files deltas that have matches in the parsed diff.
 	// The key of the map is the index of the delta in the diff.
-	Diff map[int]FileDiffHighlight
+	Diff map[int]MatchedFileDiff
 }
 
 // Merge merges another CommitHighlights into this one, returning the result.
-func (c *CommitHighlights) Merge(other *CommitHighlights) *CommitHighlights {
+func (c *MatchedCommit) Merge(other *MatchedCommit) *MatchedCommit {
 	if c == nil {
 		return other
 	}
@@ -39,39 +39,39 @@ func (c *CommitHighlights) Merge(other *CommitHighlights) *CommitHighlights {
 	return c
 }
 
-type FileDiffHighlight struct {
-	OldFile        protocol.Ranges
-	NewFile        protocol.Ranges
-	HunkHighlights map[int]HunkHighlight
+type MatchedFileDiff struct {
+	OldFile      protocol.Ranges
+	NewFile      protocol.Ranges
+	MatchedHunks map[int]MatchedHunk
 }
 
-func (f FileDiffHighlight) Merge(other FileDiffHighlight) FileDiffHighlight {
+func (f MatchedFileDiff) Merge(other MatchedFileDiff) MatchedFileDiff {
 	f.OldFile = append(f.OldFile, other.OldFile...)
 	sort.Sort(f.OldFile)
 
 	f.NewFile = append(f.NewFile, other.NewFile...)
 	sort.Sort(f.NewFile)
 
-	if f.HunkHighlights == nil {
-		f.HunkHighlights = other.HunkHighlights
+	if f.MatchedHunks == nil {
+		f.MatchedHunks = other.MatchedHunks
 	} else {
-		for i, hh := range other.HunkHighlights {
-			f.HunkHighlights[i] = f.HunkHighlights[i].Merge(hh)
+		for i, hh := range other.MatchedHunks {
+			f.MatchedHunks[i] = f.MatchedHunks[i].Merge(hh)
 		}
 	}
 	return f
 }
 
-type HunkHighlight struct {
-	LineHighlights map[int]protocol.Ranges
+type MatchedHunk struct {
+	MatchedLines map[int]protocol.Ranges
 }
 
-func (h HunkHighlight) Merge(other HunkHighlight) HunkHighlight {
-	if h.LineHighlights == nil {
-		h.LineHighlights = other.LineHighlights
+func (h MatchedHunk) Merge(other MatchedHunk) MatchedHunk {
+	if h.MatchedLines == nil {
+		h.MatchedLines = other.MatchedLines
 	} else {
-		for i, lh := range other.LineHighlights {
-			h.LineHighlights[i] = h.LineHighlights[i].Merge(lh)
+		for i, lh := range other.MatchedLines {
+			h.MatchedLines[i] = h.MatchedLines[i].Merge(lh)
 		}
 	}
 	return h

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -53,7 +53,7 @@ func ToMatchTree(q protocol.SearchQuery) (MatchTree, error) {
 type MatchTree interface {
 	// Match returns whether the given predicate matches a commit and, if it does,
 	// the portions of the commit that match in the form of *CommitHighlights
-	Match(*LazyCommit) (matched bool, highlights *CommitHighlights, err error)
+	Match(*LazyCommit) (matched bool, highlights *MatchedCommit, err error)
 }
 
 // AuthorMatches is a predicate that matches if the author's name or email address
@@ -62,7 +62,7 @@ type AuthorMatches struct {
 	*casetransform.Regexp
 }
 
-func (a *AuthorMatches) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
+func (a *AuthorMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	return a.Regexp.Match(lc.AuthorName, &lc.LowerBuf) || a.Regexp.Match(lc.AuthorEmail, &lc.LowerBuf), nil, nil
 }
 
@@ -72,7 +72,7 @@ type CommitterMatches struct {
 	*casetransform.Regexp
 }
 
-func (c *CommitterMatches) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
+func (c *CommitterMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	return c.Regexp.Match(lc.CommitterName, &lc.LowerBuf) || c.Regexp.Match(lc.CommitterEmail, &lc.LowerBuf), nil, nil
 }
 
@@ -81,7 +81,7 @@ type CommitBefore struct {
 	protocol.CommitBefore
 }
 
-func (c *CommitBefore) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
+func (c *CommitBefore) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	authorDate, err := lc.AuthorDate()
 	if err != nil {
 		return false, nil, err
@@ -94,7 +94,7 @@ type CommitAfter struct {
 	protocol.CommitAfter
 }
 
-func (c *CommitAfter) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
+func (c *CommitAfter) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	authorDate, err := lc.AuthorDate()
 	if err != nil {
 		return false, nil, err
@@ -108,13 +108,13 @@ type MessageMatches struct {
 	*casetransform.Regexp
 }
 
-func (m *MessageMatches) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
+func (m *MessageMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	results := m.FindAllIndex(lc.Message, -1, &lc.LowerBuf)
 	if results == nil {
 		return false, nil, nil
 	}
 
-	return true, &CommitHighlights{
+	return true, &MatchedCommit{
 		Message: matchesToRanges(lc.Message, results),
 	}, nil
 }
@@ -125,7 +125,7 @@ type DiffMatches struct {
 	*casetransform.Regexp
 }
 
-func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
+func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	diff, err := lc.Diff()
 	if err != nil {
 		return false, nil, err
@@ -133,9 +133,9 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
 
 	foundMatch := false
 
-	var fileDiffHighlights map[int]FileDiffHighlight
+	var fileDiffHighlights map[int]MatchedFileDiff
 	for fileIdx, fileDiff := range diff {
-		var hunkHighlights map[int]HunkHighlight
+		var hunkHighlights map[int]MatchedHunk
 		for hunkIdx, hunk := range fileDiff.Hunks {
 			var lineHighlights map[int]protocol.Ranges
 			for lineIdx, line := range bytes.Split(hunk.Body, []byte("\n")) {
@@ -162,20 +162,20 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
 
 			if len(lineHighlights) > 0 {
 				if hunkHighlights == nil {
-					hunkHighlights = make(map[int]HunkHighlight, 1)
+					hunkHighlights = make(map[int]MatchedHunk, 1)
 				}
-				hunkHighlights[hunkIdx] = HunkHighlight{lineHighlights}
+				hunkHighlights[hunkIdx] = MatchedHunk{lineHighlights}
 			}
 		}
 		if len(hunkHighlights) > 0 {
 			if fileDiffHighlights == nil {
-				fileDiffHighlights = make(map[int]FileDiffHighlight)
+				fileDiffHighlights = make(map[int]MatchedFileDiff)
 			}
-			fileDiffHighlights[fileIdx] = FileDiffHighlight{HunkHighlights: hunkHighlights}
+			fileDiffHighlights[fileIdx] = MatchedFileDiff{MatchedHunks: hunkHighlights}
 		}
 	}
 
-	return foundMatch, &CommitHighlights{
+	return foundMatch, &MatchedCommit{
 		Diff: fileDiffHighlights,
 	}, nil
 }
@@ -186,30 +186,30 @@ type DiffModifiesFile struct {
 	*casetransform.Regexp
 }
 
-func (dmf *DiffModifiesFile) Match(lc *LazyCommit) (bool, *CommitHighlights, error) {
+func (dmf *DiffModifiesFile) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	diff, err := lc.Diff()
 	if err != nil {
 		return false, nil, err
 	}
 
 	foundMatch := false
-	var fileDiffHighlights map[int]FileDiffHighlight
+	var fileDiffHighlights map[int]MatchedFileDiff
 	for fileIdx, fileDiff := range diff {
 		oldFileMatches := dmf.FindAllIndex([]byte(fileDiff.OrigName), -1, &lc.LowerBuf)
 		newFileMatches := dmf.FindAllIndex([]byte(fileDiff.NewName), -1, &lc.LowerBuf)
 		if oldFileMatches != nil || newFileMatches != nil {
 			if fileDiffHighlights == nil {
-				fileDiffHighlights = make(map[int]FileDiffHighlight)
+				fileDiffHighlights = make(map[int]MatchedFileDiff)
 			}
 			foundMatch = true
-			fileDiffHighlights[fileIdx] = FileDiffHighlight{
+			fileDiffHighlights[fileIdx] = MatchedFileDiff{
 				OldFile: matchesToRanges([]byte(fileDiff.OrigName), oldFileMatches),
 				NewFile: matchesToRanges([]byte(fileDiff.NewName), newFileMatches),
 			}
 		}
 	}
 
-	return foundMatch, &CommitHighlights{
+	return foundMatch, &MatchedCommit{
 		Diff: fileDiffHighlights,
 	}, nil
 }
@@ -219,8 +219,8 @@ type Operator struct {
 	Operands []MatchTree
 }
 
-func (o *Operator) Match(commit *LazyCommit) (bool, *CommitHighlights, error) {
-	var resultMatches *CommitHighlights
+func (o *Operator) Match(commit *LazyCommit) (bool, *MatchedCommit, error) {
+	var resultMatches *MatchedCommit
 	hasMatch := false
 	for _, operand := range o.Operands {
 		matched, matches, err := operand.Match(commit)

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -65,8 +65,8 @@ func TestSearch(t *testing.T) {
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		var commits []*LazyCommit
-		var highlights []*CommitHighlights
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *CommitHighlights) bool {
+		var highlights []*MatchedCommit
+		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -81,8 +81,8 @@ func TestSearch(t *testing.T) {
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		var commits []*LazyCommit
-		var highlights []*CommitHighlights
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *CommitHighlights) bool {
+		var highlights []*MatchedCommit
+		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -99,8 +99,8 @@ func TestSearch(t *testing.T) {
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		var commits []*LazyCommit
-		var highlights []*CommitHighlights
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *CommitHighlights) bool {
+		var highlights []*MatchedCommit
+		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -116,8 +116,8 @@ func TestSearch(t *testing.T) {
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		var commits []*LazyCommit
-		var highlights []*CommitHighlights
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *CommitHighlights) bool {
+		var highlights []*MatchedCommit
+		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -133,8 +133,8 @@ func TestSearch(t *testing.T) {
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		var commits []*LazyCommit
-		var highlights []*CommitHighlights
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *CommitHighlights) bool {
+		var highlights []*MatchedCommit
+		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -156,8 +156,8 @@ func TestSearch(t *testing.T) {
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		var commits []*LazyCommit
-		var highlights []*CommitHighlights
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *CommitHighlights) bool {
+		var highlights []*MatchedCommit
+		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -166,12 +166,12 @@ func TestSearch(t *testing.T) {
 		require.Len(t, commits, 1)
 		require.Len(t, highlights, 1)
 		require.Equal(t, commits[0].AuthorName, []byte("camden1"))
-		expectedHighlights := &CommitHighlights{
-			Diff: map[int]FileDiffHighlight{
+		expectedHighlights := &MatchedCommit{
+			Diff: map[int]MatchedFileDiff{
 				0: {
-					HunkHighlights: map[int]HunkHighlight{
+					MatchedHunks: map[int]MatchedHunk{
 						0: {
-							LineHighlights: map[int]protocol.Ranges{
+							MatchedLines: map[int]protocol.Ranges{
 								0: {{
 									Start: protocol.Location{},
 									End:   protocol.Location{Offset: 5, Column: 5},

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -171,14 +171,14 @@ func protocolMatchToCommitMatch(repo types.RepoName, diff bool, in protocol.Comm
 
 	if diff {
 		matchBody = "```diff\n" + in.Diff.Content + "\n```"
-		matchHighlights = searchRangesToHighlights(matchBody, in.Diff.Highlights.Add(gitprotocol.Location{Line: 1, Offset: len("```diff\n")}))
+		matchHighlights = searchRangesToHighlights(matchBody, in.Diff.MatchedRanges.Add(gitprotocol.Location{Line: 1, Offset: len("```diff\n")}))
 		diffPreview = &result.HighlightedString{
 			Value:      in.Diff.Content,
-			Highlights: searchRangesToHighlights(in.Diff.Content, in.Diff.Highlights),
+			Highlights: searchRangesToHighlights(in.Diff.Content, in.Diff.MatchedRanges),
 		}
 	} else {
 		matchBody = "```COMMIT_EDITMSG\n" + in.Message.Content + "\n```"
-		matchHighlights = searchRangesToHighlights(matchBody, in.Message.Highlights.Add(gitprotocol.Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")}))
+		matchHighlights = searchRangesToHighlights(matchBody, in.Message.MatchedRanges.Add(gitprotocol.Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")}))
 	}
 
 	return &result.CommitMatch{
@@ -200,7 +200,7 @@ func protocolMatchToCommitMatch(repo types.RepoName, diff bool, in protocol.Comm
 		Repo: repo,
 		MessagePreview: &result.HighlightedString{
 			Value:      in.Message.Content,
-			Highlights: searchRangesToHighlights(in.Message.Content, in.Message.Highlights),
+			Highlights: searchRangesToHighlights(in.Message.Content, in.Message.MatchedRanges),
 		},
 		DiffPreview: diffPreview,
 		Body: result.HighlightedString{


### PR DESCRIPTION
In response to @rvantonder 's comment [here](https://github.com/sourcegraph/sourcegraph/pull/25006#discussion_r715196117), this changes the naming from "highlighted", which implies text decoration, to "matched", which does not.

Consolidation of these types with the types in `internal/search/result` coming soon
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
