### PR TITLE
database: fix version check for schemadoc

### DIFF
--- a/internal/database/schemadoc/main.go
+++ b/internal/database/schemadoc/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -32,7 +31,7 @@ const containerName = "schemadoc"
 
 var logger = log.New(os.Stderr, "", log.LstdFlags)
 
-var versionRe = lazyregexp.New(fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta(`12\.\d+`)))
+var versionRe = lazyregexp.New(`\b12\.\d+\b`)
 
 var databases = map[*dbconn.Database]string{
 	dbconn.Frontend:  "schema.md",


### PR DESCRIPTION
We would always run via docker, even if psql was at 12.x.
