### PR TITLE
API docs: codeintel: begin indexing API docs for search

### DIFF
--- a/doc/dev/background-information/codeintel/apidocs/index.md
+++ b/doc/dev/background-information/codeintel/apidocs/index.md
@@ -100,7 +100,7 @@ On Sourcegraph.com, only a few thousand repos have Go LSIF data (as of Sept 15, 
 
 We make it easy to limit the amount of resources going to API docs search as a feature, since it is desirable to both prevent unbounded growth issues on e.g. Sourcegraph.com and prevent any unexpected resource consumption on enterprise instances (e.g. if someone out there has a Postgres instance provisioned well today, but has hundreds of thousands of Go repositories with LSIF indexing, adding this table may increase resource usage.)
 
-In specific, a site configuration option `"apidocs.search-index-limit-factor": 1.0` enables limiting the index size. The value `1.0` is a multiple of 250 million symbols, i.e., `1.0` indicates 250 million symbols (approx 12.5k Go repos) can be in the public and private search indexes independently (500 million total), `2.0` indicates 500 million symbols (approx 50k Go repos), and so on.
+In specific, a site configuration option `"apidocs.search.index-size-limit-factor": 1.0` enables limiting the index size. The value `1.0` is a multiple of 250 million symbols, i.e., `1.0` indicates 250 million symbols (approx 12.5k Go repos) can be in the public and private search indexes independently (500 million total), `2.0` indicates 500 million symbols (approx 50k Go repos), and so on.
 
 We implement this by merely requesting an estimate number of rows in the table:
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/iface.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/iface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
@@ -56,7 +57,7 @@ type LSIFStore interface {
 	WriteResultChunks(ctx context.Context, bundleID int, resultChunks chan precise.IndexedResultChunkData) error
 	WriteDefinitions(ctx context.Context, bundleID int, monikerLocations chan precise.MonikerLocations) error
 	WriteReferences(ctx context.Context, bundleID int, monikerLocations chan precise.MonikerLocations) error
-	WriteDocumentationPages(ctx context.Context, bundleID int, documentation chan *precise.DocumentationPageData) error
+	WriteDocumentationPages(ctx context.Context, upload dbstore.Upload, repo *types.Repo, isDefaultBranch bool, documentation chan *precise.DocumentationPageData) error
 	WriteDocumentationPathInfo(ctx context.Context, bundleID int, documentation chan *precise.DocumentationPathInfoData) error
 	WriteDocumentationMappings(ctx context.Context, bundleID int, mappings chan precise.DocumentationMapping) error
 }
@@ -78,4 +79,5 @@ type GitserverClient interface {
 	DirectoryChildren(ctx context.Context, repositoryID int, commit string, dirnames []string) (map[string][]string, error)
 	CommitDate(ctx context.Context, repositoryID int, commit string) (time.Time, error)
 	ResolveRevision(ctx context.Context, repositoryID int, versionString string) (api.CommitID, error)
+	DefaultBranchContains(ctx context.Context, repositoryID int, commit string) (bool, error)
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 	"time"
 
+	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	types "github.com/sourcegraph/sourcegraph/internal/types"
 	precise "github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
@@ -1586,6 +1588,9 @@ type MockGitserverClient struct {
 	// CommitDateFunc is an instance of a mock function object controlling
 	// the behavior of the method CommitDate.
 	CommitDateFunc *GitserverClientCommitDateFunc
+	// DefaultBranchContainsFunc is an instance of a mock function object
+	// controlling the behavior of the method DefaultBranchContains.
+	DefaultBranchContainsFunc *GitserverClientDefaultBranchContainsFunc
 	// DirectoryChildrenFunc is an instance of a mock function object
 	// controlling the behavior of the method DirectoryChildren.
 	DirectoryChildrenFunc *GitserverClientDirectoryChildrenFunc
@@ -1602,6 +1607,11 @@ func NewMockGitserverClient() *MockGitserverClient {
 		CommitDateFunc: &GitserverClientCommitDateFunc{
 			defaultHook: func(context.Context, int, string) (time.Time, error) {
 				return time.Time{}, nil
+			},
+		},
+		DefaultBranchContainsFunc: &GitserverClientDefaultBranchContainsFunc{
+			defaultHook: func(context.Context, int, string) (bool, error) {
+				return false, nil
 			},
 		},
 		DirectoryChildrenFunc: &GitserverClientDirectoryChildrenFunc{
@@ -1624,6 +1634,9 @@ func NewMockGitserverClientFrom(i GitserverClient) *MockGitserverClient {
 	return &MockGitserverClient{
 		CommitDateFunc: &GitserverClientCommitDateFunc{
 			defaultHook: i.CommitDate,
+		},
+		DefaultBranchContainsFunc: &GitserverClientDefaultBranchContainsFunc{
+			defaultHook: i.DefaultBranchContains,
 		},
 		DirectoryChildrenFunc: &GitserverClientDirectoryChildrenFunc{
 			defaultHook: i.DirectoryChildren,
@@ -1743,6 +1756,122 @@ func (c GitserverClientCommitDateFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverClientCommitDateFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverClientDefaultBranchContainsFunc describes the behavior when the
+// DefaultBranchContains method of the parent MockGitserverClient instance
+// is invoked.
+type GitserverClientDefaultBranchContainsFunc struct {
+	defaultHook func(context.Context, int, string) (bool, error)
+	hooks       []func(context.Context, int, string) (bool, error)
+	history     []GitserverClientDefaultBranchContainsFuncCall
+	mutex       sync.Mutex
+}
+
+// DefaultBranchContains delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockGitserverClient) DefaultBranchContains(v0 context.Context, v1 int, v2 string) (bool, error) {
+	r0, r1 := m.DefaultBranchContainsFunc.nextHook()(v0, v1, v2)
+	m.DefaultBranchContainsFunc.appendCall(GitserverClientDefaultBranchContainsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// DefaultBranchContains method of the parent MockGitserverClient instance
+// is invoked and the hook queue is empty.
+func (f *GitserverClientDefaultBranchContainsFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DefaultBranchContains method of the parent MockGitserverClient instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *GitserverClientDefaultBranchContainsFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *GitserverClientDefaultBranchContainsFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *GitserverClientDefaultBranchContainsFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverClientDefaultBranchContainsFunc) nextHook() func(context.Context, int, string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientDefaultBranchContainsFunc) appendCall(r0 GitserverClientDefaultBranchContainsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// GitserverClientDefaultBranchContainsFuncCall objects describing the
+// invocations of this function.
+func (f *GitserverClientDefaultBranchContainsFunc) History() []GitserverClientDefaultBranchContainsFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientDefaultBranchContainsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientDefaultBranchContainsFuncCall is an object that describes
+// an invocation of method DefaultBranchContains on an instance of
+// MockGitserverClient.
+type GitserverClientDefaultBranchContainsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientDefaultBranchContainsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientDefaultBranchContainsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -2042,7 +2171,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		WriteDocumentationPagesFunc: &LSIFStoreWriteDocumentationPagesFunc{
-			defaultHook: func(context.Context, int, chan *precise.DocumentationPageData) error {
+			defaultHook: func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error {
 				return nil
 			},
 		},
@@ -2543,24 +2672,24 @@ func (c LSIFStoreWriteDocumentationMappingsFuncCall) Results() []interface{} {
 // WriteDocumentationPages method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreWriteDocumentationPagesFunc struct {
-	defaultHook func(context.Context, int, chan *precise.DocumentationPageData) error
-	hooks       []func(context.Context, int, chan *precise.DocumentationPageData) error
+	defaultHook func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error
+	hooks       []func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error
 	history     []LSIFStoreWriteDocumentationPagesFuncCall
 	mutex       sync.Mutex
 }
 
 // WriteDocumentationPages delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) WriteDocumentationPages(v0 context.Context, v1 int, v2 chan *precise.DocumentationPageData) error {
-	r0 := m.WriteDocumentationPagesFunc.nextHook()(v0, v1, v2)
-	m.WriteDocumentationPagesFunc.appendCall(LSIFStoreWriteDocumentationPagesFuncCall{v0, v1, v2, r0})
+func (m *MockLSIFStore) WriteDocumentationPages(v0 context.Context, v1 dbstore.Upload, v2 *types.Repo, v3 bool, v4 chan *precise.DocumentationPageData) error {
+	r0 := m.WriteDocumentationPagesFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.WriteDocumentationPagesFunc.appendCall(LSIFStoreWriteDocumentationPagesFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // WriteDocumentationPages method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreWriteDocumentationPagesFunc) SetDefaultHook(hook func(context.Context, int, chan *precise.DocumentationPageData) error) {
+func (f *LSIFStoreWriteDocumentationPagesFunc) SetDefaultHook(hook func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error) {
 	f.defaultHook = hook
 }
 
@@ -2569,7 +2698,7 @@ func (f *LSIFStoreWriteDocumentationPagesFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreWriteDocumentationPagesFunc) PushHook(hook func(context.Context, int, chan *precise.DocumentationPageData) error) {
+func (f *LSIFStoreWriteDocumentationPagesFunc) PushHook(hook func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2578,7 +2707,7 @@ func (f *LSIFStoreWriteDocumentationPagesFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *LSIFStoreWriteDocumentationPagesFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, chan *precise.DocumentationPageData) error {
+	f.SetDefaultHook(func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error {
 		return r0
 	})
 }
@@ -2586,12 +2715,12 @@ func (f *LSIFStoreWriteDocumentationPagesFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *LSIFStoreWriteDocumentationPagesFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, chan *precise.DocumentationPageData) error {
+	f.PushHook(func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error {
 		return r0
 	})
 }
 
-func (f *LSIFStoreWriteDocumentationPagesFunc) nextHook() func(context.Context, int, chan *precise.DocumentationPageData) error {
+func (f *LSIFStoreWriteDocumentationPagesFunc) nextHook() func(context.Context, dbstore.Upload, *types.Repo, bool, chan *precise.DocumentationPageData) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2630,10 +2759,16 @@ type LSIFStoreWriteDocumentationPagesFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 dbstore.Upload
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 chan *precise.DocumentationPageData
+	Arg2 *types.Repo
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 bool
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 chan *precise.DocumentationPageData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -2642,7 +2777,7 @@ type LSIFStoreWriteDocumentationPagesFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreWriteDocumentationPagesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -342,10 +342,10 @@ func (c *Client) DefaultBranchContains(ctx context.Context, repositoryID int, co
 		return false, errors.Wrap(err, "RefDescriptions")
 	}
 	var defaultBranchName string
-	for name, descriptions := range descriptions {
+	for _, descriptions := range descriptions {
 		for _, ref := range descriptions {
 			if ref.IsDefaultBranch {
-				defaultBranchName = name
+				defaultBranchName = ref.Name
 				break
 			}
 		}

--- a/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
@@ -2,20 +2,30 @@ package lsifstore
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
 // WriteDocumentationPages is called (transactionally) from the precise-code-intel-worker.
-func (s *Store) WriteDocumentationPages(ctx context.Context, bundleID int, documentationPages chan *precise.DocumentationPageData) (err error) {
+func (s *Store) WriteDocumentationPages(ctx context.Context, upload dbstore.Upload, repo *types.Repo, isDefaultBranch bool, documentationPages chan *precise.DocumentationPageData) (err error) {
 	ctx, traceLog, endObservation := s.operations.writeDocumentationPages.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("bundleID", bundleID),
+		log.Int("bundleID", upload.ID),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -31,14 +41,16 @@ func (s *Store) WriteDocumentationPages(ctx context.Context, bundleID int, docum
 	}
 
 	var count uint32
+	var pages []*precise.DocumentationPageData
 	inserter := func(inserter *batch.Inserter) error {
-		for v := range documentationPages {
-			data, err := s.serializer.MarshalDocumentationPageData(v)
+		for page := range documentationPages {
+			pages = append(pages, page)
+			data, err := s.serializer.MarshalDocumentationPageData(page)
 			if err != nil {
 				return err
 			}
 
-			if err := inserter.Insert(ctx, v.Tree.PathID, data); err != nil {
+			if err := inserter.Insert(ctx, page.Tree.PathID, data); err != nil {
 				return err
 			}
 
@@ -59,9 +71,18 @@ func (s *Store) WriteDocumentationPages(ctx context.Context, bundleID int, docum
 	}
 	traceLog(log.Int("numResultChunkRecords", int(count)))
 
+	// Note: If someone disables API docs search indexing, uploads during that time will not be
+	// indexed even if it is turned back on. Only future uploads would be.
+	if conf.APIDocsSearchIndexingEnabled() {
+		// Perform search indexing for API docs pages.
+		if err := tx.WriteDocumentationSearch(ctx, upload, repo, isDefaultBranch, pages); err != nil {
+			return errors.Wrap(err, "WriteDocumentationSearch")
+		}
+	}
+
 	// Insert the values from the temporary table into the target table. We select a
 	// parameterized dump id here since it is the same for all rows in this operation.
-	return tx.Exec(ctx, sqlf.Sprintf(writeDocumentationPagesInsertQuery, bundleID))
+	return tx.Exec(ctx, sqlf.Sprintf(writeDocumentationPagesInsertQuery, upload.ID))
 }
 
 const writeDocumentationPagesTemporaryTableQuery = `
@@ -74,8 +95,8 @@ CREATE TEMPORARY TABLE t_lsif_data_documentation_pages (
 
 const writeDocumentationPagesInsertQuery = `
 -- source: enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go:WriteDocumentationPages
-INSERT INTO lsif_data_documentation_pages (dump_id, path_id, data)
-SELECT %s, source.path_id, source.data
+INSERT INTO lsif_data_documentation_pages (dump_id, path_id, data, search_indexed)
+SELECT %s, source.path_id, source.data, 'true'
 FROM t_lsif_data_documentation_pages source
 `
 
@@ -207,3 +228,209 @@ INSERT INTO lsif_data_documentation_mappings (dump_id, path_id, result_id, file_
 SELECT %s, source.path_id, source.result_id, source.file_path
 FROM t_lsif_data_documentation_mappings source
 `
+
+// WriteDocumentationSearch is called (within a transaction) to write the search index for a given documentation page.
+func (s *Store) WriteDocumentationSearch(ctx context.Context, upload dbstore.Upload, repo *types.Repo, isDefaultBranch bool, pages []*precise.DocumentationPageData) (err error) {
+	if !isDefaultBranch {
+		// We do not index non-default branches for API docs search.
+		return nil
+	}
+
+	ctx, traceLog, endObservation := s.operations.writeDocumentationSearch.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("repo", upload.RepositoryName),
+		log.Int("bundleID", upload.ID),
+		log.Int("pages", len(pages)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	// This will not always produce a proper language name, e.g. if an indexer is not named after
+	// the language or is not in "lsif-$LANGUAGE" format. That's OK: in that case, the "language"
+	// is the indexer name which is likely good enough since we use fuzzy search / partial text matching
+	// over it.
+	languageOrIndexerName := strings.ToLower(strings.TrimPrefix(upload.Indexer, "lsif-"))
+
+	const (
+		tableNamePublic  = "lsif_data_documentation_search_public"
+		tableNamePrivate = "lsif_data_documentation_search_private"
+	)
+	tableName := tableNamePublic
+	if repo.Private {
+		tableName = tableNamePrivate
+	}
+
+	// This upload is for a commit on the default branch of the repository, so it is eligible for API
+	// docs search indexing. It will replace any existing data that we have or this unique (repo_id, lang, root)
+	// tuple in either table so we go ahead and purge the old data now.
+	for _, tableName := range []string{tableNamePublic, tableNamePrivate} {
+		if err := s.Exec(ctx, sqlf.Sprintf(
+			strings.ReplaceAll(purgeDocumentationSearchOldData, "$TABLE_NAME", tableName),
+			upload.RepositoryID,
+			upload.Root,
+			languageOrIndexerName,
+		)); err != nil {
+			return errors.Wrap(err, "purging old data")
+		}
+	}
+
+	var index func(node *precise.DocumentationNode) error
+	index = func(node *precise.DocumentationNode) error {
+		if node.Documentation.SearchKey != "" {
+			tags := []string{}
+			for _, tag := range node.Documentation.Tags {
+				tags = append(tags, string(tag))
+			}
+			err := s.Exec(ctx, sqlf.Sprintf(
+				strings.ReplaceAll(writeDocumentationSearchInsertQuery, "$TABLE_NAME", tableName),
+				upload.ID,
+				upload.Root,
+				node.PathID,
+				languageOrIndexerName,
+				upload.RepositoryName,
+				node.Documentation.SearchKey,
+				truncate(node.Label.String(), 256),     // 256 bytes, enough for ~100 characters in all languages
+				truncate(node.Detail.String(), 5*1024), // 5 KiB - just for sanity
+				strings.Join(tags, " "),
+				upload.RepositoryID,
+			))
+			if err != nil {
+				return err
+			}
+		}
+
+		// Index descendants.
+		for _, child := range node.Children {
+			if child.Node != nil {
+				if err := index(child.Node); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	// Index each page.
+	for _, page := range pages {
+		traceLog(log.String("page", page.Tree.PathID))
+		if err := index(page.Tree); err != nil {
+			return err
+		}
+	}
+
+	// Truncate the search index size if it exceeds our configured limit now.
+	for _, tableName := range []string{tableNamePublic, tableNamePrivate} {
+		if err := s.truncateDocumentationSearchIndexSize(ctx, tableName); err != nil {
+			return errors.Wrap(err, "truncating documentation search index size")
+		}
+	}
+	return nil
+}
+
+const purgeDocumentationSearchOldData = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go:WriteDocumentationSearch
+WITH candidates AS (
+	SELECT dump_id FROM $TABLE_NAME
+	WHERE repo_id=%s
+	AND dump_root=%s
+
+	-- Lock these rows in a deterministic order so that we don't deadlock with other processes
+	-- updating the lsif_data_documentation_search_* tables.
+	ORDER BY dump_id FOR UPDATE
+)
+DELETE FROM $TABLE_NAME
+WHERE dump_id IN (SELECT dump_id FROM candidates)
+AND lang=%s
+RETURNING dump_id
+`
+
+const writeDocumentationSearchInsertQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go:WriteDocumentationSearch
+INSERT INTO $TABLE_NAME (dump_id, dump_root, path_id, lang, repo_name, search_key, label, detail, tags, repo_id)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+`
+
+var (
+	lastTruncationWarningMu   sync.Mutex
+	lastTruncationWarningTime time.Time
+)
+
+// truncateDocumentationSearchIndexSize is called (within a transaction) to truncate the
+// documentation search index size according to the site config apidocs.search-index-limit-factor.
+func (s *Store) truncateDocumentationSearchIndexSize(ctx context.Context, tableName string) error {
+	totalRows, exists, err := basestore.ScanFirstInt64(s.Query(ctx, sqlf.Sprintf(
+		strings.ReplaceAll(countDocumentationSearchRowsQuery, "$TABLE_NAME", tableName),
+	)))
+	if !exists {
+		return fmt.Errorf("failed to count table size")
+	}
+	if err != nil {
+		return errors.Wrap(err, "counting table size")
+	}
+
+	searchIndexLimitFactor := conf.Get().ApidocsSearchIndexSizeLimitFactor
+	if searchIndexLimitFactor <= 0 {
+		searchIndexLimitFactor = 1.0
+	}
+	searchIndexRowsLimit := int64(searchIndexLimitFactor * 250_000_000)
+	rowsToDelete := totalRows - searchIndexRowsLimit
+	if rowsToDelete <= 0 {
+		return nil
+	}
+
+	lastTruncationWarningMu.Lock()
+	if lastTruncationWarningTime.IsZero() || time.Since(lastTruncationWarningTime) > 5*time.Minute {
+		lastTruncationWarningTime = time.Now()
+		log15.Warn(
+			"API docs search index size exceeded configured limit, truncating index",
+			"apidocs.search-index-limit-factor", searchIndexLimitFactor,
+			"rows_limit", searchIndexRowsLimit,
+			"total_rows", totalRows,
+			"deleting", rowsToDelete,
+		)
+	}
+	lastTruncationWarningMu.Unlock()
+
+	// Delete the first (oldest) N rows
+	if err := s.Exec(ctx, sqlf.Sprintf(
+		strings.ReplaceAll(truncateDocumentationSearchRowsQuery, "$TABLE_NAME", tableName),
+		rowsToDelete,
+	)); err != nil {
+		return errors.Wrap(err, "truncating search index rows")
+	}
+	return nil
+}
+
+// TODO(apidocs): future: introduce materialized count for this table and for other interesting API
+// docs data points in general. https://github.com/sourcegraph/sourcegraph/pull/25206#discussion_r714270738
+const countDocumentationSearchRowsQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go:truncateDocumentationSearchIndexSize
+SELECT count(*)::bigint FROM $TABLE_NAME
+`
+
+const truncateDocumentationSearchRowsQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go:truncateDocumentationSearchIndexSize
+WITH candidates AS (
+	SELECT ctid FROM $TABLE_NAME
+
+	-- Lock these rows in a deterministic order so that we don't deadlock with other processes
+	-- updating the lsif_data_documentation_search_* tables.
+	ORDER BY dump_id FOR UPDATE
+	LIMIT %s
+)
+DELETE FROM $TABLE_NAME
+WHERE ctid IN (SELECT ctid FROM candidates)
+RETURNING ctid
+`
+
+// truncate truncates a string to limitBytes, taking into account multi-byte runes. If the string
+// is truncated, an ellipsis "…" is added to the end.
+func truncate(s string, limitBytes int) string {
+	runes := []rune(s)
+	bytes := 0
+	for i, r := range runes {
+		if bytes+len(string(r)) >= limitBytes {
+			return string(runes[:i-1]) + "…"
+		}
+		bytes += len(string(r))
+	}
+	return s
+}

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -35,6 +35,7 @@ type operations struct {
 	writeDocumentationPages       *observation.Operation
 	writeDocumentationPathInfo    *observation.Operation
 	writeDocumentationMappings    *observation.Operation
+	writeDocumentationSearch      *observation.Operation
 
 	locations           *observation.Operation
 	locationsWithinFile *observation.Operation
@@ -93,6 +94,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		writeDocumentationPages:       op("WriteDocumentationPages"),
 		writeDocumentationPathInfo:    op("WriteDocumentationPathInfo"),
 		writeDocumentationMappings:    op("WriteDocumentationMappings"),
+		writeDocumentationSearch:      op("WriteDocumentationSearch"),
 
 		locations:           subOp("locations"),
 		locationsWithinFile: subOp("locationsWithinFile"),

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -298,6 +298,14 @@ func EventLoggingEnabled() bool {
 	return val == "enabled"
 }
 
+func APIDocsSearchIndexingEnabled() bool {
+	val := ExperimentalFeatures().ApidocsSearchIndexing
+	if val == "" {
+		return true
+	}
+	return val == "enabled"
+}
+
 func StructuralSearchEnabled() bool {
 	val := ExperimentalFeatures().StructuralSearch
 	if val == "" {

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -129,8 +129,8 @@ Associates documentation page pathIDs to information about what is at that pathI
 
 # Table "public.lsif_data_documentation_search_private"
 ```
-   Column   |  Type   | Collation | Nullable | Default 
-------------+---------+-----------+----------+---------
+   Column   |  Type   | Collation | Nullable | Default  
+------------+---------+-----------+----------+----------
  dump_id    | integer |           | not null | 
  repo_id    | integer |           | not null | 
  path_id    | text    |           | not null | 
@@ -140,6 +140,7 @@ Associates documentation page pathIDs to information about what is at that pathI
  search_key | text    |           | not null | 
  label      | text    |           | not null | 
  tags       | text    |           | not null | 
+ dump_root  | text    |           | not null | ''::text
 Indexes:
     "lsif_data_documentation_search_private_pkey" PRIMARY KEY, btree (dump_id, path_id)
     "lsif_data_documentation_search_private_label_trgm" gin (label gin_trgm_ops)
@@ -157,6 +158,8 @@ A trigram index over documentation for search (private repos only)
 
 **dump_id**: The identifier of the associated dump in the lsif_uploads table (state=completed).
 
+**dump_root**: Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.
+
 **label**: The label string of the result, e.g. a one-line function signature. See protocol/documentation.go:Documentation
 
 **lang**: The lowercase language name (go, java, etc.) OR, if unknown, the LSIF indexer name
@@ -173,8 +176,8 @@ A trigram index over documentation for search (private repos only)
 
 # Table "public.lsif_data_documentation_search_public"
 ```
-   Column   |  Type   | Collation | Nullable | Default 
-------------+---------+-----------+----------+---------
+   Column   |  Type   | Collation | Nullable | Default  
+------------+---------+-----------+----------+----------
  dump_id    | integer |           | not null | 
  repo_id    | integer |           | not null | 
  path_id    | text    |           | not null | 
@@ -184,8 +187,11 @@ A trigram index over documentation for search (private repos only)
  search_key | text    |           | not null | 
  label      | text    |           | not null | 
  tags       | text    |           | not null | 
+ dump_root  | text    |           | not null | ''::text
 Indexes:
     "lsif_data_documentation_search_public_pkey" PRIMARY KEY, btree (dump_id, path_id)
+    "lsif_data_documentation_search_private_dump_root_idx" btree (dump_root)
+    "lsif_data_documentation_search_public_dump_root_idx" btree (dump_root)
     "lsif_data_documentation_search_public_label_trgm" gin (label gin_trgm_ops)
     "lsif_data_documentation_search_public_lang_trgm" gin (lang gin_trgm_ops)
     "lsif_data_documentation_search_public_repo_id_idx" btree (repo_id)
@@ -200,6 +206,8 @@ A trigram index over documentation for search (public repos only)
 **detail**: The detail string (e.g. the full function signature and its docs). See protocol/documentation.go:Documentation
 
 **dump_id**: The identifier of the associated dump in the lsif_uploads table (state=completed).
+
+**dump_root**: Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.
 
 **label**: The label string of the result, e.g. a one-line function signature. See protocol/documentation.go:Documentation
 

--- a/migrations/codeintel/1000000023_apidocs_add_dump_root_column.down.sql
+++ b/migrations/codeintel/1000000023_apidocs_add_dump_root_column.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE lsif_data_documentation_search_public DROP COLUMN IF EXISTS dump_root;
+ALTER TABLE lsif_data_documentation_search_private DROP COLUMN IF EXISTS dump_root;
+
+COMMIT;

--- a/migrations/codeintel/1000000023_apidocs_add_dump_root_column.up.sql
+++ b/migrations/codeintel/1000000023_apidocs_add_dump_root_column.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE lsif_data_documentation_search_public ADD COLUMN dump_root TEXT NOT NULL DEFAULT '';
+COMMENT ON COLUMN lsif_data_documentation_search_public.dump_root IS 'Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.';
+CREATE INDEX lsif_data_documentation_search_public_dump_root_idx ON lsif_data_documentation_search_public USING BTREE(dump_root);
+
+ALTER TABLE lsif_data_documentation_search_private ADD COLUMN dump_root TEXT NOT NULL DEFAULT '';
+COMMENT ON COLUMN lsif_data_documentation_search_private.dump_root IS 'Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.';
+CREATE INDEX lsif_data_documentation_search_private_dump_root_idx ON lsif_data_documentation_search_public USING BTREE(dump_root);
+
+-- Truncate both tables; we don't care about reindexing given so little has been indexed to date.
+TRUNCATE lsif_data_documentation_search_public;
+TRUNCATE lsif_data_documentation_search_private;
+
+COMMIT;

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -538,6 +538,8 @@ type ExpandedGitCommitDescription struct {
 type ExperimentalFeatures struct {
 	// AndOrQuery description: DEPRECATED: Interpret a search input query as an and/or query.
 	AndOrQuery string `json:"andOrQuery,omitempty"`
+	// ApidocsSearchIndexing description: Index API docs for search, see https://docs.sourcegraph.com/code_intelligence/apidocs
+	ApidocsSearchIndexing string `json:"apidocs.search.indexing,omitempty"`
 	// BitbucketServerFastPerm description: DEPRECATED: Configure in Bitbucket Server config.
 	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
 	// CustomGitFetch description: JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command.
@@ -1438,6 +1440,8 @@ type SettingsExperimentalFeatures struct {
 type SiteConfiguration struct {
 	// ApiRatelimit description: Configuration for API rate limiting
 	ApiRatelimit *ApiRatelimit `json:"api.ratelimit,omitempty"`
+	// ApidocsSearchIndexSizeLimitFactor description: Limit factor for API docs search index size. A multiple of 250 million symbols. 1.0 indicates 250 million symbols (approx 12.5k repos) can be indexed. 2.0 indicates double that, and so on. See https://docs.sourcegraph.com/code_intelligence/apidocs
+	ApidocsSearchIndexSizeLimitFactor float64 `json:"apidocs.search.index-size-limit-factor,omitempty"`
 	// AuthAccessTokens description: Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.
 	AuthAccessTokens *AuthAccessTokens `json:"auth.accessTokens,omitempty"`
 	// AuthEnableUsernameChanges description: Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -44,6 +44,12 @@
       "group": "Debug",
       "examples": [["20"]]
     },
+    "apidocs.search.index-size-limit-factor": {
+      "description": "Limit factor for API docs search index size. A multiple of 250 million symbols. 1.0 indicates 250 million symbols (approx 12.5k repos) can be indexed. 2.0 indicates double that, and so on. See https://docs.sourcegraph.com/code_intelligence/apidocs",
+      "type": "number",
+      "default": 1.0,
+      "additionalProperties": false
+    },
     "experimentalFeatures": {
       "description": "Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.",
       "type": "object",
@@ -71,6 +77,12 @@
               "default": false
             }
           }
+        },
+        "apidocs.search.indexing": {
+          "description": "Index API docs for search, see https://docs.sourcegraph.com/code_intelligence/apidocs",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "enabled"
         },
         "structuralSearch": {
           "description": "Enables structural search.",


### PR DESCRIPTION
## Third time's the charm :)

* I had first sent this change in #25206. It turned out to have a [fatal flaw](https://github.com/sourcegraph/sourcegraph/pull/25206#discussion_r715167502) in which it was reading from a table in the wrong DB, an easy mistake to make due to us testing and developing against a single DB. Tests wouldn't have helped here, but me and @efritz have discussed some options for preventing this in the future including maybe running separate databases (in the same postgres instance) in dev, CI, or dev+CI environments.
* I secondarily fixed the issue, which was a small change, in #25666 - but completely fumbled communication with my reviewer and prematurely merged the PR without approval (I've since chatted with both him and my manager, and will make sure this doesn't happen again - sorry again!)
* Now I'm re-sending again. Third time's the charm (maybe?) :) 

## Background

* In #25197 I landed architecture docs to detail how we arrived at using Postgres FTS for API docs search integration, the tradeoffs/implications of doing so, general implementation plan for it, etc.
* In #25199 I landed the initial DB schema for adding a Postgres FTS index over API docs data (i.e. all symbols we have stored/indexed in API docs, currently just a few thousand Go repos.) 

## This PR

This PR updates the codeintel worker, and lsifstore, to begin actually writing API docs data to the new `lsif_data_documentation_search_public` and ``lsif_data_documentation_search_private` tables when new LSIF bundles are uploaded. This is on by default, but can be disabled via the new site config feature flag `"apidocs.search.indexing": "disabled"`.

These tables are for API docs _search indexing only_, and to prevent any scaling issues / not break the DB, the default configuration `"apidocs.search.index-size-limit-factor": 1.0` limits the size of each table independently to 250 million symbols (rows) (500 million across both tables, approx. 12.5k Go repos total). This was arrived at through [some estimation documented in the architecture design doc.](https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/background-information/codeintel/apidocs/index.md#scaling-estimation)

Once queries against the table have solidified more, things have settled, and I've optimized the table further (to eliminate data that is needlessly repetitive across rows) we will begin to relax the search index size limit to beyond 500 million symbols / 12.5k Go repos.

Helps #25193

## Future

To keep this PR small, the next PRs I have staged are for:

1. codeintel: Add an OOB migration which migrates existing data into the search index
2. codeintel: Add the actual code for querying this index, add a new GraphQL API for exposing it, etc.
3. search: Integrate this into search suggestions
