### PR TITLE
ci: add a preview flag to output computed steps

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -50,7 +50,7 @@ func previewPipeline(w io.Writer, c ci.Config, bk *buildkite.Pipeline) {
 	fmt.Fprintln(w, "Detected changes:")
 	fmt.Fprintf(w, "\tAffects Client: %t\n", c.ChangedFiles.AffectsClient())
 	fmt.Fprintf(w, "\tAffects Go: %t\n", c.ChangedFiles.AffectsGo())
-	fmt.Fprintf(w, "\tAffects DockerFile: %t\n", c.ChangedFiles.AffectsDockerfiles())
+	fmt.Fprintf(w, "\tAffects Dockerfiles: %t\n", c.ChangedFiles.AffectsDockerfiles())
 	fmt.Fprintf(w, "\tAffects GraphQL: %t\n", c.ChangedFiles.AffectsGraphQL())
 	fmt.Fprintf(w, "\tAffects SG: %t\n", c.ChangedFiles.AffectsSg())
 	fmt.Fprintf(w, "Computed Build Steps:\n")

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -3,13 +3,26 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"io"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci"
 )
 
+var preview bool
+
+func init() {
+	flag.BoolVar(&preview, "preview", false, "Preview the pipeline steps")
+}
+
 func main() {
+	flag.Parse()
+
 	config := ci.NewConfig(time.Now())
 
 	pipeline, err := ci.GeneratePipeline(config)
@@ -17,8 +30,36 @@ func main() {
 		panic(err)
 	}
 
+	if preview {
+		previewPipeline(os.Stdout, config, pipeline)
+		return
+	}
+
 	_, err = pipeline.WriteTo(os.Stdout)
 	if err != nil {
 		panic(err)
+	}
+}
+
+func previewPipeline(w io.Writer, c ci.Config, bk *buildkite.Pipeline) {
+	fmt.Fprintf(w, "Detected run type: %s\n", c.RunType.String())
+	fmt.Fprintf(w, "Detected Changed files (%d):\n", len(c.ChangedFiles))
+	for _, f := range c.ChangedFiles {
+		fmt.Fprintf(w, "\t%s\n", f)
+	}
+	fmt.Fprintln(w, "Detected changes:")
+	fmt.Fprintf(w, "\tAffects Client: %t\n", c.ChangedFiles.AffectsClient())
+	fmt.Fprintf(w, "\tAffects Go: %t\n", c.ChangedFiles.AffectsGo())
+	fmt.Fprintf(w, "\tAffects DockerFile: %t\n", c.ChangedFiles.AffectsDockerfiles())
+	fmt.Fprintf(w, "\tAffects GraphQL: %t\n", c.ChangedFiles.AffectsGraphQL())
+	fmt.Fprintf(w, "\tAffects SG: %t\n", c.ChangedFiles.AffectsSg())
+	fmt.Fprintf(w, "Computed Build Steps:\n")
+	for _, raw := range bk.Steps {
+		if step, ok := raw.(*buildkite.Step); ok {
+			fmt.Fprintf(w, "\t%s\n", step.Label)
+			if len(step.DependsOn) > 0 {
+				fmt.Fprintf(w, "\t→ depends on %s\n", strings.Join(step.DependsOn, " "))
+			}
+		}
 	}
 }

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -104,5 +104,5 @@ func (t RunType) String() string {
 	case BackendDryRun:
 		return "Backend dry run"
 	}
-	return ""
+	panic("Run type does not have a full name defined")
 }

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -78,3 +78,31 @@ func (t RunType) Is(oneOfTypes ...RunType) bool {
 	}
 	return false
 }
+
+func (t RunType) String() string {
+	switch t {
+	case PullRequest:
+		return "PullRequest"
+	case MainBranch:
+		return "MainBranch"
+	case TaggedRelease:
+		return "TaggedRelease"
+	case ReleaseBranch:
+		return "ReleaseBranch"
+	case BextReleaseBranch:
+		return "Browser Extension Release Build"
+	case BextNightly:
+		return "Browser Extension Release Build"
+	case ImagePatch:
+		return "Patched Image"
+	case ImagePatchNoTest:
+		return "Patched Image without testing"
+	case CandidatesNoTest:
+		return "Build All candidates without testing"
+	case MainDryRun:
+		return "Main dry run"
+	case BackendDryRun:
+		return "Backend dry run"
+	}
+	return ""
+}


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/25479

```
$ go run enterprise/dev/ci/gen-pipeline.go -preview
Detected run type: PullRequest
Detected Changed files (2):
        enterprise/dev/ci/gen-pipeline.go
        enterprise/dev/ci/internal/ci/runtype.go
Detected changes:
        Affects Client: false
        Affects Go: true
        Affects DockerFile: false
        Affects GraphQL: false
        Affects SG: false
Computed Build Steps:
        :lipstick: Prettier
        :white_check_mark: Misc Linters
        :go: Test
        :go: Build
```