### PR TITLE
extension: use streaming search for suggestions

### DIFF
--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -148,7 +148,7 @@ async function main(): Promise<void> {
     )
 
     if (browser.omnibox) {
-        initializeOmniboxInterface(requestGraphQL)
+        initializeOmniboxInterface()
 
         // Configure the omnibox when the sourcegraphURL changes.
         subscriptions.add(

--- a/client/browser/src/shared/cli/index.ts
+++ b/client/browser/src/shared/cli/index.ts
@@ -1,9 +1,7 @@
-import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
-
 import { SearchCommand } from './search'
 
-export function initializeOmniboxInterface(requestGraphQL: PlatformContext['requestGraphQL']): void {
-    const searchCommand = new SearchCommand(requestGraphQL)
+export function initializeOmniboxInterface(): void {
+    const searchCommand = new SearchCommand()
     browser.omnibox.onInputChanged.addListener(async (query, suggest) => {
         try {
             const suggestions = await searchCommand.getSuggestions(query)

--- a/client/browser/src/shared/cli/search.ts
+++ b/client/browser/src/shared/cli/search.ts
@@ -1,7 +1,6 @@
 import { from } from 'rxjs'
 import { take } from 'rxjs/operators'
 
-import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isDefined, isNot } from '@sourcegraph/shared/src/util/types'
@@ -18,23 +17,22 @@ const IS_EXTENSION = true // This feature is only supported in browser extension
 export class SearchCommand {
     public description = 'Enter a search query'
 
-    private suggestionFetcher = createSuggestionFetcher(20, this.requestGraphQL)
+    private suggestionFetcher = createSuggestionFetcher()
 
     private prev: { query: string; suggestions: browser.omnibox.SuggestResult[] } = { query: '', suggestions: [] }
 
-    constructor(private requestGraphQL: PlatformContext['requestGraphQL']) {}
-
-    public getSuggestions = (query: string): Promise<browser.omnibox.SuggestResult[]> =>
-        new Promise(resolve => {
+    public getSuggestions = async (query: string): Promise<browser.omnibox.SuggestResult[]> => {
+        const sourcegraphURL = await observeSourcegraphURL(IS_EXTENSION).pipe(take(1)).toPromise()
+        return new Promise(resolve => {
             if (this.prev.query === query) {
                 resolve(this.prev.suggestions)
                 return
             }
 
             this.suggestionFetcher({
-                query,
-                handler: async suggestions => {
-                    const sourcegraphURL = await observeSourcegraphURL(IS_EXTENSION).pipe(take(1)).toPromise()
+                sourcegraphURL,
+                queries: [`${query} type:repo count:5`, `${query} type:path count:5`, `${query} type:symbol count:5`],
+                handler: suggestions => {
                     const built = suggestions.map(({ title, url, urlLabel }) => ({
                         content: `${sourcegraphURL}${url}`,
                         description: `${title} - ${urlLabel}`,
@@ -49,6 +47,7 @@ export class SearchCommand {
                 },
             })
         })
+    }
 
     public action = async (
         query: string,

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -421,6 +421,7 @@ export interface StreamSearchOptions {
     caseSensitive: boolean
     versionContext: string | undefined
     trace: string | undefined
+    sourcegraphURL?: string
     decorationKinds?: string[]
     decorationContextLines?: number
 }
@@ -441,6 +442,7 @@ function search(
         trace,
         decorationKinds,
         decorationContextLines,
+        sourcegraphURL = '',
     }: StreamSearchOptions,
     messageHandlers: MessageHandlers
 ): Observable<SearchEvent> {
@@ -462,7 +464,7 @@ function search(
         }
         const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
 
-        const eventSource = new EventSource('/search/stream?' + parameterEncoded)
+        const eventSource = new EventSource(`${sourcegraphURL}/search/stream?${parameterEncoded}`)
         const subscriptions = new Subscription()
         for (const [eventType, handleMessages] of Object.entries(messageHandlers)) {
             subscriptions.add(

--- a/client/shared/src/search/suggestions/index.ts
+++ b/client/shared/src/search/suggestions/index.ts
@@ -4,7 +4,7 @@ import { map } from 'rxjs/operators'
 import { SearchPatternType, SearchVersion } from '../../graphql-operations'
 import { firstMatchStreamingSearch, SearchMatch } from '../stream'
 
-export function fetchStreamSuggestions(query: string): Observable<SearchMatch[]> {
+export function fetchStreamSuggestions(query: string, sourcegraphURL?: string): Observable<SearchMatch[]> {
     return firstMatchStreamingSearch({
         query,
         version: SearchVersion.V2,
@@ -12,5 +12,6 @@ export function fetchStreamSuggestions(query: string): Observable<SearchMatch[]>
         caseSensitive: false,
         versionContext: undefined,
         trace: undefined,
+        sourcegraphURL,
     }).pipe(map(suggestions => suggestions.results))
 }


### PR DESCRIPTION
We are moving away from GQL suggestions towards using our streaming search as a suggestions source. See base PR: https://github.com/sourcegraph/sourcegraph/pull/25512

It also turns out that in the current extension the suggestions do not appear. So I made a small change to get them working again.

Fixes #780