### PR TITLE
sg: remove extra newline when using Linef

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -151,13 +151,13 @@ func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
 
 	globalConf, err = ParseConfigFile(confFile)
 	if err != nil {
-		return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s\n", output.StyleBold, confFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
+		return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s", output.StyleBold, confFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
 	}
 
 	if ok, _ := fileExists(overwriteFile); ok {
 		overwriteConf, err := ParseConfigFile(overwriteFile)
 		if err != nil {
-			return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s\n", output.StyleBold, overwriteFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
+			return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s", output.StyleBold, overwriteFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
 		}
 		globalConf.Merge(overwriteConf)
 	}

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -41,12 +41,12 @@ func constructLiveCmdLongHelp() string {
 
 func liveExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No environment specified\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "No environment specified"))
 		return flag.ErrHelp
 	}
 
 	if len(args) != 1 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -55,7 +55,7 @@ func liveExec(ctx context.Context, args []string) error {
 		if customURL, err := url.Parse(args[0]); err == nil {
 			e = environment{Name: customURL.Host, URL: customURL.String()}
 		} else {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: environment %q not found, or is not a valid URL :(\n", args[0]))
+			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: environment %q not found, or is not a valid URL :(", args[0]))
 			return flag.ErrHelp
 		}
 	}

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -109,11 +109,11 @@ func constructMigrationSubcmdLongHelp() string {
 
 func migrationAddExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No migration name specified\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "No migration name specified"))
 		return flag.ErrHelp
 	}
 	if len(args) != 1 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -123,7 +123,7 @@ func migrationAddExec(ctx context.Context, args []string) error {
 		database, ok  = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(\n", databaseName))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(", databaseName))
 		return flag.ErrHelp
 	}
 
@@ -142,7 +142,7 @@ func migrationAddExec(ctx context.Context, args []string) error {
 
 func migrationUpExec(ctx context.Context, args []string) error {
 	if len(args) != 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -151,7 +151,7 @@ func migrationUpExec(ctx context.Context, args []string) error {
 		database, ok = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(\n", databaseName))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(", databaseName))
 		return flag.ErrHelp
 	}
 
@@ -170,7 +170,7 @@ func migrationUpExec(ctx context.Context, args []string) error {
 
 func migrationDownExec(ctx context.Context, args []string) error {
 	if len(args) != 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -179,7 +179,7 @@ func migrationDownExec(ctx context.Context, args []string) error {
 		database, ok = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(\n", databaseName))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(", databaseName))
 		return flag.ErrHelp
 	}
 
@@ -196,11 +196,11 @@ const minimumMigrationSquashDistance = 2
 
 func migrationSquashExec(ctx context.Context, args []string) (err error) {
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No current-version specified\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "No current-version specified"))
 		return flag.ErrHelp
 	}
 	if len(args) != 1 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -210,7 +210,7 @@ func migrationSquashExec(ctx context.Context, args []string) (err error) {
 		database, ok  = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(\n", databaseName))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(", databaseName))
 		return flag.ErrHelp
 	}
 
@@ -228,7 +228,7 @@ func migrationSquashExec(ctx context.Context, args []string) (err error) {
 
 func migrationFixupExec(ctx context.Context, args []string) (err error) {
 	if len(args) != 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -250,7 +250,7 @@ func migrationFixupExec(ctx context.Context, args []string) (err error) {
 	} else {
 		database, ok := db.DatabaseByName(databaseName)
 		if !ok {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(\n", databaseName))
+			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: database %q not found :(", databaseName))
 			return flag.ErrHelp
 		}
 

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -33,7 +33,7 @@ func runExec(ctx context.Context, args []string) error {
 	}
 
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No command specified\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "No command specified"))
 		return flag.ErrHelp
 	}
 
@@ -41,7 +41,7 @@ func runExec(ctx context.Context, args []string) error {
 	for _, arg := range args {
 		cmd, ok := globalConf.Commands[arg]
 		if !ok {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: command %q not found :(\n", arg))
+			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: command %q not found :(", arg))
 			return flag.ErrHelp
 		}
 		cmds = append(cmds, cmd)

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -91,7 +91,7 @@ func startExec(ctx context.Context, args []string) error {
 	}
 
 	if len(args) > 2 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -101,7 +101,7 @@ func startExec(ctx context.Context, args []string) error {
 
 	set, ok := globalConf.Commandsets[args[0]]
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: commandset %q not found :(\n", args[0]))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: commandset %q not found :(", args[0]))
 		return flag.ErrHelp
 	}
 
@@ -143,7 +143,7 @@ func startExec(ctx context.Context, args []string) error {
 	for _, name := range set.Checks {
 		check, ok := globalConf.Checks[name]
 		if !ok {
-			out.WriteLine(output.Linef("", output.StyleWarning, "WARNING: check %s not found in config\n", name))
+			out.WriteLine(output.Linef("", output.StyleWarning, "WARNING: check %s not found in config", name))
 			continue
 		}
 		checks = append(checks, check)
@@ -151,11 +151,11 @@ func startExec(ctx context.Context, args []string) error {
 
 	ok, err := run.Checks(ctx, globalConf.Env, checks...)
 	if err != nil {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: checks could not be run: %s\n", err))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: checks could not be run: %s", err))
 	}
 
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: checks did not pass, aborting start of commandset %s\n", set.Name))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: checks did not pass, aborting start of commandset %s", set.Name))
 		return nil
 	}
 

--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -31,13 +31,13 @@ func testExec(ctx context.Context, args []string) error {
 	}
 
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No test suite specified\n"))
+		out.WriteLine(output.Linef("", output.StyleWarning, "No test suite specified"))
 		return flag.ErrHelp
 	}
 
 	cmd, ok := globalConf.Tests[args[0]]
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(\n", args[0]))
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(", args[0]))
 		return flag.ErrHelp
 	}
 


### PR DESCRIPTION
I noticed a lot of uses of Linef include a trailing newline. However,
Linef adds a newline. It is possible one of the updates I did
intentionally had the extra newline.