### PR TITLE
client/regression: relax timeouts

### DIFF
--- a/client/web/src/regression/util/api.ts
+++ b/client/web/src/regression/util/api.ts
@@ -66,8 +66,8 @@ export function waitForRepo(
     {
         logStatusMessages,
         shouldNotExist = false,
-        retryPeriod = 2000, // 2 seconds
-        timeout = 60000, // 1 minute
+        retryPeriod = 5000, // 5 seconds
+        timeout = 300000, // 5 minutes
         indexed: mustBeIndexed = false,
     }: WaitForRepoOptions = {}
 ): Observable<void> {


### PR DESCRIPTION
Related: #25519 

https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1632929998081600

Let's just see if these tests _ever_ pass before restricting timeouts

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
