### PR TITLE
zoekt: handle partially indexed RepositoryRevisions

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -84,9 +84,11 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 	// Assume for large searches they will mostly involve indexed
 	// revisions, so just allocate that.
 	var unindexed []search.RevisionSpecifier
-	indexed := make([]search.RevisionSpecifier, 0, len(reporev.Revs))
 
 	branches := make([]string, 0, len(reporev.Revs))
+	reporev = reporev.Copy()
+	indexed := reporev.Revs[:0]
+
 	for _, rev := range reporev.Revs {
 		if rev.RevSpec == "" || rev.RevSpec == "HEAD" {
 			// Zoekt convention that first branch is HEAD
@@ -119,6 +121,7 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 
 	// We found indexed branches! Track them.
 	if len(indexed) > 0 {
+		reporev.Revs = indexed
 		rb.repoRevs[string(reporev.Repo.Name)] = reporev
 		rb.repoBranches[string(reporev.Repo.Name)] = branches
 		for _, branch := range branches {


### PR DESCRIPTION
This commit fixes `IndexedRepoRevs.add` to correctly filter out unindexed `search.RevisionSpecifiers` from a `*search.RepositoryRevisions` with *some* indexed rev specs.

Benchmarks show no real diff:

```
name              old time/op    new time/op    delta
SearchResults-12     1.33s ± 7%     1.29s ± 2%   ~     (p=0.114 n=9+7)

name              old alloc/op   new alloc/op   delta
SearchResults-12     469MB ± 0%     469MB ± 0%   ~     (p=0.955 n=7+8)

name              old allocs/op  new allocs/op  delta
SearchResults-12     5.52M ± 0%     5.52M ± 0%   ~     (p=0.650 n=9+9)
```


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
