### PR TITLE
Revert "[CLOUD-78] authz: re-enable user-centric perms syncing for us…

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
-	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -301,7 +300,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 	for _, acct := range accts {
 		provider := byServiceID[acct.ServiceID]
 		if provider == nil {
-			// We have no authz provider configured for this external account
+			// We have no authz provider configured for this external account or service
 			continue
 		}
 
@@ -324,7 +323,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 				if err != nil {
 					return nil, nil, errors.Wrapf(err, "set expired for external account %d", acct.ID)
 				}
-				log15.Debug("PermsSyncer.fetchUserPermsViaExternalAccounts.setExternalAccountExpired",
+				log15.Debug("PermsSyncer.syncUserPerms.setExternalAccountExpired",
 					"userID", user.ID,
 					"id", acct.ID,
 					"unauthorized", unauthorized,
@@ -338,7 +337,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 
 			// Process partial results if this is an initial fetch.
 			if !noPerms {
-				return nil, nil, errors.Wrapf(err, "fetch user permissions for external account %d", acct.ID)
+				return nil, nil, errors.Wrap(err, "fetch user permissions")
 			}
 			log15.Warn("PermsSyncer.syncUserPerms.proceedWithPartialResults", "userID", user.ID, "error", err)
 		} else {
@@ -423,142 +422,6 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 	return repoIDs, subRepoPerms, nil
 }
 
-// fetchUserPermsViaExternalServices uses user code connections to list all
-// accessible private repositories on code hosts for the given user.
-func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, userID int32, fetchOpts authz.FetchPermsOptions) (repoIDs []uint32, err error) {
-	has, err := s.permsStore.UserIsMemberOfOrgHasCodeHostConnection(ctx, userID)
-	if err != nil {
-		return nil, errors.Wrap(err, "check user organization membership with a code host connection")
-	}
-
-	// NOTE: User-centric permissions syncing needs parity from the repo-centric
-	//  permissions syncing. Therefore, if the user is not a member of any
-	//  organization that has a code host connection connected, there is no point to
-	//  do the user-centric syncing.
-	if !has {
-		return []uint32{}, nil
-	}
-
-	svcs, err := database.ExternalServicesWith(s.reposStore).List(ctx,
-		database.ExternalServicesListOptions{
-			NamespaceUserID: userID,
-			Kinds:           []string{extsvc.KindGitHub, extsvc.KindGitLab},
-		},
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "list user external services")
-	}
-
-	var repoSpecs, includeContainsSpecs, excludeContainsSpecs []api.ExternalRepoSpec
-	for _, svc := range svcs {
-		provider, err := eauthz.ProviderFromExternalService(conf.Get().SiteConfiguration, svc)
-		if err != nil {
-			return nil, errors.Wrapf(err, "new provider from external service %d", svc.ID)
-		}
-		if provider == nil {
-			// We have no authz provider configured for this external service
-			continue
-		}
-
-		token, err := extsvc.ExtractToken(svc.Config, svc.Kind)
-		if err != nil {
-			return nil, errors.Wrapf(err, "extract token from external service %d", svc.ID)
-		}
-		if token == "" {
-			return nil, errors.Errorf("empty token from external service %d", svc.ID)
-		}
-
-		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
-			return nil, errors.Wrap(err, "wait for rate limiter")
-		}
-
-		extPerms, err := provider.FetchUserPermsByToken(ctx, token, fetchOpts)
-		if err != nil {
-			// The "401 Unauthorized" is returned by code hosts when the token is no longer valid
-			unauthorized := errcode.IsUnauthorized(err)
-
-			forbidden := errcode.IsForbidden(err)
-
-			// Detect GitHub account suspension error
-			accountSuspended := errcode.IsAccountSuspended(err)
-
-			if unauthorized || accountSuspended || forbidden {
-				log15.Warn("PermsSyncer.fetchUserPermsViaExternalServices.expiredExternalService",
-					"userID", userID,
-					"id", svc.ID,
-					"unauthorized", unauthorized,
-					"accountSuspended", accountSuspended,
-					"forbidden", forbidden,
-				)
-
-				// We still want to continue processing other external services
-				continue
-			}
-			return nil, errors.Wrapf(err, "fetch user permissions for external service %d", svc.ID)
-		}
-
-		if extPerms == nil {
-			continue
-		}
-
-		for _, exact := range extPerms.Exacts {
-			repoSpecs = append(repoSpecs,
-				api.ExternalRepoSpec{
-					ID:          string(exact),
-					ServiceType: provider.ServiceType(),
-					ServiceID:   provider.ServiceID(),
-				},
-			)
-		}
-		for _, includePrefix := range extPerms.IncludeContains {
-			includeContainsSpecs = append(includeContainsSpecs,
-				api.ExternalRepoSpec{
-					ID:          string(includePrefix),
-					ServiceType: provider.ServiceType(),
-					ServiceID:   provider.ServiceID(),
-				},
-			)
-		}
-		for _, excludePrefix := range extPerms.ExcludeContains {
-			excludeContainsSpecs = append(excludeContainsSpecs,
-				api.ExternalRepoSpec{
-					ID:          string(excludePrefix),
-					ServiceType: provider.ServiceType(),
-					ServiceID:   provider.ServiceID(),
-				},
-			)
-		}
-	}
-
-	// Get corresponding internal database IDs
-	repoNames, err := s.listPrivateRepoNamesBySpecs(ctx, repoSpecs)
-	if err != nil {
-		return nil, errors.Wrap(err, "list external repositories by exact matching")
-	}
-
-	// Exclusions are relative to inclusions, so if there is no inclusion, exclusion
-	// are meaningless and no need to trigger a DB query.
-	if len(includeContainsSpecs) > 0 {
-		rs, err := s.reposStore.RepoStore.ListRepoNames(ctx,
-			database.ReposListOptions{
-				ExternalRepoIncludeContains: includeContainsSpecs,
-				ExternalRepoExcludeContains: excludeContainsSpecs,
-				OnlyPrivate:                 true,
-			},
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "list external repositories by contains matching")
-		}
-		repoNames = append(repoNames, rs...)
-	}
-
-	repoIDs = make([]uint32, 0, len(repoNames))
-	for _, r := range repoNames {
-		repoIDs = append(repoIDs, uint32(r.ID))
-	}
-	return repoIDs, nil
-}
-
 // syncUserPerms processes permissions syncing request in user-centric way. When `noPerms` is true,
 // the method will use partial results to update permissions tables even when error occurs.
 func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms bool, fetchOpts authz.FetchPermsOptions) (err error) {
@@ -577,14 +440,9 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		return errors.Wrap(err, "list external service repo IDs by user ID")
 	}
 
-	externalAccountsRepoIDs, subRepoPerms, err := s.fetchUserPermsViaExternalAccounts(ctx, user, noPerms, fetchOpts)
+	fetchedRepoIDs, subRepoPerms, err := s.fetchUserPermsViaExternalAccounts(ctx, user, noPerms, fetchOpts)
 	if err != nil {
 		return errors.Wrap(err, "fetch user permissions via external accounts")
-	}
-
-	externalServicesRepoIDs, err := s.fetchUserPermsViaExternalServices(ctx, user.ID, fetchOpts)
-	if err != nil {
-		return errors.Wrap(err, "fetch user permissions via external services")
 	}
 
 	// Save permissions to database
@@ -597,8 +455,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	for i := range repoIDs {
 		p.IDs.Add(uint32(repoIDs[i]))
 	}
-	p.IDs.AddMany(externalAccountsRepoIDs)
-	p.IDs.AddMany(externalServicesRepoIDs)
+	p.IDs.AddMany(fetchedRepoIDs)
 
 	err = s.permsStore.SetUserPermissions(ctx, p)
 	if err != nil {
@@ -674,7 +531,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	// always nil and no user IDs here because we don't restrict access to
 	// non-private repositories.
 	if provider == nil && len(userIDs) == 0 {
-		log15.Debug("PermsSyncer.syncRepoPerms.skipFetchPerms",
+		log15.Debug("PermsSyncer.syncRepoPerms.noProvider",
 			"repoID", repo.ID,
 			"private", repo.Private,
 		)
@@ -703,11 +560,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		// return a nil error and log a warning message.
 		var e *github.APIError
 		if errors.As(err, &e) && e.Code == http.StatusNotFound {
-			log15.Warn("PermsSyncer.syncRepoPerms.ignoreUnauthorizedAPIError",
-				"repoID", repo.ID,
-				"err", err,
-				"suggestion", "GitHub access token user may only have read access to the repository, but needs write for permissions",
-			)
+			log15.Warn("PermsSyncer.syncRepoPerms.ignoreUnauthorizedAPIError", "repoID", repo.ID, "err", err, "suggestion", "GitHub access token user may only have read access to the repository, but needs write for permissions")
 			return errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
 		}
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
 
-	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -24,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestPermsSyncer_ScheduleUsers(t *testing.T) {
@@ -70,9 +67,8 @@ type mockProvider struct {
 	serviceType string
 	serviceID   string
 
-	fetchUserPerms        func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error)
-	fetchUserPermsByToken func(ctx context.Context, token string) (*authz.ExternalUserPermissions, error)
-	fetchRepoPerms        func(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error)
+	fetchUserPerms func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error)
+	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error)
 }
 
 func (*mockProvider) FetchAccount(context.Context, *types.User, []*extsvc.Account, []string) (*extsvc.Account, error) {
@@ -88,15 +84,22 @@ func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account,
 	return p.fetchUserPerms(ctx, acct)
 }
 
-func (p *mockProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return p.fetchUserPermsByToken(ctx, token)
-}
-
 func (p *mockProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	return p.fetchRepoPerms(ctx, repo, opts)
 }
 
-func TestPermsSyncer_syncUserPerms(t *testing.T) {
+// NOTE: With the latest set of changes, we will be relying on the external_service_repos
+//  table to satisfy repo permissions. That means we don't need to make the external
+//  service calls we currently do, because the data is already present.
+//
+//  We are choosing to _leave_ the current code and tests alone, since the new data
+//  is additive. All existing tests should pass, and this new test captures the new
+//  behavior. We will revisit the issue shortly and excise the old code.
+//
+//  In the test below, the external service has one repo that's visible due to a limited
+//  sign-in connection scope, but additional repositories in the external_service_repos
+//  table. At the end we expect a union of both sets of data.
+func TestPermsSyncer_syncUserPerms_unionExternalServiceRepos(t *testing.T) {
 	p := &mockProvider{
 		id:          1,
 		serviceType: extsvc.TypeGitLab,
@@ -115,7 +118,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 		ID:              1,
 		Kind:            extsvc.KindGitLab,
 		DisplayName:     "GITLAB1",
-		Config:          `{"token": "limited", "authorization": {}}`,
+		Config:          `{"token": "limited"}`,
 		NamespaceUserID: 1,
 	}
 
@@ -129,26 +132,17 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 		return []*extsvc.Account{&extAccount}, nil
 	}
 	edb.Mocks.Perms.SetUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
-		wantIDs := []uint32{1, 2, 3, 4, 5}
+		wantIDs := []uint32{1, 2, 3, 4}
 		if diff := cmp.Diff(wantIDs, p.IDs.ToArray()); diff != "" {
 			return errors.Errorf("IDs mismatch (-want +got):\n%s", diff)
 		}
 		return nil
 	}
-	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
-		return true, nil
-	}
 	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
 		}
-
-		names := make([]types.RepoName, 0, len(args.ExternalRepos))
-		for _, r := range args.ExternalRepos {
-			id, _ := strconv.Atoi(r.ID)
-			names = append(names, types.RepoName{ID: api.RepoID(id)})
-		}
-		return names, nil
+		return []types.RepoName{{ID: 1}}, nil
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
@@ -162,13 +156,9 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{2, 3, 4}, nil
 	}
-	eauthz.MockProviderFromExternalService = func(siteConfig schema.SiteConfiguration, svc *types.ExternalService) (authz.Provider, error) {
-		return p, nil
-	}
 	defer func() {
 		database.Mocks = database.MockStores{}
 		edb.Mocks.Perms = edb.MockPerms{}
-		eauthz.MockProviderFromExternalService = nil
 	}()
 
 	permsStore := edb.Perms(nil, timeutil.Now)
@@ -179,11 +169,6 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 			Exacts: []extsvc.RepoID{"1"},
 		}, nil
 	}
-	p.fetchUserPermsByToken = func(ctx context.Context, s string) (*authz.ExternalUserPermissions, error) {
-		return &authz.ExternalUserPermissions{
-			Exacts: []extsvc.RepoID{"5"},
-		}, nil
-	}
 
 	err := s.syncUserPerms(context.Background(), 1, true, authz.FetchPermsOptions{})
 	if err != nil {
@@ -191,7 +176,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 }
 
-func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
+func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	p := &mockProvider{
 		id:          1,
 		serviceType: extsvc.TypeGitLab,
@@ -227,9 +212,6 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 		}
 		return nil
 	}
-	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
-		return true, nil
-	}
 	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
@@ -238,17 +220,6 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
-	}
-	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-		return []*types.ExternalService{
-			{
-				ID:              1,
-				Kind:            extsvc.KindGitHub,
-				DisplayName:     "GITHUB #1",
-				Config:          `{"token": "mytoken"}`,
-				NamespaceUserID: opt.NamespaceUserID,
-			},
-		}, nil
 	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
 		return []api.RepoID{}, nil
@@ -283,11 +254,6 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 					Exacts: []extsvc.RepoID{"1"},
 				}, test.fetchErr
 			}
-			p.fetchUserPermsByToken = func(ctx context.Context, token string) (*authz.ExternalUserPermissions, error) {
-				return &authz.ExternalUserPermissions{
-					Exacts: []extsvc.RepoID{"2"},
-				}, nil
-			}
 
 			err := s.syncUserPerms(context.Background(), 1, test.noPerms, authz.FetchPermsOptions{})
 			if err != nil {
@@ -321,9 +287,6 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 	edb.Mocks.Perms.SetUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
 		return nil
 	}
-	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
-		return true, nil
-	}
 	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
@@ -331,9 +294,6 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 		return []types.RepoName{{ID: 1}}, nil
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
-		return nil, nil
-	}
-	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return nil, nil
 	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
@@ -442,9 +402,6 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	edb.Mocks.Perms.SetUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
 		return nil
 	}
-	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
-		return true, nil
-	}
 	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
@@ -456,9 +413,6 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 		return []types.RepoName{{ID: 1}}, nil
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
-		return nil, nil
-	}
-	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 		return nil, nil
 	}
 	database.Mocks.Repos.ListExternalServiceRepoIDsByUserID = func(ctx context.Context, userID int32) ([]api.RepoID, error) {
@@ -511,9 +465,6 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	}
 	edb.Mocks.Perms.SetUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
 		return nil
-	}
-	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
-		return false, nil
 	}
 	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
 		if !args.OnlyPrivate {

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -48,7 +48,7 @@ func ProvidersFromConfig(
 	}()
 
 	opt := database.ExternalServicesListOptions{
-		ExcludeNamespaceUser: true,
+		NoNamespace: true,
 		Kinds: []string{
 			extsvc.KindGitHub,
 			extsvc.KindGitLab,
@@ -113,6 +113,7 @@ func ProvidersFromConfig(
 				log15.Error("ProvidersFromConfig", "error", errors.Errorf("unexpected connection type: %T", cfg))
 				continue
 			}
+
 		}
 
 		if len(svcs) < opt.Limit {
@@ -128,7 +129,7 @@ func ProvidersFromConfig(
 	}
 
 	if len(gitLabConns) > 0 {
-		glProviders, glProblems, glWarnings := gitlab.NewAuthzProviders(cfg.SiteConfiguration, gitLabConns)
+		glProviders, glProblems, glWarnings := gitlab.NewAuthzProviders(cfg, gitLabConns)
 		providers = append(providers, glProviders...)
 		seriousProblems = append(seriousProblems, glProblems...)
 		warnings = append(warnings, glWarnings...)
@@ -165,76 +166,4 @@ func ProvidersFromConfig(
 	}
 
 	return allowAccessByDefault, providers, seriousProblems, warnings
-}
-
-var MockProviderFromExternalService func(siteConfig schema.SiteConfiguration, svc *types.ExternalService) (authz.Provider, error)
-
-// ProviderFromExternalService returns the parsed authz.Provider derived from
-// the site config and the given external service.
-//
-// It returns `(nil, nil)` if no authz.Provider can be derived and no error had
-// occurred.
-func ProviderFromExternalService(siteConfig schema.SiteConfiguration, svc *types.ExternalService) (authz.Provider, error) {
-	if MockProviderFromExternalService != nil {
-		return MockProviderFromExternalService(siteConfig, svc)
-	}
-
-	cfg, err := extsvc.ParseConfig(svc.Kind, svc.Config)
-	if err != nil {
-		return nil, errors.Wrap(err, "parse config")
-	}
-
-	var providers []authz.Provider
-	var problems []string
-	switch c := cfg.(type) {
-	case *schema.GitHubConnection:
-		providers, problems, _ = github.NewAuthzProviders(
-			[]*types.GitHubConnection{
-				{
-					URN:              svc.URN(),
-					GitHubConnection: c,
-				},
-			},
-			siteConfig.AuthProviders,
-		)
-	case *schema.GitLabConnection:
-		providers, problems, _ = gitlab.NewAuthzProviders(
-			siteConfig,
-			[]*types.GitLabConnection{
-				{
-					URN:              svc.URN(),
-					GitLabConnection: c,
-				},
-			},
-		)
-	case *schema.BitbucketServerConnection:
-		providers, problems, _ = bitbucketserver.NewAuthzProviders(
-			[]*types.BitbucketServerConnection{
-				{
-					URN:                       svc.URN(),
-					BitbucketServerConnection: c,
-				},
-			},
-		)
-	case *schema.PerforceConnection:
-		providers, problems, _ = perforce.NewAuthzProviders(
-			[]*types.PerforceConnection{
-				{
-					URN:                svc.URN(),
-					PerforceConnection: c,
-				},
-			},
-		)
-	default:
-		return nil, errors.Errorf("unsupported connection type %T", cfg)
-	}
-
-	if len(problems) > 0 {
-		return nil, errors.New(problems[0])
-	}
-
-	if len(providers) == 0 {
-		return nil, nil
-	}
-	return providers[0], nil
 }

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -52,10 +52,6 @@ func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Accou
 	panic("should never be called")
 }
 
-func (m gitlabAuthzProviderParams) FetchUserPermsByToken(context.Context, string, authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	panic("should never be called")
-}
-
 func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository, authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	panic("should never be called")
 }

--- a/enterprise/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/internal/authz/bitbucketserver/provider.go
@@ -155,12 +155,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	}, err
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, errors.New("not implemented")
-}
-
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given repo on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -199,8 +199,8 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 		}
 	}
 
-	// We're done if groups caching is disabled or no accountID is available.
-	if p.groupsCache == nil || accountID == "" {
+	// If groups caching is disabled, we are done.
+	if p.groupsCache == nil {
 		return perms, nil
 	}
 
@@ -292,12 +292,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	}
 
 	return p.fetchUserPermsByToken(ctx, extsvc.AccountID(account.AccountID), tok.AccessToken, opts)
-}
-
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return p.fetchUserPermsByToken(ctx, "", token, opts)
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/enterprise/internal/authz/gitlab/gitlab.go
+++ b/enterprise/internal/authz/gitlab/gitlab.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -18,7 +19,7 @@ import (
 // "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
 func NewAuthzProviders(
-	cfg schema.SiteConfiguration,
+	cfg *conf.Unified,
 	conns []*types.GitLabConnection,
 ) (ps []authz.Provider, problems []string, warnings []string) {
 	// Authorization (i.e., permissions) providers

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -102,13 +102,6 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 	return listProjects(ctx, client)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *OAuthProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	client := p.clientProvider.GetOAuthClient(token)
-	return listProjects(ctx, client)
-}
-
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given project on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/enterprise/internal/authz/gitlab/sudo.go
+++ b/enterprise/internal/authz/gitlab/sudo.go
@@ -212,13 +212,6 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 	return listProjects(ctx, client)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *SudoProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	client := p.clientProvider.GetOAuthClient(token)
-	return listProjects(ctx, client)
-}
-
 // listProjects is a helper function to request for all private projects that are accessible
 // (access level: 20 => Reporter access) by the authenticated or impersonated user in the client.
 // It may return partial but valid results in case of error, and it is up to callers to decide

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -179,12 +179,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	return perms, errors.Wrap(err, "scanRepoIncludesExcludes.Err")
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, errors.New("not implemented")
-}
-
 // getAllUserEmails returns a set of username <-> email pairs of all users in the Perforce server.
 func (p *Provider) getAllUserEmails(ctx context.Context) (map[string]string, error) {
 	if p.cachedAllUserEmails != nil {

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -58,7 +58,6 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"RepoIDsWithNoPerms", testPermsStore_RepoIDsWithNoPerms(db)},
 		{"UserIDsWithOldestPerms", testPermsStore_UserIDsWithOldestPerms(db)},
 		{"ReposIDsWithOldestPerms", testPermsStore_ReposIDsWithOldestPerms(db)},
-		{"UserIsMemberOfOrgHasCodeHostConnection", testPermsStore_UserIsMemberOfOrgHasCodeHostConnection(db)},
 		{"Metrics", testPermsStore_Metrics(db)},
 	} {
 		t.Run(tc.name, tc.test)

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1546,32 +1546,6 @@ func (s *PermsStore) loadIDsWithTime(ctx context.Context, q *sqlf.Query) (map[in
 	return results, nil
 }
 
-// UserIsMemberOfOrgHasCodeHostConnection returns true if the user is a member
-// of any organization that has added code host connection.
-func (s *PermsStore) UserIsMemberOfOrgHasCodeHostConnection(ctx context.Context, userID int32) (has bool, err error) {
-	if Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection != nil {
-		return Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection(ctx, userID)
-	}
-
-	ctx, save := s.observe(ctx, "UserIsMemberOfOrgHasCodeHostConnection", "")
-	defer func() { save(&err, otlog.Int32("userID", userID)) }()
-
-	q := sqlf.Sprintf(`
--- source: enterprise/internal/database/perms_store.go:PermsStore.UserIsMemberOfOrgHasCodeHostConnection
-SELECT EXISTS (
-	SELECT
-	FROM org_members
-	JOIN external_services ON external_services.namespace_org_id = org_id
-	WHERE user_id = %s
-)
-`, userID)
-	err = s.QueryRow(ctx, q).Scan(&has)
-	if err != nil {
-		return false, err
-	}
-	return has, nil
-}
-
 // PermsMetrics contains metrics values calculated by querying the database.
 type PermsMetrics struct {
 	// The number of users with stale permissions.

--- a/enterprise/internal/database/perms_store_mock.go
+++ b/enterprise/internal/database/perms_store_mock.go
@@ -8,16 +8,15 @@ import (
 )
 
 type MockPerms struct {
-	Transact                               func(ctx context.Context) (*PermsStore, error)
-	LoadRepoPermissions                    func(ctx context.Context, p *authz.RepoPermissions) error
-	LoadUserPermissions                    func(ctx context.Context, p *authz.UserPermissions) error
-	LoadUserPendingPermissions             func(ctx context.Context, p *authz.UserPendingPermissions) error
-	SetUserPermissions                     func(ctx context.Context, p *authz.UserPermissions) error
-	SetRepoPermissions                     func(ctx context.Context, p *authz.RepoPermissions) error
-	SetRepoPendingPermissions              func(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) error
-	TouchRepoPermissions                   func(ctx context.Context, repoID int32) error
-	ListPendingUsers                       func(ctx context.Context) ([]string, error)
-	ListExternalAccounts                   func(ctx context.Context, userID int32) ([]*extsvc.Account, error)
-	GetUserIDsByExternalAccounts           func(ctx context.Context, accounts *extsvc.Accounts) (map[string]int32, error)
-	UserIsMemberOfOrgHasCodeHostConnection func(ctx context.Context, userID int32) (bool, error)
+	Transact                     func(ctx context.Context) (*PermsStore, error)
+	LoadRepoPermissions          func(ctx context.Context, p *authz.RepoPermissions) error
+	LoadUserPermissions          func(ctx context.Context, p *authz.UserPermissions) error
+	LoadUserPendingPermissions   func(ctx context.Context, p *authz.UserPendingPermissions) error
+	SetUserPermissions           func(ctx context.Context, p *authz.UserPermissions) error
+	SetRepoPermissions           func(ctx context.Context, p *authz.RepoPermissions) error
+	SetRepoPendingPermissions    func(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) error
+	TouchRepoPermissions         func(ctx context.Context, repoID int32) error
+	ListPendingUsers             func(ctx context.Context) ([]string, error)
+	ListExternalAccounts         func(ctx context.Context, userID int32) ([]*extsvc.Account, error)
+	GetUserIDsByExternalAccounts func(ctx context.Context, accounts *extsvc.Accounts) (map[string]int32, error)
 }

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -17,17 +17,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func cleanupPermsTables(t *testing.T, s *PermsStore) {
@@ -2732,8 +2727,7 @@ func testPermsStore_ReposIDsWithOldestPerms(db *sql.DB) func(*testing.T) {
 				return
 			}
 
-			q := `TRUNCATE TABLE external_services, repo CASCADE`
-			if err := s.execute(ctx, sqlf.Sprintf(q)); err != nil {
+			if err := s.execute(ctx, sqlf.Sprintf(`DELETE FROM repo`)); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -2825,88 +2819,6 @@ WHERE repo_id = 2`, clock().AddDate(1, 0, 0))
 		if diff := cmp.Diff(wantResults, results); diff != "" {
 			t.Fatalf("Results mismatch (-want +got):\n%s", diff)
 		}
-	}
-}
-
-func testPermsStore_UserIsMemberOfOrgHasCodeHostConnection(db *sql.DB) func(*testing.T) {
-	return func(t *testing.T) {
-		s := Perms(db, clock)
-		ctx := context.Background()
-		t.Cleanup(func() {
-			if t.Failed() {
-				return
-			}
-
-			q := `TRUNCATE TABLE external_services, orgs, users CASCADE`
-			if err := s.execute(ctx, sqlf.Sprintf(q)); err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		// Set up users with:
-		//  1. Is not a member of any organization
-		//  2. Is a member of an organization without a code host connection
-		//  3. Is a member of an organization with a code host connection
-		users := database.Users(db)
-		alice, err := users.Create(ctx,
-			database.NewUser{
-				Email:           "alice@example.com",
-				Username:        "alice",
-				EmailIsVerified: true,
-			},
-		)
-		require.NoError(t, err)
-		bob, err := users.Create(ctx,
-			database.NewUser{
-				Email:           "bob@example.com",
-				Username:        "bob",
-				EmailIsVerified: true,
-			},
-		)
-		require.NoError(t, err)
-		cindy, err := users.Create(ctx,
-			database.NewUser{
-				Email:           "cindy@example.com",
-				Username:        "cindy",
-				EmailIsVerified: true,
-			},
-		)
-		require.NoError(t, err)
-
-		orgs := database.Orgs(db)
-		bobOrg, err := orgs.Create(ctx, "bob-org", nil)
-		require.NoError(t, err)
-		cindyOrg, err := orgs.Create(ctx, "cindy-org", nil)
-		require.NoError(t, err)
-
-		orgMembers := database.OrgMembers(db)
-		_, err = orgMembers.Create(ctx, bobOrg.ID, bob.ID)
-		require.NoError(t, err)
-		_, err = orgMembers.Create(ctx, cindyOrg.ID, cindy.ID)
-		require.NoError(t, err)
-
-		err = database.ExternalServices(db).Create(ctx,
-			func() *conf.Unified { return &conf.Unified{} },
-			&types.ExternalService{
-				Kind:           extsvc.KindGitHub,
-				DisplayName:    "GitHub (cindy-org)",
-				Config:         `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-				NamespaceOrgID: cindyOrg.ID,
-			},
-		)
-		require.NoError(t, err)
-
-		has, err := s.UserIsMemberOfOrgHasCodeHostConnection(ctx, alice.ID)
-		assert.NoError(t, err)
-		assert.False(t, has)
-
-		has, err = s.UserIsMemberOfOrgHasCodeHostConnection(ctx, bob.ID)
-		assert.NoError(t, err)
-		assert.False(t, has)
-
-		has, err = s.UserIsMemberOfOrgHasCodeHostConnection(ctx, cindy.ID)
-		assert.NoError(t, err)
-		assert.True(t, has)
 	}
 }
 

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -116,10 +116,6 @@ type Provider interface {
 	// to decide whether to discard.
 	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts FetchPermsOptions) ([]extsvc.AccountID, error)
 
-	// FetchUserPermsByToken is similar to FetchUserPerms but only requires a token
-	// in order to communicate with the code host.
-	FetchUserPermsByToken(ctx context.Context, token string, opts FetchPermsOptions) (*ExternalUserPermissions, error)
-
 	// ServiceType returns the service type (e.g., "gitlab") of this authz provider.
 	ServiceType() string
 

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -145,12 +145,8 @@ type ExternalServicesListOptions struct {
 	// When specified, only include external services with the given IDs.
 	IDs []int64
 	// When true, only include external services not under any namespace (i.e. owned
-	// by all site admins), and values of NamespaceUserID, NamespaceOrgID and
-	// ExcludeNamespaceUser are ignored.
+	// by all site admins), and value of NamespaceUserID is ignored.
 	NoNamespace bool
-	// When true, will exclude external services under any user namespace, and
-	// values of NamespaceUserID and NamespaceOrgID are ignored.
-	ExcludeNamespaceUser bool
 	// When specified, only include external services under given user namespace.
 	NamespaceUserID int32
 	// When specified, only include external services under given organization namespace.
@@ -194,8 +190,6 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 	}
 	if o.NoNamespace {
 		conds = append(conds, sqlf.Sprintf(`namespace_user_id IS NULL AND namespace_org_id IS NULL`))
-	} else if o.ExcludeNamespaceUser {
-		conds = append(conds, sqlf.Sprintf(`namespace_user_id IS NULL`))
 	} else if o.NamespaceUserID > 0 {
 		conds = append(conds, sqlf.Sprintf(`namespace_user_id = %d`, o.NamespaceUserID))
 	} else if o.NamespaceOrgID > 0 {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -30,18 +30,17 @@ import (
 
 func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 	tests := []struct {
-		name                 string
-		noNamespace          bool
-		excludeNamespaceUser bool
-		namespaceUserID      int32
-		namespaceOrgID       int32
-		kinds                []string
-		afterID              int64
-		wantQuery            string
-		onlyCloudDefault     bool
-		includeDeleted       bool
-		noCachedWebhooks     bool
-		wantArgs             []interface{}
+		name             string
+		noNamespace      bool
+		namespaceUserID  int32
+		namespaceOrgID   int32
+		kinds            []string
+		afterID          int64
+		wantQuery        string
+		onlyCloudDefault bool
+		includeDeleted   bool
+		noCachedWebhooks bool
+		wantArgs         []interface{}
 	}{
 		{
 			name:      "no condition",
@@ -79,11 +78,6 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 			wantQuery:       "deleted_at IS NULL AND namespace_user_id IS NULL AND namespace_org_id IS NULL",
 		},
 		{
-			name:                 "want exclude namespace user",
-			excludeNamespaceUser: true,
-			wantQuery:            "deleted_at IS NULL AND namespace_user_id IS NULL",
-		},
-		{
 			name:      "has after ID",
 			afterID:   10,
 			wantQuery: "deleted_at IS NULL AND id < $1",
@@ -108,15 +102,14 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			opts := ExternalServicesListOptions{
-				NoNamespace:          test.noNamespace,
-				ExcludeNamespaceUser: test.excludeNamespaceUser,
-				NamespaceUserID:      test.namespaceUserID,
-				NamespaceOrgID:       test.namespaceOrgID,
-				Kinds:                test.kinds,
-				AfterID:              test.afterID,
-				OnlyCloudDefault:     test.onlyCloudDefault,
-				IncludeDeleted:       test.includeDeleted,
-				noCachedWebhooks:     test.noCachedWebhooks,
+				NoNamespace:      test.noNamespace,
+				NamespaceUserID:  test.namespaceUserID,
+				NamespaceOrgID:   test.namespaceOrgID,
+				Kinds:            test.kinds,
+				AfterID:          test.afterID,
+				OnlyCloudDefault: test.onlyCloudDefault,
+				IncludeDeleted:   test.includeDeleted,
+				noCachedWebhooks: test.noCachedWebhooks,
 			}
 			q := sqlf.Join(opts.sqlConditions(), "AND")
 			if diff := cmp.Diff(test.wantQuery, q.Query(sqlf.PostgresBindVar)); diff != "" {

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -41,10 +41,6 @@ func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account, authz.Fe
 	return nil, nil
 }
 
-func (p *fakeProvider) FetchUserPermsByToken(context.Context, string, authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, nil
-}
-
 func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository, authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	return nil, nil
 }


### PR DESCRIPTION
…er code host conns (#26828)"

This reverts commit 0bb1db875849896f3537f92f44052ea5355a1089.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
