### PR TITLE
convert most *MatchedCommit to MatchedCommit

### DIFF
--- a/internal/gitserver/search/diff_test.go
+++ b/internal/gitserver/search/diff_test.go
@@ -33,7 +33,7 @@ func TestDiffSearch(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, matched)
 
-	expectedHighlights := &MatchedCommit{
+	expectedHighlights := MatchedCommit{
 		Diff: map[int]MatchedFileDiff{
 			1: {
 				MatchedHunks: map[int]MatchedHunk{

--- a/internal/gitserver/search/highlight.go
+++ b/internal/gitserver/search/highlight.go
@@ -17,15 +17,7 @@ type MatchedCommit struct {
 }
 
 // Merge merges another CommitHighlights into this one, returning the result.
-func (c *MatchedCommit) Merge(other *MatchedCommit) *MatchedCommit {
-	if c == nil {
-		return other
-	}
-
-	if other == nil {
-		return c
-	}
-
+func (c MatchedCommit) Merge(other MatchedCommit) MatchedCommit {
 	c.Message = c.Message.Merge(other.Message)
 
 	if c.Diff == nil {

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -54,7 +54,7 @@ func ToMatchTree(q protocol.Node) (MatchTree, error) {
 type MatchTree interface {
 	// Match returns whether the given predicate matches a commit and, if it does,
 	// the portions of the commit that match in the form of *CommitHighlights
-	Match(*LazyCommit) (matched bool, highlights *MatchedCommit, err error)
+	Match(*LazyCommit) (matched bool, highlights MatchedCommit, err error)
 }
 
 // AuthorMatches is a predicate that matches if the author's name or email address
@@ -63,8 +63,8 @@ type AuthorMatches struct {
 	*casetransform.Regexp
 }
 
-func (a *AuthorMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
-	return a.Regexp.Match(lc.AuthorName, &lc.LowerBuf) || a.Regexp.Match(lc.AuthorEmail, &lc.LowerBuf), nil, nil
+func (a *AuthorMatches) Match(lc *LazyCommit) (bool, MatchedCommit, error) {
+	return a.Regexp.Match(lc.AuthorName, &lc.LowerBuf) || a.Regexp.Match(lc.AuthorEmail, &lc.LowerBuf), MatchedCommit{}, nil
 }
 
 // CommitterMatches is a predicate that matches if the author's name or email address
@@ -73,8 +73,8 @@ type CommitterMatches struct {
 	*casetransform.Regexp
 }
 
-func (c *CommitterMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
-	return c.Regexp.Match(lc.CommitterName, &lc.LowerBuf) || c.Regexp.Match(lc.CommitterEmail, &lc.LowerBuf), nil, nil
+func (c *CommitterMatches) Match(lc *LazyCommit) (bool, MatchedCommit, error) {
+	return c.Regexp.Match(lc.CommitterName, &lc.LowerBuf) || c.Regexp.Match(lc.CommitterEmail, &lc.LowerBuf), MatchedCommit{}, nil
 }
 
 // CommitBefore is a predicate that matches if the commit is before the given date
@@ -82,12 +82,12 @@ type CommitBefore struct {
 	protocol.CommitBefore
 }
 
-func (c *CommitBefore) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
+func (c *CommitBefore) Match(lc *LazyCommit) (bool, MatchedCommit, error) {
 	authorDate, err := lc.AuthorDate()
 	if err != nil {
-		return false, nil, err
+		return false, MatchedCommit{}, err
 	}
-	return authorDate.Before(c.Time), nil, nil
+	return authorDate.Before(c.Time), MatchedCommit{}, nil
 }
 
 // CommitAfter is a predicate that matches if the commit is after the given date
@@ -95,12 +95,12 @@ type CommitAfter struct {
 	protocol.CommitAfter
 }
 
-func (c *CommitAfter) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
+func (c *CommitAfter) Match(lc *LazyCommit) (bool, MatchedCommit, error) {
 	authorDate, err := lc.AuthorDate()
 	if err != nil {
-		return false, nil, err
+		return false, MatchedCommit{}, err
 	}
-	return authorDate.After(c.Time), nil, nil
+	return authorDate.After(c.Time), MatchedCommit{}, nil
 }
 
 // MessageMatches is a predicate that matches if the commit message matches
@@ -109,13 +109,13 @@ type MessageMatches struct {
 	*casetransform.Regexp
 }
 
-func (m *MessageMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
+func (m *MessageMatches) Match(lc *LazyCommit) (bool, MatchedCommit, error) {
 	results := m.FindAllIndex(lc.Message, -1, &lc.LowerBuf)
 	if results == nil {
-		return false, nil, nil
+		return false, MatchedCommit{}, nil
 	}
 
-	return true, &MatchedCommit{
+	return true, MatchedCommit{
 		Message: matchesToRanges(lc.Message, results),
 	}, nil
 }
@@ -126,10 +126,10 @@ type DiffMatches struct {
 	*casetransform.Regexp
 }
 
-func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
+func (dm *DiffMatches) Match(lc *LazyCommit) (bool, MatchedCommit, error) {
 	diff, err := lc.Diff()
 	if err != nil {
-		return false, nil, err
+		return false, MatchedCommit{}, err
 	}
 
 	foundMatch := false
@@ -176,7 +176,7 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
 		}
 	}
 
-	return foundMatch, &MatchedCommit{
+	return foundMatch, MatchedCommit{
 		Diff: fileDiffHighlights,
 	}, nil
 }
@@ -187,10 +187,10 @@ type DiffModifiesFile struct {
 	*casetransform.Regexp
 }
 
-func (dmf *DiffModifiesFile) Match(lc *LazyCommit) (bool, *MatchedCommit, error) {
+func (dmf *DiffModifiesFile) Match(lc *LazyCommit) (bool, MatchedCommit, error) {
 	diff, err := lc.Diff()
 	if err != nil {
-		return false, nil, err
+		return false, MatchedCommit{}, err
 	}
 
 	foundMatch := false
@@ -210,7 +210,7 @@ func (dmf *DiffModifiesFile) Match(lc *LazyCommit) (bool, *MatchedCommit, error)
 		}
 	}
 
-	return foundMatch, &MatchedCommit{
+	return foundMatch, MatchedCommit{
 		Diff: fileDiffHighlights,
 	}, nil
 }
@@ -220,38 +220,38 @@ type Operator struct {
 	Operands []MatchTree
 }
 
-func (o *Operator) Match(commit *LazyCommit) (bool, *MatchedCommit, error) {
+func (o *Operator) Match(commit *LazyCommit) (bool, MatchedCommit, error) {
 	switch o.Kind {
 	case protocol.Not:
 		matched, _, err := o.Operands[0].Match(commit)
 		if err != nil {
-			return false, nil, err
+			return false, MatchedCommit{}, err
 		}
-		return matched, nil, nil
+		return matched, MatchedCommit{}, nil
 	case protocol.And:
-		resultMatches := &MatchedCommit{}
+		resultMatches := MatchedCommit{}
 		for _, operand := range o.Operands {
 			matched, matches, err := operand.Match(commit)
 			if err != nil {
-				return false, nil, err
+				return false, MatchedCommit{}, err
 			}
 			if !matched {
-				return false, nil, err
+				return false, MatchedCommit{}, err
 			}
-			resultMatches.Merge(matches)
+			resultMatches = resultMatches.Merge(matches)
 		}
 		return true, resultMatches, nil
 	case protocol.Or:
-		resultMatches := &MatchedCommit{}
+		resultMatches := MatchedCommit{}
 		hasMatch := false
 		for _, operand := range o.Operands {
 			matched, matches, err := operand.Match(commit)
 			if err != nil {
-				return false, nil, err
+				return false, MatchedCommit{}, err
 			}
 			if matched {
 				hasMatch = true
-				resultMatches.Merge(matches)
+				resultMatches = resultMatches.Merge(matches)
 			}
 		}
 		return hasMatch, resultMatches, nil

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -349,11 +349,7 @@ func (c *CommitScanner) Err() error {
 	return c.err
 }
 
-func CreateCommitMatch(lc *LazyCommit, hc *MatchedCommit, includeDiff bool) (*protocol.CommitMatch, error) {
-	if hc == nil {
-		hc = &MatchedCommit{}
-	}
-
+func CreateCommitMatch(lc *LazyCommit, hc MatchedCommit, includeDiff bool) (*protocol.CommitMatch, error) {
 	authorDate, err := lc.AuthorDate()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Nil checking was getting complicated, and there is very little cost to
just always using the zero-value of the struct, so this converts pointer
types to value types for MatchedCommit.

In response to [Rijnard's comment](https://github.com/sourcegraph/sourcegraph/pull/25614#discussion_r720594698)
Stacked on #25621 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
