### PR TITLE
search: restructure zoektGlobalQuery to only include q once

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -400,7 +400,7 @@ func zoektGlobalQuery(q zoektquery.Q, repoOptions search.RepoOptions, userPrivat
 		apply(zoektquery.RcOnlyForks, repoOptions.OnlyForks)
 		apply(zoektquery.RcNoForks, repoOptions.NoForks)
 
-		qs = append(qs, zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc, q))
+		qs = append(qs, zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc))
 	}
 
 	// Private or Any
@@ -410,10 +410,10 @@ func zoektGlobalQuery(q zoektquery.Q, repoOptions search.RepoOptions, userPrivat
 		for _, r := range userPrivateRepos {
 			privateRepoSet[string(r.Name)] = head
 		}
-		qs = append(qs, zoektquery.NewAnd(&zoektquery.RepoBranches{Set: privateRepoSet}, q))
+		qs = append(qs, &zoektquery.RepoBranches{Set: privateRepoSet})
 	}
 
-	return zoektquery.Simplify(zoektquery.NewOr(qs...))
+	return zoektquery.Simplify(zoektquery.NewAnd(q, zoektquery.NewOr(qs...)))
 }
 
 func doZoektSearchGlobal(ctx context.Context, args *search.ZoektParameters, c streaming.Sender) error {


### PR DESCRIPTION
Previously from a query "q" created a query that looked like this:

  (OR (AND q public...) (AND q private...))

Now we create the query:

  (AND q (OR public... private...))

I believe it is much faster for zoekt to evaluate. If I am not mistaken
this will half the matchtree size.

Co-authored-by: @eseliger 