### PR TITLE
database: quiet external service migration errors

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -902,7 +902,7 @@ func (e *ExternalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 			// Legacy configurations might not be valid JSON; in that case, they
 			// also can't have webhooks, so we'll just log the issue and move
 			// on.
-			log15.Warn("cannot parse external service configuration as JSON", "err", err)
+			log15.Warn("cannot parse external service configuration as JSON", "err", err, "id", id)
 			hasWebhooks = false
 		}
 		update.Config = &newSvc.Config
@@ -1427,7 +1427,7 @@ func (e *ExternalServiceStore) recalculateFields(es *types.ExternalService, rawC
 	} else {
 		// Legacy configurations might not be valid JSON; in that case, they
 		// also can't have webhooks, so we'll just log the issue and move on.
-		log15.Warn("cannot parse external service configuration as JSON", "err", err)
+		log15.Warn("cannot parse external service configuration as JSON", "err", err, "id", es.ID)
 	}
 	es.HasWebhooks = &hasWebhooks
 

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
@@ -895,10 +896,15 @@ func (e *ExternalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 			return errors.Wrapf(err, "error unredacting config")
 		}
 		cfg, err := newSvc.Configuration()
-		if err != nil {
-			return errors.Wrap(err, "parsing config")
+		if err == nil {
+			hasWebhooks = configurationHasWebhooks(cfg)
+		} else {
+			// Legacy configurations might not be valid JSON; in that case, they
+			// also can't have webhooks, so we'll just log the issue and move
+			// on.
+			log15.Warn("cannot parse external service configuration as JSON", "err", err)
+			hasWebhooks = false
 		}
-		hasWebhooks = configurationHasWebhooks(cfg)
 		update.Config = &newSvc.Config
 
 		normalized, err = e.ValidateConfig(ctx, ValidateExternalServiceConfigOptions{
@@ -1414,11 +1420,15 @@ WHERE EXISTS(
 func (e *ExternalServiceStore) recalculateFields(es *types.ExternalService, rawConfig string) error {
 	es.Unrestricted = !envvar.SourcegraphDotComMode() && !gjson.Get(es.Config, "authorization").Exists()
 
+	hasWebhooks := false
 	cfg, err := extsvc.ParseConfig(es.Kind, rawConfig)
-	if err != nil {
-		return errors.Wrap(err, "parsing configuration")
+	if err == nil {
+		hasWebhooks = configurationHasWebhooks(cfg)
+	} else {
+		// Legacy configurations might not be valid JSON; in that case, they
+		// also can't have webhooks, so we'll just log the issue and move on.
+		log15.Warn("cannot parse external service configuration as JSON", "err", err)
 	}
-	hasWebhooks := configurationHasWebhooks(cfg)
 	es.HasWebhooks = &hasWebhooks
 
 	return nil


### PR DESCRIPTION
The OOB migrator added in #26759 to populate the `has_webhooks` field of external services would error if the JSON configuration in the external service record was invalid. It turns out that we have at least one external service on cloud that has invalid JSON, as this wasn't always enforced, so this means the OOB migration will never succeed.

Instead, we'll demote that to a log message and complete the migration anyway.