### PR TITLE
dev/ci: do not deploy cadvisor daemonset when testing

### DIFF
--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -49,12 +49,13 @@ function cluster_setup() {
   kubectl get -n "$NAMESPACE" pods
 
   pushd "$DIR/deploy-sourcegraph/"
-  pwd
-  # see $DOCKER_CLUSTER_IMAGES_TXT in pipeline-steps.go for env var
-  # replace all docker image tags with previously built candidate images
   set +e
   set +o pipefail
   pushd base
+  # Remove cAdvisor, it deploys on all Buildkite nodes as a daemonset and is non-critical.
+  rm -rf ./cadvisor
+  # See $DOCKER_CLUSTER_IMAGES_TXT in pipeline-steps.go for env var
+  # replace all docker image tags with previously built candidate images
   while IFS= read -r line; do
     echo "$line"
     grep -lr '.' -e "index.docker.io/sourcegraph/$line" --include \*.yaml | xargs sed -i -E "s#index.docker.io/sourcegraph/$line:.*#us.gcr.io/sourcegraph-dev/$line:$CANDIDATE_VERSION#g"


### PR DESCRIPTION
Right now test clusters deploy into the same cluster as buildkite agents, but under a different namespace. This causes some weirdness with daemonsets like cAdvisor, which will deploy one very node that the test cluster has a service on, which can be quite a few due to the number of buildkite agents. We don't really get anything out of deploying cAdvisor for these tests, so we just remove `base/cadvisor` entirely.

Closes #25349 

---

https://buildkite.com/sourcegraph/qa/builds/5760#b5d38f23-8357-415c-b346-be193cdd9122/101-399 - See #25349 for all the cAdvisors that used to be here


```
2021-09-28 20:41:31 UTC | + kubectl get pods
-- | --
  | 2021-09-28 20:41:31 UTC | NAME                                        READY   STATUS              RESTARTS   AGE
  | 2021-09-28 20:41:31 UTC | codeinsights-db-7554fcfdc7-bbq6n            0/1     Pending             0          4s
  | 2021-09-28 20:41:31 UTC | codeintel-db-5c5d7f7f69-5pfht               0/2     Pending             0          4s
  | 2021-09-28 20:41:31 UTC | github-proxy-5884c5bb77-v9pkh               0/2     ContainerCreating   0          3s
  | 2021-09-28 20:41:31 UTC | gitserver-0                                 0/2     Pending             0          3s
  | 2021-09-28 20:41:31 UTC | grafana-0                                   0/1     Pending             0          3s
  | 2021-09-28 20:41:31 UTC | indexed-search-0                            0/2     Pending             0          3s
  | 2021-09-28 20:41:31 UTC | jaeger-7dff9bd4c5-w59jw                     0/1     ContainerCreating   0          2s
  | 2021-09-28 20:41:31 UTC | minio-7984c68767-8xdk4                      0/1     Pending             0          2s
  | 2021-09-28 20:41:31 UTC | pgsql-778ddd44fd-2nz2q                      0/2     Pending             0          2s
  | 2021-09-28 20:41:31 UTC | precise-code-intel-worker-d54ddfdbc-4v7d6   0/1     ContainerCreating   0          2s
  | 2021-09-28 20:41:31 UTC | precise-code-intel-worker-d54ddfdbc-l2n2l   0/1     ContainerCreating   0          2s
  | 2021-09-28 20:41:31 UTC | prometheus-5bbdc8965-zz97v                  0/1     Pending             0          2s
  | 2021-09-28 20:41:31 UTC | query-runner-77dfbf48b6-hfwq8               0/2     ContainerCreating   0          2s
  | 2021-09-28 20:41:31 UTC | redis-cache-5c9d7b7c-74bw5                  0/2     Pending             0          2s
  | 2021-09-28 20:41:31 UTC | redis-store-6785ffb5dc-rxf87                0/2     Pending             0          1s
  | 2021-09-28 20:41:31 UTC | repo-updater-6db5f48474-j2t8q               0/2     ContainerCreating   0          1s
  | 2021-09-28 20:41:31 UTC | searcher-69c4f98864-gv9pb                   0/2     ContainerCreating   0          1s
  | 2021-09-28 20:41:31 UTC | searcher-69c4f98864-x49lv                   0/2     ContainerCreating   0          1s
  | 2021-09-28 20:41:31 UTC | sourcegraph-frontend-f9448968c-5vpl2        0/2     ContainerCreating   0          2s
  | 2021-09-28 20:41:31 UTC | sourcegraph-frontend-f9448968c-cgmlk        0/2     ContainerCreating   0          2s
  | 2021-09-28 20:41:31 UTC | symbols-f468d8674-t869n                     0/2     ContainerCreating   0          1s
  | 2021-09-28 20:41:31 UTC | syntect-server-744669c989-ch9qr             0/1     ContainerCreating   0          1s
  | 2021-09-28 20:41:31 UTC | worker-7c5cc4c44d-z4b65                     0/1     ContainerCreating   0          1s


```


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
