### PR TITLE
new commit/diff search: fix null deref error

### DIFF
--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -220,7 +220,7 @@ type Operator struct {
 }
 
 func (o *Operator) Match(commit *LazyCommit) (bool, *MatchedCommit, error) {
-	var resultMatches *MatchedCommit
+	resultMatches := &MatchedCommit{}
 	hasMatch := false
 	for _, operand := range o.Operands {
 		matched, matches, err := operand.Match(commit)


### PR DESCRIPTION
This fixes an issue that would cause null deref panics on the new
commit/diff search path when a commit matches without any highlights
(e.g. only author matches).



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
