### PR TITLE
web: filter out empty-url events

### DIFF
--- a/client/web/src/search/panels/RecentFilesPanel.tsx
+++ b/client/web/src/search/panels/RecentFilesPanel.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Observable } from 'rxjs'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { not } from '@sourcegraph/shared/src/search/query/patternMatcher'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 

--- a/client/web/src/search/panels/RecentFilesPanel.tsx
+++ b/client/web/src/search/panels/RecentFilesPanel.tsx
@@ -126,32 +126,27 @@ function processRecentFiles(eventLogResult?: EventLogResult): RecentFile[] | nul
     const recentFiles: RecentFile[] = []
 
     for (const node of eventLogResult.nodes) {
-        if (node.argument) {
-            try {
-                const parsedArguments = JSON.parse(node.argument)
-                let repoName = parsedArguments?.repoName as string
-                let filePath = parsedArguments?.filePath as string
+        if (node.argument && node.url) {
+            const parsedArguments = JSON.parse(node.argument)
+            let repoName = parsedArguments?.repoName as string
+            let filePath = parsedArguments?.filePath as string
 
-                if (!repoName || !filePath) {
-                    ;({ repoName, filePath } = extractFileInfoFromUrl(node.url))
-                }
+            if (!repoName || !filePath) {
+                ;({ repoName, filePath } = extractFileInfoFromUrl(node.url))
+            }
 
-                if (
-                    filePath &&
-                    repoName &&
-                    !recentFiles.some(file => file.repoName === repoName && file.filePath === filePath) // Don't show the same file twice
-                ) {
-                    const parsedUrl = new URL(node.url)
-                    recentFiles.push({
-                        url: parsedUrl.pathname + parsedUrl.search, // Strip domain from URL so clicking on it doesn't reload page
-                        repoName,
-                        filePath,
-                        timestamp: node.timestamp,
-                    })
-                }
-            } catch (error: unknown) {
-                console.error('RecentFilesPanel: Error parsing event')
-                console.error(error)
+            if (
+                filePath &&
+                repoName &&
+                !recentFiles.some(file => file.repoName === repoName && file.filePath === filePath) // Don't show the same file twice
+            ) {
+                const parsedUrl = new URL(node.url)
+                recentFiles.push({
+                    url: parsedUrl.pathname + parsedUrl.search, // Strip domain from URL so clicking on it doesn't reload page
+                    repoName,
+                    filePath,
+                    timestamp: node.timestamp,
+                })
             }
         }
     }

--- a/client/web/src/search/panels/RecentSearchesPanel.tsx
+++ b/client/web/src/search/panels/RecentSearchesPanel.tsx
@@ -192,22 +192,30 @@ function processRecentSearches(eventLogResult?: EventLogResult): RecentSearch[] 
     const recentSearches: RecentSearch[] = []
 
     for (const node of eventLogResult.nodes) {
-        if (node.argument) {
-            const parsedArguments = JSON.parse(node.argument)
-            const searchText: string | undefined = parsedArguments?.code_search?.query_data?.combined
+        if (node.argument && node.url) {
+            try {
+                const parsedArguments = JSON.parse(node.argument)
+                const searchText: string | undefined = parsedArguments?.code_search?.query_data?.combined
 
-            if (searchText) {
-                if (recentSearches.length > 0 && recentSearches[recentSearches.length - 1].searchText === searchText) {
-                    recentSearches[recentSearches.length - 1].count += 1
-                } else {
-                    const parsedUrl = new URL(node.url)
-                    recentSearches.push({
-                        count: 1,
-                        url: parsedUrl.pathname + parsedUrl.search, // Strip domain from URL so clicking on it doesn't reload page
-                        searchText,
-                        timestamp: node.timestamp,
-                    })
+                if (searchText) {
+                    if (
+                        recentSearches.length > 0 &&
+                        recentSearches[recentSearches.length - 1].searchText === searchText
+                    ) {
+                        recentSearches[recentSearches.length - 1].count += 1
+                    } else {
+                        const parsedUrl = new URL(node.url)
+                        recentSearches.push({
+                            count: 1,
+                            url: parsedUrl.pathname + parsedUrl.search, // Strip domain from URL so clicking on it doesn't reload page
+                            searchText,
+                            timestamp: node.timestamp,
+                        })
+                    }
                 }
+            } catch (error: unknown) {
+                console.error('RecentSearchesPanel: Error parsing event')
+                console.error(error)
             }
         }
     }

--- a/client/web/src/search/panels/RecentSearchesPanel.tsx
+++ b/client/web/src/search/panels/RecentSearchesPanel.tsx
@@ -193,29 +193,21 @@ function processRecentSearches(eventLogResult?: EventLogResult): RecentSearch[] 
 
     for (const node of eventLogResult.nodes) {
         if (node.argument && node.url) {
-            try {
-                const parsedArguments = JSON.parse(node.argument)
-                const searchText: string | undefined = parsedArguments?.code_search?.query_data?.combined
+            const parsedArguments = JSON.parse(node.argument)
+            const searchText: string | undefined = parsedArguments?.code_search?.query_data?.combined
 
-                if (searchText) {
-                    if (
-                        recentSearches.length > 0 &&
-                        recentSearches[recentSearches.length - 1].searchText === searchText
-                    ) {
-                        recentSearches[recentSearches.length - 1].count += 1
-                    } else {
-                        const parsedUrl = new URL(node.url)
-                        recentSearches.push({
-                            count: 1,
-                            url: parsedUrl.pathname + parsedUrl.search, // Strip domain from URL so clicking on it doesn't reload page
-                            searchText,
-                            timestamp: node.timestamp,
-                        })
-                    }
+            if (searchText) {
+                if (recentSearches.length > 0 && recentSearches[recentSearches.length - 1].searchText === searchText) {
+                    recentSearches[recentSearches.length - 1].count += 1
+                } else {
+                    const parsedUrl = new URL(node.url)
+                    recentSearches.push({
+                        count: 1,
+                        url: parsedUrl.pathname + parsedUrl.search, // Strip domain from URL so clicking on it doesn't reload page
+                        searchText,
+                        timestamp: node.timestamp,
+                    })
                 }
-            } catch (error: unknown) {
-                console.error('RecentSearchesPanel: Error parsing event')
-                console.error(error)
             }
         }
     }

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -131,17 +131,22 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
     const recentlySearchedRepos: string[] = []
 
     for (const node of eventLogResult.nodes) {
-        const url = new URL(node.url)
-        const queryFromURL = parseSearchURLQuery(url.search)
-        const scannedQuery = scanSearchQuery(queryFromURL || '')
-        if (scannedQuery.type === 'success') {
-            for (const token of scannedQuery.term) {
-                if (isRepoFilter(token)) {
-                    if (token.value && !recentlySearchedRepos.includes(token.value.value)) {
-                        recentlySearchedRepos.push(token.value.value)
+        try {
+            const url = new URL(node.url)
+            const queryFromURL = parseSearchURLQuery(url.search)
+            const scannedQuery = scanSearchQuery(queryFromURL || '')
+            if (scannedQuery.type === 'success') {
+                for (const token of scannedQuery.term) {
+                    if (isRepoFilter(token)) {
+                        if (token.value && !recentlySearchedRepos.includes(token.value.value)) {
+                            recentlySearchedRepos.push(token.value.value)
+                        }
                     }
                 }
             }
+        } catch (error: unknown) {
+            console.error('RepositoriesPanel: Error parsing event')
+            console.error(error)
         }
     }
     return recentlySearchedRepos

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -131,7 +131,7 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
     const recentlySearchedRepos: string[] = []
 
     for (const node of eventLogResult.nodes) {
-        try {
+        if (node.url) {
             const url = new URL(node.url)
             const queryFromURL = parseSearchURLQuery(url.search)
             const scannedQuery = scanSearchQuery(queryFromURL || '')
@@ -144,9 +144,6 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
                     }
                 }
             }
-        } catch (error: unknown) {
-            console.error('RepositoriesPanel: Error parsing event')
-            console.error(error)
         }
     }
     return recentlySearchedRepos


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/25573.
Don't crash if there are errors parsing events with empty URL from the event log.

Slack [thread](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1633099541105100).