### PR TITLE
db: Drop unused indexes on security_event_logs table

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1803,12 +1803,7 @@ Referenced by:
  timestamp         | timestamp with time zone |           | not null | 
 Indexes:
     "security_event_logs_pkey" PRIMARY KEY, btree (id)
-    "security_event_logs_anonymous_user_id" btree (anonymous_user_id)
-    "security_event_logs_name" btree (name)
-    "security_event_logs_source" btree (source)
     "security_event_logs_timestamp" btree ("timestamp")
-    "security_event_logs_timestamp_at_utc" btree (date(timezone('UTC'::text, "timestamp")))
-    "security_event_logs_user_id" btree (user_id)
 Check constraints:
     "security_event_logs_check_has_user" CHECK (user_id = 0 AND anonymous_user_id <> ''::text OR user_id <> 0 AND anonymous_user_id = ''::text OR user_id <> 0 AND anonymous_user_id <> ''::text)
     "security_event_logs_check_name_not_empty" CHECK (name <> ''::text)

--- a/migrations/frontend/1528395902_drop_unused_security_events_index_0.down.sql
+++ b/migrations/frontend/1528395902_drop_unused_security_events_index_0.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS security_event_logs_anonymous_user_id ON security_event_logs USING btree (anonymous_user_id);

--- a/migrations/frontend/1528395902_drop_unused_security_events_index_0.up.sql
+++ b/migrations/frontend/1528395902_drop_unused_security_events_index_0.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS security_event_logs_anonymous_user_id;
+
+COMMIT;

--- a/migrations/frontend/1528395903_drop_unused_security_events_index_1.down.sql
+++ b/migrations/frontend/1528395903_drop_unused_security_events_index_1.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS security_event_logs_user_id ON security_event_logs USING btree (user_id);

--- a/migrations/frontend/1528395903_drop_unused_security_events_index_1.up.sql
+++ b/migrations/frontend/1528395903_drop_unused_security_events_index_1.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS security_event_logs_user_id;
+
+COMMIT;

--- a/migrations/frontend/1528395904_drop_unused_security_events_index_2.down.sql
+++ b/migrations/frontend/1528395904_drop_unused_security_events_index_2.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS security_event_logs_name ON security_event_logs USING btree (name);

--- a/migrations/frontend/1528395904_drop_unused_security_events_index_2.up.sql
+++ b/migrations/frontend/1528395904_drop_unused_security_events_index_2.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS security_event_logs_name;
+
+COMMIT;

--- a/migrations/frontend/1528395905_drop_unused_security_events_index_3.down.sql
+++ b/migrations/frontend/1528395905_drop_unused_security_events_index_3.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS security_event_logs_source ON security_event_logs USING btree (source);

--- a/migrations/frontend/1528395905_drop_unused_security_events_index_3.up.sql
+++ b/migrations/frontend/1528395905_drop_unused_security_events_index_3.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS security_event_logs_source;
+
+COMMIT;

--- a/migrations/frontend/1528395906_drop_unused_security_events_index_4.down.sql
+++ b/migrations/frontend/1528395906_drop_unused_security_events_index_4.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS security_event_logs_timestamp_at_utc ON security_event_logs USING btree (date(timezone('UTC'::text, "timestamp")));

--- a/migrations/frontend/1528395906_drop_unused_security_events_index_4.up.sql
+++ b/migrations/frontend/1528395906_drop_unused_security_events_index_4.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS security_event_logs_timestamp_at_utc;
+
+COMMIT;


### PR DESCRIPTION
These indexes seem to just be copied over from the event_logs table, where we actually use them. We don't require them here though and the cost is very high, these are in fact the heaviest indexes we have. Dropping these on will
- Give us faster inserts, so less impact by logging security events
- On dotcom, free 25351MB of disk space
- On dotcom, give us up to 25G back for other things to cache in memory, if postgres decided the indexes need to be in memory (which it probably did)

