### PR TITLE
codeintel: Do not perform data-retention scans on stale repositories

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
@@ -20,7 +20,7 @@ type DBStore interface {
 	DeleteUploadsWithoutRepository(ctx context.Context, now time.Time) (map[int]int, error)
 	HardDeleteUploadByID(ctx context.Context, ids ...int) error
 	GetConfigurationPolicies(ctx context.Context, opts dbstore.GetConfigurationPoliciesOptions) ([]dbstore.ConfigurationPolicy, error)
-	SelectRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) (map[int]*time.Time, error)
+	SelectRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) ([]int, error)
 	CommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) ([]string, *string, error)
 	UpdateUploadRetention(ctx context.Context, protectedIDs, expiredIDs []int) error
 	SoftDeleteExpiredUploads(ctx context.Context) (int, error)

--- a/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_dbstore_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_dbstore_test.go
@@ -99,20 +99,14 @@ func (s *uploadExpirerMockStore) UpdateUploadRetention(ctx context.Context, prot
 	return nil
 }
 
-func (state *uploadExpirerMockStore) SelectRepositoriesForRetentionScanFunc(ctx context.Context, processDelay time.Duration, limit int) (map[int]*time.Time, error) {
-	var scannedIDs []int
+func (state *uploadExpirerMockStore) SelectRepositoriesForRetentionScanFunc(ctx context.Context, processDelay time.Duration, limit int) (scannedIDs []int, _ error) {
 	if len(state.repositoryIDs) <= limit {
 		scannedIDs, state.repositoryIDs = state.repositoryIDs, nil
 	} else {
 		scannedIDs, state.repositoryIDs = state.repositoryIDs[:limit], state.repositoryIDs[limit:]
 	}
 
-	idsMap := map[int]*time.Time{}
-	for _, id := range scannedIDs {
-		idsMap[id] = nil
-	}
-
-	return idsMap, nil
+	return scannedIDs, nil
 }
 
 func (state *uploadExpirerMockStore) GetConfigurationPolicies(ctx context.Context, opts dbstore.GetConfigurationPoliciesOptions) ([]dbstore.ConfigurationPolicy, error) {

--- a/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_test.go
@@ -132,7 +132,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		SelectRepositoriesForRetentionScanFunc: &DBStoreSelectRepositoriesForRetentionScanFunc{
-			defaultHook: func(context.Context, time.Duration, int) (map[int]*time.Time, error) {
+			defaultHook: func(context.Context, time.Duration, int) ([]int, error) {
 				return nil, nil
 			},
 		},
@@ -1444,15 +1444,15 @@ func (c DBStoreRefreshCommitResolvabilityFuncCall) Results() []interface{} {
 // the SelectRepositoriesForRetentionScan method of the parent MockDBStore
 // instance is invoked.
 type DBStoreSelectRepositoriesForRetentionScanFunc struct {
-	defaultHook func(context.Context, time.Duration, int) (map[int]*time.Time, error)
-	hooks       []func(context.Context, time.Duration, int) (map[int]*time.Time, error)
+	defaultHook func(context.Context, time.Duration, int) ([]int, error)
+	hooks       []func(context.Context, time.Duration, int) ([]int, error)
 	history     []DBStoreSelectRepositoriesForRetentionScanFuncCall
 	mutex       sync.Mutex
 }
 
 // SelectRepositoriesForRetentionScan delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockDBStore) SelectRepositoriesForRetentionScan(v0 context.Context, v1 time.Duration, v2 int) (map[int]*time.Time, error) {
+func (m *MockDBStore) SelectRepositoriesForRetentionScan(v0 context.Context, v1 time.Duration, v2 int) ([]int, error) {
 	r0, r1 := m.SelectRepositoriesForRetentionScanFunc.nextHook()(v0, v1, v2)
 	m.SelectRepositoriesForRetentionScanFunc.appendCall(DBStoreSelectRepositoriesForRetentionScanFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -1461,7 +1461,7 @@ func (m *MockDBStore) SelectRepositoriesForRetentionScan(v0 context.Context, v1 
 // SetDefaultHook sets function that is called when the
 // SelectRepositoriesForRetentionScan method of the parent MockDBStore
 // instance is invoked and the hook queue is empty.
-func (f *DBStoreSelectRepositoriesForRetentionScanFunc) SetDefaultHook(hook func(context.Context, time.Duration, int) (map[int]*time.Time, error)) {
+func (f *DBStoreSelectRepositoriesForRetentionScanFunc) SetDefaultHook(hook func(context.Context, time.Duration, int) ([]int, error)) {
 	f.defaultHook = hook
 }
 
@@ -1470,7 +1470,7 @@ func (f *DBStoreSelectRepositoriesForRetentionScanFunc) SetDefaultHook(hook func
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *DBStoreSelectRepositoriesForRetentionScanFunc) PushHook(hook func(context.Context, time.Duration, int) (map[int]*time.Time, error)) {
+func (f *DBStoreSelectRepositoriesForRetentionScanFunc) PushHook(hook func(context.Context, time.Duration, int) ([]int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1478,21 +1478,21 @@ func (f *DBStoreSelectRepositoriesForRetentionScanFunc) PushHook(hook func(conte
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DBStoreSelectRepositoriesForRetentionScanFunc) SetDefaultReturn(r0 map[int]*time.Time, r1 error) {
-	f.SetDefaultHook(func(context.Context, time.Duration, int) (map[int]*time.Time, error) {
+func (f *DBStoreSelectRepositoriesForRetentionScanFunc) SetDefaultReturn(r0 []int, r1 error) {
+	f.SetDefaultHook(func(context.Context, time.Duration, int) ([]int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DBStoreSelectRepositoriesForRetentionScanFunc) PushReturn(r0 map[int]*time.Time, r1 error) {
-	f.PushHook(func(context.Context, time.Duration, int) (map[int]*time.Time, error) {
+func (f *DBStoreSelectRepositoriesForRetentionScanFunc) PushReturn(r0 []int, r1 error) {
+	f.PushHook(func(context.Context, time.Duration, int) ([]int, error) {
 		return r0, r1
 	})
 }
 
-func (f *DBStoreSelectRepositoriesForRetentionScanFunc) nextHook() func(context.Context, time.Duration, int) (map[int]*time.Time, error) {
+func (f *DBStoreSelectRepositoriesForRetentionScanFunc) nextHook() func(context.Context, time.Duration, int) ([]int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1538,7 +1538,7 @@ type DBStoreSelectRepositoriesForRetentionScanFuncCall struct {
 	Arg2 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 map[int]*time.Time
+	Result0 []int
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
@@ -48,13 +48,13 @@ func NewUploadExpirer(
 	interval time.Duration,
 	metrics *metrics,
 ) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background() /*interval*/, time.Second, &uploadExpirer{
+	return goroutine.NewPeriodicGoroutine(context.Background(), time.Second, &uploadExpirer{
 		dbStore:                dbStore,
 		gitserverClient:        gitserverClient,
 		metrics:                metrics,
-		repositoryProcessDelay: time.Second, // repositoryProcessDelay,
+		repositoryProcessDelay: repositoryProcessDelay,
 		repositoryBatchSize:    repositoryBatchSize,
-		uploadProcessDelay:     time.Second, // uploadProcessDelay,
+		uploadProcessDelay:     uploadProcessDelay,
 		uploadBatchSize:        uploadBatchSize,
 		commitBatchSize:        commitBatchSize,
 		branchesCacheMaxKeys:   branchesCacheMaxKeys,

--- a/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
@@ -48,13 +48,13 @@ func NewUploadExpirer(
 	interval time.Duration,
 	metrics *metrics,
 ) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, &uploadExpirer{
+	return goroutine.NewPeriodicGoroutine(context.Background() /*interval*/, time.Second, &uploadExpirer{
 		dbStore:                dbStore,
 		gitserverClient:        gitserverClient,
 		metrics:                metrics,
-		repositoryProcessDelay: repositoryProcessDelay,
+		repositoryProcessDelay: time.Second, // repositoryProcessDelay,
 		repositoryBatchSize:    repositoryBatchSize,
-		uploadProcessDelay:     uploadProcessDelay,
+		uploadProcessDelay:     time.Second, // uploadProcessDelay,
 		uploadBatchSize:        uploadBatchSize,
 		commitBatchSize:        commitBatchSize,
 		branchesCacheMaxKeys:   branchesCacheMaxKeys,
@@ -65,12 +65,14 @@ func (e *uploadExpirer) Handle(ctx context.Context) (err error) {
 	// Get the batch of repositories that we'll handle in this invocation of the periodic goroutine. This
 	// set should contain repositories that have yet to be updated, or that have been updated least recently.
 	// This allows us to update every repository reliably, even if it takes a long time to process through
-	// the backlog.
-	lastUpdatedAtByRepository, err := e.dbStore.SelectRepositoriesForRetentionScan(ctx, e.repositoryProcessDelay, e.repositoryBatchSize)
+	// the backlog. Note that this set of repositories require a fresh commit graph, so we're not trying to
+	// process records that have been uploaded but the commits from which they are visible have yet to be
+	// determined (and appearing as if they are visible to no commit).
+	repositories, err := e.dbStore.SelectRepositoriesForRetentionScan(ctx, e.repositoryProcessDelay, e.repositoryBatchSize)
 	if err != nil {
 		return errors.Wrap(err, "dbstore.SelectRepositoriesForRetentionScan")
 	}
-	if len(lastUpdatedAtByRepository) == 0 {
+	if len(repositories) == 0 {
 		// All repositories updated recently enough
 		return nil
 	}
@@ -86,8 +88,8 @@ func (e *uploadExpirer) Handle(ctx context.Context) (err error) {
 
 	now := timeutil.Now()
 
-	for repositoryID, repositoryLastUpdatedAt := range lastUpdatedAtByRepository {
-		if repositoryErr := e.handleRepository(ctx, repositoryID, repositoryLastUpdatedAt, globalPolicies, now); repositoryErr != nil {
+	for _, repositoryID := range repositories {
+		if repositoryErr := e.handleRepository(ctx, repositoryID, globalPolicies, now); repositoryErr != nil {
 			if err == nil {
 				err = repositoryErr
 			} else {
@@ -107,7 +109,6 @@ func (e *uploadExpirer) HandleError(err error) {
 func (e *uploadExpirer) handleRepository(
 	ctx context.Context,
 	repositoryID int,
-	repositoryLastUpdatedAt *time.Time,
 	globalPolicies []dbstore.ConfigurationPolicy,
 	now time.Time,
 ) error {
@@ -173,7 +174,6 @@ func (e *uploadExpirer) handleRepository(
 			OldestFirst:             true,
 			Limit:                   e.uploadBatchSize,
 			LastRetentionScanBefore: &lastRetentionScanBefore,
-			UploadedBefore:          repositoryLastUpdatedAt,
 		})
 		if err != nil || len(uploads) == 0 {
 			return err

--- a/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
@@ -48,7 +48,7 @@ func NewUploadExpirer(
 	interval time.Duration,
 	metrics *metrics,
 ) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), time.Second, &uploadExpirer{
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, &uploadExpirer{
 		dbStore:                dbStore,
 		gitserverClient:        gitserverClient,
 		metrics:                metrics,

--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -920,51 +920,44 @@ func TestSelectRepositoriesForRetentionScan(t *testing.T) {
 	)
 
 	now := timeutil.Now()
-	t1 := now.Add(time.Hour * 1)
-	t2 := now.Add(time.Hour * 2)
-	t3 := now.Add(time.Hour * 3)
 
-	for repositoryID, now := range map[int]time.Time{
-		50: t1,
-		51: t2,
-		52: t3,
-	} {
+	for _, repositoryID := range []int{50, 51, 52, 53, 54} {
 		// Only call this to insert a record into the lsif_dirty_repositories table
 		if err := store.MarkRepositoryAsDirty(context.Background(), repositoryID); err != nil {
 			t.Fatalf("unexpected error marking repository as dirty`: %s", err)
 		}
 
 		// Only call this to update the updated_at field in the lsif_dirty_repositories table
-		if err := store.CalculateVisibleUploads(context.Background(), repositoryID, gitserver.ParseCommitGraph(nil), nil, time.Hour, time.Hour, 5, now); err != nil {
+		if err := store.CalculateVisibleUploads(context.Background(), repositoryID, gitserver.ParseCommitGraph(nil), nil, time.Hour, time.Hour, 1, now); err != nil {
 			t.Fatalf("unexpected error updating commit graph: %s", err)
 		}
 	}
 
 	// Can return nulls
-	if repositoriesLastUpdated, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 2, now); err != nil {
+	if repositories, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 2, now); err != nil {
 		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
-	} else if diff := cmp.Diff(map[int]*time.Time{50: &t1, 51: &t2}, repositoriesLastUpdated); diff != "" {
+	} else if diff := cmp.Diff([]int{50, 51}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 20 minutes later, first two repositories are still on cooldown
-	if repositoriesLastUpdated, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*20)); err != nil {
+	if repositories, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*20)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
-	} else if diff := cmp.Diff(map[int]*time.Time{52: &t3, 53: nil}, repositoriesLastUpdated); diff != "" {
+	} else if diff := cmp.Diff([]int{52, 53}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 30 minutes later, all repositories are still on cooldown
-	if repositoriesLastUpdated, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*30)); err != nil {
+	if repositories, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*30)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
-	} else if diff := cmp.Diff(map[int]*time.Time{}, repositoriesLastUpdated); diff != "" {
+	} else if diff := cmp.Diff([]int(nil), repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 90 minutes later, all repositories are visible
-	if repositoriesLastUpdated, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*90)); err != nil {
+	if repositories, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*90)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
-	} else if diff := cmp.Diff(map[int]*time.Time{50: &t1, 51: &t2, 52: &t3, 53: nil}, repositoriesLastUpdated); diff != "" {
+	} else if diff := cmp.Diff([]int{50, 51, 52, 53}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
@@ -976,7 +969,7 @@ func TestSelectRepositoriesForRetentionScan(t *testing.T) {
 	// 95 minutes later, only new repository is visible
 	if repositoryIDs, err := store.selectRepositoriesForRetentionScan(context.Background(), time.Hour, 100, now.Add(time.Minute*95)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for retention scan: %s", err)
-	} else if diff := cmp.Diff(map[int]*time.Time{54: nil}, repositoryIDs); diff != "" {
+	} else if diff := cmp.Diff([]int{54}, repositoryIDs); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Same effort as #25571. There is ~an obvious bug~ obviously a bug that causes valid records to be deleted while the repository's commit graph is stale. I noticed this on the codeintel-qa pipeline, which always starts with a fresh instance. We were not seeing this on local instances which were already running because the test timing happened to miss the data retention janitor. Ensuring they run concurrently shows a lot of records marked as expired that shouldn't be.

This PR changes the data retention process to only work on repositories with updated commit graphs. This is a simplifying condition, and the only change in behavior here is the frequency that records are removed for repositories _that are always stale_. This is another issue entirely.