### PR TITLE
Better repository pages: a re-think of how repository navigation works

### DIFF
--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -25,6 +25,7 @@ export interface Settings {
         batchChangesExecution?: boolean
         showSearchContext?: boolean
         showSearchContextManagement?: boolean
+        betterRepoPages?: boolean
     }
     [key: string]: any
 

--- a/client/web/src/enterprise/repo/settings/routes.tsx
+++ b/client/web/src/enterprise/repo/settings/routes.tsx
@@ -30,6 +30,7 @@ export const enterpriseRepoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[] 
             },
         }: RouteComponentProps<{ id: string }>) => <Redirect to={`../uploads/${id}`} />,
     },
+    // Used by betterRepoPages feature flag when users are admins only.
     {
         path: '/code-intelligence',
         exact: false,

--- a/client/web/src/enterprise/repo/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/repo/settings/sidebaritems.ts
@@ -16,6 +16,11 @@ export const enterpriseRepoSettingsSidebarGroups: RepoSettingsSideBarGroups = re
                             exact: true,
                             label: 'Permissions',
                         },
+                        {
+                            to: '/code-intelligence',
+                            exact: true,
+                            label: 'Code intelligence',
+                        },
                     ],
                 },
             ]

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -43,11 +43,15 @@ import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps, useWebActionItems } from '../extensions/components/ActionItemsBar'
 import { ExternalLinkFields, RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
+import { KeyboardShortcutsProps } from '../keyboardShortcuts/keyboardShortcuts'
 import { IS_CHROME } from '../marketing/util'
 import { Settings } from '../schema/settings.schema'
+import { VersionContext } from '../schema/site.schema'
 import {
     CaseSensitivityProps,
+    ParsedSearchQueryProps,
     PatternTypeProps,
+    SearchContextInputProps,
     SearchContextProps,
     searchQueryForRepoRevision,
     SearchStreamingProps,
@@ -85,8 +89,11 @@ export interface RepoContainerContext
         ActivationProps,
         PatternTypeProps,
         CaseSensitivityProps,
+        KeyboardShortcutsProps,
         VersionContextProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
+        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        SearchContextInputProps,
         BreadcrumbSetters,
         ActionItemsBarProps,
         SearchStreamingProps,
@@ -104,6 +111,9 @@ export interface RepoContainerContext
 
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 
+    isSourcegraphDotCom: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
     globbing: boolean
 
     showSearchNotebook: boolean
@@ -129,8 +139,11 @@ interface RepoContainerProps
         ExtensionAlertProps,
         PatternTypeProps,
         CaseSensitivityProps,
+        KeyboardShortcutsProps,
         VersionContextProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
+        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        SearchContextInputProps,
         BreadcrumbSetters,
         BreadcrumbsProps,
         SearchStreamingProps,
@@ -145,6 +158,9 @@ interface RepoContainerProps
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
     authenticatedUser: AuthenticatedUser | null
     history: H.History
+    isSourcegraphDotCom: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
     globbing: boolean
     showSearchNotebook: boolean
     isMacPlatform: boolean

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -41,9 +41,7 @@ import {
     SearchContextInputProps,
     ParsedSearchQueryProps,
 } from '../search'
-import { SubmitSearchParameters } from '../search/helpers'
 import { StreamingSearchResultsListProps } from '../search/results/StreamingSearchResultsList'
-import { ThemePreferenceProps } from '../theme'
 import { RouteDescriptor } from '../util/contributions'
 
 import { CopyPathAction } from './actions/CopyPathAction'
@@ -64,7 +62,6 @@ export interface RepoRevisionContainerContext
         ExtensionsControllerProps,
         PlatformContextProps,
         ThemeProps,
-        ThemePreferenceProps,
         TelemetryProps,
         HoverThresholdProps,
         ActivationProps,
@@ -76,7 +73,6 @@ export interface RepoRevisionContainerContext
         CodeIntelligenceProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
         Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
-        Pick<SubmitSearchParameters, 'source'>,
         SearchContextInputProps,
         RevisionSpec,
         BreadcrumbSetters,
@@ -117,8 +113,11 @@ interface RepoRevisionContainerProps
         ActivationProps,
         PatternTypeProps,
         CaseSensitivityProps,
+        KeyboardShortcutsProps,
         VersionContextProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
+        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        SearchContextInputProps,
         RevisionSpec,
         BreadcrumbSetters,
         ActionItemsBarProps,
@@ -131,7 +130,6 @@ interface RepoRevisionContainerProps
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
     repo: RepositoryFields
-    authenticatedUser: AuthenticatedUser | null
     routePrefix: string
 
     /**
@@ -142,6 +140,10 @@ interface RepoRevisionContainerProps
 
     history: H.History
 
+    authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
     globbing: boolean
 
     showSearchNotebook: boolean

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -33,7 +33,14 @@ import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { KeyboardShortcutsProps } from '../keyboardShortcuts/keyboardShortcuts'
 import { VersionContext } from '../schema/site.schema'
-import { PatternTypeProps, CaseSensitivityProps, SearchContextProps, SearchStreamingProps, SearchContextInputProps, ParsedSearchQueryProps } from '../search'
+import {
+    PatternTypeProps,
+    CaseSensitivityProps,
+    SearchContextProps,
+    SearchStreamingProps,
+    SearchContextInputProps,
+    ParsedSearchQueryProps,
+} from '../search'
 import { SubmitSearchParameters } from '../search/helpers'
 import { StreamingSearchResultsListProps } from '../search/results/StreamingSearchResultsList'
 import { ThemePreferenceProps } from '../theme'

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -31,8 +31,12 @@ import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
 import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
-import { PatternTypeProps, CaseSensitivityProps, SearchContextProps, SearchStreamingProps } from '../search'
+import { KeyboardShortcutsProps } from '../keyboardShortcuts/keyboardShortcuts'
+import { VersionContext } from '../schema/site.schema'
+import { PatternTypeProps, CaseSensitivityProps, SearchContextProps, SearchStreamingProps, SearchContextInputProps, ParsedSearchQueryProps } from '../search'
+import { SubmitSearchParameters } from '../search/helpers'
 import { StreamingSearchResultsListProps } from '../search/results/StreamingSearchResultsList'
+import { ThemePreferenceProps } from '../theme'
 import { RouteDescriptor } from '../util/contributions'
 
 import { CopyPathAction } from './actions/CopyPathAction'
@@ -53,14 +57,20 @@ export interface RepoRevisionContainerContext
         ExtensionsControllerProps,
         PlatformContextProps,
         ThemeProps,
+        ThemePreferenceProps,
         TelemetryProps,
         HoverThresholdProps,
         ActivationProps,
         Omit<RepoContainerContext, 'onDidUpdateExternalLinks'>,
         PatternTypeProps,
         CaseSensitivityProps,
+        KeyboardShortcutsProps,
         VersionContextProps,
+        CodeIntelligenceProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
+        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        Pick<SubmitSearchParameters, 'source'>,
+        SearchContextInputProps,
         RevisionSpec,
         BreadcrumbSetters,
         ActionItemsBarProps,
@@ -74,6 +84,10 @@ export interface RepoRevisionContainerContext
     /** The URL route match for {@link RepoRevisionContainer}. */
     routePrefix: string
 
+    authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
     globbing: boolean
 
     showSearchNotebook: boolean

--- a/client/web/src/repo/blob/RenderedFile.tsx
+++ b/client/web/src/repo/blob/RenderedFile.tsx
@@ -12,15 +12,17 @@ interface Props {
     dangerousInnerHTML: string
 
     location: H.Location
+
+    className?: string
 }
 
 /**
  * Displays a file whose contents are rendered to HTML, such as a Markdown file.
  */
-export const RenderedFile: React.FunctionComponent<Props> = ({ dangerousInnerHTML, location }) => {
+export const RenderedFile: React.FunctionComponent<Props> = ({ dangerousInnerHTML, location, className }) => {
     useScrollToLocationHash(location)
     return (
-        <div className="rendered-file">
+        <div className={className || 'rendered-file'}>
             <div className="rendered-file__container">
                 <Markdown dangerousInnerHTML={dangerousInnerHTML} />
             </div>

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -142,8 +142,13 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
             // and https://github.com/ReactTraining/history/issues/505
             const filePath = decodeURIComponent(match.params.filePath || '') // empty string is root
 
+            const enableBetterRepoPage =
+                !isErrorLike(context.settingsCascade.final) &&
+                context.settingsCascade.final?.experimentalFeatures?.betterRepoPages !== false
+
             // Redirect tree and blob routes pointing to the root to the repo page
-            if (match.params.objectType && filePath.replace(/\/+$/g, '') === '') {
+            // If betterRepoPages is enabled, tree at repo root is a distinct page
+            if (match.params.objectType && filePath.replace(/\/+$/g, '') === '' && !enableBetterRepoPage) {
                 return <Redirect to={toRepoURL({ repoName: repo.name, revision: context.revision })} />
             }
 
@@ -218,7 +223,12 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                                         }
                                     />
                                 ) : (
-                                    <TreePage {...context} {...repoRevisionProps} repo={repo} />
+                                    <TreePage
+                                        {...context}
+                                        {...repoRevisionProps}
+                                        repo={repo}
+                                        isRootRepoPage={match.params.objectType !== 'tree' && filePath === ''}
+                                    />
                                 )}
                             </ErrorBoundary>
                         </div>

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -144,7 +144,7 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
 
             const enableBetterRepoPage =
                 !isErrorLike(context.settingsCascade.final) &&
-                context.settingsCascade.final?.experimentalFeatures?.betterRepoPages !== false
+                context.settingsCascade.final?.experimentalFeatures?.betterRepoPages === true
 
             // Redirect tree and blob routes pointing to the root to the repo page
             // If betterRepoPages is enabled, tree at repo root is a distinct page

--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -16,6 +16,9 @@
         flex: 1;
         background-color: var(--code-bg);
     }
+    &__inner-container {
+        max-width: 50rem;
+    }
 
     &__title {
         display: flex;

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -1,6 +1,5 @@
 import { subYears, formatISO } from 'date-fns'
 import * as H from 'history'
-import BarChartIcon from 'mdi-react/BarChartIcon'
 import BookOpenVariantIcon from 'mdi-react/BookOpenVariantIcon'
 import BrainIcon from 'mdi-react/BrainIcon'
 import FolderIcon from 'mdi-react/FolderIcon'

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -361,7 +361,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
     )
 
     const enableBetterRepoPage =
-        !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.betterRepoPages !== false
+        !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.betterRepoPages === true
 
     const blobInfoOrError = useCallback(
         (filePath: string): Observable<BlobFileFields | null> =>

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -60,8 +60,6 @@ import {
     SearchContextInputProps,
     searchQueryForRepoRevision,
 } from '../../search'
-import { SubmitSearchParameters } from '../../search/helpers'
-import { ThemePreferenceProps } from '../../theme'
 import { basename } from '../../util/path'
 import { serviceKindDisplayNameAndIcon } from '../actions/GoToCodeHostAction'
 import { externalLinkFieldsFragment, fetchTreeEntries } from '../backend'
@@ -127,7 +125,6 @@ interface Props
         ExtensionsControllerProps,
         PlatformContextProps,
         ThemeProps,
-        ThemePreferenceProps,
         TelemetryProps,
         ActivationProps,
         PatternTypeProps,
@@ -139,7 +136,6 @@ interface Props
         CodeInsightsProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
         Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
-        Pick<SubmitSearchParameters, 'source'>,
         SearchContextInputProps,
         BreadcrumbSetters {
     repo: TreePageRepositoryFields

--- a/client/web/src/repo/tree/TreePageSearchInput.tsx
+++ b/client/web/src/repo/tree/TreePageSearchInput.tsx
@@ -1,0 +1,96 @@
+import classNames from 'classnames'
+import * as H from 'history'
+import React, { useState, useCallback, useEffect } from 'react'
+import { Form } from 'reactstrap'
+
+import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+
+import { AuthenticatedUser } from '../../auth'
+import { KeyboardShortcutsProps } from '../../keyboardShortcuts/keyboardShortcuts'
+import { Settings } from '../../schema/settings.schema'
+import { VersionContext } from '../../schema/site.schema'
+import { PatternTypeProps, CaseSensitivityProps, ParsedSearchQueryProps, SearchContextInputProps } from '../../search'
+import { submitSearch, SubmitSearchParameters } from '../../search/helpers'
+import { SearchBox } from '../../search/input/SearchBox'
+import { ThemePreferenceProps } from '../../theme'
+
+interface Props
+    extends SettingsCascadeProps<Settings>,
+        ThemeProps,
+        ThemePreferenceProps,
+        ActivationProps,
+        PatternTypeProps,
+        CaseSensitivityProps,
+        KeyboardShortcutsProps,
+        TelemetryProps,
+        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL'>,
+        Pick<SubmitSearchParameters, 'source'>,
+        VersionContextProps,
+        SearchContextInputProps {
+    authenticatedUser: AuthenticatedUser | null
+    location: H.Location
+    history: H.History
+    isSourcegraphDotCom: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
+    /** Whether globbing is enabled for filters. */
+    globbing: boolean
+    /** A query fragment to appear at the beginning of the input. */
+    queryPrefix?: string
+    /** A query fragment to be prepended to queries. This will not appear in the input until a search is submitted. */
+    hiddenQueryPrefix?: string
+    className?: string
+}
+
+export const TreePageSearchInput: React.FunctionComponent<Props> = (props: Props) => {
+    /** The value entered by the user in the query input */
+    const [userQueryState, setUserQueryState] = useState({
+        query: props.queryPrefix ? props.queryPrefix : '',
+    })
+
+    useEffect(() => {
+        setUserQueryState({ query: props.queryPrefix || '' })
+    }, [props.queryPrefix])
+
+    const onSubmit = useCallback(
+        (event?: React.FormEvent<HTMLFormElement>): void => {
+            event?.preventDefault()
+            submitSearch({
+                ...props,
+                query: props.hiddenQueryPrefix
+                    ? `${props.hiddenQueryPrefix} ${userQueryState.query}`
+                    : userQueryState.query,
+                source: 'repo',
+            })
+        },
+        [props, userQueryState.query]
+    )
+
+    return (
+        <div className={classNames('d-flex flex-row flex-shrink-past-contents', props.className)}>
+            <Form className="flex-grow-1 flex-shrink-past-contents" onSubmit={onSubmit}>
+                <div className="d-flex w-100">
+                    <SearchBox
+                        showSearchContextFeatureTour={false}
+                        {...props}
+                        submitSearchOnSearchContextChange={false}
+                        hasGlobalQueryBehavior={false}
+                        queryState={userQueryState}
+                        onChange={setUserQueryState}
+                        onSubmit={onSubmit}
+                        autoFocus={false}
+                        isSearchOnboardingTourVisible={false}
+                        hideVersionContexts={true}
+                        hideHelpButton={true}
+                    />
+                </div>
+            </Form>
+        </div>
+    )
+}

--- a/client/web/src/repo/tree/TreePageSearchInput.tsx
+++ b/client/web/src/repo/tree/TreePageSearchInput.tsx
@@ -3,7 +3,6 @@ import * as H from 'history'
 import React, { useState, useCallback, useEffect } from 'react'
 import { Form } from 'reactstrap'
 
-import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -15,22 +14,18 @@ import { KeyboardShortcutsProps } from '../../keyboardShortcuts/keyboardShortcut
 import { Settings } from '../../schema/settings.schema'
 import { VersionContext } from '../../schema/site.schema'
 import { PatternTypeProps, CaseSensitivityProps, ParsedSearchQueryProps, SearchContextInputProps } from '../../search'
-import { submitSearch, SubmitSearchParameters } from '../../search/helpers'
+import { submitSearch } from '../../search/helpers'
 import { SearchBox } from '../../search/input/SearchBox'
-import { ThemePreferenceProps } from '../../theme'
 
 interface Props
     extends SettingsCascadeProps<Settings>,
         ThemeProps,
-        ThemePreferenceProps,
-        ActivationProps,
         PatternTypeProps,
         CaseSensitivityProps,
         KeyboardShortcutsProps,
         TelemetryProps,
         Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
         PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL'>,
-        Pick<SubmitSearchParameters, 'source'>,
         VersionContextProps,
         SearchContextInputProps {
     authenticatedUser: AuthenticatedUser | null

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -255,8 +255,10 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
                 editor.revealPosition(position)
             }
         }
-        editor.focus()
-    }, [editor, queryState])
+        if (autoFocus) {
+            editor.focus()
+        }
+    }, [editor, autoFocus, queryState])
 
     // Prevent newline insertion in model, and surface query changes with stripped newlines.
     useEffect(() => {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -334,6 +334,11 @@ func redirectTreeOrBlob(routeName, path string, common *Common, w http.ResponseW
 	}
 
 	if path == "/" || path == "" {
+		if routeName == "tree" {
+			// Disabled for now as part of betterRepoPages experiment. The frontend redirects anyway if this
+			// setting is disabled, so this could only harm e.g. Google SEO by not being enabled.
+			return false, nil
+		}
 		if routeName != routeRepo {
 			// Redirect to repo route
 			target := "/" + string(common.Repo.Name) + common.Rev

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -328,21 +328,23 @@ func TestRedirectTreeOrBlob(t *testing.T) {
 			expLocation:   "/github.com/user/repo@master/-/tree/some/dir",
 		},
 
-		// "/github.com/user/repo/-/tree" -> "/github.com/user/repo"
-		{
-			name:  "redirct tree to root",
-			route: routeTree,
-			path:  "",
-			common: &Common{
-				Repo: &types.Repo{
-					Name: "github.com/user/repo",
-				},
-				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
-			},
-			expHandled:    true,
-			expStatusCode: http.StatusTemporaryRedirect,
-			expLocation:   "/github.com/user/repo",
-		},
+		// disabled as part of betterRepoPages experiment; see redirectTreeOrBlob
+		// docs.
+		// // "/github.com/user/repo/-/tree" -> "/github.com/user/repo"
+		// {
+		// 	name:  "redirct tree to root",
+		// 	route: routeTree,
+		// 	path:  "",
+		// 	common: &Common{
+		// 		Repo: &types.Repo{
+		// 			Name: "github.com/user/repo",
+		// 		},
+		// 		CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
+		// 	},
+		// 	expHandled:    true,
+		// 	expStatusCode: http.StatusTemporaryRedirect,
+		// 	expLocation:   "/github.com/user/repo",
+		// },
 		// "/github.com/user/repo/-/blob" -> "/github.com/user/repo"
 		{
 			name:  "redirct blob to root",
@@ -358,22 +360,24 @@ func TestRedirectTreeOrBlob(t *testing.T) {
 			expStatusCode: http.StatusTemporaryRedirect,
 			expLocation:   "/github.com/user/repo",
 		},
-		// "/github.com/user/repo@master/-/tree" -> "/github.com/user/repo"
-		{
-			name:  "redirct tree to root on a revision",
-			route: routeTree,
-			path:  "",
-			common: &Common{
-				Repo: &types.Repo{
-					Name: "github.com/user/repo",
-				},
-				Rev:      "@master",
-				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
-			},
-			expHandled:    true,
-			expStatusCode: http.StatusTemporaryRedirect,
-			expLocation:   "/github.com/user/repo@master",
-		},
+		// disabled as part of betterRepoPages experiment; see redirectTreeOrBlob
+		// docs.
+		// // "/github.com/user/repo@master/-/tree" -> "/github.com/user/repo"
+		// {
+		// 	name:  "redirct tree to root on a revision",
+		// 	route: routeTree,
+		// 	path:  "",
+		// 	common: &Common{
+		// 		Repo: &types.Repo{
+		// 			Name: "github.com/user/repo",
+		// 		},
+		// 		Rev:      "@master",
+		// 		CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
+		// 	},
+		// 	expHandled:    true,
+		// 	expStatusCode: http.StatusTemporaryRedirect,
+		// 	expLocation:   "/github.com/user/repo@master",
+		// },
 		// "/github.com/user/repo@master/-/blob" -> "/github.com/user/repo"
 		{
 			name:  "redirct blob to root on a revision",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1394,6 +1394,8 @@ type SettingsExperimentalFeatures struct {
 	ApiDocs *bool `json:"apiDocs,omitempty"`
 	// BatchChangesExecution description: Enables/disables the Batch Changes server side execution feature.
 	BatchChangesExecution *bool `json:"batchChangesExecution,omitempty"`
+	// BetterRepoPages description: Enables better repository pages.
+	BetterRepoPages *bool `json:"betterRepoPages,omitempty"`
 	// CodeInsights description: Enables code insights on directory pages.
 	CodeInsights *bool `json:"codeInsights,omitempty"`
 	// CodeInsightsAllRepos description: DEPRECATED: Enables the experimental ability to run an insight over all repositories on the instance.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -12,6 +12,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "betterRepoPages": {
+          "description": "Enables better repository pages.",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
+        },
         "codeInsights": {
           "description": "Enables code insights on directory pages.",
           "type": "boolean",


### PR DESCRIPTION
Demo + explanation video: https://youtu.be/sgqtPb8ubAw

<details>
<summary>an even more verbose explanation of what this is about, no need to read this</summary>

# The problem

I have a lot of complaints about our repository pages as they stand today:

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/3173176/135195389-58437b8d-aa41-4488-9940-45db42a8273c.png">

## A repository page today is not the best way to navigate a repository on Sourcegraph

That's a _really_ strange statement, but it's true:

An _experienced_ Sourcegraph user will typically:

1. Use a `repo:` filter directly, or navigate to the repo and then type in the search bar at the top of the page
2. Use `file:`, `type:symbol`, etc. options to search within a repository to get to the file they're looking for (or, hopefully in the future, use the better fuzzy-file navigation option I can't ever remember the keyboard shortcut for.)

An _inexperienced_ Sourcegraph user will:

1. Go to a repository page via our search, Google's, or the browser extension
2. Be faced with TONS of options competing for their attention visually: tens of buttons, a complete dump of files/directories in no apparent order, Git history, and maybe insights if they have those enabled.
3. Question to themselves "how is this better than GitHub that I'm used to?" and leave, or _hopefully_ realize the search bar at the top of the page is super useful.

The best way to navigate a repository on Sourcegraph is through search. But new users don't know this, and our repository page UX makes every effort to prevent them from learning this.

## Repository pages are overpopulated

Here's how the repository page for Sourcegraph's repository looks today, it's crazy - there's just too much on the page:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3173176/135196259-326a9cef-a2af-4649-a0aa-4f2306c129af.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3173176/135196339-c0778e11-cacd-4ce3-898e-bb05d1f5d343.png">

Past discussions and attempts to fix our repository pages have focused primarily around how we can organize and cram more content onto these pages - how we can make them customizable via widgets, or similar. I think that there's a better approach.

## Why the repository view is so critical to growth and user traction

A user's first journey through Sourcegraph is likely going to land them on a repository page first. That's the most natural path of navigation - and how people are familiar with navigating code _everywhere_ else (in their filesystem, on GitHub/GitLab, in their editor, etc.)

People end up on repository pages through the browser extension, Google, documentation links, and (sometimes) through typing the repository name into Sourcegraph search.

In my experience, people really familiar with Sourcegraph tend to avoid repository pages as they're not a good experience - search is.

If we want first-time Sourcegraph users to stick around, we need to do better at communicating why browsing code on Sourcegraph is so powerful - and make the repository page experience less of a "this is a different, bad flavor, of what I'm used to on GitHub"

# Simplification

Simplicity is the name of the game. My ideas going into this were:

* A dump of file names in whatever order this is, should not exist. The sidebar is the best way to navigate a tree of files in a repository - so one should either use that or use search.
* Commits shouldn't be shown on this page. Shown on a different page, or via the branch dropdown menu.
* "Code Intelligence" shouldn't have a dedicated button/page, instead it should go under repository "Settings" (currently only available to site admins - that's a problem in doing this)
* Insights should not be on this page. There should _absolutely_ be a way to view insights for a specific repository, but cramming it onto this page is not the way to go in my view. If we continue down this route, we should be asking:
  * Should we also cram Batch Changes onto this page? After all, someone will want to view the batch changes in the repo.
  * Should we also cram API docs onto this page?


I want this page to **communicate** the best way to navigate code on Sourcegraph. People are ending up here as their first experience with Sourcegraph, it _needs_ to do that.

# Implementation

Here's the new repository page:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3173176/135197701-763423c5-4c61-4721-ae91-0e390fee6177.png">

Note that:

* If you click the repository name (GitHub icon), it'll now bring you to the code host.
* READMEs are now shown - I think that's important and the default expectation of 95% of users when viewing a repository.
* At the top of the page, you get search inputs which **communicate** how you can search for files, symbols, commits and diffs. It being front-and-center makes it obvious that this (or the sidebar file tree) is the best way to navigate a repository. (these add the relevant `repo:` filter upon pressing enter.)
* `Code intelligence` has been removed as an option; if you're an admin you'll see `Settings` with code intelligence linked below that. If you're not an admin, `Code intelligence` will appear.
  * FUTURE: Ideally, I think `Settings` should be a non-admin page with code intelligence settings under it.
* `Browse` is a new button, it brings you to the directory view. Having a directory view is still important, and ultimately I would like for us to have this page reflect GitHub's directory view more closely. For now, though, it looks like this:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3173176/135198408-53af7e46-8e2b-4ac3-868a-698c91a16666.png">

Extracting code insights into its own repository (or directory) page was too hard (given this was just a less-than-2-day hackathon project), so I didn't implement this. Instead, it will cram itself into the directory page as it did before this change (if the option is enabled). I believe that we should move this to a separate page though - or at least seriously reconsider how it works.

</details>

# Feature flag

This was for a < 2 day hackathon. The code quality is good, I didn't do anything egregious, so I think we can merge it.

It's all behind a feature flag in user/org/global settings `"betterRepoPages": true`.

Once merged, I will turn this on for all Sourcegraph employees. If feedback is good after 1-4 weeks, I would turn it on by default.

If feedback on it is poor or there are a lot of changes needed to make everyone happy, I may choose to just axe it all.

Helps https://github.com/sourcegraph/sourcegraph/issues/15057
Helps https://github.com/sourcegraph/sourcegraph/issues/14459