### PR TITLE
db: Add index to speed up extension list query

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1584,6 +1584,7 @@ Indexes:
     "registry_extension_releases_pkey" PRIMARY KEY, btree (id)
     "registry_extension_releases_version" UNIQUE, btree (registry_extension_id, release_version) WHERE release_version IS NOT NULL
     "registry_extension_releases_registry_extension_id" btree (registry_extension_id, release_tag, created_at DESC) WHERE deleted_at IS NULL
+    "registry_extension_releases_registry_extension_id_created_at" btree (registry_extension_id, created_at) WHERE deleted_at IS NULL
 Foreign-key constraints:
     "registry_extension_releases_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     "registry_extension_releases_registry_extension_id_fkey" FOREIGN KEY (registry_extension_id) REFERENCES registry_extensions(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/migrations/frontend/1528395897_extensions_list_missing_index.down.sql
+++ b/migrations/frontend/1528395897_extensions_list_missing_index.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS registry_extension_releases_registry_extension_id_created_at;
+COMMIT;

--- a/migrations/frontend/1528395897_extensions_list_missing_index.up.sql
+++ b/migrations/frontend/1528395897_extensions_list_missing_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS registry_extension_releases_registry_extension_id_created_at ON registry_extension_releases(registry_extension_id, created_at) WHERE deleted_at IS NULL;


### PR DESCRIPTION
This index speeds up the list extensions queryl. This is called ~7k/h and takes ~260ms. It now takes ~20ms. This is currently the sixth heaviest query by load according to query insights results from the last hour (and the second heaviest query over the last day).

**Representative query**:

This query is a slight reduction of the query given in [this trace](https://console.cloud.google.com/sql/instances/sg-cloud-732a936743/insights;database=sg;duration=PT1H;trace=b7e516830b10900e940276f8b19b8fbc;span=d1db540dfec75fd0;norm_query_id=SELECT%20x.id,%20x.uuid,%20x.publisher_user_id,%20x.publisher_org_id,%20x.name,%20x.created_at,%20x.updated_at,%20CONCAT%28COALESCE%28users.username,%20orgs.name%29,%20$40,%20x.name%29%20AS%20non_canonical_extension_id,%20COALESCE%28users.username,%20orgs.name%29%20AS%20non_canonical_publisher_name,%20%28rer.manifest%20IS%20NULL%20OR%20COALESCE%28%28rer.manifest-%3E%3E$41%29::jsonb%20%3D%20$42::jsonb,%20$43%29%29%20AS%20non_canonical_is_work_in_progress%20FROM%20registry_extensions%20x%20LEFT%20JOIN%20users%20ON%20users.id%3Dpublisher_user_id%20AND%20users.deleted_at%20IS%20NULL%20LEFT%20JOIN%20orgs%20ON%20orgs.id%3Dpublisher_org_id%20AND%20orgs.deleted_at%20IS%20NULL%20LEFT%20JOIN%20registry_extension_releases%20rer%20ON%20rer.registry_extension_id%3Dx.id%20AND%20rer.deleted_at%20IS%20NULL%20WHERE%20%28CONCAT%28COALESCE%28users.username,%20orgs.name%29,%20$44,%20x.name%29%20IN%20%28$1%20,%20$2%20,%20$3%20,%20$4%20,%20$5%20,%20$6%20,%20$7%20,%20$8%20,%20$9%20,%20$10%20,%20$11%20,%20$12%20,%20$13%20,%20$14%20,%20$15%20,%20$16%20,%20$17%20,%20$18%20,%20$19%20,%20$20%20,%20$21%20,%20$22%20,%20$23%20,%20$24%20,%20$25%20,%20$26%20,%20$27%20,%20$28%20,%20$29%20,%20$30%20,%20$31%20,%20$32%20,%20$33%20,%20$34%20,%20$35%20,%20$36%20,%20$37%20,%20$45%29%29%20--%20Join%20only%20to%20latest%20release%20from%20registry_extension_releases.%20AND%20NOT%20EXISTS%20%28SELECT%20$46%20FROM%20registry_extension_releases%20rer2%20WHERE%20rer.registry_extension_id%3Drer2.registry_extension_id%20AND%20rer2.deleted_at%20IS%20NULL%20AND%20rer2.created_at%20%3E%20rer.created_at%20%29%20AND%20x.deleted_at%20IS%20NULL%20ORDER%20BY%20CONCAT%28COALESCE%28users.username,%20orgs.name%29,%20$47,%20x.name%29%20IN%20%28$48%29%20ASC%20,%20$49,%20--%20Always%20sort%20WIP%20extensions%20last.%20%28rer.manifest%20IS%20NULL%20OR%20COALESCE%28%28rer.manifest-%3E%3E'wip'%29::jsonb%20%3D%20'true'::jsonb,%20false%29%29%20ASC,%20x.id%20ASC%20LIMIT%20$38%20OFFSET%20$39;sort_by=TOTAL_EXEC_TIME?authuser=1&project=sourcegraph-dev).

```sql
SELECT
    x.id,
    x.uuid,
    x.publisher_user_id,
    x.publisher_org_id,
    x.name,
    x.created_at,
    x.updated_at,
    users.username,
    orgs.name,
    rer.manifest
FROM registry_extensions x
LEFT JOIN users ON users.id=publisher_user_id AND users.deleted_at IS NULL
LEFT JOIN orgs ON orgs.id=publisher_org_id AND orgs.deleted_at IS NULL
LEFT JOIN registry_extension_releases rer ON rer.registry_extension_id=x.id AND rer.deleted_at IS NULL
WHERE
    NOT EXISTS (
        SELECT 1 
        FROM registry_extension_releases rer2 
        WHERE 
            rer.registry_extension_id=rer2.registry_extension_id AND 
            rer2.deleted_at IS NULL AND 
            rer2.created_at > rer.created_at 
    )
    AND x.deleted_at IS NULL
;
```

**Previous query plan:**

```
                                                                                                   QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Hash Anti Join  (cost=1150.97..1979.84 rows=5699 width=238) (actual time=6.392..266.323 rows=298 loops=1)
   Hash Cond: (rer.registry_extension_id = rer2.registry_extension_id)
   Join Filter: (rer2.created_at > rer.created_at)
   Rows Removed by Join Filter: 1600190
   ->  Hash Right Join  (cost=674.16..1395.46 rows=8549 width=250) (actual time=1.330..11.451 rows=11621 loops=1)
         Hash Cond: (rer.registry_extension_id = x.id)
         ->  Seq Scan on registry_extension_releases rer  (cost=0.00..587.04 rows=13003 width=175) (actual time=0.004..4.195 rows=13003 loops=1)
               Filter: (deleted_at IS NULL)
               Rows Removed by Filter: 1
         ->  Hash  (cost=669.99..669.99 rows=334 width=75) (actual time=1.289..1.293 rows=298 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 39kB
               ->  Hash Left Join  (cost=23.32..669.99 rows=334 width=75) (actual time=0.389..1.192 rows=298 loops=1)
                     Hash Cond: (x.publisher_org_id = orgs.id)
                     ->  Nested Loop Left Join  (cost=0.29..646.09 rows=334 width=66) (actual time=0.017..0.742 rows=298 loops=1)
                           ->  Seq Scan on registry_extensions x  (cost=0.00..12.08 rows=334 width=55) (actual time=0.010..0.124 rows=298 loops=1)
                                 Filter: (deleted_at IS NULL)
                                 Rows Removed by Filter: 144
                           ->  Index Scan using users_pkey on users  (cost=0.29..1.90 rows=1 width=15) (actual time=0.002..0.002 rows=1 loops=298)
                                 Index Cond: (id = x.publisher_user_id)
                                 Filter: (deleted_at IS NULL)
                     ->  Hash  (cost=14.19..14.19 rows=707 width=13) (actual time=0.353..0.353 rows=707 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 41kB
                           ->  Seq Scan on orgs  (cost=0.00..14.19 rows=707 width=13) (actual time=0.004..0.176 rows=707 loops=1)
                                 Filter: (deleted_at IS NULL)
                                 Rows Removed by Filter: 12
   ->  Hash  (cost=314.27..314.27 rows=13003 width=12) (actual time=4.930..4.931 rows=13003 loops=1)
         Buckets: 16384  Batches: 1  Memory Usage: 738kB
         ->  Index Only Scan using registry_extension_releases_registry_extension_id on registry_extension_releases rer2  (cost=0.29..314.27 rows=13003 width=12) (actual time=0.022..2.377 rows=13003 loops=1)
               Heap Fetches: 1119
 Planning Time: 1.751 ms
 Execution Time: 266.545 ms
(31 rows)
```

**Current query plan:**

```
                                                                                                        QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Hash Anti Join  (cost=1123.01..1951.87 rows=5699 width=238) (actual time=5.420..18.935 rows=298 loops=1)
   Hash Cond: (rer.registry_extension_id = rer2.registry_extension_id)
   Join Filter: (rer2.created_at > rer.created_at)
   Rows Removed by Join Filter: 11478
   ->  Hash Right Join  (cost=674.16..1395.46 rows=8549 width=250) (actual time=1.295..10.531 rows=11621 loops=1)
         Hash Cond: (rer.registry_extension_id = x.id)
         ->  Seq Scan on registry_extension_releases rer  (cost=0.00..587.04 rows=13003 width=175) (actual time=0.004..3.627 rows=13003 loops=1)
               Filter: (deleted_at IS NULL)
               Rows Removed by Filter: 1
         ->  Hash  (cost=669.99..669.99 rows=334 width=75) (actual time=1.283..1.294 rows=298 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 39kB
               ->  Hash Left Join  (cost=23.32..669.99 rows=334 width=75) (actual time=0.311..1.196 rows=298 loops=1)
                     Hash Cond: (x.publisher_org_id = orgs.id)
                     ->  Nested Loop Left Join  (cost=0.29..646.09 rows=334 width=66) (actual time=0.016..0.794 rows=298 loops=1)
                           ->  Seq Scan on registry_extensions x  (cost=0.00..12.08 rows=334 width=55) (actual time=0.009..0.142 rows=298 loops=1)
                                 Filter: (deleted_at IS NULL)
                                 Rows Removed by Filter: 144
                           ->  Index Scan using users_pkey on users  (cost=0.29..1.90 rows=1 width=15) (actual time=0.002..0.002 rows=1 loops=298)
                                 Index Cond: (id = x.publisher_user_id)
                                 Filter: (deleted_at IS NULL)
                     ->  Hash  (cost=14.19..14.19 rows=707 width=13) (actual time=0.288..0.289 rows=707 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 41kB
                           ->  Seq Scan on orgs  (cost=0.00..14.19 rows=707 width=13) (actual time=0.004..0.154 rows=707 loops=1)
                                 Filter: (deleted_at IS NULL)
                                 Rows Removed by Filter: 12
   ->  Hash  (cost=286.31..286.31 rows=13003 width=12) (actual time=4.087..4.087 rows=13003 loops=1)
         Buckets: 16384  Batches: 1  Memory Usage: 738kB
         ->  Index Only Scan using registry_extension_releases_registry_extension_id_created_at on registry_extension_releases rer2  (cost=0.29..286.31 rows=13003 width=12) (actual time=0.038..1.884 rows=13003 loops=1)
               Heap Fetches: 1119
 Planning Time: 0.726 ms
 Execution Time: 19.019 ms
(31 rows)
```

The top Hash Anti-Join node is the heaviest and occurs due to the `NOT EXISTS` correlated subquery. Adding this index allows fewer rows to be fetched from the table so that the join condition does not need to filter them - the index scan filters them by virtue of an ordered index.