### PR TITLE
Add original filename to git blame GraphQL response

### DIFF
--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -51,3 +51,7 @@ func (r *hunkResolver) Message() string {
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
 	return toGitCommitResolver(r.repo, r.db, r.hunk.CommitID, nil), nil
 }
+
+func (r *hunkResolver) Filename() string {
+	return r.hunk.Filename
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4217,6 +4217,10 @@ type Hunk {
     The commit that contains the hunk.
     """
     commit: GitCommit!
+    """
+    The filename at the commit.
+    """
+    filename: String!
 }
 
 """

--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -21,15 +21,26 @@ func TestRepository_BlameFile(t *testing.T) {
 		"echo line2 >> f",
 		"git add f",
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"git mv f f2",
+		"echo line3 >> f2",
+		"git add f2",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 	}
 	gitWantHunks := []*Hunk{
 		{
 			StartLine: 1, EndLine: 2, StartByte: 0, EndByte: 6, CommitID: "e6093374dcf5725d8517db0dccbbf69df65dbde0",
 			Message: "foo", Author: gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Filename: "f",
 		},
 		{
 			StartLine: 2, EndLine: 3, StartByte: 6, EndByte: 12, CommitID: "fad406f4fe02c358a09df0d03ec7a36c2c8a20f1",
 			Message: "foo", Author: gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Filename: "f",
+		},
+		{
+			StartLine: 3, EndLine: 4, StartByte: 12, EndByte: 18, CommitID: "311d75a2b414a77f5158a0ed73ec476f5469b286",
+			Message: "foo", Author: gitapi.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Filename: "f2",
 		},
 	}
 	tests := map[string]struct {
@@ -41,7 +52,7 @@ func TestRepository_BlameFile(t *testing.T) {
 	}{
 		"git cmd": {
 			repo: MakeGitRepository(t, gitCommands...),
-			path: "f",
+			path: "f2",
 			opt: &BlameOptions{
 				NewestCommit: "master",
 			},


### PR DESCRIPTION
Previously, the GraphQL endpoint for git blame didn't include the name of the original
file where the blame got added. If the file got renamed, it was not possible to
show the file at the commit where that blame got added. This commit adds
a new `filename: String!` field to the `Hunk` type in the GraphQL
schema.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
