### PR TITLE
nix: use go1.17 from unstable

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,8 @@
 # - Runs postgres under ~/.sourcegraph with a unix socket. No need to manage a
 #   service. Must remember to run "pg_ctl stop" if you want to stop it.
 #
-# Status: go test ./... and yarn works
+# Status: everything works on linux. Go1.17 is currently broken on
+# darwin. https://github.com/NixOS/nixpkgs/commit/9675a865c9c3eeec36c06361f7215e109925654c
 
 { pkgs ? import <nixpkgs> { }, ... }:
 
@@ -18,26 +19,13 @@ let
     exec ${pkgs.universal-ctags}/bin/ctags "$@"
   '';
 
-  # go1.17 is not yet available in nixpkgs and is held up due to go requiring
-  # macOS 10.13 or later. So we use official go releases.
-  go_1_17 =
-    pkgs.callPackage "${<nixpkgs>}/pkgs/development/compilers/go/binary.nix" {
-      version = "1.17";
-      hashes = {
-        linux-amd64 =
-          "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d";
-        darwin-amd64 =
-          "355bd544ce08d7d484d9d7de05a71b5c6f5bc10aa4b316688c2192aeb3dacfd1";
-      };
-    };
-
   # need unstable to get the latest version of node. We pin a very specific
   # commit to make this reproducable.
   unstable = import (pkgs.fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "f3706ab27f99b2ffdaeb6dd03ee6e2f26511c6db";
-    sha256 = "1fb3z0y08y1jjhzffsg4qa5y9mk434s167n55avcwbqqjwd7kj1c";
+    rev = "9675a865c9c3eeec36c06361f7215e109925654c";
+    sha256 = "1agsmz77bwdpga9p35ayw4pmwacpa4m31d43c6zdksr7qkknyavx";
   }) { };
 
 in pkgs.mkShell {
@@ -53,10 +41,10 @@ in pkgs.mkShell {
 
     # Used by symbols and zoekt-git-index to extract symbols from
     # sourcecode.
-    universal-ctags
+    pkgs.universal-ctags
 
     # Build our backend.
-    go_1_17
+    unstable.go_1_17
 
     # Lots of our tooling and go tests rely on git et al.
     pkgs.git
@@ -84,10 +72,4 @@ in pkgs.mkShell {
   # By explicitly setting this environment variable we avoid starting up
   # universal-ctags via docker.
   CTAGS_COMMAND = "${universal-ctags}/bin/universal-ctags";
-
-  # Official go release expects GOROOT to be /usr/local/go. While we are using
-  # the official release we need to point it to the correct place and disable
-  # CGO.
-  GOROOT = "${go_1_17}/share/go";
-  CGO_ENABLED = "0";
 }


### PR DESCRIPTION
go1.17 is in nixpkgs. It doesn't yet work for darwin, but I believe
everyone using nix is doing so on Linux. I sometimes use darwin +
nix, but switching back to brew won't break my workflow.