### PR TITLE
search: support -repo: in global search optimization

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -133,7 +133,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context, q query.Q)
 	archivedNotSet := archived == nil
 
 	// Handle repogroup-only scenarios.
-	if len(repoFilters) == 0 && len(repoGroupFilters) == 0 {
+	if len(repoFilters) == 0 && len(repoGroupFilters) == 0 && len(minusRepoFilters) == 0 {
 		return &searchAlert{
 			prometheusType: "no_resolved_repos__no_repositories",
 			title:          "Add repositories or connect repository hosts",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -549,8 +549,10 @@ func withMode(args search.TextParameters, st query.SearchType, versionContext *s
 			switch n.Field {
 			case query.FieldContext:
 				return searchcontexts.IsGlobalSearchContextSpec(n.Value)
+			case query.FieldRepo:
+				// We allow -repo: in global search.
+				return n.Negated
 			case
-				query.FieldRepo,
 				query.FieldRepoGroup,
 				query.FieldRepoHasFile:
 				return false

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -434,7 +434,12 @@ func zoektGlobalQuery(q zoektquery.Q, repoOptions search.RepoOptions, userPrivat
 		apply(zoektquery.RcOnlyForks, repoOptions.OnlyForks)
 		apply(zoektquery.RcNoForks, repoOptions.NoForks)
 
-		qs = append(qs, zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc))
+		children := []zoektquery.Q{&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc}
+		for _, pat := range repoOptions.MinusRepoFilters {
+			children = append(children, &zoektquery.Not{Child: &zoektquery.Repo{Pattern: pat}})
+		}
+
+		qs = append(qs, zoektquery.NewAnd(children...))
 	}
 
 	// Private or Any

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -450,7 +450,7 @@ func zoektGlobalQueryScope(repoOptions search.RepoOptions, userPrivateRepos []ty
 		for _, pat := range repoOptions.MinusRepoFilters {
 			re, err := regexp.Compile(`(?i)` + pat)
 			if err != nil {
-				return nil, errors.Wrapf(err, "invalid regex for -repo filter %q", err)
+				return nil, errors.Wrapf(err, "invalid regex for -repo filter %q", pat)
 			}
 			children = append(children, &zoektquery.Not{Child: &zoektquery.RepoRegexp{Regexp: re}})
 		}


### PR DESCRIPTION
For global searches with `-repo:` filters we can ask zoekt to do the filtering for us using the recently introduced `query.RepoRegexp`.

Before this commit `-repo:` filters would generate very large lists of repositories to search. They are usually generated by code-intel for finding references in other repos. This now includes `-repo:` in our global search optimizations.

Co-authored-by: @eseliger 