### PR TITLE
sg: fix `sg start -debug zoekt-webserver-0`

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -194,7 +194,12 @@ func logLevelOverrides() map[string]string {
 	overrides := make(map[string]string)
 	for level, services := range levelServices {
 		for _, service := range services {
-			overrides[service] = level
+			if level == "debug" && strings.HasPrefix(service, "zoekt-") {
+				// zoekt-indexserver and zoekt-webserver expects "dbug", not "debug".
+				overrides[service] = "dbug"
+			} else {
+				overrides[service] = level
+			}
 		}
 	}
 


### PR DESCRIPTION
Zoekt expects the env var to be "dbug", not "debug". It's slightly
easier to fix the logic here than to bump a zoekt version to change the
logic.