### PR TITLE
cmd/server: use redis=~5.0

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add --no-cache \
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     'bash=5.0.17-r0' \
-    'redis=5.0.13-r0' \
+    'redis>=5.0.13-r0' \
     # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
     'git>=2.18' \
     git-p4 \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 # hadolint ignore=DL3018
-RUN apk update && apk add --no-cache \
+RUN apk update && apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
@@ -49,7 +49,7 @@ RUN apk update && apk add --no-cache \
     postgresql-contrib
 
 # This is installed separately due to the upstream edge repo requirement
-RUN apk update && apk add --no-cache \
+RUN apk update && apk add --no-cache --verbose \
     'python3>=3.9.5' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add --no-cache \
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     'bash=5.0.17-r0' \
-    'redis>=5.0.13-r0' \
+    'redis=~5.0' \
     # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
     'git>=2.18' \
     git-p4 \

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -46,7 +46,7 @@ func computeRunType(tag, branch string) RunType {
 	case strings.HasPrefix(branch, "docker-images-patch/"):
 		return ImagePatch
 	case strings.HasPrefix(branch, "docker-images-patch-notest/"):
-		return ImagePatch
+		return ImagePatchNoTest
 	case branch == "docker-images-candidates-notest":
 		return CandidatesNoTest
 


### PR DESCRIPTION
The redis release we depend on for this image got pulled: https://pkgs.alpinelinux.org/packages?name=redis&branch=v3.12
[This is currently causing persistent build failures in main.](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1633397543124500)

This PR makes the constraint looser so that we can pull the dependency at least, which comes with the unfortunate tradeoff that we cannot pin the version, but we also found the following:

> Unfortunately, Alpine-Linux Package Management drops older packages when there are newer versions available. This makes it hard to use Alpine Linux with docker since you want a reproducible image with exact versions.

https://superuser.com/questions/1174021/why-does-alpine-apk-report-unsatisfiable-constraints-when-installing-an-older/1486407#1486407

> You should avoid being explicit on package versions unless controlling your own package mirror and package builds, rather allow the package system to handle it for the Alpine release in use.

https://superuser.com/questions/1174021/why-does-alpine-apk-report-unsatisfiable-constraints-when-installing-an-older

Perhaps we shouldn't be pinning any of these dependencies 🤔 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
