### PR TITLE
ci: add possibility to skip a step

### DIFF
--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -33,7 +33,7 @@ If a step is flaky we need to get the build back to reliable as soon as possible
 
 An example use of `Skip`:
 
-``` diff
+```diff
 --- a/enterprise/dev/ci/internal/ci/operations.go
 +++ b/enterprise/dev/ci/internal/ci/operations.go
 @@ -260,7 +260,9 @@ func addGoBuild(pipeline *bk.Pipeline) {

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -13,3 +13,34 @@ go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 ## Testing
 
 To test this you can run `env BUILDKITE_BRANCH=TESTBRANCH go run ./enterprise/dev/ci/gen-pipeline.go` and inspect the YAML output. To change the behaviour set the relevant `BUILDKITE_` environment variables.
+
+## Flaky Tests
+
+Use language specific functionality to skip a test. If the language allows for a skip reason, include a link to track re-enabling the test.
+
+- Go :: [testing.T.Skip](https://pkg.go.dev/testing#hdr-Skipping).
+- Typescript :: [.skip()](https://mochajs.org/#inclusive-tests)
+
+Ping an owner about the skipping (normally on the PR skipping it).
+
+## Flaky Step
+
+If a step is flaky we need to get the build back to reliable as soon as possible. If there is not already a discussion in `#buildkite-main` create one and link what step you take. Here are the recommended approaches in order:
+
+1. Revert the PR if a recent change introduced the instability. Ping author.
+2. Use `Skip` StepOpt when creating the step. Include reason and a link to context. This will still show the step on builds so we don't forget about it.
+3. Use `SoftFail` StepOpt. This will still run the step, but won't block the build. Note: we don't yet have a convenient way to collect reliability information on a step.
+
+An example use of `Skip`:
+
+``` diff
+--- a/enterprise/dev/ci/internal/ci/operations.go
++++ b/enterprise/dev/ci/internal/ci/operations.go
+@@ -260,7 +260,9 @@ func addGoBuild(pipeline *bk.Pipeline) {
+ func addDockerfileLint(pipeline *bk.Pipeline) {
+        pipeline.AddStep(":docker: Lint",
+                bk.Cmd("./dev/ci/docker-lint.sh"),
++               bk.Skip("2021-09-29 example message https://github.com/sourcegraph/sourcegraph/issues/123"),
+        )
+ }
+```

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -39,6 +39,7 @@ type Step struct {
 	ArtifactPaths    string                 `json:"artifact_paths,omitempty"`
 	ConcurrencyGroup string                 `json:"concurrency_group,omitempty"`
 	Concurrency      int                    `json:"concurrency,omitempty"`
+	Skip             string                 `json:"skip,omitempty"`
 	SoftFail         bool                   `json:"soft_fail,omitempty"`
 	Retry            *RetryOptions          `json:"retry,omitempty"`
 	Agents           map[string]string      `json:"agents,omitempty"`
@@ -140,6 +141,12 @@ func Concurrency(limit int) StepOpt {
 func Env(name, value string) StepOpt {
 	return func(step *Step) {
 		step.Env[name] = value
+	}
+}
+
+func Skip(reason string) StepOpt {
+	return func(step *Step) {
+		step.Skip = reason
 	}
 }
 


### PR DESCRIPTION
This is to simplify disabling a bad step as well as giving better
context. I noticed people having to do quite large changes to disable a
test, when it should be a one liner.

Documented in buildkite README. There is probably a better place in our
docs or handbook? Unsure, but then we should atleast link to it in the
README I update.