### PR TITLE
search: remove Mode dependency for structural search job

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -629,11 +629,11 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 		// It which specializes search logic in doResults. In time, all
 		// of the above logic should be used to create search jobs
 		// across all of Sourcegraph.
-		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
-			globalSearch := args.Mode == search.ZoektGlobalSearch
-			skipUnindexed := args.Mode == search.SkipUnindexed || (globalSearch && envvar.SourcegraphDotComMode())
-			searcherOnly := args.Mode == search.SearcherOnly || (globalSearch && !envvar.SourcegraphDotComMode())
 
+		globalSearch := args.Mode == search.ZoektGlobalSearch
+		skipUnindexed := args.Mode == search.SkipUnindexed || (globalSearch && envvar.SourcegraphDotComMode())
+		searcherOnly := args.Mode == search.SearcherOnly || (globalSearch && !envvar.SourcegraphDotComMode())
+		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
 			if !skipUnindexed {
 				typ := search.TextRequest
 				// TODO(rvantonder): we don't always have to run
@@ -694,7 +694,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 				ZoektArgs:    zoektArgs,
 				SearcherArgs: searcherArgs,
 
-				Mode:              args.Mode,
+				NotSearcherOnly:   !searcherOnly,
 				UseIndex:          args.PatternInfo.Index,
 				ContainsRefGlobs:  query.ContainsRefGlobs(q),
 				OnMissingRepoRevs: zoektutil.MissingRepoRevStatus(r.stream),

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -151,7 +151,7 @@ type StructuralSearch struct {
 	ZoektArgs    *search.ZoektParameters
 	SearcherArgs *search.SearcherParameters
 
-	Mode              search.GlobalSearchMode
+	NotSearcherOnly   bool
 	UseIndex          query.YesNoOnly
 	ContainsRefGlobs  bool
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
@@ -169,7 +169,7 @@ func (s *StructuralSearch) Run(ctx context.Context, stream streaming.Sender, rep
 		}
 	}
 
-	partitionedRepos, err := PartitionRepos(request, s.Mode != search.SearcherOnly)
+	partitionedRepos, err := PartitionRepos(request, s.NotSearcherOnly)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/26853.

As in description. This is consistent with the Text search job in `unindexed.go`. I will top-down remove the need for this value later, for now it's good to remove the dependency on `Mode` entirely.