### PR TITLE
search: lookup RepositoryRevisions by RepoID for Zoekt

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -18,7 +19,7 @@ type repoData interface {
 	IsIndexed() bool
 }
 
-type IndexedMap map[string]*search.RepositoryRevisions
+type IndexedMap map[api.RepoID]*search.RepositoryRevisions
 
 func (m IndexedMap) AsList() []*search.RepositoryRevisions {
 	reposList := make([]*search.RepositoryRevisions, 0, len(m))

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -31,7 +31,7 @@ import (
 type IndexedRepoRevs struct {
 	// repoRevs is the Sourcegraph representation of a the list of repoRevs
 	// repository and revisions to search.
-	repoRevs map[string]*search.RepositoryRevisions
+	repoRevs map[api.RepoID]*search.RepositoryRevisions
 
 	// repoBranches will be used when we query zoekt. The order of branches
 	// must match that in a reporev such that we can map back results. IE this
@@ -70,7 +70,7 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 	}
 
 	if len(reporev.Revs) == 1 && repo.Branches[0].Name == "HEAD" && (reporev.Revs[0].RevSpec == "" || reporev.Revs[0].RevSpec == "HEAD") {
-		rb.repoRevs[string(reporev.Repo.Name)] = reporev
+		rb.repoRevs[reporev.Repo.ID] = reporev
 		rb.repoBranches[string(reporev.Repo.Name)] = headBranch
 		br, ok := rb.branchRepos["HEAD"]
 		if !ok {
@@ -122,7 +122,7 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 	// We found indexed branches! Track them.
 	if len(indexed) > 0 {
 		reporev.Revs = indexed
-		rb.repoRevs[string(reporev.Repo.Name)] = reporev
+		rb.repoRevs[reporev.Repo.ID] = reporev
 		rb.repoBranches[string(reporev.Repo.Name)] = branches
 		for _, branch := range branches {
 			br, ok := rb.branchRepos[branch]
@@ -139,7 +139,7 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 
 // getRepoInputRev returns the repo and inputRev associated with file.
 func (rb *IndexedRepoRevs) getRepoInputRev(file *zoekt.FileMatch) (repo types.RepoName, inputRevs []string) {
-	repoRev := rb.repoRevs[file.Repository]
+	repoRev := rb.repoRevs[api.RepoID(file.RepositoryID)]
 
 	// We search zoekt by repo ID. It is possible that the name has come out
 	// of sync, so the above lookup will fail. We fallback to linking the rev
@@ -178,7 +178,7 @@ func (rb *IndexedRepoRevs) getRepoInputRev(file *zoekt.FileMatch) (repo types.Re
 // (2) IndexedSubsetSearchRequest that searches over an indexed subset of repos in the universe of indexed repositories.
 type IndexedSearchRequest interface {
 	Search(context.Context, streaming.Sender) error
-	IndexedRepos() map[string]*search.RepositoryRevisions
+	IndexedRepos() map[api.RepoID]*search.RepositoryRevisions
 	UnindexedRepos() []*search.RepositoryRevisions
 }
 
@@ -246,8 +246,8 @@ func (s *IndexedUniverseSearchRequest) Search(ctx context.Context, c streaming.S
 
 // IndexedRepos for a request over the indexed universe cannot answer which
 // repositories are searched. This return value is always empty.
-func (s *IndexedUniverseSearchRequest) IndexedRepos() map[string]*search.RepositoryRevisions {
-	return map[string]*search.RepositoryRevisions{}
+func (s *IndexedUniverseSearchRequest) IndexedRepos() map[api.RepoID]*search.RepositoryRevisions {
+	return map[api.RepoID]*search.RepositoryRevisions{}
 }
 
 // UnindexedRepos over the indexed universe implies that we do not search unindexed repositories.
@@ -305,7 +305,7 @@ type IndexedSubsetSearchRequest struct {
 
 // IndxedRepos is a map of indexed repository revisions will be searched by
 // Zoekt. Do not mutate.
-func (s *IndexedSubsetSearchRequest) IndexedRepos() map[string]*search.RepositoryRevisions {
+func (s *IndexedSubsetSearchRequest) IndexedRepos() map[api.RepoID]*search.RepositoryRevisions {
 	if s.RepoRevs == nil {
 		return nil
 	}
@@ -756,7 +756,7 @@ func zoektIndexedRepos(indexedSet map[uint32]*zoekt.MinimalRepoListEntry, revs [
 	// PERF: If len(revs) is large, we expect to be doing an indexed
 	// search. So set indexed to the max size it can be to avoid growing.
 	indexed = &IndexedRepoRevs{
-		repoRevs:     make(map[string]*search.RepositoryRevisions, len(revs)),
+		repoRevs:     make(map[api.RepoID]*search.RepositoryRevisions, len(revs)),
 		repoBranches: make(map[string][]string, len(revs)),
 		branchRepos:  make(map[string]*zoektquery.BranchRepos, 1),
 	}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -50,6 +50,9 @@ func TestIndexedSearch(t *testing.T) {
 		},
 	}}
 
+	fooSlashBar := zoektRepos[0].Repository
+	fooSlashFooBar := zoektRepos[1].Repository
+
 	tests := []struct {
 		name               string
 		args               args
@@ -107,10 +110,11 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: false,
 				results: []zoekt.FileMatch{
 					{
-						Repository: "foo/bar",
-						Branches:   []string{"HEAD"},
-						Version:    "1",
-						FileName:   "baz.go",
+						Repository:   "foo/bar",
+						RepositoryID: fooSlashBar.ID,
+						Branches:     []string{"HEAD"},
+						Version:      "1",
+						FileName:     "baz.go",
 						LineMatches: []zoekt.LineMatch{
 							{
 								Line: []byte("I'm like 1.5+ hours into writing this test :'("),
@@ -128,10 +132,11 @@ func TestIndexedSearch(t *testing.T) {
 						},
 					},
 					{
-						Repository: "foo/foobar",
-						Branches:   []string{"HEAD"},
-						Version:    "2",
-						FileName:   "baz.go",
+						Repository:   "foo/foobar",
+						RepositoryID: fooSlashFooBar.ID,
+						Branches:     []string{"HEAD"},
+						Version:      "2",
+						FileName:     "baz.go",
 						LineMatches: []zoekt.LineMatch{
 							{
 								Line: []byte("s/rain/pain"),
@@ -165,17 +170,19 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: false,
 				results: []zoekt.FileMatch{
 					{
-						Repository: "foo/bar",
+						Repository:   "foo/bar",
+						RepositoryID: fooSlashBar.ID,
 						// baz.go is the same in HEAD and dev
 						Branches: []string{"HEAD", "dev"},
 						FileName: "baz.go",
 						Version:  "1",
 					},
 					{
-						Repository: "foo/bar",
-						Branches:   []string{"dev"},
-						FileName:   "bam.go",
-						Version:    "2",
+						Repository:   "foo/bar",
+						RepositoryID: fooSlashBar.ID,
+						Branches:     []string{"dev"},
+						FileName:     "bam.go",
+						Version:      "2",
 					},
 				},
 				since: func(time.Time) time.Duration { return 0 },
@@ -205,10 +212,11 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: false,
 				results: []zoekt.FileMatch{
 					{
-						Repository: "foo/bar",
-						Branches:   []string{"HEAD"},
-						FileName:   "baz.go",
-						Version:    "1",
+						Repository:   "foo/bar",
+						RepositoryID: fooSlashBar.ID,
+						Branches:     []string{"HEAD"},
+						FileName:     "baz.go",
+						Version:      "1",
 					},
 				},
 			},
@@ -550,7 +558,7 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 	}
 
 	type ret struct {
-		Indexed   map[string]*search.RepositoryRevisions
+		Indexed   map[api.RepoID]*search.RepositoryRevisions
 		Unindexed []*search.RepositoryRevisions
 	}
 
@@ -650,10 +658,10 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 	}
 }
 
-func repoRevsSliceToMap(rs []*search.RepositoryRevisions) map[string]*search.RepositoryRevisions {
-	m := map[string]*search.RepositoryRevisions{}
+func repoRevsSliceToMap(rs []*search.RepositoryRevisions) map[api.RepoID]*search.RepositoryRevisions {
+	m := map[api.RepoID]*search.RepositoryRevisions{}
 	for _, r := range rs {
-		m[string(r.Repo.Name)] = r
+		m[r.Repo.ID] = r
 	}
 	return m
 }


### PR DESCRIPTION
Previously we were name based. However, Zoekt stores and returns the
repository ID. So we can instead store the lookup data by ID. This is
not only smaller in memory, but helps us move towards a world where we
don't need the name.

This commit is mostly a refactor around updating type signatures.