### PR TITLE
web: stop reporting the `ResizeObserver loop limit exceeded` error to Sentry

### DIFF
--- a/client/web/src/sentry.ts
+++ b/client/web/src/sentry.ts
@@ -15,7 +15,6 @@ window.addEventListener('error', error => {
 
     if (process.env.NODE_ENV === 'production' && isResizeObserverLoopError) {
         error.stopImmediatePropagation()
-        error.stopPropagation()
     }
 })
 

--- a/client/web/src/sentry.ts
+++ b/client/web/src/sentry.ts
@@ -2,6 +2,23 @@ import * as sentry from '@sentry/browser'
 
 import { authenticatedUser } from './auth'
 
+window.addEventListener('error', error => {
+    /**
+     * The "ResizeObserver loop limit exceeded" error means that `ResizeObserver` was not
+     * able to deliver all observations within a single animation frame. It doesn't break
+     * the functionality of the application. The W3C considers converting this error to a warning:
+     * https://github.com/w3c/csswg-drafts/issues/5023
+     * We can safely ignore it in the production environment to avoid hammering Sentry and other
+     * libraries relying on `window.addEventListener('error', callback)`.
+     */
+    const isResizeObserverLoopError = error.message === 'ResizeObserver loop limit exceeded'
+
+    if (process.env.NODE_ENV === 'production' && isResizeObserverLoopError) {
+        error.stopImmediatePropagation()
+        error.stopPropagation()
+    }
+})
+
 if (window.context.sentryDSN) {
     sentry.init({
         dsn: window.context.sentryDSN,

--- a/client/web/src/util/dom.ts
+++ b/client/web/src/util/dom.ts
@@ -8,17 +8,25 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 /**
  * An Observable wrapper around ResizeObserver
  */
-export const observeResize = (target: HTMLElement): Observable<ResizeObserverEntry | undefined> =>
-    new Observable(function subscribe(observer) {
+export const observeResize = (target: HTMLElement): Observable<ResizeObserverEntry | undefined> => {
+    let animationFrameID: number
+
+    return new Observable(function subscribe(observer) {
         const resizeObserver = new ResizeObserver(entries => {
-            observer.next(head(entries))
+            // Move `ResizeObserver` measurements into a RAF to avoid the "ResizeObserver loop limit exceeded" error.
+            // See the thread for background info: https://github.com/WICG/resize-observer/issues/38
+            animationFrameID = window.requestAnimationFrame(() => {
+                observer.next(head(entries))
+            })
         })
         resizeObserver.observe(target)
 
         return function unsubscribe() {
+            window.cancelAnimationFrame(animationFrameID)
             resizeObserver.disconnect()
         }
     })
+}
 
 interface ObserveQuerySelectorInit {
     selector: string


### PR DESCRIPTION
## Context
 
The `ResizeObserver loop limit` error means that `ResizeObserver` was not able to deliver all observations within a single animation frame. It doesn't break the functionality of the application. The W3C considers converting this error to a warning:   https://github.com/w3c/csswg-drafts/issues/5023. We can safely ignore it in the production environment to avoid hammering Sentry and other libraries relying on `window.addEventListener('error', callback)`.

And we _need_ to ignore it because it eats up our Sentry quota quickly.:
<img width="1543" alt="Screenshot 2021-10-05 at 12 03 20" src="https://user-images.githubusercontent.com/3846380/135993685-aa88cd1a-a12c-4feb-b24c-8c441dc75c31.png">

## Changes

- Catch the `ResizeObserver loop limit` error to prevent it from going to the Sentry.
- Move the `ResizeObserver` callback into RAF to prevent errors from happening.
    - Note: this doesn't prevent all `ResizeObserver loop limit` errors. Some third-party libraries use it without RAF; that's why catching the error in production is necessary.
