### PR TITLE
search frontend: fix parser adding extraneous node

### DIFF
--- a/client/shared/src/search/query/parser.test.ts
+++ b/client/shared/src/search/query/parser.test.ts
@@ -30,6 +30,11 @@ describe('parseSearchQuery', () => {
 
     test('query with parentheses that override precedence', () =>
         expect(parse('a and (b or c)')).toMatchInlineSnapshot(
-            '[{"type":"operator","operands":[{"type":"pattern","kind":1,"value":"a","quoted":false,"negated":false},{"type":"operator","operands":[{"type":"pattern","kind":1,"value":"b","quoted":false,"negated":false},{"type":"pattern","kind":1,"value":"c","quoted":false,"negated":false}],"kind":"OR"},{"type":"pattern","kind":1,"value":"c","quoted":false,"negated":false}],"kind":"AND"}]'
+            '[{"type":"operator","operands":[{"type":"pattern","kind":1,"value":"a","quoted":false,"negated":false},{"type":"operator","operands":[{"type":"pattern","kind":1,"value":"b","quoted":false,"negated":false},{"type":"pattern","kind":1,"value":"c","quoted":false,"negated":false}],"kind":"OR"}],"kind":"AND"}]'
+        ))
+
+    test('query with mixed explicit and implicit operators inside parens', () =>
+        expect(parse('(aaa bbb and ccc)')).toMatchInlineSnapshot(
+            '[{"type":"operator","operands":[{"type":"pattern","kind":1,"value":"aaa","quoted":false,"negated":false},{"type":"pattern","kind":1,"value":"bbb","quoted":false,"negated":false},{"type":"pattern","kind":1,"value":"ccc","quoted":false,"negated":false}],"kind":"AND"}]'
         ))
 })

--- a/client/shared/src/search/query/parser.ts
+++ b/client/shared/src/search/query/parser.ts
@@ -120,7 +120,7 @@ export const parseAnd = (tokens: Token[]): State => {
         return { result: left.result, tokens }
     }
     if (left.tokens[0] === undefined) {
-        return { result: left.result, tokens }
+        return { result: left.result, tokens: [] }
     }
     if (!(left.tokens[0].type === 'keyword' && left.tokens[0].kind === KeywordKind.And)) {
         return { result: left.result, tokens: left.tokens }
@@ -146,7 +146,7 @@ export const parseOr = (tokens: Token[]): State => {
         return { result: left.result, tokens }
     }
     if (left.tokens[0] === undefined) {
-        return { result: left.result, tokens }
+        return { result: left.result, tokens: [] }
     }
     if (!(left.tokens[0].type === 'keyword' && left.tokens[0].kind === KeywordKind.Or)) {
         return { result: left.result, tokens: left.tokens }


### PR DESCRIPTION
Frontend parser added/duplicated a node when it reached the end of a group of terms. It turns out we already have a test case (with an incorrect oracle) for this, that I missed in the initial implementation. I added another one that's similar but different that I care about.

This doesn't affect any features that I'm aware of, since the parser output isn't yet used to drive parts of our logic.

@novoselrok ran into this while trying to use the parser, thanks for trialing :-)

I will reformat the tests in this file to be more readable in next PR.