### PR TITLE
fix: too small line height on commit node UI

### DIFF
--- a/client/web/src/repo/commits/GitCommitNode.scss
+++ b/client/web/src/repo/commits/GitCommitNode.scss
@@ -118,7 +118,6 @@
         flex: 1;
         min-width: 0;
         padding-right: 1rem;
-        line-height: 1;
     }
     &--compact &__message-subject {
         font-weight: normal;


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

## Description
- Fix: clipped text on repo overview page by changing its line height

## Screenshot

<img width="1679" alt="Screenshot at Oct 06 08-20-23" src="https://user-images.githubusercontent.com/51897872/136125814-6abb20e8-1e11-4194-9e44-ade67114d4db.png">

## Refs
- https://github.com/sourcegraph/sourcegraph/issues/23137
