### PR TITLE
avoid "no results" alert when there are results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1469,7 +1469,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		cancel()
 		requiredWg.Wait()
 		optionalWg.Wait()
-		_, _, _ = agg.Get()
+		_, _, _, _ = agg.Get()
 	}()
 
 	args.RepoOptions = r.toRepoOptions(args.Query, resolveRepositoriesOpts{})
@@ -1640,7 +1640,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 // toSearchResults relies on all WaitGroups being done since it relies on
 // collecting from the streams.
 func (r *searchResolver) toSearchResults(ctx context.Context, agg *run.Aggregator) (*SearchResults, error) {
-	matches, common, aggErrs := agg.Get()
+	matches, common, matchCount, aggErrs := agg.Get()
 
 	if aggErrs == nil {
 		return nil, errors.New("aggErrs should never be nil")
@@ -1648,7 +1648,7 @@ func (r *searchResolver) toSearchResults(ctx context.Context, agg *run.Aggregato
 
 	ao := alertObserver{
 		Inputs:     r.SearchInputs,
-		hasResults: len(matches) > 0,
+		hasResults: matchCount > 0,
 	}
 	for _, err := range aggErrs.Errors {
 		ao.Error(ctx, err)


### PR DESCRIPTION
When streaming results, the aggregator does not hold the list of results
in memory, so the alertObserver was being created with 
`hasResults == false` even though we've streamed results. That caused us
to show a "no results" alert in some cases even though we've sent results.

This commit adds a resultCount field to the aggregator so it can track
how many results it has streamed, and use that for creating the
alertObserver and for generating alerts.

An alternative here would be to add a result count to the Stats struct,
but it felt strange to be updating that when no stats event was sent
down the stream.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
