### PR TITLE
Change Docker for Mac detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- An issue that causes the server to panic when performing a structural search via the GQL API for a query that also matches missing repos (affected versions 3.33.0 and 3.32.0). [#26630](https://github.com/sourcegraph/sourcegraph/pull/26630)
+- An issue that causes the server to panic when performing a structural search via the GQL API for a query that also
+  matches missing repos (affected versions 3.33.0 and 3.32.0)
+  . [#26630](https://github.com/sourcegraph/sourcegraph/pull/26630)
+- Improve detection for Docker running in non-linux
+  environments. [#23477](https://github.com/sourcegraph/sourcegraph/issues/23477)
 
 ### Removed
 

--- a/cmd/frontend/internal/app/jscontext/jscontext_test.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext_test.go
@@ -1,6 +1,9 @@
 package jscontext
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestIsBot(t *testing.T) {
 	tests := map[string]bool{
@@ -13,5 +16,26 @@ func TestIsBot(t *testing.T) {
 		if got != want {
 			t.Errorf("%q: want %v, got %v", userAgent, got, want)
 		}
+	}
+}
+
+func Test_likelyDockerOnMac(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.SkipNow()
+	}
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"base",
+			false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := likelyDockerOnMac(); got != tt.want {
+				t.Errorf("likelyDockerOnMac() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Detect if we are on docker for mac via `host.docker.internal` DNS entry

Fixes https://github.com/sourcegraph/sourcegraph/issues/23477


Added a test that should fail if this changes