### PR TITLE
internal/search/backend: Fix log15 error

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -160,7 +160,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 
 	metricReorderQueueSize.WithLabelValues().Observe(float64(resultQueueMaxLength))
 	if len(resultQueue) > 0 {
-		log15.Warn("HorizontalSearcher.Streamsearch: results not sent in core loop", len(resultQueue))
+		log15.Warn("HorizontalSearcher.Streamsearch: results not sent in core loop", "resultQueue", len(resultQueue))
 		for len(resultQueue) > 0 {
 			streamer.Send(heap.Pop(&resultQueue).(*zoekt.SearchResult))
 		}


### PR DESCRIPTION
Noticed this error in production today:

```
t=2021-10-31T18:47:22+0000 lvl=warn msg="HorizontalSearcher.Streamsearch: results not sent in core loop" LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
```

This should fix it.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
