### PR TITLE
search: promote hard error on index:only and ref globs

### DIFF
--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -436,6 +436,20 @@ func validateTypeStructural(nodes []Node) error {
 	return nil
 }
 
+func validateRefGlobs(nodes []Node) error {
+	if !ContainsRefGlobs(nodes) {
+		return nil
+	}
+	var indexValue string
+	VisitField(nodes, FieldIndex, func(value string, _ bool, _ Annotation) {
+		indexValue = value
+	})
+	if ParseYesNoOnly(indexValue) == Only {
+		return errors.Errorf("invalid index:%s (revisions with glob pattern cannot be resolved for indexed searches)", indexValue)
+	}
+	return nil
+}
+
 // validatePredicates validates predicate parameters with respect to their validation logic.
 func validatePredicate(field, value string, negated bool) error {
 	if negated {
@@ -542,6 +556,7 @@ func validate(nodes []Node) error {
 		validateRepoHasFile,
 		validateCommitParameters,
 		validateTypeStructural,
+		validateRefGlobs,
 	)
 }
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -310,9 +310,6 @@ func newIndexedSubsetSearchRequest(ctx context.Context, repos []*search.Reposito
 	tr, ctx := trace.New(ctx, "newIndexedSubsetSearchRequest", string(zoektArgs.Typ))
 	// Fallback to Unindexed if the query contains ref-globs
 	if query.ContainsRefGlobs(q) {
-		if index == query.Only {
-			return nil, errors.Errorf("invalid index:%q (revsions with glob pattern cannot be resolved for indexed searches)", index)
-		}
 		return &IndexedSubsetSearchRequest{
 			Unindexed: limitUnindexedRepos(repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
 		}, nil


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/25493

Runs a hard error validation check based on static values earlier in the search pipeline. Helps cut down on downstream logic.