### PR TITLE
dev/sg: fix redis-postgres persistence

### DIFF
--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -22,7 +22,9 @@ services:
       - POSTGRES_DB=${PGDATABASE:-sourcegraph}
       - "POSTGRES_INITDB_ARGS= --encoding=UTF8 "
     volumes:
-      - ${PGDATA_DIR:-postgres_data}:/var/lib/postgresql/data
+      # Match PGDATA in Dockerfile
+      # https://sourcegraph.com/search?q=context:%40sourcegraph/all+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Edocker-images/postgres.*/Dockerfile+PGDATA
+      - ${PGDATA_DIR:-postgres_data}:/data/pgdata-12
 volumes:
   redis_data:
   postgres_data:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -515,6 +515,7 @@ commands:
       # Set the following to a path on disk to persist data (or unset to not persist data)
       PGDATA_DIR: $HOME/.sourcegraph-dev/data/postgresql
       REDIS_DATA_DIR: ""
+
   jaeger:
     cmd: |
       .bin/jaeger-all-in-one-${JAEGER_VERSION}-$(go env GOOS)-$(go env GOARCH) --log-level ${JAEGER_LOG_LEVEL} >> "${JAEGER_LOGS}"/jaeger.log 2>&1

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -509,8 +509,12 @@ commands:
     #       PGUSER: sourcegraph
     #
     # You could also add an overwrite to add `redis-postgres` to the relevant command set(s).
-    cmd: docker-compose -f dev/redis-postgres.yml up --force-recreate
-
+    cmd: docker-compose -f dev/redis-postgres.yml up $COMPOSE_ARGS
+    env:
+      COMPOSE_ARGS: --force-recreate
+      # Set the following to a path on disk to persist data (or unset to not persist data)
+      PGDATA_DIR: $HOME/.sourcegraph-dev/data/postgresql
+      REDIS_DATA_DIR: ""
   jaeger:
     cmd: |
       .bin/jaeger-all-in-one-${JAEGER_VERSION}-$(go env GOOS)-$(go env GOARCH) --log-level ${JAEGER_LOG_LEVEL} >> "${JAEGER_LOGS}"/jaeger.log 2>&1


### PR DESCRIPTION
Looks like the new `postgres-12.6` image has a custom `PGDATA` set (https://github.com/sourcegraph/sourcegraph/pull/22414) - which means that no volume has been attached to Postgres, so anyone using `redis-postgres` would not have had any database persistence. This updates the volume mount to point to the correct directory.

This change also persists pg data to disk by default because that's what all the other dev services seem to be doing too (`$HOME/.sourcegraph-dev/data/...`)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
