### PR TITLE
web: disable manual retry for Puppeteer agents

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -25,6 +25,8 @@ type BuildOptions struct {
 	Env      map[string]string      `json:"env,omitempty"`
 }
 
+// Matches Buildkite pipeline JSON schema:
+// https://github.com/buildkite/pipeline-schema/blob/master/schema.json
 type Step struct {
 	Label                  string                 `json:"label"`
 	Key                    string                 `json:"key,omitempty"`
@@ -48,10 +50,16 @@ type Step struct {
 
 type RetryOptions struct {
 	Automatic *AutomaticRetryOptions `json:"automatic,omitempty"`
+	Manual    *ManualRetryOptions    `json:"manual,omitempty"`
 }
 
 type AutomaticRetryOptions struct {
 	Limit int `json:"limit,omitempty"`
+}
+
+type ManualRetryOptions struct {
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reason,omitempty"`
 }
 
 // BeforeEveryStepOpts are e.g. commands that are run before every AddStep, similar to
@@ -157,11 +165,28 @@ func SoftFail(softFail bool) StepOpt {
 	}
 }
 
+// AutomaticRetry enables automatic retry for the step with the number of times this job can be retried.
+// The maximum value this can be set to is 10.
+// Docs: https://buildkite.com/docs/pipelines/command-step#automatic-retry-attributes
 func AutomaticRetry(limit int) StepOpt {
 	return func(step *Step) {
 		step.Retry = &RetryOptions{
 			Automatic: &AutomaticRetryOptions{
 				Limit: limit,
+			},
+		}
+	}
+}
+
+// DisableManualRetry disables manual retry for the step. The reason string passed
+// will be displayed in a tooltip on the Retry button in the Buildkite interface.
+// Docs: https://buildkite.com/docs/pipelines/command-step#manual-retry-attributes
+func DisableManualRetry(reason string) StepOpt {
+	return func(step *Step) {
+		step.Retry = &RetryOptions{
+			Manual: &ManualRetryOptions{
+				Allowed: false,
+				Reason:  reason,
 			},
 		}
 	}

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -199,6 +199,7 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 		pipeline.AddStep(stepLabel,
 			bk.Key(stepKey),
 			bk.DependsOn(prepStepKey),
+			bk.DisableManualRetry("The Percy build is finalized even if one of the concurrent agents fails. To retry correctly, restart the entire pipeline."),
 			percyBrowserExecutableEnv,
 			bk.Env("PERCY_ON", "true"),
 			bk.Cmd(fmt.Sprintf(`dev/ci/yarn-web-integration.sh "%s"`, chunkTestFiles)),


### PR DESCRIPTION
## Context

To unburden people answering questions about failed Puppeteer step retry we can disable the retry button through [the Buildkite configuration](https://buildkite.com/docs/pipelines/command-step#manual-retry-attributes). It allows communicating the reason behind the disabled retry button.

<img width="739" alt="Screenshot 2021-10-04 at 13 25 34" src="https://user-images.githubusercontent.com/3846380/135835445-867bf12f-408e-4d1b-9cab-549af6f3e30f.png">

Slack [thread](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1633029941111300).
Tested in this PR: https://github.com/sourcegraph/sourcegraph/pull/25630.