### PR TITLE
authz: Add a basic SubRepoPerms client

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -612,7 +612,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	)
 
 	// Set sub-repository permissions
-	srp := edb.SubRepoPerms(s.reposStore.Handle().DB(), time.Now)
+	srp := database.SubRepoPerms(s.reposStore.Handle().DB(), time.Now)
 	for spec, perm := range subRepoPerms {
 		if err := srp.UpsertWithSpec(ctx, user.ID, spec, perm); err != nil {
 			return errors.Wrapf(err, "upserting sub repo perms %v for user %d", spec, user.ID)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -612,7 +612,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	)
 
 	// Set sub-repository permissions
-	srp := database.SubRepoPerms(s.reposStore.Handle().DB(), time.Now)
+	srp := database.SubRepoPerms(s.reposStore.Handle().DB())
 	for spec, perm := range subRepoPerms {
 		if err := srp.UpsertWithSpec(ctx, user.ID, spec, perm); err != nil {
 			return errors.Wrapf(err, "upserting sub repo perms %v for user %d", spec, user.ID)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -532,14 +532,14 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 		return []api.RepoID{}, nil
 	}
 	var upsertWithSpecCalled int
-	edb.Mocks.SubRepoPerms.UpsertWithSpec = func(ctx context.Context, userID int32, spec api.ExternalRepoSpec, perms authz.SubRepoPermissions) error {
+	database.Mocks.SubRepoPerms.UpsertWithSpec = func(ctx context.Context, userID int32, spec api.ExternalRepoSpec, perms authz.SubRepoPermissions) error {
 		upsertWithSpecCalled++
 		return nil
 	}
 	defer func() {
 		database.Mocks = database.MockStores{}
 		edb.Mocks.Perms = edb.MockPerms{}
-		edb.Mocks.SubRepoPerms = edb.MockSubRepoPerms{}
+		database.Mocks.SubRepoPerms = database.MockSubRepoPerms{}
 	}()
 
 	permsStore := edb.Perms(nil, timeutil.Now)

--- a/enterprise/internal/database/mockstores.go
+++ b/enterprise/internal/database/mockstores.go
@@ -5,6 +5,5 @@ var Mocks MockStores
 // MockStores has a field for each store interface with the concrete mock type
 // (to obviate the need for tedious type assertions in test code).
 type MockStores struct {
-	Perms        MockPerms
-	SubRepoPerms MockSubRepoPerms
+	Perms MockPerms
 }

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -1,0 +1,83 @@
+package authz
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gobwas/glob"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+// RepoContent specifies data existing in a repo. It currently only supports
+// paths but will be extended in future to support other pieces of metadata, for
+// example branch.
+type RepoContent struct {
+	Repo api.RepoID
+	Path string
+}
+
+// PermissionsGetter allow getting sub repository permissions.
+type PermissionsGetter interface {
+	GetByUser(ctx context.Context, userID int32) (map[api.RepoID]SubRepoPermissions, error)
+}
+
+// SubRepoPermsClient is responsible for checking whether a user has access to
+// data within a repo. The intention is for this client to be created once at
+// startup and passed in to all places that need to check sub repo permissions.
+type SubRepoPermsClient struct {
+	PermissionsGetter PermissionsGetter
+}
+
+func (s *SubRepoPermsClient) CheckPermissions(ctx context.Context, userID int32, content RepoContent) (Perms, error) {
+	if s.PermissionsGetter == nil {
+		return None, errors.New("PermissionsGetter is nil")
+	}
+
+	srp, err := s.PermissionsGetter.GetByUser(ctx, userID)
+	if err != nil {
+		return None, errors.Wrap(err, "getting permissions")
+	}
+
+	// Check repo
+	repoRules, ok := srp[content.Repo]
+	if !ok {
+		// No sub-repository rules exist so we'll assume read access has already been
+		// enforced at the repo level
+		return Read, nil
+	}
+
+	// TODO: This will be very slow until we can cache compiled rules
+	includeMatchers := make([]glob.Glob, 0, len(repoRules.PathIncludes))
+	for _, rule := range repoRules.PathIncludes {
+		g, err := glob.Compile(rule, '/')
+		if err != nil {
+			return None, errors.Wrap(err, "building include matcher")
+		}
+		includeMatchers = append(includeMatchers, g)
+	}
+	excludeMatchers := make([]glob.Glob, 0, len(repoRules.PathExcludes))
+	for _, rule := range repoRules.PathExcludes {
+		g, err := glob.Compile(rule, '/')
+		if err != nil {
+			return None, errors.Wrap(err, "building exclude matcher")
+		}
+		excludeMatchers = append(excludeMatchers, g)
+	}
+
+	// The current path needs to either be included or NOT excluded and we'll give
+	// preference to exclusion.
+	for _, rule := range excludeMatchers {
+		if rule.Match(content.Path) {
+			return None, nil
+		}
+	}
+	for _, rule := range includeMatchers {
+		if rule.Match(content.Path) {
+			return Read, nil
+		}
+	}
+
+	// Return None if no rule matches to be safe
+	return None, nil
+}

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -32,8 +32,10 @@ type SubRepoPermissionChecker interface {
 var _ SubRepoPermissionChecker = &SubRepoPermsClient{}
 
 // SubRepoPermsClient is responsible for checking whether a user has access to
-// data within a repo. The intention is for this client to be created once at
-// startup and passed in to all places that need to check sub repo permissions.
+// data within a repo. Sub-repository permissions enforcement is on top of existing
+// repository permissions, which means the user must already have access to the
+// repository itself. The intention is for this client to be created once at startup
+// and passed in to all places that need to check sub repo permissions.
 type SubRepoPermsClient struct {
 	PermissionsGetter PermissionsGetter
 }

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -23,6 +23,14 @@ type PermissionsGetter interface {
 	GetByUser(ctx context.Context, userID int32) (map[api.RepoName]SubRepoPermissions, error)
 }
 
+// PermissionChecker is the interface exposed by the SubRepoPermsClient and is
+// exposed to allow consumers to mock out the client.
+type PermissionChecker interface {
+	CheckPermissions(ctx context.Context, userID int32, content RepoContent) (Perms, error)
+}
+
+var _ PermissionChecker = &SubRepoPermsClient{}
+
 // SubRepoPermsClient is responsible for checking whether a user has access to
 // data within a repo. The intention is for this client to be created once at
 // startup and passed in to all places that need to check sub repo permissions.

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"path"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gobwas/glob"
@@ -66,15 +67,18 @@ func (s *SubRepoPermsClient) CheckPermissions(ctx context.Context, userID int32,
 		excludeMatchers = append(excludeMatchers, g)
 	}
 
+	// Rules are created including the repo name
+	toMatch := path.Join(string(content.Repo), content.Path)
+
 	// The current path needs to either be included or NOT excluded and we'll give
 	// preference to exclusion.
 	for _, rule := range excludeMatchers {
-		if rule.Match(content.Path) {
+		if rule.Match(toMatch) {
 			return None, nil
 		}
 	}
 	for _, rule := range includeMatchers {
-		if rule.Match(content.Path) {
+		if rule.Match(toMatch) {
 			return Read, nil
 		}
 	}

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -42,9 +42,10 @@ func (s *SubRepoPermsClient) CheckPermissions(ctx context.Context, userID int32,
 	// Check repo
 	repoRules, ok := srp[content.Repo]
 	if !ok {
-		// No sub-repository rules exist so we'll assume read access has already been
-		// enforced at the repo level
-		return Read, nil
+		// All repos that support sub-repo permissions should at the very least have an
+		// "allow all" rule. If no rules exist it implies that we haven't performed a
+		// permissions sync yet and it is safer to assume no access is allowed.
+		return None, nil
 	}
 
 	// TODO: This will be very slow until we can cache compiled rules

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -13,13 +13,13 @@ import (
 // paths but will be extended in future to support other pieces of metadata, for
 // example branch.
 type RepoContent struct {
-	Repo api.RepoID
+	Repo api.RepoName
 	Path string
 }
 
 // PermissionsGetter allow getting sub repository permissions.
 type PermissionsGetter interface {
-	GetByUser(ctx context.Context, userID int32) (map[api.RepoID]SubRepoPermissions, error)
+	GetByUser(ctx context.Context, userID int32) (map[api.RepoName]SubRepoPermissions, error)
 }
 
 // SubRepoPermsClient is responsible for checking whether a user has access to

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -23,13 +23,13 @@ type PermissionsGetter interface {
 	GetByUser(ctx context.Context, userID int32) (map[api.RepoName]SubRepoPermissions, error)
 }
 
-// PermissionChecker is the interface exposed by the SubRepoPermsClient and is
+// SubRepoPermissionChecker is the interface exposed by the SubRepoPermsClient and is
 // exposed to allow consumers to mock out the client.
-type PermissionChecker interface {
+type SubRepoPermissionChecker interface {
 	CheckPermissions(ctx context.Context, userID int32, content RepoContent) (Perms, error)
 }
 
-var _ PermissionChecker = &SubRepoPermsClient{}
+var _ SubRepoPermissionChecker = &SubRepoPermsClient{}
 
 // SubRepoPermsClient is responsible for checking whether a user has access to
 // data within a repo. The intention is for this client to be created once at

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -19,6 +19,7 @@ type MockStores struct {
 	Users           MockUsers
 	UserCredentials MockUserCredentials
 	UserEmails      MockUserEmails
+	SubRepoPerms    MockSubRepoPerms
 
 	ExternalAccounts MockExternalAccounts
 

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/keegancsmith/sqlf"
@@ -27,7 +26,7 @@ type SubRepoPermsStore struct {
 }
 
 // SubRepoPerms returns a new SubRepoPermsStore with the given parameters.
-func SubRepoPerms(db dbutil.DB, clock func() time.Time) *SubRepoPermsStore {
+func SubRepoPerms(db dbutil.DB) *SubRepoPermsStore {
 	return &SubRepoPermsStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -24,17 +24,15 @@ const SubRepoPermsVersion = 1
 // data consistency over sub_repo_permissions table.
 type SubRepoPermsStore struct {
 	*basestore.Store
-
-	clock func() time.Time
 }
 
 // SubRepoPerms returns a new SubRepoPermsStore with the given parameters.
 func SubRepoPerms(db dbutil.DB, clock func() time.Time) *SubRepoPermsStore {
-	return &SubRepoPermsStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), clock: clock}
+	return &SubRepoPermsStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 func (s *SubRepoPermsStore) With(other basestore.ShareableStore) *SubRepoPermsStore {
-	return &SubRepoPermsStore{Store: s.Store.With(other), clock: s.clock}
+	return &SubRepoPermsStore{Store: s.Store.With(other)}
 }
 
 // Transact begins a new transaction and make a new SubRepoPermsStore over it.
@@ -44,7 +42,7 @@ func (s *SubRepoPermsStore) Transact(ctx context.Context) (*SubRepoPermsStore, e
 	}
 
 	txBase, err := s.Store.Transact(ctx)
-	return &SubRepoPermsStore{Store: txBase, clock: s.clock}, err
+	return &SubRepoPermsStore{Store: txBase}, err
 }
 
 func (s *SubRepoPermsStore) Done(err error) error {

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -133,10 +133,11 @@ WHERE user_id = %s
 }
 
 // GetByUser fetches all sub repo perms for a user keyed by repo.
-func (s *SubRepoPermsStore) GetByUser(ctx context.Context, userID int32) (map[api.RepoID]authz.SubRepoPermissions, error) {
+func (s *SubRepoPermsStore) GetByUser(ctx context.Context, userID int32) (map[api.RepoName]authz.SubRepoPermissions, error) {
 	q := sqlf.Sprintf(`
-SELECT repo_id, path_includes, path_excludes
+SELECT r.name, path_includes, path_excludes
 FROM sub_repo_permissions
+JOIN repo r on r.id = repo_id
 WHERE user_id = %s
   AND version = %s
 `, userID, SubRepoPermsVersion)
@@ -146,14 +147,14 @@ WHERE user_id = %s
 		return nil, errors.Wrap(err, "getting sub repo permissions by user")
 	}
 
-	result := make(map[api.RepoID]authz.SubRepoPermissions)
+	result := make(map[api.RepoName]authz.SubRepoPermissions)
 	for rows.Next() {
 		var perms authz.SubRepoPermissions
-		var repoID api.RepoID
-		if err := rows.Scan(&repoID, pq.Array(&perms.PathIncludes), pq.Array(&perms.PathExcludes)); err != nil {
+		var repoName api.RepoName
+		if err := rows.Scan(&repoName, pq.Array(&perms.PathIncludes), pq.Array(&perms.PathExcludes)); err != nil {
 			return nil, errors.Wrap(err, "scanning row")
 		}
-		result[repoID] = perms
+		result[repoName] = perms
 	}
 
 	if err := rows.Close(); err != nil {

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
@@ -22,7 +21,7 @@ func TestSubRepoPermsInsert(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, time.Now)
+	s := SubRepoPerms(db)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)
@@ -54,7 +53,7 @@ func TestSubRepoPermsUpsert(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, time.Now)
+	s := SubRepoPerms(db)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)
@@ -96,7 +95,7 @@ func TestSubRepoPermsUpsertWithSpec(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, time.Now)
+	s := SubRepoPerms(db)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)
@@ -143,7 +142,7 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, time.Now)
+	s := SubRepoPerms(db)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -167,12 +167,13 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := map[api.RepoID]authz.SubRepoPermissions{
-		1: {
+
+	want := map[api.RepoName]authz.SubRepoPermissions{
+		"github.com/foo/bar": {
 			PathIncludes: []string{"/src/foo/*"},
 			PathExcludes: []string{"/src/bar/*"},
 		},
-		2: {
+		"github.com/foo/baz": {
 			PathIncludes: []string{"/src/foo2/*"},
 			PathExcludes: []string{"/src/bar2/*"},
 		},

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
@@ -21,7 +22,7 @@ func TestSubRepoPermsInsert(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, clock)
+	s := SubRepoPerms(db, time.Now)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)
@@ -53,7 +54,7 @@ func TestSubRepoPermsUpsert(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, clock)
+	s := SubRepoPerms(db, time.Now)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)
@@ -95,7 +96,7 @@ func TestSubRepoPermsUpsertWithSpec(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, clock)
+	s := SubRepoPerms(db, time.Now)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)
@@ -142,7 +143,7 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
-	s := SubRepoPerms(db, clock)
+	s := SubRepoPerms(db, time.Now)
 	prepareSubRepoTestData(ctx, t, s)
 
 	userID := int32(1)


### PR DESCRIPTION
This is a skeleton implemenation intended to allow to start plugging it
into all the places where we intend to check sub repo permissions.

The SubRepoPermsStore was moved from enterprise to OSS since only the
actual PermSyncer needs to stay enterprise.

Part of https://github.com/sourcegraph/sourcegraph/issues/26645