### PR TITLE
dev/ci: roll all QA pipelines into one

### DIFF
--- a/.buildkite/pipeline.codeintel.yml
+++ b/.buildkite/pipeline.codeintel.yml
@@ -1,9 +1,0 @@
-env:
-  VAGRANT_RUN_ENV: "CI"
-steps:
-- label: ':docker::brain: Code Intel'
-  command:
-    - .buildkite/vagrant-run.sh sourcegraph-code-intel-test
-  artifact_paths: ./*.log
-  agents:
-    queue: 'baremetal'

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -1,9 +1,0 @@
-env:
-  VAGRANT_RUN_ENV: 'CI'
-steps:
-  - label: ':chromium: Sourcegraph E2E'
-    artifact_paths: ./*.png;./*.mp4;./ffmpeg.log
-    command:
-      - .buildkite/vagrant-run.sh sourcegraph-e2e
-    agents:
-      queue: 'baremetal'

--- a/.buildkite/pipeline.qa.yml
+++ b/.buildkite/pipeline.qa.yml
@@ -1,6 +1,13 @@
 env:
   VAGRANT_RUN_ENV: "CI"
 steps:
+- label: ':chromium: Sourcegraph E2E'
+  artifact_paths: ./*.png;./*.mp4;./ffmpeg.log
+  command:
+    - .buildkite/vagrant-run.sh sourcegraph-e2e
+  agents:
+    queue: 'baremetal'
+
 - label: ':docker::chromium: Sourcegraph QA'
   command:
     - .buildkite/vagrant-run.sh sourcegraph-qa-test
@@ -22,3 +29,11 @@ steps:
   concurrency: 1
   concurrency_group: "cluster-test"
   timeout_in_minutes: 30
+
+# code-intel-qa is disabled, see https://github.com/sourcegraph/sourcegraph/issues/25387
+# - label: ':docker::brain: Code Intel QA'
+#   command:
+#     - .buildkite/vagrant-run.sh sourcegraph-code-intel-test
+#   artifact_paths: ./*.log
+#   agents:
+#     queue: 'baremetal'

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -418,22 +418,11 @@ func triggerE2EandQA(opts e2eAndQAOptions) operations.Operation {
 	customOptions.Env["DOCKER_CLUSTER_IMAGES_TXT"] = clusterDockerImages(images.SourcegraphDockerImages)
 
 	return func(pipeline *bk.Pipeline) {
-		pipeline.AddTrigger(":chromium: Trigger E2E",
-			bk.Trigger("sourcegraph-e2e"),
-			bk.Async(opts.async),
-			bk.Build(customOptions),
-		)
-		pipeline.AddTrigger(":chromium: Trigger QA",
+		pipeline.AddTrigger(":chromium: Trigger QA pipeline",
 			bk.Trigger("qa"),
 			bk.Async(opts.async),
 			bk.Build(customOptions),
 		)
-		// code-intel-qa is disabled, see https://github.com/sourcegraph/sourcegraph/issues/25387
-		// pipeline.AddTrigger(":chromium: Trigger Code Intel QA",
-		// 	bk.Trigger("code-intel-qa"),
-		// 	bk.Async(opts.async),
-		// 	bk.Build(customOptions),
-		// )
 	}
 }
 


### PR DESCRIPTION
It's a bit frustrating to jump back and forth between 5 pipelines: sourcegraph, sourcegraph-async, qa, e2e, codeintel-qa (when that was enabled), and more (updater pipelines??)

qa, e2e, codeintel-qa all do pretty similar things (vagrant -> test), get triggered at the same point, and are all defined outside the pipeline generator as async pipelines. This change brings them all under the same roof for easier management (qa pipeline)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
