### PR TITLE
db: Reduce pressure from status messages

### DIFF
--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -81,17 +81,17 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 
 	// Look for any repository that we could not sync
 	opts = database.ReposListOptions{
-		ExternalServiceIDs: extsvcIDs,
 		FailedFetch:        true,
+		ExternalServiceIDs: extsvcIDs,
 		LimitOffset: &database.LimitOffset{
 			Limit: 1,
 		},
 	}
-	failedSync, err := database.Repos(db).Count(ctx, opts)
+	failedSync, err := database.Repos(db).ListRepoNames(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "counting repo sync failures")
 	}
-	if failedSync > 0 {
+	if len(failedSync) > 0 {
 		messages = append(messages, StatusMessage{
 			SyncError: &SyncError{
 				Message: "Some repositories could not be synced",


### PR DESCRIPTION
The count query in this graphql request is currently the dominating query in Cloud according to query insights. Instead of doing a full aggregate of the number of repos (which can be slow for site-admins), we should check if there exists _any_ repos matching the same conditions.

This should preserve the current behavior, but tagged @sourcegraph/repo-management to confirm.