### PR TITLE
move Location, Range, and MatchedString into `internal/search/result`

### DIFF
--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 type SearchRequest struct {
@@ -62,8 +63,8 @@ type CommitMatch struct {
 	Refs       []string       `json:",omitempty"`
 	SourceRefs []string       `json:",omitempty"`
 
-	Message MatchedString `json:",omitempty"`
-	Diff    MatchedString `json:",omitempty"`
+	Message result.MatchedString `json:",omitempty"`
+	Diff    result.MatchedString `json:",omitempty"`
 }
 
 type Signature struct {

--- a/internal/gitserver/search/diff_format.go
+++ b/internal/gitserver/search/diff_format.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/go-diff/diff"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 const (
@@ -17,10 +17,10 @@ const (
 	maxFiles          = 5
 )
 
-func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (string, protocol.Ranges) {
+func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (string, result.Ranges) {
 	var buf strings.Builder
-	var loc protocol.Location
-	var ranges protocol.Ranges
+	var loc result.Location
+	var ranges result.Ranges
 
 	fileCount := 0
 	for fileIdx, fileDiff := range rawDiff {
@@ -118,7 +118,7 @@ func splitHunkMatches(hunks []*diff.Hunk, hunkHighlights map[int]MatchedHunk, ma
 		var cur *diff.Hunk
 		var curLines [][]byte
 		origHighlights := hunkHighlights[i].MatchedLines
-		curHighlights := make(map[int]protocol.Ranges, len(hunkHighlights))
+		curHighlights := make(map[int]result.Ranges, len(hunkHighlights))
 
 		lines := bytes.SplitAfter(hunk.Body, []byte("\n"))
 		lineInfo := computeDiffHunkInfo(lines, hunkHighlights[i].MatchedLines, matchContextLines)
@@ -161,7 +161,7 @@ func splitHunkMatches(hunks []*diff.Hunk, hunkHighlights map[int]MatchedHunk, ma
 				cur.Body = bytes.Join(curLines, nil)
 				if len(curHighlights) > 0 {
 					newHighlights[len(results)] = MatchedHunk{MatchedLines: curHighlights}
-					curHighlights = make(map[int]protocol.Ranges)
+					curHighlights = make(map[int]result.Ranges)
 				}
 				results = append(results, cur)
 				cur = nil
@@ -199,7 +199,7 @@ type diffHunkLineInfo struct {
 
 func (info diffHunkLineInfo) changed() bool { return info.added || info.removed }
 
-func computeDiffHunkInfo(lines [][]byte, lineHighlights map[int]protocol.Ranges, matchContextLines int) []diffHunkLineInfo {
+func computeDiffHunkInfo(lines [][]byte, lineHighlights map[int]result.Ranges, matchContextLines int) []diffHunkLineInfo {
 	// Return context line numbers for a given line number.
 	contextLines := func(line int) (start, end int) {
 		start = line - matchContextLines

--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 func TestDiffFormat(t *testing.T) {
@@ -26,10 +26,10 @@ index dbace57d5f..53357b4971 100644
 
 		highlights := map[int]MatchedFileDiff{
 			0: {MatchedHunks: map[int]MatchedHunk{
-				0: {MatchedLines: map[int]protocol.Ranges{
+				0: {MatchedLines: map[int]result.Ranges{
 					2: {{
-						Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
-						End:   protocol.Location{Offset: 6, Line: 0, Column: 6},
+						Start: result.Location{Offset: 0, Line: 0, Column: 0},
+						End:   result.Location{Offset: 6, Line: 0, Column: 6},
 					}},
 				}},
 			}},
@@ -43,9 +43,9 @@ index dbace57d5f..53357b4971 100644
 `
 		require.Equal(t, expectedFormatted, formatted)
 
-		expectedRanges := protocol.Ranges{{
-			Start: protocol.Location{Offset: 142, Line: 3, Column: 1},
-			End:   protocol.Location{Offset: 148, Line: 3, Column: 7},
+		expectedRanges := result.Ranges{{
+			Start: result.Location{Offset: 142, Line: 3, Column: 1},
+			End:   result.Location{Offset: 148, Line: 3, Column: 7},
 		}}
 		require.Equal(t, expectedRanges, ranges)
 

--- a/internal/gitserver/search/diff_test.go
+++ b/internal/gitserver/search/diff_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 var (
@@ -37,20 +38,20 @@ func TestDiffSearch(t *testing.T) {
 			1: {
 				MatchedHunks: map[int]MatchedHunk{
 					0: {
-						MatchedLines: map[int]protocol.Ranges{
+						MatchedLines: map[int]result.Ranges{
 							3: {{
-								Start: protocol.Location{Offset: 9, Column: 9},
-								End:   protocol.Location{Offset: 14, Column: 14},
+								Start: result.Location{Offset: 9, Column: 9},
+								End:   result.Location{Offset: 14, Column: 14},
 							}, {
-								Start: protocol.Location{Offset: 24, Column: 24},
-								End:   protocol.Location{Offset: 29, Column: 29},
+								Start: result.Location{Offset: 24, Column: 24},
+								End:   result.Location{Offset: 29, Column: 29},
 							}},
 							4: {{
-								Start: protocol.Location{Offset: 9, Column: 9},
-								End:   protocol.Location{Offset: 14, Column: 14},
+								Start: result.Location{Offset: 9, Column: 9},
+								End:   result.Location{Offset: 14, Column: 14},
 							}, {
-								Start: protocol.Location{Offset: 43, Column: 43},
-								End:   protocol.Location{Offset: 48, Column: 48},
+								Start: result.Location{Offset: 43, Column: 43},
+								End:   result.Location{Offset: 48, Column: 48},
 							}},
 						},
 					},
@@ -69,18 +70,18 @@ func TestDiffSearch(t *testing.T) {
  import { PuppeteerAdapter } from './polly/PuppeteerAdapter'
 `
 
-	expectedRanges := protocol.Ranges{{
-		Start: protocol.Location{Line: 3, Column: 10, Offset: 200},
-		End:   protocol.Location{Line: 3, Column: 15, Offset: 205},
+	expectedRanges := result.Ranges{{
+		Start: result.Location{Line: 3, Column: 10, Offset: 200},
+		End:   result.Location{Line: 3, Column: 15, Offset: 205},
 	}, {
-		Start: protocol.Location{Line: 3, Column: 25, Offset: 215},
-		End:   protocol.Location{Line: 3, Column: 30, Offset: 220},
+		Start: result.Location{Line: 3, Column: 25, Offset: 215},
+		End:   result.Location{Line: 3, Column: 30, Offset: 220},
 	}, {
-		Start: protocol.Location{Line: 4, Column: 10, Offset: 239},
-		End:   protocol.Location{Line: 4, Column: 15, Offset: 244},
+		Start: result.Location{Line: 4, Column: 10, Offset: 239},
+		End:   result.Location{Line: 4, Column: 15, Offset: 244},
 	}, {
-		Start: protocol.Location{Line: 4, Column: 44, Offset: 273},
-		End:   protocol.Location{Line: 4, Column: 49, Offset: 278},
+		Start: result.Location{Line: 4, Column: 44, Offset: 273},
+		End:   result.Location{Line: 4, Column: 49, Offset: 278},
 	}}
 
 	require.Equal(t, expectedFormatted, formatted)

--- a/internal/gitserver/search/highlight.go
+++ b/internal/gitserver/search/highlight.go
@@ -3,13 +3,13 @@ package search
 import (
 	"sort"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // MatchedCommit are the portions of a commit that match a query
 type MatchedCommit struct {
 	// Message is the set of ranges of the commit message that were matched
-	Message protocol.Ranges
+	Message result.Ranges
 
 	// Diff is the set of files deltas that have matches in the parsed diff.
 	// The key of the map is the index of the delta in the diff.
@@ -40,8 +40,8 @@ func (c *MatchedCommit) Merge(other *MatchedCommit) *MatchedCommit {
 }
 
 type MatchedFileDiff struct {
-	OldFile      protocol.Ranges
-	NewFile      protocol.Ranges
+	OldFile      result.Ranges
+	NewFile      result.Ranges
 	MatchedHunks map[int]MatchedHunk
 }
 
@@ -63,7 +63,7 @@ func (f MatchedFileDiff) Merge(other MatchedFileDiff) MatchedFileDiff {
 }
 
 type MatchedHunk struct {
-	MatchedLines map[int]protocol.Ranges
+	MatchedLines map[int]result.Ranges
 }
 
 func (h MatchedHunk) Merge(other MatchedHunk) MatchedHunk {

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/search/casetransform"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // ToMatchTree converts a protocol.SearchQuery into its equivalent MatchTree.
@@ -137,7 +138,7 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 	for fileIdx, fileDiff := range diff {
 		var hunkHighlights map[int]MatchedHunk
 		for hunkIdx, hunk := range fileDiff.Hunks {
-			var lineHighlights map[int]protocol.Ranges
+			var lineHighlights map[int]result.Ranges
 			for lineIdx, line := range bytes.Split(hunk.Body, []byte("\n")) {
 				if len(line) == 0 {
 					continue
@@ -154,7 +155,7 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 				if matches != nil {
 					foundMatch = true
 					if lineHighlights == nil {
-						lineHighlights = make(map[int]protocol.Ranges, 1)
+						lineHighlights = make(map[int]result.Ranges, 1)
 					}
 					lineHighlights[lineIdx] = matchesToRanges(lineWithoutPrefix, matches)
 				}
@@ -257,7 +258,7 @@ func (o *Operator) Match(commit *LazyCommit) (bool, *MatchedCommit, error) {
 // and converts it to Ranges.
 // INVARIANT: matches must be ordered and non-overlapping,
 // which is guaranteed by regexp.FindAllIndex()
-func matchesToRanges(content []byte, matches [][]int) protocol.Ranges {
+func matchesToRanges(content []byte, matches [][]int) result.Ranges {
 	var (
 		unscannedOffset          = 0
 		scannedNewlines          = 0
@@ -278,13 +279,13 @@ func matchesToRanges(content []byte, matches [][]int) protocol.Ranges {
 		return scannedNewlines, column, scannedRunes
 	}
 
-	res := make(protocol.Ranges, 0, len(matches))
+	res := make(result.Ranges, 0, len(matches))
 	for _, match := range matches {
 		startLine, startColumn, startOffset := lineColumnOffset(match[0])
 		endLine, endColumn, endOffset := lineColumnOffset(match[1])
-		res = append(res, protocol.Range{
-			Start: protocol.Location{Line: startLine, Column: startColumn, Offset: startOffset},
-			End:   protocol.Location{Line: endLine, Column: endColumn, Offset: endOffset},
+		res = append(res, result.Range{
+			Start: result.Location{Line: startLine, Column: startColumn, Offset: startOffset},
+			End:   result.Location{Line: endLine, Column: endColumn, Offset: endOffset},
 		})
 	}
 	return res

--- a/internal/gitserver/search/match_tree_test.go
+++ b/internal/gitserver/search/match_tree_test.go
@@ -6,78 +6,78 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 func Test_matchesToRanges(t *testing.T) {
 	type testCase struct {
 		input          string
 		matches        [][]int
-		expectedRanges protocol.Ranges
+		expectedRanges result.Ranges
 	}
 
 	cases := [...]testCase{
 		0: {
 			input:   "abc",
 			matches: [][]int{{0, 1}, {2, 3}},
-			expectedRanges: protocol.Ranges{{
-				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
-				End:   protocol.Location{Offset: 1, Line: 0, Column: 1},
+			expectedRanges: result.Ranges{{
+				Start: result.Location{Offset: 0, Line: 0, Column: 0},
+				End:   result.Location{Offset: 1, Line: 0, Column: 1},
 			}, {
-				Start: protocol.Location{Offset: 2, Line: 0, Column: 2},
-				End:   protocol.Location{Offset: 3, Line: 0, Column: 3},
+				Start: result.Location{Offset: 2, Line: 0, Column: 2},
+				End:   result.Location{Offset: 3, Line: 0, Column: 3},
 			}},
 		},
 		1: {
 			input:   "a\nc",
 			matches: [][]int{{0, 1}, {2, 3}},
-			expectedRanges: protocol.Ranges{{
-				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
-				End:   protocol.Location{Offset: 1, Line: 0, Column: 1},
+			expectedRanges: result.Ranges{{
+				Start: result.Location{Offset: 0, Line: 0, Column: 0},
+				End:   result.Location{Offset: 1, Line: 0, Column: 1},
 			}, {
-				Start: protocol.Location{Offset: 2, Line: 1, Column: 0},
-				End:   protocol.Location{Offset: 3, Line: 1, Column: 1},
+				Start: result.Location{Offset: 2, Line: 1, Column: 0},
+				End:   result.Location{Offset: 3, Line: 1, Column: 1},
 			}},
 		},
 		2: {
 			input:   "a\n\nc",
 			matches: [][]int{{0, 1}, {3, 4}},
-			expectedRanges: protocol.Ranges{{
-				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
-				End:   protocol.Location{Offset: 1, Line: 0, Column: 1},
+			expectedRanges: result.Ranges{{
+				Start: result.Location{Offset: 0, Line: 0, Column: 0},
+				End:   result.Location{Offset: 1, Line: 0, Column: 1},
 			}, {
-				Start: protocol.Location{Offset: 3, Line: 2, Column: 0},
-				End:   protocol.Location{Offset: 4, Line: 2, Column: 1},
+				Start: result.Location{Offset: 3, Line: 2, Column: 0},
+				End:   result.Location{Offset: 4, Line: 2, Column: 1},
 			}},
 		},
 		3: {
 			input:   "a\nb\nc\n",
 			matches: [][]int{{0, 3}, {4, 5}},
-			expectedRanges: protocol.Ranges{{
-				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
-				End:   protocol.Location{Offset: 3, Line: 1, Column: 1},
+			expectedRanges: result.Ranges{{
+				Start: result.Location{Offset: 0, Line: 0, Column: 0},
+				End:   result.Location{Offset: 3, Line: 1, Column: 1},
 			}, {
-				Start: protocol.Location{Offset: 4, Line: 2, Column: 0},
-				End:   protocol.Location{Offset: 5, Line: 2, Column: 1},
+				Start: result.Location{Offset: 4, Line: 2, Column: 0},
+				End:   result.Location{Offset: 5, Line: 2, Column: 1},
 			}},
 		},
 		4: {
 			input:   "abc\ndef\n",
 			matches: [][]int{{1, 3}, {5, 7}},
-			expectedRanges: protocol.Ranges{{
-				Start: protocol.Location{Offset: 1, Line: 0, Column: 1},
-				End:   protocol.Location{Offset: 3, Line: 0, Column: 3},
+			expectedRanges: result.Ranges{{
+				Start: result.Location{Offset: 1, Line: 0, Column: 1},
+				End:   result.Location{Offset: 3, Line: 0, Column: 3},
 			}, {
-				Start: protocol.Location{Offset: 5, Line: 1, Column: 1},
-				End:   protocol.Location{Offset: 7, Line: 1, Column: 3},
+				Start: result.Location{Offset: 5, Line: 1, Column: 1},
+				End:   result.Location{Offset: 7, Line: 1, Column: 3},
 			}},
 		},
 		5: {
 			input:   "›a", // three-byte unicode character
 			matches: [][]int{{3, 4}},
-			expectedRanges: protocol.Ranges{{
-				Start: protocol.Location{Offset: 1, Line: 0, Column: 1},
-				End:   protocol.Location{Offset: 2, Line: 0, Column: 2},
+			expectedRanges: result.Ranges{{
+				Start: result.Location{Offset: 1, Line: 0, Column: 1},
+				End:   result.Location{Offset: 2, Line: 0, Column: 2},
 			}},
 		},
 	}

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // Git formatting directives as described in man git-log (see PRETTY FORMATS)
@@ -363,7 +364,7 @@ func CreateCommitMatch(lc *LazyCommit, hc *MatchedCommit, includeDiff bool) (*pr
 		return nil, err
 	}
 
-	diff := protocol.MatchedString{}
+	diff := result.MatchedString{}
 	if includeDiff {
 		rawDiff, err := lc.Diff()
 		if err != nil {
@@ -387,7 +388,7 @@ func CreateCommitMatch(lc *LazyCommit, hc *MatchedCommit, includeDiff bool) (*pr
 		Parents:    lc.ParentIDs(),
 		SourceRefs: lc.SourceRefs(),
 		Refs:       lc.RefNames(),
-		Message: protocol.MatchedString{
+		Message: result.MatchedString{
 			Content:       string(lc.Message),
 			MatchedRanges: hc.Message,
 		},

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // initGitRepository initializes a new Git repository and runs cmds in a new
@@ -171,13 +172,13 @@ func TestSearch(t *testing.T) {
 				0: {
 					MatchedHunks: map[int]MatchedHunk{
 						0: {
-							MatchedLines: map[int]protocol.Ranges{
+							MatchedLines: map[int]result.Ranges{
 								0: {{
-									Start: protocol.Location{},
-									End:   protocol.Location{Offset: 5, Column: 5},
+									Start: result.Location{},
+									End:   result.Location{Offset: 5, Column: 5},
 								}, {
-									Start: protocol.Location{Offset: 6, Column: 6},
-									End:   protocol.Location{Offset: 11, Column: 11},
+									Start: result.Location{Offset: 6, Column: 6},
+									End:   result.Location{Offset: 11, Column: 11},
 								}},
 							},
 						},
@@ -340,21 +341,21 @@ index 0000000000..7e54670557
 
 	require.Equal(t, expectedFormatted, formatted)
 
-	expectedRanges := protocol.Ranges{{
-		Start: protocol.Location{Offset: 115, Line: 3, Column: 60},
-		End:   protocol.Location{Offset: 121, Line: 3, Column: 66},
+	expectedRanges := result.Ranges{{
+		Start: result.Location{Offset: 115, Line: 3, Column: 60},
+		End:   result.Location{Offset: 121, Line: 3, Column: 66},
 	}, {
-		Start: protocol.Location{Offset: 152, Line: 6, Column: 24},
-		End:   protocol.Location{Offset: 158, Line: 6, Column: 30},
+		Start: result.Location{Offset: 152, Line: 6, Column: 24},
+		End:   result.Location{Offset: 158, Line: 6, Column: 30},
 	}, {
-		Start: protocol.Location{Offset: 288, Line: 8, Column: 33},
-		End:   protocol.Location{Offset: 292, Line: 8, Column: 37},
+		Start: result.Location{Offset: 288, Line: 8, Column: 33},
+		End:   result.Location{Offset: 292, Line: 8, Column: 37},
 	}, {
-		Start: protocol.Location{Offset: 345, Line: 11, Column: 9},
-		End:   protocol.Location{Offset: 349, Line: 11, Column: 13},
+		Start: result.Location{Offset: 345, Line: 11, Column: 9},
+		End:   result.Location{Offset: 349, Line: 11, Column: 13},
 	}, {
-		Start: protocol.Location{Offset: 453, Line: 14, Column: 60},
-		End:   protocol.Location{Offset: 459, Line: 14, Column: 66},
+		Start: result.Location{Offset: 453, Line: 14, Column: 60},
+		End:   result.Location{Offset: 459, Line: 14, Column: 66},
 	}}
 
 	require.Equal(t, expectedRanges, ranges)

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -171,14 +171,14 @@ func protocolMatchToCommitMatch(repo types.RepoName, diff bool, in protocol.Comm
 
 	if diff {
 		matchBody = "```diff\n" + in.Diff.Content + "\n```"
-		matchHighlights = searchRangesToHighlights(matchBody, in.Diff.MatchedRanges.Add(gitprotocol.Location{Line: 1, Offset: len("```diff\n")}))
+		matchHighlights = searchRangesToHighlights(matchBody, in.Diff.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```diff\n")}))
 		diffPreview = &result.HighlightedString{
 			Value:      in.Diff.Content,
 			Highlights: searchRangesToHighlights(in.Diff.Content, in.Diff.MatchedRanges),
 		}
 	} else {
 		matchBody = "```COMMIT_EDITMSG\n" + in.Message.Content + "\n```"
-		matchHighlights = searchRangesToHighlights(matchBody, in.Message.MatchedRanges.Add(gitprotocol.Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")}))
+		matchHighlights = searchRangesToHighlights(matchBody, in.Message.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")}))
 	}
 
 	return &result.CommitMatch{
@@ -210,7 +210,7 @@ func protocolMatchToCommitMatch(repo types.RepoName, diff bool, in protocol.Comm
 	}
 }
 
-func searchRangesToHighlights(s string, ranges []gitprotocol.Range) []result.HighlightedRange {
+func searchRangesToHighlights(s string, ranges []result.Range) []result.HighlightedRange {
 	res := make([]result.HighlightedRange, 0, len(ranges))
 	for _, r := range ranges {
 		res = append(res, searchRangeToHighlights(s, r)...)
@@ -223,7 +223,7 @@ func searchRangesToHighlights(s string, ranges []gitprotocol.Range) []result.Hig
 // correctly, we need the string that is being highlighted in order to identify
 // line-end boundaries within multi-line ranges.
 // TODO(camdencheek): push the Range format up the stack so we can be smarter about multi-line highlights.
-func searchRangeToHighlights(s string, r gitprotocol.Range) []result.HighlightedRange {
+func searchRangeToHighlights(s string, r result.Range) []result.HighlightedRange {
 	var res []result.HighlightedRange
 
 	// Use a scanner to handle \r?\n

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -369,16 +368,16 @@ func TestOrderedFuzzyRegexp(t *testing.T) {
 func Test_searchRangeToHighlights(t *testing.T) {
 	type testCase struct {
 		input      string
-		inputRange gitprotocol.Range
+		inputRange result.Range
 		output     []result.HighlightedRange
 	}
 
 	cases := []testCase{
 		{
 			input: "abc",
-			inputRange: gitprotocol.Range{
-				Start: gitprotocol.Location{Offset: 1, Line: 0, Column: 1},
-				End:   gitprotocol.Location{Offset: 2, Line: 0, Column: 2},
+			inputRange: result.Range{
+				Start: result.Location{Offset: 1, Line: 0, Column: 1},
+				End:   result.Location{Offset: 2, Line: 0, Column: 2},
 			},
 			output: []result.HighlightedRange{{
 				Line:      0,
@@ -388,9 +387,9 @@ func Test_searchRangeToHighlights(t *testing.T) {
 		},
 		{
 			input: "abc\ndef\n",
-			inputRange: gitprotocol.Range{
-				Start: gitprotocol.Location{Offset: 2, Line: 0, Column: 2},
-				End:   gitprotocol.Location{Offset: 5, Line: 1, Column: 1},
+			inputRange: result.Range{
+				Start: result.Location{Offset: 2, Line: 0, Column: 2},
+				End:   result.Location{Offset: 5, Line: 1, Column: 1},
 			},
 			output: []result.HighlightedRange{{
 				Line:      0,
@@ -404,9 +403,9 @@ func Test_searchRangeToHighlights(t *testing.T) {
 		},
 		{
 			input: "abc\ndef\nghi\n",
-			inputRange: gitprotocol.Range{
-				Start: gitprotocol.Location{Offset: 0, Line: 0, Column: 0},
-				End:   gitprotocol.Location{Offset: 11, Line: 2, Column: 3},
+			inputRange: result.Range{
+				Start: result.Location{Offset: 0, Line: 0, Column: 0},
+				End:   result.Location{Offset: 11, Line: 2, Column: 3},
 			},
 			output: []result.HighlightedRange{{
 				Line:      0,

--- a/internal/search/result/range.go
+++ b/internal/search/result/range.go
@@ -1,4 +1,4 @@
-package protocol
+package result
 
 import (
 	"encoding/json"

--- a/internal/search/result/range.go
+++ b/internal/search/result/range.go
@@ -10,17 +10,15 @@ type MatchedString struct {
 	MatchedRanges Ranges `json:"matched_ranges"`
 }
 
-func (h *MatchedString) Merge(other MatchedString) {
-	if h.Content == "" {
-		h.Content = other.Content
-	}
-	h.MatchedRanges = append(h.MatchedRanges, other.MatchedRanges...)
-	sort.Sort(h.MatchedRanges)
-}
-
 type Location struct {
+	// Offset is the number of unicode code points (not bytes) from the
+	// beginning of the matched text
 	Offset int
-	Line   int
+
+	// Line is the count of newlines before the offset in the matched text
+	Line int
+
+	// Column is the count of unicode code points after the last newline in the matched text
 	Column int
 }
 


### PR DESCRIPTION
This moves the `Location`, `Range`, and `MatchedString` types from the gitserver protocol package into our search package so they can be reused outside of gitserver. The design of these types are based off the similarly-named types in the `compute` package. 

Once the new commit/diff search is default and the old search path is removed, I'd like to start pushing these types up into our result types so that we can more correctly represent multi-line matches throughout our backends. For now, I'm just moving them into a sharable package. 

Stacked on #25568 
Progresses to #25175 (doesn't actually completely fix it, but I think this is as far as I want to go this sprint)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
