### PR TITLE
convert explicit And/Or/Not into unified Operator type

### DIFF
--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -86,39 +86,37 @@ func (d DiffModifiesFile) String() string {
 	return fmt.Sprintf("%T(%s)", d, d.Expr)
 }
 
-// And is a predicate that matches if all of its children predicates match
-type And struct {
-	Children []SearchQuery
+type OperatorKind int
+
+const (
+	And OperatorKind = iota
+	Or
+	Not
+)
+
+type Operator struct {
+	Kind     OperatorKind
+	Operands []SearchQuery
 }
 
-func (a And) String() string {
-	cs := make([]string, 0, len(a.Children))
-	for _, child := range a.Children {
-		cs = append(cs, child.String())
+func (o Operator) String() string {
+	if o.Kind == Not {
+		return "NOT " + o.Operands[0].String()
 	}
-	return "(" + strings.Join(cs, " AND ") + ")"
-}
 
-// Or is a predicate that matches if any of its children predicates match
-type Or struct {
-	Children []SearchQuery
-}
-
-func (o Or) String() string {
-	cs := make([]string, 0, len(o.Children))
-	for _, child := range o.Children {
-		cs = append(cs, child.String())
+	var sep string
+	switch o.Kind {
+	case And:
+		sep = " AND "
+	case Or:
+		sep = " OR "
 	}
-	return "(" + strings.Join(cs, " OR ") + ")"
-}
 
-// Not is a predicate that matches if its child predicate does not match
-type Not struct {
-	Child SearchQuery
-}
-
-func (n Not) String() string {
-	return "NOT " + n.Child.String()
+	cs := make([]string, 0, len(o.Operands))
+	for _, operand := range o.Operands {
+		cs = append(cs, operand.String())
+	}
+	return "(" + strings.Join(cs, sep) + ")"
 }
 
 // Regexp is a thin wrapper around the stdlib Regexp type that enables gob encoding
@@ -146,8 +144,6 @@ func RegisterGob() {
 		gob.Register(&MessageMatches{})
 		gob.Register(&DiffMatches{})
 		gob.Register(&DiffModifiesFile{})
-		gob.Register(&And{})
-		gob.Register(&Or{})
-		gob.Register(&Not{})
+		gob.Register(&Operator{})
 	})
 }

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -100,23 +100,22 @@ type Operator struct {
 }
 
 func (o Operator) String() string {
-	if o.Kind == Not {
-		return "NOT " + o.Operands[0].String()
-	}
-
-	var sep string
+	var sep, prefix string
 	switch o.Kind {
 	case And:
 		sep = " AND "
 	case Or:
 		sep = " OR "
+	case Not:
+		sep = " AND NOT "
+		prefix = "NOT "
 	}
 
 	cs := make([]string, 0, len(o.Operands))
 	for _, operand := range o.Operands {
 		cs = append(cs, operand.String())
 	}
-	return "(" + strings.Join(cs, sep) + ")"
+	return "(" + prefix + strings.Join(cs, sep) + ")"
 }
 
 // Regexp is a thin wrapper around the stdlib Regexp type that enables gob encoding

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -146,10 +146,13 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("and match", func(t *testing.T) {
-		query := &protocol.And{[]protocol.SearchQuery{
-			&protocol.DiffMatches{Expr: "lorem"},
-			&protocol.DiffMatches{Expr: "ipsum"},
-		}}
+		query := &protocol.Operator{
+			Kind: protocol.And,
+			Operands: []protocol.SearchQuery{
+				&protocol.DiffMatches{Expr: "lorem"},
+				&protocol.DiffMatches{Expr: "ipsum"},
+			},
+		}
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		var commits []*LazyCommit
@@ -295,14 +298,20 @@ index 0000000000..7e54670557
 		diff: parsedDiff,
 	}
 
-	mt, err := ToMatchTree(&protocol.And{[]protocol.SearchQuery{
-		&protocol.AuthorMatches{Expr: "Camden"},
-		&protocol.DiffModifiesFile{Expr: "test"},
-		&protocol.And{[]protocol.SearchQuery{
-			&protocol.DiffMatches{Expr: "result"},
-			&protocol.DiffMatches{Expr: "test"},
-		}},
-	}})
+	mt, err := ToMatchTree(&protocol.Operator{
+		Kind: protocol.And,
+		Operands: []protocol.SearchQuery{
+			&protocol.AuthorMatches{Expr: "Camden"},
+			&protocol.DiffModifiesFile{Expr: "test"},
+			&protocol.Operator{
+				Kind: protocol.And,
+				Operands: []protocol.SearchQuery{
+					&protocol.DiffMatches{Expr: "result"},
+					&protocol.DiffMatches{Expr: "test"},
+				},
+			},
+		},
+	})
 	require.NoError(t, err)
 
 	matches, highlights, err := mt.Match(lc)

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -37,7 +37,7 @@ func searchInReposNew(ctx context.Context, db dbutil.DB, textParams *search.Text
 		args := &protocol.SearchRequest{
 			Repo:        rr.Repo.Name,
 			Revisions:   searchRevsToGitserverRevs(rr.Revs),
-			Query:       &gitprotocol.And{Children: queryNodesToPredicates(query, query.IsCaseSensitive(), diff)},
+			Query:       &gitprotocol.Operator{Kind: protocol.And, Operands: queryNodesToPredicates(query, query.IsCaseSensitive(), diff)},
 			IncludeDiff: diff,
 			Limit:       limit,
 		}
@@ -100,9 +100,9 @@ func queryNodesToPredicates(nodes []query.Node, caseSensitive, diff bool) []gitp
 func queryOperatorToPredicate(op query.Operator, caseSensitive, diff bool) gitprotocol.SearchQuery {
 	switch op.Kind {
 	case query.And:
-		return &gitprotocol.And{Children: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
+		return &gitprotocol.Operator{Kind: protocol.And, Operands: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
 	case query.Or:
-		return &gitprotocol.Or{Children: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
+		return &gitprotocol.Operator{Kind: protocol.And, Operands: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
 	default:
 		// I don't think we should have concats at this point, but ignore it if we do
 		return nil
@@ -123,7 +123,7 @@ func queryPatternToPredicate(pattern query.Pattern, caseSensitive, diff bool) gi
 	}
 
 	if pattern.Negated {
-		return &gitprotocol.Not{Child: newPred}
+		return &gitprotocol.Operator{Kind: protocol.Not, Operands: []gitprotocol.SearchQuery{newPred}}
 	}
 	return newPred
 }
@@ -155,7 +155,7 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	}
 
 	if parameter.Negated {
-		return &gitprotocol.Not{Child: newPred}
+		return &gitprotocol.Operator{Kind: protocol.Not, Operands: []gitprotocol.SearchQuery{newPred}}
 	}
 	return newPred
 }


### PR DESCRIPTION
This is a first step towards resolving the @rvantonder's feedback [here](https://github.com/sourcegraph/sourcegraph/pull/25006#discussion_r715201052). 

Essentially, it unifies the `And`, `Or`, and `Not` types into a single operator type. This makes it easier to do things like query optimization, modification, etc. at the cost of being very slightly more verbose.

I'm honestly not sure what the next step will be, since I don't think we can unify the `Atom` variants under a single type like we do with our query tree since each variant has different required parameters. @rvantonder I'd be interested in pairing on this if you see an opportunity to go further with this. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
