### PR TITLE
commit/diff search: remove formatWithoutRefs

### DIFF
--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -33,9 +33,9 @@ const (
 )
 
 var (
-	partsPerCommit = len(formatWithRefs)
+	partsPerCommit = len(commitFields)
 
-	formatWithRefs = []string{
+	commitFields = []string{
 		hash,
 		refNames,
 		sourceRefs,
@@ -49,31 +49,15 @@ var (
 		parentHashes,
 	}
 
-	formatWithoutRefs = []string{
-		hash,
-		"",
-		sourceRefs,
-		authorName,
-		authorEmail,
-		authorDate,
-		committerName,
-		committerEmail,
-		committerDate,
-		rawBody,
-		parentHashes,
-	}
-
-	baseLogArgs = []string{
+	logArgs = []string{
 		"log",
 		"--decorate=full",
 		"-z",
 		"--no-merges",
+		"--format=format:" + strings.Join(commitFields, "%x00") + "%x00",
 	}
 
-	// TODO(@camdencheek) support adding refs (issue #25356)
-	// logArgsWithRefs    = append(baseLogArgs, "--format=format:"+strings.Join(formatWithRefs, "%x00")+"%x00")
-	logArgsWithoutRefs = append(baseLogArgs, "--format=format:"+strings.Join(formatWithoutRefs, "%x00")+"%x00")
-	sep                = []byte{0x0}
+	sep = []byte{0x0}
 )
 
 type job struct {
@@ -139,7 +123,7 @@ func (cs *CommitSearcher) Search(ctx context.Context, onMatch func(*protocol.Com
 
 func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, resultChans chan chan *protocol.CommitMatch) error {
 	revArgs := revsToGitArgs(cs.Revisions)
-	cmd := exec.CommandContext(ctx, "git", append(logArgsWithoutRefs, revArgs...)...)
+	cmd := exec.CommandContext(ctx, "git", append(logArgs, revArgs...)...)
 	cmd.Dir = cs.RepoDir
 	stdoutReader, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
This removes formatWithoutRefs, which becomes unused since we always
do commit/diff search with refs. In our current commit/diff code, this
is only used for listing commits (not for searching). If we want to port
the listing code to use the search endpoint, we should implement
skipping refs then, but for now, this change matches the behavior of our
current search paths.

Fixes #25356 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
