### PR TITLE
Markdown files: Fix switching between 'code' and 'formatted' views

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -469,7 +469,10 @@ function findLineInSearchParameters(searchParameters: URLSearchParams): LineOrPo
     return key ? parseLineOrPositionOrRange(key) : undefined
 }
 
-function findLineKeyInSearchParameters(searchParameters: URLSearchParams): string | undefined {
+/**
+ * Finds an existing line range search parameter like "L1-2:3"
+ */
+export function findLineKeyInSearchParameters(searchParameters: URLSearchParams): string | undefined {
     for (const key of searchParameters.keys()) {
         if (key.startsWith('L')) {
             return key

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -33,6 +33,7 @@ import { RepoHeaderContributionPortal } from '../RepoHeaderContributionPortal'
 import { ToggleHistoryPanel } from './actions/ToggleHistoryPanel'
 import { ToggleLineWrap } from './actions/ToggleLineWrap'
 import { ToggleRenderedFileMode } from './actions/ToggleRenderedFileMode'
+import { getModeFromURL } from './actions/utils'
 import { fetchBlob } from './backend'
 import { Blob, BlobInfo } from './Blob'
 import { GoToRawAction } from './GoToRawAction'
@@ -65,7 +66,7 @@ interface Props
 
 export const BlobPage: React.FunctionComponent<Props> = props => {
     const [wrapCode, setWrapCode] = useState(ToggleLineWrap.getValue())
-    let renderMode = ToggleRenderedFileMode.getModeFromURL(props.location)
+    let renderMode = getModeFromURL(props.location)
     const { repoName, revision, commitID, filePath, isLightTheme, useBreadcrumb, mode, repoUrl } = props
 
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
@@ -284,12 +285,11 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                     id="toggle-rendered-file-mode"
                     repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
                 >
-                    {context => (
+                    {({ actionType }) => (
                         <ToggleRenderedFileMode
                             key="toggle-rendered-file-mode"
                             mode={renderMode || 'rendered'}
-                            location={props.location}
-                            {...context}
+                            actionType={actionType}
                         />
                     )}
                 </RepoHeaderContributionPortal>

--- a/client/web/src/repo/blob/actions/ToggleRenderedFileMode.test.tsx
+++ b/client/web/src/repo/blob/actions/ToggleRenderedFileMode.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { renderWithRouter } from '@sourcegraph/shared/src/testing/render-with-router'
+
+import { ToggleRenderedFileMode } from './ToggleRenderedFileMode'
+
+describe('ToggleRenderedFileMode', () => {
+    const route = '/github.com/sourcegraph/sourcegraph/-/blob/README.md'
+
+    describe('in rendered view', () => {
+        it('renders link correctly', () => {
+            const renderResult = renderWithRouter(<ToggleRenderedFileMode mode="rendered" actionType="nav" />, {
+                route,
+            })
+
+            const toggle = renderResult.getByText('Raw')
+            expect(toggle.closest('a')).toHaveAttribute('href', `${route}?view=code`)
+        })
+    })
+
+    describe('in code view', () => {
+        it('renders link correctly', () => {
+            const renderResult = renderWithRouter(<ToggleRenderedFileMode mode="code" actionType="nav" />, {
+                route: `${route}?view=code`,
+            })
+
+            const toggle = renderResult.getByText('Formatted')
+            expect(toggle.closest('a')).toHaveAttribute('href', route)
+        })
+
+        it('still renders link correctly when a line has been selected', () => {
+            const renderResult = renderWithRouter(<ToggleRenderedFileMode mode="code" actionType="nav" />, {
+                route: `${route}?L10&view=code`,
+            })
+
+            const toggle = renderResult.getByText('Formatted')
+            expect(toggle.closest('a')).toHaveAttribute('href', route)
+        })
+    })
+})

--- a/client/web/src/repo/blob/actions/ToggleRenderedFileMode.tsx
+++ b/client/web/src/repo/blob/actions/ToggleRenderedFileMode.tsx
@@ -1,6 +1,6 @@
-import * as H from 'history'
 import EyeIcon from 'mdi-react/EyeIcon'
-import * as React from 'react'
+import React, { useEffect } from 'react'
+import { useLocation } from 'react-router'
 
 import { Tooltip } from '@sourcegraph/branded/src/components/tooltip/Tooltip'
 import { ButtonLink } from '@sourcegraph/shared/src/components/LinkOrButton'
@@ -8,8 +8,10 @@ import { RenderMode } from '@sourcegraph/shared/src/util/url'
 
 import { RepoHeaderContext } from '../../RepoHeader'
 
-interface Props extends RepoHeaderContext {
-    location: H.Location
+import { getURLForMode } from './utils'
+
+interface ToggledRenderedFileModeProps {
+    actionType: RepoHeaderContext['actionType']
     mode: RenderMode
 }
 
@@ -17,64 +19,36 @@ interface Props extends RepoHeaderContext {
  * A repository header action that toggles between showing a rendered file and the file's original
  * source, for files that can be rendered (such as Markdown files).
  */
-export class ToggleRenderedFileMode extends React.PureComponent<Props> {
-    private static URL_QUERY_PARAM = 'view'
-
+export const ToggleRenderedFileMode: React.FunctionComponent<ToggledRenderedFileModeProps> = ({ mode, actionType }) => {
     /**
-     * Reports whether the location's URL displays the blob as rendered or source.
+     * The opposite mode of the current mode.
+     * Used to enable switching between modes.
      */
-    public static getModeFromURL(location: H.Location): RenderMode {
-        const searchParameters = new URLSearchParams(location.search)
+    const otherMode: RenderMode = mode === 'code' ? 'rendered' : 'code'
+    const label = mode === 'rendered' ? 'Show raw code file' : 'Show formatted file'
+    const location = useLocation()
 
-        if (!searchParameters.has(ToggleRenderedFileMode.URL_QUERY_PARAM)) {
-            return undefined
-        }
-        return searchParameters.get(ToggleRenderedFileMode.URL_QUERY_PARAM) === 'code' ? 'code' : 'rendered' // default to rendered
-    }
+    useEffect(() => {
+        Tooltip.forceUpdate()
+    }, [mode])
 
-    /**
-     * Returns the URL that displays the blob using the specified mode.
-     */
-    private getURLForMode(location: H.Location, mode: RenderMode): H.Location {
-        const searchParameters = new URLSearchParams(location.search)
-        if (mode === 'code') {
-            searchParameters.set(ToggleRenderedFileMode.URL_QUERY_PARAM, mode)
-        } else {
-            searchParameters.delete(ToggleRenderedFileMode.URL_QUERY_PARAM)
-        }
-        return { ...location, search: searchParameters.toString() }
-    }
-
-    public componentDidUpdate(previousProps: Props): void {
-        if (previousProps.mode !== this.props.mode) {
-            Tooltip.forceUpdate()
-        }
-    }
-
-    public render(): JSX.Element | null {
-        const otherMode: RenderMode = this.props.mode === 'code' ? 'rendered' : 'code'
-
-        if (this.props.actionType === 'dropdown') {
-            return (
-                <ButtonLink
-                    className="btn repo-header__file-action"
-                    to={this.getURLForMode(this.props.location, otherMode)}
-                >
-                    <EyeIcon className="icon-inline" />
-                    <span>{otherMode === 'code' ? 'Show raw code file' : 'Show formatted file'}</span>
-                </ButtonLink>
-            )
-        }
-
+    if (actionType === 'dropdown') {
         return (
-            <ButtonLink
-                to={this.getURLForMode(this.props.location, otherMode)}
-                data-tooltip={otherMode === 'code' ? 'Show raw code file' : 'Show formatted file'}
-                className="btn btn-icon repo-header__action"
-            >
-                <EyeIcon className="icon-inline" />{' '}
-                <span className="d-none d-lg-inline ml-1">{otherMode === 'code' ? 'Raw' : 'Formatted'}</span>
+            <ButtonLink className="btn repo-header__file-action" to={getURLForMode(location, otherMode)}>
+                <EyeIcon className="icon-inline" />
+                <span>{label}</span>
             </ButtonLink>
         )
     }
+
+    return (
+        <ButtonLink
+            to={getURLForMode(location, otherMode)}
+            data-tooltip={label}
+            className="btn btn-icon repo-header__action"
+        >
+            <EyeIcon className="icon-inline" />{' '}
+            <span className="d-none d-lg-inline ml-1">{mode === 'rendered' ? 'Raw' : 'Formatted'}</span>
+        </ButtonLink>
+    )
 }

--- a/client/web/src/repo/blob/actions/utils.ts
+++ b/client/web/src/repo/blob/actions/utils.ts
@@ -1,0 +1,38 @@
+import * as H from 'history'
+
+import { findLineKeyInSearchParameters, RenderMode } from '@sourcegraph/shared/src/util/url'
+
+const URL_QUERY_PARAM = 'view'
+
+/**
+ * Reports whether the location's URL displays the blob as rendered or source.
+ */
+export const getModeFromURL = (location: H.Location): RenderMode => {
+    const searchParameters = new URLSearchParams(location.search)
+
+    if (!searchParameters.has(URL_QUERY_PARAM)) {
+        return undefined
+    }
+    return searchParameters.get(URL_QUERY_PARAM) === 'code' ? 'code' : 'rendered' // default to rendered
+}
+
+/**
+ * Returns the URL that displays the blob using the specified mode.
+ */
+export const getURLForMode = (location: H.Location, mode: RenderMode): H.Location => {
+    const searchParameters = new URLSearchParams(location.search)
+
+    if (mode === 'code') {
+        searchParameters.set(URL_QUERY_PARAM, mode)
+    } else {
+        // We remove any existing line ranges as they are not supported in rendered mode.
+        const existingLineRangeKey = findLineKeyInSearchParameters(searchParameters)
+        if (existingLineRangeKey) {
+            searchParameters.delete(existingLineRangeKey)
+        }
+
+        searchParameters.delete(URL_QUERY_PARAM)
+    }
+
+    return { ...location, search: searchParameters.toString() }
+}


### PR DESCRIPTION
Feedback from user: https://sourcegraph.slack.com/archives/C0W2E592M/p1632997733328500

Fixes a bug where it was not possible to switch back to 'formatted' mode on Markdown files if a line range had been selected.

Also cleaned up the code a little and added some tests
