### PR TITLE
search: fix BenchmarkSearchResults

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -890,7 +890,7 @@ func TestEvaluateAnd(t *testing.T) {
 		},
 	}
 
-	minimalRepos, _, zoektRepos := generateRepos(5000)
+	minimalRepos, zoektRepos := generateRepos(5000)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/search/backend/cached_test.go
+++ b/internal/search/backend/cached_test.go
@@ -2,6 +2,8 @@ package backend
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -88,6 +90,9 @@ type mockUncachedSearcher struct {
 }
 
 func (s *mockUncachedSearcher) List(ctx context.Context, q zoektquery.Q, opts *zoekt.ListOptions) (*zoekt.RepoList, error) {
+	fmt.Println()
+	debug.PrintStack()
+	fmt.Println()
 	atomic.AddInt64(&s.ListCalls, 1)
 	return s.FakeSearcher.List(ctx, q, opts)
 }


### PR DESCRIPTION
This was a useful benchmark which captured a lot of the work we did
converting zoekt results into sourcegraph results. It has rotted, so
this PR fixes it. We removed the db integration benchmark since it has
also rotted and doesn't seem as useful to us right now.

Co-authored-by: @tsenart 