### PR TITLE
search: Fix incorrect query diagnostic for empty repo: filters

### DIFF
--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -299,6 +299,26 @@ describe('getDiagnostics()', () => {
                   }
                 ]
             `)
+            expect(parseAndDiagnose('rev:main repo:', SearchPatternType.literal)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": 8,
+                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 10,
+                    "endColumn": 14
+                  },
+                  {
+                    "severity": 8,
+                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
+                    "startLineNumber": 1,
+                    "endLineNumber": 1,
+                    "startColumn": 1,
+                    "endColumn": 4
+                  }
+                ]
+            `)
         })
 
         test('accepts rev filter if valid repo filter is present', () => {

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -125,7 +125,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
                 not(some({ ...repoFilterPattern, value: { value: value => value !== '' } })),
                 some({
                     ...repoFilterPattern,
-                    value: { value: '' },
+                    value: oneOf(undefined, { value: '' }),
                     $data: (token: Token, context: MatchContext<PatternData>) => {
                         const errorMessage =
                             'Error: query contains `rev:` with an empty `repo:` filter. Add a non-empty `repo:` filter.'

--- a/client/shared/src/search/query/patternMatcher.test.ts
+++ b/client/shared/src/search/query/patternMatcher.test.ts
@@ -82,11 +82,14 @@ describe('matchValue', () => {
 
             // @ts-expect-error cannot use a non-existing field to match an object
             expect({ field1: 42, field2: 21 }).not.toBeMatchedBy({ field3: 42 })
+            expect({ field1: undefined } as { field1: undefined | { field2: number } }).not.toBeMatchedBy({
+                field1: { field2: 42 },
+            })
         })
 
-        it('allows self reference objects as patterns', () => {
+        it('allows wrapper patterns ', () => {
             expect(42).toBeMatchedBy({ $pattern: 42, $data: {} })
-            // Self referenced objects must use a function as pattern
+            // Wrapper patterns for objects must use a function as pattern
             expect({ field1: 0 }).toBeMatchedBy({ $pattern: ({ field1 }) => field1 === 0 })
             expect({ field1: 0, field2: 21 }).toBeMatchedBy({ $pattern: ({ field1 }) => field1 === 0, field2: 21 })
             expect({ field1: 0, field2: 21 }).not.toBeMatchedBy({ $pattern: ({ field1 }) => field1 === 0, field2: 42 })


### PR DESCRIPTION
The pattern to verify whether the value contains a `@` matched because object patterns defaulted to a positive match result, even if the input value wasn't an object and therefore the pattern was never applied.

I added the missing tests that would have caught that issue.


Fixes #25466 
