### PR TITLE
client/testing: relax puppeteer timeout

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -765,7 +765,7 @@ export async function createDriverForTest(options?: Partial<DriverOptions>): Pro
         ...resolvedOptions,
         args,
         defaultViewport: null,
-        timeout: 30000,
+        timeout: 300000,
     }
     let browser: puppeteer.Browser
     const browserName = resolvedOptions.browser || 'chrome'


### PR DESCRIPTION
relax this timeout from one magic number (30000ms) to another (300000ms aka 5m) which is also used [elsewhere](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/testing/driver.ts#L411:37). This timeout seems to be getting hit in various flakes, e.g. https://buildkite.com/sourcegraph/qa/builds/5781#64f82fac-0650-47d9-9a67-47c4f91afcb1/874-971:

```
sourcegraph-e2e:   1 failing
--
  | sourcegraph-e2e:   1) e2e test suite
  | sourcegraph-e2e:        "before all" hook in "e2e test suite":
  | sourcegraph-e2e:      TimeoutError: Navigation timeout of 30000 ms exceeded
```

This is a pretty frequent flake and nothing seems to be wrong when deployed, so this should be a safe change.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
