### PR TITLE
Revert "search: lift unindexed search fallback logic"

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -148,34 +148,17 @@ type IndexedSearchRequest interface {
 	UnindexedRepos() []*search.RepositoryRevisions
 }
 
-func fallbackIndexUnavailable(repos []*search.RepositoryRevisions, limit int, onMissing OnMissingRepoRevs) *IndexedSubsetSearchRequest {
-	return &IndexedSubsetSearchRequest{
-		Unindexed:        limitUnindexedRepos(repos, limit, onMissing),
-		IndexUnavailable: true,
-	}
-}
-
-func fallbackUnindexed(repos []*search.RepositoryRevisions, limit int, onMissing OnMissingRepoRevs) *IndexedSubsetSearchRequest {
-	return &IndexedSubsetSearchRequest{
-		Unindexed: limitUnindexedRepos(repos, limit, onMissing),
-	}
-}
-
 func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ search.IndexedRequestType, onMissing OnMissingRepoRevs) (IndexedSearchRequest, error) {
 	// If Zoekt is disabled just fallback to Unindexed.
 	if args.Zoekt == nil {
 		if args.PatternInfo.Index == query.Only {
 			return nil, errors.Errorf("invalid index:%q (indexed search is not enabled)", args.PatternInfo.Index)
 		}
-		return fallbackIndexUnavailable(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing), nil
-	}
-	// Fallback to Unindexed if the query contains valid ref-globs.
-	if query.ContainsRefGlobs(args.Query) {
-		return fallbackUnindexed(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing), nil
-	}
-	// Fallback to Unindexed if index:no
-	if args.PatternInfo.Index == query.No {
-		return fallbackUnindexed(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing), nil
+
+		return &IndexedSubsetSearchRequest{
+			Unindexed:        limitUnindexedRepos(args.Repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
+			IndexUnavailable: true,
+		}, nil
 	}
 
 	q, err := search.QueryToZoektQuery(args.PatternInfo, typ == search.SymbolRequest)
@@ -325,6 +308,20 @@ func MissingRepoRevStatus(stream streaming.Sender) OnMissingRepoRevs {
 // out the kind of indexed search to run.
 func newIndexedSubsetSearchRequest(ctx context.Context, repos []*search.RepositoryRevisions, q query.Q, index query.YesNoOnly, zoektArgs *search.ZoektParameters, onMissing OnMissingRepoRevs) (_ *IndexedSubsetSearchRequest, err error) {
 	tr, ctx := trace.New(ctx, "newIndexedSubsetSearchRequest", string(zoektArgs.Typ))
+	// Fallback to Unindexed if the query contains ref-globs
+	if query.ContainsRefGlobs(q) {
+		return &IndexedSubsetSearchRequest{
+			Unindexed: limitUnindexedRepos(repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
+		}, nil
+	}
+
+	// Fallback to Unindexed if index:no
+	if index == query.No {
+		return &IndexedSubsetSearchRequest{
+			Unindexed: limitUnindexedRepos(repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
+		}, nil
+	}
+
 	// Only include indexes with symbol information if a symbol request.
 	var filter func(repo *zoekt.MinimalRepoListEntry) bool
 	if zoektArgs.Typ == search.SymbolRequest {
@@ -347,7 +344,10 @@ func newIndexedSubsetSearchRequest(ctx context.Context, repos []*search.Reposito
 			log15.Warn("zoektIndexedRepos failed", "error", err)
 		}
 
-		return fallbackIndexUnavailable(repos, maxUnindexedRepoRevSearchesPerQuery, onMissing), ctx.Err()
+		return &IndexedSubsetSearchRequest{
+			Unindexed:        limitUnindexedRepos(repos, maxUnindexedRepoRevSearchesPerQuery, onMissing),
+			IndexUnavailable: true,
+		}, ctx.Err()
 	}
 
 	tr.LogFields(log.Int("all_indexed_set.size", len(list.Minimal)))

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -274,34 +274,23 @@ func TestIndexedSearch(t *testing.T) {
 				Zoekt:          zoekt,
 			}
 
-			args := &search.TextParameters{
-				Repos: tt.args.repos,
-				PatternInfo: &search.TextPatternInfo{
-					Index:          tt.args.patternInfo.Index,
-					FileMatchLimit: zoektArgs.FileMatchLimit,
-					Select:         zoektArgs.Select,
-				},
-				Query: q,
-				Zoekt: zoektArgs.Zoekt,
-			}
-
-			indexed, err := NewIndexedSearchRequest(
+			indexed, err := newIndexedSubsetSearchRequest(
 				context.Background(),
-				args,
-				search.TextRequest,
+				tt.args.repos,
+				q,
+				tt.args.patternInfo.Index,
+				zoektArgs,
 				MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})),
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			indexedSubset := indexed.(*IndexedSubsetSearchRequest)
-
-			if diff := cmp.Diff(tt.wantUnindexed, indexedSubset.Unindexed, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tt.wantUnindexed, indexed.Unindexed, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("unindexed mismatch (-want +got):\n%s", diff)
 			}
 
-			indexedSubset.since = tt.args.since
+			indexed.since = tt.args.since
 
 			// This is a quick fix which will break once we enable the zoekt client for true streaming.
 			// Once we return more than one event we have to account for the proper order of results


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#25497 (ping @rvantonder) 

Similar to https://github.com/sourcegraph/sourcegraph/pull/25543 

cc @sourcegraph/frontend-platform 