### PR TITLE
sg: Fix migration command connecting to default database

### DIFF
--- a/dev/sg/internal/migration/migration.go
+++ b/dev/sg/internal/migration/migration.go
@@ -342,7 +342,13 @@ func makePostgresDSN(database db.Database) string {
 	if user, err := user.Current(); err == nil {
 		username = user.Username
 	}
-	return postgresdsn.New(database.Name, username, os.Getenv)
+
+	prefix := ""
+	if database.Name != db.DefaultDatabase.Name {
+		prefix = strings.ToUpper(database.Name) + "_"
+	}
+
+	return postgresdsn.New(prefix, username, os.Getenv)
 }
 
 // ReadFilenamesNamesInDirectory returns a list of names in the given directory.


### PR DESCRIPTION
This fixes the regression introduced in 11239b098b362cc4d00d53da7308daeb3c987933.

Before 11239b0 we didn't need a prefix for the `PG*` env vars to
connect to the default database, meaning that all the `PGUSER` env vars
etc. would be used unchanged.

11239b0 removed the prefix defaulting to "" which broke that behaviour.

This reintroduces it.
