### PR TITLE
Add basic metrics to user notifications

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import * as H from 'history'
-import { isEqual } from 'lodash'
+import { isEqual, upperFirst } from 'lodash'
 import AlertIcon from 'mdi-react/AlertIcon'
 import CheckboxCircleIcon from 'mdi-react/CheckboxMarkedCircleIcon'
 import CloudOffOutlineIcon from 'mdi-react/CloudOffOutlineIcon'
@@ -248,8 +248,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                     this.setState({ messagesOrError })
 
                     if (first) {
-                        const payload = this.getOpenedNotificationsPayload(messagesOrError)
-                        eventLogger.log('UserNotificationsLoaded', payload, payload)
+                        this.trackUserNotificationsEvent('loaded')
                         first = false
                     }
                 })
@@ -458,12 +457,18 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         return { status: messageTypes.length === 0 ? ['success'] : messageTypes }
     }
 
+    private trackUserNotificationsEvent(eventName: string): void {
+        if (window.context.sourcegraphDotComMode && this.state.messagesOrError) {
+            const payload = this.getOpenedNotificationsPayload(this.state.messagesOrError)
+            eventLogger.log(`UserNotifications${upperFirst(eventName)}`, payload, payload)
+        }
+    }
+
     public render(): JSX.Element | null {
-        const { messagesOrError, isOpen } = this.state
+        const { isOpen } = this.state
 
         if (isOpen) {
-            const payload = this.getOpenedNotificationsPayload(messagesOrError)
-            eventLogger.log('UserNotificationsOpened', payload, payload)
+            this.trackUserNotificationsEvent('opened')
         }
 
         return (

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -119,7 +119,7 @@ const getMessageColor = (entryType: EntryType): string => {
 
 const StatusMessagesNavItemEntry: React.FunctionComponent<StatusMessageEntryProps> = props => {
     const onLinkClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
-        const payload = { href: props.linkTo, notificationType: props.entryType }
+        const payload = { notificationType: props.entryType }
         eventLogger.log('UserNotificationsLinkClicked', payload, payload)
         props.linkOnClick(event)
     }

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -441,20 +441,22 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const { messagesOrError } = this.state
+        const { messagesOrError, isOpen } = this.state
 
-        const messageTypes =
-            typeof messagesOrError === 'string'
-                ? [messagesOrError]
-                : isErrorLike(messagesOrError)
-                ? ['error']
-                : messagesOrError.map(message => message.__typename)
+        if (isOpen) {
+            const messageTypes =
+                typeof messagesOrError === 'string'
+                    ? [messagesOrError]
+                    : isErrorLike(messagesOrError)
+                    ? ['error']
+                    : messagesOrError.map(message => message.type)
 
-        const payload = {
-            status: messageTypes || ['success'],
+            const payload = {
+                status: messageTypes.length === 0 ? ['success'] : messageTypes,
+            }
+
+            eventLogger.log('UserNotificationsOpened', payload, payload)
         }
-
-        eventLogger.log('UserNotificationsOpened', payload, payload)
 
         return (
             <ButtonDropdown

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -26,6 +26,7 @@ import { ErrorAlert } from '../components/alerts'
 import { CircleDashedIcon } from '../components/CircleDashedIcon'
 import { queryExternalServices } from '../components/externalServices/backend'
 import { StatusMessagesResult } from '../graphql-operations'
+import { eventLogger } from '../tracking/eventLogger'
 
 function fetchAllStatusMessages(): Observable<StatusMessagesResult['statusMessages']> {
     return requestGraphQL<StatusMessagesResult>(
@@ -116,43 +117,56 @@ const getMessageColor = (entryType: EntryType): string => {
     return ''
 }
 
-const StatusMessagesNavItemEntry: React.FunctionComponent<StatusMessageEntryProps> = props => (
-    <div key={props.message} className="status-messages-nav-item__entry">
-        <h4 className="d-flex align-items-center mb-0">
-            {entryIcon(props.entryType)}
-            {props.title ? props.title : 'Your repositories'}
-        </h4>
-        {props.entryType === 'not-active' ? (
-            <div className="status-messages-nav-item__entry-card status-messages-nav-item__entry-card--inactive border-0">
-                <p className="text-muted status-messages-nav-item__entry-message">{props.message}</p>
-                <Link className="text-primary" to={props.linkTo} onClick={props.linkOnClick}>
-                    {props.linkText}
-                </Link>
-            </div>
-        ) : (
-            <div
-                className={classNames(
-                    'status-messages-nav-item__entry-card status-messages-nav-item__entry-card--active',
-                    `status-messages-nav-item__entry--border-${props.entryType}`
-                )}
-            >
-                <p className={classNames('status-messages-nav-item__entry-message', getMessageColor(props.entryType))}>
-                    {props.message}
-                </p>
-                {props.messageHint && (
-                    <>
-                        <small className="text-muted d-inline-block mb-1">{props.messageHint}</small>
-                        <br />
-                    </>
-                )}
-                <Link className="text-primary" to={props.linkTo} onClick={props.linkOnClick}>
-                    {props.linkText}
-                </Link>
-            </div>
-        )}
-        {props.progressHint && <small className="text-muted">{props.progressHint}</small>}
-    </div>
-)
+const StatusMessagesNavItemEntry: React.FunctionComponent<StatusMessageEntryProps> = props => {
+    const onLinkClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+        const payload = { href: props.linkTo, notificationType: props.entryType }
+        eventLogger.log('UserNotificationsLinkClicked', payload, payload)
+        props.linkOnClick(event)
+    }
+
+    return (
+        <div key={props.message} className="status-messages-nav-item__entry">
+            <h4 className="d-flex align-items-center mb-0">
+                {entryIcon(props.entryType)}
+                {props.title ? props.title : 'Your repositories'}
+            </h4>
+            {props.entryType === 'not-active' ? (
+                <div className="status-messages-nav-item__entry-card status-messages-nav-item__entry-card--inactive border-0">
+                    <p className="text-muted status-messages-nav-item__entry-message">{props.message}</p>
+                    <Link className="text-primary" to={props.linkTo} onClick={onLinkClick}>
+                        {props.linkText}
+                    </Link>
+                </div>
+            ) : (
+                <div
+                    className={classNames(
+                        'status-messages-nav-item__entry-card status-messages-nav-item__entry-card--active',
+                        `status-messages-nav-item__entry--border-${props.entryType}`
+                    )}
+                >
+                    <p
+                        className={classNames(
+                            'status-messages-nav-item__entry-message',
+                            getMessageColor(props.entryType)
+                        )}
+                    >
+                        {props.message}
+                    </p>
+                    {props.messageHint && (
+                        <>
+                            <small className="text-muted d-inline-block mb-1">{props.messageHint}</small>
+                            <br />
+                        </>
+                    )}
+                    <Link className="text-primary" to={props.linkTo} onClick={onLinkClick}>
+                        {props.linkText}
+                    </Link>
+                </div>
+            )}
+            {props.progressHint && <small className="text-muted">{props.progressHint}</small>}
+        </div>
+    )
+}
 
 interface User {
     id: string
@@ -167,8 +181,8 @@ interface Props {
 }
 
 enum ExternalServiceNoActivityReasons {
-    NO_CODEHOSTS = 'NO_CODEHOSTS',
-    NO_REPOS = 'NO_REPOS',
+    NoCodehosts = 'NoCodehosts',
+    NoRepos = 'NoRepos',
 }
 
 type ExternalServiceNoActivityReason = keyof typeof ExternalServiceNoActivityReasons
@@ -195,7 +209,9 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
 
     public state: State = { isOpen: false, messagesOrError: [] }
 
-    private toggleIsOpen = (): void => this.setState(previousState => ({ isOpen: !previousState.isOpen }))
+    private toggleIsOpen = (): void => {
+        this.setState(previousState => ({ isOpen: !previousState.isOpen }))
+    }
 
     public componentDidMount(): void {
         this.subscriptions.add(
@@ -208,14 +224,14 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                     switchMap(({ nodes: services }) => {
                         if (!this.props.user.isSiteAdmin) {
                             if (services.length === 0) {
-                                return of(ExternalServiceNoActivityReasons.NO_CODEHOSTS)
+                                return of(ExternalServiceNoActivityReasons.NoCodehosts)
                             }
 
                             if (
                                 !services.some(service => service.repoCount !== 0) &&
                                 services.every(service => service.lastSyncError === null && service.warning === null)
                             ) {
-                                return of(ExternalServiceNoActivityReasons.NO_REPOS)
+                                return of(ExternalServiceNoActivityReasons.NoRepos)
                             }
                         }
 
@@ -275,7 +291,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
 
         // no code hosts or no repos
         if (isNoActivityReason(noActivityOrStatus)) {
-            if (noActivityOrStatus === ExternalServiceNoActivityReasons.NO_REPOS) {
+            if (noActivityOrStatus === ExternalServiceNoActivityReasons.NoRepos) {
                 return (
                     <StatusMessagesNavItemEntry
                         key={noActivityOrStatus}
@@ -390,7 +406,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                     data-tooltip={
                         this.state.isOpen
                             ? undefined
-                            : this.state.messagesOrError === 'NO_CODEHOSTS'
+                            : this.state.messagesOrError === ExternalServiceNoActivityReasons.NoCodehosts
                             ? 'No code host connections'
                             : 'No repositories'
                     }
@@ -425,6 +441,21 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
+        const { messagesOrError } = this.state
+
+        const messageTypes =
+            typeof messagesOrError === 'string'
+                ? [messagesOrError]
+                : isErrorLike(messagesOrError)
+                ? ['error']
+                : messagesOrError.map(message => message.__typename)
+
+        const payload = {
+            status: messageTypes || ['success'],
+        }
+
+        eventLogger.log('UserNotificationsOpened', payload, payload)
+
         return (
             <ButtonDropdown
                 isOpen={this.state.isOpen}


### PR DESCRIPTION
### Description

This PR adds basic metrics to user notifications, specifically:
- when a user opens a notifications dropdown
- when a user clicks on the notification link

### User notifications are loaded, tracking cases:

**event name**: `UserNotificationsLoaded`
**payload**:  see `UserNotificationsOpened`, payload variations are the same

### User opens notifications dropdown, tracking cases:

1. **No notifications, everything is synced and up-to-date**

      **event name**: `UserNotificationsOpened`
      **payload**: 
      ```json
      {
        "status": "success"
      }
      ```
    <details>
     <summary>Everything is up-to-date demo</summary>
     <br/>
    <img width="1790" alt="All OK" src="https://user-images.githubusercontent.com/1319181/135964223-d2d8531f-f28b-4624-8b19-ae4dc0e22df9.png">
    </details>

1. **No added code hosts** 

      **event name**: `UserNotificationsOpened`
      **payload**: 
      ```json
      {
        "status": "NoCodehosts"
      }
      ```
    <details>
     <summary>No code hosts demo</summary>
     <br/>
    <img width="1792" alt="No Codehosts" src="https://user-images.githubusercontent.com/1319181/135964555-2b878a33-f401-485a-a2a5-a0c42dc6301a.png">
    </details>

1. **No added repositories**

      **event name**: `UserNotificationsOpened`
      **payload**: 
      ```json
      {
        "status": "NoRepos"
      }
      ```
    <details>
     <summary>No repos demo</summary>
     <br/>
    <img width="1791" alt="No Repos" src="https://user-images.githubusercontent.com/1319181/135964721-f27cbe22-af5d-46eb-9e9e-f92315292be8.png">
    </details>
    
  1. **Multiple in-progress and error notifications**

      **event name**: `UserNotificationsOpened`
      **payload**: 
      ```ts
      {
        "status":  ["CloningProgress" | "IndexingProgress" | "ExternalServiceSyncError" | "SyncError" | "IndexingError"] 
      }
      ```
      <details>
       <summary>multiple notifications demo</summary>
       <br/>
      <img width="1783" alt="Multiple notification statuses" src="https://user-images.githubusercontent.com/1319181/135965640-30a0d785-a7bf-400f-9fbb-e87e555ed5c4.png">
      </details>

### User clicks a notifications link:

**event name**: `UserNotificationsLinkClicked`
**payload**: 
```ts
{
  "href": string,
  "notificationType":  "not-active" | "progress" | "warning" | "success" | "error"
}
```
<details>
 <summary>notifications link tracking demo</summary>
 <br/>
 
 https://user-images.githubusercontent.com/1319181/135966649-78ccfc6c-b4c9-4d5e-a0a0-2e0b53485111.mov
</details>

## Tests

Tested locally and on .com



