### PR TITLE
Validate ChangesetSpecs on server

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -436,7 +436,7 @@ type BatchSpecResolver interface {
 	ActAsCampaignSpec() bool
 
 	AutoApplyEnabled() bool
-	State() string
+	State(context.Context) string
 	StartedAt(ctx context.Context) (*DateTime, error)
 	FinishedAt(ctx context.Context) (*DateTime, error)
 	FailureMessage(ctx context.Context) (*string, error)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -663,7 +663,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 			User:      userID,
 			Repo:      repo.ID,
 			BatchSpec: batchSpec.ID,
-			HeadRef:   "main",
+			HeadRef:   "refs/heads/my-branch-1",
 		})
 
 		// We need a couple more changeset specs to make this useful: we need to
@@ -675,14 +675,14 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 			User:      userID,
 			Repo:      repo.ID,
 			BatchSpec: otherBatchSpec.ID,
-			HeadRef:   "main",
+			HeadRef:   "refs/heads/my-branch-2",
 		})
 
 		publishedChangesetSpec := ct.CreateChangesetSpec(t, ctx, cstore, ct.TestSpecOpts{
 			User:      userID,
 			Repo:      repo.ID,
 			BatchSpec: batchSpec.ID,
-			HeadRef:   "main",
+			HeadRef:   "refs/heads/my-branch-3",
 			Published: true,
 		})
 

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -67,7 +67,8 @@ func (s *Service) ApplyBatchChange(
 		return nil, err
 	}
 
-	// Validate ChangesetSpecs and return error if not
+	// Validate ChangesetSpecs and return error if they're invalid and the
+	// BatchSpec can't be applied safely.
 	if err := s.ValidateChangesetSpecs(ctx, batchSpec.ID); err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -67,6 +67,11 @@ func (s *Service) ApplyBatchChange(
 		return nil, err
 	}
 
+	// Validate ChangesetSpecs and return error if not
+	if err := s.ValidateChangesetSpecs(ctx, batchSpec.ID); err != nil {
+		return nil, err
+	}
+
 	batchChange, previousSpecID, err := s.ReconcileBatchChange(ctx, batchSpec)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -421,7 +421,7 @@ type ChangesetSpecHeadRefConflict struct {
 }
 
 var listChangesetSpecsWithConflictingHeadQueryFmtstr = `
--- source: enterprise/internal/batches/store.go:ListChangesetSpecsWithConflictingHeadRef
+-- source: enterprise/internal/batches/store/changeset_specs.go:ListChangesetSpecsWithConflictingHeadRef
 SELECT
 	repo_id, spec->>'headRef', COUNT(*)
 FROM
@@ -433,7 +433,6 @@ AND
 GROUP BY
 	repo_id, spec->>'headRef'
 HAVING COUNT(*) > 1
-;
 `
 
 func (s *Store) ListChangesetSpecsWithConflictingHeadRef(ctx context.Context, batchSpecID int64) (conflicts []ChangesetSpecHeadRefConflict, err error) {
@@ -469,7 +468,7 @@ func (s *Store) DeleteExpiredChangesetSpecs(ctx context.Context) (err error) {
 }
 
 var deleteExpiredChangesetSpecsQueryFmtstr = `
--- source: enterprise/internal/batches/store.go:DeleteExpiredChangesetSpecs
+-- source: enterprise/internal/batches/store/changeset_specs.go:DeleteExpiredChangesetSpecs
 DELETE FROM
   changeset_specs cspecs
 WHERE

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -421,6 +421,7 @@ type ChangesetSpecHeadRefConflict struct {
 }
 
 var listChangesetSpecsWithConflictingHeadQueryFmtstr = `
+-- source: enterprise/internal/batches/store.go:ListChangesetSpecsWithConflictingHeadRef
 SELECT
 	repo_id, spec->>'headRef', COUNT(*)
 FROM

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -427,6 +427,8 @@ FROM
 	changeset_specs
 WHERE
 	batch_spec_id = %s
+AND
+	spec->>'headRef' IS NOT NULL
 GROUP BY
 	repo_id, spec->>'headRef'
 HAVING COUNT(*) > 1

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -689,6 +689,63 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 			}
 		})
 	})
+
+	t.Run("ListChangesetSpecsWithConflictingHeadRef", func(t *testing.T) {
+		user := ct.CreateTestUser(t, s.DB(), true)
+
+		repo2 := ct.TestRepo(t, esStore, extsvc.KindGitHub)
+		if err := repoStore.Create(ctx, repo2); err != nil {
+			t.Fatal(err)
+		}
+		repo3 := ct.TestRepo(t, esStore, extsvc.KindGitHub)
+		if err := repoStore.Create(ctx, repo3); err != nil {
+			t.Fatal(err)
+		}
+
+		conflictingBatchSpec := ct.CreateBatchSpec(t, ctx, s, "no-conflicts", user.ID)
+		conflictingRef := "refs/heads/conflicting-head-ref"
+		for _, opts := range []ct.TestSpecOpts{
+			{HeadRef: conflictingRef, Repo: repo.ID, BatchSpec: conflictingBatchSpec.ID},
+			{HeadRef: conflictingRef, Repo: repo.ID, BatchSpec: conflictingBatchSpec.ID},
+			{HeadRef: conflictingRef, Repo: repo2.ID, BatchSpec: conflictingBatchSpec.ID},
+			{HeadRef: conflictingRef, Repo: repo2.ID, BatchSpec: conflictingBatchSpec.ID},
+			{HeadRef: conflictingRef, Repo: repo3.ID, BatchSpec: conflictingBatchSpec.ID},
+		} {
+			ct.CreateChangesetSpec(t, ctx, s, opts)
+		}
+
+		conflicts, err := s.ListChangesetSpecsWithConflictingHeadRef(ctx, conflictingBatchSpec.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if have, want := len(conflicts), 2; have != want {
+			t.Fatalf("wrong number of conflicts. want=%d, have=%d", want, have)
+		}
+		for _, c := range conflicts {
+			if c.RepoID != repo.ID && c.RepoID != repo2.ID {
+				t.Fatalf("conflict has wrong RepoID: %d", c.RepoID)
+			}
+		}
+
+		nonConflictingBatchSpec := ct.CreateBatchSpec(t, ctx, s, "no-conflicts", user.ID)
+		for _, opts := range []ct.TestSpecOpts{
+			{HeadRef: "refs/heads/branch-1", Repo: repo.ID, BatchSpec: nonConflictingBatchSpec.ID},
+			{HeadRef: "refs/heads/branch-2", Repo: repo.ID, BatchSpec: nonConflictingBatchSpec.ID},
+			{HeadRef: "refs/heads/branch-1", Repo: repo2.ID, BatchSpec: nonConflictingBatchSpec.ID},
+			{HeadRef: "refs/heads/branch-2", Repo: repo2.ID, BatchSpec: nonConflictingBatchSpec.ID},
+			{HeadRef: "refs/heads/branch-1", Repo: repo3.ID, BatchSpec: nonConflictingBatchSpec.ID},
+		} {
+			ct.CreateChangesetSpec(t, ctx, s, opts)
+		}
+
+		conflicts, err = s.ListChangesetSpecsWithConflictingHeadRef(ctx, nonConflictingBatchSpec.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if have, want := len(conflicts), 0; have != want {
+			t.Fatalf("wrong number of conflicts. want=%d, have=%d", want, have)
+		}
+	})
 }
 
 func testStoreGetRewirerMappingWithArchivedChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -705,6 +705,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 		conflictingBatchSpec := ct.CreateBatchSpec(t, ctx, s, "no-conflicts", user.ID)
 		conflictingRef := "refs/heads/conflicting-head-ref"
 		for _, opts := range []ct.TestSpecOpts{
+			{ExternalID: "4321", Repo: repo.ID, BatchSpec: conflictingBatchSpec.ID},
 			{HeadRef: conflictingRef, Repo: repo.ID, BatchSpec: conflictingBatchSpec.ID},
 			{HeadRef: conflictingRef, Repo: repo.ID, BatchSpec: conflictingBatchSpec.ID},
 			{HeadRef: conflictingRef, Repo: repo2.ID, BatchSpec: conflictingBatchSpec.ID},
@@ -729,6 +730,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 
 		nonConflictingBatchSpec := ct.CreateBatchSpec(t, ctx, s, "no-conflicts", user.ID)
 		for _, opts := range []ct.TestSpecOpts{
+			{ExternalID: "1234", Repo: repo.ID, BatchSpec: nonConflictingBatchSpec.ID},
 			{HeadRef: "refs/heads/branch-1", Repo: repo.ID, BatchSpec: nonConflictingBatchSpec.ID},
 			{HeadRef: "refs/heads/branch-2", Repo: repo.ID, BatchSpec: nonConflictingBatchSpec.ID},
 			{HeadRef: "refs/heads/branch-1", Repo: repo2.ID, BatchSpec: nonConflictingBatchSpec.ID},

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -192,14 +192,15 @@ type operations struct {
 	createChangesetJob *observation.Operation
 	getChangesetJob    *observation.Operation
 
-	createChangesetSpec         *observation.Operation
-	updateChangesetSpec         *observation.Operation
-	deleteChangesetSpec         *observation.Operation
-	countChangesetSpecs         *observation.Operation
-	getChangesetSpec            *observation.Operation
-	listChangesetSpecs          *observation.Operation
-	deleteExpiredChangesetSpecs *observation.Operation
-	getRewirerMappings          *observation.Operation
+	createChangesetSpec                      *observation.Operation
+	updateChangesetSpec                      *observation.Operation
+	deleteChangesetSpec                      *observation.Operation
+	countChangesetSpecs                      *observation.Operation
+	getChangesetSpec                         *observation.Operation
+	listChangesetSpecs                       *observation.Operation
+	deleteExpiredChangesetSpecs              *observation.Operation
+	getRewirerMappings                       *observation.Operation
+	listChangesetSpecsWithConflictingHeadRef *observation.Operation
 
 	createChangeset                   *observation.Operation
 	deleteChangeset                   *observation.Operation
@@ -311,14 +312,15 @@ func newOperations(observationContext *observation.Context) *operations {
 			createChangesetJob: op("CreateChangesetJob"),
 			getChangesetJob:    op("GetChangesetJob"),
 
-			createChangesetSpec:         op("CreateChangesetSpec"),
-			updateChangesetSpec:         op("UpdateChangesetSpec"),
-			deleteChangesetSpec:         op("DeleteChangesetSpec"),
-			countChangesetSpecs:         op("CountChangesetSpecs"),
-			getChangesetSpec:            op("GetChangesetSpec"),
-			listChangesetSpecs:          op("ListChangesetSpecs"),
-			deleteExpiredChangesetSpecs: op("DeleteExpiredChangesetSpecs"),
-			getRewirerMappings:          op("GetRewirerMappings"),
+			createChangesetSpec:                      op("CreateChangesetSpec"),
+			updateChangesetSpec:                      op("UpdateChangesetSpec"),
+			deleteChangesetSpec:                      op("DeleteChangesetSpec"),
+			countChangesetSpecs:                      op("CountChangesetSpecs"),
+			getChangesetSpec:                         op("GetChangesetSpec"),
+			listChangesetSpecs:                       op("ListChangesetSpecs"),
+			deleteExpiredChangesetSpecs:              op("DeleteExpiredChangesetSpecs"),
+			getRewirerMappings:                       op("GetRewirerMappings"),
+			listChangesetSpecsWithConflictingHeadRef: op("ListChangesetSpecsWithConflictingHeadRef"),
 
 			createChangeset:                   op("CreateChangeset"),
 			deleteChangeset:                   op("DeleteChangeset"),


### PR DESCRIPTION
With SSBC we need to validate on the server that the ChangesetSpecs we built won't push to the same branch in the same repository. In `src-cli` we did that at the end, before uploading the changeset specs, [here in this method](https://sourcegraph.com/github.com/sourcegraph/src-cli/-/blob/internal/batches/service/service.go?L202).

Since it's a bit cumbersome to kick off the validation once all changeset specs are done (lots of race conditions waiting there!), Erik and I decided on the solution here:

1. We validate the ChangesetSpecs in the `FailureMessage` and `State` methods of the `BatchSpecResolver`.
2. The UI can then disable the "Preview" (or "Apply") button if `State == Failed` or `FailureMessage != nil`.
3. In `ApplyBatchChange`, the method that applies a batch spec, we do the validation again to error.

 The code here is just the backend portion (the `State()` and `FailureMessage()` need more stuff once we flesh out the UI!).

In the future we can also statically validate the batch spec beforehand to say "hey, you're using `workspaces` or `transformChanges` but all the changesets would get the same branch", or something.