### PR TITLE
[CLOUD-78] db: update `authzQuery` to consult org-added repos

### DIFF
--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -93,7 +93,7 @@ OR  (                             -- Restricted repositories require checking pe
 		AND (
 				(user_id IS NULL AND org_id IS NULL)  -- The repository was added at the instance level
 			OR  user_id = %s                          -- The authenticated user added this repository
-			OR  EXISTS (                              -- The authenticated user is a member of an organization added this repository
+			OR  EXISTS (                              -- The authenticated user is a member of an organization that added this repository
 				SELECT
 				FROM org_members
 				WHERE

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -171,7 +171,7 @@ func TestAuthzQueryConds(t *testing.T) {
 	}
 }
 
-func TestRepos_nonSiteAdminCanViewOwnPrivateCode(t *testing.T) {
+func TestRepoStore_nonSiteAdminCanViewOwnPrivateCode(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -241,6 +241,21 @@ VALUES (%s, %s, NULLIF(%s, 0), '')
 		t.Fatal(err)
 	}
 
+	q = sqlf.Sprintf(`
+INSERT INTO user_permissions (user_id, permission, object_type, object_ids_ints, updated_at)
+VALUES
+	(%s, 'read', 'repos', %s, NOW())
+`,
+		alice.ID, pq.Array([]int32{int32(alicePrivateRepo.ID)}),
+	)
+	_, err = db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authz.SetProviders(false, []authz.Provider{&fakeProvider{}})
+	defer authz.SetProviders(true, nil)
+
 	// Alice should be able to see both her public and private repos
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
 	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
@@ -248,6 +263,118 @@ VALUES (%s, %s, NULLIF(%s, 0), '')
 		t.Fatal(err)
 	}
 	wantRepos := []*types.Repo{alicePublicRepo, alicePrivateRepo}
+	if diff := cmp.Diff(wantRepos, repos, cmpopts.IgnoreFields(types.Repo{}, "Sources")); diff != "" {
+		t.Fatalf("Mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRepoStore_nonSiteAdminCanViewOrgPrivateCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	db := dbtest.NewDB(t)
+	ctx := context.Background()
+
+	// Add a single user who is NOT a site admin
+	alice, err := Users(db).Create(ctx,
+		NewUser{
+			Email:                 "alice@example.com",
+			Username:              "alice",
+			Password:              "alice",
+			EmailVerificationCode: "alice",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Users(db).SetIsSiteAdmin(ctx, alice.ID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up two private repositories the user has access to both on the code host:
+	//  1. One is not added to the organization code host connection
+	//  2. One is added to the organization code host connection
+	internalCtx := actor.WithInternalActor(ctx)
+	privateRepo1 := mustCreate(internalCtx, t, db,
+		&types.Repo{
+			Name:    "private_repo_1",
+			Private: true,
+			ExternalRepo: api.ExternalRepoSpec{
+				ID:          "private_repo_1",
+				ServiceType: extsvc.TypeGitHub,
+				ServiceID:   "https://github.com/",
+			},
+		},
+	)[0]
+	privateRepo2 := mustCreate(internalCtx, t, db,
+		&types.Repo{
+			Name:    "private_repo_2",
+			Private: true,
+			ExternalRepo: api.ExternalRepoSpec{
+				ID:          "private_repo_2",
+				ServiceType: extsvc.TypeGitHub,
+				ServiceID:   "https://github.com/",
+			},
+		},
+	)[0]
+
+	// Create an organization and add alice as a member
+	org, err := Orgs(db).Create(ctx, "org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = OrgMembers(db).Create(ctx, org.ID, alice.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	extsvc := &types.ExternalService{
+		Kind:           extsvc.KindGitHub,
+		DisplayName:    "GITHUB #1",
+		Config:         `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
+		NamespaceOrgID: org.ID,
+	}
+	err = ExternalServices(db).Create(ctx, confGet, extsvc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q := sqlf.Sprintf(`
+INSERT INTO external_service_repos (external_service_id, repo_id, org_id, clone_url)
+VALUES (%s, %s, NULLIF(%s, 0), '')
+`, extsvc.ID, privateRepo2.ID, extsvc.NamespaceOrgID)
+	_, err = db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q = sqlf.Sprintf(`
+INSERT INTO user_permissions (user_id, permission, object_type, object_ids_ints, updated_at)
+VALUES
+	(%s, 'read', 'repos', %s, NOW())
+`,
+		alice.ID, pq.Array([]int32{int32(privateRepo1.ID), int32(privateRepo2.ID)}),
+	)
+	_, err = db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authz.SetProviders(false, []authz.Provider{&fakeProvider{}})
+	defer authz.SetProviders(true, nil)
+
+	// Alice should be able to see both her public and private repos
+	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
+	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRepos := []*types.Repo{privateRepo2}
 	if diff := cmp.Diff(wantRepos, repos, cmpopts.IgnoreFields(types.Repo{}, "Sources")); diff != "" {
 		t.Fatalf("Mismatch (-want +got):\n%s", diff)
 	}
@@ -272,7 +399,7 @@ func createGitHubExternalService(t *testing.T, db dbutil.DB, userID int32) *type
 }
 
 // 🚨 SECURITY: Tests are necessary to ensure security.
-func TestRepos_List_checkPermissions(t *testing.T) {
+func TestRepoStore_List_checkPermissions(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -467,8 +594,9 @@ VALUES
 	authz.SetProviders(false, []authz.Provider{&fakeProvider{}})
 	defer authz.SetProviders(true, nil)
 
-	// Alice should see "alice_public_repo", "alice_private_repo", "bob_public_repo", "cindy_private_repo"
-	// "cindy_private_repos" comes from an unrestricted external service
+	// Alice should see "alice_public_repo", "alice_private_repo",
+	// "bob_public_repo", "cindy_private_repo". The "cindy_private_repo" comes from
+	// an unrestricted external service
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
 	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
 	if err != nil {
@@ -479,8 +607,9 @@ VALUES
 		t.Fatalf("Mismatch (-want +got):\n%s", diff)
 	}
 
-	// Bob should see "alice_public_repo", "bob_private_repo", "bob_public_repo", "cindy_private_repo"
-	// "cindy_private_repos" comes from an unrestricted external service
+	// Bob should see "alice_public_repo", "bob_private_repo", "bob_public_repo",
+	// "cindy_private_repo". The "cindy_private_repo" comes from an unrestricted
+	// external service
 	bobCtx := actor.WithActor(ctx, &actor.Actor{UID: bob.ID})
 	repos, err = Repos(db).List(bobCtx, ReposListOptions{})
 	if err != nil {
@@ -531,7 +660,7 @@ VALUES
 }
 
 // 🚨 SECURITY: Tests are necessary to ensure security.
-func TestRepos_List_permissionsUserMapping(t *testing.T) {
+func TestRepoStore_List_permissionsUserMapping(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
This PR alters the `authzQuery` to enforce org-added repo visibility to users that:

1. Have access on the code host
2. Being added to the organization

---

- Jira: CLOUD-78
- Should be merged after #26828
