### PR TITLE
Replacing fmt.Sprintf with strconv.Itoa

### DIFF
--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,7 +74,7 @@ func TestExtractCloneURL(t *testing.T) {
 			}
 
 			for idx := range tc.configs {
-				repo.Sources[fmt.Sprintf("%d", idx)] = &types.SourceInfo{
+				repo.Sources[strconv.Itoa(idx)] = &types.SourceInfo{
 					ID: fmt.Sprintf("::%d", idx), // see SourceInfo.ExternalServiceID
 				}
 			}

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1232,7 +1233,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				}
 				for i := 1; i <= countToExceedParameterLimit; i++ {
-					u.accounts.AccountIDs[i-1] = fmt.Sprintf("%d", i)
+					u.accounts.AccountIDs[i-1] = strconv.Itoa(i)
 				}
 				return []update{u}
 			}(),
@@ -1242,7 +1243,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					perms[extsvc.AccountSpec{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
-						AccountID:   fmt.Sprintf("%d", i),
+						AccountID:   strconv.Itoa(i),
 					}] = []uint32{1}
 				}
 				return perms
@@ -1254,7 +1255,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						accounts[i-1] = extsvc.AccountSpec{
 							ServiceType: authz.SourcegraphServiceType,
 							ServiceID:   authz.SourcegraphServiceID,
-							AccountID:   fmt.Sprintf("%d", i),
+							AccountID:   strconv.Itoa(i),
 						}
 					}
 					return accounts

--- a/internal/cmd/tracking-issue/issue_loader.go
+++ b/internal/cmd/tracking-issue/issue_loader.go
@@ -207,7 +207,7 @@ func (l *IssueLoader) performRequest(ctx context.Context, cli *graphql.Client, r
 // This is used to later construct a GraphQL request with a subset of these queries.
 func makeFragmentArgs(n int) (fragments []string, args [][]string) {
 	for i := 0; i < n; i++ {
-		fragments = append(fragments, makeSearchQuery(fmt.Sprintf("%d", i)))
+		fragments = append(fragments, makeSearchQuery(strconv.Itoa(i)))
 
 		args = append(args, []string{
 			fmt.Sprintf("$query%d: String!", i),

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -417,7 +418,7 @@ func TestStoreAddExecutionLogEntry(t *testing.T) {
 	numEntries := 5
 
 	for i := 0; i < numEntries; i++ {
-		command := []string{"ls", "-a", fmt.Sprintf("%d", i+1)}
+		command := []string{"ls", "-a", strconv.Itoa(i + 1)}
 		payload := fmt.Sprintf("<load payload %d>", i+1)
 
 		entry := workerutil.ExecutionLogEntry{
@@ -450,7 +451,7 @@ func TestStoreAddExecutionLogEntry(t *testing.T) {
 		}
 
 		expected := workerutil.ExecutionLogEntry{
-			Command: []string{"ls", "-a", fmt.Sprintf("%d", i+1)},
+			Command: []string{"ls", "-a", strconv.Itoa(i + 1)},
 			Out:     fmt.Sprintf("<load payload %d>", i+1),
 		}
 		if diff := cmp.Diff(expected, entry); diff != "" {
@@ -486,7 +487,7 @@ func TestStoreUpdateExecutionLogEntry(t *testing.T) {
 
 	numEntries := 5
 	for i := 0; i < numEntries; i++ {
-		command := []string{"ls", "-a", fmt.Sprintf("%d", i+1)}
+		command := []string{"ls", "-a", strconv.Itoa(i + 1)}
 		payload := fmt.Sprintf("<load payload %d>", i+1)
 
 		entry := workerutil.ExecutionLogEntry{
@@ -524,7 +525,7 @@ func TestStoreUpdateExecutionLogEntry(t *testing.T) {
 		}
 
 		expected := workerutil.ExecutionLogEntry{
-			Command: []string{"ls", "-a", fmt.Sprintf("%d", i+1)},
+			Command: []string{"ls", "-a", strconv.Itoa(i + 1)},
 			Out:     fmt.Sprintf("<load payload %d>\n<load payload %d again, nobody was at home>", i+1, i+1),
 		}
 		if diff := cmp.Diff(expected, entry); diff != "" {

--- a/lib/codeintel/tools/lsif-index-tester/range_differ.go
+++ b/lib/codeintel/tools/lsif-index-tester/range_differ.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -65,7 +66,7 @@ func DrawLocations(contents string, expected, actual Location, context int) (str
 
 		text := header(expected) + "\n"
 
-		prefixWidth := len(fmt.Sprintf("%d", line+1+context))
+		prefixWidth := len(strconv.Itoa(line + 1 + context))
 
 		for offset := context; offset > 0; offset-- {
 			newLine := line - offset


### PR DESCRIPTION
This campiagn replaces `fmt.Sprintf` with `strconv.Itoa`

[_Created by Sourcegraph batch change `david.rohnow/comby-go-fmt`._](https://demo.sourcegraph.com/users/david.rohnow/batch-changes/comby-go-fmt)