### PR TITLE
[SG-25115] Repository commits page shows author date but labels as commit date

### DIFF
--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -56,9 +56,9 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
                     {!compact ? (
                         <>
                             {messageElement}
-                            <PersonLink person={author.person} className="font-weight-bold" /> authored and{' '}
-                            <PersonLink person={committer.person} className="font-weight-bold" /> commited{' '}
-                            <Timestamp date={author.date} />
+                            <PersonLink person={author.person} className="font-weight-bold" /> authored and commited by{' '}
+                            <PersonLink person={committer.person} className="font-weight-bold" />{' '}
+                            <Timestamp date={committer.date} />
                             {commitMessageBody}
                         </>
                     ) : (

--- a/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
     >
       Alice Zhao
     </span>
-     authored and
+     authored and commited by
      
     <a
       className="font-weight-bold"
@@ -104,13 +104,12 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
     >
       bYang
     </a>
-     commited
      
     <span
       className="timestamp"
-      data-tooltip="1990-01-01"
+      data-tooltip="1991-01-01"
     >
-      about 16 years ago
+      about 15 years ago
     </span>
   </div>
 </div>
@@ -145,7 +144,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
     >
       Alice Zhao
     </span>
-     authored and
+     authored and commited by
      
     <a
       className="font-weight-bold"
@@ -154,13 +153,12 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
     >
       bYang
     </a>
-     commited
      
     <span
       className="timestamp"
-      data-tooltip="1990-01-01"
+      data-tooltip="1991-01-01"
     >
-      about 16 years ago
+      about 15 years ago
     </span>
   </div>
 </div>


### PR DESCRIPTION
## Description

- In commit node UI, using `committer.date` instead of `author.date` in `Timestamp`
- Update text: `committed by XYZ X days ago`

## Ref

- sourcegraph/sourcegraph#25115

