### PR TITLE
Refactor Survey code, use Apollo, add tests

### DIFF
--- a/client/web/src/marketing/SurveyCta.tsx
+++ b/client/web/src/marketing/SurveyCta.tsx
@@ -1,0 +1,69 @@
+import classNames from 'classnames'
+import { range } from 'lodash'
+import React, { useState } from 'react'
+import { useHistory } from 'react-router'
+
+import { eventLogger } from '../tracking/eventLogger'
+
+import toastStyles from './Toast.module.scss'
+
+interface SurveyCTAProps {
+    ariaLabelledby?: string
+    className?: string
+    score?: number
+    onChange?: (score: number) => void
+    openSurveyInNewTab?: boolean
+    'aria-labelledby'?: string
+}
+
+export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
+    const history = useHistory()
+    const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
+
+    const handleFocus = (index: number): void => {
+        setFocusedIndex(index)
+    }
+
+    const handleBlur = (): void => {
+        setFocusedIndex(null)
+    }
+
+    const handleChange = (score: number): void => {
+        eventLogger.log('SurveyButtonClicked', { score }, { score })
+        history.push(`/survey/${score}`)
+
+        if (props.onChange) {
+            props.onChange(score)
+        }
+    }
+
+    return (
+        <fieldset aria-labelledby={props.ariaLabelledby} className={props.className} onBlur={handleBlur}>
+            {range(0, 11).map(score => {
+                const pressed = score === props.score
+                const focused = score === focusedIndex
+
+                return (
+                    <label
+                        key={score}
+                        className={classNames('btn btn-primary', toastStyles.ratingBtn, {
+                            active: pressed,
+                            focus: focused,
+                        })}
+                    >
+                        <input
+                            type="radio"
+                            name="survey-score"
+                            value={score}
+                            onChange={() => handleChange(score)}
+                            onFocus={() => handleFocus(score)}
+                            className={toastStyles.ratingRadio}
+                        />
+
+                        {score}
+                    </label>
+                )
+            })}
+        </fieldset>
+    )
+}

--- a/client/web/src/marketing/SurveyForm.tsx
+++ b/client/web/src/marketing/SurveyForm.tsx
@@ -20,7 +20,7 @@ interface SurveyFormProps {
     onSubmit?: () => void
 }
 
-const SUBMIT_SURVEY = gql`
+export const SUBMIT_SURVEY = gql`
     mutation SubmitSurvey($input: SurveySubmissionInput!) {
         submitSurvey(input: $input) {
             alwaysNil

--- a/client/web/src/marketing/SurveyForm.tsx
+++ b/client/web/src/marketing/SurveyForm.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react'
+import { useHistory } from 'react-router'
+
+import { Form } from '@sourcegraph/branded/src/components/Form'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { useMutation } from '@sourcegraph/shared/src/graphql/apollo'
+import { gql } from '@sourcegraph/shared/src/graphql/graphql'
+
+import { AuthenticatedUser } from '../auth'
+import { SubmitSurveyResult, SubmitSurveyVariables } from '../graphql-operations'
+import { eventLogger } from '../tracking/eventLogger'
+
+import { SurveyCTA } from './SurveyCta'
+import styles from './SurveyPage.module.scss'
+
+interface SurveyFormProps {
+    authenticatedUser: AuthenticatedUser | null
+    score?: number
+    onScoreChange?: (score: number) => void
+    onSubmit?: () => void
+}
+
+const SUBMIT_SURVEY = gql`
+    mutation SubmitSurvey($input: SurveySubmissionInput!) {
+        submitSurvey(input: $input) {
+            alwaysNil
+        }
+    }
+`
+
+export const SurveyForm: React.FunctionComponent<SurveyFormProps> = ({
+    authenticatedUser,
+    score,
+    onScoreChange,
+    onSubmit,
+}) => {
+    const history = useHistory()
+    const [reason, setReason] = useState('')
+    const [betterProduct, setBetterProduct] = useState('')
+    const [email, setEmail] = useState('')
+    const [validationMessage, setValidationMessage] = useState('')
+
+    const [submitSurvey, response] = useMutation<SubmitSurveyResult, SubmitSurveyVariables>(SUBMIT_SURVEY, {
+        onCompleted: () => {
+            if (onSubmit) {
+                onSubmit()
+            }
+
+            history.push({
+                pathname: '/survey/thanks',
+                state: {
+                    score,
+                    feedback: reason,
+                },
+            })
+        },
+    })
+
+    const handleScoreChange = (score: number): void => {
+        if (onScoreChange) {
+            onScoreChange(score)
+        }
+        setValidationMessage('')
+    }
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+        event.preventDefault()
+
+        if (score === undefined) {
+            setValidationMessage('Please select a score')
+            return
+        }
+
+        eventLogger.log('SurveySubmitted')
+
+        await submitSurvey({
+            variables: {
+                input: {
+                    score,
+                    email,
+                    reason,
+                    better: betterProduct,
+                },
+            },
+        })
+    }
+
+    const error = validationMessage || response.error?.message
+
+    return (
+        <Form className={styles.surveyForm} onSubmit={handleSubmit}>
+            {error && <p className={styles.error}>{error}</p>}
+            {/* Label is associated with control through aria-labelledby */}
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label id="survey-form-scores" className={styles.label}>
+                How likely is it that you would recommend Sourcegraph to a friend?
+            </label>
+            <SurveyCTA
+                ariaLabelledby="survey-form-scores"
+                className={styles.scores}
+                onChange={handleScoreChange}
+                score={score}
+            />
+            {!authenticatedUser && (
+                <div className="form-group">
+                    <input
+                        className="form-control"
+                        type="text"
+                        placeholder="Email"
+                        onChange={event => setEmail(event.target.value)}
+                        value={email}
+                        disabled={response.loading}
+                    />
+                </div>
+            )}
+            <div className="form-group">
+                <label className={styles.label} htmlFor="survey-form-score-reason">
+                    What is the most important reason for the score you gave Sourcegraph?
+                </label>
+                <textarea
+                    id="survey-form-score-reason"
+                    className="form-control"
+                    onChange={event => setReason(event.target.value)}
+                    value={reason}
+                    disabled={response.loading}
+                    autoFocus={true}
+                />
+            </div>
+            <div className="form-group">
+                <label className={styles.label} htmlFor="survey-form-better-product">
+                    What could Sourcegraph do to provide a better product?
+                </label>
+                <textarea
+                    id="survey-form-better-product"
+                    className="form-control"
+                    onChange={event => setBetterProduct(event.target.value)}
+                    value={betterProduct}
+                    disabled={response.loading}
+                />
+            </div>
+            <div className="form-group">
+                <button className="btn btn-primary btn-block" type="submit" disabled={response.loading}>
+                    Submit
+                </button>
+            </div>
+            {response.loading && (
+                <div className={styles.loader}>
+                    <LoadingSpinner className="icon-inline" />
+                </div>
+            )}
+            <div>
+                <small>
+                    Your response to this survey will be sent to Sourcegraph, and will be visible to your Sourcegraph
+                    site admins.
+                </small>
+            </div>
+        </Form>
+    )
+}

--- a/client/web/src/marketing/SurveyPage.test.tsx
+++ b/client/web/src/marketing/SurveyPage.test.tsx
@@ -1,0 +1,115 @@
+import { MockedResponse, MockedProviderProps } from '@apollo/client/testing'
+import { cleanup, fireEvent, within, waitFor } from '@testing-library/react'
+import { createMemoryHistory } from 'history'
+import React from 'react'
+import { Route } from 'react-router'
+
+import { getDocumentNode } from '@sourcegraph/shared/src/graphql/apollo'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { renderWithRouter, RenderWithRouterResult } from '@sourcegraph/shared/src/testing/render-with-router'
+
+import { SubmitSurveyResult } from '../graphql-operations'
+
+import { SUBMIT_SURVEY } from './SurveyForm'
+import { SurveyPage } from './SurveyPage'
+
+interface RenderSurveyPageParameters {
+    mocks: MockedProviderProps['mocks']
+    routerProps?: {
+        matchParam?: string
+        locationState?: {
+            score: number
+            feedback: string
+        }
+    }
+}
+
+describe('SurveyPage', () => {
+    let renderResult: RenderWithRouterResult
+
+    afterEach(cleanup)
+
+    const renderSurveyPage = ({ mocks, routerProps }: RenderSurveyPageParameters) => {
+        const history = createMemoryHistory()
+        history.push(`/survey/${routerProps?.matchParam || ''}`, routerProps?.locationState)
+
+        return renderWithRouter(
+            <MockedTestProvider mocks={mocks}>
+                <Route path="/survey/:score?">
+                    <SurveyPage authenticatedUser={null} />
+                </Route>
+            </MockedTestProvider>,
+            { route: '/', history }
+        )
+    }
+
+    describe('Prior to submission', () => {
+        const mockScore = 10
+        const mockReason = 'I like it'
+        const mockSuggestion = 'Read my mind'
+        const submitSurveyMock: MockedResponse<SubmitSurveyResult> = {
+            request: {
+                query: getDocumentNode(SUBMIT_SURVEY),
+                variables: {
+                    input: {
+                        score: mockScore,
+                        email: '',
+                        reason: mockReason,
+                        better: mockSuggestion,
+                    },
+                },
+            },
+            result: {
+                data: {
+                    submitSurvey: {
+                        alwaysNil: null,
+                        __typename: 'EmptyResponse',
+                    },
+                },
+            },
+        }
+
+        beforeEach(() => {
+            renderResult = renderSurveyPage({ mocks: [submitSurveyMock] })
+        })
+
+        it('renders and handles form fields correctly', async () => {
+            const recommendRadioGroup = renderResult.getByLabelText(
+                'How likely is it that you would recommend Sourcegraph to a friend?'
+            )
+            expect(recommendRadioGroup).toBeVisible()
+            const score10 = within(recommendRadioGroup).getByLabelText(mockScore)
+            fireEvent.click(score10)
+
+            const reasonInput = renderResult.getByLabelText(
+                'What is the most important reason for the score you gave Sourcegraph?'
+            )
+            expect(reasonInput).toBeVisible()
+            fireEvent.change(reasonInput, { target: { value: mockReason } })
+
+            const betterProductInput = renderResult.getByLabelText(
+                'What could Sourcegraph do to provide a better product?'
+            )
+            expect(betterProductInput).toBeVisible()
+            fireEvent.change(betterProductInput, { target: { value: mockSuggestion } })
+
+            fireEvent.click(renderResult.getByText('Submit'))
+
+            await waitFor(() => expect(renderResult.history.location.pathname).toBe('/survey/thanks'))
+        })
+    })
+
+    describe('After submission', () => {
+        beforeEach(() => {
+            renderResult = renderSurveyPage({
+                mocks: [],
+                routerProps: { matchParam: 'thanks', locationState: { score: 10, feedback: 'great' } },
+            })
+        })
+
+        it('renders correct thank you message', () => {
+            expect(renderResult.getByText('Thanks for the feedback!')).toBeVisible()
+            expect(renderResult.getByText('Tweet feedback', { selector: 'a' })).toBeVisible()
+        })
+    })
+})

--- a/client/web/src/marketing/SurveyPage.tsx
+++ b/client/web/src/marketing/SurveyPage.tsx
@@ -1,12 +1,6 @@
-import * as H from 'history'
-import TwitterIcon from 'mdi-react/TwitterIcon'
-import * as React from 'react'
+import React, { useEffect } from 'react'
 import { RouteComponentProps } from 'react-router'
-import { Subscription } from 'rxjs'
-import { catchError } from 'rxjs/operators'
 
-import { Form } from '@sourcegraph/branded/src/components/Form'
-import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { AuthenticatedUser } from '../auth'
@@ -15,249 +9,47 @@ import { HeroPage } from '../components/HeroPage'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 
-import { submitSurvey } from './backend'
+import { SurveyForm } from './SurveyForm'
 import styles from './SurveyPage.module.scss'
-import { SurveyCTA } from './SurveyToast'
-
-interface SurveyFormProps {
-    location: H.Location
-    history: H.History
-    authenticatedUser: AuthenticatedUser | null
-    score?: number
-    onScoreChange?: (score: number) => void
-    onSubmit?: () => void
-}
-
-interface SurveyFormState {
-    error?: Error
-    reason: string
-    betterProduct: string
-    email: string
-    loading: boolean
-}
-
-export interface SurveyResponse {
-    score: number
-    email?: string
-    reason?: string
-    better?: string
-}
-
-class SurveyForm extends React.Component<SurveyFormProps, SurveyFormState> {
-    private subscriptions = new Subscription()
-
-    constructor(props: SurveyFormProps) {
-        super(props)
-        this.state = {
-            reason: '',
-            betterProduct: '',
-            email: '',
-            loading: false,
-        }
-    }
-
-    public render(): JSX.Element | null {
-        return (
-            <Form className={styles.surveyForm} onSubmit={this.handleSubmit}>
-                {this.state.error && <p className={styles.error}>{this.state.error.message}</p>}
-                {/* Label is associated with control through aria-labelledby */}
-                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                <label id="survey-form-scores" className={styles.label}>
-                    How likely is it that you would recommend Sourcegraph to a friend?
-                </label>
-                <SurveyCTA
-                    ariaLabelledby="survey-form-scores"
-                    className={styles.scores}
-                    onChange={this.onScoreChange}
-                    score={this.props.score}
-                />
-                {!this.props.authenticatedUser && (
-                    <div className="form-group">
-                        <input
-                            className="form-control"
-                            type="text"
-                            placeholder="Email"
-                            onChange={this.onEmailFieldChange}
-                            value={this.state.email}
-                            disabled={this.state.loading}
-                        />
-                    </div>
-                )}
-                <div className="form-group">
-                    <label className={styles.label} htmlFor="survey-form-score-reason">
-                        What is the most important reason for the score you gave Sourcegraph?
-                    </label>
-                    <textarea
-                        id="survey-form-score-reason"
-                        className="form-control"
-                        onChange={this.onReasonFieldChange}
-                        value={this.state.reason}
-                        disabled={this.state.loading}
-                        autoFocus={true}
-                    />
-                </div>
-                <div className="form-group">
-                    <label className={styles.label} htmlFor="survey-form-better-product">
-                        What could Sourcegraph do to provide a better product?
-                    </label>
-                    <textarea
-                        id="survey-form-better-product"
-                        className="form-control"
-                        onChange={this.onBetterProductFieldChange}
-                        value={this.state.betterProduct}
-                        disabled={this.state.loading}
-                    />
-                </div>
-                <div className="form-group">
-                    <button className="btn btn-primary btn-block" type="submit" disabled={this.state.loading}>
-                        Submit
-                    </button>
-                </div>
-                {this.state.loading && (
-                    <div className={styles.loader}>
-                        <LoadingSpinner className="icon-inline" />
-                    </div>
-                )}
-                <div>
-                    <small>
-                        Your response to this survey will be sent to Sourcegraph, and will be visible to your
-                        Sourcegraph site admins.
-                    </small>
-                </div>
-            </Form>
-        )
-    }
-
-    private onScoreChange = (score: number): void => {
-        if (this.props.onScoreChange) {
-            this.props.onScoreChange(score)
-        }
-        this.setState({ error: undefined })
-    }
-
-    private onEmailFieldChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        this.setState({ email: event.target.value })
-    }
-
-    private onReasonFieldChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
-        this.setState({ reason: event.target.value })
-    }
-
-    private onBetterProductFieldChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
-        this.setState({ betterProduct: event.target.value })
-    }
-
-    private handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
-        event.preventDefault()
-        if (this.state.loading) {
-            return
-        }
-
-        if (this.props.score === undefined) {
-            this.setState({ error: new Error('Please select a score') })
-            return
-        }
-
-        eventLogger.log('SurveySubmitted')
-        this.setState({ loading: true })
-
-        this.subscriptions.add(
-            submitSurvey({
-                score: this.props.score,
-                email: this.state.email,
-                reason: this.state.reason,
-                better: this.state.betterProduct,
-            })
-                .pipe(
-                    catchError(error => {
-                        this.setState({ error })
-                        return []
-                    })
-                )
-                .subscribe(() => {
-                    if (this.props.onSubmit) {
-                        this.props.onSubmit()
-                    }
-                    this.props.history.push({
-                        pathname: '/survey/thanks',
-                        state: {
-                            score: this.props.score,
-                            feedback: this.state.reason,
-                        },
-                    })
-                })
-        )
-    }
-}
+import { TweetFeedback } from './TweetFeedback'
 
 interface SurveyPageProps extends RouteComponentProps<{ score?: string }>, ThemeProps {
     authenticatedUser: AuthenticatedUser | null
 }
 
-export interface TweetFeedbackProps {
-    score: number
-    feedback: string
-}
+// TODO: Better naming
+const intScore = (score?: string): number | undefined =>
+    score ? Math.max(0, Math.min(10, Math.round(+score))) : undefined
 
-const SCORE_TO_TWEET = 9
-const TweetFeedback: React.FunctionComponent<TweetFeedbackProps> = ({ feedback, score }) => {
-    if (score >= SCORE_TO_TWEET) {
-        const url = new URL('https://twitter.com/intent/tweet')
-        url.searchParams.set('text', `After using @sourcegraph: ${feedback}`)
-        return (
-            <>
-                <p className="mt-2">
-                    One more favor, could you share your feedback on Twitter? We'd really appreciate it!
-                </p>
-                <a
-                    className="d-inline-block mt-2 btn btn-primary"
-                    href={url.href}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                >
-                    <TwitterIcon className="icon-inline mr-2" />
-                    Tweet feedback
-                </a>
-            </>
-        )
-    }
-    return null
-}
+export const SurveyPage: React.FunctionComponent<SurveyPageProps> = props => {
+    const {
+        location,
+        match: {
+            params: { score },
+        },
+    } = props
 
-export class SurveyPage extends React.Component<SurveyPageProps> {
-    public componentDidMount(): void {
+    useEffect(() => {
         eventLogger.logViewEvent('Survey')
-    }
+    }, [])
 
-    public render(): JSX.Element | null {
-        if (this.props.match.params.score === 'thanks') {
-            return (
-                <div className={styles.surveyPage}>
-                    <PageTitle title="Thanks" />
-                    <HeroPage
-                        title="Thanks for the feedback!"
-                        body={
-                            <TweetFeedback
-                                score={this.props.location.state.score}
-                                feedback={this.props.location.state.feedback}
-                            />
-                        }
-                        cta={<FeedbackText headerText="Anything else?" />}
-                    />
-                </div>
-            )
-        }
+    if (score === 'thanks') {
         return (
             <div className={styles.surveyPage}>
-                <PageTitle title="Almost there..." />
+                <PageTitle title="Thanks" />
                 <HeroPage
-                    title="Almost there..."
-                    cta={<SurveyForm score={this.intScore(this.props.match.params.score)} {...this.props} />}
+                    title="Thanks for the feedback!"
+                    body={<TweetFeedback score={location.state.score} feedback={location.state.feedback} />}
+                    cta={<FeedbackText headerText="Anything else?" />}
                 />
             </div>
         )
     }
 
-    private intScore = (score?: string): number | undefined =>
-        score ? Math.max(0, Math.min(10, Math.round(+score))) : undefined
+    return (
+        <div className={styles.surveyPage}>
+            <PageTitle title="Almost there..." />
+            <HeroPage title="Almost there..." cta={<SurveyForm score={intScore(score)} {...props} />} />
+        </div>
+    )
 }

--- a/client/web/src/marketing/SurveyPage.tsx
+++ b/client/web/src/marketing/SurveyPage.tsx
@@ -15,8 +15,7 @@ interface SurveyPageProps {
     authenticatedUser: AuthenticatedUser | null
 }
 
-// TODO: Better naming
-const intScore = (score?: string): number | undefined =>
+const getScoreFromString = (score?: string): number | undefined =>
     score ? Math.max(0, Math.min(10, Math.round(+score))) : undefined
 
 export const SurveyPage: React.FunctionComponent<SurveyPageProps> = props => {
@@ -43,7 +42,7 @@ export const SurveyPage: React.FunctionComponent<SurveyPageProps> = props => {
     return (
         <div className={styles.surveyPage}>
             <PageTitle title="Almost there..." />
-            <HeroPage title="Almost there..." cta={<SurveyForm score={intScore(score)} {...props} />} />
+            <HeroPage title="Almost there..." cta={<SurveyForm score={getScoreFromString(score)} {...props} />} />
         </div>
     )
 }

--- a/client/web/src/marketing/SurveyPage.tsx
+++ b/client/web/src/marketing/SurveyPage.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react'
-import { RouteComponentProps } from 'react-router'
-
-import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { useLocation, useParams } from 'react-router'
 
 import { AuthenticatedUser } from '../auth'
 import { FeedbackText } from '../components/FeedbackText'
@@ -13,7 +11,7 @@ import { SurveyForm } from './SurveyForm'
 import styles from './SurveyPage.module.scss'
 import { TweetFeedback } from './TweetFeedback'
 
-interface SurveyPageProps extends RouteComponentProps<{ score?: string }>, ThemeProps {
+interface SurveyPageProps {
     authenticatedUser: AuthenticatedUser | null
 }
 
@@ -22,12 +20,8 @@ const intScore = (score?: string): number | undefined =>
     score ? Math.max(0, Math.min(10, Math.round(+score))) : undefined
 
 export const SurveyPage: React.FunctionComponent<SurveyPageProps> = props => {
-    const {
-        location,
-        match: {
-            params: { score },
-        },
-    } = props
+    const location = useLocation()
+    const { score } = useParams<{ score?: string }>()
 
     useEffect(() => {
         eventLogger.logViewEvent('Survey')

--- a/client/web/src/marketing/SurveyToast.test.tsx
+++ b/client/web/src/marketing/SurveyToast.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, within, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+import { renderWithRouter, RenderWithRouterResult } from '@sourcegraph/shared/src/testing/render-with-router'
+
+import { DAYS_ACTIVE_STORAGE_KEY, HAS_DISMISSED_TOAST_STORAGE_KEY } from './constants'
+import { SurveyToast } from './SurveyToast'
+
+describe('SurveyToast', () => {
+    let renderResult: RenderWithRouterResult
+
+    afterEach(cleanup)
+
+    const setDaysActive = (daysActive: string) => localStorage.setItem(DAYS_ACTIVE_STORAGE_KEY, daysActive)
+    const setToastDismissed = (dismissed: string) => localStorage.setItem(HAS_DISMISSED_TOAST_STORAGE_KEY, dismissed)
+
+    describe('before day 3', () => {
+        beforeEach(() => {
+            setDaysActive('1')
+            setToastDismissed('false')
+            renderResult = renderWithRouter(<SurveyToast />)
+        })
+
+        it('the user is not surveyed', () => {
+            expect(renderResult.container).toBeEmptyDOMElement()
+        })
+    })
+
+    describe('on day 3', () => {
+        beforeEach(() => {
+            setDaysActive('3')
+            setToastDismissed('false')
+            renderResult = renderWithRouter(<SurveyToast />)
+        })
+
+        it('the user is surveyed', () => {
+            expect(renderResult.getByText('Tell us what you think')).toBeVisible()
+        })
+
+        it('submitting the form correctly navigates to the survey page and dismisses the toast', () => {
+            const mockScore = 10
+            const recommendRadioGroup = renderResult.getByLabelText(
+                'How likely is it that you would recommend Sourcegraph to a friend?'
+            )
+            expect(recommendRadioGroup).toBeVisible()
+            const score10 = within(recommendRadioGroup).getByLabelText(mockScore)
+            fireEvent.click(score10)
+            expect(renderResult.history.location.pathname).toBe(`/survey/${mockScore}`)
+            expect(localStorage.getItem(HAS_DISMISSED_TOAST_STORAGE_KEY)).toBe('true')
+        })
+    })
+
+    describe('on day 4', () => {
+        beforeEach(() => {
+            setDaysActive('4')
+            setToastDismissed('false')
+            renderResult = renderWithRouter(<SurveyToast />)
+        })
+
+        it('the user is not surveyed', () => {
+            expect(renderResult.container).toBeEmptyDOMElement()
+        })
+    })
+
+    describe('on day 33', () => {
+        beforeEach(() => {
+            setDaysActive('33')
+            setToastDismissed('false')
+            renderResult = renderWithRouter(<SurveyToast />)
+        })
+
+        it('the user is surveyed as it has been 30 days since the last notification', () => {
+            expect(renderResult.getByText('Tell us what you think')).toBeVisible()
+        })
+    })
+})

--- a/client/web/src/marketing/SurveyToast.tsx
+++ b/client/web/src/marketing/SurveyToast.tsx
@@ -1,121 +1,50 @@
-import classNames from 'classnames'
-import { range } from 'lodash'
 import EmoticonIcon from 'mdi-react/EmoticonIcon'
-import React, { useState } from 'react'
-import { useHistory } from 'react-router'
+import React, { useEffect, useState } from 'react'
 
 import { AuthenticatedUser } from '../auth'
 import { eventLogger } from '../tracking/eventLogger'
 
+import { SurveyCTA } from './SurveyCta'
 import { Toast } from './Toast'
-import toastStyles from './Toast.module.scss'
 import { daysActiveCount } from './util'
 
 const HAS_DISMISSED_TOAST_KEY = 'has-dismissed-survey-toast'
 
-interface SurveyCTAProps {
-    ariaLabelledby?: string
-    className?: string
-    score?: number
-    onChange?: (score: number) => void
-    openSurveyInNewTab?: boolean
-    'aria-labelledby'?: string
-}
-
-export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
-    const history = useHistory()
-    const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
-
-    const handleFocus = (index: number): void => {
-        setFocusedIndex(index)
-    }
-
-    const handleBlur = (): void => {
-        setFocusedIndex(null)
-    }
-
-    const handleChange = (score: number): void => {
-        eventLogger.log('SurveyButtonClicked', { score }, { score })
-        history.push(`/survey/${score}`)
-
-        if (props.onChange) {
-            props.onChange(score)
-        }
-    }
-
-    return (
-        <fieldset aria-labelledby={props.ariaLabelledby} className={props.className} onBlur={handleBlur}>
-            {range(0, 11).map(score => {
-                const pressed = score === props.score
-                const focused = score === focusedIndex
-
-                return (
-                    <label
-                        key={score}
-                        className={classNames('btn btn-primary', toastStyles.ratingBtn, {
-                            active: pressed,
-                            focus: focused,
-                        })}
-                    >
-                        <input
-                            type="radio"
-                            name="survey-score"
-                            value={score}
-                            onChange={() => handleChange(score)}
-                            onFocus={() => handleFocus(score)}
-                            className={toastStyles.ratingRadio}
-                        />
-
-                        {score}
-                    </label>
-                )
-            })}
-        </fieldset>
-    )
-}
-
-interface Props {
+interface SurveyToastProps {
     authenticatedUser: AuthenticatedUser | null
 }
 
-interface State {
-    visible: boolean
-}
+export const SurveyToast: React.FunctionComponent<SurveyToastProps> = () => {
+    const [visible, setVisible] = useState(
+        localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' && daysActiveCount % 30 === 3
+    )
 
-export class SurveyToast extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props)
-        this.state = {
-            visible: localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' && daysActiveCount % 30 === 3,
-        }
-        if (this.state.visible) {
+    useEffect(() => {
+        if (visible) {
             eventLogger.log('SurveyReminderViewed')
         } else if (daysActiveCount % 30 === 0) {
             // Reset toast dismissal 3 days before it will be shown
             localStorage.setItem(HAS_DISMISSED_TOAST_KEY, 'false')
         }
-    }
+    }, [visible])
 
-    public render(): JSX.Element | null {
-        if (!this.state.visible) {
-            return null
-        }
-
-        return (
-            <Toast
-                icon={<EmoticonIcon className="icon-inline" />}
-                title="Tell us what you think"
-                subtitle="How likely is it that you would recommend Sourcegraph to a friend?"
-                cta={<SurveyCTA onChange={this.onChangeScore} openSurveyInNewTab={true} />}
-                onDismiss={this.onDismiss}
-            />
-        )
-    }
-
-    private onChangeScore = (): void => this.onDismiss()
-
-    private onDismiss = (): void => {
+    const handleDismiss = (): void => {
         localStorage.setItem(HAS_DISMISSED_TOAST_KEY, 'true')
-        this.setState({ visible: false })
+        // TODO: Check weird condition where this is immediately set back to false if 3 days before shown again
+        setVisible(false)
     }
+
+    if (!visible) {
+        return null
+    }
+
+    return (
+        <Toast
+            icon={<EmoticonIcon className="icon-inline" />}
+            title="Tell us what you think"
+            subtitle="How likely is it that you would recommend Sourcegraph to a friend?"
+            cta={<SurveyCTA onChange={handleDismiss} openSurveyInNewTab={true} />}
+            onDismiss={handleDismiss}
+        />
+    )
 }

--- a/client/web/src/marketing/Toast.tsx
+++ b/client/web/src/marketing/Toast.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 
 import styles from './Toast.module.scss'
 
-interface Props {
+interface ToastProps {
     icon: JSX.Element
     title: string
     subtitle?: string
@@ -12,7 +12,7 @@ interface Props {
     onDismiss: () => void
 }
 
-export const Toast: React.FunctionComponent<Props> = props => (
+export const Toast: React.FunctionComponent<ToastProps> = props => (
     <div className={classNames('card', styles.toast)}>
         <div className="card-body px-3 pb-3 pt-2">
             <header className="card-title d-flex align-items-center">

--- a/client/web/src/marketing/Toast.tsx
+++ b/client/web/src/marketing/Toast.tsx
@@ -6,8 +6,8 @@ import styles from './Toast.module.scss'
 
 interface ToastProps {
     icon: JSX.Element
-    title: string
-    subtitle?: string
+    title: React.ReactNode
+    subtitle?: React.ReactNode
     cta?: JSX.Element
     onDismiss: () => void
 }

--- a/client/web/src/marketing/TweetFeedback.tsx
+++ b/client/web/src/marketing/TweetFeedback.tsx
@@ -1,0 +1,34 @@
+import TwitterIcon from 'mdi-react/TwitterIcon'
+import * as React from 'react'
+
+export interface TweetFeedbackProps {
+    score: number
+    feedback: string
+}
+
+const SCORE_TO_TWEET = 9
+
+export const TweetFeedback: React.FunctionComponent<TweetFeedbackProps> = ({ feedback, score }) => {
+    if (score >= SCORE_TO_TWEET) {
+        const url = new URL('https://twitter.com/intent/tweet')
+        url.searchParams.set('text', `After using @sourcegraph: ${feedback}`)
+        return (
+            <>
+                <p className="mt-2">
+                    One more favor, could you share your feedback on Twitter? We'd really appreciate it!
+                </p>
+                <a
+                    className="d-inline-block mt-2 btn btn-primary"
+                    href={url.href}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                >
+                    <TwitterIcon className="icon-inline mr-2" />
+                    Tweet feedback
+                </a>
+            </>
+        )
+    }
+
+    return null
+}

--- a/client/web/src/marketing/backend.ts
+++ b/client/web/src/marketing/backend.ts
@@ -13,28 +13,8 @@ import {
     FetchSurveyResponsesVariables,
     RequestTrialResult,
     RequestTrialVariables,
-    SubmitSurveyResult,
-    SubmitSurveyVariables,
     UserActivePeriod,
 } from '../graphql-operations'
-
-import { SurveyResponse } from './SurveyPage'
-
-/**
- * Submits a user satisfaction survey.
- */
-export function submitSurvey(input: SurveyResponse): Observable<void> {
-    return requestGraphQL<SubmitSurveyResult, SubmitSurveyVariables>(
-        gql`
-            mutation SubmitSurvey($input: SurveySubmissionInput!) {
-                submitSurvey(input: $input) {
-                    alwaysNil
-                }
-            }
-        `,
-        { input }
-    ).pipe(map(dataOrThrowErrors), mapTo(undefined))
-}
 
 /**
  * Fetches survey responses.

--- a/client/web/src/marketing/constants.ts
+++ b/client/web/src/marketing/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Local storage key to track the number of days the user has been using the application.
+ */
+export const DAYS_ACTIVE_STORAGE_KEY = 'days-active-count'
+
+/**
+ * Local storage key to track the last time the user accessed the application.
+ */
+export const LAST_DAY_ACTIVE_STORAGE_KEY = 'last-day-active'
+
+/**
+ * Local storage key to when a user dismisses the Survey toast notification.
+ */
+export const HAS_DISMISSED_TOAST_STORAGE_KEY = 'has-dismissed-survey-toast'

--- a/client/web/src/marketing/util.tsx
+++ b/client/web/src/marketing/util.tsx
@@ -1,17 +1,17 @@
+import { DAYS_ACTIVE_STORAGE_KEY, LAST_DAY_ACTIVE_STORAGE_KEY } from './constants'
+
 export const IS_CHROME = !!window.chrome
 
-let lastDayActive = localStorage.getItem('last-day-active')
-export let daysActiveCount = parseInt(localStorage.getItem('days-active-count') || '', 10) || 0
+export const getDaysActiveCount = (): number => parseInt(localStorage.getItem(DAYS_ACTIVE_STORAGE_KEY) || '', 10) || 0
 
 /**
  * Function called upon initial app load that checks if the user is visiting
  * on a new day, and if so, updates persistent local storage with that information
  */
 export function updateUserSessionStores(): void {
-    if (new Date().toDateString() !== lastDayActive) {
-        daysActiveCount++
-        lastDayActive = new Date().toDateString()
-        localStorage.setItem('days-active-count', daysActiveCount.toString())
-        localStorage.setItem('last-day-active', lastDayActive)
+    if (new Date().toDateString() !== localStorage.getItem(LAST_DAY_ACTIVE_STORAGE_KEY)) {
+        const daysActiveCount = getDaysActiveCount() + 1
+        localStorage.setItem(DAYS_ACTIVE_STORAGE_KEY, daysActiveCount.toString())
+        localStorage.setItem(LAST_DAY_ACTIVE_STORAGE_KEY, new Date().toDateString())
     }
 }


### PR DESCRIPTION
**Changes:**
- Refactors our Survey components from class components to functional ones
- Adds tests for the standalone SurveyPage and the notification SurveyToast components
- Updates to use Apollo when submitting a survey

This work is linked to https://github.com/sourcegraph/sourcegraph/issues/25010. Refactoring and adding tests now will make that implementation easier, and makes sense to be done in a different PR