### PR TITLE
sg: warn if no commands to run

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -169,6 +169,10 @@ func startExec(ctx context.Context, args []string) error {
 		cmds = append(cmds, cmd)
 	}
 
+	if len(cmds) == 0 {
+		out.WriteLine(output.Linef("", output.StyleWarning, "WARNING: no commands to run"))
+	}
+
 	levelOverrides := logLevelOverrides()
 	for _, cmd := range cmds {
 		enrichWithLogLevels(&cmd, levelOverrides)


### PR DESCRIPTION
This happened to me when I had a misconfigured overwrite file. Sg would
start up and exit with no output. This warning would of helped me
diagnose the problem faster.