### PR TITLE
sg: properly respect PGUSER/PGDATABASE env vars

### DIFF
--- a/dev/sg/internal/migration/dbutil.go
+++ b/dev/sg/internal/migration/dbutil.go
@@ -1,0 +1,65 @@
+package migration
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Copied from internal/database/dbutil/dbutil.go
+func postgresDSN(prefix, currentUser string, getenv func(string) string) string {
+	if prefix != "" {
+		prefix = fmt.Sprintf("%s_", strings.ToUpper(prefix))
+	}
+
+	env := func(name string) string {
+		return getenv(prefix + name)
+	}
+
+	// PGDATASOURCE is a sourcegraph specific variable for just setting the DSN
+	if dsn := env("PGDATASOURCE"); dsn != "" {
+		return dsn
+	}
+
+	// TODO match logic in lib/pq
+	// https://sourcegraph.com/github.com/lib/pq@d6156e141ac6c06345c7c73f450987a9ed4b751f/-/blob/connector.go#L42
+	dsn := &url.URL{
+		Scheme: "postgres",
+		Host:   "127.0.0.1:5432",
+	}
+
+	// Username preference: PGUSER, $USER, postgres
+	username := "postgres"
+	if currentUser != "" {
+		username = currentUser
+	}
+	if user := env("PGUSER"); user != "" {
+		username = user
+	}
+
+	if password := env("PGPASSWORD"); password != "" {
+		dsn.User = url.UserPassword(username, password)
+	} else {
+		dsn.User = url.User(username)
+	}
+
+	if host := env("PGHOST"); host != "" {
+		dsn.Host = host
+	}
+
+	if port := env("PGPORT"); port != "" {
+		dsn.Host += ":" + port
+	}
+
+	if db := env("PGDATABASE"); db != "" {
+		dsn.Path = db
+	}
+
+	if sslmode := env("PGSSLMODE"); sslmode != "" {
+		qry := dsn.Query()
+		qry.Set("sslmode", sslmode)
+		dsn.RawQuery = qry.Encode()
+	}
+
+	return dsn.String()
+}

--- a/dev/sg/internal/migration/dbutil_test.go
+++ b/dev/sg/internal/migration/dbutil_test.go
@@ -1,0 +1,70 @@
+package migration
+
+import "testing"
+
+// Copied from internal/database/dbutil/dbutil_test.go
+func Test_postgresDSN(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		dsn  string
+	}{{
+		name: "default",
+		env:  map[string]string{},
+		dsn:  "postgres://testuser@127.0.0.1:5432",
+	}, {
+		name: "deploy-sourcegraph",
+		env: map[string]string{
+			"PGDATABASE": "sg",
+			"PGHOST":     "pgsql",
+			"PGPORT":     "5432",
+			"PGSSLMODE":  "disable",
+			"PGUSER":     "sg",
+		},
+		dsn: "postgres://sg@pgsql:5432/sg?sslmode=disable",
+	}, {
+		name: "deploy-sourcegraph password",
+		env: map[string]string{
+			"PGDATABASE": "sg",
+			"PGHOST":     "pgsql",
+			"PGPASSWORD": "REDACTED",
+			"PGPORT":     "5432",
+			"PGSSLMODE":  "disable",
+			"PGUSER":     "sg",
+		},
+		dsn: "postgres://sg:REDACTED@pgsql:5432/sg?sslmode=disable",
+	}, {
+		name: "sourcegraph server",
+		env: map[string]string{
+			"PGHOST":     "127.0.0.1",
+			"PGUSER":     "postgres",
+			"PGDATABASE": "sourcegraph",
+			"PGSSLMODE":  "disable",
+		},
+		dsn: "postgres://postgres@127.0.0.1/sourcegraph?sslmode=disable",
+	}, {
+		name: "datasource",
+		env: map[string]string{
+			"PGDATASOURCE": "postgres://foo@bar/bam",
+		},
+		dsn: "postgres://foo@bar/bam",
+	}, {
+		name: "datasource ignore",
+		env: map[string]string{
+			"PGHOST":       "pgsql",
+			"PGDATASOURCE": "postgres://foo@bar/bam",
+		},
+		dsn: "postgres://foo@bar/bam",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			have := postgresDSN("", "testuser", func(e string) string {
+				return tc.env[e]
+			})
+			if have != tc.dsn {
+				t.Errorf("unexpected computed DSN\nhave: %s\nwant: %s", have, tc.dsn)
+			}
+		})
+	}
+}

--- a/dev/sg/internal/migration/migration.go
+++ b/dev/sg/internal/migration/migration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/user"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -336,22 +337,11 @@ func doRunMigrations(database db.Database, n *int, name string, f func(*migrate.
 // the default, the PG* environment variables are prefixed with the database name. The
 // resulting address depends on the environment.
 func makePostgresDSN(database db.Database) string {
-	var prefix string
-	if database.Name != db.DefaultDatabase.Name {
-		prefix = strings.ToUpper(database.Name) + "_"
+	username := ""
+	if user, err := user.Current(); err == nil {
+		username = user.Username
 	}
-
-	var port string
-	if value := os.Getenv(fmt.Sprintf("%sPGPORT", prefix)); value != "" {
-		port = ":" + value
-	}
-
-	return fmt.Sprintf(
-		"postgres://%s%s/%s",
-		os.Getenv(fmt.Sprintf("%sPGHOST", prefix)),
-		port,
-		os.Getenv(fmt.Sprintf("%sPGDATABASE", prefix)),
-	)
+	return postgresDSN(database.Name, username, os.Getenv)
 }
 
 // ReadFilenamesNamesInDirectory returns a list of names in the given directory.


### PR DESCRIPTION
I encountered issues where `sg start` was failing to properly migrate by DB schema
on startup, and also issues where `sg migrate up -db codeintel` was incorrectly reporting
the DB schema was up-to-date.

https://sourcegraph.slack.com/archives/C01N83PS4TU/p1633379941267400

The cause turned out to be that my `PGUSER` and `PGDATABASE` were not being respected,
and so it was migrating the wrong DB.

I found that migration.go reproduced some code to build a postgres DSN somewhat incorrectly,
we already have a more correct implementation in `internal/database/dbutil`. It's not possible
to merely import it here, since `dev/sg` is a separate Go module - and I think copying it is
not bad given it is simple so I've merely copied it into the package.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>