### PR TITLE
allow defaultCommandset to be overridden

### DIFF
--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -113,6 +113,10 @@ func (c *Config) Merge(other *Config) {
 		c.Commandsets[k] = v
 	}
 
+	if other.DefaultCommandset != "" {
+		c.DefaultCommandset = other.DefaultCommandset
+	}
+
 	for k, v := range other.Tests {
 		if original, ok := c.Tests[k]; ok {
 			c.Tests[k] = original.Merge(v)


### PR DESCRIPTION
The new defaultCommandset does not respect an override in
sg.config.overwrite.yaml, so this adds that field to the merge function
so it will be respected.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
