### PR TITLE
ci: increase backend integration test setup to 120s

### DIFF
--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -49,14 +49,14 @@ socat tcp-listen:7080,reuseaddr,fork system:"docker exec -i $CONTAINER socat std
 
 echo "--- Waiting for $URL to be up"
 set +e
-timeout 60s bash -c "until curl --output /dev/null --silent --head --fail $URL; do
+timeout 120s bash -c "until curl --output /dev/null --silent --head --fail $URL; do
     echo Waiting 5s for $URL...
     sleep 5
 done"
 # shellcheck disable=SC2181
 if [ $? -ne 0 ]; then
   echo "^^^ +++"
-  echo "$URL was not accessible within 60s. Here's the output of docker inspect and docker logs:"
+  echo "$URL was not accessible within 120s. Here's the output of docker inspect and docker logs:"
   docker inspect "$CONTAINER"
   exit 1
 fi


### PR DESCRIPTION
This seems to flake occasionally. Recent example: [the server is up](https://buildkite.com/sourcegraph/sourcegraph/builds/109851#62546b06-6262-4857-8b19-a08f5536614a/75-119) but just not ready for whatever reason (see logs). This bumps the timeout in hopes of smoothing out the startup.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
