### PR TITLE
rename SearchQuery to Node

### DIFF
--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -11,7 +11,7 @@ import (
 type SearchRequest struct {
 	Repo        api.RepoName
 	Revisions   []RevisionSpecifier
-	Query       SearchQuery
+	Query       Node
 	IncludeDiff bool
 	Limit       int
 }

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-type SearchQuery interface {
+type Node interface {
 	String() string
 }
 
@@ -96,7 +96,7 @@ const (
 
 type Operator struct {
 	Kind     OperatorKind
-	Operands []SearchQuery
+	Operands []Node
 }
 
 func (o Operator) String() string {

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -13,7 +13,7 @@ import (
 // ToMatchTree converts a protocol.SearchQuery into its equivalent MatchTree.
 // We don't send a match tree directly over the wire so using the protocol
 // package doesn't pull in all the dependencies that the match tree needs.
-func ToMatchTree(q protocol.SearchQuery) (MatchTree, error) {
+func ToMatchTree(q protocol.Node) (MatchTree, error) {
 	switch v := q.(type) {
 	case *protocol.CommitBefore:
 		return &CommitBefore{*v}, nil

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -148,7 +148,7 @@ func TestSearch(t *testing.T) {
 	t.Run("and match", func(t *testing.T) {
 		query := &protocol.Operator{
 			Kind: protocol.And,
-			Operands: []protocol.SearchQuery{
+			Operands: []protocol.Node{
 				&protocol.DiffMatches{Expr: "lorem"},
 				&protocol.DiffMatches{Expr: "ipsum"},
 			},
@@ -300,12 +300,12 @@ index 0000000000..7e54670557
 
 	mt, err := ToMatchTree(&protocol.Operator{
 		Kind: protocol.And,
-		Operands: []protocol.SearchQuery{
+		Operands: []protocol.Node{
 			&protocol.AuthorMatches{Expr: "Camden"},
 			&protocol.DiffModifiesFile{Expr: "test"},
 			&protocol.Operator{
 				Kind: protocol.And,
-				Operands: []protocol.SearchQuery{
+				Operands: []protocol.Node{
 					&protocol.DiffMatches{Expr: "result"},
 					&protocol.DiffMatches{Expr: "test"},
 				},


### PR DESCRIPTION
Semantics-preserving. Just a rename. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
