### PR TITLE
sg: check dev-private exists in 'sg start'

### DIFF
--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -60,9 +60,9 @@ type Commandset struct {
 	Checks   []string          `yaml:"checks"`
 	Env      map[string]string `yaml:"env"`
 
-	// If this is set to true, then the commandset doesn't need the dev-private
-	// repository.
-	NoDevPrivate bool `yaml:"noDevPrivate"`
+	// If this is set to true, then the commandset requires the dev-private
+	// repository to be cloned at the same level as the sourcegraph repository.
+	RequiresDevPrivate bool `yaml:"requiresDevPrivate"`
 }
 
 // UnmarshalYAML implements the Unmarshaler interface.

--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -59,6 +59,10 @@ type Commandset struct {
 	Commands []string          `yaml:"commands"`
 	Checks   []string          `yaml:"checks"`
 	Env      map[string]string `yaml:"env"`
+
+	// If this is set to true, then the commandset doesn't need the dev-private
+	// repository.
+	NoDevPrivate bool `yaml:"noDevPrivate"`
 }
 
 // UnmarshalYAML implements the Unmarshaler interface.

--- a/dev/sg/sg.config.example.yaml
+++ b/dev/sg/sg.config.example.yaml
@@ -123,6 +123,17 @@ commandsets:
     env:
       SOURCEGRAPHDOTCOM_MODE: true
 
+  oss:
+    noDevPrivate: true
+    checks:
+      - docker
+      - redis
+    commands:
+      - frontend
+      - repo-updater
+      - gitserver
+      - web
+
 tests:
   # These can be run with `sg test [name]`
   # Every command is run from the repository root.

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -107,7 +107,7 @@ func startExec(ctx context.Context, args []string) error {
 
 	// If the commandset requires the dev-private repository to be cloned, we
 	// check that it's at the right location here.
-	if !set.NoDevPrivate {
+	if set.RequiresDevPrivate {
 		repoRoot, err := root.RepositoryRoot()
 		if err != nil {
 			out.WriteLine(output.Linef("", output.StyleWarning, "Failed to determine repository root location: %s", err))
@@ -124,6 +124,17 @@ func startExec(ctx context.Context, args []string) error {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: dev-private repository not found!"))
 			out.WriteLine(output.Linef("", output.StyleWarning, "It's expected to exist at: %s", devPrivatePath))
 			out.WriteLine(output.Line("", output.StyleWarning, "See the documentation for how to clone it: https://docs.sourcegraph.com/dev/getting-started/quickstart_2_clone_repository"))
+
+			out.Write("")
+			overwritePath := filepath.Join(repoRoot, "sg.config.overwrite.yaml")
+			out.WriteLine(output.Linef("", output.StylePending, "If you know what you're doing and want disable the check, add the following to %s:", overwritePath))
+			out.Write("")
+			out.Write(fmt.Sprintf(`  commandsets:
+    %s:
+      requiresDevPrivate: false
+`, set.Name))
+			out.Write("")
+
 			os.Exit(1)
 		}
 	}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -670,9 +670,9 @@ checks:
     failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
 
 commandsets:
-  # TODO: Should we be able to define "env" vars _per set_?
-
   oss:
+    # open-source version doesn't require the dev-private repository
+    noDevPrivate: true
     checks:
       - docker
       - redis

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -672,7 +672,7 @@ checks:
 commandsets:
   oss:
     # open-source version doesn't require the dev-private repository
-    noDevPrivate: true
+    requiresDevPrivate: false
     checks:
       - docker
       - redis
@@ -696,6 +696,7 @@ commandsets:
       - zoekt-webserver-1
 
   enterprise: &enterprise_set
+    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -726,6 +727,7 @@ commandsets:
       SOURCEGRAPHDOTCOM_MODE: true
 
   enterprise-codeintel:
+    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -752,6 +754,7 @@ commandsets:
       - codeintel-executor
 
   enterprise-codeinsights:
+    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -779,6 +782,7 @@ commandsets:
       DISABLE_CODE_INSIGHTS: false
 
   api-only:
+    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -797,6 +801,7 @@ commandsets:
       - zoekt-webserver-1
 
   batches:
+    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -821,6 +826,7 @@ commandsets:
       - batches-executor
 
   core-app:
+    requiresDevPrivate: true
     checks:
       - docker
       - redis


### PR DESCRIPTION
First attempt at https://github.com/sourcegraph/sourcegraph/issues/25501.

I think this is fine for now and can avoid new colleagues running into this problem.

It also got me thinking: I could've defined this as "check" in
`sg.config.yaml`. But then I realised that in order to get a readable
error message out of that I'd have to do some bash scripting. And that
in turn reinforces my thought that the `checks:` should probably be Go
functions. Thoughts?