### PR TITLE
codeintel: Add retention policy to configure minimum age of all uploads

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/configuration_policies.go
+++ b/enterprise/internal/codeintel/stores/dbstore/configuration_policies.go
@@ -242,7 +242,7 @@ RETURNING
 `
 
 var errUnknownConfigurationPolicy = errors.New("unknown configuration policy")
-var errIllegalConfigurationPolicyUpdate = errors.New("protected configuration policies must keep the same names, types, patterns, and retention enabled values")
+var errIllegalConfigurationPolicyUpdate = errors.New("protected configuration policies must keep the same names, types, patterns, and retention values (except duration)")
 var errIllegalConfigurationPolicyDelete = errors.New("protected configuration policies cannot be deleted")
 
 // UpdateConfigurationPolicy updates the fields of the configuration policy record with the given identifier.
@@ -282,7 +282,7 @@ func (s *Store) UpdateConfigurationPolicy(ctx context.Context, policy Configurat
 		return errUnknownConfigurationPolicy
 	}
 	if currentPolicy.Protected {
-		if policy.Name != currentPolicy.Name || policy.Type != currentPolicy.Type || policy.Pattern != currentPolicy.Pattern || policy.RetentionEnabled != currentPolicy.RetentionEnabled {
+		if policy.Name != currentPolicy.Name || policy.Type != currentPolicy.Type || policy.Pattern != currentPolicy.Pattern || policy.RetentionEnabled != currentPolicy.RetentionEnabled || policy.RetainIntermediateCommits != currentPolicy.RetainIntermediateCommits {
 			return errIllegalConfigurationPolicyUpdate
 		}
 	}

--- a/enterprise/internal/codeintel/stores/dbstore/configuration_policies_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/configuration_policies_test.go
@@ -339,6 +339,15 @@ func TestUpdateProtectedConfigurationPolicy(t *testing.T) {
 				t.Fatalf("expected error updating protected configuration policy")
 			}
 		})
+
+		t.Run("RetainIntermediateCommits", func(t *testing.T) {
+			newConfigurationPolicy := hydratedConfigurationPolicy
+			newConfigurationPolicy.RetainIntermediateCommits = true
+
+			if err := store.UpdateConfigurationPolicy(context.Background(), newConfigurationPolicy); err == nil {
+				t.Fatalf("expected error updating protected configuration policy")
+			}
+		})
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -348,7 +357,6 @@ func TestUpdateProtectedConfigurationPolicy(t *testing.T) {
 		newConfigurationPolicy := hydratedConfigurationPolicy
 		newConfigurationPolicy.Protected = true
 		newConfigurationPolicy.RetentionDuration = &d3
-		newConfigurationPolicy.RetainIntermediateCommits = true
 		newConfigurationPolicy.IndexingEnabled = true
 		newConfigurationPolicy.IndexCommitMaxAge = &d4
 		newConfigurationPolicy.IndexIntermediateCommits = false

--- a/migrations/frontend/1528395902_more_default_lsif_configuration_policies.down.sql
+++ b/migrations/frontend/1528395902_more_default_lsif_configuration_policies.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Nothing on down
+
+COMMIT;

--- a/migrations/frontend/1528395902_more_default_lsif_configuration_policies.up.sql
+++ b/migrations/frontend/1528395902_more_default_lsif_configuration_policies.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+INSERT INTO lsif_configuration_policies
+    (
+        name,
+        protected, pattern, type,
+        retention_enabled, retain_intermediate_commits, retention_duration_hours,
+        indexing_enabled, index_intermediate_commits, index_commit_max_age_hours
+    )
+VALUES
+    (
+        'Default commit retention policy',
+        true, '*', 'GIT_TREE',
+        true, true, 168, -- 1 week (168 hours) * 4 * 3
+        false, false, 0
+    );
+
+COMMIT;


### PR DESCRIPTION
The codeintel-qa pipeline seems to be failing because _records disappear during the test_. I think this is a timing issue that is difficult to make happen locally but happens pretty consistently (though not always) in CI.

I believe the issue is that some test indexes are not visible from a tagged commit, nor from the tip of the default branch and are deleted while waiting for the set of indexes to be processes.

This PR adds another default/protected global data retention policy that sets the minimum age for any upload before deletion to 1 week. This duration configurable via the UI. This PR also locks the RetainIntermediateCommits value for protected uploads.