### PR TITLE
migrations: undo API docs changes to Sourcegraph.com and k8s.sgdev.org

### DIFF
--- a/migrations/codeintel/1000000021_reverted.down.sql
+++ b/migrations/codeintel/1000000021_reverted.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Empty migration, this migration was reverted: https://github.com/sourcegraph/sourcegraph/pull/25715
+
+COMMIT;

--- a/migrations/codeintel/1000000021_reverted.up.sql
+++ b/migrations/codeintel/1000000021_reverted.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Empty migration, this migration was reverted: https://github.com/sourcegraph/sourcegraph/pull/25715
+
+COMMIT;

--- a/migrations/codeintel/1000000022_undo_apidocs_root_column.down.sql
+++ b/migrations/codeintel/1000000022_undo_apidocs_root_column.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Nothing to do, the up migration undid changes previously made.
+
+COMMIT;

--- a/migrations/codeintel/1000000022_undo_apidocs_root_column.up.sql
+++ b/migrations/codeintel/1000000022_undo_apidocs_root_column.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+-- Undo the changes corresponding to https://github.com/sourcegraph/sourcegraph/pull/25715
+ALTER TABLE lsif_data_documentation_search_public DROP COLUMN IF EXISTS dump_root;
+ALTER TABLE lsif_data_documentation_search_private DROP COLUMN IF EXISTS dump_root;
+
+COMMIT;

--- a/migrations/frontend/1528395908_reverted.down.sql
+++ b/migrations/frontend/1528395908_reverted.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Empty migration, this migration was reverted: https://github.com/sourcegraph/sourcegraph/pull/25715
+
+COMMIT;

--- a/migrations/frontend/1528395908_reverted.up.sql
+++ b/migrations/frontend/1528395908_reverted.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Empty migration, this migration was reverted: https://github.com/sourcegraph/sourcegraph/pull/25715
+
+COMMIT;

--- a/migrations/frontend/1528395909_undo_apidocs_oob_migration.down.sql
+++ b/migrations/frontend/1528395909_undo_apidocs_oob_migration.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Nothing to do, the up migration undid changes previously made.
+
+COMMIT;

--- a/migrations/frontend/1528395909_undo_apidocs_oob_migration.up.sql
+++ b/migrations/frontend/1528395909_undo_apidocs_oob_migration.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- Undo the changes corresponding to https://github.com/sourcegraph/sourcegraph/pull/25715
+DELETE FROM out_of_band_migrations WHERE id=12 AND team='apidocs';
+
+COMMIT;


### PR DESCRIPTION
This undoes some DB migrations that were already rolled out to Sourcegraph.com and k8s.sgdev.org, completing the revert of a PR. See #25715

This is following new documentation I've added for how to revert DB migrations in #25718 