### PR TITLE
Fix: team label no longer adds to project board

### DIFF
--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -15,7 +15,7 @@ jobs:
         columns-to-ignore: "*"
     - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
       with:
-        action-token: "${{ secrets.LABELER_GITHUB_TOKEN }}"
+        action-token: ${{ secrets.LABELER_GITHUB_TOKEN }}
         project-url: "https://github.com/orgs/sourcegraph/projects/216"
         column-name: "Triage"
         label-name: "team/batchers"


### PR DESCRIPTION
Adding the team label should add the issue to our project board.
