### PR TITLE
move commit, signature, and message to own package

### DIFF
--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -11,14 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type MockRepos struct {
 	Get          func(v0 context.Context, id api.RepoID) (*types.Repo, error)
 	GetByName    func(v0 context.Context, name api.RepoName) (*types.Repo, error)
 	List         func(v0 context.Context, v1 database.ReposListOptions) ([]*types.Repo, error)
-	GetCommit    func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error)
+	GetCommit    func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*gitapi.Commit, error)
 	ResolveRev   func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
 	GetInventory func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
 }
@@ -107,9 +107,9 @@ func (s *MockRepos) MockResolveRev_NotFound(t *testing.T, wantRepo api.RepoID, w
 	return
 }
 
-func (s *MockRepos) MockGetCommit_Return_NoCheck(t *testing.T, commit *git.Commit) (called *bool) {
+func (s *MockRepos) MockGetCommit_Return_NoCheck(t *testing.T, commit *gitapi.Commit) (called *bool) {
 	called = new(bool)
-	s.GetCommit = func(ctx context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error) {
+	s.GetCommit = func(ctx context.Context, repo *types.Repo, commitID api.CommitID) (*gitapi.Commit, error) {
 		*called = true
 		return commit, nil
 	}

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type MockRepos struct {

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 // ResolveRev will return the absolute commit for a commit-ish spec in a repo.
@@ -30,7 +31,7 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 	return git.ResolveRevision(ctx, repo.Name, rev, git.ResolveRevisionOptions{})
 }
 
-func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *git.Commit, err error) {
+func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *gitapi.Commit, err error) {
 	if Mocks.Repos.GetCommit != nil {
 		return Mocks.Repos.GetCommit(ctx, repo, commitID)
 	}

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // ResolveRev will return the absolute commit for a commit-ish spec in a repo.

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestRepos_ResolveRev_noRevSpecified_getsDefaultBranch(t *testing.T) {
@@ -183,9 +184,9 @@ func TestRepos_GetCommit_repoupdaterError(t *testing.T) {
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 	var calledVCSRepoGetCommit bool
-	git.Mocks.GetCommit = func(commitID api.CommitID) (*git.Commit, error) {
+	git.Mocks.GetCommit = func(commitID api.CommitID) (*gitapi.Commit, error) {
 		calledVCSRepoGetCommit = true
-		return &git.Commit{ID: want}, nil
+		return &gitapi.Commit{ID: want}, nil
 	}
 	defer git.ResetMocks()
 

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestRepos_ResolveRev_noRevSpecified_getsDefaultBranch(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func (r *schemaResolver) gitCommitByID(ctx context.Context, id graphql.ID) (*GitCommitResolver, error) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func (r *schemaResolver) gitCommitByID(ctx context.Context, id graphql.ID) (*GitCommitResolver, error) {
@@ -49,14 +50,14 @@ type GitCommitResolver struct {
 
 	// commit should not be accessed directly since it might not be initialized.
 	// Use the resolver methods instead.
-	commit     *git.Commit
+	commit     *gitapi.Commit
 	commitOnce sync.Once
 	commitErr  error
 }
 
 // When set to nil, commit will be loaded lazily as needed by the resolver. Pass in a commit when you have batch loaded
 // a bunch of them and already have them at hand.
-func toGitCommitResolver(repo *RepositoryResolver, db dbutil.DB, id api.CommitID, commit *git.Commit) *GitCommitResolver {
+func toGitCommitResolver(repo *RepositoryResolver, db dbutil.DB, id api.CommitID, commit *gitapi.Commit) *GitCommitResolver {
 	return &GitCommitResolver{
 		db:              db,
 		repoResolver:    repo,
@@ -67,7 +68,7 @@ func toGitCommitResolver(repo *RepositoryResolver, db dbutil.DB, id api.CommitID
 	}
 }
 
-func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*git.Commit, error) {
+func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*gitapi.Commit, error) {
 	r.commitOnce.Do(func() {
 		if r.commit != nil {
 			return

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -14,22 +14,23 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestGitCommitResolver(t *testing.T) {
 	ctx := context.Background()
 	db := new(dbtesting.MockDB)
 
-	commit := &git.Commit{
+	commit := &gitapi.Commit{
 		ID:      "c1",
 		Message: "subject: Changes things\nBody of changes",
 		Parents: []api.CommitID{"p1", "p2"},
-		Author: git.Signature{
+		Author: gitapi.Signature{
 			Name:  "Bob",
 			Email: "bob@alice.com",
 			Date:  time.Now(),
 		},
-		Committer: &git.Signature{
+		Committer: &gitapi.Signature{
 			Name:  "Alice",
 			Email: "alice@bob.com",
 			Date:  time.Now(),
@@ -37,7 +38,7 @@ func TestGitCommitResolver(t *testing.T) {
 	}
 
 	t.Run("Lazy loading", func(t *testing.T) {
-		git.Mocks.GetCommit = func(api.CommitID) (*git.Commit, error) {
+		git.Mocks.GetCommit = func(api.CommitID) (*gitapi.Commit, error) {
 			return commit, nil
 		}
 		t.Cleanup(func() {
@@ -123,7 +124,7 @@ func TestGitCommitFileNames(t *testing.T) {
 		}
 		return exampleCommitSHA1, nil
 	}
-	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &git.Commit{ID: exampleCommitSHA1})
+	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitapi.Commit{ID: exampleCommitSHA1})
 	git.Mocks.LsFiles = func(repo api.RepoName, commit api.CommitID) ([]string, error) {
 		return []string{"a", "b"}, nil
 	}

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestGitCommitResolver(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type gitCommitConnectionResolver struct {
@@ -23,12 +24,12 @@ type gitCommitConnectionResolver struct {
 
 	// cache results because it is used by multiple fields
 	once    sync.Once
-	commits []*git.Commit
+	commits []*gitapi.Commit
 	err     error
 }
 
-func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*git.Commit, error) {
-	do := func() ([]*git.Commit, error) {
+func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitapi.Commit, error) {
+	do := func() ([]*gitapi.Commit, error) {
 		var n int32
 		if r.first != nil {
 			n = *r.first

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type gitCommitConnectionResolver struct {

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 )
 
@@ -26,7 +27,7 @@ func TestGitTree(t *testing.T) {
 		}
 		return exampleCommitSHA1, nil
 	}
-	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &git.Commit{ID: exampleCommitSHA1})
+	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitapi.Commit{ID: exampleCommitSHA1})
 
 	git.Mocks.Stat = func(commit api.CommitID, path string) (fs.FileInfo, error) {
 		if string(commit) != exampleCommitSHA1 {

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 )
 

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestPreviewRepositoryComparisonResolver(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestPreviewRepositoryComparisonResolver(t *testing.T) {
@@ -389,11 +390,11 @@ func mockBackendCommits(t *testing.T, revs ...api.CommitID) {
 	}
 	t.Cleanup(func() { backend.Mocks.Repos.ResolveRev = nil })
 
-	backend.Mocks.Repos.GetCommit = func(_ context.Context, _ *types.Repo, id api.CommitID) (*git.Commit, error) {
+	backend.Mocks.Repos.GetCommit = func(_ context.Context, _ *types.Repo, id api.CommitID) (*gitapi.Commit, error) {
 		if _, ok := byRev[id]; !ok {
 			t.Fatalf("GetCommit received unexpected ID: %s", id)
 		}
-		return &git.Commit{ID: id}, nil
+		return &gitapi.Commit{ID: id}, nil
 	}
 	t.Cleanup(func() { backend.Mocks.Repos.GetCommit = nil })
 }

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestRepositoryComparison(t *testing.T) {
@@ -90,12 +91,12 @@ func TestRepositoryComparison(t *testing.T) {
 	})
 
 	t.Run("Commits", func(t *testing.T) {
-		commits := []*git.Commit{
+		commits := []*gitapi.Commit{
 			{ID: api.CommitID(wantBaseRevision)},
 			{ID: api.CommitID(wantHeadRevision)},
 		}
 
-		git.Mocks.Commits = func(repo api.RepoName, opts git.CommitsOptions) ([]*git.Commit, error) {
+		git.Mocks.Commits = func(repo api.RepoName, opts git.CommitsOptions) ([]*gitapi.Commit, error) {
 			wantRange := fmt.Sprintf("%s..%s", wantBaseRevision, wantHeadRevision)
 
 			if have, want := opts.Range, wantRange; have != want {

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestRepositoryComparison(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type refsArgs struct {
@@ -69,7 +70,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 			}
 
 			if ok {
-				date := func(c *git.Commit) time.Time {
+				date := func(c *gitapi.Commit) time.Time {
 					if c.Committer == nil {
 						return c.Author.Date
 					}

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type refsArgs struct {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 const exampleCommitSHA1 = "1234567890123456789012345678901234567890"

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 const exampleCommitSHA1 = "1234567890123456789012345678901234567890"
@@ -31,7 +32,7 @@ func TestRepository_Commit(t *testing.T) {
 		}
 		return exampleCommitSHA1, nil
 	}
-	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &git.Commit{ID: exampleCommitSHA1})
+	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitapi.Commit{ID: exampleCommitSHA1})
 
 	RunTests(t, []*Test{
 		{

--- a/cmd/frontend/graphqlbackend/signature.go
+++ b/cmd/frontend/graphqlbackend/signature.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type signatureResolver struct {
@@ -20,7 +20,7 @@ func (r signatureResolver) Date() string {
 	return r.date.Format(time.RFC3339)
 }
 
-func toSignatureResolver(db dbutil.DB, sig *git.Signature, includeUserInfo bool) *signatureResolver {
+func toSignatureResolver(db dbutil.DB, sig *gitapi.Signature, includeUserInfo bool) *signatureResolver {
 	if sig == nil {
 		return nil
 	}

--- a/cmd/frontend/graphqlbackend/signature.go
+++ b/cmd/frontend/graphqlbackend/signature.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type signatureResolver struct {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -13,6 +13,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
@@ -211,10 +212,10 @@ func (r *gitCommitDescriptionResolver) Author() *graphqlbackend.PersonResolver {
 }
 func (r *gitCommitDescriptionResolver) Message() string { return r.message }
 func (r *gitCommitDescriptionResolver) Subject() string {
-	return git.Message(r.message).Subject()
+	return gitapi.Message(r.message).Subject()
 }
 func (r *gitCommitDescriptionResolver) Body() *string {
-	body := git.Message(r.message).Body()
+	body := gitapi.Message(r.message).Body()
 	if body == "" {
 		return nil
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -13,7 +13,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 var update = flag.Bool("update", false, "update testdata")

--- a/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 var update = flag.Bool("update", false, "update testdata")
@@ -173,11 +174,11 @@ func mockBackendCommits(t *testing.T, revs ...api.CommitID) {
 	}
 	t.Cleanup(func() { backend.Mocks.Repos.ResolveRev = nil })
 
-	backend.Mocks.Repos.GetCommit = func(_ context.Context, _ *types.Repo, id api.CommitID) (*git.Commit, error) {
+	backend.Mocks.Repos.GetCommit = func(_ context.Context, _ *types.Repo, id api.CommitID) (*gitapi.Commit, error) {
 		if _, ok := byRev[id]; !ok {
 			t.Fatalf("GetCommit received unexpected ID: %s", id)
 		}
-		return &git.Commit{ID: id}, nil
+		return &gitapi.Commit{ID: id}, nil
 	}
 	t.Cleanup(func() { backend.Mocks.Repos.GetCommit = nil })
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 const numRoutines = 5

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 const numRoutines = 5
@@ -49,9 +50,9 @@ func TestCachedLocationResolver(t *testing.T) {
 	}
 
 	var commitCalls uint32
-	git.Mocks.GetCommit = func(commitID api.CommitID) (*git.Commit, error) {
+	git.Mocks.GetCommit = func(commitID api.CommitID) (*gitapi.Commit, error) {
 		atomic.AddUint32(&commitCalls, 1)
-		return &git.Commit{ID: commitID}, nil
+		return &gitapi.Commit{ID: commitID}, nil
 	}
 
 	cachedResolver := NewCachedLocationResolver(db)
@@ -252,8 +253,8 @@ func TestResolveLocations(t *testing.T) {
 		return api.CommitID(spec), nil
 	}
 
-	backend.Mocks.Repos.GetCommit = func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error) {
-		return &git.Commit{ID: commitID}, nil
+	backend.Mocks.Repos.GetCommit = func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*gitapi.Commit, error) {
+		return &gitapi.Commit{ID: commitID}, nil
 	}
 
 	r1 := lsifstore.Range{Start: lsifstore.Position{Line: 11, Character: 12}, End: lsifstore.Position{Line: 13, Character: 14}}

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -8,28 +8,20 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	itypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
-	"github.com/sourcegraph/sourcegraph/internal/types"
-
-	"github.com/sourcegraph/sourcegraph/internal/insights/priority"
-
-	"github.com/cockroachdb/errors"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
-
 	"golang.org/x/time/rate"
 
+	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xhit/go-str2duration/v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	itypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -37,10 +29,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbcache"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/insights/priority"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 // The historical enqueuer takes regular search insights like a search for `errorf` and runs them
@@ -141,7 +136,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 			return err
 		},
 		gitFirstEverCommit: (&cachedGitFirstEverCommit{impl: git.FirstEverCommit}).gitFirstEverCommit,
-		gitFindRecentCommit: func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*git.Commit, error) {
+		gitFindRecentCommit: func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitapi.Commit, error) {
 			return git.Commits(ctx, repoName, git.CommitsOptions{N: 1, Before: target.Format(time.RFC3339), DateOrder: true})
 		},
 
@@ -225,8 +220,8 @@ type historicalEnqueuer struct {
 	dataSeriesStore       store.DataSeriesStore
 	repoStore             RepoStore
 	enqueueQueryRunnerJob func(ctx context.Context, job *queryrunner.Job) error
-	gitFirstEverCommit    func(ctx context.Context, repoName api.RepoName) (*git.Commit, error)
-	gitFindRecentCommit   func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*git.Commit, error)
+	gitFirstEverCommit    func(ctx context.Context, repoName api.RepoName) (*gitapi.Commit, error)
+	gitFindRecentCommit   func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitapi.Commit, error)
 	frameFilter           compression.DataFrameFilter
 
 	// framesToBackfill describes the number of historical timeframes to backfill data for.
@@ -397,7 +392,7 @@ type buildSeriesContext struct {
 	repo *types.Repo
 
 	// The first commit made in the repository on the default branch.
-	firstHEADCommit *git.Commit
+	firstHEADCommit *gitapi.Commit
 
 	// The series we're building historical data for.
 	seriesID string
@@ -497,7 +492,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 			hardErr = errors.Wrap(err, "FindNearestCommit")
 			return
 		}
-		var nearestCommit *git.Commit
+		var nearestCommit *gitapi.Commit
 		if len(recentCommits) > 0 {
 			nearestCommit = recentCommits[0]
 		}
@@ -526,17 +521,17 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 // using a map, and entries are never evicted because they are expected to be small and in general
 // unchanging.
 type cachedGitFirstEverCommit struct {
-	impl func(ctx context.Context, repoName api.RepoName) (*git.Commit, error)
+	impl func(ctx context.Context, repoName api.RepoName) (*gitapi.Commit, error)
 
 	mu    sync.Mutex
-	cache map[api.RepoName]*git.Commit
+	cache map[api.RepoName]*gitapi.Commit
 }
 
-func (c *cachedGitFirstEverCommit) gitFirstEverCommit(ctx context.Context, repoName api.RepoName) (*git.Commit, error) {
+func (c *cachedGitFirstEverCommit) gitFirstEverCommit(ctx context.Context, repoName api.RepoName) (*gitapi.Commit, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.cache == nil {
-		c.cache = map[api.RepoName]*git.Commit{}
+		c.cache = map[api.RepoName]*gitapi.Commit{}
 	}
 	if cached, ok := c.cache[repoName]; ok {
 		return cached, nil

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -35,7 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // The historical enqueuer takes regular search insights like a search for `errorf` and runs them

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -6,20 +6,18 @@ import (
 	"testing"
 	"time"
 
-	itypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
-
 	"golang.org/x/time/rate"
 
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	itypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type testParams struct {
@@ -117,18 +115,18 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 		return nil
 	}
 
-	gitFirstEverCommit := func(ctx context.Context, repoName api.RepoName) (*git.Commit, error) {
+	gitFirstEverCommit := func(ctx context.Context, repoName api.RepoName) (*gitapi.Commit, error) {
 		if repoName == "repo/1" {
 			daysAgo := clock().Add(-3 * 24 * time.Hour)
-			return &git.Commit{Committer: &git.Signature{Date: daysAgo}}, nil
+			return &gitapi.Commit{Committer: &gitapi.Signature{Date: daysAgo}}, nil
 		}
 		yearsAgo := clock().Add(-2 * 365 * 24 * time.Hour)
-		return &git.Commit{Committer: &git.Signature{Date: yearsAgo}}, nil
+		return &gitapi.Commit{Committer: &gitapi.Signature{Date: yearsAgo}}, nil
 	}
 
-	gitFindRecentCommit := func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*git.Commit, error) {
+	gitFindRecentCommit := func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitapi.Commit, error) {
 		nearby := target.Add(-2 * 24 * time.Hour)
-		return []*git.Commit{{Committer: &git.Signature{Date: nearby}}}, nil
+		return []*gitapi.Commit{{Committer: &gitapi.Signature{Date: nearby}}}, nil
 	}
 
 	limiter := rate.NewLimiter(10, 1)

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -17,7 +17,7 @@ import (
 	itypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type testParams struct {

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type DBCommitStore struct {

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type DBCommitStore struct {
@@ -19,11 +19,11 @@ type DBCommitStore struct {
 }
 
 type CommitStore interface {
-	Save(ctx context.Context, id api.RepoID, commit *git.Commit) error
+	Save(ctx context.Context, id api.RepoID, commit *gitapi.Commit) error
 	Get(ctx context.Context, id api.RepoID, start time.Time, end time.Time) ([]CommitStamp, error)
 	GetMetadata(ctx context.Context, id api.RepoID) (CommitIndexMetadata, error)
 	UpsertMetadataStamp(ctx context.Context, id api.RepoID) (CommitIndexMetadata, error)
-	InsertCommits(ctx context.Context, id api.RepoID, commits []*git.Commit) error
+	InsertCommits(ctx context.Context, id api.RepoID, commits []*gitapi.Commit) error
 }
 
 func NewCommitStore(db dbutil.DB) *DBCommitStore {
@@ -41,7 +41,7 @@ func (c *DBCommitStore) Transact(ctx context.Context) (*DBCommitStore, error) {
 	return &DBCommitStore{Store: txBase}, err
 }
 
-func (c *DBCommitStore) Save(ctx context.Context, id api.RepoID, commit *git.Commit) error {
+func (c *DBCommitStore) Save(ctx context.Context, id api.RepoID, commit *gitapi.Commit) error {
 	commitID := commit.ID
 	if err := c.Exec(ctx, sqlf.Sprintf(insertCommitIndexStr, id, dbutil.CommitBytea(commitID), commit.Committer.Date)); err != nil {
 		return errors.Errorf("error saving commit for repo_id: %v commit_id %v: %w", id, commitID, err)
@@ -50,7 +50,7 @@ func (c *DBCommitStore) Save(ctx context.Context, id api.RepoID, commit *git.Com
 	return nil
 }
 
-func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commits []*git.Commit) (err error) {
+func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commits []*gitapi.Commit) (err error) {
 	tx, err := c.Transact(ctx)
 	if err != nil {
 		return err

--- a/enterprise/internal/insights/compression/mock_commit_store.go
+++ b/enterprise/internal/insights/compression/mock_commit_store.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	api "github.com/sourcegraph/sourcegraph/internal/api"
-	git "github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	api1 "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 // MockCommitStore is a mock implementation of the CommitStore interface
@@ -48,12 +48,12 @@ func NewMockCommitStore() *MockCommitStore {
 			},
 		},
 		InsertCommitsFunc: &CommitStoreInsertCommitsFunc{
-			defaultHook: func(context.Context, api.RepoID, []*git.Commit) error {
+			defaultHook: func(context.Context, api.RepoID, []*api1.Commit) error {
 				return nil
 			},
 		},
 		SaveFunc: &CommitStoreSaveFunc{
-			defaultHook: func(context.Context, api.RepoID, *git.Commit) error {
+			defaultHook: func(context.Context, api.RepoID, *api1.Commit) error {
 				return nil
 			},
 		},
@@ -314,15 +314,15 @@ func (c CommitStoreGetMetadataFuncCall) Results() []interface{} {
 // CommitStoreInsertCommitsFunc describes the behavior when the
 // InsertCommits method of the parent MockCommitStore instance is invoked.
 type CommitStoreInsertCommitsFunc struct {
-	defaultHook func(context.Context, api.RepoID, []*git.Commit) error
-	hooks       []func(context.Context, api.RepoID, []*git.Commit) error
+	defaultHook func(context.Context, api.RepoID, []*api1.Commit) error
+	hooks       []func(context.Context, api.RepoID, []*api1.Commit) error
 	history     []CommitStoreInsertCommitsFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertCommits delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockCommitStore) InsertCommits(v0 context.Context, v1 api.RepoID, v2 []*git.Commit) error {
+func (m *MockCommitStore) InsertCommits(v0 context.Context, v1 api.RepoID, v2 []*api1.Commit) error {
 	r0 := m.InsertCommitsFunc.nextHook()(v0, v1, v2)
 	m.InsertCommitsFunc.appendCall(CommitStoreInsertCommitsFuncCall{v0, v1, v2, r0})
 	return r0
@@ -331,7 +331,7 @@ func (m *MockCommitStore) InsertCommits(v0 context.Context, v1 api.RepoID, v2 []
 // SetDefaultHook sets function that is called when the InsertCommits method
 // of the parent MockCommitStore instance is invoked and the hook queue is
 // empty.
-func (f *CommitStoreInsertCommitsFunc) SetDefaultHook(hook func(context.Context, api.RepoID, []*git.Commit) error) {
+func (f *CommitStoreInsertCommitsFunc) SetDefaultHook(hook func(context.Context, api.RepoID, []*api1.Commit) error) {
 	f.defaultHook = hook
 }
 
@@ -339,7 +339,7 @@ func (f *CommitStoreInsertCommitsFunc) SetDefaultHook(hook func(context.Context,
 // InsertCommits method of the parent MockCommitStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *CommitStoreInsertCommitsFunc) PushHook(hook func(context.Context, api.RepoID, []*git.Commit) error) {
+func (f *CommitStoreInsertCommitsFunc) PushHook(hook func(context.Context, api.RepoID, []*api1.Commit) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -348,7 +348,7 @@ func (f *CommitStoreInsertCommitsFunc) PushHook(hook func(context.Context, api.R
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CommitStoreInsertCommitsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoID, []*git.Commit) error {
+	f.SetDefaultHook(func(context.Context, api.RepoID, []*api1.Commit) error {
 		return r0
 	})
 }
@@ -356,12 +356,12 @@ func (f *CommitStoreInsertCommitsFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CommitStoreInsertCommitsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoID, []*git.Commit) error {
+	f.PushHook(func(context.Context, api.RepoID, []*api1.Commit) error {
 		return r0
 	})
 }
 
-func (f *CommitStoreInsertCommitsFunc) nextHook() func(context.Context, api.RepoID, []*git.Commit) error {
+func (f *CommitStoreInsertCommitsFunc) nextHook() func(context.Context, api.RepoID, []*api1.Commit) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -402,7 +402,7 @@ type CommitStoreInsertCommitsFuncCall struct {
 	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 []*git.Commit
+	Arg2 []*api1.Commit
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -423,15 +423,15 @@ func (c CommitStoreInsertCommitsFuncCall) Results() []interface{} {
 // CommitStoreSaveFunc describes the behavior when the Save method of the
 // parent MockCommitStore instance is invoked.
 type CommitStoreSaveFunc struct {
-	defaultHook func(context.Context, api.RepoID, *git.Commit) error
-	hooks       []func(context.Context, api.RepoID, *git.Commit) error
+	defaultHook func(context.Context, api.RepoID, *api1.Commit) error
+	hooks       []func(context.Context, api.RepoID, *api1.Commit) error
 	history     []CommitStoreSaveFuncCall
 	mutex       sync.Mutex
 }
 
 // Save delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockCommitStore) Save(v0 context.Context, v1 api.RepoID, v2 *git.Commit) error {
+func (m *MockCommitStore) Save(v0 context.Context, v1 api.RepoID, v2 *api1.Commit) error {
 	r0 := m.SaveFunc.nextHook()(v0, v1, v2)
 	m.SaveFunc.appendCall(CommitStoreSaveFuncCall{v0, v1, v2, r0})
 	return r0
@@ -439,7 +439,7 @@ func (m *MockCommitStore) Save(v0 context.Context, v1 api.RepoID, v2 *git.Commit
 
 // SetDefaultHook sets function that is called when the Save method of the
 // parent MockCommitStore instance is invoked and the hook queue is empty.
-func (f *CommitStoreSaveFunc) SetDefaultHook(hook func(context.Context, api.RepoID, *git.Commit) error) {
+func (f *CommitStoreSaveFunc) SetDefaultHook(hook func(context.Context, api.RepoID, *api1.Commit) error) {
 	f.defaultHook = hook
 }
 
@@ -447,7 +447,7 @@ func (f *CommitStoreSaveFunc) SetDefaultHook(hook func(context.Context, api.Repo
 // Save method of the parent MockCommitStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *CommitStoreSaveFunc) PushHook(hook func(context.Context, api.RepoID, *git.Commit) error) {
+func (f *CommitStoreSaveFunc) PushHook(hook func(context.Context, api.RepoID, *api1.Commit) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -456,7 +456,7 @@ func (f *CommitStoreSaveFunc) PushHook(hook func(context.Context, api.RepoID, *g
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CommitStoreSaveFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoID, *git.Commit) error {
+	f.SetDefaultHook(func(context.Context, api.RepoID, *api1.Commit) error {
 		return r0
 	})
 }
@@ -464,12 +464,12 @@ func (f *CommitStoreSaveFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CommitStoreSaveFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoID, *git.Commit) error {
+	f.PushHook(func(context.Context, api.RepoID, *api1.Commit) error {
 		return r0
 	})
 }
 
-func (f *CommitStoreSaveFunc) nextHook() func(context.Context, api.RepoID, *git.Commit) error {
+func (f *CommitStoreSaveFunc) nextHook() func(context.Context, api.RepoID, *api1.Commit) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -510,7 +510,7 @@ type CommitStoreSaveFuncCall struct {
 	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 *git.Commit
+	Arg2 *api1.Commit
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error

--- a/enterprise/internal/insights/compression/mock_commit_store.go
+++ b/enterprise/internal/insights/compression/mock_commit_store.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	api "github.com/sourcegraph/sourcegraph/internal/api"
-	api1 "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // MockCommitStore is a mock implementation of the CommitStore interface
@@ -48,12 +48,12 @@ func NewMockCommitStore() *MockCommitStore {
 			},
 		},
 		InsertCommitsFunc: &CommitStoreInsertCommitsFunc{
-			defaultHook: func(context.Context, api.RepoID, []*api1.Commit) error {
+			defaultHook: func(context.Context, api.RepoID, []*gitapi.Commit) error {
 				return nil
 			},
 		},
 		SaveFunc: &CommitStoreSaveFunc{
-			defaultHook: func(context.Context, api.RepoID, *api1.Commit) error {
+			defaultHook: func(context.Context, api.RepoID, *gitapi.Commit) error {
 				return nil
 			},
 		},
@@ -314,15 +314,15 @@ func (c CommitStoreGetMetadataFuncCall) Results() []interface{} {
 // CommitStoreInsertCommitsFunc describes the behavior when the
 // InsertCommits method of the parent MockCommitStore instance is invoked.
 type CommitStoreInsertCommitsFunc struct {
-	defaultHook func(context.Context, api.RepoID, []*api1.Commit) error
-	hooks       []func(context.Context, api.RepoID, []*api1.Commit) error
+	defaultHook func(context.Context, api.RepoID, []*gitapi.Commit) error
+	hooks       []func(context.Context, api.RepoID, []*gitapi.Commit) error
 	history     []CommitStoreInsertCommitsFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertCommits delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockCommitStore) InsertCommits(v0 context.Context, v1 api.RepoID, v2 []*api1.Commit) error {
+func (m *MockCommitStore) InsertCommits(v0 context.Context, v1 api.RepoID, v2 []*gitapi.Commit) error {
 	r0 := m.InsertCommitsFunc.nextHook()(v0, v1, v2)
 	m.InsertCommitsFunc.appendCall(CommitStoreInsertCommitsFuncCall{v0, v1, v2, r0})
 	return r0
@@ -331,7 +331,7 @@ func (m *MockCommitStore) InsertCommits(v0 context.Context, v1 api.RepoID, v2 []
 // SetDefaultHook sets function that is called when the InsertCommits method
 // of the parent MockCommitStore instance is invoked and the hook queue is
 // empty.
-func (f *CommitStoreInsertCommitsFunc) SetDefaultHook(hook func(context.Context, api.RepoID, []*api1.Commit) error) {
+func (f *CommitStoreInsertCommitsFunc) SetDefaultHook(hook func(context.Context, api.RepoID, []*gitapi.Commit) error) {
 	f.defaultHook = hook
 }
 
@@ -339,7 +339,7 @@ func (f *CommitStoreInsertCommitsFunc) SetDefaultHook(hook func(context.Context,
 // InsertCommits method of the parent MockCommitStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *CommitStoreInsertCommitsFunc) PushHook(hook func(context.Context, api.RepoID, []*api1.Commit) error) {
+func (f *CommitStoreInsertCommitsFunc) PushHook(hook func(context.Context, api.RepoID, []*gitapi.Commit) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -348,7 +348,7 @@ func (f *CommitStoreInsertCommitsFunc) PushHook(hook func(context.Context, api.R
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CommitStoreInsertCommitsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoID, []*api1.Commit) error {
+	f.SetDefaultHook(func(context.Context, api.RepoID, []*gitapi.Commit) error {
 		return r0
 	})
 }
@@ -356,12 +356,12 @@ func (f *CommitStoreInsertCommitsFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CommitStoreInsertCommitsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoID, []*api1.Commit) error {
+	f.PushHook(func(context.Context, api.RepoID, []*gitapi.Commit) error {
 		return r0
 	})
 }
 
-func (f *CommitStoreInsertCommitsFunc) nextHook() func(context.Context, api.RepoID, []*api1.Commit) error {
+func (f *CommitStoreInsertCommitsFunc) nextHook() func(context.Context, api.RepoID, []*gitapi.Commit) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -402,7 +402,7 @@ type CommitStoreInsertCommitsFuncCall struct {
 	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 []*api1.Commit
+	Arg2 []*gitapi.Commit
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -423,15 +423,15 @@ func (c CommitStoreInsertCommitsFuncCall) Results() []interface{} {
 // CommitStoreSaveFunc describes the behavior when the Save method of the
 // parent MockCommitStore instance is invoked.
 type CommitStoreSaveFunc struct {
-	defaultHook func(context.Context, api.RepoID, *api1.Commit) error
-	hooks       []func(context.Context, api.RepoID, *api1.Commit) error
+	defaultHook func(context.Context, api.RepoID, *gitapi.Commit) error
+	hooks       []func(context.Context, api.RepoID, *gitapi.Commit) error
 	history     []CommitStoreSaveFuncCall
 	mutex       sync.Mutex
 }
 
 // Save delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockCommitStore) Save(v0 context.Context, v1 api.RepoID, v2 *api1.Commit) error {
+func (m *MockCommitStore) Save(v0 context.Context, v1 api.RepoID, v2 *gitapi.Commit) error {
 	r0 := m.SaveFunc.nextHook()(v0, v1, v2)
 	m.SaveFunc.appendCall(CommitStoreSaveFuncCall{v0, v1, v2, r0})
 	return r0
@@ -439,7 +439,7 @@ func (m *MockCommitStore) Save(v0 context.Context, v1 api.RepoID, v2 *api1.Commi
 
 // SetDefaultHook sets function that is called when the Save method of the
 // parent MockCommitStore instance is invoked and the hook queue is empty.
-func (f *CommitStoreSaveFunc) SetDefaultHook(hook func(context.Context, api.RepoID, *api1.Commit) error) {
+func (f *CommitStoreSaveFunc) SetDefaultHook(hook func(context.Context, api.RepoID, *gitapi.Commit) error) {
 	f.defaultHook = hook
 }
 
@@ -447,7 +447,7 @@ func (f *CommitStoreSaveFunc) SetDefaultHook(hook func(context.Context, api.Repo
 // Save method of the parent MockCommitStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *CommitStoreSaveFunc) PushHook(hook func(context.Context, api.RepoID, *api1.Commit) error) {
+func (f *CommitStoreSaveFunc) PushHook(hook func(context.Context, api.RepoID, *gitapi.Commit) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -456,7 +456,7 @@ func (f *CommitStoreSaveFunc) PushHook(hook func(context.Context, api.RepoID, *a
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CommitStoreSaveFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoID, *api1.Commit) error {
+	f.SetDefaultHook(func(context.Context, api.RepoID, *gitapi.Commit) error {
 		return r0
 	})
 }
@@ -464,12 +464,12 @@ func (f *CommitStoreSaveFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CommitStoreSaveFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoID, *api1.Commit) error {
+	f.PushHook(func(context.Context, api.RepoID, *gitapi.Commit) error {
 		return r0
 	})
 }
 
-func (f *CommitStoreSaveFunc) nextHook() func(context.Context, api.RepoID, *api1.Commit) error {
+func (f *CommitStoreSaveFunc) nextHook() func(context.Context, api.RepoID, *gitapi.Commit) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -510,7 +510,7 @@ type CommitStoreSaveFuncCall struct {
 	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 *api1.Commit
+	Arg2 *gitapi.Commit
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type RepoStore interface {

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type RepoStore interface {
@@ -34,7 +35,7 @@ type CommitIndexer struct {
 	limiter           *rate.Limiter
 	allReposIterator  func(ctx context.Context, each func(repoName string) error) error
 	getRepoID         func(ctx context.Context, name api.RepoName) (*types.Repo, error)
-	getCommits        func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*git.Commit, error)
+	getCommits        func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitapi.Commit, error)
 	commitStore       CommitStore
 	maxHistoricalTime time.Time
 	background        context.Context
@@ -177,7 +178,7 @@ func (i *CommitIndexer) index(name string) (err error) {
 }
 
 //getCommits fetches the commits from the remote gitserver for a repository after a certain time.
-func getCommits(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) (_ []*git.Commit, err error) {
+func getCommits(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) (_ []*gitapi.Commit, err error) {
 	ctx, endObservation := operation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestCommitIndexer_indexAll(t *testing.T) {
@@ -34,7 +34,7 @@ func TestCommitIndexer_indexAll(t *testing.T) {
 	// "repo-one" has commits but has disabled indexing
 	// "really-big-repo" has commits and has enabled indexing, it should update
 	// "no-commits" has no commits but is enabled, and will not update the index but will update the metadata
-	commits := map[string][]*git.Commit{
+	commits := map[string][]*gitapi.Commit{
 		"repo-one": {
 			commit("ref1", "2020-05-01T00:00:00+00:00"),
 			commit("ref2", "2020-05-10T00:00:00+00:00"),
@@ -187,17 +187,17 @@ func mockIterator(repos []string) func(ctx context.Context, each func(repoName s
 }
 
 // commit build a fake commit for test scenarios
-func commit(ref string, commitTime string) *git.Commit {
+func commit(ref string, commitTime string) *gitapi.Commit {
 	t, _ := time.Parse(time.RFC3339, commitTime)
 
-	return &git.Commit{
+	return &gitapi.Commit{
 		ID:        api.CommitID(ref),
-		Committer: &git.Signature{Date: t},
+		Committer: &gitapi.Signature{Date: t},
 	}
 }
 
-func mockCommits(commits map[string][]*git.Commit) func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*git.Commit, error) {
-	return func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*git.Commit, error) {
+func mockCommits(commits map[string][]*gitapi.Commit) func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitapi.Commit, error) {
+	return func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitapi.Commit, error) {
 		return commits[(string(name))], nil
 	}
 }

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestCommitIndexer_indexAll(t *testing.T) {

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func searchInReposNew(ctx context.Context, db dbutil.DB, textParams *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) error {
@@ -182,19 +182,19 @@ func protocolMatchToCommitMatch(repo types.RepoName, diff bool, in protocol.Comm
 	}
 
 	return &result.CommitMatch{
-		Commit: git.Commit{
+		Commit: gitapi.Commit{
 			ID: in.Oid,
-			Author: git.Signature{
+			Author: gitapi.Signature{
 				Name:  in.Author.Name,
 				Email: in.Author.Email,
 				Date:  in.Author.Date,
 			},
-			Committer: &git.Signature{
+			Committer: &gitapi.Signature{
 				Name:  in.Committer.Name,
 				Email: in.Committer.Email,
 				Date:  in.Committer.Date,
 			},
-			Message: git.Message(in.Message.Content),
+			Message: gitapi.Message(in.Message.Content),
 			Parents: in.Parents,
 		},
 		Repo: repo,

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func searchInReposNew(ctx context.Context, db dbutil.DB, textParams *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) error {

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestSearchCommitsInRepo(t *testing.T) {

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestSearchCommitsInRepo(t *testing.T) {
@@ -31,7 +32,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
 	var calledVCSRawLogDiffSearch bool
-	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
+	gitSignatureWithDate := gitapi.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
 	git.Mocks.RawLogDiffSearch = func(opt git.RawLogDiffSearchOptions) ([]*git.LogCommitSearchResult, bool, error) {
 		calledVCSRawLogDiffSearch = true
 		if want := "p"; opt.Query.Pattern != want {
@@ -48,7 +49,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		}
 		return []*git.LogCommitSearchResult{
 			{
-				Commit: git.Commit{ID: "c1", Author: gitSignatureWithDate},
+				Commit: gitapi.Commit{ID: "c1", Author: gitSignatureWithDate},
 				Diff:   &git.RawDiff{Raw: "x"},
 			},
 		}, true, nil
@@ -74,7 +75,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 
 	want := []*result.CommitMatch{{
-		Commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
+		Commit:      gitapi.Commit{ID: "c1", Author: gitSignatureWithDate},
 		Repo:        types.RepoName{ID: 1, Name: "repo"},
 		DiffPreview: &result.HighlightedString{Value: "x", Highlights: []result.HighlightedRange{}},
 		Body:        result.HighlightedString{Value: "```diff\nx```", Highlights: []result.HighlightedRange{}},

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type CommitMatch struct {

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -5,14 +5,15 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/xeonx/timeago"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	"github.com/xeonx/timeago"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 type CommitMatch struct {
-	Commit         git.Commit
+	Commit         gitapi.Commit
 	Repo           types.RepoName
 	Refs           []string
 	SourceRefs     []string

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestDeduper(t *testing.T) {
@@ -16,7 +16,7 @@ func TestDeduper(t *testing.T) {
 			Repo: types.RepoName{
 				Name: api.RepoName(repo),
 			},
-			Commit: git.Commit{
+			Commit: gitapi.Commit{
 				ID: api.CommitID(id),
 			},
 		}
@@ -27,7 +27,7 @@ func TestDeduper(t *testing.T) {
 			Repo: types.RepoName{
 				Name: api.RepoName(repo),
 			},
-			Commit: git.Commit{
+			Commit: gitapi.Commit{
 				ID: api.CommitID(id),
 			},
 			DiffPreview: &HighlightedString{},

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestDeduper(t *testing.T) {

--- a/internal/search/result/merge_test.go
+++ b/internal/search/result/merge_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func commitResult(repo, commit string) *CommitMatch {

--- a/internal/search/result/merge_test.go
+++ b/internal/search/result/merge_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func commitResult(repo, commit string) *CommitMatch {
 	return &CommitMatch{
 		Repo: types.RepoName{Name: api.RepoName(repo)},
-		Commit: git.Commit{
+		Commit: gitapi.Commit{
 			ID: api.CommitID(commit),
 		},
 	}
@@ -24,7 +24,7 @@ func diffResult(repo, commit string) *CommitMatch {
 	return &CommitMatch{
 		DiffPreview: &HighlightedString{},
 		Repo:        types.RepoName{Name: api.RepoName(repo)},
-		Commit: git.Commit{
+		Commit: gitapi.Commit{
 			ID: api.CommitID(commit),
 		},
 	}

--- a/internal/vcs/git/api/api.go
+++ b/internal/vcs/git/api/api.go
@@ -1,0 +1,49 @@
+// Package api contains types to be shared across much of the application.
+// This is partitionined into its own subpackage so importing these
+// widely-used types does not add transitive dependencies on all of
+// the dependencies of internal/vcs/git.
+package api
+
+import (
+	"strings"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+type Commit struct {
+	ID        api.CommitID `json:"ID,omitempty"`
+	Author    Signature    `json:"Author"`
+	Committer *Signature   `json:"Committer,omitempty"`
+	Message   Message      `json:"Message,omitempty"`
+	// Parents are the commit IDs of this commit's parent commits.
+	Parents []api.CommitID `json:"Parents,omitempty"`
+}
+
+type Message string
+
+// Subject returns the first line of the commit message
+func (m Message) Subject() string {
+	message := string(m)
+	i := strings.Index(message, "\n")
+	if i == -1 {
+		return strings.TrimSpace(message)
+	}
+	return strings.TrimSpace(message[:i])
+}
+
+// Body returns the contents of the Git commit message after the subject.
+func (m Message) Body() string {
+	message := string(m)
+	i := strings.Index(message, "\n")
+	if i == -1 {
+		return ""
+	}
+	return strings.TrimSpace(message[i:])
+}
+
+type Signature struct {
+	Name  string    `json:"Name,omitempty"`
+	Email string    `json:"Email,omitempty"`
+	Date  time.Time `json:"Date"`
+}

--- a/internal/vcs/git/blame.go
+++ b/internal/vcs/git/blame.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // BlameOptions configures a blame.

--- a/internal/vcs/git/blame.go
+++ b/internal/vcs/git/blame.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 // BlameOptions configures a blame.
@@ -30,7 +31,7 @@ type Hunk struct {
 	StartByte int // 0-indexed start byte position (inclusive)
 	EndByte   int // 0-indexed end byte position (exclusive)
 	api.CommitID
-	Author  Signature
+	Author  gitapi.Signature
 	Message string
 }
 
@@ -72,7 +73,7 @@ func blameFileCmd(ctx context.Context, command cmdFunc, path string, opt *BlameO
 		return nil, nil
 	}
 
-	commits := make(map[string]Commit)
+	commits := make(map[string]gitapi.Commit)
 	hunks := make([]*Hunk, 0)
 	remainingLines := strings.Split(string(out[:len(out)-1]), "\n")
 	byteOffset := 0
@@ -108,10 +109,10 @@ func blameFileCmd(ctx context.Context, command cmdFunc, path string, opt *BlameO
 				return nil, errors.Errorf("Failed to parse author-time %q", remainingLines[3])
 			}
 			summary := strings.Join(strings.Split(remainingLines[9], " ")[1:], " ")
-			commit := Commit{
+			commit := gitapi.Commit{
 				ID:      api.CommitID(commitID),
-				Message: Message(summary),
-				Author: Signature{
+				Message: gitapi.Message(summary),
+				Author: gitapi.Signature{
 					Name:  author,
 					Email: email,
 					Date:  time.Unix(authorTime, 0).UTC(),

--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestRepository_BlameFile(t *testing.T) {

--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestRepository_BlameFile(t *testing.T) {
@@ -24,11 +25,11 @@ func TestRepository_BlameFile(t *testing.T) {
 	gitWantHunks := []*Hunk{
 		{
 			StartLine: 1, EndLine: 2, StartByte: 0, EndByte: 6, CommitID: "e6093374dcf5725d8517db0dccbbf69df65dbde0",
-			Message: "foo", Author: Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Message: "foo", Author: gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 		},
 		{
 			StartLine: 2, EndLine: 3, StartByte: 6, EndByte: 12, CommitID: "fad406f4fe02c358a09df0d03ec7a36c2c8a20f1",
-			Message: "foo", Author: Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Message: "foo", Author: gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 		},
 	}
 	tests := map[string]struct {

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // CommitsOptions specifies options for (Repository).Commits (Repository).CommitCount.

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -20,44 +20,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
-
-type Commit struct {
-	ID        api.CommitID `json:"ID,omitempty"`
-	Author    Signature    `json:"Author"`
-	Committer *Signature   `json:"Committer,omitempty"`
-	Message   Message      `json:"Message,omitempty"`
-	// Parents are the commit IDs of this commit's parent commits.
-	Parents []api.CommitID `json:"Parents,omitempty"`
-}
-
-type Message string
-
-// Subject returns the first line of the commit message
-func (m Message) Subject() string {
-	message := string(m)
-	i := strings.Index(message, "\n")
-	if i == -1 {
-		return strings.TrimSpace(message)
-	}
-	return strings.TrimSpace(message[:i])
-}
-
-// Body returns the contents of the Git commit message after the subject.
-func (m Message) Body() string {
-	message := string(m)
-	i := strings.Index(message, "\n")
-	if i == -1 {
-		return ""
-	}
-	return strings.TrimSpace(message[i:])
-}
-
-type Signature struct {
-	Name  string    `json:"Name,omitempty"`
-	Email string    `json:"Email,omitempty"`
-	Date  time.Time `json:"Date"`
-}
 
 // CommitsOptions specifies options for (Repository).Commits (Repository).CommitCount.
 type CommitsOptions struct {
@@ -88,7 +52,7 @@ var logEntryPattern = lazyregexp.New(`^\s*([0-9]+)\s+(.*)$`)
 var recordGetCommitQueries = os.Getenv("RECORD_GET_COMMIT_QUERIES") == "1"
 
 // getCommit returns the commit with the given id.
-func getCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions) (_ *Commit, err error) {
+func getCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions) (_ *gitapi.Commit, err error) {
 	if Mocks.GetCommit != nil {
 		return Mocks.GetCommit(id)
 	}
@@ -141,7 +105,7 @@ func getCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt Reso
 // The remoteURLFunc is called to get the Git remote URL if it's not set in repo and if it is
 // needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
 // the repository or if the commit must be fetched from the remote.
-func GetCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions) (*Commit, error) {
+func GetCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions) (*gitapi.Commit, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetCommit")
 	span.SetTag("Commit", id)
 	defer span.Finish()
@@ -150,7 +114,7 @@ func GetCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt Reso
 }
 
 // Commits returns all commits matching the options.
-func Commits(ctx context.Context, repo api.RepoName, opt CommitsOptions) ([]*Commit, error) {
+func Commits(ctx context.Context, repo api.RepoName, opt CommitsOptions) ([]*gitapi.Commit, error) {
 	if Mocks.Commits != nil {
 		return Mocks.Commits(repo, opt)
 	}
@@ -198,7 +162,7 @@ func isBadObjectErr(output, obj string) bool {
 // commitLog returns a list of commits.
 //
 // The caller is responsible for doing checkSpecArgSafety on opt.Head and opt.Base.
-func commitLog(ctx context.Context, repo api.RepoName, opt CommitsOptions) (commits []*Commit, err error) {
+func commitLog(ctx context.Context, repo api.RepoName, opt CommitsOptions) (commits []*gitapi.Commit, err error) {
 	args, err := commitLogArgs([]string{"log", logFormatWithoutRefs}, opt)
 	if err != nil {
 		return nil, err
@@ -215,7 +179,7 @@ func commitLog(ctx context.Context, repo api.RepoName, opt CommitsOptions) (comm
 // runCommitLog sends the git command to gitserver. It interprets missing
 // revision responses and converts them into RevisionNotFoundError.
 // It is declared as a variable so that we can swap it out in tests
-var runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*Commit, error) {
+var runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*gitapi.Commit, error) {
 	data, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		data = bytes.TrimSpace(data)
@@ -227,9 +191,9 @@ var runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOpti
 
 	allParts := bytes.Split(data, []byte{'\x00'})
 	numCommits := len(allParts) / partsPerCommit
-	commits := make([]*Commit, 0, numCommits)
+	commits := make([]*gitapi.Commit, 0, numCommits)
 	for len(data) > 0 {
-		var commit *Commit
+		var commit *gitapi.Commit
 		var err error
 		commit, _, data, err = parseCommitFromLog(data)
 		if err != nil {
@@ -311,7 +275,7 @@ func CommitCount(ctx context.Context, repo api.RepoName, opt CommitsOptions) (ui
 }
 
 // FirstEverCommit returns the first commit ever made to the repository.
-func FirstEverCommit(ctx context.Context, repo api.RepoName) (*Commit, error) {
+func FirstEverCommit(ctx context.Context, repo api.RepoName) (*gitapi.Commit, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: FirstEverCommit")
 	defer span.Finish()
 
@@ -331,7 +295,7 @@ func FirstEverCommit(ctx context.Context, repo api.RepoName) (*Commit, error) {
 //
 // Can return a commit very far away if no nearby one exists.
 // Can theoretically return nil, nil if no commits at all are found.
-func FindNearestCommit(ctx context.Context, repoName api.RepoName, revSpec string, target time.Time) (*Commit, error) {
+func FindNearestCommit(ctx context.Context, repoName api.RepoName, revSpec string, target time.Time) (*gitapi.Commit, error) {
 	if revSpec == "" {
 		revSpec = "HEAD"
 	}
@@ -351,7 +315,7 @@ func FindNearestCommit(ctx context.Context, repoName api.RepoName, revSpec strin
 	if err != nil {
 		return nil, err
 	}
-	var commitOnOrAfter *Commit
+	var commitOnOrAfter *gitapi.Commit
 	if len(commitsAfter) > 0 {
 		commitOnOrAfter = commitsAfter[0]
 	}
@@ -366,7 +330,7 @@ func FindNearestCommit(ctx context.Context, repoName api.RepoName, revSpec strin
 	if err != nil {
 		return nil, err
 	}
-	var commitBefore *Commit
+	var commitBefore *gitapi.Commit
 	if len(commitsBefore) > 0 {
 		commitBefore = commitsBefore[0]
 	}
@@ -410,7 +374,7 @@ const (
 // parseCommitFromLog parses the next commit from data and returns the commit and the remaining
 // data. The data arg is a byte array that contains NUL-separated log fields as formatted by
 // logFormatFlag.
-func parseCommitFromLog(data []byte) (commit *Commit, refs []string, rest []byte, err error) {
+func parseCommitFromLog(data []byte) (commit *gitapi.Commit, refs []string, rest []byte, err error) {
 	parts := bytes.SplitN(data, []byte{'\x00'}, partsPerCommit+1)
 	if len(parts) < partsPerCommit {
 		return nil, nil, nil, errors.Errorf("invalid commit log entry: %q", parts)
@@ -443,11 +407,11 @@ func parseCommitFromLog(data []byte) (commit *Commit, refs []string, rest []byte
 		refs = strings.Split(string(parts[1]), ", ")
 	}
 
-	commit = &Commit{
+	commit = &gitapi.Commit{
 		ID:        commitID,
-		Author:    Signature{Name: string(parts[2]), Email: string(parts[3]), Date: time.Unix(authorTime, 0).UTC()},
-		Committer: &Signature{Name: string(parts[5]), Email: string(parts[6]), Date: time.Unix(committerTime, 0).UTC()},
-		Message:   Message(strings.TrimSuffix(string(parts[8]), "\n")),
+		Author:    gitapi.Signature{Name: string(parts[2]), Email: string(parts[3]), Date: time.Unix(authorTime, 0).UTC()},
+		Committer: &gitapi.Signature{Name: string(parts[5]), Email: string(parts[6]), Date: time.Unix(committerTime, 0).UTC()},
+		Message:   gitapi.Message(strings.TrimSuffix(string(parts[8]), "\n")),
 		Parents:   parents,
 	}
 

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestRepository_GetCommit(t *testing.T) {

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestRepository_GetCommit(t *testing.T) {
@@ -20,17 +21,17 @@ func TestRepository_GetCommit(t *testing.T) {
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 	}
-	wantGitCommit := &Commit{
+	wantGitCommit := &gitapi.Commit{
 		ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-		Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-		Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+		Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+		Committer: &gitapi.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
 		Message:   "bar",
 		Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 	}
 	tests := map[string]struct {
 		repo             api.RepoName
 		id               api.CommitID
-		wantCommit       *Commit
+		wantCommit       *gitapi.Commit
 		noEnsureRevision bool
 	}{
 		"git cmd with NoEnsureRevision false": {
@@ -54,7 +55,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		t.Cleanup(func() {
 			runCommitLog = oldRunCommitLog
 		})
-		runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*Commit, error) {
+		runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*gitapi.Commit, error) {
 			// Track the value of NoEnsureRevision we pass to gitserver
 			noEnsureRevision = opt.NoEnsureRevision
 			return oldRunCommitLog(ctx, cmd, opt)
@@ -272,18 +273,18 @@ func TestRepository_Commits(t *testing.T) {
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 	}
-	wantGitCommits := []*Commit{
+	wantGitCommits := []*gitapi.Commit{
 		{
 			ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-			Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+			Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+			Committer: &gitapi.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
 			Message:   "bar",
 			Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 		},
 		{
 			ID:        "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
-			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-			Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 			Message:   "foo",
 			Parents:   nil,
 		},
@@ -291,7 +292,7 @@ func TestRepository_Commits(t *testing.T) {
 	tests := map[string]struct {
 		repo        api.RepoName
 		id          api.CommitID
-		wantCommits []*Commit
+		wantCommits []*gitapi.Commit
 		wantTotal   uint
 	}{
 		"git cmd": {
@@ -324,7 +325,7 @@ func TestRepository_Commits(t *testing.T) {
 		}
 
 		for i := 0; i < len(commits) || i < len(test.wantCommits); i++ {
-			var gotC, wantC *Commit
+			var gotC, wantC *gitapi.Commit
 			if i < len(commits) {
 				gotC = commits[i]
 			}
@@ -352,20 +353,20 @@ func TestRepository_Commits_options(t *testing.T) {
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:08Z git commit --allow-empty -m qux --author='a <a@a.com>' --date 2006-01-02T15:04:08Z",
 	}
-	wantGitCommits := []*Commit{
+	wantGitCommits := []*gitapi.Commit{
 		{
 			ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-			Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+			Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+			Committer: &gitapi.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
 			Message:   "bar",
 			Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 		},
 	}
-	wantGitCommits2 := []*Commit{
+	wantGitCommits2 := []*gitapi.Commit{
 		{
 			ID:        "ade564eba4cf904492fb56dcd287ac633e6e082c",
-			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
-			Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
+			Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
+			Committer: &gitapi.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
 			Message:   "qux",
 			Parents:   []api.CommitID{"b266c7e3ca00b1a17ad0b1449825d0854225c007"},
 		},
@@ -373,7 +374,7 @@ func TestRepository_Commits_options(t *testing.T) {
 	tests := map[string]struct {
 		repo        api.RepoName
 		opt         CommitsOptions
-		wantCommits []*Commit
+		wantCommits []*gitapi.Commit
 		wantTotal   uint
 	}{
 		"git cmd": {
@@ -397,11 +398,11 @@ func TestRepository_Commits_options(t *testing.T) {
 				Range:  "HEAD",
 				N:      1,
 			},
-			wantCommits: []*Commit{
+			wantCommits: []*gitapi.Commit{
 				{
 					ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-					Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-					Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+					Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+					Committer: &gitapi.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
 					Message:   "bar",
 					Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 				},
@@ -432,7 +433,7 @@ func TestRepository_Commits_options(t *testing.T) {
 		}
 
 		for i := 0; i < len(commits) || i < len(test.wantCommits); i++ {
-			var gotC, wantC *Commit
+			var gotC, wantC *gitapi.Commit
 			if i < len(commits) {
 				gotC = commits[i]
 			}
@@ -458,11 +459,11 @@ func TestRepository_Commits_options_path(t *testing.T) {
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit2 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m commit3 --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 	}
-	wantGitCommits := []*Commit{
+	wantGitCommits := []*gitapi.Commit{
 		{
 			ID:        "546a3ef26e581624ef997cb8c0ba01ee475fc1dc",
-			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-			Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 			Message:   "commit2",
 			Parents:   []api.CommitID{"a04652fa1998a0a7d2f2f77ecb7021de943d3aab"},
 		},
@@ -470,7 +471,7 @@ func TestRepository_Commits_options_path(t *testing.T) {
 	tests := map[string]struct {
 		repo        api.RepoName
 		opt         CommitsOptions
-		wantCommits []*Commit
+		wantCommits []*gitapi.Commit
 		wantTotal   uint
 	}{
 		"git cmd Path 0": {
@@ -515,7 +516,7 @@ func TestRepository_Commits_options_path(t *testing.T) {
 		}
 
 		for i := 0; i < len(commits) || i < len(test.wantCommits); i++ {
-			var gotC, wantC *Commit
+			var gotC, wantC *gitapi.Commit
 			if i < len(commits) {
 				gotC = commits[i]
 			}
@@ -680,7 +681,7 @@ func TestLogOnelineBatchScanner_small(t *testing.T) {
 
 func TestMessage(t *testing.T) {
 	t.Run("Body", func(t *testing.T) {
-		tests := map[Message]string{
+		tests := map[gitapi.Message]string{
 			"hello":                 "",
 			"hello\n":               "",
 			"hello\n\n":             "",

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/pathmatch"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 // TextSearchOptions contains common options for text search commands.
@@ -82,9 +83,9 @@ type RawLogDiffSearchOptions struct {
 
 // LogCommitSearchResult describes a matching diff from (Repository).RawLogDiffSearch.
 type LogCommitSearchResult struct {
-	Commit         Commit      // the commit whose diff was matched
-	Diff           *RawDiff    // the diff, with non-matching/irrelevant portions deleted (respecting diff syntax)
-	DiffHighlights []Highlight // highlighted query matches in the diff
+	Commit         gitapi.Commit // the commit whose diff was matched
+	Diff           *RawDiff      // the diff, with non-matching/irrelevant portions deleted (respecting diff syntax)
+	DiffHighlights []Highlight   // highlighted query matches in the diff
 
 	// Refs is the list of ref names of this commit (from `git log --decorate`).
 	Refs []string
@@ -382,7 +383,7 @@ func rawShowSearch(ctx context.Context, repo api.RepoName, opt RawLogDiffSearchO
 		return nil, complete, err
 	}
 	for len(data) > 0 {
-		var commit *Commit
+		var commit *gitapi.Commit
 		var refs []string
 		var err error
 		commit, refs, data, err = parseCommitFromLog(data)

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/pathmatch"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // TextSearchOptions contains common options for text search commands.

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestRepository_RawLogDiffSearch(t *testing.T) {

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestRepository_RawLogDiffSearch(t *testing.T) {
@@ -58,10 +59,10 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			Diff:  true,
 		},
 		want: []*LogCommitSearchResult{{
-			Commit: Commit{
+			Commit: gitapi.Commit{
 				ID:        "b9b2349a02271ca96e82c70f384812f9c62c26ab",
-				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
 				Message:   "branch1",
 				Parents:   []api.CommitID{"ce72ece27fd5c8180cfbc1c412021d32fd1cda0d"},
 			},
@@ -69,10 +70,10 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			SourceRefs: []string{"refs/heads/branch2"},
 			Diff:       &RawDiff{Raw: "diff --git f f\nindex d8649da..1193ff4 100644\n--- f\n+++ f\n@@ -1,1 +1,1 @@\n-root\n+branch1\n"},
 		}, {
-			Commit: Commit{
+			Commit: gitapi.Commit{
 				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
-				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 				Message:   "root",
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
@@ -87,10 +88,10 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			Args:  []string{"--glob=refs/tags/*"},
 		},
 		want: []*LogCommitSearchResult{{
-			Commit: Commit{
+			Commit: gitapi.Commit{
 				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
-				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 				Message:   "root",
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
@@ -104,20 +105,20 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			Args:  []string{"--grep=branch1|root", "--extended-regexp"},
 		},
 		want: []*LogCommitSearchResult{{
-			Commit: Commit{
+			Commit: gitapi.Commit{
 				ID:        "b9b2349a02271ca96e82c70f384812f9c62c26ab",
-				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
 				Message:   "branch1",
 				Parents:   []api.CommitID{"ce72ece27fd5c8180cfbc1c412021d32fd1cda0d"},
 			},
 			Refs:       []string{"refs/heads/branch1"},
 			SourceRefs: []string{"refs/heads/branch2"},
 		}, {
-			Commit: Commit{
+			Commit: gitapi.Commit{
 				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
-				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 				Message:   "root",
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},

--- a/internal/vcs/git/gitapi/api.go
+++ b/internal/vcs/git/gitapi/api.go
@@ -1,8 +1,8 @@
-// Package api contains types to be shared across much of the application.
+// Package gitapi contains types to be shared across much of the application.
 // This is partitionined into its own subpackage so importing these
 // widely-used types does not add transitive dependencies on all of
 // the dependencies of internal/vcs/git.
-package api
+package gitapi
 
 import (
 	"strings"

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 var root string
@@ -137,7 +138,7 @@ func MakeGitRepository(t testing.TB, cmds ...string) api.RepoName {
 	return repo
 }
 
-func CommitsEqual(a, b *Commit) bool {
+func CommitsEqual(a, b *gitapi.Commit) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 var root string

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 // Mocks is used to mock behavior in tests. Tests must call ResetMocks() when finished to ensure its
@@ -12,7 +13,7 @@ import (
 //
 // (The emptyMocks is used by ResetMocks to zero out Mocks without needing to use a named type.)
 var Mocks, emptyMocks struct {
-	GetCommit        func(api.CommitID) (*Commit, error)
+	GetCommit        func(api.CommitID) (*gitapi.Commit, error)
 	ExecSafe         func(params []string) (stdout, stderr []byte, exitCode int, err error)
 	ExecReader       func(args []string) (reader io.ReadCloser, err error)
 	RawLogDiffSearch func(opt RawLogDiffSearchOptions) ([]*LogCommitSearchResult, bool, error)
@@ -23,7 +24,7 @@ var Mocks, emptyMocks struct {
 	ResolveRevision  func(spec string, opt ResolveRevisionOptions) (api.CommitID, error)
 	Stat             func(commit api.CommitID, name string) (fs.FileInfo, error)
 	GetObject        func(objectName string) (OID, ObjectType, error)
-	Commits          func(repo api.RepoName, opt CommitsOptions) ([]*Commit, error)
+	Commits          func(repo api.RepoName, opt CommitsOptions) ([]*gitapi.Commit, error)
 	MergeBase        func(repo api.RepoName, a, b api.CommitID) (api.CommitID, error)
 	GetDefaultBranch func(repo api.RepoName) (refName string, commit api.CommitID, err error)
 }

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // Mocks is used to mock behavior in tests. Tests must call ResetMocks() when finished to ensure its

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 // HumanReadableBranchName returns a human readable branch name from the
@@ -65,7 +66,7 @@ type Branch struct {
 	Head api.CommitID `json:"Head,omitempty"`
 	// Commit optionally contains commit information for this branch's head commit.
 	// It is populated if IncludeCommit option is set.
-	Commit *Commit `json:"Commit,omitempty"`
+	Commit *gitapi.Commit `json:"Commit,omitempty"`
 	// Counts optionally contains the commit counts relative to specified branch.
 	Counts *BehindAhead `json:"Counts,omitempty"`
 }

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 // HumanReadableBranchName returns a human readable branch name from the

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 func TestHumanReadableBranchName(t *testing.T) {

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	gitapi "github.com/sourcegraph/sourcegraph/internal/vcs/git/api"
 )
 
 func TestHumanReadableBranchName(t *testing.T) {
@@ -223,20 +224,20 @@ func TestRepository_Branches_IncludeCommit(t *testing.T) {
 	wantBranchesGit := []*Branch{
 		{
 			Name: "b0", Head: "c4a53701494d1d788b1ceeb8bf32e90224962473",
-			Commit: &Commit{
+			Commit: &gitapi.Commit{
 				ID:        "c4a53701494d1d788b1ceeb8bf32e90224962473",
-				Author:    Signature{Name: "b", Email: "b@b.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-				Committer: &Signature{Name: "b", Email: "b@b.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Author:    gitapi.Signature{Name: "b", Email: "b@b.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Committer: &gitapi.Signature{Name: "b", Email: "b@b.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
 				Message:   "foo1",
 				Parents:   []api.CommitID{"a3c1537db9797215208eec56f8e7c9c37f8358ca"},
 			},
 		},
 		{
 			Name: "master", Head: "a3c1537db9797215208eec56f8e7c9c37f8358ca",
-			Commit: &Commit{
+			Commit: &gitapi.Commit{
 				ID:        "a3c1537db9797215208eec56f8e7c9c37f8358ca",
-				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Author:    gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Committer: &gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 				Message:   "foo0",
 				Parents:   nil,
 			},


### PR DESCRIPTION
This PR moves `git.Commit`, `git.Message`, and `git.Signature` to their own subpackage `internal/vcs/git/api`.

Motivation: Transitive dependency thinning. These types are used widely across our application, and importing them adds all the dependencies of `internal/vcs/git`, which is many (see `go list -f '{{ .Deps }}' ./internal/vcs/git`). This has been causing some pain trying to avoid circular dependencies between packages that really shouldn't depend on each other, and moving these into their own package will help alleviate that. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
