### PR TITLE
search: propagate unindexed/indexed request separation to all callers

### DIFF
--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -58,9 +58,15 @@ func Search(ctx context.Context, args *search.TextParameters, limit int, stream 
 	ctx, stream, cancel := streaming.WithLimit(ctx, stream, limit)
 	defer cancel()
 
-	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, search.SymbolRequest, zoektutil.MissingRepoRevStatus(stream))
+	request, onlyUnindexed, err := zoektutil.UseOnlyUnindexedSearchRequest(args, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
+	}
+	if !onlyUnindexed {
+		request, err = zoektutil.NewIndexedSearchRequest(ctx, args, search.SymbolRequest, zoektutil.MissingRepoRevStatus(stream))
+		if err != nil {
+			return err
+		}
 	}
 
 	run := parallel.NewRun(conf.SearchSymbolsParallelism())

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -70,9 +70,15 @@ func NewRepoFetcher(stream streaming.Sender, args *search.TextParameters) RepoFe
 // allows parameterizing the request to specify a context, for when multiple
 // Get() calls are required with different limits or timeouts.
 func (r *RepoFetcher) Get(ctx context.Context) ([]repoData, error) {
-	request, err := zoektutil.NewIndexedSearchRequest(ctx, r.args, search.TextRequest, r.onMissingRepoRevs)
+	request, onlyUnindexed, err := zoektutil.UseOnlyUnindexedSearchRequest(r.args, r.onMissingRepoRevs)
 	if err != nil {
 		return nil, err
+	}
+	if !onlyUnindexed {
+		request, err = zoektutil.NewIndexedSearchRequest(ctx, r.args, search.TextRequest, r.onMissingRepoRevs)
+		if err != nil {
+			return nil, err
+		}
 	}
 	repoSets := []repoData{UnindexedList(request.UnindexedRepos())} // unindexed included by default
 	if r.mode != search.SearcherOnly {

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -59,9 +59,15 @@ func SearchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		trace.Stringer("global_search_mode", args.Mode),
 	)
 
-	request, err := zoektutil.NewIndexedSearchRequest(ctx, args, search.TextRequest, zoektutil.MissingRepoRevStatus(stream))
+	request, onlyUnindexed, err := zoektutil.UseOnlyUnindexedSearchRequest(args, zoektutil.MissingRepoRevStatus(stream))
 	if err != nil {
 		return err
+	}
+	if !onlyUnindexed {
+		request, err = zoektutil.NewIndexedSearchRequest(ctx, args, search.TextRequest, zoektutil.MissingRepoRevStatus(stream))
+		if err != nil {
+			return err
+		}
 	}
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -222,14 +222,6 @@ func UseOnlyUnindexedSearchRequest(args *search.TextParameters, onMissing OnMiss
 }
 
 func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ search.IndexedRequestType, onMissing OnMissingRepoRevs) (IndexedSearchRequest, error) {
-	request, onlyUnindexed, err := UseOnlyUnindexedSearchRequest(args, onMissing)
-	if err != nil {
-		return nil, err
-	}
-	if onlyUnindexed {
-		return request, nil
-	}
-
 	q, err := search.QueryToZoektQuery(args.PatternInfo, typ == search.SymbolRequest)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/25670.

This extracts logic out of the `NewIndexedSearchRequest` function and inlines it in all callers. Purely mechanical and semantics preserving. There are only [4 callers (3 in code, 1 in test)](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+NewIndexedSearchRequest&patternType=structural). 

This temporarily means these functions should be called together, as a "pair". If you read some of the inline comments, it becomes a bit clearer that it's not really sensible/maintainable to keep this logic grouped together. Once I'm done the separation will be clearer.

---

This gets us closer to:

- extracting zoekt query construction out of `NewIndexedSearch`
- will allow to pass only the subset of state needed (not the bloated `args`, nor `patterninfo`)
- incrementally pull the logic up into the call chain for the main line code search path, and defer the other stuff. basically, if I tried to perform this operation in its current state, I needed to deal with too much other fallout in our code (`repoHasFile` depending on this and whole bunch of other things)