### PR TITLE
gomod: support SRC_LOG_LEVEL=debug in zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210929185015-a1cf13fc7c3b
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210930070257-9ef8decb6851
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20210809100802-88b656a8713e

--- a/go.sum
+++ b/go.sum
@@ -1415,8 +1415,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20210929185015-a1cf13fc7c3b h1:fwe9IuKhlS0wntTQfC1p2iXyxelvSQAmtyapZljERyY=
-github.com/sourcegraph/zoekt v0.0.0-20210929185015-a1cf13fc7c3b/go.mod h1:aLcDL//nbHjkOFRadYDb9yNiFc3yOq+3ZSFKSGESiME=
+github.com/sourcegraph/zoekt v0.0.0-20210930070257-9ef8decb6851 h1:pyvWwX3mUmw9Q4+kdUiDkWhqrFSwnI999Gn6Z2OMcO4=
+github.com/sourcegraph/zoekt v0.0.0-20210930070257-9ef8decb6851/go.mod h1:aLcDL//nbHjkOFRadYDb9yNiFc3yOq+3ZSFKSGESiME=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
The zoekt version changes to include one more commit:

- 9ef8dec all: support SRC_LOG_LEVEL debug

This was noticed via the SG tool setting the value to debug.