### PR TITLE
nix: specify PGUSER

### DIFF
--- a/dev/nix/start-postgres.sh
+++ b/dev/nix/start-postgres.sh
@@ -11,6 +11,7 @@ export PGHOST="${SG_DATA_DIR:-$HOME/.sourcegraph}/postgres"
 export PGDATA="${PGHOST}/${PGVER}"
 export PGDATABASE=postgres
 export PGDATASOURCE="postgresql:///postgres?host=${PGHOST}"
+export PGUSER="${USER}"
 
 if [ ! -d "$PGHOST" ]; then
   mkdir -p "$PGHOST"


### PR DESCRIPTION
sg adds a default PGUSER=sourcegraph. However, our auto database support
in nix uses the current user since it is via a unix socket.