### PR TITLE
compute: add regexp substitution to output command

### DIFF
--- a/internal/compute/output_command.go
+++ b/internal/compute/output_command.go
@@ -3,6 +3,8 @@ package compute
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -17,6 +19,31 @@ func (c *Output) String() string {
 	return fmt.Sprintf("Output with separator: (%s) -> (%s) separator: %s", c.MatchPattern.String(), c.OutputPattern, c.Separator)
 }
 
-func (c *Output) Run(context.Context, *result.FileMatch) (Result, error) {
-	return nil, nil
+func substituteRegexp(content string, match *regexp.Regexp, replacePattern, separator string) string {
+	var b strings.Builder
+	for _, submatches := range match.FindAllStringSubmatchIndex(content, -1) {
+		b.Write(match.ExpandString([]byte{}, replacePattern, content, submatches))
+		b.WriteString(separator)
+	}
+	return b.String()
+}
+
+func output(ctx context.Context, fragment string, matchPattern MatchPattern, replacePattern string, separator string) (*Text, error) {
+	var newFragment string
+	switch match := matchPattern.(type) {
+	case *Regexp:
+		newFragment = substituteRegexp(fragment, match.Value, replacePattern, separator)
+	case *Comby:
+		return nil, nil
+	}
+	return &Text{Value: newFragment, Kind: "output"}, nil
+}
+
+func (c *Output) Run(ctx context.Context, fm *result.FileMatch) (Result, error) {
+	lines := make([]string, 0, len(fm.LineMatches))
+	for _, line := range fm.LineMatches {
+		lines = append(lines, line.Preview)
+	}
+	fragment := strings.Join(lines, "\n")
+	return output(ctx, fragment, c.MatchPattern, c.OutputPattern, c.Separator)
 }

--- a/internal/compute/output_command_test.go
+++ b/internal/compute/output_command_test.go
@@ -1,0 +1,28 @@
+package compute
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/hexops/autogold"
+)
+
+func Test_output(t *testing.T) {
+	test := func(input string, cmd *Output) string {
+		result, err := output(context.Background(), input, cmd.MatchPattern, cmd.OutputPattern, cmd.Separator)
+		if err != nil {
+			return err.Error()
+		}
+		return result.Value
+	}
+
+	autogold.Want(
+		"regexp search outputs only digits",
+		"(1)~(2)~(3)~").
+		Equal(t, test("a 1 b 2 c 3", &Output{
+			MatchPattern:  &Regexp{Value: regexp.MustCompile(`(\d)`)},
+			OutputPattern: "($1)",
+			Separator:     "~",
+		}))
+}


### PR DESCRIPTION
As in title. The output command is like replace, except it's not in place, it's just a substitution of captured variables in some template. See test for example.