### PR TITLE
Clarify Fields for Batch Changes GitHub Webhooks

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -93,14 +93,17 @@ To set up webhooks:
    * **Payload URL**: the URL you copied above from Sourcegraph.
    * **Content type**: this must be set to `application/json`.
    * **Secret**: the secret token you configured Sourcegraph to use above.
-   * **Which events**: select **Let me select individual events**, and then enable:
-     - Issue comments
-     - Pull requests
-     - Pull request reviews
-     - Pull request review comments
-     - Check runs
-     - Check suites
-     - Statuses
+   * **Which events**: 
+     * Select ***Let me select individual events***
+     * Enable these required events: *(push events are enabled by default, but are not required)*
+       - Issue comments
+       - Pull requests
+       - Pull request reviews
+       - Pull request review comments
+       - Check runs
+       - Check suites
+       - Statuses
+     
    * **Active**: ensure this is enabled.
 1. Click **Add webhook**.
 1. Confirm that the new webhook is listed.


### PR DESCRIPTION
The "pushes" field is active by default when creating a GitHub webhook, but we do not consume this event.  This commit clarifies the instructions.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
