### PR TITLE
codeintel: Add experimental docs to enable auto-indexing

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/schema.json
+++ b/client/web/src/enterprise/codeintel/configuration/schema.json
@@ -9,7 +9,7 @@
       "type": "object",
       "properties": {
         "root": {
-          "description": "The working directly within the docker container.",
+          "description": "The working directory within the docker container.",
           "type": "string"
         },
         "image": {

--- a/client/web/src/enterprise/codeintel/configuration/schema.json
+++ b/client/web/src/enterprise/codeintel/configuration/schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "code_intel_auto_index.schema.json#",
   "title": "CodeIntelAutoIndex",
-  "description": "Configuration settings for repository code intel auto indexing.",
+  "description": "Configuration settings for repository code intel auto-indexing.",
   "allowComments": true,
   "definitions": {
     "docker_step": {

--- a/client/web/src/enterprise/codeintel/configuration/schema.json
+++ b/client/web/src/enterprise/codeintel/configuration/schema.json
@@ -9,7 +9,7 @@
       "type": "object",
       "properties": {
         "root": {
-          "description": "The working directory within the docker container.",
+          "description": "The working directory within the Docker container.",
           "type": "string"
         },
         "image": {

--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -126,7 +126,7 @@ const sidebarRoutes: CodeIntelSideBarGroups = [
             },
             {
                 to: '/indexes',
-                label: 'Auto indexing',
+                label: 'Auto-indexing',
                 condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
             },
             {

--- a/client/web/src/enterprise/site-admin/routes.ts
+++ b/client/web/src/enterprise/site-admin/routes.ts
@@ -106,7 +106,7 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
     },
 
-    // Auto indexing routes
+    // Auto-indexing routes
     {
         path: '/code-intelligence/indexes',
         render: lazyComponent(() => import('../codeintel/list/CodeIntelIndexesPage'), 'CodeIntelIndexesPage'),

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -88,7 +88,7 @@ const codeIntelGroup: SiteAdminSideBarGroup = {
         },
         {
             to: '/site-admin/code-intelligence/indexes',
-            label: 'Auto indexing',
+            label: 'Auto-indexing',
             condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
         },
         {

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -18,7 +18,7 @@ This job periodically removes expired and unreachable code intelligence data and
 
 #### `codeintel-auto-indexing`
 
-This job periodically checks for repositories that can be auto-indexed and queues indexing jobs for a remote executor instance to perform. Read how to [enable](../code_intelligence/how-to/enable_auto_indexing) and [configure](../code_intelligence/how-to/configure_auto_indexing) auto-indexing.
+This job periodically checks for repositories that can be auto-indexed and queues indexing jobs for a remote executor instance to perform. Read how to [enable](../code_intelligence/how-to/enable_auto_indexing.md) and [configure](../code_intelligence/how-to/configure_auto_indexing.md) auto-indexing.
 
 #### `insights-job`
 This job contains all of the backgrounds processes for Code Insights. These processes periodically run and execute different tasks for Code Insights:

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -18,9 +18,7 @@ This job periodically removes expired and unreachable code intelligence data and
 
 #### `codeintel-auto-indexing`
 
-This job periodically checks for repositories that can be auto-indexed and queues indexing jobs for a remote executor instance to perform.
-
-_This job currently no-ops outside of our public Cloud instance_. Keep an eye on our release notes for when this feature becomes generally available.
+This job periodically checks for repositories that can be auto-indexed and queues indexing jobs for a remote executor instance to perform. Read how to [enable](../code_intelligence/how-to/enable_auto_indexing) and [configure](../code_intelligence/how-to/configure_auto_indexing) auto-indexing.
 
 #### `insights-job`
 This job contains all of the backgrounds processes for Code Insights. These processes periodically run and execute different tasks for Code Insights:

--- a/doc/code_intelligence/explanations/auto_indexing.md
+++ b/doc/code_intelligence/explanations/auto_indexing.md
@@ -12,5 +12,5 @@ For now here's some documentation we _do_ have:
 
 - [Enable auto-indexing](../how-to/enable_auto_indexing.md)
 - [Configure auto-indexing](../how-to/configure_auto_indexing.md)
-- [Auto indexing inference](auto_indexing_inference.md)
-- [Auto indexing configuration](../references/auto_indexing_configuration.md)
+- [Auto-indexing inference](auto_indexing_inference.md)
+- [Auto-indexing configuration](../references/auto_indexing_configuration.md)

--- a/doc/code_intelligence/explanations/auto_indexing.md
+++ b/doc/code_intelligence/explanations/auto_indexing.md
@@ -1,0 +1,16 @@
+# Auto-indexing
+
+<aside class="experimental">
+<p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>
+
+<p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
+Auto-indexing is a experimental feature (therefore light on documentation). Stay tuned while we fill out context!
+
+For now here's some documentation we _do_ have:
+
+- [Enable auto-indexing](../how-to/enable_auto_indexing.md)
+- [Configure auto-indexing](../how-to/configure_auto_indexing.md)
+- [Auto indexing inference](auto_indexing_inference.md)
+- [Auto indexing configuration](../references/auto_indexing_configuration.md)

--- a/doc/code_intelligence/explanations/auto_indexing_inference.md
+++ b/doc/code_intelligence/explanations/auto_indexing_inference.md
@@ -6,9 +6,9 @@
 <p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 </aside>
 
-When a commit of a repository is selected as a candidate for [auto-indexing](./auto_indexing) but does not have an explicitly supplied index job configuration, index jobs are inferred from the content of the repository at that commit.
+When a commit of a repository is selected as a candidate for [auto-indexing](./auto_indexing.md) but does not have an explicitly supplied index job configuration, index jobs are inferred from the content of the repository at that commit.
 
-This document describes the heuristics used to determine the set of index jobs to schedule. See [configuration reference](../references/auto_indexing_configuration) for additional documentation on how index jobs are configured.
+This document describes the heuristics used to determine the set of index jobs to schedule. See [configuration reference](../references/auto_indexing_configuration.md) for additional documentation on how index jobs are configured.
 
 As a general rule of thumb, an LSIF indexer can be invoked successfully if the source code to index can be compiled successfully. The heuristics below attempt to cover the common cases of dependency resolution, but may not be sufficient if the target code requires additional steps such as code generation, header file linking, or installation of system dependencies to compile from a fresh clone of the repository. For such cases, we recommend using the inferred job as a starting point to [explicitly supply index job configuration](../how-to/configure_auto_indexing.md#explicit-index-job-configuration).
 

--- a/doc/code_intelligence/explanations/auto_indexing_inference.md
+++ b/doc/code_intelligence/explanations/auto_indexing_inference.md
@@ -1,4 +1,4 @@
-# Inference of auto indexing jobs
+# Inference of auto-indexing jobs
 
 <aside class="experimental">
 <p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>
@@ -6,7 +6,7 @@
 <p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 </aside>
 
-When a commit of a repository is selected as a candidate for [auto indexing](./auto_indexing) but does not have an explicitly supplied index job configuration, index jobs are inferred from the content of the repository at that commit.
+When a commit of a repository is selected as a candidate for [auto-indexing](./auto_indexing) but does not have an explicitly supplied index job configuration, index jobs are inferred from the content of the repository at that commit.
 
 This document describes the heuristics used to determine the set of index jobs to schedule. See [configuration reference](../references/auto_indexing_configuration) for additional documentation on how index jobs are configured.
 

--- a/doc/code_intelligence/explanations/auto_indexing_inference.md
+++ b/doc/code_intelligence/explanations/auto_indexing_inference.md
@@ -1,0 +1,109 @@
+# Inference of auto indexing jobs
+
+<aside class="experimental">
+<p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>
+
+<p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
+When a commit of a repository is selected as a candidate for [auto indexing](./auto_indexing) but does not have an explicitly supplied index job configuration, index jobs are inferred from the content of the repository at that commit.
+
+This document describes the heuristics used to determine the set of index jobs to schedule. See [configuration reference](../references/auto_indexing_configuration) for additional documentation on how index jobs are configured.
+
+As a general rule of thumb, an LSIF indexer can be invoked successfully if the source code to index can be compiled successfully. The heuristics below attempt to cover the common cases of dependency resolution, but may not be sufficient if the target code requires additional steps such as code generation, header file linking, or installation of system dependencies to compile from a fresh clone of the repository. For such cases, we recommend using the inferred job as a starting point to [explicitly supply index job configuration](../how-to/configure_auto_indexing.md#explicit-index-job-configuration).
+
+## Go
+
+For each directory containing a `go.mod` file, the following index job is scheduled.
+
+```yaml
+indexing_jobs:
+  - steps:
+      - root: <dir>
+        image: sourcegraph/lsif-go
+        commands:
+          - go mod download
+    root: <dir>
+    indexer: sourcegraph/lsif-go
+    indexer_args:
+      - lsif-go
+      - --no-animation
+```
+
+For every _other_ directory excluding `vendor/` directories and their children containing one or more `*.go` files, the following index job is scheduled.
+
+```yaml
+indexing_jobs:
+  - root: <dir>
+    indexer: sourcegraph/lsif-go
+    indexer_args:
+      - GO111MODULE=off
+      - lsif-go
+      - --no-animation
+```
+
+## TypeScript
+
+For each directory excluding `node_modules/` directories and their children containing a `tsconfig.json` file, the following index job is scheduled. Note that there are a dynamic number of pre-indexing steps used to resolve dependencies: for each ancestor directory `ancestor(dir)` containing a `package.json` file, the dependencies are installed via either `yarn` or `npm`. These steps run in order, depth-first.
+
+```yaml
+indexing_jobs:
+  - steps:
+      - root: <ancestor(dir)>
+        image: sourcegraph/lsif-node:autoindex
+        commands:
+          # Yarn is used to resolve dependencies in an ancestor directory
+          # when lerna.json configuration specifies "yarn" as the npmClient
+          # or if the directory contains a yarn.lock file.
+          - yarn --ignore-engines
+      - root: <ancestor(dir)>
+        image: sourcegraph/lsif-node:autoindex
+        commands:
+          # NPM is used to resolve dependencies otherwise.
+          - npm install
+      - ...
+    local_steps:
+      # This is run directly before indexing if a node version can be determined
+      # from the package.json "engines" field, or any of the files:
+      #   - .nvmrc
+      #   - .node-version
+      #   - .n-node-version
+      - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl autol
+    root: <dir>
+    indexer: sourcegraph/lsif-node:autoindex
+    indexer_args:
+      - lsif-tsc
+      - -p
+      - .
+```
+
+## Rust
+
+If the repository contains a `Cargo.toml` file, the following index job is scheduled.
+
+```yaml
+indexing_jobs:
+  - root: ''
+    indexer: sourcegraph/lsif-rust
+    indexer_args:
+      - lsif-rust
+      - index
+    outfile: dump.lsif
+```
+
+## Java
+
+> NOTE: Inference for languages supported by [lsif-java](https://github.com/sourcegraph/lsif-java) is currently restricted to Sourcegraph Cloud.
+
+If the repository contains both a `lsif-java.json` file as well as `*.java`, `*.scala`, or `*.kt` files, the following index job is scheduled.
+
+```yaml
+indexing_jobs:
+  - root: ''
+    indexer: sourcegraph/lsif-java
+    indexer_args:
+      - lsif-java
+      - index
+      - --build-tool=lsif
+    outfile: dump.lsif
+```

--- a/doc/code_intelligence/explanations/index.md
+++ b/doc/code_intelligence/explanations/index.md
@@ -8,5 +8,5 @@
   - [Find references](./features.md#find-references)
   - [Symbol search](./features.md#symbol-search)
 - [Writing an indexer](writing_an_indexer.md)
-- <span class="badge badge-experimental">Experimental</span> [Auto indexing](auto_indexing.md)
-- <span class="badge badge-experimental">Experimental</span> [Auto indexing inference](auto_indexing_inference.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto-indexing](auto_indexing.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto-indexing inference](auto_indexing_inference.md)

--- a/doc/code_intelligence/explanations/index.md
+++ b/doc/code_intelligence/explanations/index.md
@@ -8,3 +8,5 @@
   - [Find references](./features.md#find-references)
   - [Symbol search](./features.md#symbol-search)
 - [Writing an indexer](writing_an_indexer.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto indexing](auto_indexing.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto indexing inference](auto_indexing_inference.md)

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -45,32 +45,32 @@ Precise code intelligence indexing jobs are scheduled periodically in the backgr
 
 Site admins can create indexing policies that apply to _all repositories_ on their Sourcegraph instance. In order to view and edit these policies, navigate to the code intelligence configuration in the site-admin dashboard.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/list.png" class="screenshot" alt="Global auto-indexing policy configuration list page">
 
 New policies can also be created to apply to the HEAD of the default branch, or to apply to any arbitrary Git branch or tag pattern. For example, you may want to index the tip of the default branch for all of your repositories (in this example, repositories whose last commit is older than five years of age will not apply).
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/create.png" class="screenshot">
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/post-create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/create.png" class="screenshot" alt="Global auto-indexing policy configuration edit page">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/post-create.png" class="screenshot" alt="Global auto-indexing policy configuration created confirmation">
 
 New policies can be created to apply to a set of repositories that are matched by name. For example, you may want to enable indexing for a particular set of repositories (in this example, repositories in the `sourcegraph` organization).
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/create-repo-list.png" class="screenshot">
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/post-create-repo-list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/create-repo-list.png" class="screenshot" alt="Global auto-indexing policy with repository patterns configuration edit page">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/post-create-repo-list.png" class="screenshot" alt="Global auto-indexing policy with repository patterns configuration created confirmation">
 
 ### Applying indexing policies to a specific repository
 
 Indexing policies can also be created on a per-repository basis as commit and merge workflows differ wildly from project to project. In order to view and edit repository-specific policies, navigate to the code intelligence settings in the target repository's index page.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot" alt="Repository index page">
 
 The settings page will show all policies that apply to the given repository, including both repository-specific policies as well as global policies that match the repository.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/empty.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/empty.png" class="screenshot" alt="Repository-specific auto-indexing policy configuration list page">
 
 In this example, we create an indexing policy that applies to all _versioned_ tags (those prefixed with `v`). the _`:bestcoder:` branch retention policy_ that ensures all commits visible to the tip of any branch matching the pattern `ef/*` will not be removed for at least one year.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/create.png" class="screenshot">
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/post-create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/create.png" class="screenshot" alt="Repository-specific auto-indexing policy configuration edit page">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/post-create.png" class="screenshot" alt="Repository-specific auto-indexing policy configuration created confirmation">
 
 ## Explicit index job configuration
 
@@ -80,8 +80,8 @@ Explicit index job configuration can be supplied to a repository in two ways (li
 
 1. Configure index jobs via the target repository's code intelligence settings UI. In order to view and edit the indexing configuration for a repository, navigate to the code intelligence settings in the target repository's index page.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot" alt="Repository index page">
 
 From there you can view or edit the repository's configuration. We use a superset of JSON that allows for comments and trailing commas. The set of index jobs that would be [inferred](../explanations/auto_indexing_inference.md) from the content of the repository (at the current tip of the default branch) can be viewed and may often be useful as a starting point to define more elaborate indexing jobs.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/configuration.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/configuration.png" class="screenshot" alt="Auto-indexing configuration editor">

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -43,7 +43,7 @@ Precise code intelligence indexing jobs are scheduled periodically in the backgr
 
 ### Applying indexing policies globally
 
-Site admins may create indexing policies that are applied to _all repositories_ on your Sourcegraph instance. In order to view and edit these policies, navigate to teh code intelligence configuration in the site-admin dashboard.
+Site admins can create indexing policies that apply to _all repositories_ on their Sourcegraph instance. In order to view and edit these policies, navigate to the code intelligence configuration in the site-admin dashboard.
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/list.png" class="screenshot">
 

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -78,7 +78,7 @@ Explicit index job configuration can be supplied to a repository in two ways (li
 
 1. Configure index jobs by committing a `sourcegraph.yaml` file to the root of the target repository. If you're new to YAML and want a short introduction, see [Learn YAML in five minutes](https://learnxinyminutes.com/docs/yaml/). Note that YAML is a strict superset of JSON, therefore the file contents can also be encoded as valid JSON (despite the file extension).
 
-1. Configure index jobs via the target repository's code intelligence settings UI. In order to view and edit the indexing configuration for a repository, navigate navigate to the code intelligence settings in the target repository's index page.
+1. Configure index jobs via the target repository's code intelligence settings UI. In order to view and edit the indexing configuration for a repository, navigate to the code intelligence settings in the target repository's index page.
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot">
 

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -1,0 +1,87 @@
+# Configure code intelligence auto indexing
+
+<style>
+img.screenshot {
+  display: block;
+  margin: 1em auto;
+  max-width: 600px;
+  margin-bottom: 0.5em;
+  border: 1px solid lightgrey;
+  border-radius: 10px;
+}
+
+img.screenshot.thin-screenshot {
+  max-width: 200px;
+}
+</style>
+
+<aside class="experimental">
+<p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>
+
+<p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
+Precise code intelligence auto indexing jobs are scheduled based on two fronts of configuration.
+
+The first front selects the set of repositories and commits within those repositories that are candidates for auto-indexing. These candidates are controlled by [configuring auto indexing policies](#configure-auto-indexing-policies).
+
+The second front determines the set of index jobs that can run over candidate commits. By default, index jobs are [inferred](../explanations/auto_indexing_inference.md) from the repository structure's on disk. Index job inference uses heuristics such as the presence or contents of particular files to determine the paths and commands required to index a repository. Alternatively, index job configuration [can be supplied explicitly](#explicit-index-job-configuration) for a repository when the inference heuristics are not powerful enough to create an index job that produces the correct results. This might be necessary for projects that have non-standard or complex dependency resolution or pre-compilation steps, for example.
+
+## Configure auto indexing policies
+
+This guide shows how to configure policies to control the scheduling of precise code intelligence indexing jobs. Indexing jobs [produce a precise code intelligence index](../explanations/precise_code_intelligence) and uploads it to your Sourcegraph instance for use with code navigation.
+
+Each policy has a number of configurable options, including:
+
+- The set of Git branches or tags to which the policy applies
+- The maximum age of commits that should be indexed (e.g., skip indexing commits made last year)
+- For branches, whether or not to consider the _tip_ of the branch only, or all commits contained in that branch
+
+Note that when auto indexing is enabled, we will also attempt to schedule index jobs for _dependencies_ of repositories which receive an uploaded precise code intelligence index. This helps to ensure that no matter where symbols are defined, you will be able to navigate to its definition and find a relevant set of references as long as your Sourcegraph instance has knowledge of that code.
+
+Precise code intelligence indexing jobs are scheduled periodically in the background for each repository matching an indexing policy.
+
+### Applying indexing policies globally
+
+Site admins may create indexing policies that are applied to _all repositories_ on your Sourcegraph instance. In order to view and edit these policies, navigate to teh code intelligence configuration in the site-admin dashboard.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/list.png" class="screenshot">
+
+New policies can also be created to apply to the HEAD of the default branch, or to apply to any arbitrary Git branch or tag pattern. For example, you may want to index the tip of the default branch for all of your repositories (in this example, repositories whose last commit is older than five years of age will not apply).
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/post-create.png" class="screenshot">
+
+New policies can be created to apply to a set of repositories that are matched by name. For example, you may want to enable indexing for a particular set of repositories (in this example, repositories in the `sourcegraph` organization).
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/create-repo-list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/global/post-create-repo-list.png" class="screenshot">
+
+### Applying indexing policies to a specific repository
+
+Indexing policies can also be created on a per-repository basis as commit and merge workflows differ wildly from project to project. In order to view and edit repository-specific policies, navigate to the code intelligence settings in the target repository's index page.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot">
+
+The settings page will show all policies that apply to the given repository, including both repository-specific policies as well as global policies that match the repository.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/empty.png" class="screenshot">
+
+In this example, we create an indexing policy that applies to all _versioned_ tags (those prefixed with `v`). the _`:bestcoder:` branch retention policy_ that ensures all commits visible to the tip of any branch matching the pattern `ef/*` will not be removed for at least one year.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/post-create.png" class="screenshot">
+
+## Explicit index job configuration
+
+Explicit index job configuration can be supplied to a repository in two ways (listed below in order of precedence). Both methods of configuration share a common expected schema. See the [reference documentation](../references/auto_indexing_configuration) for additional information on the shape and content of the configuration.
+
+1. Configure index jobs by committing a `sourcegraph.yaml` file to the root of the target repository. If you're new to YAML and want a short introduction, see [Learn YAML in five minutes](https://learnxinyminutes.com/docs/yaml/). Note that YAML is a strict superset of JSON, therefore the file contents can also be encoded as valid JSON (despite the file extension).
+
+1. Configure index jobs via the target repository's code intelligence settings UI. In order to view and edit the indexing configuration for a repository, navigate navigate to the code intelligence settings in the target repository's index page.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot">
+
+From there you can view or edit the repository's configuration. We use a superset of JSON that allows for comments and trailing commas. The set of index jobs that would be [inferred](../explanations/auto_indexing_inference.md) from the content of the repository (at the current tip of the default branch) can be viewed and may often be useful as a starting point to define more elaborate indexing jobs.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/indexing/repo/configuration.png" class="screenshot">

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -29,7 +29,7 @@ The second front determines the set of index jobs that can run over candidate co
 
 ## Configure auto-indexing policies
 
-This guide shows how to configure policies to control the scheduling of precise code intelligence indexing jobs. Indexing jobs [produce a precise code intelligence index](../explanations/precise_code_intelligence) and uploads it to your Sourcegraph instance for use with code navigation.
+This guide shows how to configure policies to control the scheduling of precise code intelligence indexing jobs. Indexing jobs [produce a precise code intelligence index](../explanations/precise_code_intelligence.md) and uploads it to your Sourcegraph instance for use with code navigation.
 
 Each policy has a number of configurable options, including:
 
@@ -74,7 +74,7 @@ In this example, we create an indexing policy that applies to all _versioned_ ta
 
 ## Explicit index job configuration
 
-Explicit index job configuration can be supplied to a repository in two ways (listed below in order of decreasing precedence). Both methods of configuration share a common expected schema. See the [reference documentation](../references/auto_indexing_configuration) for additional information on the shape and content of the configuration.
+Explicit index job configuration can be supplied to a repository in two ways (listed below in order of decreasing precedence). Both methods of configuration share a common expected schema. See the [reference documentation](../references/auto_indexing_configuration.md) for additional information on the shape and content of the configuration.
 
 1. Configure index jobs by committing a `sourcegraph.yaml` file to the root of the target repository. If you're new to YAML and want a short introduction, see [Learn YAML in five minutes](https://learnxinyminutes.com/docs/yaml/). Note that YAML is a strict superset of JSON, therefore the file contents can also be encoded as valid JSON (despite the file extension).
 

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -21,7 +21,7 @@ img.screenshot.thin-screenshot {
 <p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 </aside>
 
-Precise code intelligence auto indexing jobs are scheduled based on two fronts of configuration.
+Precise code intelligence auto-indexing jobs are scheduled based on two fronts of configuration.
 
 The first front selects the set of repositories and commits within those repositories that are candidates for auto-indexing. These candidates are controlled by [configuring auto indexing policies](#configure-auto-indexing-policies).
 

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -23,11 +23,11 @@ img.screenshot.thin-screenshot {
 
 Precise code intelligence auto-indexing jobs are scheduled based on two fronts of configuration.
 
-The first front selects the set of repositories and commits within those repositories that are candidates for auto-indexing. These candidates are controlled by [configuring auto indexing policies](#configure-auto-indexing-policies).
+The first front selects the set of repositories and commits within those repositories that are candidates for auto-indexing. These candidates are controlled by [configuring auto-indexing policies](#configure-auto-indexing-policies).
 
 The second front determines the set of index jobs that can run over candidate commits. By default, index jobs are [inferred](../explanations/auto_indexing_inference.md) from the repository structure's on disk. Index job inference uses heuristics such as the presence or contents of particular files to determine the paths and commands required to index a repository. Alternatively, index job configuration [can be supplied explicitly](#explicit-index-job-configuration) for a repository when the inference heuristics are not powerful enough to create an index job that produces the correct results. This might be necessary for projects that have non-standard or complex dependency resolution or pre-compilation steps, for example.
 
-## Configure auto indexing policies
+## Configure auto-indexing policies
 
 This guide shows how to configure policies to control the scheduling of precise code intelligence indexing jobs. Indexing jobs [produce a precise code intelligence index](../explanations/precise_code_intelligence) and uploads it to your Sourcegraph instance for use with code navigation.
 
@@ -37,7 +37,7 @@ Each policy has a number of configurable options, including:
 - The maximum age of commits that should be indexed (e.g., skip indexing commits made last year)
 - For branches, whether or not to consider the _tip_ of the branch only, or all commits contained in that branch
 
-Note that when auto indexing is enabled, we will also attempt to schedule index jobs for _dependencies_ of repositories which receive an uploaded precise code intelligence index. This helps to ensure that no matter where symbols are defined, you will be able to navigate to its definition and find a relevant set of references as long as your Sourcegraph instance has knowledge of that code.
+Note that when auto-indexing is enabled, we will also attempt to schedule index jobs for _dependencies_ of repositories which receive an uploaded precise code intelligence index. This helps to ensure that no matter where symbols are defined, you will be able to navigate to its definition and find a relevant set of references as long as your Sourcegraph instance has knowledge of that code.
 
 Precise code intelligence indexing jobs are scheduled periodically in the background for each repository matching an indexing policy.
 

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -1,4 +1,4 @@
-# Configure code intelligence auto indexing
+# Configure code intelligence auto-indexing
 
 <style>
 img.screenshot {

--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -74,7 +74,7 @@ In this example, we create an indexing policy that applies to all _versioned_ ta
 
 ## Explicit index job configuration
 
-Explicit index job configuration can be supplied to a repository in two ways (listed below in order of precedence). Both methods of configuration share a common expected schema. See the [reference documentation](../references/auto_indexing_configuration) for additional information on the shape and content of the configuration.
+Explicit index job configuration can be supplied to a repository in two ways (listed below in order of decreasing precedence). Both methods of configuration share a common expected schema. See the [reference documentation](../references/auto_indexing_configuration) for additional information on the shape and content of the configuration.
 
 1. Configure index jobs by committing a `sourcegraph.yaml` file to the root of the target repository. If you're new to YAML and want a short introduction, see [Learn YAML in five minutes](https://learnxinyminutes.com/docs/yaml/). Note that YAML is a strict superset of JSON, therefore the file contents can also be encoded as valid JSON (despite the file extension).
 

--- a/doc/code_intelligence/how-to/configure_data_retention.md
+++ b/doc/code_intelligence/how-to/configure_data_retention.md
@@ -1,17 +1,5 @@
 # Configure precise code intelligence data retention policies
 
-This guide shows how to configure the retention policies for precise code intelligence data. As code intelligence data ages, it gets less and less relevant. Users tend to need code intelligence on newer commits, tagged commits, and in branches. The data providing intelligence for an old commit on the main development branch is very unlikely to be used, but takes up valuable space in the database.
-
-Each policy has a number of configurable options, including:
-
-- The set of Git commits, branches, or tags to which the policy applies
-- How long to keep the associated code intelligence data
-- For branches, whether or not to consider the _tip_ of the branch only, or all commits contained in that branch
-
-Note that we also track cross-repository dependencies and will not delete any data that is referenced by another precise code intelligence index. This ensures that we don't delete code intelligence for dependencies pinned to older versions (or dependencies that have reached a steady state and no longer receives frequent updates).
-
-All upload records will be periodically compared against global and their target repository's data retention policies with the exception of uploads that provide code intelligence for the tip of the default branch. These uploads will never expire due to age.
-
 <style>
 img.screenshot {
   display: block;
@@ -27,32 +15,49 @@ img.screenshot.thin-screenshot {
 }
 </style>
 
+This guide shows how to configure the retention policies for precise code intelligence data. As code intelligence data ages, it gets less and less relevant. Users tend to need code intelligence on newer commits, tagged commits, and in branches. The data providing intelligence for an old commit on the main development branch is very unlikely to be used, but takes up valuable space in the database.
+
+Each policy has a number of configurable options, including:
+
+- The set of Git branches or tags to which the policy applies
+- How long to keep the associated code intelligence data
+- For branches, whether or not to consider the _tip_ of the branch only, or all commits contained in that branch
+
+Note that we also track cross-repository dependencies and will not delete any data that is referenced by another precise code intelligence index. This ensures that we don't delete code intelligence for dependencies pinned to older versions (or dependencies that have reached a steady state and no longer receives frequent updates).
+
+All upload records will be periodically compared against global data retention policies as well as their target repository's data retention policies. Uploads on the tip of the default branch for a repository will never expire regardless of age.
+
 ## Applying data retention policies globally
 
-Data retention policies can be applied to _all repositories_ on your Sourcegraph instance. In order to view and edit these policies, navigate to the code intelligence configuration in the site-admin dashboard.
+Site admins may create data retention policies that are applied to _all repositories_ on your Sourcegraph instance. In order to view and edit these policies, navigate to the code intelligence configuration in the site-admin dashboard.
 
-<img src="https://sourcegraphstatic.com/docs/images/code-intelligence/retention-config-sidebar.png" class="screenshot thin-screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/list.png" class="screenshot">
 
-By default, there are two _protected_ policies which cannot be deleted or disabled. These policies refer to all tagged commits (associated data being kept for one year by default), and the tip of all branches (associated data being kept for three months by default). 
+By default, there are three _protected_ policies which cannot be deleted or disabled. These policies refer to all tagged commits (associated data being kept for one year by default), the tip of all branches (associated data being kept for three months by default), and the HEAD of the default branch (associated data being kept forever by default) for all repositories. Protected policies cannot be deleted or disabled, but the retention length can be modified to suit your instance's usage patterns.
 
-<img src="https://sourcegraphstatic.com/docs/images/code-intelligence/retention-config-global-list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/protected.png" class="screenshot">
 
-The retention length for protected policies can be modified to suit your instance's usage patterns.
+New policies can also be created to apply to the HEAD of the default branch, or to apply to any arbitrary Git branch or tag pattern. For example, you may want to never expire any data for any major version tags in your organization.
 
-<img src="https://sourcegraphstatic.com/docs/images/code-intelligence/retention-config-global-detail.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/post-create.png" class="screenshot">
 
-New policies can also be created to apply to any arbitrary Git commit, branch, or tag patterns. For example, you may want to **never** expire any data on the tip of any `main` or `master` branch in your organization.
+New policies can be created to apply to a set of repositories that are matched by name. For example, you may want to change duration retention on branches that exist within a particular set of repositories (in this example, repositories in the same organization matching `lsif-*`).
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/create-repo-list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/post-create-repo-list.png" class="screenshot">
 
 ## Applying data retention policies to a specific repository
 
-Data retention policies can also be created per-repository basis as commit and merge workflows differ wildly from project to project. In order to view and edit repository-specific policies, navigate to the code intelligence settings in the target repository's index page.
+Data retention policies can also be created on a per-repository basis as commit and merge workflows differ wildly from project to project. In order to view and edit repository-specific policies, navigate to the code intelligence settings in the target repository's index page.
 
-<img src="https://sourcegraphstatic.com/docs/images/code-intelligence/retention-config-repo.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot">
 
-Global policies continue to apply to repositories that define additional policies.
+The settings page will show all policies that apply to the given repository, including both repository-specific policies as well as global policies that match the repository.
 
-<img src="https://sourcegraphstatic.com/docs/images/code-intelligence/retention-config-repo-list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/empty.png" class="screenshot">
 
-In this example, we create a policy that ensures all commits visible to the tip of any branch matching the pattern `ef/*` will not be removed for at least one year.
+In this example, we create the _`:bestcoder:` branch retention policy_ that ensures all commits visible to the tip of any branch matching the pattern `ef/*` will not be removed for at least one year.
 
-<img src="https://sourcegraphstatic.com/docs/images/code-intelligence/retention-config-repo-detail.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/post-create.png" class="screenshot">

--- a/doc/code_intelligence/how-to/configure_data_retention.md
+++ b/doc/code_intelligence/how-to/configure_data_retention.md
@@ -31,33 +31,33 @@ All upload records will be periodically compared against global data retention p
 
 Site admins may create data retention policies that are applied to _all repositories_ on your Sourcegraph instance. In order to view and edit these policies, navigate to the code intelligence configuration in the site-admin dashboard.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/list.png" class="screenshot" alt="Global data retention policy configuration list page">
 
 By default, there are three _protected_ policies which cannot be deleted or disabled. These policies refer to all tagged commits (associated data being kept for one year by default), the tip of all branches (associated data being kept for three months by default), and the HEAD of the default branch (associated data being kept forever by default) for all repositories. Protected policies cannot be deleted or disabled, but the retention length can be modified to suit your instance's usage patterns.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/protected.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/protected.png" class="screenshot" alt="Protected global data retention policy edit page">
 
 New policies can also be created to apply to the HEAD of the default branch, or to apply to any arbitrary Git branch or tag pattern. For example, you may want to never expire any data for any major version tags in your organization.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/create.png" class="screenshot">
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/post-create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/create.png" class="screenshot" alt="Global data retention policy configuration edit page">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/post-create.png" class="screenshot" alt="Global data retention policy configuration created confirmation">
 
 New policies can be created to apply to a set of repositories that are matched by name. For example, you may want to change duration retention on branches that exist within a particular set of repositories (in this example, repositories in the same organization matching `lsif-*`).
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/create-repo-list.png" class="screenshot">
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/post-create-repo-list.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/create-repo-list.png" class="screenshot" alt="Global data retention policy with repository patterns configuration edit page">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/global/post-create-repo-list.png" class="screenshot" alt="Global data retention policy with repository patterns configuration created confirmation">
 
 ## Applying data retention policies to a specific repository
 
 Data retention policies can also be created on a per-repository basis as commit and merge workflows differ wildly from project to project. In order to view and edit repository-specific policies, navigate to the code intelligence settings in the target repository's index page.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/repository-page.png" class="screenshot" alt="Repository index page">
 
 The settings page will show all policies that apply to the given repository, including both repository-specific policies as well as global policies that match the repository.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/empty.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/empty.png" class="screenshot" alt="Repository-specific data retention policy configuration list page">
 
 In this example, we create the _`:bestcoder:` branch retention policy_ that ensures all commits visible to the tip of any branch matching the pattern `ef/*` will not be removed for at least one year.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/create.png" class="screenshot">
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/post-create.png" class="screenshot">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/create.png" class="screenshot" alt="Repository-specific data retention policy configuration edit page">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.33/retention/repo/post-create.png" class="screenshot" alt="Repository-specific data retention policy configuration created confirmation">

--- a/doc/code_intelligence/how-to/enable_auto_indexing.md
+++ b/doc/code_intelligence/how-to/enable_auto_indexing.md
@@ -1,4 +1,4 @@
-# Enable code intelligence auto indexing
+# Enable code intelligence auto-indexing
 
 <aside class="experimental">
 <p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>
@@ -12,7 +12,7 @@ First, [deploy the executor service](../../../../admin/deploy_executors) targeti
 
 ## Enable index job scheduling
 
-Next, enable the precise code intelligence auto indexing feature by enabling the following feature flag in your Sourcegraph instance's site configuration.
+Next, enable the precise code intelligence auto-indexing feature by enabling the following feature flag in your Sourcegraph instance's site configuration.
 
 ```yaml
 {
@@ -22,11 +22,11 @@ Next, enable the precise code intelligence auto indexing feature by enabling the
 
 This step will control the scheduling of indexing jobs which are made available to the executors deployed in the previous step.
 
-## Configure auto indexing policies
+## Configure auto-indexing policies
 
-Once auto indexing has been enabled, [create auto indexing policies](configure_auto_indexing) to control the set of repositories and commits that are eligible for indexing.
+Once auto-indexing has been enabled, [create auto-indexing policies](configure_auto_indexing) to control the set of repositories and commits that are eligible for indexing.
 
-> NOTE: If you are running Sourcegraph 3.33, then only the repositories that exist within one or more [search contexts](../../../../code_search/how-to/search_contexts) are eligible for auto indexing. This is a temporary and vestigial artifact of auto-indexing being developed on our Cloud instance, which has an extremely large corpus of repositories. We advise you to create a `code-intel-indexing-corpus` search context and add the set of repositories you wish to have indexed. This is not required post-Sourcegraph 3.33.
+> NOTE: If you are running Sourcegraph 3.33, then only the repositories that exist within one or more [search contexts](../../../../code_search/how-to/search_contexts) are eligible for auto-indexing. This is a temporary and vestigial artifact of auto-indexing being developed on our Cloud instance, which has an extremely large corpus of repositories. We advise you to create a `code-intel-indexing-corpus` search context and add the set of repositories you wish to have indexed. This is not required post-Sourcegraph 3.33.
 
 ## Tune the index scheduler
 

--- a/doc/code_intelligence/how-to/enable_auto_indexing.md
+++ b/doc/code_intelligence/how-to/enable_auto_indexing.md
@@ -1,0 +1,41 @@
+# Enable code intelligence auto indexing
+
+<aside class="experimental">
+<p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>
+
+<p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
+## Deploy executors
+
+First, [deploy the executor service](../../../../admin/deploy_executors) targeting your Sourcegraph instance. This will provide the necessary compute resources that clone the target Git repository, analyze the code to produce a precise code intelligence index, then upload that index to your Sourcegraph instance for processing.
+
+## Enable index job scheduling
+
+Next, enable the precise code intelligence auto indexing feature by enabling the following feature flag in your Sourcegraph instance's site configuration.
+
+```yaml
+{
+  "codeIntelAutoIndexing.enabled": true
+}
+```
+
+This step will control the scheduling of indexing jobs which are made available to the executors deployed in the previous step.
+
+## Configure auto indexing policies
+
+Once auto indexing has been enabled, [create auto indexing policies](configure_auto_indexing) to control the set of repositories and commits that are eligible for indexing.
+
+> NOTE: If you are running Sourcegraph 3.33, then only the repositories that exist within one or more [search contexts](../../../../code_search/how-to/search_contexts) are eligible for auto indexing. This is a temporary and vestigial artifact of auto-indexing being developed on our Cloud instance, which has an extremely large corpus of repositories. We advise you to create a `code-intel-indexing-corpus` search context and add the set of repositories you wish to have indexed. This is not required post-Sourcegraph 3.33.
+
+## Tune the index scheduler
+
+The frequency of index job scheduling can be tuned via the following environment variables read by `worker` service containers running the [`codeintel-auto-indexing`](../../../admin/workers#codeintel-auto-indexing) task.
+
+**`PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL`**: The frequency with which to run periodic codeintel auto-indexing tasks. Default is every 10 minutes.
+
+**`PRECISE_CODE_INTEL_AUTO_INDEXING_REPOSITORY_PROCESS_DELAY`**: The minimum frequency that the same repository can be considered for auto-index scheduling. Default is every 24 hours.
+
+**`PRECISE_CODE_INTEL_AUTO_INDEXING_REPOSITORY_BATCH_SIZE`**: The number of repositories to consider for auto-indexing scheduling at a time. Default is 100.
+
+**`PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_INSPECTED_PER_SECOND`**: The maximum number of repositories inspected for auto-indexing per second. Set to zero to disable limit. Default is 0.

--- a/doc/code_intelligence/how-to/enable_auto_indexing.md
+++ b/doc/code_intelligence/how-to/enable_auto_indexing.md
@@ -8,7 +8,7 @@
 
 ## Deploy executors
 
-First, [deploy the executor service](../../../../admin/deploy_executors) targeting your Sourcegraph instance. This will provide the necessary compute resources that clone the target Git repository, securely analyze the code to produce a precise code intelligence index, then upload that index to your Sourcegraph instance for processing.
+First, [deploy the executor service](../../../../admin/deploy_executors.md) targeting your Sourcegraph instance. This will provide the necessary compute resources that clone the target Git repository, securely analyze the code to produce a precise code intelligence index, then upload that index to your Sourcegraph instance for processing.
 
 ## Enable index job scheduling
 
@@ -24,13 +24,13 @@ This step will control the scheduling of indexing jobs which are made available 
 
 ## Configure auto-indexing policies
 
-Once auto-indexing has been enabled, [create auto-indexing policies](configure_auto_indexing) to control the set of repositories and commits that are eligible for indexing.
+Once auto-indexing has been enabled, [create auto-indexing policies](configure_auto_indexing.md) to control the set of repositories and commits that are eligible for indexing.
 
-> NOTE: If you are running Sourcegraph 3.33, then only the repositories that exist within one or more [search contexts](../../../../code_search/how-to/search_contexts) are eligible for auto-indexing. This is a temporary and vestigial artifact of auto-indexing being developed on our Cloud instance, which has an extremely large corpus of repositories. We advise you to create a `code-intel-indexing-corpus` search context and add the set of repositories you wish to have indexed. This is not required post-Sourcegraph 3.33.
+> NOTE: If you are running Sourcegraph 3.33, then only the repositories that exist within one or more [search contexts](../../../../code_search/how-to/search_contexts.md) are eligible for auto-indexing. This is a temporary and vestigial artifact of auto-indexing being developed on our Cloud instance, which has an extremely large corpus of repositories. We advise you to create a `code-intel-indexing-corpus` search context and add the set of repositories you wish to have indexed. This is not required post-Sourcegraph 3.33.
 
 ## Tune the index scheduler
 
-The frequency of index job scheduling can be tuned via the following environment variables read by `worker` service containers running the [`codeintel-auto-indexing`](../../../admin/workers#codeintel-auto-indexing) task.
+The frequency of index job scheduling can be tuned via the following environment variables read by `worker` service containers running the [`codeintel-auto-indexing`](../../../admin/workers.md#codeintel-auto-indexing) task.
 
 **`PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL`**: The frequency with which to run periodic codeintel auto-indexing tasks. Default is every 10 minutes.
 

--- a/doc/code_intelligence/how-to/enable_auto_indexing.md
+++ b/doc/code_intelligence/how-to/enable_auto_indexing.md
@@ -8,7 +8,7 @@
 
 ## Deploy executors
 
-First, [deploy the executor service](../../../../admin/deploy_executors) targeting your Sourcegraph instance. This will provide the necessary compute resources that clone the target Git repository, analyze the code to produce a precise code intelligence index, then upload that index to your Sourcegraph instance for processing.
+First, [deploy the executor service](../../../../admin/deploy_executors) targeting your Sourcegraph instance. This will provide the necessary compute resources that clone the target Git repository, securely analyze the code to produce a precise code intelligence index, then upload that index to your Sourcegraph instance for processing.
 
 ## Enable index job scheduling
 

--- a/doc/code_intelligence/how-to/index.md
+++ b/doc/code_intelligence/how-to/index.md
@@ -16,4 +16,5 @@
 
 - [Add LSIF to many repositories](adding_lsif_to_many_repos.md)
 - [Adding LSIF to CI workflows](adding_lsif_to_workflows.md)
-
+- <span class="badge badge-experimental">Experimental</span> [Enable auto-indexing](enable_auto_indexing.md)
+- <span class="badge badge-experimental">Experimental</span> [Configure auto-indexing](configure_auto_indexing.md)

--- a/doc/code_intelligence/index.md
+++ b/doc/code_intelligence/index.md
@@ -63,12 +63,12 @@ Code intelligence provides advanced code navigation features that let developers
   - [Find references](explanations/features.md#find-references)
   - [Symbol search](explanations/features.md#symbol-search)
 - [Writing an indexer](explanations/writing_an_indexer.md)
-- <span class="badge badge-experimental">Experimental</span> [Auto indexing](explanations/auto_indexing.md)
-- <span class="badge badge-experimental">Experimental</span> [Auto indexing inference](explanations/auto_indexing_inference.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto-indexing](explanations/auto_indexing.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto-indexing inference](explanations/auto_indexing_inference.md)
 
 ## [References](references/index.md)
 
 - [Troubleshooting](references/troubleshooting.md)
 - [Sourcegraph recommended indexers](references/indexers.md)
 - [LSIF.dev](https://lsif.dev/)
-- <span class="badge badge-experimental">Experimental</span> [Auto indexing configuration](references/auto_indexing_configuration.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto-indexing configuration](references/auto_indexing_configuration.md)

--- a/doc/code_intelligence/index.md
+++ b/doc/code_intelligence/index.md
@@ -37,7 +37,6 @@ Code intelligence provides advanced code navigation features that let developers
 
 ## [How-tos](how-to/index.md)
 
-
 - [Configure data retention policies](how-to/configure_data_retention.md)
 - [Add a GitHub repository to your Sourcegraph instance](how-to/add_a_repository.md)
 - [Index a Go repository](how-to/index_a_go_repository.md)
@@ -46,6 +45,8 @@ Code intelligence provides advanced code navigation features that let developers
 - [Index other languages](how-to/index_other_languages.md)
 - [Add LSIF to many repositories](how-to/adding_lsif_to_many_repos.md)
 - [Adding LSIF to CI workflows](how-to/adding_lsif_to_workflows.md)
+- <span class="badge badge-experimental">Experimental</span> [Enable auto-indexing](how-to/enable_auto_indexing.md)
+- <span class="badge badge-experimental">Experimental</span> [Configure auto-indexing](how-to/configure_auto_indexing.md)
 
 ## [Tutorials](tutorials/index.md)
 
@@ -62,9 +63,12 @@ Code intelligence provides advanced code navigation features that let developers
   - [Find references](explanations/features.md#find-references)
   - [Symbol search](explanations/features.md#symbol-search)
 - [Writing an indexer](explanations/writing_an_indexer.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto indexing](explanations/auto_indexing.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto indexing inference](explanations/auto_indexing_inference.md)
 
 ## [References](references/index.md)
 
 - [Troubleshooting](references/troubleshooting.md)
 - [Sourcegraph recommended indexers](references/indexers.md)
 - [LSIF.dev](https://lsif.dev/)
+- <span class="badge badge-experimental">Experimental</span> [Auto indexing configuration](references/auto_indexing_configuration.md)

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -1,4 +1,4 @@
-# Auto indexing configuration reference
+# Auto-indexing configuration reference
 
 <aside class="experimental">
 <p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -53,7 +53,7 @@ index_jobs:
 
 ## Index job object
 
-Each configured index job is run by a single executor process and multiple index jobs configured for the same repository may be executed by different executor instances, out of order, and possibly in parallel.
+Each configured index job is run by a single executor process. Multiple index jobs configured for the same repository may be executed by different executor instances, out of order, and possibly in parallel.
 
 The basic outline of an index job is as follows.
 

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -62,7 +62,7 @@ The basic outline of an index job is as follows.
 3. A separate Docker container for the indexer is started.
 4. Local steps (if configured) are executed within the running container.
 5. The indexer is invoked within the running container to produce an index artifact.
-6. The [`src` CLI](/cli/index.md) binary is invoked to upload the index artifact to the Sourcegraph instance.
+6. The [`src` CLI](../../cli/index.md) binary is invoked to upload the index artifact to the Sourcegraph instance.
 
 The pre-indexing steps, indexer container, local steps, and indexer arguments are configurable via this object.
 
@@ -92,7 +92,7 @@ The working directory within the Docker container where the provided local steps
 
 #### [`outfile`](#index-job-outfile)
 
-The path to the precise code intelligence index artifact produced by the indexer, which is uploaded to the target Sourcegraph instance via [`src` CLI](/cli/index.md) after the index step has completed successfully. This path is relative to the index job `root` (defined above). If not supplied, the value is assumed to be `dump.lsif` (which is the default artifact name of many indexers).
+The path to the precise code intelligence index artifact produced by the indexer, which is uploaded to the target Sourcegraph instance via [`src` CLI](../../cli/index.md) after the index step has completed successfully. This path is relative to the index job `root` (defined above). If not supplied, the value is assumed to be `dump.lsif` (which is the default artifact name of many indexers).
 
 Supply this argument when the target indexer produces a differently named artifact. Alternatively, some indexers provide flags to change the artifact name; in which case `dump.lsif` can be supplied there and a value for this key can be omitted.
 

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -22,7 +22,7 @@ The shared steps field defines an ordered sequence of pre-indexing actions (form
 
 ## Examples
 
-In the following example, we have a repository configured to index three different projects: `cmd/foo`, `cmd/bar`, and `cmd/baz`. These projects are executed concurrently by free executor processes. Each index job shares a common setup step that runs a `setup.sh` script in the root of the repository and installs Go dependencies. The index job for `cmd/bar` additionally require sa codegen step, which is performed after the shared step but before the indexer invocation.
+In the following example, we have a repository configured to index three different projects: `cmd/foo`, `cmd/bar`, and `cmd/baz`. These projects are executed concurrently by available executor processes. Each index job shares an initial step that runs a `setup.sh` script in the root of the repository and installs Go dependencies. The index job for `cmd/bar` additionally requires a code generation step, which is performed after the shared step but before the indexer invocation.
 
 ```yaml
 shared_steps:

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -114,7 +114,7 @@ indexer_args:
 root: dev/sg
 ```
 
-The following example uses the Docker image `sourcegraph/lsif-node` pinned at the tag `autoindex`. This index configuration will run `npm install` followed by the TypeScript indexer in the `editors/code` directory. In this job, the `npm install` and the `lsif-tsc` are performed using the same workspace, but are invoked in different Docker containers. Both containers happen to be based on the same image, but that's not necessary.
+The following example uses the Docker image `sourcegraph/lsif-node` pinned at the tag `autoindex`. This index configuration will run `npm install` followed by the TypeScript indexer `lsif-tsc` in the `editors/code` directory. In this job, both commands run in the same workspace, but are invoked in different Docker containers. Both containers happen to be based on the same image, but that's not necessary.
 
 ```yaml
 steps:

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -57,12 +57,12 @@ Each configured index job is run by a single executor process. Multiple index jo
 
 The basic outline of an index job is as follows.
 
-1. The target repository is cloned into the job's workspace
-2. Pre-indexing steps (if configured) executed in individual Docker container that volume mount the workspace
-3. A Docker container for the indexer is started
-4. Local steps (if configured) are executed within the running container
-5. The indexer is invoked within the running container to produce an index artifact
-6. The src cli is invoked to upload the index artifact to the Sourcegraph instance
+1. The target repository is cloned into the job's workspace from Sourcegraph.
+2. Pre-indexing steps (if any are configured) are executed sequentially in individual Docker containers that volume mount the workspace.
+3. A separate Docker container for the indexer is started.
+4. Local steps (if configured) are executed within the running container.
+5. The indexer is invoked within the running container to produce an index artifact.
+6. The [`src` CLI](/cli/index.md) is invoked to upload the index artifact to the Sourcegraph instance.
 
 The pre-indexing steps, indexer container, local steps, and indexer arguments are configurable via this object.
 

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -62,7 +62,7 @@ The basic outline of an index job is as follows.
 3. A separate Docker container for the indexer is started.
 4. Local steps (if configured) are executed within the running container.
 5. The indexer is invoked within the running container to produce an index artifact.
-6. The [`src` CLI](/cli/index.md) is invoked to upload the index artifact to the Sourcegraph instance.
+6. The [`src` CLI](/cli/index.md) binary is invoked to upload the index artifact to the Sourcegraph instance.
 
 The pre-indexing steps, indexer container, local steps, and indexer arguments are configurable via this object.
 
@@ -92,7 +92,7 @@ The working directory within the Docker container where the provided local steps
 
 #### [`outfile`](#index-job-outfile)
 
-The path to the precise code intelligence index artifact produced by the indexer, which is uploaded to the target Sourcegraph instance via src-cli after the index step has completed successfully. This path is relative to the index job `root` (defined above). If not supplied, the value is assumed to be `dump.lsif` (which is the default artifact name of many indexers).
+The path to the precise code intelligence index artifact produced by the indexer, which is uploaded to the target Sourcegraph instance via [`src` CLI](/cli/index.md) after the index step has completed successfully. This path is relative to the index job `root` (defined above). If not supplied, the value is assumed to be `dump.lsif` (which is the default artifact name of many indexers).
 
 Supply this argument when the target indexer produces a differently named artifact. Alternatively, some indexers provide flags to change the artifact name; in which case `dump.lsif` can be supplied there and a value for this key can be omitted.
 

--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -1,0 +1,198 @@
+# Auto indexing configuration reference
+
+<aside class="experimental">
+<p><span class="badge badge-experimental">Experimental</span> This feature is available as an experimental feature in Sourcegraph 3.33 or later. As long as this feature is marked as experimental, instance and deployment requirements, behavior, and performance profiles are subject to change in the future without notice.</p>
+
+<p><b>We'd love to ensure that this feature is meeting the requirements of our users.</b> If you have input or feedback on this feature, you can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
+This document details the expected contents of [explicit index job configuration](../how-to/configure_auto_indexing.md#explicit-index-job-configuration) for a particular repository. Depending on how this configuration is supplied, it may be encoded as YAML or JSON.
+
+## Keys
+
+The root of the configuration has two top-level keys, `index_jobs` and `shared_steps`, documented below.
+
+### [`index_jobs`](#index-jobs)
+
+The index jobs field defines a set of [index job objects](#index-job-object) describing the actions to perform to successfully index a fresh clone of a repository. Each index job is executed independently (and possibly in parallel) by an executor.
+
+### [`shared_steps`](#shared-steps)
+
+The shared steps field defines an ordered sequence of pre-indexing actions (formatted as a [Docker step object](#docker-step-object)). Each step is executed before each index job is executed. Shared steps are executed individually once _per indexing job_ and are designed to be used as a way of sharing code and common configuration for projects within a repository (but are not designed as a way to share compute resources).
+
+## Examples
+
+In the following example, we have a repository configured to index three different projects: `cmd/foo`, `cmd/bar`, and `cmd/baz`. These projects are executed concurrently by free executor processes. Each index job shares a common setup step that runs a `setup.sh` script in the root of the repository and installs Go dependencies. The index job for `cmd/bar` additionally require sa codegen step, which is performed after the shared step but before the indexer invocation.
+
+```yaml
+shared_steps:
+  image: sourcegraph/lsif-go
+  commands:
+    - ./setup.sh      # Run a custom setup script
+    - go mod download # Download dependencies
+
+index_jobs:
+  # Index cmd/foo
+  - indexer: sourcegraph/lsif-go
+    root: cmd/foo
+
+  # Index cmd/bar
+  # Requires an additional codegen step
+  - indexer: sourcegraph/lsif-go
+    steps:
+      - image: sourcegraph/lsif-go
+        commands:
+          - go generate ./...
+        root: cmd/bar
+    root: cmd/bar
+  
+  # Index cmd/baz
+  - indexer: sourcegraph/lsif-go
+    root: cmd/baz
+```
+
+## Index job object
+
+Each configured index job is run by a single executor process and multiple index jobs configured for the same repository may be executed by different executor instances, out of order, and possibly in parallel.
+
+The basic outline of an index job is as follows.
+
+1. The target repository is cloned into the job's workspace
+2. Pre-indexing steps (if configured) executed in individual Docker container that volume mount the workspace
+3. A Docker container for the indexer is started
+4. Local steps (if configured) are executed within the running container
+5. The indexer is invoked within the running container to produce an index artifact
+6. The src cli is invoked to upload the index artifact to the Sourcegraph instance
+
+The pre-indexing steps, indexer container, local steps, and indexer arguments are configurable via this object.
+
+### Keys
+
+Each indexing job object can be configured with the following keys.
+
+#### [`steps`](#index-job-steps)
+
+The steps field defines an ordered sequence of pre-indexing actions (formatted as a [Docker step object](#docker-step-object)). If `shared_steps` are defined in the top level of the configuration, those steps are **prepended** to this sequence. Each step is executed before the indexer itself is invoked.
+
+#### [`indexer`](#index-job-indexer)
+
+The name of the Docker image distribution of the target indexer.
+
+#### [`local_steps`](#index-job-local-steps)
+
+An ordered sequence of commands to execute within a container running the configured indexer image. These commands are passed directly into the target container via `docker exec`, one at a time. Local steps should be used over Docker steps when the intended side effects alter state outside of the workspace on disk (e.g., setting up environment variables or installing OS packages require by the indexer tool).
+
+#### [`indexer_args`](#index-job-indexer-args)
+
+An ordered sequence of arguments that make up the indexing command. The indexing command is passed directly into the target container via `docker exec`. This step is expected to produce a precise code intelligence index artifact (as described by the `root` and `outfile` fields, described below).
+
+#### [`root`](#index-job-root)
+
+The working directory within the Docker container where the provided local steps and indexer commands are executed. This working directory is relative to the root of the target repository. An empty value (the default) indicates the root of the repository. This is also the directory relative to the path where the precise code intelligence index artifact is produced.
+
+#### [`outfile`](#index-job-outfile)
+
+The path to the precise code intelligence index artifact produced by the indexer, which is uploaded to the target Sourcegraph instance via src-cli after the index step has completed successfully. This path is relative to the index job `root` (defined above). If not supplied, the value is assumed to be `dump.lsif` (which is the default artifact name of many indexers).
+
+Supply this argument when the target indexer produces a differently named artifact. Alternatively, some indexers provide flags to change the artifact name; in which case `dump.lsif` can be supplied there and a value for this key can be omitted.
+
+### Examples
+
+The following example uses the Docker image `sourcegraph/lsif-go` pinned at the tag `v1.6.7` and additionally secured with an image digest. This index configuration runs the Go indexer with quiet output in the `dev/sg` directory and uploads the resulting index file (`dump.lsif` by default).
+
+```yaml
+indexer: sourcegraph/lsif-go:v1.6.7@sha256::9c2d9cf...1baed2b
+
+# sourcegraph/lsif-go does not define a Docker entrypoint, so we need to
+# indicate which binary to invoke (along with any additional arguments).
+# Here, -q and --no-animation are lsif-go flags that control verbosity.
+indexer_args:
+  - lsif-go
+  - -q
+  - --no-animation
+
+root: dev/sg
+```
+
+The following example uses the Docker image `sourcegraph/lsif-node` pinned at the tag `autoindex`. This index configuration will run `npm install` followed by the TypeScript indexer in the `editors/code` directory. In this job, the `npm install` and the `lsif-tsc` are performed using the same workspace, but are invoked in different Docker containers. Both containers happen to be based on the same image, but that's not necessary.
+
+```yaml
+steps:
+  - image: sourcegraph/lsif-node:autoindex
+    commands:
+      - npm install
+    root: editors/code
+
+# sourcegraph/lsif-node does not define a Docker entrypoint, so we need 
+# to indicate which binary to invoke (along with any additional arguments).
+# Here, -p and . are passed to the underlying TypeScript language analyzer.
+indexer: sourcegraph/lsif-node:autoiondex
+indexer_args:
+    - lsif-tsc
+    - -p
+    - .
+
+root: editors/code
+```
+
+The following example uses the Docker image `sourcegraph/lsif-clang` using the default tag. This index configuration will run a series of commands followed by the Clang indexer. Because these commands are defined as _local_ steps, they will occur in the same Docker container as the index operation. This distinction is necessary when the setup process must affect more than the filesystem - here we needed to install OS packages and install a build-time tool.
+
+```yaml
+indexer: sourcegraph/lsif-clang
+local_steps:
+  - apt-get update
+  - DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential ... clang-10
+  - python3 -m pip install compiledb
+  - python3 -m compiledb -n make
+
+# sourcegraph/lsif-clang does not define a Docker entrypoint, so we need 
+# to indicate which binary to invoke (along with any additional arguments).
+# Here, we have lsif-clang consume the compile_commands.json manifest generated
+# by the local steps defined above.
+indexer_args:
+  - lsif-clang
+  - compile_commands.json
+
+# Ensure lsif-clang generates the file expected by src lsif upload.
+outfile: dump.lsif
+```
+
+## Docker step object
+
+Each configured Docker step is executed sequentially using the same volume-mounted workspace, which is initially seeded with a fresh clone of the target repository. If the contents of the workspace is modified by one step, the changes will be visible in the next. This makes Docker steps especially useful for pre-indexing tasks that require modification of the source code, such as dependency resolution (e.g., `npm install`, `go mod download`) and code generation (e.g., `go generate ./...`) required for successful compilation or indexing of the project.
+
+### Keys
+
+Each Docker step object can be configured with the following keys.
+
+#### [`image`](#docker-step-image)
+
+The name of the Docker image in which the configured commands are executed.
+
+#### [`commands`](#docker-step-commands)
+
+An ordered sequence of commands to execute within a container running the configured image. These commands are passed directly into the target container via `docker exec`, one at a time.
+
+#### [`root`](#docker-step-root)
+
+The working directory within the Docker container where the provided commands are executed. This working directory is relative to the root of the target repository. An empty value (the default) indicates the root of the repository.
+
+### Examples
+
+The following example runs `go generate` over all packages in the root of the repository.
+
+```yaml
+indexer: golang:1.17.3-buster@sha256:c1bae5f...3e4f07b
+commands:
+  - go generate ./...
+```
+
+The following example runs a series of commands to install dependencies in the `lib/proj` directory.
+
+```yaml
+indexer: node:alpine3.12@sha256:4435145...fd06fd3
+commands:
+  - yarn config set ignore-engines true
+  - yarn install
+root: lib/proj
+```

--- a/doc/code_intelligence/references/index.md
+++ b/doc/code_intelligence/references/index.md
@@ -3,3 +3,4 @@
 - [Troubleshooting](troubleshooting.md)
 - [Sourcegraph recommended indexers](indexers.md)
 - [LSIF.dev](https://lsif.dev/)
+- <span class="badge badge-experimental">Experimental</span> [Auto indexing configuration](auto_indexing_configuration.md)

--- a/doc/code_intelligence/references/index.md
+++ b/doc/code_intelligence/references/index.md
@@ -3,4 +3,4 @@
 - [Troubleshooting](troubleshooting.md)
 - [Sourcegraph recommended indexers](indexers.md)
 - [LSIF.dev](https://lsif.dev/)
-- <span class="badge badge-experimental">Experimental</span> [Auto indexing configuration](auto_indexing_configuration.md)
+- <span class="badge badge-experimental">Experimental</span> [Auto-indexing configuration](auto_indexing_configuration.md)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -25,7 +25,7 @@ const (
 	DefaultIndexPageSize  = 50
 )
 
-var errAutoIndexingNotEnabled = errors.New("precise code intelligence auto indexing is not enabled")
+var errAutoIndexingNotEnabled = errors.New("precise code intelligence auto-indexing is not enabled")
 
 // Resolver is the main interface to code intel-related operations exposted to the GraphQL API. This
 // resolver concerns itself with GraphQL/API-specific behaviors (auth, validation, marshaling, etc.).

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1388,7 +1388,7 @@ type Settings struct {
 	AlertsShowPatchUpdates bool `json:"alerts.showPatchUpdates,omitempty"`
 	// CodeHostUseNativeTooltips description: Whether to use the code host's native hover tooltips when they exist (GitHub's jump-to-definition tooltips, for example).
 	CodeHostUseNativeTooltips bool `json:"codeHost.useNativeTooltips,omitempty"`
-	// CodeIntelligenceAutoIndexPopularRepoLimit description: Up to this number of repos are auto indexed automatically. Ordered by star count.
+	// CodeIntelligenceAutoIndexPopularRepoLimit description: Up to this number of repos are auto-indexed automatically. Ordered by star count.
 	CodeIntelligenceAutoIndexPopularRepoLimit int `json:"codeIntelligence.autoIndexPopularRepoLimit,omitempty"`
 	// CodeIntelligenceAutoIndexRepositoryGroups description: A list of search.repositoryGroups that have auto-indexing enabled.
 	CodeIntelligenceAutoIndexRepositoryGroups []string `json:"codeIntelligence.autoIndexRepositoryGroups,omitempty"`
@@ -1553,7 +1553,7 @@ type SiteConfiguration struct {
 	CampaignsRestrictToAdmins *bool `json:"campaigns.restrictToAdmins,omitempty"`
 	// CloneProgressLog description: Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.
 	CloneProgressLog bool `json:"cloneProgress.log,omitempty"`
-	// CodeIntelAutoIndexingEnabled description: Enables/disables the code intel auto indexing feature. This feature is currently supported only on certain managed Sourcegraph instances.
+	// CodeIntelAutoIndexingEnabled description: Enables/disables the code intel auto-indexing feature. This feature is currently supported only on certain managed Sourcegraph instances.
 	CodeIntelAutoIndexingEnabled *bool `json:"codeIntelAutoIndexing.enabled,omitempty"`
 	// CorsOrigin description: Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
 	CorsOrigin string `json:"corsOrigin,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -268,7 +268,7 @@
       }
     },
     "codeIntelligence.autoIndexPopularRepoLimit": {
-      "description": "Up to this number of repos are auto indexed automatically. Ordered by star count.",
+      "description": "Up to this number of repos are auto-indexed automatically. Ordered by star count.",
       "type": "integer",
       "minimum": 0,
       "default": 0

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -393,7 +393,7 @@
       "default": false
     },
     "codeIntelAutoIndexing.enabled": {
-      "description": "Enables/disables the code intel auto indexing feature. This feature is currently supported only on certain managed Sourcegraph instances.",
+      "description": "Enables/disables the code intel auto-indexing feature. This feature is currently supported only on certain managed Sourcegraph instances.",
       "type": "boolean",
       "!go": { "pointer": true },
       "group": "Code intelligence",


### PR DESCRIPTION
Fixes #24989.

@eseliger and I have been working on deployment docs for the executor. We've roughly drafted those to be correct, then I threw this down as a template.

@olafurpg: Feel free to do as much or as little as you want to the structure of the docs we have here.