### PR TITLE
search: add ZoektGlobalQuery abstraction

### DIFF
--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -718,7 +718,8 @@ func TestZoektGlobalQueryScope(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			q, err := zoektGlobalQueryScope(tc.opts, tc.priv)
+			includePrivate := tc.opts.Visibility == query.Private || tc.opts.Visibility == query.Any
+			defaultScope, err := DefaultGlobalQueryScope(tc.opts)
 			if err != nil || tc.wantErr != "" {
 				if got := fmt.Sprintf("%s", err); !strings.Contains(got, tc.wantErr) {
 					t.Fatalf("expected error to contain %q: %s", tc.wantErr, got)
@@ -728,6 +729,9 @@ func TestZoektGlobalQueryScope(t *testing.T) {
 				}
 				return
 			}
+			zoektGlobalQuery := NewGlobalZoektQuery(&zoektquery.Const{Value: true}, defaultScope, includePrivate)
+			zoektGlobalQuery.ApplyPrivateFilter(tc.priv)
+			q := zoektGlobalQuery.Generate()
 			if got := zoektquery.Simplify(q).String(); got != tc.want {
 				t.Fatalf("unexpected scoped query:\nwant: %s\ngot:  %s", tc.want, got)
 			}

--- a/internal/search/zoekt/zoekt_global.go
+++ b/internal/search/zoekt/zoekt_global.go
@@ -1,0 +1,88 @@
+package zoekt
+
+import (
+	"regexp"
+
+	"github.com/cockroachdb/errors"
+	zoektquery "github.com/google/zoekt/query"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// DefaultGlobalQueryScope returns a Zoekt query that applies a default
+// repository scope based on RepoOptions. This default scope is determined
+// statically from a query, and does not depend on runtime values.
+func DefaultGlobalQueryScope(repoOptions search.RepoOptions) (zoektquery.Q, error) {
+	if !(repoOptions.Visibility == query.Public || repoOptions.Visibility == query.Any) {
+		// If "Public" or "Any" repos are excluded, the default scope
+		// static scope is empty, and implies a different RepoVisibility
+		// (e.g., "Private")
+		return nil, nil
+	}
+	rc := zoektquery.RcOnlyPublic
+	apply := func(f zoektquery.RawConfig, b bool) {
+		if !b {
+			return
+		}
+		rc |= f
+	}
+	apply(zoektquery.RcOnlyArchived, repoOptions.OnlyArchived)
+	apply(zoektquery.RcNoArchived, repoOptions.NoArchived)
+	apply(zoektquery.RcOnlyForks, repoOptions.OnlyForks)
+	apply(zoektquery.RcNoForks, repoOptions.NoForks)
+
+	children := []zoektquery.Q{&zoektquery.Branch{Pattern: "HEAD", Exact: true}, rc}
+	for _, pat := range repoOptions.MinusRepoFilters {
+		re, err := regexp.Compile(`(?i)` + pat)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid regex for -repo filter %q", pat)
+		}
+		children = append(children, &zoektquery.Not{Child: &zoektquery.RepoRegexp{Regexp: re}})
+	}
+	return zoektquery.NewAnd(children...), nil
+}
+
+// GlobalZoektQuery is an object that represents a query to Zoekt across all its
+// replicas. It exposes methods to modify the scope of such a query, (e.g., to
+// ensure repo privacy filters). A `Generate` method converts the object to a
+// Zoekt query that ensures appropriate repo privacy scopes.
+type GlobalZoektQuery struct {
+	query          zoektquery.Q
+	repoScope      []zoektquery.Q
+	includePrivate bool
+}
+
+func NewGlobalZoektQuery(query zoektquery.Q, scope zoektquery.Q, includePrivate bool) *GlobalZoektQuery {
+	repoScope := []zoektquery.Q{}
+	if scope != nil {
+		repoScope = append(repoScope, scope)
+	}
+	return &GlobalZoektQuery{
+		query:          query,
+		repoScope:      repoScope,
+		includePrivate: includePrivate,
+	}
+}
+
+// ApplyPrivateFilter ensures that the argument, a set of user private
+// repositories, are included in a Global Zoekt search scope. Note that this
+// method only adds a set of private repositories to the scope, if the
+// construction of a GlobalZoektQuery was permitted to includePrivate
+// repositories.
+func (q *GlobalZoektQuery) ApplyPrivateFilter(userPrivateRepos []types.RepoName) {
+	if q.includePrivate && len(userPrivateRepos) > 0 {
+		ids := make([]uint32, 0, len(userPrivateRepos))
+		for _, r := range userPrivateRepos {
+			ids = append(ids, uint32(r.ID))
+		}
+		q.repoScope = append(q.repoScope, zoektquery.NewSingleBranchesRepos("HEAD", ids...))
+	}
+}
+
+// Generate generates a Global Zoekt query that ensures the appropriate repo
+// scope (i.e., whether to either exclusively public, exclusively private, or
+// either public or private repositories)
+func (q *GlobalZoektQuery) Generate() zoektquery.Q {
+	return zoektquery.Simplify(zoektquery.NewAnd(q.query, zoektquery.NewOr(q.repoScope...)))
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/26854.

This is prep for a global Zoekt search job. It's necessary to create a Zoekt query that can be initialized based on static properties and mutated/augmented at a later point to incorporate private repo permissions.

And actually, to bring back discussion with @tsenart and @stefanhengl: I think your work for repo pagination _would_ affect global zoekt queries at some point (i.e., we would benefit from it, but we can probably ignore the cursor work in the context of global searches for now), because we sometimes have to look up private repo data, before we can do a Zoekt global search. This abstraction is going to help us also exactly expose Zoekt global search to a cursor, that could, for example, serve private repo data (or IDs) for global searches. So yeah "this is important and will help a lot". See inline comments.
