### PR TITLE
dev/ci/cluster: deploy to unique BUILDKITE_JOB_ID namespace

### DIFF
--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -8,7 +8,7 @@ root_dir="$(dirname "${BASH_SOURCE[0]}")/../../../.."
 cd "$root_dir"
 root_dir=$(pwd)
 
-export NAMESPACE="cluster-ci-$BUILDKITE_BUILD_NUMBER"
+export NAMESPACE="cluster-ci-$BUILDKITE_BUILD_NUMBER-$BUILDKITE_JOB_ID"
 
 # Capture information about the state of the test cluster
 function cluster_capture_state() {


### PR DESCRIPTION
Using just `BUILDKITE_BUILD_NUMBER` means that namespaces will be used across re-runs of the cluster test job. If you attempt a re-run before the previous cluster has had time to properly spin down, this can cause a re-run to fail, e.g. https://buildkite.com/sourcegraph/qa/builds/5959#31bc1366-5e4a-4e8d-ac31-9bdf4d323b6a:

```
Error from server (Forbidden): error when creating "base/worker/worker.Deployment.yaml": deployments.apps "worker" is forbidden: unable to create new content in namespace cluster-ci-5959 because it is being terminated
```

It seems `BUILDKITE_JOB_ID` is unique across retries so we use that in cluster namespace as well.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
