### PR TITLE
dev/sg: move RFC functions into package internal/rfc

### DIFF
--- a/dev/sg/internal/open/url.go
+++ b/dev/sg/internal/open/url.go
@@ -1,4 +1,4 @@
-package urlutil
+package open
 
 import (
 	"fmt"
@@ -6,7 +6,7 @@ import (
 	"runtime"
 )
 
-func OpenURL(url string) error {
+func URL(url string) error {
 	var err error
 	switch runtime.GOOS {
 	case "linux":

--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -1,0 +1,189 @@
+package rfc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/urlutil"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+)
+
+const (
+	googleTokenFileName = ".sg.token.json"
+	credentials         = `{"installed":{"client_id":"1043390970557-1okrt0mo0qt2ogn2mkp217cfrirr1rfd.apps.googleusercontent.com","project_id":"sg-cli","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_secret":"gkQ2alKQZr2088IFGr55ET_I","redirect_uris":["urn:ietf:wg:oauth:2.0:oob","http://localhost"]}}` // CI:LOCALHOST_OK
+)
+
+// Retrieve a token, saves the token, then returns the generated client.
+func getClient(ctx context.Context, config *oauth2.Config, out *output.Output) (*http.Client, error) {
+	homePath, err := root.GetSGHomePath()
+	if err != nil {
+		return nil, err
+	}
+	fp := filepath.Join(homePath, googleTokenFileName)
+
+	// Try to read token from file...
+	tok, err := readTokenFromFile(fp)
+	if err != nil {
+		// ...if it doesn't exist, open browser and ask user to give us
+		// permissions
+		tok, err = getTokenFromWeb(ctx, config, out)
+		if err != nil {
+			return nil, err
+		}
+		if err := saveToken(fp, tok); err != nil {
+			return nil, err
+		}
+	}
+
+	return config.Client(ctx, tok), nil
+}
+
+// Request a token from the web, then returns the retrieved token.
+func getTokenFromWeb(ctx context.Context, config *oauth2.Config, out *output.Output) (*oauth2.Token, error) {
+	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+
+	out.Writef("Opening %s ...", authURL)
+	if err := urlutil.OpenURL(authURL); err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Paste the OAuth token here: ")
+	var authCode string
+	if _, err := fmt.Scan(&authCode); err != nil {
+		return nil, err
+	}
+
+	return config.Exchange(ctx, authCode)
+}
+
+// Retrieves a token from a local file.
+func readTokenFromFile(file string) (*oauth2.Token, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	tok := &oauth2.Token{}
+	return tok, json.NewDecoder(f).Decode(tok)
+}
+
+// Saves a token to a file path.
+func saveToken(path string, token *oauth2.Token) error {
+	fmt.Printf("Saving credential file to: %s\n", path)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.Wrap(err, "unable to cache oauth token")
+	}
+	defer f.Close()
+
+	return json.NewEncoder(f).Encode(token)
+}
+
+func queryRFCs(ctx context.Context, query string, orderBy string, pager func(r *drive.FileList) error, out *output.Output) error {
+	// If modifying these scopes, delete your previously saved token.json.
+	config, err := google.ConfigFromJSON([]byte(credentials), drive.DriveMetadataReadonlyScope)
+	if err != nil {
+		return errors.Wrap(err, "Unable to parse client secret file to config")
+	}
+	client, err := getClient(ctx, config, out)
+	if err != nil {
+		return errors.Wrap(err, "Unable to build client")
+	}
+
+	srv, err := drive.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return errors.Wrap(err, "Unable to retrieve Drive client")
+	}
+
+	if query == "" {
+		query = "name contains 'RFC'"
+	}
+	q := fmt.Sprintf("%s and parents in '1zP3FxdDlcSQGC1qvM9lHZRaHH4I9Jwwa' or %s and parents in '1KCq4tMLnVlC0a1rwGuU5OSCw6mdDxLuv'", query, query)
+
+	list := srv.Files.List().
+		Corpora("drive").SupportsAllDrives(true).
+		DriveId("0AK4DcztHds_pUk9PVA").
+		IncludeItemsFromAllDrives(true).
+		SupportsAllDrives(true).
+		PageSize(100).
+		Q(q).
+		Fields("nextPageToken, files(id, name, parents)")
+
+	if orderBy != "" {
+		list = list.OrderBy(orderBy)
+	}
+
+	return list.Pages(ctx, pager)
+}
+
+func ListRFCs(ctx context.Context, out *output.Output) error {
+	return queryRFCs(ctx, "", "createdTime,name", rfcTitlesPrinter(out), out)
+}
+
+func SearchRFCs(ctx context.Context, query string, out *output.Output) error {
+	return queryRFCs(ctx, fmt.Sprintf("(name contains '%s' or fullText contains '%s')", query, query), "", rfcTitlesPrinter(out), out)
+}
+
+func OpenRFC(ctx context.Context, number string, out *output.Output) error {
+	return queryRFCs(ctx, fmt.Sprintf("name contains 'RFC %s'", number), "", func(r *drive.FileList) error {
+		for _, f := range r.Files {
+			urlutil.OpenURL(fmt.Sprintf("https://docs.google.com/document/d/%s/edit", f.Id))
+		}
+		return nil
+	}, out)
+}
+
+var rfcTitleRegex = regexp.MustCompile(`RFC\s(\d+):*\s(\w+):\s(.*)$`)
+
+func rfcTitlesPrinter(out *output.Output) func(r *drive.FileList) error {
+	return func(r *drive.FileList) error {
+		if len(r.Files) == 0 {
+			return nil
+		}
+
+		for _, i := range r.Files {
+			matches := rfcTitleRegex.FindStringSubmatch(i.Name)
+			if len(matches) == 4 {
+				number := matches[1]
+				status := matches[2]
+				name := matches[3]
+
+				var statusColor output.Style
+				switch strings.ToUpper(status) {
+				case "WIP":
+					statusColor = output.StylePending
+				case "REVIEW":
+					statusColor = output.Fg256Color(208)
+				case "IMPLEMENTED", "APPROVED":
+					statusColor = output.StyleSuccess
+				case "ABANDONED", "PAUSED":
+					statusColor = output.StyleSearchAlertTitle
+				}
+
+				numberColor := output.Fg256Color(8)
+
+				out.Writef("RFC %s%s %s%s%s %s", numberColor, number, statusColor, status, output.StyleReset, name)
+			} else {
+				out.Writef("%s%s", i.Name, output.StyleReset)
+			}
+		}
+
+		return nil
+	}
+
+}

--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/urlutil"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -57,7 +57,7 @@ func getTokenFromWeb(ctx context.Context, config *oauth2.Config, out *output.Out
 	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
 
 	out.Writef("Opening %s ...", authURL)
-	if err := urlutil.OpenURL(authURL); err != nil {
+	if err := open.URL(authURL); err != nil {
 		return nil, err
 	}
 
@@ -131,18 +131,18 @@ func queryRFCs(ctx context.Context, query string, orderBy string, pager func(r *
 	return list.Pages(ctx, pager)
 }
 
-func ListRFCs(ctx context.Context, out *output.Output) error {
+func List(ctx context.Context, out *output.Output) error {
 	return queryRFCs(ctx, "", "createdTime,name", rfcTitlesPrinter(out), out)
 }
 
-func SearchRFCs(ctx context.Context, query string, out *output.Output) error {
+func Search(ctx context.Context, query string, out *output.Output) error {
 	return queryRFCs(ctx, fmt.Sprintf("(name contains '%s' or fullText contains '%s')", query, query), "", rfcTitlesPrinter(out), out)
 }
 
-func OpenRFC(ctx context.Context, number string, out *output.Output) error {
+func Open(ctx context.Context, number string, out *output.Output) error {
 	return queryRFCs(ctx, fmt.Sprintf("name contains 'RFC %s'", number), "", func(r *drive.FileList) error {
 		for _, f := range r.Files {
-			urlutil.OpenURL(fmt.Sprintf("https://docs.google.com/document/d/%s/edit", f.Id))
+			open.URL(fmt.Sprintf("https://docs.google.com/document/d/%s/edit", f.Id))
 		}
 		return nil
 	}, out)

--- a/dev/sg/internal/urlutil/url.go
+++ b/dev/sg/internal/urlutil/url.go
@@ -1,0 +1,22 @@
+package urlutil
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func OpenURL(url string) error {
+	var err error
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+	return err
+}

--- a/dev/sg/root/root.go
+++ b/dev/sg/root/root.go
@@ -53,3 +53,16 @@ func findRoot(wd string) (string, error) {
 		return "", errors.Errorf("not running inside sourcegraph/sourcegraph")
 	}
 }
+
+func GetSGHomePath() (string, error) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(homedir, ".sourcegraph")
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -2,30 +2,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
-	"fmt"
-	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"runtime"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
-	"google.golang.org/api/drive/v3"
-	"google.golang.org/api/option"
-
-	"github.com/sourcegraph/sourcegraph/lib/output"
-)
-
-const (
-	tokenFileName = ".sg.token.json"
-	credentials   = `{"installed":{"client_id":"1043390970557-1okrt0mo0qt2ogn2mkp217cfrirr1rfd.apps.googleusercontent.com","project_id":"sg-cli","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_secret":"gkQ2alKQZr2088IFGr55ET_I","redirect_uris":["urn:ietf:wg:oauth:2.0:oob","http://localhost"]}}` // CI:LOCALHOST_OK
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/rfc"
 )
 
 var (
@@ -40,193 +21,6 @@ var (
 	}
 )
 
-func tokenFilePath() (string, error) {
-	homedir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	tokenFilePath := filepath.Join(homedir, ".sourcegraph", tokenFileName)
-
-	if err := os.MkdirAll(filepath.Dir(tokenFilePath), os.ModePerm); err != nil {
-		return "", err
-	}
-
-	return tokenFilePath, nil
-}
-
-// Retrieve a token, saves the token, then returns the generated client.
-func getClient(ctx context.Context, config *oauth2.Config) (*http.Client, error) {
-	fp, err := tokenFilePath()
-	if err != nil {
-		return nil, err
-	}
-
-	// Try to read token from file...
-	tok, err := readTokenFromFile(fp)
-	if err != nil {
-		// ...if it doesn't exist, open browser and ask user to give us
-		// permissions
-		tok, err = getTokenFromWeb(ctx, config)
-		if err != nil {
-			return nil, err
-		}
-		if err := saveToken(fp, tok); err != nil {
-			return nil, err
-		}
-	}
-
-	return config.Client(ctx, tok), nil
-}
-
-// Request a token from the web, then returns the retrieved token.
-func getTokenFromWeb(ctx context.Context, config *oauth2.Config) (*oauth2.Token, error) {
-	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
-
-	out.Writef("Opening %s ...", authURL)
-	if err := openURL(authURL); err != nil {
-		return nil, err
-	}
-
-	fmt.Printf("Paste the OAuth token here: ")
-	var authCode string
-	if _, err := fmt.Scan(&authCode); err != nil {
-		return nil, err
-	}
-
-	return config.Exchange(ctx, authCode)
-}
-
-// Retrieves a token from a local file.
-func readTokenFromFile(file string) (*oauth2.Token, error) {
-	f, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	tok := &oauth2.Token{}
-	return tok, json.NewDecoder(f).Decode(tok)
-}
-
-// Saves a token to a file path.
-func saveToken(path string, token *oauth2.Token) error {
-	fmt.Printf("Saving credential file to: %s\n", path)
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return errors.Wrap(err, "unable to cache oauth token")
-	}
-	defer f.Close()
-
-	return json.NewEncoder(f).Encode(token)
-}
-
-func queryRFCs(ctx context.Context, query string, orderBy string, pager func(r *drive.FileList) error) error {
-	// If modifying these scopes, delete your previously saved token.json.
-	config, err := google.ConfigFromJSON([]byte(credentials), drive.DriveMetadataReadonlyScope)
-	if err != nil {
-		return errors.Wrap(err, "Unable to parse client secret file to config")
-	}
-	client, err := getClient(ctx, config)
-	if err != nil {
-		return errors.Wrap(err, "Unable to build client")
-	}
-
-	srv, err := drive.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return errors.Wrap(err, "Unable to retrieve Drive client")
-	}
-
-	if query == "" {
-		query = "name contains 'RFC'"
-	}
-	q := fmt.Sprintf("%s and parents in '1zP3FxdDlcSQGC1qvM9lHZRaHH4I9Jwwa' or %s and parents in '1KCq4tMLnVlC0a1rwGuU5OSCw6mdDxLuv'", query, query)
-
-	list := srv.Files.List().
-		Corpora("drive").SupportsAllDrives(true).
-		DriveId("0AK4DcztHds_pUk9PVA").
-		IncludeItemsFromAllDrives(true).
-		SupportsAllDrives(true).
-		PageSize(100).
-		Q(q).
-		Fields("nextPageToken, files(id, name, parents)")
-
-	if orderBy != "" {
-		list = list.OrderBy(orderBy)
-	}
-
-	return list.Pages(ctx, pager)
-}
-
-func listRFCs(ctx context.Context) error {
-	return queryRFCs(ctx, "", "createdTime,name", printRFCTitles)
-}
-
-func searchRFCs(ctx context.Context, query string) error {
-	return queryRFCs(ctx, fmt.Sprintf("(name contains '%s' or fullText contains '%s')", query, query), "", printRFCTitles)
-}
-
-var rfcTitleRegex = regexp.MustCompile(`RFC\s(\d+):*\s(\w+):\s(.*)$`)
-
-func printRFCTitles(r *drive.FileList) error {
-	if len(r.Files) == 0 {
-		return nil
-	}
-
-	for _, i := range r.Files {
-		matches := rfcTitleRegex.FindStringSubmatch(i.Name)
-		if len(matches) == 4 {
-			number := matches[1]
-			status := matches[2]
-			name := matches[3]
-
-			var statusColor output.Style
-			switch strings.ToUpper(status) {
-			case "WIP":
-				statusColor = output.StylePending
-			case "REVIEW":
-				statusColor = output.Fg256Color(208)
-			case "IMPLEMENTED", "APPROVED":
-				statusColor = output.StyleSuccess
-			case "ABANDONED", "PAUSED":
-				statusColor = output.StyleSearchAlertTitle
-			}
-
-			numberColor := output.Fg256Color(8)
-
-			out.Writef("RFC %s%s %s%s%s %s", numberColor, number, statusColor, status, output.StyleReset, name)
-		} else {
-			out.Writef("%s%s", i.Name, output.StyleReset)
-		}
-	}
-
-	return nil
-}
-
-func openURL(url string) error {
-	var err error
-	switch runtime.GOOS {
-	case "linux":
-		err = exec.Command("xdg-open", url).Start()
-	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		err = exec.Command("open", url).Start()
-	default:
-		err = fmt.Errorf("unsupported platform")
-	}
-	return err
-}
-
-func openRFC(ctx context.Context, number string) error {
-	return queryRFCs(ctx, fmt.Sprintf("name contains 'RFC %s'", number), "", func(r *drive.FileList) error {
-		for _, f := range r.Files {
-			openURL(fmt.Sprintf("https://docs.google.com/document/d/%s/edit", f.Id))
-		}
-		return nil
-	})
-}
-
 func rfcExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
 		args = append(args, "list")
@@ -234,21 +28,21 @@ func rfcExec(ctx context.Context, args []string) error {
 
 	switch args[0] {
 	case "list":
-		return listRFCs(ctx)
+		return rfc.ListRFCs(ctx, out)
 
 	case "search":
 		if len(args) != 2 {
 			return errors.New("no search query given")
 		}
 
-		return searchRFCs(ctx, args[1])
+		return rfc.SearchRFCs(ctx, args[1], out)
 
 	case "open":
 		if len(args) != 2 {
 			return errors.New("no number given")
 		}
 
-		return openRFC(ctx, args[1])
+		return rfc.OpenRFC(ctx, args[1], out)
 	}
 
 	return nil

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -28,21 +28,21 @@ func rfcExec(ctx context.Context, args []string) error {
 
 	switch args[0] {
 	case "list":
-		return rfc.ListRFCs(ctx, out)
+		return rfc.List(ctx, out)
 
 	case "search":
 		if len(args) != 2 {
 			return errors.New("no search query given")
 		}
 
-		return rfc.SearchRFCs(ctx, args[1], out)
+		return rfc.Search(ctx, args[1], out)
 
 	case "open":
 		if len(args) != 2 {
 			return errors.New("no number given")
 		}
 
-		return rfc.OpenRFC(ctx, args[1], out)
+		return rfc.Open(ctx, args[1], out)
 	}
 
 	return nil


### PR DESCRIPTION
I'm hoping to embed Buildkite query functionality using e.g. https://github.com/buildkite/go-buildkite into `sg` (for https://github.com/sourcegraph/sourcegraph/issues/25562). It will likely have its own auth token to store and client to make. The RFC command features a lot of generically named helpers that was making this awkward, so I extracted them out of the root package to avoid polluting the namespace even further. I also moved a few things I anticipate being shared int ~~`urlutil`~~ `open` and `root`

Main code changes:

- Google token path that gets stuff from `~/.sourcegraph` is now joined from the new `GetSGHomePath()`, which can be used as a home for other bits of `sg` data
- RFC functions accept `*output.Output` for writing things

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
