### PR TITLE
codeintel: Add missing indexes

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1057,6 +1057,7 @@ Indexes:
     "lsif_indexes_pkey" PRIMARY KEY, btree (id)
     "lsif_indexes_commit_last_checked_at" btree (commit_last_checked_at) WHERE state <> 'deleted'::text
     "lsif_indexes_repository_id_commit" btree (repository_id, commit)
+    "lsif_indexes_state" btree (state)
 Check constraints:
     "lsif_uploads_commit_valid_chars" CHECK (commit ~ '^[a-z0-9]{40}$'::text)
 
@@ -1254,7 +1255,7 @@ Indexes:
     "lsif_uploads_associated_index_id" btree (associated_index_id)
     "lsif_uploads_commit_last_checked_at" btree (commit_last_checked_at) WHERE state <> 'deleted'::text
     "lsif_uploads_committed_at" btree (committed_at) WHERE state = 'completed'::text
-    "lsif_uploads_repository_id" btree (repository_id)
+    "lsif_uploads_repository_id_commit" btree (repository_id, commit)
     "lsif_uploads_state" btree (state)
     "lsif_uploads_uploaded_at" btree (uploaded_at)
 Check constraints:

--- a/migrations/frontend/1528395899_add_index_for_lsif_indexes_state.down.sql
+++ b/migrations/frontend/1528395899_add_index_for_lsif_indexes_state.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS lsif_indexes_state;
+COMMIT;

--- a/migrations/frontend/1528395899_add_index_for_lsif_indexes_state.up.sql
+++ b/migrations/frontend/1528395899_add_index_for_lsif_indexes_state.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_indexes_state ON lsif_indexes(state);

--- a/migrations/frontend/1528395900_add_commit_to_lsif_uploads_repository_index.down.sql
+++ b/migrations/frontend/1528395900_add_commit_to_lsif_uploads_repository_index.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS lsif_uploads_repository_id_commit;
+COMMIT;

--- a/migrations/frontend/1528395900_add_commit_to_lsif_uploads_repository_index.up.sql
+++ b/migrations/frontend/1528395900_add_commit_to_lsif_uploads_repository_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_uploads_repository_id_commit ON lsif_uploads(repository_id, commit);

--- a/migrations/frontend/1528395901_remove_duplicate_index.down.sql
+++ b/migrations/frontend/1528395901_remove_duplicate_index.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_uploads_repository_id ON lsif_uploads(repository_id);

--- a/migrations/frontend/1528395901_remove_duplicate_index.up.sql
+++ b/migrations/frontend/1528395901_remove_duplicate_index.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS lsif_uploads_repository_id;
+COMMIT;


### PR DESCRIPTION
This shouldn't really do anything, these were added mostly for symmetry and some _slight_ improvements to the queue count query that's currently non-dominating and will be called less frequently in the near future.