### PR TITLE
reduce commit/diff queries on construction

### DIFF
--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -127,38 +127,9 @@ func (o Operator) String() string {
 }
 
 func newOperator(kind OperatorKind, operands ...Node) *Operator {
-	// Merge sibling operators of the same type
-	merged := operands[:0]
-	var mergedOrOperands, mergedAndOperands []Node
-	for _, operand := range operands {
-		operator, ok := operand.(*Operator)
-		if !ok || operator.Kind == Not {
-			merged = append(merged, operand)
-			continue
-		}
-
-		if operator.Kind == And {
-			mergedAndOperands = append(mergedAndOperands, operator.Operands...)
-			continue
-		}
-
-		if operator.Kind == Or {
-			mergedOrOperands = append(mergedOrOperands, operator.Operands...)
-			continue
-		}
-	}
-
-	if len(mergedOrOperands) > 0 {
-		merged = append(merged, NewOr(mergedOrOperands...))
-	}
-
-	if len(mergedAndOperands) > 0 {
-		merged = append(merged, NewAnd(mergedAndOperands...))
-	}
-
 	return &Operator{
 		Kind:     kind,
-		Operands: merged,
+		Operands: operands,
 	}
 }
 

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -173,7 +173,17 @@ func NewAnd(operands ...Node) Node {
 		return operands[0]
 	}
 
-	return NewOperator(And, operands...)
+	// Flatten any nested And operands
+	flattened := make([]Node, 0, len(operands))
+	for _, operand := range operands {
+		if nestedOperator, ok := operand.(*Operator); ok && nestedOperator.Kind == And {
+			flattened = append(flattened, nestedOperator.Operands...)
+		} else {
+			flattened = append(flattened, operand)
+		}
+	}
+
+	return NewOperator(And, flattened...)
 }
 
 func NewOr(operands ...Node) Node {
@@ -187,7 +197,17 @@ func NewOr(operands ...Node) Node {
 		return operands[0]
 	}
 
-	return NewOperator(Or, operands...)
+	// Flatten any nested Or operands
+	flattened := make([]Node, 0, len(operands))
+	for _, operand := range operands {
+		if nestedOperator, ok := operand.(*Operator); ok && nestedOperator.Kind == Or {
+			flattened = append(flattened, nestedOperator.Operands...)
+		} else {
+			flattened = append(flattened, operand)
+		}
+	}
+
+	return NewOperator(Or, flattened...)
 }
 
 func NewNot(operand Node) Node {

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -126,7 +126,7 @@ func (o Operator) String() string {
 	return "(" + prefix + strings.Join(cs, sep) + ")"
 }
 
-func NewOperator(kind OperatorKind, operands ...Node) *Operator {
+func newOperator(kind OperatorKind, operands ...Node) *Operator {
 	// Merge sibling operators of the same type
 	merged := operands[:0]
 	var mergedOrOperands, mergedAndOperands []Node
@@ -183,7 +183,7 @@ func NewAnd(operands ...Node) Node {
 		}
 	}
 
-	return NewOperator(And, flattened...)
+	return newOperator(And, flattened...)
 }
 
 func NewOr(operands ...Node) Node {
@@ -207,7 +207,7 @@ func NewOr(operands ...Node) Node {
 		}
 	}
 
-	return NewOperator(Or, flattened...)
+	return newOperator(Or, flattened...)
 }
 
 func NewNot(operand Node) Node {
@@ -237,7 +237,7 @@ func NewNot(operand Node) Node {
 	}
 
 	// If an atom node, just negate it
-	return NewOperator(Not, operand)
+	return newOperator(Not, operand)
 }
 
 var registerOnce sync.Once

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -85,12 +85,12 @@ func (d DiffModifiesFile) String() string {
 	return fmt.Sprintf("%T(%s)", d, d.Expr)
 }
 
-// Constant is a predicate that will either always match or never match
-type Constant struct {
+// Boolean is a predicate that will either always match or never match
+type Boolean struct {
 	Value bool
 }
 
-func (c Constant) String() string {
+func (c Boolean) String() string {
 	return fmt.Sprintf("%T(%t)", c, c.Value)
 }
 
@@ -141,7 +141,7 @@ func newOperator(kind OperatorKind, operands ...Node) *Operator {
 func NewAnd(operands ...Node) Node {
 	// An empty And operator will always match a commit
 	if len(operands) == 0 {
-		return &Constant{true}
+		return &Boolean{true}
 	}
 
 	// An And operator with a single operand can be unwrapped
@@ -171,7 +171,7 @@ func NewAnd(operands ...Node) Node {
 func NewOr(operands ...Node) Node {
 	// An empty Or operator will never match a commit
 	if len(operands) == 0 {
-		return &Constant{false}
+		return &Boolean{false}
 	}
 
 	// An Or operator with a single operand can be unwrapped
@@ -217,7 +217,7 @@ func RegisterGob() {
 		gob.Register(&MessageMatches{})
 		gob.Register(&DiffMatches{})
 		gob.Register(&DiffModifiesFile{})
-		gob.Register(&Constant{})
+		gob.Register(&Boolean{})
 		gob.Register(&Operator{})
 	})
 }

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -133,9 +133,7 @@ func newOperator(kind OperatorKind, operands ...Node) *Operator {
 	}
 }
 
-// NewOr creates a new Or node from the given operands
-// NewOr will always return the result in conjunctive normal form (CNF), so
-// the returned node may not always be an actual Or node.
+// NewAnd creates a new And node from the given operands
 // Optimizations/simplifications:
 // - And() => Constant(true)
 // - And(x) => x
@@ -165,9 +163,7 @@ func NewAnd(operands ...Node) Node {
 	return newOperator(And, flattened...)
 }
 
-// NewOr creates a new Or node from the given operands
-// NewOr will always return the result in conjunctive normal form (CNF), so
-// the returned node may not always be an actual Or node.
+// NewOr creates a new Or node from the given operands.
 // Optimizations/simplifications:
 // - Or() => Constant(false)
 // - Or(x) => x
@@ -197,14 +193,9 @@ func NewOr(operands ...Node) Node {
 	return newOperator(Or, flattened...)
 }
 
-// NewNot creates a new negated node from the given operand. It will always
-// return a tree in conjunctive normal form (CNF).
-// If passed a non-atom node, it will recursively push the negation down to the
-// node's constituent atom nodes.
+// NewNot creates a new negated node from the given operand.
 // Optimizations/simplifications:
 // - Not(Not(x)) => x
-// - Not(And(x,y)) => Or(Not(x), Not(y))
-// - Not(Or(x,y)) => And(Not(x), Not(y))
 func NewNot(operand Node) Node {
 	// If an operator, push the negation down to the atom nodes recursively
 	if operator, ok := operand.(*Operator); ok && operator.Kind == Not {

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -131,3 +131,22 @@ func RegisterGob() {
 		gob.Register(&Operator{})
 	})
 }
+
+func NewOperator(kind OperatorKind, operands ...Node) *Operator {
+	return &Operator{
+		Kind:     kind,
+		Operands: operands,
+	}
+}
+
+func NewAnd(operands ...Node) *Operator {
+	return NewOperator(And, operands...)
+}
+
+func NewOr(operands ...Node) *Operator {
+	return NewOperator(Or, operands...)
+}
+
+func NewNot(operand Node) *Operator {
+	return NewOperator(Not, operand)
+}

--- a/internal/gitserver/protocol/search.go
+++ b/internal/gitserver/protocol/search.go
@@ -127,9 +127,38 @@ func (o Operator) String() string {
 }
 
 func NewOperator(kind OperatorKind, operands ...Node) *Operator {
+	// Merge sibling operators of the same type
+	merged := operands[:0]
+	var mergedOrOperands, mergedAndOperands []Node
+	for _, operand := range operands {
+		operator, ok := operand.(*Operator)
+		if !ok || operator.Kind == Not {
+			merged = append(merged, operand)
+			continue
+		}
+
+		if operator.Kind == And {
+			mergedAndOperands = append(mergedAndOperands, operator.Operands...)
+			continue
+		}
+
+		if operator.Kind == Or {
+			mergedOrOperands = append(mergedOrOperands, operator.Operands...)
+			continue
+		}
+	}
+
+	if len(mergedOrOperands) > 0 {
+		merged = append(merged, NewOr(mergedOrOperands...))
+	}
+
+	if len(mergedAndOperands) > 0 {
+		merged = append(merged, NewAnd(mergedAndOperands...))
+	}
+
 	return &Operator{
 		Kind:     kind,
-		Operands: operands,
+		Operands: merged,
 	}
 }
 

--- a/internal/gitserver/protocol/search_test.go
+++ b/internal/gitserver/protocol/search_test.go
@@ -8,34 +8,34 @@ import (
 
 func TestQueryConstruction(t *testing.T) {
 	t.Run("zero-length and is reduced", func(t *testing.T) {
-		require.Equal(t, &Constant{true}, NewAnd())
+		require.Equal(t, &Boolean{true}, NewAnd())
 	})
 
 	t.Run("single-element and is unwrapped", func(t *testing.T) {
-		require.Equal(t, &Constant{true}, NewAnd(&Constant{true}))
+		require.Equal(t, &Boolean{true}, NewAnd(&Boolean{true}))
 	})
 
 	t.Run("zero-length or is reduced", func(t *testing.T) {
-		require.Equal(t, &Constant{false}, NewOr())
+		require.Equal(t, &Boolean{false}, NewOr())
 	})
 
 	t.Run("single-element or is unwrapped", func(t *testing.T) {
-		require.Equal(t, &Constant{true}, NewOr(&Constant{true}))
+		require.Equal(t, &Boolean{true}, NewOr(&Boolean{true}))
 	})
 
 	t.Run("double negation cancels", func(t *testing.T) {
-		require.Equal(t, &Constant{true}, NewNot(NewNot(&Constant{true})))
+		require.Equal(t, &Boolean{true}, NewNot(NewNot(&Boolean{true})))
 	})
 
 	t.Run("nested and operators are flattened", func(t *testing.T) {
 		input := NewAnd(
-			NewAnd(&Constant{true}, &Constant{false}),
+			NewAnd(&Boolean{true}, &Boolean{false}),
 		)
 		expected := &Operator{
 			Kind: And,
 			Operands: []Node{
-				&Constant{true},
-				&Constant{false},
+				&Boolean{true},
+				&Boolean{false},
 			},
 		}
 		require.Equal(t, expected, input)
@@ -43,13 +43,13 @@ func TestQueryConstruction(t *testing.T) {
 
 	t.Run("nested or operators are flattened", func(t *testing.T) {
 		input := NewOr(
-			NewOr(&Constant{false}, &Constant{true}),
+			NewOr(&Boolean{false}, &Boolean{true}),
 		)
 		expected := &Operator{
 			Kind: Or,
 			Operands: []Node{
-				&Constant{false},
-				&Constant{true},
+				&Boolean{false},
+				&Boolean{true},
 			},
 		}
 		require.Equal(t, expected, input)

--- a/internal/gitserver/protocol/search_test.go
+++ b/internal/gitserver/protocol/search_test.go
@@ -110,4 +110,52 @@ func TestQueryConstruction(t *testing.T) {
 		}
 		require.Equal(t, expected, input)
 	})
+
+	t.Run("nested and operators are flattened", func(t *testing.T) {
+		input := NewAnd(
+			NewOr(&Constant{false}, &Constant{true}),
+			NewAnd(&Constant{true}, &Constant{false}),
+			&AuthorMatches{},
+		)
+		expected := &Operator{
+			Kind: And,
+			Operands: []Node{
+				&Constant{true},
+				&Constant{false},
+				&AuthorMatches{},
+				&Operator{
+					Kind: Or,
+					Operands: []Node{
+						&Constant{false},
+						&Constant{true},
+					},
+				},
+			},
+		}
+		require.Equal(t, expected, input)
+	})
+
+	t.Run("nested or operators are flattened", func(t *testing.T) {
+		input := NewOr(
+			NewAnd(&Constant{true}, &Constant{false}),
+			NewOr(&Constant{false}, &Constant{true}),
+			&AuthorMatches{},
+		)
+		expected := &Operator{
+			Kind: Or,
+			Operands: []Node{
+				&Constant{false},
+				&Constant{true},
+				&AuthorMatches{},
+				&Operator{
+					Kind: And,
+					Operands: []Node{
+						&Constant{true},
+						&Constant{false},
+					},
+				},
+			},
+		}
+		require.Equal(t, expected, input)
+	})
 }

--- a/internal/gitserver/protocol/search_test.go
+++ b/internal/gitserver/protocol/search_test.go
@@ -62,4 +62,52 @@ func TestQueryConstruction(t *testing.T) {
 		}
 		require.Equal(t, expected, input)
 	})
+
+	t.Run("sibling and operators are merged", func(t *testing.T) {
+		input := NewOr(
+			NewAnd(&Constant{true}, &Constant{false}),
+			&AuthorMatches{},
+			NewAnd(&Constant{false}, &Constant{true}),
+		)
+		expected := &Operator{
+			Kind: Or,
+			Operands: []Node{
+				&AuthorMatches{},
+				&Operator{
+					Kind: And,
+					Operands: []Node{
+						&Constant{true},
+						&Constant{false},
+						&Constant{false},
+						&Constant{true},
+					},
+				},
+			},
+		}
+		require.Equal(t, expected, input)
+	})
+
+	t.Run("sibling or operators are merged", func(t *testing.T) {
+		input := NewAnd(
+			NewOr(&Constant{true}, &Constant{false}),
+			&AuthorMatches{},
+			NewOr(&Constant{false}, &Constant{true}),
+		)
+		expected := &Operator{
+			Kind: And,
+			Operands: []Node{
+				&AuthorMatches{},
+				&Operator{
+					Kind: Or,
+					Operands: []Node{
+						&Constant{true},
+						&Constant{false},
+						&Constant{false},
+						&Constant{true},
+					},
+				},
+			},
+		}
+		require.Equal(t, expected, input)
+	})
 }

--- a/internal/gitserver/protocol/search_test.go
+++ b/internal/gitserver/protocol/search_test.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryConstruction(t *testing.T) {
+	t.Run("zero-length and is reduced", func(t *testing.T) {
+		require.Equal(t, &Constant{true}, NewAnd())
+	})
+
+	t.Run("single-element and is unwrapped", func(t *testing.T) {
+		require.Equal(t, &Constant{true}, NewAnd(&Constant{true}))
+	})
+
+	t.Run("zero-length or is reduced", func(t *testing.T) {
+		require.Equal(t, &Constant{false}, NewOr())
+	})
+
+	t.Run("single-element or is unwrapped", func(t *testing.T) {
+		require.Equal(t, &Constant{true}, NewOr(&Constant{true}))
+	})
+
+	t.Run("double negation cancels", func(t *testing.T) {
+		require.Equal(t, &Constant{true}, NewNot(NewNot(&Constant{true})))
+	})
+
+	t.Run("negation of and is pushed to atoms", func(t *testing.T) {
+		input := NewNot(NewAnd(&Constant{true}, &Constant{false}))
+		expected := &Operator{
+			Kind: Or,
+			Operands: []Node{
+				&Operator{
+					Kind:     Not,
+					Operands: []Node{&Constant{true}},
+				},
+				&Operator{
+					Kind:     Not,
+					Operands: []Node{&Constant{false}},
+				},
+			},
+		}
+		require.Equal(t, expected, input)
+	})
+
+	t.Run("negation of or is pushed to atoms", func(t *testing.T) {
+		input := NewNot(NewOr(&Constant{true}, &Constant{false}))
+		expected := &Operator{
+			Kind: And,
+			Operands: []Node{
+				&Operator{
+					Kind:     Not,
+					Operands: []Node{&Constant{true}},
+				},
+				&Operator{
+					Kind:     Not,
+					Operands: []Node{&Constant{false}},
+				},
+			},
+		}
+		require.Equal(t, expected, input)
+	})
+}

--- a/internal/gitserver/protocol/search_test.go
+++ b/internal/gitserver/protocol/search_test.go
@@ -63,54 +63,6 @@ func TestQueryConstruction(t *testing.T) {
 		require.Equal(t, expected, input)
 	})
 
-	t.Run("sibling and operators are merged", func(t *testing.T) {
-		input := NewOr(
-			NewAnd(&Constant{true}, &Constant{false}),
-			&AuthorMatches{},
-			NewAnd(&Constant{false}, &Constant{true}),
-		)
-		expected := &Operator{
-			Kind: Or,
-			Operands: []Node{
-				&AuthorMatches{},
-				&Operator{
-					Kind: And,
-					Operands: []Node{
-						&Constant{true},
-						&Constant{false},
-						&Constant{false},
-						&Constant{true},
-					},
-				},
-			},
-		}
-		require.Equal(t, expected, input)
-	})
-
-	t.Run("sibling or operators are merged", func(t *testing.T) {
-		input := NewAnd(
-			NewOr(&Constant{true}, &Constant{false}),
-			&AuthorMatches{},
-			NewOr(&Constant{false}, &Constant{true}),
-		)
-		expected := &Operator{
-			Kind: And,
-			Operands: []Node{
-				&AuthorMatches{},
-				&Operator{
-					Kind: Or,
-					Operands: []Node{
-						&Constant{true},
-						&Constant{false},
-						&Constant{false},
-						&Constant{true},
-					},
-				},
-			},
-		}
-		require.Equal(t, expected, input)
-	})
-
 	t.Run("nested and operators are flattened", func(t *testing.T) {
 		input := NewAnd(
 			NewOr(&Constant{false}, &Constant{true}),
@@ -120,9 +72,6 @@ func TestQueryConstruction(t *testing.T) {
 		expected := &Operator{
 			Kind: And,
 			Operands: []Node{
-				&Constant{true},
-				&Constant{false},
-				&AuthorMatches{},
 				&Operator{
 					Kind: Or,
 					Operands: []Node{
@@ -130,6 +79,9 @@ func TestQueryConstruction(t *testing.T) {
 						&Constant{true},
 					},
 				},
+				&Constant{true},
+				&Constant{false},
+				&AuthorMatches{},
 			},
 		}
 		require.Equal(t, expected, input)
@@ -144,9 +96,6 @@ func TestQueryConstruction(t *testing.T) {
 		expected := &Operator{
 			Kind: Or,
 			Operands: []Node{
-				&Constant{false},
-				&Constant{true},
-				&AuthorMatches{},
 				&Operator{
 					Kind: And,
 					Operands: []Node{
@@ -154,6 +103,9 @@ func TestQueryConstruction(t *testing.T) {
 						&Constant{false},
 					},
 				},
+				&Constant{false},
+				&Constant{true},
+				&AuthorMatches{},
 			},
 		}
 		require.Equal(t, expected, input)

--- a/internal/gitserver/protocol/search_test.go
+++ b/internal/gitserver/protocol/search_test.go
@@ -1,10 +1,7 @@
 package protocol
 
 import (
-	"rand"
-	"reflect"
 	"testing"
-	"testing/quick"
 
 	"github.com/stretchr/testify/require"
 )
@@ -28,42 +25,6 @@ func TestQueryConstruction(t *testing.T) {
 
 	t.Run("double negation cancels", func(t *testing.T) {
 		require.Equal(t, &Constant{true}, NewNot(NewNot(&Constant{true})))
-	})
-
-	t.Run("negation of and is pushed to atoms", func(t *testing.T) {
-		input := NewNot(NewAnd(&Constant{true}, &Constant{false}))
-		expected := &Operator{
-			Kind: Or,
-			Operands: []Node{
-				&Operator{
-					Kind:     Not,
-					Operands: []Node{&Constant{true}},
-				},
-				&Operator{
-					Kind:     Not,
-					Operands: []Node{&Constant{false}},
-				},
-			},
-		}
-		require.Equal(t, expected, input)
-	})
-
-	t.Run("negation of or is pushed to atoms", func(t *testing.T) {
-		input := NewNot(NewOr(&Constant{true}, &Constant{false}))
-		expected := &Operator{
-			Kind: And,
-			Operands: []Node{
-				&Operator{
-					Kind:     Not,
-					Operands: []Node{&Constant{true}},
-				},
-				&Operator{
-					Kind:     Not,
-					Operands: []Node{&Constant{false}},
-				},
-			},
-		}
-		require.Equal(t, expected, input)
 	})
 
 	t.Run("nested and operators are flattened", func(t *testing.T) {
@@ -91,40 +52,6 @@ func TestQueryConstruction(t *testing.T) {
 				&Constant{true},
 			},
 		}
-		require.Equal(t, expected, input)
-	})
-
-	t.Run("queries are CNF-ed", func(t *testing.T) {
-		input := NewOr(
-			&AuthorMatches{Expr: "P"},
-			NewAnd(
-				&AuthorMatches{Expr: "Q"},
-				&AuthorMatches{Expr: "R"},
-			),
-			&AuthorMatches{Expr: "S"},
-		)
-		expected := &Operator{
-			Kind: And,
-			Operands: []Node{
-				&Operator{
-					Kind: Or,
-					Operands: []Node{
-						&AuthorMatches{Expr: "P"},
-						&AuthorMatches{Expr: "S"},
-						&AuthorMatches{Expr: "Q"},
-					},
-				},
-				&Operator{
-					Kind: Or,
-					Operands: []Node{
-						&AuthorMatches{Expr: "P"},
-						&AuthorMatches{Expr: "S"},
-						&AuthorMatches{Expr: "R"},
-					},
-				},
-			},
-		}
-		// P ∨ (Q ∧ R) ∨ S <=> (P ∨ S) ∨ (Q ∧ R) <=> (P ∨ S ∨ Q) ∧ (P ∨ S ∨ R)
 		require.Equal(t, expected, input)
 	})
 }

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -35,7 +35,7 @@ func ToMatchTree(q protocol.Node) (MatchTree, error) {
 	case *protocol.DiffModifiesFile:
 		re, err := casetransform.CompileRegexp(v.Expr, v.IgnoreCase)
 		return &DiffModifiesFile{re}, err
-	case *protocol.Constant:
+	case *protocol.Boolean:
 		return &Constant{v.Value}, nil
 	case *protocol.Operator:
 		operands := make([]MatchTree, 0, len(v.Operands))

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -35,6 +35,8 @@ func ToMatchTree(q protocol.Node) (MatchTree, error) {
 	case *protocol.DiffModifiesFile:
 		re, err := casetransform.CompileRegexp(v.Expr, v.IgnoreCase)
 		return &DiffModifiesFile{re}, err
+	case *protocol.Constant:
+		return &Constant{v.Value}, nil
 	case *protocol.Operator:
 		operands := make([]MatchTree, 0, len(v.Operands))
 		for _, operand := range v.Operands {
@@ -213,6 +215,14 @@ func (dmf *DiffModifiesFile) Match(lc *LazyCommit) (bool, MatchedCommit, error) 
 	return foundMatch, MatchedCommit{
 		Diff: fileDiffHighlights,
 	}, nil
+}
+
+type Constant struct {
+	Value bool
+}
+
+func (c *Constant) Match(_ *LazyCommit) (bool, MatchedCommit, error) {
+	return c.Value, MatchedCommit{}, nil
 }
 
 type Operator struct {

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -237,7 +237,7 @@ func (o *Operator) Match(commit *LazyCommit) (bool, MatchedCommit, error) {
 		if err != nil {
 			return false, MatchedCommit{}, err
 		}
-		return matched, MatchedCommit{}, nil
+		return !matched, MatchedCommit{}, nil
 	case protocol.And:
 		resultMatches := MatchedCommit{}
 		for _, operand := range o.Operands {

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -221,7 +221,7 @@ type Constant struct {
 	Value bool
 }
 
-func (c *Constant) Match(_ *LazyCommit) (bool, MatchedCommit, error) {
+func (c *Constant) Match(*LazyCommit) (bool, MatchedCommit, error) {
 	return c.Value, MatchedCommit{}, nil
 }
 

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -96,7 +96,7 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("and with no operands matches all", func(t *testing.T) {
-		query := &protocol.Operator{Kind: protocol.And}
+		query := protocol.NewAnd()
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		searcher := &CommitSearcher{
@@ -163,13 +163,10 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("and match", func(t *testing.T) {
-		query := &protocol.Operator{
-			Kind: protocol.And,
-			Operands: []protocol.Node{
-				&protocol.DiffMatches{Expr: "lorem"},
-				&protocol.DiffMatches{Expr: "ipsum"},
-			},
-		}
+		query := protocol.NewAnd(
+			&protocol.DiffMatches{Expr: "lorem"},
+			&protocol.DiffMatches{Expr: "ipsum"},
+		)
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		searcher := &CommitSearcher{
@@ -297,20 +294,14 @@ index 0000000000..7e54670557
 		diff: parsedDiff,
 	}
 
-	mt, err := ToMatchTree(&protocol.Operator{
-		Kind: protocol.And,
-		Operands: []protocol.Node{
-			&protocol.AuthorMatches{Expr: "Camden"},
-			&protocol.DiffModifiesFile{Expr: "test"},
-			&protocol.Operator{
-				Kind: protocol.And,
-				Operands: []protocol.Node{
-					&protocol.DiffMatches{Expr: "result"},
-					&protocol.DiffMatches{Expr: "test"},
-				},
-			},
-		},
-	})
+	mt, err := ToMatchTree(protocol.NewAnd(
+		&protocol.AuthorMatches{Expr: "Camden"},
+		&protocol.DiffModifiesFile{Expr: "test"},
+		protocol.NewAnd(
+			&protocol.DiffMatches{Expr: "result"},
+			&protocol.DiffMatches{Expr: "test"},
+		),
+	))
 	require.NoError(t, err)
 
 	matches, highlights, err := mt.Match(lc)

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -401,9 +401,9 @@ type queryGenerator struct {
 }
 
 func (queryGenerator) Generate(rand *rand.Rand, size int) reflect.Value {
-	// Set max depth because these query trees can get ridiculously large
-	if size > 4 {
-		size = 4
+	// Set max depth to avoid massive trees
+	if size > 10 {
+		size = 10
 	}
 	return reflect.ValueOf(queryGenerator{generateQuery(rand, size)})
 }

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -37,7 +37,7 @@ func searchInReposNew(ctx context.Context, db dbutil.DB, textParams *search.Text
 		args := &protocol.SearchRequest{
 			Repo:        rr.Repo.Name,
 			Revisions:   searchRevsToGitserverRevs(rr.Revs),
-			Query:       &gitprotocol.Operator{Kind: protocol.And, Operands: queryNodesToPredicates(query, query.IsCaseSensitive(), diff)},
+			Query:       gitprotocol.NewAnd(queryNodesToPredicates(query, query.IsCaseSensitive(), diff)...),
 			IncludeDiff: diff,
 			Limit:       limit,
 		}
@@ -100,9 +100,9 @@ func queryNodesToPredicates(nodes []query.Node, caseSensitive, diff bool) []gitp
 func queryOperatorToPredicate(op query.Operator, caseSensitive, diff bool) gitprotocol.Node {
 	switch op.Kind {
 	case query.And:
-		return &gitprotocol.Operator{Kind: protocol.And, Operands: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
+		return gitprotocol.NewAnd(queryNodesToPredicates(op.Operands, caseSensitive, diff)...)
 	case query.Or:
-		return &gitprotocol.Operator{Kind: protocol.And, Operands: queryNodesToPredicates(op.Operands, caseSensitive, diff)}
+		return gitprotocol.NewOr(queryNodesToPredicates(op.Operands, caseSensitive, diff)...)
 	default:
 		// I don't think we should have concats at this point, but ignore it if we do
 		return nil
@@ -123,7 +123,7 @@ func queryPatternToPredicate(pattern query.Pattern, caseSensitive, diff bool) gi
 	}
 
 	if pattern.Negated {
-		return &gitprotocol.Operator{Kind: protocol.Not, Operands: []gitprotocol.Node{newPred}}
+		return gitprotocol.NewNot(newPred)
 	}
 	return newPred
 }
@@ -157,7 +157,7 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	}
 
 	if parameter.Negated {
-		return &gitprotocol.Operator{Kind: protocol.Not, Operands: []gitprotocol.Node{newPred}}
+		return gitprotocol.NewNot(newPred)
 	}
 	return newPred
 }


### PR DESCRIPTION
This commit takes a stab at reducing commit/diff query trees during construction.

In response to [Rijnard's comment](https://github.com/sourcegraph/sourcegraph/pull/25621#pullrequestreview-769443067)

- It adds `NewAnd`, `NewOr`, `NewNot`, and `NewOperator`
- It reduces `And()` to `&Constant{true}` and `Or()` to `&Constant{false}`
- It reduces `And(x)` and `Or(x)` to `x`
- It reduces `And(And(x), y)` to `And(x, y)` and `Or(x, Or(y))` to `Or(x, y)`
- It reduces `Not(Not(x))` to `x`

This does some basic minimization during query construction to keep from generating deeply nested trees, but does not do any additional optimization passes. Those will be coming in a followup PR as a separate step.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
