### PR TITLE
web: finalize Percy build on dependency failure

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -30,7 +30,7 @@ type Step struct {
 	Key                    string                 `json:"key,omitempty"`
 	Command                []string               `json:"command,omitempty"`
 	DependsOn              []string               `json:"depends_on,omitempty"`
-	AllowDependencyFailure bool                   `json:"allowDependencyFailure,omitempty"`
+	AllowDependencyFailure bool                   `json:"allow_dependency_failure,omitempty"`
 	TimeoutInMinutes       string                 `json:"timeout_in_minutes,omitempty"`
 	Trigger                string                 `json:"trigger,omitempty"`
 	Async                  bool                   `json:"async,omitempty"`

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -26,23 +26,24 @@ type BuildOptions struct {
 }
 
 type Step struct {
-	Label            string                 `json:"label"`
-	Key              string                 `json:"key,omitempty"`
-	Command          []string               `json:"command,omitempty"`
-	DependsOn        []string               `json:"depends_on,omitempty"`
-	TimeoutInMinutes string                 `json:"timeout_in_minutes,omitempty"`
-	Trigger          string                 `json:"trigger,omitempty"`
-	Async            bool                   `json:"async,omitempty"`
-	Build            *BuildOptions          `json:"build,omitempty"`
-	Env              map[string]string      `json:"env,omitempty"`
-	Plugins          map[string]interface{} `json:"plugins,omitempty"`
-	ArtifactPaths    string                 `json:"artifact_paths,omitempty"`
-	ConcurrencyGroup string                 `json:"concurrency_group,omitempty"`
-	Concurrency      int                    `json:"concurrency,omitempty"`
-	Skip             string                 `json:"skip,omitempty"`
-	SoftFail         bool                   `json:"soft_fail,omitempty"`
-	Retry            *RetryOptions          `json:"retry,omitempty"`
-	Agents           map[string]string      `json:"agents,omitempty"`
+	Label                  string                 `json:"label"`
+	Key                    string                 `json:"key,omitempty"`
+	Command                []string               `json:"command,omitempty"`
+	DependsOn              []string               `json:"depends_on,omitempty"`
+	AllowDependencyFailure bool                   `json:"allowDependencyFailure,omitempty"`
+	TimeoutInMinutes       string                 `json:"timeout_in_minutes,omitempty"`
+	Trigger                string                 `json:"trigger,omitempty"`
+	Async                  bool                   `json:"async,omitempty"`
+	Build                  *BuildOptions          `json:"build,omitempty"`
+	Env                    map[string]string      `json:"env,omitempty"`
+	Plugins                map[string]interface{} `json:"plugins,omitempty"`
+	ArtifactPaths          string                 `json:"artifact_paths,omitempty"`
+	ConcurrencyGroup       string                 `json:"concurrency_group,omitempty"`
+	Concurrency            int                    `json:"concurrency,omitempty"`
+	Skip                   string                 `json:"skip,omitempty"`
+	SoftFail               bool                   `json:"soft_fail,omitempty"`
+	Retry                  *RetryOptions          `json:"retry,omitempty"`
+	Agents                 map[string]string      `json:"agents,omitempty"`
 }
 
 type RetryOptions struct {
@@ -197,5 +198,11 @@ func Plugin(name string, plugin interface{}) StepOpt {
 func DependsOn(dependency string) StepOpt {
 	return func(step *Step) {
 		step.DependsOn = append(step.DependsOn, dependency)
+	}
+}
+
+func AllowDependencyFailure() StepOpt {
+	return func(step *Step) {
+		step.AllowDependencyFailure = true
 	}
 }

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -201,6 +201,9 @@ func DependsOn(dependency string) StepOpt {
 	}
 }
 
+// AllowDependencyFailure enables `allow_dependency_failure` attribute on the step.
+// Such a step will run when the depended-on jobs complete, fail or even did not run.
+// See extended docs here: https://buildkite.com/docs/pipelines/dependencies#allowing-dependency-failures
 func AllowDependencyFailure() StepOpt {
 	return func(step *Step) {
 		step.AllowDependencyFailure = true

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -207,6 +207,7 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 
 	finalizeSteps := []bk.StepOpt{
 		skipGitCloneStep,
+		bk.AllowDependencyFailure(),
 		bk.Cmd("npx @percy/cli build:finalize"),
 	}
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -207,6 +207,7 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 
 	finalizeSteps := []bk.StepOpt{
 		skipGitCloneStep,
+		// Allow to teardown the Percy build even if there was a failure in the earlier Percy steps.
 		bk.AllowDependencyFailure(),
 		bk.Cmd("npx @percy/cli build:finalize"),
 	}


### PR DESCRIPTION
## Context

The web integration tests are parallelized using multiple Buildkite agents. The final step, which notifies Percy about build completion, depends on multiple agents. If one of them fails, the Percy build is never finalized, which causes subsequent Percy build to add snapshots to the last unfinished build with duplicate screenshot warnings. 

Tested in [this PR](https://github.com/sourcegraph/sourcegraph/pull/25506). The final step is [executed](https://buildkite.com/sourcegraph/sourcegraph/builds/109948#35db018f-75da-463d-a134-20cc718efdd5) despite a dependency failure.

## Changes

- Execute Percy finalize step even if dependencies fail to complete.