### PR TITLE
web: include CSS modules assets into the browser extension

### DIFF
--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -118,6 +118,7 @@ export function copyIntegrationAssets(): void {
     shelljs.cp('build/dist/js/integration.bundle.js', 'build/integration/scripts')
     shelljs.cp('build/dist/js/extensionHostWorker.bundle.js', 'build/integration/scripts')
     shelljs.cp('build/dist/css/style.bundle.css', 'build/integration/css')
+    shelljs.cp('build/dist/css/inject.bundle.css', 'build/integration/css')
     shelljs.cp('src/native-integration/extensionHostFrame.html', 'build/integration')
     // Copy to the ui/assets directory so that these files can be served by
     // the webapp.

--- a/client/browser/src/native-integration/integration.main.ts
+++ b/client/browser/src/native-integration/integration.main.ts
@@ -14,6 +14,21 @@ const IS_EXTENSION = false
 
 setLinkComponent(AnchorLink)
 
+interface InsertStyleSheetOptions {
+    id: string
+    path: string
+    assetsURL: string
+}
+
+function insertStyleSheet({ id, path, assetsURL }: InsertStyleSheetOptions): void {
+    const link = document.createElement('link')
+    link.setAttribute('rel', 'stylesheet')
+    link.setAttribute('type', 'text/css')
+    link.setAttribute('href', new URL(path, assetsURL).href)
+    link.id = id
+    document.head.append(link)
+}
+
 function init(): void {
     console.log('Sourcegraph native integration is running')
     const sourcegraphURL = window.SOURCEGRAPH_URL
@@ -30,12 +45,8 @@ function init(): void {
     } else {
         injectExtensionMarker()
     }
-    const link = document.createElement('link')
-    link.setAttribute('rel', 'stylesheet')
-    link.setAttribute('type', 'text/css')
-    link.setAttribute('href', new URL('css/style.bundle.css', assetsURL).href)
-    link.id = 'sourcegraph-styles'
-    document.head.append(link)
+    insertStyleSheet({ id: 'sourcegraph-styles', path: 'css/style.bundle.css', assetsURL })
+    insertStyleSheet({ id: 'sourcegraph-styles-css-modules', path: 'css/inject.bundle.css', assetsURL })
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL
     // TODO handle subscription

--- a/client/browser/src/native-integration/phabricator/integration.main.ts
+++ b/client/browser/src/native-integration/phabricator/integration.main.ts
@@ -16,6 +16,20 @@ const IS_EXTENSION = false
 
 setLinkComponent(AnchorLink)
 
+interface AppendHeadStylesOptions {
+    id: string
+    cssURL: string
+}
+
+async function appendHeadStyles({ id, cssURL }: AppendHeadStylesOptions): Promise<void> {
+    const css = await getPhabricatorCSS(cssURL)
+    const style = document.createElement('style')
+    style.setAttribute('type', 'text/css')
+    style.id = id
+    style.textContent = css
+    document.head.append(style)
+}
+
 async function init(): Promise<void> {
     /**
      * This is the main entry point for the phabricator in-page JavaScript plugin.
@@ -47,12 +61,19 @@ async function init(): Promise<void> {
     }
 
     window.SOURCEGRAPH_URL = sourcegraphURL
-    const css = await getPhabricatorCSS(sourcegraphURL)
-    const style = document.createElement('style')
-    style.setAttribute('type', 'text/css')
-    style.id = 'sourcegraph-styles'
-    style.textContent = css
-    document.head.append(style)
+
+    const styleSheets = [
+        {
+            id: 'sourcegraph-styles',
+            cssURL: sourcegraphURL + '/.assets/extension/css/style.bundle.css',
+        },
+        {
+            id: 'sourcegraph-styles-css-modules',
+            cssURL: sourcegraphURL + '/.assets/extension/css/style.bundle.css',
+        },
+    ]
+    await Promise.all(styleSheets.map(appendHeadStyles))
+
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     metaClickOverride()
     injectExtensionMarker()

--- a/client/browser/src/shared/code-hosts/phabricator/backend.tsx
+++ b/client/browser/src/shared/code-hosts/phabricator/backend.tsx
@@ -109,9 +109,9 @@ function createConduitRequestForm(): FormData {
  * Native installation of the Phabricator extension does not allow for us to fetch the style.bundle from a script element.
  * To get around this we fetch the bundled CSS contents and append it to the DOM.
  */
-export async function getPhabricatorCSS(sourcegraphURL: string): Promise<string> {
+export async function getPhabricatorCSS(cssURL: string): Promise<string> {
     const bundleUID = process.env.BUNDLE_UID!
-    const response = await fetch(sourcegraphURL + `/.assets/extension/css/style.bundle.css?v=${bundleUID}`, {
+    const response = await fetch(`${cssURL}?v=${bundleUID}`, {
         method: 'GET',
         credentials: 'include',
         headers: new Headers({ Accept: 'text/html' }),

--- a/client/web/src/regression/integrations.test.ts
+++ b/client/web/src/regression/integrations.test.ts
@@ -14,6 +14,7 @@ describe('Native integrations regression test suite', () => {
             '/.assets/extension/scripts/phabricator.bundle.js',
             '/.assets/extension/scripts/extensionHostWorker.bundle.js',
             '/.assets/extension/css/style.bundle.css',
+            '/.assets/extension/css/inject.bundle.css',
             '/.assets/extension/extensionHostFrame.html',
         ]
         await merge(


### PR DESCRIPTION
## Context

The migration to CSS modules [shows](https://github.com/sourcegraph/sourcegraph/pull/25631) that assets produced by the CSS module loader are not available in the browser extension build. This issue is similar to [the one](https://github.com/sourcegraph/sourcegraph/pull/25210) we encountered some time ago with the after-install page. It seems that `inject.bundle.css` should be loaded along with `style.bundle.css` to fix the issue.

### Step to repro

1. Pull-in [this commit](https://github.com/sourcegraph/sourcegraph/commit/0b82e4d3568c16354f4ac2e8c33a1ba47fa031e7).
2. Build browser extension.
3. Install it in Chrome.
4. Try to open `HoverOverlay` on Github. 

It's not visible because CSS module styles are not loaded.

## Changes

- Load `inject.bundle.css` along with `style.bundle.css`.