### PR TITLE
profiler: remove SRC_DISABLE_PROFILER envvar

### DIFF
--- a/cmd/frontend/envvar/envvar.go
+++ b/cmd/frontend/envvar/envvar.go
@@ -14,7 +14,6 @@ var HTTPAddrInternal = env.Get(
 )
 
 var sourcegraphDotComMode, _ = strconv.ParseBool(env.Get("SOURCEGRAPHDOTCOM_MODE", "false", "run as Sourcegraph.com, with add'l marketing and redirects"))
-var disableProfiler, _ = strconv.ParseBool(env.Get("SRC_DISABLE_PROFILER", "false", "Disable the gcloud profiler, for use when running locally without gcloud config"))
 var openGraphPreviewServiceURL = env.Get("OPENGRAPH_PREVIEW_SERVICE_URL", "", "The URL of the OpenGraph preview image generating service")
 
 // SourcegraphDotComMode is true if this server is running Sourcegraph.com
@@ -27,10 +26,6 @@ func SourcegraphDotComMode() bool {
 // MockSourcegraphDotComMode is used by tests to mock the result of SourcegraphDotComMode.
 func MockSourcegraphDotComMode(value bool) {
 	sourcegraphDotComMode = value
-}
-
-func DisableProfiler() bool {
-	return disableProfiler
 }
 
 func OpenGraphPreviewServiceURL() string {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -4,17 +4,21 @@ import (
 	"cloud.google.com/go/profiler"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-// Init starts the Google Cloud Profiler when in sourcegraph.com mode.
-// https://cloud.google.com/profiler/docs/profiling-go
+// Init starts the Google Cloud Profiler when in sourcegraph.com mode in
+// production.  https://cloud.google.com/profiler/docs/profiling-go
 func Init() error {
-	if envvar.DisableProfiler() {
+	if !envvar.SourcegraphDotComMode() {
 		return nil
 	}
-	if !envvar.SourcegraphDotComMode() {
+
+	// SourcegraphDotComMode can be true in dev, so check we are in a k8s
+	// cluster.
+	if !conf.IsDeployTypeKubernetes(conf.DeployType()) {
 		return nil
 	}
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -15,9 +15,6 @@ env:
   # Enable sharded indexed search mode:
   INDEXED_SEARCH_SERVERS: localhost:3070 localhost:3071
 
-  # The profiler is a GCP feature and so is not supported locally.
-  SRC_DISABLE_PROFILER: 'true'
-
   GO111MODULE: 'on'
 
   DEPLOY_TYPE: dev


### PR DESCRIPTION
This feels like a weird environment variable to have. Rather than
another bit of env for our sg.config.yaml, lets detect we are not in
production a different way.

