### PR TITLE
sg: Explicitly define default commandset in config

### DIFF
--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -86,11 +86,12 @@ func (c *Commandset) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 type Config struct {
-	Env         map[string]string      `yaml:"env"`
-	Commands    map[string]run.Command `yaml:"commands"`
-	Commandsets map[string]*Commandset `yaml:"commandsets"`
-	Tests       map[string]run.Command `yaml:"tests"`
-	Checks      map[string]run.Check   `yaml:"checks"`
+	Env               map[string]string      `yaml:"env"`
+	Commands          map[string]run.Command `yaml:"commands"`
+	Commandsets       map[string]*Commandset `yaml:"commandsets"`
+	DefaultCommandSet string                 `yaml:"defaultCommandset"`
+	Tests             map[string]run.Command `yaml:"tests"`
+	Checks            map[string]run.Check   `yaml:"checks"`
 }
 
 // Merges merges the top-level entries of two Config objects, with the receiver

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -95,8 +95,11 @@ func startExec(ctx context.Context, args []string) error {
 		return flag.ErrHelp
 	}
 
-	if len(args) == 0 {
-		args = append(args, "default")
+	if len(args) == 0 && globalConf.DefaultCommandSet != "" {
+		args = append(args, globalConf.DefaultCommandSet)
+	} else {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: No commandset specified and no 'defaultCommandSet' specified in sg.config.yaml\n"))
+		return flag.ErrHelp
 	}
 
 	set, ok := globalConf.Commandsets[args[0]]

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -672,6 +672,7 @@ checks:
     cmd: (command -v psql && psql -c 'SELECT 1;') || docker-compose -f dev/redis-postgres.yml exec -T postgresql psql -U ${PGUSER} -c 'select 1;'
     failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
 
+defaultCommandSet: enterprise
 commandsets:
   oss:
     # open-source version doesn't require the dev-private repository
@@ -721,8 +722,6 @@ commandsets:
       - zoekt-indexserver-1
       - zoekt-webserver-0
       - zoekt-webserver-1
-
-  default: *enterprise_set
 
   dotcom:
     <<: *enterprise_set


### PR DESCRIPTION
Using YAML hackery to define the default commandset can lead to subtle
bugs. If someone wants to, for example, overwrite the configuration for
the default set in `sg.config.yaml`, they can't overwrite it under
"default" but need to use the name of the actual command set.

Overwriting what the default set is is also a bit of a pain.

This would make it easier, because setting a new default set would just
require the following in `sg.config.overwrite.yaml`:

    defaultCommandSet: batches


**Question:** is this a breaking change?