### PR TITLE
[SG-24378] Long commit lines overlap in commit log view when multiple authors

### DIFF
--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -40,7 +40,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
         // The author and committer both exist and are different people.
         return (
             <div data-testid="git-commit-node-byline" className={className}>
-                <div>
+                <div className="flex-shrink-0">
                     <UserAvatar
                         className="icon-inline"
                         user={author.person}
@@ -52,7 +52,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
                         data-tooltip={`${formatPersonName(committer.person)} (committer)`}
                     />
                 </div>
-                <div>
+                <div className="overflow-hidden">
                     {!compact ? (
                         <>
                             {messageElement}
@@ -81,7 +81,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
                     data-tooltip={formatPersonName(author.person)}
                 />
             </div>
-            <div>
+            <div className="overflow-hidden">
                 {!compact && (
                     <>
                         {messageElement}

--- a/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -14,7 +14,9 @@ exports[`GitCommitNodeByline author (compact) 1`] = `
       src="http://example.com/alice.png"
     />
   </div>
-  <div>
+  <div
+    className="overflow-hidden"
+  >
     committed by 
     <span
       className="font-weight-bold"
@@ -47,7 +49,9 @@ exports[`GitCommitNodeByline author 1`] = `
       src="http://example.com/alice.png"
     />
   </div>
-  <div>
+  <div
+    className="overflow-hidden"
+  >
     committed by 
     <span
       className="font-weight-bold"
@@ -71,7 +75,9 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
   className=""
   data-testid="git-commit-node-byline"
 >
-  <div>
+  <div
+    className="flex-shrink-0"
+  >
     <img
       alt=""
       className="user-avatar icon-inline"
@@ -88,7 +94,9 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
       src="http://example.com/bob.png"
     />
   </div>
-  <div>
+  <div
+    className="overflow-hidden"
+  >
     <span
       className="font-weight-bold"
       data-tooltip="alice@example.com"
@@ -121,7 +129,9 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
   className=""
   data-testid="git-commit-node-byline"
 >
-  <div>
+  <div
+    className="flex-shrink-0"
+  >
     <img
       alt=""
       className="user-avatar icon-inline"
@@ -138,7 +148,9 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
       src="http://example.com/bob.png"
     />
   </div>
-  <div>
+  <div
+    className="overflow-hidden"
+  >
     <span
       className="font-weight-bold"
       data-tooltip="alice@example.com"
@@ -180,7 +192,9 @@ exports[`GitCommitNodeByline omit GitHub committer 1`] = `
       src="http://example.com/alice.png"
     />
   </div>
-  <div>
+  <div
+    className="overflow-hidden"
+  >
     committed by 
     <span
       className="font-weight-bold"
@@ -213,7 +227,9 @@ exports[`GitCommitNodeByline same author and committer 1`] = `
       src="http://example.com/alice.png"
     />
   </div>
-  <div>
+  <div
+    className="overflow-hidden"
+  >
     committed by 
     <span
       className="font-weight-bold"


### PR DESCRIPTION
## Description 

- Make long commit message overflow hidden with ellipsis on commit node UI

## Videos

- https://www.loom.com/share/437b22a5e96546318d6b48d4c7dd884b

## Refs
- https://github.com/sourcegraph/sourcegraph/issues/24378
