### PR TITLE
ChunkLoadError and AbortError handling

### DIFF
--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -130,10 +130,20 @@ function shouldErrorBeReported(error: unknown): boolean {
         // Ignore Server error responses (5xx)
         return error.status < 500
     }
-
+    if (isWebpackChunkError(error) || isAbortError(error) || isNotAuthenticatedError(error)) {
+        return false
+    }
     return true
 }
 
 function isWebpackChunkError(value: unknown): boolean {
     return isErrorLike(value) && value.name === 'ChunkLoadError'
+}
+
+function isAbortError(value: unknown): boolean {
+    return isErrorLike(value) && value.name === 'AbortError'
+}
+
+function isNotAuthenticatedError(value: unknown): boolean {
+    return isErrorLike(value) && value.message.includes('not authenticated')
 }

--- a/client/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/client/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -49,12 +49,12 @@ exports[`ErrorBoundary renders reload page if chunk error 1`] = `
   <div
     className="icon"
   >
-    <AlertCircleIcon />
+    <ReloadIcon />
   </div>
   <div
     className="title"
   >
-    Error
+    Reload required
   </div>
   <div
     className="subtitle"
@@ -64,15 +64,15 @@ exports[`ErrorBoundary renders reload page if chunk error 1`] = `
       className="container"
     >
       <p>
-        Sourcegraph encountered an unexpected error. If reloading the page doesn't fix it, contact your site admin or Sourcegraph support.
+        A new version of Sourcegraph is available.
       </p>
-      <p>
-        <code
-          className="text-wrap"
-        >
-          Loading chunk 123 failed.
-        </code>
-      </p>
+      <button
+        className="btn btn-primary"
+        onClick={[Function]}
+        type="button"
+      >
+        Reload to update
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
Added Logic to prevent `ChunkLoadError`, `AbortError` and `not authenticated` errors from being reported to sentry

## Refs
- https://github.com/sourcegraph/sourcegraph/issues/26002
