### PR TITLE
ci: enable autoretry on QA and E2E jobs

### DIFF
--- a/.buildkite/pipeline.qa.yml
+++ b/.buildkite/pipeline.qa.yml
@@ -3,17 +3,25 @@ env:
 steps:
 - label: ':chromium: Sourcegraph E2E'
   artifact_paths: ./*.png;./*.mp4;./ffmpeg.log
-  command:
-    - .buildkite/vagrant-run.sh sourcegraph-e2e
+  retry:
+    automatic:
+      exit_status: "*"
+      limit: 3
   agents:
     queue: 'baremetal'
+  command:
+    - .buildkite/vagrant-run.sh sourcegraph-e2e
 
 - label: ':docker::chromium: Sourcegraph QA'
-  command:
-    - .buildkite/vagrant-run.sh sourcegraph-qa-test
+  retry:
+    automatic:
+      exit_status: "*"
+      limit: 3
   artifact_paths: ./*.png;./*.mp4;./*.log
   agents:
     queue: 'baremetal'
+  command:
+    - .buildkite/vagrant-run.sh sourcegraph-qa-test
 
 - label: ':docker::arrow_double_up: Sourcegraph Upgrade'
   command:


### PR DESCRIPTION
QA and E2E steps in the QA pipeline that are just running tests will be retried 3 times at most. 

I hope that will turn improve the green ratio 🙏  