### PR TITLE
Remove left-over mentions of `dev/start.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The fastest way to run Sourcegraph self-hosted is with the Docker container. See
 1. [Configure the HTTPS reverse proxy](doc/dev/getting-started/quickstart_5_configure_https_reverse_proxy.md)
 1. [Start the development server](doc/dev/getting-started/quickstart_6_start_server.md)
    ```sh
-   ./dev/start.sh
+   sg start
    ```
 
 Sourcegraph should now be running at https://sourcegraph.test:3443.

--- a/client/web/src/enterprise/productSubscription/LicenseGenerationKeyWarning.tsx
+++ b/client/web/src/enterprise/productSubscription/LicenseGenerationKeyWarning.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 /**
  * Displays a warning in debug mode (which is on for local dev) that generated license keys aren't
- * actually valid. Local dev (in dev/start.sh) uses a test private key that does NOT correspond to
+ * actually valid. Local dev (with `sg start`) uses a test private key that does NOT correspond to
  * the license validation public key shipped with Sourcegraph instances.
  *
  * Technically it's possible to generate valid license keys in debug mode (if you manually configure

--- a/cmd/server/shared/globals.go
+++ b/cmd/server/shared/globals.go
@@ -10,7 +10,7 @@ package shared
 //
 // The same data is currently reflected in the following (and should be kept in-sync):
 //   - the SRC_PROF_SERVICES envvar when using sg
-//   - the file dev/src-prof-services.json when using by using start.sh
+//   - the file dev/src-prof-services.json when using by using `sg start`
 var SrcProfServices = []map[string]string{
 	{"Name": "frontend", "Host": "127.0.0.1:6063"},
 	{"Name": "gitserver", "Host": "127.0.0.1:6068"},

--- a/cmd/symbols/universal-ctags-dev
+++ b/cmd/symbols/universal-ctags-dev
@@ -3,7 +3,7 @@
 # This script is a wrapper around `universal-ctags`.
 #
 # To use your own `universal-ctags` binary instead of this wrapper in your local dev server, use
-# `CTAGS_COMMAND=path/to/ctags dev/start.sh`.
+# `CTAGS_COMMAND=path/to/ctags sg start`.
 
 exec docker run --rm -i \
     -a stdin -a stdout -a stderr \

--- a/dev/auth-provider/README.md
+++ b/dev/auth-provider/README.md
@@ -4,9 +4,9 @@
 
 ## Using Keycloak in local dev
 
-Keycloak is **not** started by default when you run `dev/start.sh`.
+Keycloak is **not** started by default when you run `sg start`.
 
-To enable it, use `USE_KEYCLOAK=1 dev/start.sh`.
+To enable it, run it separately with `./dev/auth-provider/keycloak.sh`.
 
 To use it, visit your local dev server's sign-in page and authenticate using an auth provider whose name contains "Keycloak".
 

--- a/dev/tilt/README.md
+++ b/dev/tilt/README.md
@@ -3,7 +3,7 @@
 > This is still a work in progress. `tilt` is useful when you have to develop k8s code and need a local cluster for your edit/compile/test cycle.
 > `tilt` can also be used with [bare processes](https://blog.tilt.dev/2020/02/12/local-dev.html) but we haven't converted and optimized our build
 > pipeline to it. The `tilt` team have given us a [starting point](https://github.com/windmilleng/sourcegraph/blob/master/Tiltfile) (thanks!).
-> For now, (until we convert, test and optimize this approach) please still use `enterprise/dev/start.sh`.
+> For now, (until we convert, test and optimize this approach) please still use `sg start`.
 
 (Instructions assume you are in this directory)
 

--- a/doc/dev/background-information/batch_changes/index.md
+++ b/doc/dev/background-information/batch_changes/index.md
@@ -19,7 +19,7 @@ Next: **create your first batch change!**
 
 > NOTE: **Make sure your local development environment is set up** by going through the "[Getting started](https://docs.sourcegraph.com/dev/getting-started)" guide.
 
-1. Since Batch Changes is an enterprise-only feature, make sure to start your local environment with `./enterprise/dev/start.sh`.
+1. Since Batch Changes is an enterprise-only feature, make sure to start your local environment with `sg start` (which defaults to `sg start enterprise`).
 1. Go through the [Quickstart for Batch Changes](https://docs.sourcegraph.com/batch_changes/quickstart) to create a batch change in your local environment. See "[Testing repositories](#testing-repositories)" for a list of repositories in which you can safely publish changesets.
 1. Now combine what you just did with some background information by reading the following:
 

--- a/doc/dev/background-information/codemonitoring/index.md
+++ b/doc/dev/background-information/codemonitoring/index.md
@@ -22,7 +22,7 @@ actions.
 Code monitoring is an enterprise functionality. To run it locally you need to start Sourcegraph as enterprise service:
 
 ```bash
-<sourcegraph root>/enterprise/dev/start.sh
+sg start # which defaults to `sg start enterprise`
 ```
 
 Code monitoring is still experimental which means you have to enable it in the

--- a/doc/dev/background-information/web/build.md
+++ b/doc/dev/background-information/web/build.md
@@ -55,7 +55,7 @@ Run `yarn upgrade -L PACKAGE`.
 
 [esbuild](https://esbuild.github.io/) is an alternative to Webpack for building `client/web` (the web app). Its usage on our codebase is **EXPERIMENTAL** and optional.
 
-To use esbuild instead of Webpack, set the env var `DEV_WEB_BUILDER=esbuild` (when using either `sg` or the `start.sh` script).
+To use esbuild instead of Webpack, set the env var `DEV_WEB_BUILDER=esbuild` (when using `sg start`).
 
 Comparison vs. Webpack:
 

--- a/doc/dev/background-information/web/web_app.md
+++ b/doc/dev/background-information/web/web_app.md
@@ -31,13 +31,13 @@ To install it, [see the instructions](../../getting-started/quickstart_6_install
 2. Start all backend services with the frontend server.
 
     ```sh
-    ./dev/start.sh
+    sg start # which defaults to `sg start enterprise`
     ```
 
-    For the enterprise version:
+    For the open-source version:
 
     ```sh
-    ./enterprise/dev/start.sh
+    sg start oss
     ```
 
 3. Regenerate GraphQL schema, Typescript types for GraphQL operations and CSS Modules.

--- a/doc/dev/how-to/debug_live_code.md
+++ b/doc/dev/how-to/debug_live_code.md
@@ -35,7 +35,7 @@ Then install `pgrep`:
 brew install proctools
 ```
 
-Make sure to run `env DELVE=true dev/start.sh` to disable optimizations during compilation, otherwise Delve will have difficulty stepping through optimized functions (line numbers will be off, you won't be able to print local variables, etc.).
+Make sure to run `env DELVE=true sg start` to disable optimizations during compilation, otherwise Delve will have difficulty stepping through optimized functions (line numbers will be off, you won't be able to print local variables, etc.).
 
 Now you can attach a debugger to any Go process (e.g. frontend, searcher, go-langserver) in 1 command:
 
@@ -55,4 +55,4 @@ Delve will pause the process once it attaches the debugger. Most used [commands]
 
 ## Attaching via Goland
 
-After running with `env DELVE=true dev/start.sh` you may use Run | Attach to Process in Goland to debug a running Go binary (⌥⇧F5 on macOS).
+After running with `env DELVE=true sg start` you may use Run | Attach to Process in Goland to debug a running Go binary (⌥⇧F5 on macOS).

--- a/doc/dev/how-to/documentation_implementation.md
+++ b/doc/dev/how-to/documentation_implementation.md
@@ -21,7 +21,7 @@ This structure is inspired by the [Divio documentation system](https://documenta
 
 ## Previewing changes locally
 
-You can preview the documentation site at http://localhost:5080 when running Sourcegraph in [local development](../getting-started/index.md) (using `dev/start.sh` or `enterprise/dev/start.sh`). It uses content, templates, and assets from the local disk. There is no caching or background build process, so you'll see all changes reflected immediately after you reload the page in your browser.
+You can preview the documentation site at http://localhost:5080 when running Sourcegraph in [local development](../getting-started/index.md) (using `sg start`). It uses content, templates, and assets from the local disk. There is no caching or background build process, so you'll see all changes reflected immediately after you reload the page in your browser.
 
 You can also run the docsite on its own with the following command:
 

--- a/doc/dev/how-to/index.md
+++ b/doc/dev/how-to/index.md
@@ -60,5 +60,5 @@ further, you *can* develop Sourcegraph with no connectivity by setting the
 `OFFLINE` environment variable:
 
 ```bash
-OFFLINE=true dev/start.sh
+OFFLINE=true sg start
 ```

--- a/doc/dev/how-to/monitoring_local_dev.md
+++ b/doc/dev/how-to/monitoring_local_dev.md
@@ -10,7 +10,8 @@ The [developing observability page](../background-information/observability/inde
 
 ### With all services
 
-The monitoring stack is included in the `./dev/start.sh` and `./enterprise/dev/start.sh` scripts.
+The monitoring stack is not included in `sg start` (or `sg start oss` and `sg start enterprise`) scripts.
+It needs to be started separately with `sg start monitoring`.
 Learn more about these in the [general development getting started guide](../getting-started/index.md).
 
 ### Without all services
@@ -79,7 +80,7 @@ One way to do this is to [start up Prometheus alongside all Sourcegraph services
 You can alternatively spin up just the frontend separately:
 
 ```sh
-./dev/start.sh --only frontend
+sg run enterprise-frontend # or: sg run frontend
 ```
 
 This should be sufficient to access the frontend API and the admin console (`/site-admin`), which is where most of the integration is.

--- a/doc/dev/how-to/troubleshooting_local_development.md
+++ b/doc/dev/how-to/troubleshooting_local_development.md
@@ -59,7 +59,7 @@ in the terminal.
 
 ## Increase maximum available file descriptors.
 
-`./dev/start.sh` may ask you to run ulimit to increase the maximum number
+`sg start` may ask you to run ulimit to increase the maximum number
 of available file descriptors for a process. You can make this setting
 permanent for every shell session by adding the following line to your
 `.*rc` file (usually `.bashrc` or `.zshrc`):
@@ -144,7 +144,7 @@ If you're running macOS 10.15.x (Catalina) reinstalling the Xcode Command Line T
 1. Uninstall the Command Line Tools with `rm -rf /Library/Developer/CommandLineTools`
 2. Reinstall it with `xcode-select --install`
 3. Go to `sourcegraph/sourcegraph`’s root directory and run `rm -rf node_modules`
-3. Re-run the launch script (`./dev/start.sh`)
+3. Re-start the dev environment (`sg start`)
 
 ## Permission errors for Grafana and Prometheus containers
 
@@ -163,14 +163,7 @@ prometheus | t=2021-05-26T10:05:26+0000 lvl=eror msg="command [/prometheus.sh --
 prometheus | t=2021-05-26T10:05:26+0000 lvl=eror msg="command [/alertmanager.sh --config.file=/sg_config_prometheus/alertmanag
 ```
 
-If you don't need these containers for your development work, the simplest solution
-is to start the development server without those containers:
-
-```sh
-./dev/start.sh --except grafana,prometheus
-```
-
-Otherwise, if files do not normally have group permissions in your environment
+If files do not normally have group permissions in your environment
 (e.g. if you set `umask 077`), then you need to
 
 1. Set group read permissions for the Grafana and Prometheus docker images, with
@@ -179,10 +172,10 @@ Otherwise, if files do not normally have group permissions in your environment
    chmod -R g=rX docker-images/{grafana,prometheus}
    ```
 
-2. Run `dev/start.sh` so that new files are group readable. If you have `umask`
-   set to a different value you can change that value just for this script by
+2. Run `sg start monitoring` so that new files are group readable. If you have `umask`
+   set to a different value you can change that value just for this command by
    starting it in a subshell:
 
    ```sh
-   (umask 027; ./dev/start.sh)
+   (umask 027; sg start monitoring)
    ```

--- a/docker-images/prometheus/config/README-dev.md
+++ b/docker-images/prometheus/config/README-dev.md
@@ -1,4 +1,4 @@
-The Prometheus lifecycle API is enabled in dev mode (when Sourcegraph is started by dev/start.sh or similar).
+The Prometheus lifecycle API is enabled in dev mode (when Sourcegraph is started by `sg start` or similar).
 You can edit, add, delete rules in this directory and then send
 
 ```shell script


### PR DESCRIPTION
We should probably do the same for `dev/db/add_migration.sh` and `dev/db/migrate.sh` (and replace with `sg migrate`) and some point.