### PR TITLE
search: export query.Exists and query.ForAll

### DIFF
--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -290,7 +290,7 @@ func TestForAll(t *testing.T) {
 		Parameter{Field: "repo", Value: "foo"},
 		Parameter{Field: "repo", Value: "bar"},
 	}
-	result := forAll(nodes, func(node Node) bool {
+	result := ForAll(nodes, func(node Node) bool {
 		_, ok := node.(Parameter)
 		return ok
 	})


### PR DESCRIPTION
This is a pure refactor commit. I want to use query.Exists outside of
the query package. I also exported ForAll since it feels like if exists
is exported, so should forall. However, I don't have a target in
mind (yet).
