### PR TITLE
compute: don't attempt to slice negative ranges

### DIFF
--- a/internal/compute/match_context_result.go
+++ b/internal/compute/match_context_result.go
@@ -70,6 +70,11 @@ func fromRegexpMatches(matches [][]int, namedGroups []string, lineValue string, 
 		for j := 0; j < len(m); j += 2 {
 			start := m[j]
 			end := m[j+1]
+			if start == -1 || end == -1 {
+				// The entire regexp matched, but a capture
+				// group inside it did not. Ignore this entry.
+				continue
+			}
 			value := lineValue[start:end]
 			range_ := newRange(lineNumber, lineNumber, start, end)
 

--- a/internal/compute/match_context_result_test.go
+++ b/internal/compute/match_context_result_test.go
@@ -53,6 +53,8 @@ func TestFromLineMatches(t *testing.T) {
   "ThisIsNamed": "b"
 }`).Equal(t, test("(a)(?P<ThisIsNamed>b)", environment))
 
+	autogold.Want("no slice out of bounds access on capture group", "{}").Equal(t, test("(lasvegans)|abcdefgh", environment))
+
 	autogold.Want("compute regexp submatch nonempty environment", `{
   "matches": [
     {


### PR DESCRIPTION
Surprisingly, `FindAllStringSubmatchIndex` may return `-1, -1` which will result in OOB on slice access.