### PR TITLE
pass database into mustParseGraphQLSchema so it can be mocked

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestAddExternalService(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
@@ -333,7 +333,7 @@ func TestAddExternalService(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			mutation {
 				addExternalService(input: {
@@ -363,7 +363,7 @@ func TestAddExternalService(t *testing.T) {
 }
 
 func TestUpdateExternalService(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
@@ -592,7 +592,7 @@ func TestUpdateExternalService(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			mutation {
 				updateExternalService(input: {
@@ -620,7 +620,7 @@ func TestUpdateExternalService(t *testing.T) {
 }
 
 func TestDeleteExternalService(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
@@ -795,7 +795,7 @@ func TestDeleteExternalService(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			mutation {
 				deleteExternalService(externalService: "RXh0ZXJuYWxTZXJ2aWNlOjQ=") {
@@ -816,7 +816,7 @@ func TestDeleteExternalService(t *testing.T) {
 }
 
 func TestExternalServices(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		t.Run("read users external services", func(t *testing.T) {
@@ -976,7 +976,7 @@ func TestExternalServices(t *testing.T) {
 	RunTests(t, []*Test{
 		// Read all external services
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			{
 				externalServices() {
@@ -996,7 +996,7 @@ func TestExternalServices(t *testing.T) {
 		},
 		// Not allowed to read someone else's external service
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			{
 				externalServices(namespace: "VXNlcjoy") {
@@ -1017,7 +1017,7 @@ func TestExternalServices(t *testing.T) {
 		},
 		// LastSyncError included
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			{
 				externalServices(namespace: "VXNlcjow") {
@@ -1041,7 +1041,7 @@ func TestExternalServices(t *testing.T) {
 		},
 		// Pagination
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			{
 				externalServices(first: 1) {
@@ -1065,7 +1065,7 @@ func TestExternalServices(t *testing.T) {
 		`,
 		},
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 			{
 				externalServices(after: "RXh0ZXJuYWxTZXJ2aWNlOjE=") {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -113,6 +113,7 @@ func TestGitCommitResolver(t *testing.T) {
 }
 
 func TestGitCommitFileNames(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return nil, nil
@@ -133,7 +134,7 @@ func TestGitCommitFileNames(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestGitTree(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return nil, nil
@@ -59,7 +60,7 @@ func TestGitTree(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -49,11 +49,12 @@ func BenchmarkPrometheusFieldName(b *testing.B) {
 }
 
 func TestRepository(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {
@@ -232,7 +233,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
 			Query: `
 			{
 				affiliatedRepositories(
@@ -281,7 +282,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
 			Query: `
 			{
 				affiliatedRepositories(
@@ -334,7 +335,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
 			Query: `
 			{
 				affiliatedRepositories(
@@ -390,7 +391,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
 			Query: `
 			{
 				affiliatedRepositories(

--- a/cmd/frontend/graphqlbackend/namespaces_test.go
+++ b/cmd/frontend/graphqlbackend/namespaces_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestNamespace(t *testing.T) {
 	t.Run("user", func(t *testing.T) {
+		db := database.NewDB(nil)
 		resetMocks()
 		const wantUserID = 3
 		database.Mocks.Users.GetByID = func(_ context.Context, id int32) (*types.User, error) {
@@ -24,7 +25,7 @@ func TestNamespace(t *testing.T) {
 		}
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					namespace(id: "VXNlcjoz") {
@@ -46,6 +47,7 @@ func TestNamespace(t *testing.T) {
 	})
 
 	t.Run("organization", func(t *testing.T) {
+		db := database.NewDB(nil)
 		resetMocks()
 		const wantOrgID = 3
 		database.Mocks.Orgs.GetByID = func(_ context.Context, id int32) (*types.Org, error) {
@@ -56,7 +58,7 @@ func TestNamespace(t *testing.T) {
 		}
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					namespace(id: "T3JnOjM=") {
@@ -78,6 +80,7 @@ func TestNamespace(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
+		db := database.NewDB(nil)
 		resetMocks()
 
 		invalidID := "aW52YWxpZDoz"
@@ -85,7 +88,7 @@ func TestNamespace(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: fmt.Sprintf(`
 				{
 					namespace(id: %q) {
@@ -112,6 +115,7 @@ func TestNamespace(t *testing.T) {
 
 func TestNamespaceByName(t *testing.T) {
 	t.Run("user", func(t *testing.T) {
+		db := database.NewDB(nil)
 		resetMocks()
 		const (
 			wantName   = "alice"
@@ -131,7 +135,7 @@ func TestNamespaceByName(t *testing.T) {
 		}
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					namespaceByName(name: "alice") {
@@ -153,6 +157,7 @@ func TestNamespaceByName(t *testing.T) {
 	})
 
 	t.Run("organization", func(t *testing.T) {
+		db := database.NewDB(nil)
 		resetMocks()
 		const (
 			wantName  = "acme"
@@ -172,7 +177,7 @@ func TestNamespaceByName(t *testing.T) {
 		}
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					namespaceByName(name: "acme") {
@@ -194,13 +199,14 @@ func TestNamespaceByName(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
+		db := database.NewDB(nil)
 		resetMocks()
 		database.Mocks.Namespaces.GetByName = func(ctx context.Context, name string) (*database.Namespace, error) {
 			return nil, database.ErrNamespaceNotFound
 		}
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					namespaceByName(name: "doesntexist") {

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestOrganization(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.Orgs.GetByName = func(context.Context, string) (*types.Org, error) {
 		return &types.Org{ID: 1, Name: "acme"}, nil
@@ -19,7 +20,7 @@ func TestOrganization(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					organization(name: "acme") {
@@ -39,6 +40,7 @@ func TestOrganization(t *testing.T) {
 }
 
 func TestOrganizationRepositories(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.Orgs.GetByName = func(context.Context, string) (*types.Org, error) {
 		return &types.Org{ID: 1, Name: "acme"}, nil
@@ -71,7 +73,7 @@ func TestOrganizationRepositories(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					organization(name: "acme") {
@@ -102,12 +104,13 @@ func TestOrganizationRepositories(t *testing.T) {
 }
 
 func TestNode_Org(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.Orgs.MockGetByID_Return(t, &types.Org{ID: 1, Name: "acme"}, nil)
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					node(id: "T3JnOjE=") {

--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestOrgs(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 		return &types.User{SiteAdmin: true}, nil
@@ -19,7 +20,7 @@ func TestOrgs(t *testing.T) {
 	database.Mocks.Orgs.Count = func(context.Context, database.OrgsListOptions) (int, error) { return 2, nil }
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					organizations {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -42,9 +42,10 @@ func TestRepositories(t *testing.T) {
 		}, nil
 	}
 
+	db := database.NewDB(nil)
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repositories {
@@ -87,7 +88,7 @@ func TestRepositories(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repositories {
@@ -112,7 +113,7 @@ func TestRepositories(t *testing.T) {
 			`,
 		},
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			// cloned and notCloned are true by default
 			// this test ensures the behavior is the same
 			// when setting them explicitly
@@ -140,7 +141,7 @@ func TestRepositories(t *testing.T) {
 			`,
 		},
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repositories(first: 2) {
@@ -162,7 +163,7 @@ func TestRepositories(t *testing.T) {
 			`,
 		},
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repositories(cloned: false) {
@@ -184,7 +185,7 @@ func TestRepositories(t *testing.T) {
 			`,
 		},
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repositories(notCloned: false) {
@@ -205,7 +206,7 @@ func TestRepositories(t *testing.T) {
 			`,
 		},
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repositories(notCloned: false, cloned: false) {
@@ -239,6 +240,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 	}
 
 	t.Run("Initial page without a cursor present", func(t *testing.T) {
+		db := database.NewDB(nil)
 		database.Mocks.Repos.List = func(ctx context.Context, opt database.ReposListOptions) ([]*types.Repo, error) {
 			return repos[0:2], nil
 		}
@@ -246,7 +248,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					repositories(first: 1) {
@@ -276,6 +278,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 	})
 
 	t.Run("Second page in ascending order", func(t *testing.T) {
+		db := database.NewDB(nil)
 		database.Mocks.Repos.List = func(ctx context.Context, opt database.ReposListOptions) ([]*types.Repo, error) {
 			return repos[1:], nil
 		}
@@ -283,7 +286,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					repositories(first: 1, after: "UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6InJlcG8yIiwiRGlyZWN0aW9uIjoibmV4dCJ9") {
@@ -313,6 +316,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 	})
 
 	t.Run("Second page in descending order", func(t *testing.T) {
+		db := database.NewDB(nil)
 		database.Mocks.Repos.List = func(ctx context.Context, opt database.ReposListOptions) ([]*types.Repo, error) {
 			return repos[1:], nil
 		}
@@ -320,7 +324,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					repositories(first: 1, after: "UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6InJlcG8yIiwiRGlyZWN0aW9uIjoicHJldiJ9", descending: true) {
@@ -350,6 +354,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 	})
 
 	t.Run("Initial page with no further rows to fetch", func(t *testing.T) {
+		db := database.NewDB(nil)
 		database.Mocks.Repos.List = func(ctx context.Context, opt database.ReposListOptions) ([]*types.Repo, error) {
 			return repos, nil
 		}
@@ -357,7 +362,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					repositories(first: 3) {
@@ -391,6 +396,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 	})
 
 	t.Run("With no repositories present", func(t *testing.T) {
+		db := database.NewDB(nil)
 		database.Mocks.Repos.List = func(ctx context.Context, opt database.ReposListOptions) ([]*types.Repo, error) {
 			return nil, nil
 		}
@@ -398,7 +404,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					repositories(first: 1) {
@@ -426,6 +432,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 	})
 
 	t.Run("With an invalid cursor provided", func(t *testing.T) {
+		db := database.NewDB(nil)
 		database.Mocks.Repos.List = func(ctx context.Context, opt database.ReposListOptions) ([]*types.Repo, error) {
 			return nil, nil
 		}
@@ -433,7 +440,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				{
 					repositories(first: 1, after: "invalid-cursor-value") {

--- a/cmd/frontend/graphqlbackend/repository_mirror_test.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror_test.go
@@ -23,6 +23,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 	}
 
 	t.Run("repository arg", func(t *testing.T) {
+		db := database.NewDB(nil)
 		backend.Mocks.Repos.Get = func(ctx context.Context, repoID api.RepoID) (*types.Repo, error) {
 			return &types.Repo{Name: repoName}, nil
 		}
@@ -39,7 +40,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				mutation {
 					checkMirrorRepositoryConnection(repository: "UmVwb3NpdG9yeToxMjM=") {
@@ -63,6 +64,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 	})
 
 	t.Run("name arg", func(t *testing.T) {
+		db := database.NewDB(nil)
 		backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
 			t.Fatal("want GetByName to not be called")
 			return nil, nil
@@ -80,7 +82,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query: `
 				mutation {
 					checkMirrorRepositoryConnection(name: "my/repo") {
@@ -181,6 +183,7 @@ func TestCheckMirrorRepositoryRemoteURL(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.repoURL, func(t *testing.T) {
+			db := database.NewDB(nil)
 			database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 				return &types.User{SiteAdmin: true}, nil
 			}
@@ -195,7 +198,7 @@ func TestCheckMirrorRepositoryRemoteURL(t *testing.T) {
 
 			RunTests(t, []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 					{
 						repository(name: "my/repo") {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -25,6 +25,7 @@ import (
 const exampleCommitSHA1 = "1234567890123456789012345678901234567890"
 
 func TestRepository_Commit(t *testing.T) {
+	db := database.NewDB(nil)
 	resetMocks()
 	database.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
@@ -37,7 +38,7 @@ func TestRepository_Commit(t *testing.T) {
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {

--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -10,13 +10,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestSavedSearches(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewDB(new(dbtesting.MockDB))
+	db := database.NewDB(nil)
 	defer resetMocks()
 
 	key := int32(1)
@@ -48,7 +47,7 @@ func TestSavedSearches(t *testing.T) {
 
 func TestSavedSearchByIDOwner(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewDB(new(dbtesting.MockDB))
+	db := database.NewDB(nil)
 	defer resetMocks()
 
 	userID := int32(1)
@@ -100,7 +99,7 @@ func TestSavedSearchByIDOwner(t *testing.T) {
 func TestSavedSearchByIDNonOwner(t *testing.T) {
 	// Non owners, including site admins cannot view a user's saved searches
 	ctx := context.Background()
-	db := database.NewDB(new(dbtesting.MockDB))
+	db := database.NewDB(nil)
 	defer resetMocks()
 
 	userID := int32(1)
@@ -138,7 +137,7 @@ func TestSavedSearchByIDNonOwner(t *testing.T) {
 func TestCreateSavedSearch(t *testing.T) {
 	ctx := context.Background()
 	defer resetMocks()
-	db := database.NewDB(new(dbtesting.MockDB))
+	db := database.NewDB(nil)
 
 	key := int32(1)
 	createSavedSearchCalled := false
@@ -199,7 +198,7 @@ func TestCreateSavedSearch(t *testing.T) {
 func TestUpdateSavedSearch(t *testing.T) {
 	ctx := context.Background()
 	defer resetMocks()
-	db := database.NewDB(new(dbtesting.MockDB))
+	db := database.NewDB(nil)
 
 	key := int32(1)
 	database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
@@ -260,7 +259,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 
 func TestDeleteSavedSearch(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewDB(new(dbtesting.MockDB))
+	db := database.NewDB(nil)
 	defer resetMocks()
 
 	key := int32(1)

--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -82,11 +82,12 @@ func TestSetExternalServiceRepos(t *testing.T) {
 		database.Mocks = database.MockStores{}
 		repoupdater.DefaultClient.HTTPClient = oldClient
 	}()
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 			mutation {
 				setExternalServiceRepos(

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -31,11 +31,12 @@ func TestSettingsMutation_EditSettings(t *testing.T) {
 		}
 		return &api.Settings{ID: 2, Contents: contents}, nil
 	}
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 				mutation($value: JSONValue) {
 					settingsMutation(input: {subject: "VXNlcjox", lastID: 1}) {
@@ -78,11 +79,12 @@ func TestSettingsMutation_OverwriteSettings(t *testing.T) {
 		}
 		return &api.Settings{ID: 2, Contents: contents}, nil
 	}
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 				mutation($contents: String!) {
 					settingsMutation(input: {subject: "VXNlcjox", lastID: 1}) {

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -12,13 +12,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestDeleteUser(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		resetMocks()
@@ -121,7 +120,7 @@ func TestDeleteUser(t *testing.T) {
 			name: "soft delete a user",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					deleteUser(user: "VXNlcjo2") {
@@ -143,7 +142,7 @@ func TestDeleteUser(t *testing.T) {
 			name: "hard delete a user",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					deleteUser(user: "VXNlcjo2", hard: true) {

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestStatusMessages(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	graphqlQuery := `
 		query StatusMessages {
@@ -66,7 +65,7 @@ func TestStatusMessages(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query:  graphqlQuery,
 				ExpectedResult: `
 				{
@@ -118,7 +117,7 @@ func TestStatusMessages(t *testing.T) {
 
 		RunTests(t, []*Test{
 			{
-				Schema: mustParseGraphQLSchema(t),
+				Schema: mustParseGraphQLSchema(t, db),
 				Query:  graphqlQuery,
 				ExpectedResult: `
 					{

--- a/cmd/frontend/graphqlbackend/temporary_settings_test.go
+++ b/cmd/frontend/graphqlbackend/temporary_settings_test.go
@@ -22,12 +22,13 @@ func TestTemporarySettingsNotSignedIn(t *testing.T) {
 	}
 
 	wantErr := errors.New("not authenticated")
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			// No actor set on context.
 			Context: context.Background(),
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 				query {
 					temporarySettings {
@@ -61,11 +62,12 @@ func TestTemporarySettings(t *testing.T) {
 		calledGetTemporarySettingsUserID = userID
 		return &ts.TemporarySettings{Contents: "{\"search.collapsedSidebarSections\": {\"types\": false}}"}, nil
 	}
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			Context: actor.WithActor(context.Background(), actor.FromUser(1)),
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 				query {
 					temporarySettings {
@@ -101,12 +103,13 @@ func TestOverwriteTemporarySettingsNotSignedIn(t *testing.T) {
 	}
 
 	wantErr := errors.New("not authenticated")
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			// No actor set on context.
 			Context: context.Background(),
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 				mutation ModifyTemporarySettings {
 					overwriteTemporarySettings(
@@ -142,11 +145,12 @@ func TestOverwriteTemporarySettings(t *testing.T) {
 		calledOverwriteTemporarySettings = true
 		return nil
 	}
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			Context: actor.WithActor(context.Background(), actor.FromUser(1)),
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 				mutation OverwriteTemporarySettings {
 					overwriteTemporarySettings(
@@ -178,11 +182,12 @@ func TestEditTemporarySettings(t *testing.T) {
 		calledEditTemporarySettings = true
 		return nil
 	}
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
 			Context: actor.WithActor(context.Background(), actor.FromUser(1)),
-			Schema:  mustParseGraphQLSchema(t),
+			Schema:  mustParseGraphQLSchema(t, db),
 			Query: `
 				mutation EditTemporarySettings {
 					editTemporarySettings(

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -15,6 +15,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 var (
@@ -23,11 +25,11 @@ var (
 	parsedSchema    *graphql.Schema
 )
 
-func mustParseGraphQLSchema(t *testing.T) *graphql.Schema {
+func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {
-		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		parsedSchema, parseSchemaErr = NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -21,6 +21,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 	database.Mocks.UserEmails.SetVerified = func(context.Context, int32, string, bool) error {
 		return nil
 	}
+	db := database.NewDB(nil)
 
 	tests := []struct {
 		name                                string
@@ -31,7 +32,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			name: "set an email to be verified",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					setUserEmailVerified(user: "VXNlcjox", email: "alice@example.com", verified: true) {
@@ -54,7 +55,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			name: "set an email to be unverified",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					setUserEmailVerified(user: "VXNlcjox", email: "alice@example.com", verified: false) {
@@ -107,6 +108,7 @@ func TestResendUserEmailVerification(t *testing.T) {
 	timeNow = func() time.Time {
 		return knownTime
 	}
+	db := database.NewDB(nil)
 
 	tests := []struct {
 		name            string
@@ -118,7 +120,7 @@ func TestResendUserEmailVerification(t *testing.T) {
 			name: "resend a verification email",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					resendVerificationEmail(user: "VXNlcjox", email: "alice@example.com") {
@@ -145,7 +147,7 @@ func TestResendUserEmailVerification(t *testing.T) {
 			name: "email already verified",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					resendVerificationEmail(user: "VXNlcjox", email: "alice@example.com") {
@@ -173,7 +175,7 @@ func TestResendUserEmailVerification(t *testing.T) {
 			name: "invalid email",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					resendVerificationEmail(user: "VXNlcjox", email: "alan@example.com") {
@@ -202,7 +204,7 @@ func TestResendUserEmailVerification(t *testing.T) {
 			name: "resend a verification email, too soon",
 			gqlTests: []*Test{
 				{
-					Schema: mustParseGraphQLSchema(t),
+					Schema: mustParseGraphQLSchema(t, db),
 					Query: `
 				mutation {
 					resendVerificationEmail(user: "VXNlcjox", email: "alice@example.com") {

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -17,9 +17,10 @@ func TestUser_UsageStatistics(t *testing.T) {
 		}, nil
 	}
 	defer func() { usagestatsdeprecated.MockGetByUserID = nil }()
+	db := database.NewDB(nil)
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					node(id: "VXNlcjox") {

--- a/cmd/frontend/graphqlbackend/users_create_test.go
+++ b/cmd/frontend/graphqlbackend/users_create_test.go
@@ -22,10 +22,11 @@ func TestCreateUser(t *testing.T) {
 		calledGrantPendingPermissions = true
 		return nil
 	}
+	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				mutation {
 					createUser(username: "alice") {

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -17,9 +17,10 @@ func TestUsers(t *testing.T) {
 		return []*types.User{{Username: "user1"}, {Username: "user2"}}, nil
 	}
 	database.Mocks.Users.Count = func(context.Context, *database.UsersListOptions) (int, error) { return 2, nil }
+	db := database.NewDB(nil)
 	RunTests(t, []*Test{
 		{
-			Schema: mustParseGraphQLSchema(t),
+			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
 				{
 					users {


### PR DESCRIPTION
This injects a database into mustParseGraphQLSchema so it can be mocked
out in the graphql tests.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
