### PR TITLE
search: refactor suggestions to use streaming search

### DIFF
--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -5,9 +5,8 @@ import { first } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 
 import { SymbolKind } from '../../graphql-operations'
-import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup, ISearchContext } from '../../graphql/schema'
 import { isDefined } from '../../util/types'
-import { SearchSuggestion } from '../suggestions'
+import { MatchedSymbol, PathMatch, RepositoryMatch, SearchMatch } from '../stream'
 
 import { FilterType, isNegatableFilter, resolveFilter, FILTERS, escapeSpaces } from './filters'
 import { toMonacoSingleLineRange } from './monaco'
@@ -66,34 +65,35 @@ const FILTER_TYPE_COMPLETIONS: Omit<Monaco.languages.CompletionItem, 'range'>[] 
     }))
 
 const repositoryToCompletion = (
-    { name }: IRepository,
+    { repository }: RepositoryMatch,
     options: { isFilterValue: boolean; globbing: boolean }
 ): PartialCompletionItem => {
-    let insertText = options.globbing ? name : `^${escapeRegExp(name)}$`
+    let insertText = options.globbing ? repository : `^${escapeRegExp(repository)}$`
     insertText = escapeSpaces(insertText)
     insertText = (options.isFilterValue ? insertText : `${FilterType.repo}:${insertText}`) + ' '
     return {
-        label: name,
+        label: repository,
         kind: repositoryCompletionItemKind,
         insertText,
-        filterText: name,
+        filterText: repository,
         detail: options.isFilterValue ? undefined : 'Repository',
     }
 }
 
 const fileToCompletion = (
-    { name, path, repository, isDirectory }: IFile,
+    { path, repository }: PathMatch,
     options: { isFilterValue: boolean; globbing: boolean }
 ): PartialCompletionItem => {
     let insertText = options.globbing ? path : `^${escapeRegExp(path)}$`
     insertText = escapeSpaces(insertText)
     insertText = (options.isFilterValue ? insertText : `${FilterType.file}:${insertText}`) + ' '
     return {
-        label: name,
-        kind: isDirectory ? Monaco.languages.CompletionItemKind.Folder : Monaco.languages.CompletionItemKind.File,
+        label: path,
+        // TODO: kind: isDirectory ? Monaco.languages.CompletionItemKind.Folder : Monaco.languages.CompletionItemKind.File,
+        kind: Monaco.languages.CompletionItemKind.File,
         insertText,
-        filterText: name,
-        detail: `${path} - ${repository.name}`,
+        filterText: path,
+        detail: `${path} - ${repository}`,
     }
 }
 
@@ -130,57 +130,28 @@ const symbolKindToCompletionItemKind: Record<SymbolKind, Monaco.languages.Comple
     TYPEPARAMETER: Monaco.languages.CompletionItemKind.TypeParameter,
 }
 
-const symbolToCompletion = ({ name, kind, location }: ISymbol): PartialCompletionItem => ({
+const symbolToCompletion = ({ name, kind }: MatchedSymbol, repository: string): PartialCompletionItem => ({
     label: name,
     kind: symbolKindToCompletionItemKind[kind],
     insertText: name + ' ',
     filterText: name,
-    detail: `${startCase(kind.toLowerCase())} - ${location.resource.repository.name}`,
-})
-
-const languageToCompletion = ({ name }: ILanguage): PartialCompletionItem | undefined =>
-    name
-        ? {
-              label: name,
-              kind: Monaco.languages.CompletionItemKind.TypeParameter,
-              insertText: name + ' ',
-              filterText: name,
-          }
-        : undefined
-
-const repoGroupToCompletion = ({ name }: IRepoGroup): PartialCompletionItem => ({
-    label: name,
-    kind: repositoryCompletionItemKind,
-    insertText: name + ' ',
-    filterText: name,
-})
-
-const searchContextToCompletion = ({ spec, description }: ISearchContext): PartialCompletionItem => ({
-    label: spec,
-    kind: repositoryCompletionItemKind,
-    insertText: spec + ' ',
-    filterText: spec,
-    detail: description,
+    detail: `${startCase(kind.toLowerCase())} - ${repository}`,
 })
 
 const suggestionToCompletionItem = (
-    suggestion: SearchSuggestion,
+    suggestion: SearchMatch,
     options: { isFilterValue: boolean; globbing: boolean }
 ): PartialCompletionItem | undefined => {
-    switch (suggestion.__typename) {
-        case 'File':
+    switch (suggestion.type) {
+        case 'path':
             return fileToCompletion(suggestion, options)
-        case 'Repository':
+        case 'repo':
             return repositoryToCompletion(suggestion, options)
-        case 'Symbol':
-            return symbolToCompletion(suggestion)
-        case 'Language':
-            return languageToCompletion(suggestion)
-        case 'RepoGroup':
-            return repoGroupToCompletion(suggestion)
-        case 'SearchContext':
-            return searchContextToCompletion(suggestion)
+        case 'symbol':
+            return symbolToCompletion(suggestion.symbols[0], suggestion.repository)
     }
+
+    return undefined
 }
 
 /**
@@ -211,7 +182,7 @@ const completeStart = (): Monaco.languages.CompletionList => ({
 })
 
 async function completeDefault(
-    dynamicSuggestions: Observable<SearchSuggestion[]>,
+    dynamicSuggestions: Observable<SearchMatch[]>,
     token: Token,
     globbing: boolean
 ): Promise<Monaco.languages.CompletionList> {
@@ -253,7 +224,7 @@ async function completeDefault(
 }
 
 async function completeFilter(
-    serverSuggestions: Observable<SearchSuggestion[]>,
+    serverSuggestions: Observable<SearchMatch[]>,
     token: Filter,
     column: number,
     globbing: boolean,
@@ -297,9 +268,9 @@ async function completeFilter(
     if (resolvedFilter.definition.suggestions) {
         // If the filter definition has an associated dynamic suggestion type,
         // use it to retrieve dynamic suggestions from the backend.
-        const suggestions = await serverSuggestions.pipe(first()).toPromise()
+        const suggestions = await serverSuggestions.toPromise()
         dynamicSuggestions = suggestions
-            .filter(({ __typename }) => __typename === resolvedFilter.definition.suggestions)
+            .filter(({ type }) => type === resolvedFilter.definition.suggestions)
             .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: true, globbing }))
             .filter(isDefined)
             .map((partialCompletionItem, index) => ({
@@ -322,9 +293,9 @@ async function completeFilter(
  * including both static and dynamically fetched suggestions.
  */
 export async function getCompletionItems(
-    tokens: Token[],
+    token: Token,
     { column }: Pick<Monaco.Position, 'column'>,
-    dynamicSuggestions: Observable<SearchSuggestion[]>,
+    dynamicSuggestions: Observable<SearchMatch[]>,
     globbing: boolean,
     isSourcegraphDotCom?: boolean
 ): Promise<Monaco.languages.CompletionList | null> {
@@ -332,11 +303,6 @@ export async function getCompletionItems(
         // Show all filter suggestions on the first column.
         return completeStart()
     }
-    const tokenAtColumn = tokens.find(({ range }) => range.start + 1 <= column && range.end + 1 >= column)
-    if (!tokenAtColumn) {
-        throw new Error('getCompletionItems: no token at column')
-    }
-    const token = tokenAtColumn
     // When the token at column is labeled as a pattern or whitespace, and none of filter,
     // operator, nor quoted value, show static filter type suggestions, followed by dynamic suggestions.
     if (token.type === 'pattern' || token.type === 'whitespace') {

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -1,6 +1,6 @@
 import { Omit } from 'utility-types'
 
-import { SearchSuggestion } from '../suggestions'
+import { SearchMatch } from '../stream'
 
 import { languageCompletion } from './languageFilter'
 import { predicateCompletion } from './predicates'
@@ -140,7 +140,7 @@ interface BaseFilterDefinition {
     alias?: string
     description: string
     discreteValues?: (value: Literal | undefined, isSourcegraphDotCom?: boolean) => Completion[]
-    suggestions?: SearchSuggestion['__typename']
+    suggestions?: SearchMatch['type']
     default?: string
     /** Whether the filter may only be used 0 or 1 times in a query. */
     singular?: boolean
@@ -213,7 +213,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     [FilterType.context]: {
         description: 'Search only repositories within a specified context',
         singular: true,
-        suggestions: 'SearchContext',
+        // suggestions: 'SearchContext',
     },
     [FilterType.count]: {
         description: 'Number of results to fetch (integer) or "all"',
@@ -224,7 +224,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         negatable: true,
         description: negated =>
             `${negated ? 'Exclude' : 'Include only'} results from files matching the given search pattern.`,
-        suggestions: 'File',
+        suggestions: 'path',
     },
     [FilterType.fork]: {
         discreteValues: () => ['yes', 'no', 'only'].map(value => ({ label: value })),
@@ -257,13 +257,12 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         ],
         description: negated =>
             `${negated ? 'Exclude' : 'Include only'} results from repositories matching the given search pattern.`,
-        suggestions: 'Repository',
+        suggestions: 'repo',
     },
     [FilterType.repogroup]: {
         alias: 'g',
         description: 'group-name (include results from the named group)',
         singular: true,
-        suggestions: 'RepoGroup',
     },
     [FilterType.repohascommitafter]: {
         description: '"string specifying time frame" (filter out stale repositories without recent commits)',

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -12,12 +12,11 @@ import { MonacoEditor } from '../components/MonacoEditor'
 import { PageTitle } from '../components/PageTitle'
 import { SearchPatternType } from '../graphql-operations'
 
-import { fetchSuggestions } from './backend'
 import { LATEST_VERSION } from './results/StreamingSearchResults'
 import { StreamingSearchResultsList, StreamingSearchResultsListProps } from './results/StreamingSearchResultsList'
 import { useQueryIntelligence, useQueryDiagnostics } from './useQueryIntelligence'
 
-import { parseSearchURLQuery, parseSearchURLPatternType, SearchStreamingProps } from '.'
+import { parseSearchURLQuery, parseSearchURLPatternType, SearchStreamingProps, fetchStreamSuggestions } from '.'
 
 interface SearchConsolePageProps
     extends SearchStreamingProps,
@@ -82,7 +81,7 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
         }, [patternType, props.location.search, streamSearch])
     )
 
-    const sourcegraphSearchLanguageId = useQueryIntelligence(fetchSuggestions, {
+    const sourcegraphSearchLanguageId = useQueryIntelligence(fetchStreamSuggestions, {
         patternType,
         globbing,
         interpretComments: true,

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -7,7 +7,12 @@ import { ISavedSearch } from '@sourcegraph/shared/src/graphql/schema'
 import { discreteValueAliases, escapeSpaces, FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { Filter } from '@sourcegraph/shared/src/search/query/token'
 import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/validate'
-import { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
+import {
+    AggregateStreamingSearchResults,
+    SearchMatch,
+    StreamSearchOptions,
+    firstMatchStreamingSearch,
+} from '@sourcegraph/shared/src/search/stream'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { memoizeObservable } from '@sourcegraph/shared/src/util/memoizeObservable'
 import { replaceRange } from '@sourcegraph/shared/src/util/strings'
@@ -27,6 +32,7 @@ import {
     deleteSearchContext,
     getUserSearchContextNamespaces,
 } from './backend'
+import { LATEST_VERSION } from './results/StreamingSearchResults'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it
@@ -288,3 +294,14 @@ export const getAvailableSearchContextSpecOrDefault = memoizeObservable(
         isSearchContextAvailable(spec).pipe(map(isAvailable => (isAvailable ? spec : defaultSpec))),
     ({ spec, defaultSpec }) => `${spec}:${defaultSpec}`
 )
+
+export function fetchStreamSuggestions(query: string): Observable<SearchMatch[]> {
+    return firstMatchStreamingSearch({
+        query,
+        version: LATEST_VERSION,
+        patternType: SearchPatternType.literal,
+        caseSensitive: false,
+        versionContext: undefined,
+        trace: undefined,
+    }).pipe(map(suggestions => suggestions.results))
+}

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -12,11 +12,10 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { hasProperty } from '@sourcegraph/shared/src/util/types'
 
-import { CaseSensitivityProps, PatternTypeProps, SearchContextProps } from '..'
+import { CaseSensitivityProps, fetchStreamSuggestions, PatternTypeProps, SearchContextProps } from '..'
 import { MonacoEditor } from '../../components/MonacoEditor'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
 import { observeResize } from '../../util/dom'
-import { fetchSuggestions } from '../backend'
 import { QueryChangeSource, QueryState } from '../helpers'
 import { useQueryIntelligence, useQueryDiagnostics } from '../useQueryIntelligence'
 
@@ -137,7 +136,8 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
     }, [editor, container])
 
     const fetchSuggestionsWithContext = useCallback(
-        (query: string) => fetchSuggestions(appendContextFilter(query, selectedSearchContextSpec, versionContext)),
+        (query: string) =>
+            fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec, versionContext)),
         [selectedSearchContextSpec, versionContext]
     )
 

--- a/client/web/src/search/notebook/SearchNotebook.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.tsx
@@ -5,8 +5,7 @@ import { SearchPatternType } from '@sourcegraph/shared/src/graphql/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { SearchStreamingProps } from '..'
-import { fetchSuggestions } from '../backend'
+import { fetchStreamSuggestions, SearchStreamingProps } from '..'
 import { StreamingSearchResultsListProps } from '../results/StreamingSearchResultsList'
 import { useQueryIntelligence } from '../useQueryIntelligence'
 
@@ -197,7 +196,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
         }
     }, [notebook, selectedBlockId, onMoveBlockSelection, setSelectedBlockId])
 
-    const sourcegraphSearchLanguageId = useQueryIntelligence(fetchSuggestions, {
+    const sourcegraphSearchLanguageId = useQueryIntelligence(fetchStreamSuggestions, {
         patternType: SearchPatternType.literal,
         globbing: props.globbing,
         interpretComments: true,

--- a/client/web/src/search/useQueryIntelligence.ts
+++ b/client/web/src/search/useQueryIntelligence.ts
@@ -7,7 +7,7 @@ import { SearchPatternType } from '@sourcegraph/shared/src/graphql/schema'
 import { getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
 import { getProviders } from '@sourcegraph/shared/src/search/query/providers'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import { SearchSuggestion } from '@sourcegraph/shared/src/search/suggestions'
+import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
 const SOURCEGRAPH_SEARCH = 'sourcegraphSearch' as const
 
@@ -15,7 +15,7 @@ const SOURCEGRAPH_SEARCH = 'sourcegraphSearch' as const
  * Adds code intelligence for the Sourcegraph search syntax to Monaco.
  */
 export function useQueryIntelligence(
-    fetchSuggestions: (query: string) => Observable<SearchSuggestion[]>,
+    fetchSuggestions: (query: string) => Observable<SearchMatch[]>,
     options: {
         patternType: SearchPatternType
         globbing: boolean


### PR DESCRIPTION
Fixes #24983

Instead of using the SearchSuggestions GQL endpoint, I refactored the client suggestions to use streaming search endpoint. For example, to get suggestions for `repo:source` filter we transform the query into `source type:repo patterntype:regexp count:50` and use the search results as suggestions.