### PR TITLE
remove "continue" return value from callback

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -993,12 +993,10 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 			IncludeDiff: args.IncludeDiff,
 		}
 
-		return searcher.Search(ctx, func(match *protocol.CommitMatch) bool {
+		return searcher.Search(ctx, func(match *protocol.CommitMatch) {
 			select {
 			case <-done:
-				return false
 			case resultChan <- match:
-				return true
 			}
 		})
 	})

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -70,9 +70,8 @@ func TestSearch(t *testing.T) {
 			Query:   tree,
 		}
 		var matches []*protocol.CommitMatch
-		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) bool {
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
 			matches = append(matches, match)
-			return true
 		})
 		require.NoError(t, err)
 		require.Len(t, matches, 1)
@@ -87,9 +86,8 @@ func TestSearch(t *testing.T) {
 			Query:   tree,
 		}
 		var matches []*protocol.CommitMatch
-		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) bool {
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
 			matches = append(matches, match)
-			return true
 		})
 		require.NoError(t, err)
 		require.Len(t, matches, 2)
@@ -106,9 +104,8 @@ func TestSearch(t *testing.T) {
 			Query:   tree,
 		}
 		var matches []*protocol.CommitMatch
-		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) bool {
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
 			matches = append(matches, match)
-			return true
 		})
 		require.NoError(t, err)
 		require.Len(t, matches, 1)
@@ -124,9 +121,8 @@ func TestSearch(t *testing.T) {
 			Query:   tree,
 		}
 		var matches []*protocol.CommitMatch
-		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) bool {
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
 			matches = append(matches, match)
-			return true
 		})
 		require.NoError(t, err)
 		require.Len(t, matches, 1)
@@ -142,9 +138,8 @@ func TestSearch(t *testing.T) {
 			Query:   tree,
 		}
 		var matches []*protocol.CommitMatch
-		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) bool {
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
 			matches = append(matches, match)
-			return true
 		})
 		require.NoError(t, err)
 		require.Len(t, matches, 1)
@@ -167,9 +162,8 @@ func TestSearch(t *testing.T) {
 			IncludeDiff: true,
 		}
 		var matches []*protocol.CommitMatch
-		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) bool {
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
 			matches = append(matches, match)
-			return true
 		})
 		require.NoError(t, err)
 		require.Len(t, matches, 1)


### PR DESCRIPTION
As it was, there were two ways to stop a search: canceling the context
or returning false from the callback. This removes the second method,
leaving just context cancellation as a signal for early search
cancellation. I chose contexts rather than callback return values
because the callback is only called when a search result is found, so if
a search has no results, it cannot be cancelled early with that method.
Additionally, this moves a context check into the inner job loop so that
if the context is canceled, the entire job doesn't need to execute
before seeing that. This cuts a second or so of extra CPU work off the
end of early-returning diff searches.

Stacked on #25615 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
