### PR TITLE
fix stalling diff fetcher

### DIFF
--- a/internal/gitserver/search/diff_fetcher.go
+++ b/internal/gitserver/search/diff_fetcher.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"io"
 	"os/exec"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 )
@@ -14,10 +13,11 @@ import (
 // DiffFetcher is a handle to the stdin and stdout of a git diff-tree subprocess
 // started with StartDiffFetcher
 type DiffFetcher struct {
-	stdin   io.WriteCloser
-	stderr  *safeBuffer
+	stdin   io.Writer
+	stderr  io.Reader
 	scanner *bufio.Scanner
 	cancel  context.CancelFunc
+	cmd     *exec.Cmd
 }
 
 // StartDiffFetcher starts a git diff-tree subprocess that waits, listening on stdin
@@ -34,14 +34,21 @@ func StartDiffFetcher(dir string) (*DiffFetcher, error) {
 	)
 	cmd.Dir = dir
 
-	stdoutReader, stdoutWriter := io.Pipe()
-	cmd.Stdout = stdoutWriter
-
-	stdinReader, stdinWriter := io.Pipe()
-	cmd.Stdin = stdinReader
-
-	var stderrBuf safeBuffer
-	cmd.Stderr = &stderrBuf
+	stdinWriter, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdoutReader, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stderrReader, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -54,10 +61,6 @@ func StartDiffFetcher(dir string) (*DiffFetcher, error) {
 		// Note that this only works when we write to stdin, then read from stdout before writing
 		// anything else to stdin, since we are using `HasSuffix` and not `Contains`.
 		if bytes.HasSuffix(data, []byte("ENDOFPATCH\n")) {
-			if bytes.Equal(data, []byte("ENDOFPATCH\n")) {
-				// Empty patch
-				return len(data), data[:0], nil
-			}
 			return len(data), data[:len(data)-len("ENDOFPATCH\n")], nil
 		}
 
@@ -67,13 +70,15 @@ func StartDiffFetcher(dir string) (*DiffFetcher, error) {
 	return &DiffFetcher{
 		stdin:   stdinWriter,
 		scanner: scanner,
-		stderr:  &stderrBuf,
+		stderr:  stderrReader,
 		cancel:  cancel,
+		cmd:     cmd,
 	}, nil
 }
 
 func (d *DiffFetcher) Stop() {
 	d.cancel()
+	d.cmd.Wait()
 }
 
 // Fetch fetches a diff from the git diff-tree subprocess, writing to its stdin
@@ -86,31 +91,17 @@ func (d *DiffFetcher) Fetch(hash []byte) ([]byte, error) {
 	// serially. We resort to sending the subprocess a bogus commit hash named "ENDOFPATCH", which it
 	// will fail to read as a tree, and print back to stdout literally. We use this as a signal
 	// that the subprocess is done outputting for this commit.
-	d.stdin.Write(append(hash, []byte("\nENDOFPATCH\n")...))
+	_, err := d.stdin.Write(append(hash, []byte("\nENDOFPATCH\n")...))
+	if err != nil {
+		return nil, err
+	}
 
 	if d.scanner.Scan() {
 		return d.scanner.Bytes(), nil
 	} else if err := d.scanner.Err(); err != nil {
 		return nil, err
-	} else if d.stderr.String() != "" {
-		return nil, errors.Errorf("git subprocess stderr: %s", d.stderr.String())
+	} else if stderr, _ := io.ReadAll(d.stderr); len(stderr) > 0 {
+		return nil, errors.Errorf("git subprocess stderr: %s", string(stderr))
 	}
 	return nil, errors.New("expected scan to succeed")
-}
-
-type safeBuffer struct {
-	buf bytes.Buffer
-	sync.Mutex
-}
-
-func (s *safeBuffer) Write(p []byte) (n int, err error) {
-	s.Lock()
-	defer s.Unlock()
-	return s.buf.Write(p)
-}
-
-func (s *safeBuffer) String() string {
-	s.Lock()
-	defer s.Unlock()
-	return s.buf.String()
 }


### PR DESCRIPTION
Convert diff fetcher to use os pipes rather than in-process pipes to
avoid the weirdness around commands not exiting until the pipes are
fully read. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
