### PR TITLE
search: repurpose debug dataset as honeycomb search-zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,6 @@ require (
 	github.com/prometheus/common v0.30.0
 	github.com/qustavo/sqlhooks/v2 v2.1.0
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be
-	github.com/rs/xid v1.3.0
 	github.com/russellhaering/gosaml2 v0.6.0
 	github.com/russellhaering/goxmldsig v1.1.1-0.20201210191726-3541f5e554ee
 	github.com/schollz/progressbar/v3 v3.5.0
@@ -273,6 +272,7 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/rs/xid v1.3.0 // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17 // indirect
 	github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480 // indirect

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -14,7 +14,6 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/rs/xid"
 
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -68,7 +67,6 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		event = honey.Event("search-zoekt")
 		event.AddField("category", cat)
 		event.AddField("query", qStr)
-		event.AddField("xid", xid.New().String())
 		for _, t := range tags {
 			event.AddField(t.Key, t.Value)
 		}
@@ -244,7 +242,6 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 		event = honey.Event("search-zoekt")
 		event.AddField("category", cat)
 		event.AddField("query", qStr)
-		event.AddField("xid", xid.New().String())
 		event.AddField("opts.minimal", opts != nil && opts.Minimal)
 		for _, t := range tags {
 			event.AddField(t.Key, t.Value)

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"os"
 	"sync"
 	"time"
 
@@ -21,8 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
-
-var searchCoreOOMDebug = os.Getenv("SRC_SEARCH_CORE_OOM_DEBUG") != ""
 
 var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "src_zoekt_request_duration_seconds",
@@ -67,8 +64,8 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	qStr := queryString(q)
 
 	var event *libhoney.Event
-	if searchCoreOOMDebug && cat == "SearchAll" {
-		event = honey.Event("search-core-oom-debug")
+	if honey.Enabled() && cat == "SearchAll" {
+		event = honey.Event("search-zoekt")
 		event.AddField("category", cat)
 		event.AddField("query", qStr)
 		event.AddField("xid", xid.New().String())
@@ -243,8 +240,8 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 	tr.LogFields(trace.Stringer("opts", opts))
 
 	var event *libhoney.Event
-	if searchCoreOOMDebug && cat == "ListAll" {
-		event = honey.Event("search-core-oom-debug")
+	if honey.Enabled() && cat == "ListAll" {
+		event = honey.Event("search-zoekt")
 		event.AddField("category", cat)
 		event.AddField("query", qStr)
 		event.AddField("xid", xid.New().String())

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -64,16 +64,14 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		}
 	}
 
-	var evBefore, evAfter *libhoney.Event
+	var evAfter *libhoney.Event
 	debugAdd := func(key string, value interface{}) {
-		if evBefore == nil {
+		if evAfter == nil {
 			return
 		}
-		evBefore.AddField(key, value)
 		evAfter.AddField(key, value)
 	}
 	if searchCoreOOMDebug && cat == "SearchAll" {
-		evBefore = honey.Event("search-core-oom-debug")
 		evAfter = honey.Event("search-core-oom-debug")
 		debugAdd("category", cat)
 		debugAdd("query", queryString(q))
@@ -135,10 +133,6 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 				writeRequestDone = time.Now()
 			},
 		})
-	}
-
-	if evBefore != nil {
-		evBefore.Send()
 	}
 
 	var (
@@ -245,16 +239,14 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 		}
 	}
 
-	var evBefore, evAfter *libhoney.Event
+	var evAfter *libhoney.Event
 	debugAdd := func(key string, value interface{}) {
-		if evBefore == nil {
+		if evAfter == nil {
 			return
 		}
-		evBefore.AddField(key, value)
 		evAfter.AddField(key, value)
 	}
 	if searchCoreOOMDebug && cat == "ListAll" {
-		evBefore = honey.Event("search-core-oom-debug")
 		evAfter = honey.Event("search-core-oom-debug")
 		debugAdd("category", cat)
 		debugAdd("query", queryString(q))
@@ -268,10 +260,6 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 	tr.LogFields(trace.Stringer("opts", opts))
 
 	debugAdd("opts.minimal", opts != nil && opts.Minimal)
-
-	if evBefore != nil {
-		evBefore.Send()
-	}
 
 	zsl, err := m.Streamer.List(ctx, q, opts)
 

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -64,18 +64,20 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		}
 	}
 
+	qStr := queryString(q)
+
 	var event *libhoney.Event
 	if searchCoreOOMDebug && cat == "SearchAll" {
 		event = honey.Event("search-core-oom-debug")
 		event.AddField("category", cat)
-		event.AddField("query", queryString(q))
+		event.AddField("query", qStr)
 		event.AddField("xid", xid.New().String())
 		for _, t := range tags {
 			event.AddField(t.Key, t.Value)
 		}
 	}
 
-	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q), tags...)
+	tr, ctx := trace.New(ctx, "zoekt."+cat, qStr, tags...)
 	defer func() {
 		tr.SetErrorIfNotContext(err)
 		tr.Finish()
@@ -235,14 +237,16 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 		}
 	}
 
-	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q), tags...)
+	qStr := queryString(q)
+
+	tr, ctx := trace.New(ctx, "zoekt."+cat, qStr, tags...)
 	tr.LogFields(trace.Stringer("opts", opts))
 
 	var event *libhoney.Event
 	if searchCoreOOMDebug && cat == "ListAll" {
 		event = honey.Event("search-core-oom-debug")
 		event.AddField("category", cat)
-		event.AddField("query", queryString(q))
+		event.AddField("query", qStr)
 		event.AddField("xid", xid.New().String())
 		event.AddField("opts.minimal", opts != nil && opts.Minimal)
 		for _, t := range tags {

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -191,8 +191,11 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		log.Int("stats.match_count", statsAgg.MatchCount),
 		log.Int("stats.ngram_matches", statsAgg.NgramMatches),
 		log.Int("stats.shard_files_considered", statsAgg.ShardFilesConsidered),
+		log.Int("stats.shards_scanned", statsAgg.ShardsScanned),
 		log.Int("stats.shards_skipped", statsAgg.ShardsSkipped),
+		log.Int("stats.shards_skipped_filter", statsAgg.ShardsSkippedFilter),
 		log.Int64("stats.wait_ms", statsAgg.Wait.Milliseconds()),
+		log.Int("stats.regexps_considered", statsAgg.RegexpsConsidered),
 	}
 	tr.LogFields(fields...)
 	if event != nil {

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -64,15 +64,15 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		}
 	}
 
-	var evAfter *libhoney.Event
+	var event *libhoney.Event
 	debugAdd := func(key string, value interface{}) {
-		if evAfter == nil {
+		if event == nil {
 			return
 		}
-		evAfter.AddField(key, value)
+		event.AddField(key, value)
 	}
 	if searchCoreOOMDebug && cat == "SearchAll" {
-		evAfter = honey.Event("search-core-oom-debug")
+		event = honey.Event("search-core-oom-debug")
 		debugAdd("category", cat)
 		debugAdd("query", queryString(q))
 		debugAdd("xid", xid.New().String())
@@ -202,15 +202,15 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		log.Int64("stats.wait_ms", statsAgg.Wait.Milliseconds()),
 	}
 	tr.LogFields(fields...)
-	if evAfter != nil {
-		evAfter.AddField("duration_ms", time.Since(start).Milliseconds())
+	if event != nil {
+		event.AddField("duration_ms", time.Since(start).Milliseconds())
 		if err != nil {
-			evAfter.AddField("error", err)
+			event.AddField("error", err)
 		}
 		for _, f := range fields {
-			evAfter.AddField(f.Key(), f.Value())
+			event.AddField(f.Key(), f.Value())
 		}
-		evAfter.Send()
+		event.Send()
 	}
 
 	// Record total duration of stream
@@ -239,15 +239,15 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 		}
 	}
 
-	var evAfter *libhoney.Event
+	var event *libhoney.Event
 	debugAdd := func(key string, value interface{}) {
-		if evAfter == nil {
+		if event == nil {
 			return
 		}
-		evAfter.AddField(key, value)
+		event.AddField(key, value)
 	}
 	if searchCoreOOMDebug && cat == "ListAll" {
-		evAfter = honey.Event("search-core-oom-debug")
+		event = honey.Event("search-core-oom-debug")
 		debugAdd("category", cat)
 		debugAdd("query", queryString(q))
 		debugAdd("xid", xid.New().String())
@@ -268,16 +268,16 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 		code = "error"
 	}
 
-	if evAfter != nil {
-		evAfter.AddField("duration_ms", time.Since(start).Milliseconds())
+	if event != nil {
+		event.AddField("duration_ms", time.Since(start).Milliseconds())
 		if zsl != nil {
-			evAfter.AddField("repos", len(zsl.Repos))
-			evAfter.AddField("minimal_repos", len(zsl.Minimal))
+			event.AddField("repos", len(zsl.Repos))
+			event.AddField("minimal_repos", len(zsl.Minimal))
 		}
 		if err != nil {
-			evAfter.AddField("error", err)
+			event.AddField("error", err)
 		}
-		evAfter.Send()
+		event.Send()
 	}
 
 	requestDuration.WithLabelValues(m.hostname, cat, code).Observe(time.Since(start).Seconds())


### PR DESCRIPTION
It would be useful to have the detailed honeycomb logging we added for debugging OOMs always on. This promotes it to it's own dataset.

This PR is a series of mechanical refactors. Highlights:

1. remove before event
2. rename honeycomb event to `search-zoekt`
3. always enable if honeycomb is enabled.
4. add in logging for new stat fields