### PR TITLE
Clarify need for using ENTERPRISE=1

### DIFF
--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -133,7 +133,7 @@ To run integration tests for the web app:
 
 1. Run `yarn watch-web` in the repository root in a separate terminal to watch files and build a JavaScript bundle. You can also launch it as the VS Code task "Watch web app".
     - Alternatively, `yarn build-web` will only build a bundle once.
-1. If you need to test Enterprise features such as Batch Changes, set `ENTERPRISE=1`
+1. If you need to test Enterprise features such as Batch Changes, set `ENTERPRISE=1` when building.
 1. Run `yarn test-integration` in the repository root to run the tests.
 
 A Sourcegraph instance does not need to be running, because all backend interactions are stubbed.

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -132,8 +132,8 @@ Test coverage from integration tests is tracked in [Codecov](https://codecov.io/
 To run integration tests for the web app:
 
 1. Run `yarn watch-web` in the repository root in a separate terminal to watch files and build a JavaScript bundle. You can also launch it as the VS Code task "Watch web app".
-  - Alternatively, `yarn build-web` will only build a bundle once.
-  - If you need to build an Enterprise bundle (to test Enterprise features such as Batch Changes), set `ENTERPRISE=1`
+    - Alternatively, `yarn build-web` will only build a bundle once.
+1. If you need to test Enterprise features such as Batch Changes, set `ENTERPRISE=1`
 1. Run `yarn test-integration` in the repository root to run the tests.
 
 A Sourcegraph instance does not need to be running, because all backend interactions are stubbed.


### PR DESCRIPTION
The wording here confused me a bit and caused me to miss that `ENTERPRISE=1` may also be needed for `watch-web`. Hopefully this clears it up.