### PR TITLE
sg: add debug-env command

### DIFF
--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -222,6 +222,8 @@ To modify your configuration locally, you can overwrite chunks of configuration 
 If an `sg.config.overwrite.yaml` file exists, its contents will be merged with the content of `sg.config.yaml`, overwriting where there are conflicts. This is useful for running custom command sets or adding environment variables
 specific to your work.
 
+You can run `sg run debug-env` to see the environment variables passed `sg`'s child processes.
+
 ### Examples
 
 #### Changing database configuration

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -650,7 +650,8 @@ commands:
       - monitoring
     continueWatchOnExit: true
 
-  env:
+  # This will execute `env`, a utility to print the process environment. Can be used to debug which global vars `sg` uses.
+  debug-env:
     cmd: env
 
 checks:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -650,6 +650,9 @@ commands:
       - monitoring
     continueWatchOnExit: true
 
+  env:
+    cmd: env
+
 checks:
   docker:
     cmd: docker version

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -650,7 +650,8 @@ commands:
       - monitoring
     continueWatchOnExit: true
 
-  # This will execute `env`, a utility to print the process environment. Can be used to debug which global vars `sg` uses.
+  # This will execute `env`, a utility to print the process environment. Can
+  # be used to debug which global vars `sg` uses.
   debug-env:
     cmd: env
 


### PR DESCRIPTION
To debug environment you can run `sg run env` to see the computed
environment.

Anywhere useful to document this?