### PR TITLE
batches: implement fuzzier version of the webhook banner backend

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -171,6 +171,7 @@ type ListViewerBatchChangesCodeHostsArgs struct {
 	First                 int32
 	After                 *string
 	OnlyWithoutCredential bool
+	OnlyWithoutWebhooks   bool
 }
 
 type BulkOperationBaseArgs struct {
@@ -506,6 +507,7 @@ type BatchChangesCodeHostResolver interface {
 	ExternalServiceKind() string
 	ExternalServiceURL() string
 	RequiresSSH() bool
+	HasWebhooks() bool
 	Credential() BatchChangesCredentialResolver
 }
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2706,6 +2706,10 @@ type BatchSpec implements Node {
         Only returns the code hosts for which the viewer doesn't have credentials.
         """
         onlyWithoutCredential: Boolean = false
+        """
+        Only returns code hosts that don't have webhooks configured.
+        """
+        onlyWithoutWebhooks: Boolean = false
     ): BatchChangesCodeHostConnection!
 
     """
@@ -2911,6 +2915,11 @@ type BatchChangesCodeHost {
     an SSH key to be configured.
     """
     requiresSSH: Boolean!
+
+    """
+    If true, the code host has webhooks configured.
+    """
+    hasWebhooks: Boolean!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -329,7 +329,8 @@ func (r *batchSpecResolver) ViewerBatchChangesCodeHosts(ctx context.Context, arg
 		onlyWithoutCredential: args.OnlyWithoutCredential,
 		store:                 r.store,
 		opts: store.ListCodeHostsOpts{
-			RepoIDs: repoIDs,
+			RepoIDs:             repoIDs,
+			OnlyWithoutWebhooks: args.OnlyWithoutWebhooks,
 		},
 		limitOffset: database.LimitOffset{
 			Limit:  int(args.First),

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -28,3 +28,7 @@ func (c *batchChangesCodeHostResolver) Credential() graphqlbackend.BatchChangesC
 func (c *batchChangesCodeHostResolver) RequiresSSH() bool {
 	return c.codeHost.RequiresSSH
 }
+
+func (c *batchChangesCodeHostResolver) HasWebhooks() bool {
+	return c.codeHost.HasWebhooks
+}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection.go
@@ -15,7 +15,6 @@ import (
 type batchChangesCodeHostConnectionResolver struct {
 	userID                *int32
 	onlyWithoutCredential bool
-	onlyWithoutWebhooks   bool
 	opts                  store.ListCodeHostsOpts
 	limitOffset           database.LimitOffset
 	store                 *store.Store

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection.go
@@ -15,6 +15,7 @@ import (
 type batchChangesCodeHostConnectionResolver struct {
 	userID                *int32
 	onlyWithoutCredential bool
+	onlyWithoutWebhooks   bool
 	opts                  store.ListCodeHostsOpts
 	limitOffset           database.LimitOffset
 	store                 *store.Store

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
@@ -79,8 +80,18 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				h := NewGitLabWebhook(store)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
-				es.Config = "invalid JSON"
-				if err := store.ExternalServices().Upsert(ctx, es); err != nil {
+				// It's harder than it used to be to get invalid JSON into the
+				// database configuration, so let's just manipulate the database
+				// directly, since it won't make it through the
+				// ExternalServiceStore.
+				if err := store.Exec(
+					ctx,
+					sqlf.Sprintf(
+						"UPDATE external_services SET config = %s WHERE id = %s",
+						"invalid JSON",
+						es.ID,
+					),
+				); err != nil {
 					t.Fatal(err)
 				}
 

--- a/enterprise/internal/batches/store/codehost.go
+++ b/enterprise/internal/batches/store/codehost.go
@@ -13,7 +13,8 @@ import (
 )
 
 type ListCodeHostsOpts struct {
-	RepoIDs []api.RepoID
+	RepoIDs             []api.RepoID
+	OnlyWithoutWebhooks bool
 }
 
 func (s *Store) ListCodeHosts(ctx context.Context, opts ListCodeHostsOpts) (cs []*btypes.CodeHost, err error) {
@@ -37,25 +38,79 @@ func (s *Store) ListCodeHosts(ctx context.Context, opts ListCodeHostsOpts) (cs [
 
 var listCodeHostsQueryFmtstr = `
 -- source: enterprise/internal/batches/store/codehost.go:ListCodeHosts
+WITH
+	-- esr_with_ssh includes all external_service_repos records where the
+	-- external service is cloned over SSH.
+    esr_with_ssh AS (
+        SELECT
+            *
+        FROM
+            external_service_repos
+        WHERE
+            -- Either start with ssh://
+            clone_url ILIKE %s OR
+            -- OR have no schema specified at all
+            clone_url !~* '[[:alpha:]]+://'
+    ),
+	-- esr_with_webhooks includes all external_service_repos records where the
+	-- external service has one or more webhooks configured.
+    esr_with_webhooks AS (
+        SELECT
+            *
+        FROM
+            external_service_repos
+        WHERE
+            external_service_id IN (
+                SELECT
+                    id
+                FROM
+                    external_services
+                WHERE
+                    -- has_webhooks can be NULL if the OOB migration hasn't yet
+                    -- calculated the field value. We'll fail open here: the
+                    -- worst case is that we report that a repo has webhooks
+                    -- when it doesn't, which is less disruptive than the
+                    -- alternative.
+                    has_webhooks IS NULL OR
+                    has_webhooks = TRUE
+            )
+    ),
+	aggregated_repos AS (
+		SELECT
+			repo.external_service_type,
+			repo.external_service_id,
+			COUNT(esr_with_ssh.external_service_id) AS ssh_required_count,
+			COUNT(esr_with_webhooks.external_service_id) AS has_webhooks_count
+		FROM
+			repo
+		LEFT JOIN
+			esr_with_ssh
+		ON
+			repo.id = esr_with_ssh.repo_id
+		LEFT JOIN
+			esr_with_webhooks
+		ON
+			repo.id = esr_with_webhooks.repo_id
+		WHERE
+			%s
+		GROUP BY
+			repo.external_service_type, repo.external_service_id
+		ORDER BY
+			repo.external_service_type ASC, repo.external_service_id ASC
+	)
 SELECT
-	repo.external_service_type, repo.external_service_id, COUNT(esr.external_service_id) > 0 AS ssh_required
-FROM repo
-LEFT JOIN external_service_repos esr
-	ON
-		esr.repo_id = repo.id AND
-		(
-			-- Either start with ssh://
-			esr.clone_url ILIKE %s OR
-			-- OR have no scheme specified at all
-			esr.clone_url !~* '[[:alpha:]]+://'
-		)
-WHERE %s
-GROUP BY repo.external_service_type, repo.external_service_id
-ORDER BY repo.external_service_type ASC, repo.external_service_id ASC
+	external_service_type,
+	external_service_id,
+	ssh_required_count > 0 AS ssh_required,
+	has_webhooks_count > 0 AS has_webhooks
+FROM
+	aggregated_repos
+WHERE
+	%s
 `
 
 func listCodeHostsQuery(opts ListCodeHostsOpts) *sqlf.Query {
-	preds := []*sqlf.Query{
+	repoPreds := []*sqlf.Query{
 		// Only for those which have any enabled repositories.
 		sqlf.Sprintf("repo.deleted_at IS NULL"),
 	}
@@ -65,13 +120,25 @@ func listCodeHostsQuery(opts ListCodeHostsOpts) *sqlf.Query {
 	for extSvcType := range btypes.SupportedExternalServices {
 		supportedTypes = append(supportedTypes, sqlf.Sprintf("%s", extSvcType))
 	}
-	preds = append(preds, sqlf.Sprintf("repo.external_service_type IN (%s)", sqlf.Join(supportedTypes, ", ")))
+	repoPreds = append(repoPreds, sqlf.Sprintf("repo.external_service_type IN (%s)", sqlf.Join(supportedTypes, ", ")))
 
 	if len(opts.RepoIDs) > 0 {
-		preds = append(preds, sqlf.Sprintf("repo.id = ANY (%s)", pq.Array(opts.RepoIDs)))
+		repoPreds = append(repoPreds, sqlf.Sprintf("repo.id = ANY (%s)", pq.Array(opts.RepoIDs)))
 	}
 
-	return sqlf.Sprintf(listCodeHostsQueryFmtstr, sqlf.Sprintf("%s", "ssh://%"), sqlf.Join(preds, "AND"))
+	var aggregatePreds []*sqlf.Query
+	if opts.OnlyWithoutWebhooks {
+		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("has_webhooks_count = 0"))
+	} else {
+		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("TRUE"))
+	}
+
+	return sqlf.Sprintf(
+		listCodeHostsQueryFmtstr,
+		sqlf.Sprintf("%s", "ssh://%"),
+		sqlf.Join(repoPreds, "AND"),
+		sqlf.Join(aggregatePreds, "AND"),
+	)
 }
 
 func scanCodeHost(c *btypes.CodeHost, sc dbutil.Scanner) error {
@@ -79,6 +146,7 @@ func scanCodeHost(c *btypes.CodeHost, sc dbutil.Scanner) error {
 		&c.ExternalServiceType,
 		&c.ExternalServiceID,
 		&c.RequiresSSH,
+		&c.HasWebhooks,
 	)
 }
 

--- a/enterprise/internal/batches/store/codehost_test.go
+++ b/enterprise/internal/batches/store/codehost_test.go
@@ -49,15 +49,18 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock ct.Clo
 					ExternalServiceType: extsvc.TypeBitbucketServer,
 					ExternalServiceID:   "https://bitbucketserver.com/",
 					RequiresSSH:         true,
+					HasWebhooks:         true,
 				},
 				{
 					ExternalServiceType: extsvc.TypeGitHub,
 					ExternalServiceID:   "https://github.com/",
 					RequiresSSH:         true,
+					HasWebhooks:         true,
 				},
 				{
 					ExternalServiceType: extsvc.TypeGitLab,
 					ExternalServiceID:   "https://gitlab.com/",
+					HasWebhooks:         true,
 				},
 			}
 			if diff := cmp.Diff(have, want); diff != "" {

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -201,7 +201,7 @@ func CreateGitHubSSHTestRepos(t *testing.T, ctx context.Context, db dbutil.DB, c
 	if err != nil {
 		t.Fatal(err)
 	}
-	return rs, nil
+	return rs, ext
 }
 
 func CreateBbsSSHTestRepos(t *testing.T, ctx context.Context, db dbutil.DB, count int) ([]*types.Repo, *types.ExternalService) {

--- a/enterprise/internal/batches/types/code_host.go
+++ b/enterprise/internal/batches/types/code_host.go
@@ -7,6 +7,7 @@ type CodeHost struct {
 	ExternalServiceType string
 	ExternalServiceID   string
 	RequiresSSH         bool
+	HasWebhooks         bool
 }
 
 // IsSupported returns true, when this code host is supported by

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -220,6 +220,33 @@ func (n NullInt) Value() (driver.Value, error) {
 	return *n.N, nil
 }
 
+type NullBool struct{ B *bool }
+
+func (n *NullBool) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case bool:
+		*n.B = v
+	case int:
+		*n.B = v != 0
+	case int32:
+		*n.B = v != 0
+	case int64:
+		*n.B = v != 0
+	case nil:
+		break
+	default:
+		return errors.Errorf("value is not bool: %T", value)
+	}
+	return nil
+}
+
+func (n NullBool) Value() (driver.Value, error) {
+	if n.B == nil {
+		return nil, nil
+	}
+	return *n.B, nil
+}
+
 // JSONInt64Set represents an int64 set as a JSONB object where the keys are
 // the ids and the values are null. It implements the sql.Scanner interface so
 // it can be used as a scan destination, similar to

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -220,8 +220,12 @@ func (n NullInt) Value() (driver.Value, error) {
 	return *n.N, nil
 }
 
+// NullBool represents a bool that may be null. NullBool implements the
+// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.NullString. When the scanned value is null, B is set to false.
 type NullBool struct{ B *bool }
 
+// Scan implements the Scanner interface.
 func (n *NullBool) Scan(value interface{}) error {
 	switch v := value.(type) {
 	case bool:
@@ -240,6 +244,7 @@ func (n *NullBool) Scan(value interface{}) error {
 	return nil
 }
 
+// Value implements the driver Valuer interface.
 func (n NullBool) Value() (driver.Value, error) {
 	if n.B == nil {
 		return nil, nil

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -346,5 +347,79 @@ func (m *ExternalAccountsMigrator) Down(ctx context.Context) (err error) {
 		}
 	}
 
+	return nil
+}
+
+// ExternalServiceWebhookMigrator is a background job that calculates the
+// has_webhooks field on external services based on the external service
+// configuration.
+type ExternalServiceWebhookMigrator struct {
+	store     *basestore.Store
+	BatchSize int
+}
+
+var _ oobmigration.Migrator = &ExternalServiceWebhookMigrator{}
+
+func NewExternalServiceWebhookMigrator(store *basestore.Store) *ExternalServiceWebhookMigrator {
+	// Batch size arbitrarily chosen to match ExternalServiceConfigMigrator.
+	return &ExternalServiceWebhookMigrator{store: store, BatchSize: 50}
+}
+
+func NewExternalServiceWebhookMigratorWithDB(db dbutil.DB) *ExternalServiceWebhookMigrator {
+	return NewExternalServiceWebhookMigrator(basestore.NewWithDB(db, sql.TxOptions{}))
+}
+
+// ID returns the migration row ID in the out_of_band_migrations table.
+//
+// This ID was defined in the migration:
+// migrations/frontend/1528395921_add_has_webhooks.up.sql
+func (m *ExternalServiceWebhookMigrator) ID() int {
+	return 13
+}
+
+// Progress returns a value from 0 to 1 representing the percentage of external
+// services that have had their has_webhooks field calculated.
+func (m *ExternalServiceWebhookMigrator) Progress(ctx context.Context) (float64, error) {
+	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(`
+		SELECT
+			CASE c2.count WHEN 0 THEN 1 ELSE
+				CAST(c1.count AS float) / CAST(c2.count AS float)
+			END
+		FROM
+			(SELECT COUNT(*) AS count FROM external_services WHERE has_webhooks IS NOT NULL) c1,
+			(SELECT COUNT(*) AS count FROM external_services) c2
+	`)))
+	return progress, err
+}
+
+// Up loads BatchSize external services, locks them, and upserts them back into
+// the database, which will calculate HasWebhooks along the way.
+func (m *ExternalServiceWebhookMigrator) Up(ctx context.Context) (err error) {
+	tx, err := m.store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	store := ExternalServicesWith(tx)
+
+	svcs, err := store.list(ctx, ExternalServicesListOptions{
+		OrderByDirection: "ASC",
+		IncludeDeleted:   true,
+		LimitOffset:      &LimitOffset{Limit: m.BatchSize},
+		noCachedWebhooks: true,
+		forUpdate:        true,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = store.Upsert(ctx, svcs...)
+	return err
+}
+
+func (*ExternalServiceWebhookMigrator) Down(context.Context) error {
+	// There's no sensible down migration here: if the SQL down migration has
+	// been run, then the field no longer exists, and there's nothing to do.
 	return nil
 }

--- a/internal/database/oob_migrate_test.go
+++ b/internal/database/oob_migrate_test.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/keegancsmith/sqlf"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -15,6 +18,7 @@ import (
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestExternalServiceConfigMigrator(t *testing.T) {
@@ -656,5 +660,159 @@ func TestExternalAccountsMigrator(t *testing.T) {
 		if rows.Err() != nil {
 			t.Fatal(err)
 		}
+	})
+}
+
+func TestExternalServiceWebhookMigrator(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := context.Background()
+
+	createExternalServices := func(t *testing.T, ctx context.Context, store *ExternalServiceStore) []*types.ExternalService {
+		t.Helper()
+		var svcs []*types.ExternalService
+
+		// Create a trivial external service of each kind, as well as duplicate
+		// services for the external service kinds that support webhooks.
+		for _, svc := range []struct {
+			kind string
+			cfg  interface{}
+		}{
+			{kind: extsvc.KindAWSCodeCommit, cfg: schema.AWSCodeCommitConnection{}},
+			{kind: extsvc.KindBitbucketServer, cfg: schema.BitbucketServerConnection{}},
+			{kind: extsvc.KindBitbucketCloud, cfg: schema.BitbucketCloudConnection{}},
+			{kind: extsvc.KindGitHub, cfg: schema.GitHubConnection{}},
+			{kind: extsvc.KindGitLab, cfg: schema.GitLabConnection{}},
+			{kind: extsvc.KindGitolite, cfg: schema.GitoliteConnection{}},
+			{kind: extsvc.KindPerforce, cfg: schema.PerforceConnection{}},
+			{kind: extsvc.KindPhabricator, cfg: schema.PhabricatorConnection{}},
+			{kind: extsvc.KindJVMPackages, cfg: schema.JVMPackagesConnection{}},
+			{kind: extsvc.KindOther, cfg: schema.OtherExternalServiceConnection{}},
+
+			{kind: extsvc.KindBitbucketServer, cfg: schema.BitbucketServerConnection{
+				Plugin: &schema.BitbucketServerPlugin{
+					Webhooks: &schema.BitbucketServerPluginWebhooks{
+						DisableSync: false,
+						Secret:      "this is a secret",
+					},
+				},
+			}},
+			{kind: extsvc.KindGitHub, cfg: schema.GitHubConnection{
+				Webhooks: []*schema.GitHubWebhook{
+					{
+						Org:    "org",
+						Secret: "this is also a secret",
+					},
+				},
+			}},
+			{kind: extsvc.KindGitLab, cfg: schema.GitLabConnection{
+				Webhooks: []*schema.GitLabWebhook{
+					{Secret: "this is yet another secret"},
+				},
+			}},
+		} {
+			buf, err := json.MarshalIndent(svc.cfg, "", "  ")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			svcs = append(svcs, &types.ExternalService{
+				Kind:        svc.kind,
+				DisplayName: svc.kind,
+				Config:      string(buf),
+			})
+		}
+
+		if err := store.Upsert(ctx, svcs...); err != nil {
+			t.Fatal(err)
+		}
+
+		return svcs
+	}
+
+	clearHasWebhooks := func(t *testing.T, ctx context.Context, store *ExternalServiceStore) {
+		t.Helper()
+
+		if err := store.Exec(
+			ctx,
+			sqlf.Sprintf("UPDATE external_services SET has_webhooks = NULL"),
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("Progress", func(t *testing.T) {
+		db := dbtest.NewDB(t)
+		store := ExternalServices(db)
+		createExternalServices(t, ctx, store)
+
+		m := NewExternalServiceWebhookMigratorWithDB(db)
+
+		// By default, all the external services should have non-NULL
+		// has_webhooks.
+		progress, err := m.Progress(ctx)
+		assert.Nil(t, err)
+		assert.EqualValues(t, 1., progress)
+
+		// Now we'll clear that flag and ensure the progress drops to zero.
+		clearHasWebhooks(t, ctx, store)
+		progress, err = m.Progress(ctx)
+		assert.Nil(t, err)
+		assert.EqualValues(t, 0., progress)
+	})
+
+	t.Run("Up", func(t *testing.T) {
+		db := dbtest.NewDB(t)
+		store := ExternalServices(db)
+		initSvcs := createExternalServices(t, ctx, store)
+
+		m := NewExternalServiceWebhookMigratorWithDB(db)
+		// Ensure that we have to run two Ups.
+		m.BatchSize = len(initSvcs) - 1
+
+		// To start with, there should be nothing to do, as Upsert will have set
+		// has_webhooks already. Let's make sure nothing happens successfully.
+		assert.Nil(t, m.Up(ctx))
+
+		// Now we'll clear out the has_webhooks flags and re-run Up. This should
+		// update all but one of the external services.
+		clearHasWebhooks(t, ctx, store)
+		assert.Nil(t, m.Up(ctx))
+
+		// Do we really have one external service left?
+		after, err := store.List(ctx, ExternalServicesListOptions{
+			noCachedWebhooks: true,
+		})
+		assert.Nil(t, err)
+		assert.EqualValues(t, 1, len(after))
+
+		// Now we'll do the last one.
+		assert.Nil(t, m.Up(ctx))
+		after, err = store.List(ctx, ExternalServicesListOptions{
+			noCachedWebhooks: true,
+		})
+		assert.Nil(t, err)
+		assert.EqualValues(t, 0, len(after))
+
+		// Finally, let's make sure we have the expected number of each: we
+		// should have three records with has_webhooks = true, and the rest
+		// should be has_webhooks = false.
+		svcs, err := store.List(ctx, ExternalServicesListOptions{})
+		assert.Nil(t, err)
+
+		hasWebhooks := 0
+		noWebhooks := 0
+		for _, svc := range svcs {
+			assert.NotNil(t, svc.HasWebhooks)
+			if *svc.HasWebhooks {
+				hasWebhooks += 1
+			} else {
+				noWebhooks += 1
+			}
+		}
+
+		assert.EqualValues(t, 3, hasWebhooks)
+		assert.EqualValues(t, len(initSvcs)-3, noWebhooks)
 	})
 }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -708,9 +708,11 @@ Foreign-key constraints:
  cloud_default     | boolean                  |           | not null | false
  encryption_key_id | text                     |           | not null | ''::text
  namespace_org_id  | integer                  |           |          | 
+ has_webhooks      | boolean                  |           |          | 
 Indexes:
     "external_services_pkey" PRIMARY KEY, btree (id)
     "kind_cloud_default" UNIQUE, btree (kind, cloud_default) WHERE cloud_default = true AND deleted_at IS NULL
+    "external_services_has_webhooks_idx" btree (has_webhooks)
     "external_services_namespace_org_id_idx" btree (namespace_org_id)
     "external_services_namespace_user_id_idx" btree (namespace_user_id)
 Check constraints:

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -476,8 +476,9 @@ type ExternalService struct {
 	NextSyncAt      time.Time
 	NamespaceUserID int32
 	NamespaceOrgID  int32
-	Unrestricted    bool // Whether access to repositories belong to this external service is unrestricted.
-	CloudDefault    bool // Whether this external service is our default public service on Cloud
+	Unrestricted    bool  // Whether access to repositories belong to this external service is unrestricted.
+	CloudDefault    bool  // Whether this external service is our default public service on Cloud
+	HasWebhooks     *bool // Whether this external service has webhooks configured; calculated from Config
 }
 
 // ExternalServiceSyncJob represents an sync job for an external service

--- a/migrations/frontend/1528395923_add_has_webhooks.down.sql
+++ b/migrations/frontend/1528395923_add_has_webhooks.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- We don't remove the out of band migration when moving down.
+
+ALTER TABLE
+    external_services
+DROP COLUMN IF EXISTS
+    has_webhooks;
+
+COMMIT;

--- a/migrations/frontend/1528395923_add_has_webhooks.up.sql
+++ b/migrations/frontend/1528395923_add_has_webhooks.up.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+ALTER TABLE
+    external_services
+ADD COLUMN IF NOT EXISTS
+    has_webhooks BOOLEAN NULL DEFAULT NULL;
+
+CREATE INDEX
+    external_services_has_webhooks_idx
+ON
+    external_services (has_webhooks);
+
+INSERT INTO
+    out_of_band_migrations (
+        id,
+        team,
+        component,
+        description,
+        introduced_version_major,
+        introduced_version_minor,
+        non_destructive
+    )
+VALUES (
+    13,
+    'batch-changes',
+    'frontend-db.external_services',
+    'Calculate the webhook state of each external service',
+    3,
+    34,
+    true
+)
+ON CONFLICT
+    DO NOTHING
+;
+
+COMMIT;


### PR DESCRIPTION
As discussed in #26469, let's denormalise a boolean to indicate if an external service has webhooks and use that in GraphQL to indicate if the code host _probably_ has a valid webhook, but without going to the trouble of doing an organisation comparison for GitHub. We'll fail open: if the OOB migration hasn't yet set `has_webhooks`, we'll assume the external service has a webhook until proven otherwise.

At the GraphQL layer, this adds one new field to `BatchChangesCodeHost` called `hasWebhooks`, and one new argument to `viewerBatchChangesCodeHosts` called `onlyWithoutWebhooks` to filter code hosts as needed.

On a purely technical level, this isn't really _much_ simpler than #26469, but this has the distinct advantage that, at most, we only have to make one extra query to power the banner (and don't have to decrypt the external service configuration at all), whereas the previous implementation required `number_of_code_hosts` queries and decryption operations. The tradeoff here is the fuzziness in the first paragraph, since we can't be totally precise in the GitHub case.

### TODO

* [x] Store tests
     * [x] External services
     * [x] Code hosts
* [x] Resolver tests
* [ ] Ensure the OOB migrator ID is still valid before merging