### PR TITLE
client/testing: relax even more timeouts

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -234,7 +234,7 @@ export class Driver {
             // you back to the login page
             await delay(1000)
             await this.page.click('button[type=submit]')
-            await this.page.waitForNavigation({ timeout: 3 * 10000 })
+            await this.page.waitForNavigation({ timeout: 300000 })
         } else if (url.pathname === '/sign-in') {
             await this.page.waitForSelector('.test-signin-form')
             await this.page.type('input', username)
@@ -242,7 +242,7 @@ export class Driver {
             // TODO(uwedeportivo): see comment above, same reason
             await delay(1000)
             await this.page.click('button[type=submit]')
-            await this.page.waitForNavigation({ timeout: 3 * 10000 })
+            await this.page.waitForNavigation({ timeout: 300000 })
         }
     }
 


### PR DESCRIPTION
Missed these two because they did _math_ instead of defining 30000 so they didn't show up in a search for #25519 

Bump timeout from 30000 -> 300000 (ms)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
