### PR TITLE
fix no filters returning no results

### DIFF
--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -95,6 +95,22 @@ func TestSearch(t *testing.T) {
 		require.Equal(t, matches[1].Author.Name, "camden1")
 	})
 
+	t.Run("and with no operands matches all", func(t *testing.T) {
+		query := &protocol.Operator{Kind: protocol.And}
+		tree, err := ToMatchTree(query)
+		require.NoError(t, err)
+		searcher := &CommitSearcher{
+			RepoDir: dir,
+			Query:   tree,
+		}
+		var matches []*protocol.CommitMatch
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
+			matches = append(matches, match)
+		})
+		require.NoError(t, err)
+		require.Len(t, matches, 2)
+	})
+
 	t.Run("match diff content", func(t *testing.T) {
 		query := &protocol.DiffMatches{Expr: "ipsum"}
 		tree, err := ToMatchTree(query)


### PR DESCRIPTION
This fixes an issue where a query like `repo:sourcegraph type:diff`
would return no results. This happened because an empty `And` operator
would not match any commits, when it should match all commits.

Stacked on #25619 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
