### PR TITLE
remove stdout/stderr redirection from jaeger

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -519,10 +519,9 @@ commands:
 
   jaeger:
     cmd: |
-      .bin/jaeger-all-in-one-${JAEGER_VERSION}-$(go env GOOS)-$(go env GOARCH) --log-level ${JAEGER_LOG_LEVEL} >> "${JAEGER_LOGS}"/jaeger.log 2>&1
+      .bin/jaeger-all-in-one-${JAEGER_VERSION}-$(go env GOOS)-$(go env GOARCH) --log-level ${JAEGER_LOG_LEVEL}
     install: |
       mkdir -p "${JAEGER_DISK}"
-      mkdir -p "${JAEGER_LOGS}"
 
       suffix="${JAEGER_VERSION}-$(go env GOOS)-$(go env GOARCH)"
       target="$PWD/.bin/jaeger-all-in-one-${suffix}"
@@ -538,7 +537,6 @@ commands:
     env:
       JAEGER_VERSION: 1.18.1
       JAEGER_DISK: $HOME/.sourcegraph-dev/data/jaeger
-      JAEGER_LOGS: $HOME/.sourcegraph-dev/logs/jaeger
       JAEGER_LOG_LEVEL: info
       QUERY_BASE_PATH: /-/debug/jaeger
 


### PR DESCRIPTION
This commit removes the redirection of stdout/stderr from jaeger when
running in sg. This was causing the bash process that spawned jaeger to
stick around as its parent process, which would catch the kill signal
from a canceled context and not kill its child jaeger process. This
caused jaeger to not be cleaned up on a failed sg start or a panic,
which meant it had to be manually killed if you wanted to restart.

Fixes #25537 

Also, #25537 mentions a couple of alternatives to this. I tried it out, and
didn't see any jaeger logs after startup, so this felt like the most reasonable
solution, but if people are attached to a separate log file, it might be worth
looking at some other solutions. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
