### PR TITLE
monitoring: Set time period for repo-updater error rate to 5m

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3094,7 +3094,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 10m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 5m0s
 
 **Possible solutions**
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3094,7 +3094,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 1m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 10m0s
 
 **Possible solutions**
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -8689,7 +8689,7 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_sched_error[1m]))`
+Query: `max(rate(src_repoupdater_sched_error[10m]))`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -8689,7 +8689,7 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_sched_error[10m]))`
+Query: `max(rate(src_repoupdater_sched_error[1m]))`
 
 </details>
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -206,7 +206,7 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:              "sched_error",
 							Description:       "repositories schedule error rate",
-							Query:             `max(rate(src_repoupdater_sched_error[10m]))`,
+							Query:             `max(rate(src_repoupdater_sched_error[1m]))`,
 							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(10 * time.Minute),
 							Panel:             monitoring.Panel().Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -206,8 +206,8 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:              "sched_error",
 							Description:       "repositories schedule error rate",
-							Query:             `max(rate(src_repoupdater_sched_error[1m]))`,
-							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(time.Minute),
+							Query:             `max(rate(src_repoupdater_sched_error[10m]))`,
+							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(10 * time.Minute),
 							Panel:             monitoring.Panel().Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: "Check repo-updater logs for errors",

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -207,7 +207,7 @@ func RepoUpdater() *monitoring.Container {
 							Name:              "sched_error",
 							Description:       "repositories schedule error rate",
 							Query:             `max(rate(src_repoupdater_sched_error[1m]))`,
-							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(10 * time.Minute),
+							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(5 * time.Minute),
 							Panel:             monitoring.Panel().Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: "Check repo-updater logs for errors",


### PR DESCRIPTION
This alert is triggered when gitserver is being deployed. We want to
avoid false positives. Increasing the time window to 10minutes should
help.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
