### PR TITLE
sg: restore `CTAGS_COMMAND=$(which ctags) sg start` functionality

### DIFF
--- a/cmd/symbols/universal-ctags-dev
+++ b/cmd/symbols/universal-ctags-dev
@@ -3,7 +3,9 @@
 # This script is a wrapper around `universal-ctags`.
 #
 # To use your own `universal-ctags` binary instead of this wrapper in your local dev server, use
-# `CTAGS_COMMAND=path/to/ctags dev/start.sh`.
+# `CTAGS_COMMAND=path/to/ctags sg start`.
+
+[[ -n $CTAGS_COMMAND ]] && exec "$CTAGS_COMAND" "$@"
 
 exec docker run --rm -i \
     -a stdin -a stdout -a stderr \


### PR DESCRIPTION
On Linux, constantly starting new docker containers to run ctags can
cause annoying transient network interruptions. A local ctags binary
solves this, but sg was missing the workaround that start.sh had.
