### PR TITLE
database: remove 2nd param from AccessTokens.DeleteByID

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -123,13 +123,12 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 		if err != nil {
 			return nil, err
 		}
-		subjectUserID = token.SubjectUserID
 
 		// 🚨 SECURITY: Only site admins and the user can delete a user's access token.
 		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, token.SubjectUserID); err != nil {
 			return nil, err
 		}
-		if err := database.AccessTokens(r.db).DeleteByID(ctx, token.ID, token.SubjectUserID); err != nil {
+		if err := database.AccessTokens(r.db).DeleteByID(ctx, token.ID); err != nil {
 			return nil, err
 		}
 

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -278,12 +278,9 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
 	mockAccessTokens := func(t *testing.T) {
-		database.Mocks.AccessTokens.DeleteByID = func(id int64, subjectUserID int32) error {
+		database.Mocks.AccessTokens.DeleteByID = func(id int64) error {
 			if want := int64(1); id != want {
 				t.Errorf("got %q, want %q", id, want)
-			}
-			if want := int32(2); subjectUserID != want {
-				t.Errorf("got %v, want %v", subjectUserID, want)
 			}
 			return nil
 		}

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -264,14 +264,14 @@ func (s *AccessTokenStore) Count(ctx context.Context, opt AccessTokensListOption
 	return count, nil
 }
 
-// DeleteByID deletes an access token given its ID and associated subject user.
+// DeleteByID deletes an access token given its ID.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is permitted to delete the token.
-func (s *AccessTokenStore) DeleteByID(ctx context.Context, id int64, subjectUserID int32) error {
+func (s *AccessTokenStore) DeleteByID(ctx context.Context, id int64) error {
 	if Mocks.AccessTokens.DeleteByID != nil {
-		return Mocks.AccessTokens.DeleteByID(id, subjectUserID)
+		return Mocks.AccessTokens.DeleteByID(id)
 	}
-	return s.delete(ctx, sqlf.Sprintf("id=%d AND subject_user_id=%d", id, subjectUserID))
+	return s.delete(ctx, sqlf.Sprintf("id=%d", id))
 }
 
 // DeleteByToken deletes an access token given the secret token value itself (i.e., the same value
@@ -310,7 +310,7 @@ func toSHA256Bytes(input []byte) []byte {
 
 type MockAccessTokens struct {
 	Create     func(subjectUserID int32, scopes []string, note string, creatorUserID int32) (id int64, token string, err error)
-	DeleteByID func(id int64, subjectUserID int32) error
+	DeleteByID func(id int64) error
 	Lookup     func(tokenHexEncoded, requiredScope string) (subjectUserID int32, err error)
 	GetByID    func(id int64) (*AccessToken, error)
 }

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -216,7 +216,7 @@ func TestAccessTokens_Lookup(t *testing.T) {
 	}
 
 	// Delete a token and ensure Lookup fails on it.
-	if err := AccessTokens(db).DeleteByID(ctx, tid0, subject.ID); err != nil {
+	if err := AccessTokens(db).DeleteByID(ctx, tid0); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := AccessTokens(db).Lookup(ctx, tv0, "a"); err == nil {


### PR DESCRIPTION
This param is not required. `access_tokens.id` is the primary key for
the table and unique, we don't need to also pass in `subject_id`.

In the GraphQL layer the token is loaded too and permissions are checked
against `token.SubjectUserID`, so there's also no additional hidden
benefit to passing in this 2nd param.

It makes the method harder to use, though, because one needs to load the
token first to delete it (I'm working with access tokens in a separate
branch).

I suspect it's a leftover from a refactor where the permission check was
in `DeleteByID`.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
