### PR TITLE
Fix dead links in the Sourcegraph OSS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ The fastest way to run Sourcegraph is to run a pre-built Docker images. See the 
 To use Sourcegraph OSS:
 
 1. Clone this repository
-1. [Ensure Docker is running](doc/dev/getting-started/quickstart_2_start_docker.md)
-1. [Initialize the PostgreSQL database](doc/dev/getting-started/quickstart_3_initialize_database.md)
+1. [Ensure Docker is running](doc/dev/getting-started/quickstart_3_start_docker.md)
+1. [Initialize the PostgreSQL database](doc/dev/getting-started/quickstart_4_initialize_database.md)
 1. [Configure the HTTPS reverse proxy](doc/dev/getting-started/quickstart_5_configure_https_reverse_proxy.md)
-1. [Start the development server](doc/dev/getting-started/quickstart_6_start_server.md)
+1. [Start the development server](doc/dev/getting-started/quickstart_7_start_server.md)
    ```sh
    ./dev/start.sh
    ```


### PR DESCRIPTION
Currently all links in the [Sourcegraph OSS](https://github.com/sourcegraph/sourcegraph#sourcegraph-oss) section of the main Readme lead to 404 pages. It seems some steps were added and changed in the past, without updating the main Readme of the repository.

The list also does not seem to be fully up to date. Some steps are missing, the numbers in the main Readme do not correspond to the ones to the pages they would lead to and the command for step 5 "Start the development server" is different from the one in the linked document.

This PR only fixes the dead links, so somebody who wants to try out the OSS version does not have to manually click through the folders to arrive at the setup guide.