### PR TITLE
create CommitSearcher struct

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -986,8 +986,14 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 			return err
 		}
 
+		searcher := &search.CommitSearcher{
+			RepoDir:   dir.Path(),
+			Revisions: args.Revisions,
+			Query:     mt,
+		}
+
 		var conversionErr error
-		err = search.Search(ctx, dir.Path(), args.Revisions, mt, func(match *search.LazyCommit, highlights *search.MatchedCommit) bool {
+		err = searcher.Search(ctx, func(match *search.LazyCommit, highlights *search.MatchedCommit) bool {
 			res, err := search.CreateCommitMatch(match, highlights, args.IncludeDiff)
 			if err != nil {
 				conversionErr = err

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -67,7 +67,11 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, err)
 		var commits []*LazyCommit
 		var highlights []*MatchedCommit
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
+		searcher := &CommitSearcher{
+			RepoDir: dir,
+			Query:   tree,
+		}
+		err = searcher.Search(context.Background(), func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -83,7 +87,11 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, err)
 		var commits []*LazyCommit
 		var highlights []*MatchedCommit
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
+		searcher := &CommitSearcher{
+			RepoDir: dir,
+			Query:   tree,
+		}
+		err = searcher.Search(context.Background(), func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -101,7 +109,11 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, err)
 		var commits []*LazyCommit
 		var highlights []*MatchedCommit
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
+		searcher := &CommitSearcher{
+			RepoDir: dir,
+			Query:   tree,
+		}
+		err = searcher.Search(context.Background(), func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -118,7 +130,11 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, err)
 		var commits []*LazyCommit
 		var highlights []*MatchedCommit
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
+		searcher := &CommitSearcher{
+			RepoDir: dir,
+			Query:   tree,
+		}
+		err = searcher.Search(context.Background(), func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -135,7 +151,11 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, err)
 		var commits []*LazyCommit
 		var highlights []*MatchedCommit
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
+		searcher := &CommitSearcher{
+			RepoDir: dir,
+			Query:   tree,
+		}
+		err = searcher.Search(context.Background(), func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true
@@ -158,7 +178,11 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, err)
 		var commits []*LazyCommit
 		var highlights []*MatchedCommit
-		err = Search(context.Background(), dir, nil, tree, func(lc *LazyCommit, hl *MatchedCommit) bool {
+		searcher := &CommitSearcher{
+			RepoDir: dir,
+			Query:   tree,
+		}
+		err = searcher.Search(context.Background(), func(lc *LazyCommit, hl *MatchedCommit) bool {
 			commits = append(commits, lc)
 			highlights = append(highlights, hl)
 			return true


### PR DESCRIPTION
This commit creates the CommitSearcher struct, simplifies the Search()
function call and will allow me to refactor the Search function into
something a little more manageable

Stacked on #25612 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
