### PR TITLE
Add example to templating docs that shows combination of helpers

### DIFF
--- a/doc/batch_changes/references/batch_spec_templating.md
+++ b/doc/batch_changes/references/batch_spec_templating.md
@@ -295,3 +295,13 @@ steps:
     run: echo "hello workspace" >> workspace.txt
     container: golang
 ```
+
+Combine the [template helper functions](#template-helpers-functions) with the helper functions built into Go's [`text/template`](https://pkg.go.dev/text/template) library:
+
+```yaml
+changesetTemplate:
+  # [...]
+  body: |
+    The host of the repository: ${{ index (split repository.name "/") 0 }}
+    The org of the repository: ${{ index (split repository.name "/") 1 }}
+```


### PR DESCRIPTION
A customer asked how they can use the result of the `split` function (which we built in). I pointed them to the docs for `text/template`, which are admittedly bad. So this example shows how to combine the builtin helpers with the `text/template` helpers.