### PR TITLE
add worker to custom redis changes

### DIFF
--- a/doc/admin/install/kubernetes/configure.md
+++ b/doc/admin/install/kubernetes/configure.md
@@ -758,6 +758,7 @@ If you want to specify a custom Redis server, you'll need specify the correspond
 
 - `sourcegraph-frontend`
 - `repo-updater`
+- `worker`
 
 ## Connect to an external Jaeger instance
 


### PR DESCRIPTION
Add `worker` to list of deployments that must be updated if changing the redis endpoint

See [this Slack thread](https://sourcegraph.slack.com/archives/C01QNMSLTFZ/p1635181980020600?thread_ts=1635181892.020300&cid=C01QNMSLTFZ) for details

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
