### PR TITLE
ci: add documentation regarding secrets management

### DIFF
--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -12,7 +12,7 @@ go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 
 ## Managing secrets
 
-Our CI pipeline must never leak secrets:
+The term *secret* refers to authentication credentials like passwords, API keys, tokens, etc. which are used to access a particular service. Our CI pipeline must never leak secrets:
 
 - to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every step.
 - use an environment variable name with one of the following suffixes to ensure it gets redacted in the logs: `*_PASSWORD, *_SECRET, *_TOKEN, *_ACCESS_KEY, *_SECRET_KEY, *_CREDENTIALS`

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -12,7 +12,7 @@ go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 
 ## Managing secrets
 
-The term *secret* refers to authentication credentials like passwords, API keys, tokens, etc. which are used to access a particular service. Our CI pipeline must never leak secrets:
+The term _secret_ refers to authentication credentials like passwords, API keys, tokens, etc. which are used to access a particular service. Our CI pipeline must never leak secrets:
 
 - to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every step.
 - use an environment variable name with one of the following suffixes to ensure it gets redacted in the logs: `*_PASSWORD, *_SECRET, *_TOKEN, *_ACCESS_KEY, *_SECRET_KEY, *_CREDENTIALS`

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -10,7 +10,7 @@ In the [pipeline settings](https://buildkite.com/sourcegraph/sourcegraph/setting
 go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 ```
 
-## Secrets managements
+## Managing secrets
 
 Our CI pipeline must never leak secrets:
 

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -14,7 +14,7 @@ go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 
 Our CI pipeline must never leak secrets:
 
-- to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every steps.
+- to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every step.
 - use an environment variable name suffixed as following to ensure it gets redacted in the logs: `*_PASSWORD,*_SECRET,*_TOKEN,*_ACCESS_KEY,*_SECRET_KEY,*_CREDENTIALS`
 - while environment variables can be assigned when declaring steps, they should never be used for secrets:
   - they won't get redacted, even if they match the above pattern.

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -17,7 +17,6 @@ Our CI pipeline must never leak secrets:
 - to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every step.
 - use an environment variable name with one of the following suffixes to ensure it gets redacted in the logs: `*_PASSWORD, *_SECRET, *_TOKEN, *_ACCESS_KEY, *_SECRET_KEY, *_CREDENTIALS`
 - while environment variables can be assigned when declaring steps, they should never be used for secrets, because they won't get redacted, even if they match one of the above patterns.
-  - they won't get redacted, even if they match the above pattern.
 
 ## Testing
 

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -10,7 +10,7 @@ In the [pipeline settings](https://buildkite.com/sourcegraph/sourcegraph/setting
 go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 ```
 
-## Secrets managements 
+## Secrets managements
 
 Our CI pipeline must never leak secrets:
 

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -10,6 +10,15 @@ In the [pipeline settings](https://buildkite.com/sourcegraph/sourcegraph/setting
 go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 ```
 
+## Secrets managements 
+
+Our CI pipeline must never leak secrets:
+
+- to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every steps.
+- use an environment variable name suffixed as following to ensure it gets redacted in the logs: `*_PASSWORD,*_SECRET,*_TOKEN,*_ACCESS_KEY,*_SECRET_KEY,*_CREDENTIALS`
+- while environment variables can be assigned when declaring steps, they should never be used for secrets:
+  - they won't get redacted, even if they match the above pattern.
+
 ## Testing
 
 To test this you can run `env BUILDKITE_BRANCH=TESTBRANCH go run ./enterprise/dev/ci/gen-pipeline.go` and inspect the YAML output. To change the behaviour set the relevant `BUILDKITE_` environment variables.

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -16,7 +16,7 @@ Our CI pipeline must never leak secrets:
 
 - to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every step.
 - use an environment variable name with one of the following suffixes to ensure it gets redacted in the logs: `*_PASSWORD, *_SECRET, *_TOKEN, *_ACCESS_KEY, *_SECRET_KEY, *_CREDENTIALS`
-- while environment variables can be assigned when declaring steps, they should never be used for secrets:
+- while environment variables can be assigned when declaring steps, they should never be used for secrets, because they won't get redacted, even if they match one of the above patterns.
   - they won't get redacted, even if they match the above pattern.
 
 ## Testing

--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -15,7 +15,7 @@ go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
 Our CI pipeline must never leak secrets:
 
 - to add a secret, use the Secret Manager on Google Cloud and then inject it at deployment time as an environment variable in the CI agents, which will make it available to every step.
-- use an environment variable name suffixed as following to ensure it gets redacted in the logs: `*_PASSWORD,*_SECRET,*_TOKEN,*_ACCESS_KEY,*_SECRET_KEY,*_CREDENTIALS`
+- use an environment variable name with one of the following suffixes to ensure it gets redacted in the logs: `*_PASSWORD, *_SECRET, *_TOKEN, *_ACCESS_KEY, *_SECRET_KEY, *_CREDENTIALS`
 - while environment variables can be assigned when declaring steps, they should never be used for secrets:
   - they won't get redacted, even if they match the above pattern.
 


### PR DESCRIPTION
I'm adding this here so we don't forget it when we extract the CI documentation in the handbook. 