### PR TITLE
refactor gitserver search errors and instrumentation

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -922,112 +922,117 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	tr, ctx := trace.New(r.Context(), "search", "")
+	defer tr.Finish()
+
+	// Decode the request
 	protocol.RegisterGob()
-	var req protocol.SearchRequest
-	if err := gob.NewDecoder(r.Body).Decode(&req); err != nil {
+	var args protocol.SearchRequest
+	if err := gob.NewDecoder(r.Body).Decode(&args); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	s.search(w, r, &req)
-}
-
-func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.SearchRequest) {
-	var searchErr error
-	tr, ctx := trace.New(r.Context(), "search", "")
 	tr.LogFields(
+		otlog.String("repo", string(args.Repo)),
+		otlog.Bool("include_diff", args.IncludeDiff),
 		otlog.String("query", args.Query.String()),
 		otlog.Int("limit", args.Limit),
 	)
-	defer func() {
-		tr.SetError(searchErr)
-		tr.Finish()
-	}()
-
-	searchRunning.Inc()
-	defer searchRunning.Dec()
 
 	searchStart := time.Now()
 	defer func() { searchDuration.Observe(time.Since(searchStart).Seconds()) }()
+	searchRunning.Inc()
+	defer searchRunning.Dec()
 
-	defer func() {
-		if honey.Enabled() || traceLogs {
-			actor := r.Header.Get("X-Sourcegraph-Actor")
-			ev := honey.Event("gitserver-search")
-			ev.SampleRate = 1
-			ev.AddField("repo", args.Repo)
-			ev.AddField("revisions", args.Revisions)
-			ev.AddField("include_diff", args.IncludeDiff)
-			ev.AddField("actor", actor)
-			ev.AddField("query", args.Query.String())
-			ev.AddField("limit", args.Limit)
-			ev.AddField("duration_ms", time.Since(searchStart).Milliseconds())
-			if searchErr != nil {
-				ev.AddField("error", searchErr.Error())
-			}
-			if traceID := trace.ID(ctx); traceID != "" {
-				ev.AddField("traceID", traceID)
-				ev.AddField("trace", trace.URL(traceID))
-			}
-			if honey.Enabled() {
-				_ = ev.Send()
-			}
-			if traceLogs {
-				log15.Debug("TRACE gitserver search", mapToLog15Ctx(ev.Fields())...)
-			}
+	eventWriter, err := streamhttp.NewWriter(w)
+	if err != nil {
+		tr.SetError(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var latencyOnce sync.Once
+	matchesBuf := streamhttp.NewJSONArrayBuf(8*1024, func(data []byte) error {
+		tr.LogFields(otlog.Int("flushing", len(data)))
+		latencyOnce.Do(func() {
+			searchLatency.Observe(time.Since(searchStart).Seconds())
+		})
+		return eventWriter.EventBytes("matches", data)
+	})
+
+	// Run the search
+	limitHit, err := s.search(ctx, matchesBuf, &args)
+	eventWriter.Event("done", protocol.NewSearchEventDone(false, err))
+	tr.LogFields(otlog.Bool("limit_hit", limitHit))
+	tr.SetError(err)
+
+	if honey.Enabled() || traceLogs {
+		actor := r.Header.Get("X-Sourcegraph-Actor")
+		ev := honey.Event("gitserver-search")
+		ev.SampleRate = 1
+		ev.AddField("repo", args.Repo)
+		ev.AddField("revisions", args.Revisions)
+		ev.AddField("include_diff", args.IncludeDiff)
+		ev.AddField("actor", actor)
+		ev.AddField("query", args.Query.String())
+		ev.AddField("limit", args.Limit)
+		ev.AddField("duration_ms", time.Since(searchStart).Milliseconds())
+		if err != nil {
+			ev.AddField("error", err.Error())
 		}
-	}()
+		if traceID := trace.ID(ctx); traceID != "" {
+			ev.AddField("traceID", traceID)
+			ev.AddField("trace", trace.URL(traceID))
+		}
+		if honey.Enabled() {
+			_ = ev.Send()
+		}
+		if traceLogs {
+			log15.Debug("TRACE gitserver search", mapToLog15Ctx(ev.Fields())...)
+		}
+	}
+
+}
+
+func (s *Server) search(ctx context.Context, matchesBuf *streamhttp.JSONArrayBuf, args *protocol.SearchRequest) (limitHit bool, err error) {
 
 	args.Repo = protocol.NormalizeRepo(args.Repo)
 	if args.Limit == 0 {
 		args.Limit = math.MaxInt32
 	}
 
-	eventWriter, searchErr := streamhttp.NewWriter(w)
-	if searchErr != nil {
-		http.Error(w, searchErr.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	dir := s.dir(args.Repo)
 	if !repoCloned(dir) {
 		if conf.Get().DisableAutoGitUpdates {
 			log15.Debug("not cloning on demand as DisableAutoGitUpdates is set")
-			searchErr = &gitdomain.RepoNotExistError{
+			return false, &gitdomain.RepoNotExistError{
 				Repo: args.Repo,
 			}
-			eventWriter.Event("done", protocol.NewSearchEventDone(false, searchErr))
-			return
 		}
 
 		cloneProgress, cloneInProgress := s.locker.Status(dir)
 		if cloneInProgress {
-			searchErr = &gitdomain.RepoNotExistError{
+			return false, &gitdomain.RepoNotExistError{
 				Repo:            args.Repo,
 				CloneInProgress: true,
 				CloneProgress:   cloneProgress,
 			}
-			eventWriter.Event("done", protocol.NewSearchEventDone(false, searchErr))
-			return
 		}
 
 		cloneProgress, err := s.cloneRepo(ctx, args.Repo, nil)
 		if err != nil {
 			log15.Debug("error starting repo clone", "repo", args.Repo, "err", err)
-			err = &gitdomain.RepoNotExistError{
+			return false, &gitdomain.RepoNotExistError{
 				Repo:            args.Repo,
 				CloneInProgress: false,
 			}
-			eventWriter.Event("done", protocol.NewSearchEventDone(false, err))
-			return
 		}
 
-		err = &gitdomain.RepoNotExistError{
+		return false, &gitdomain.RepoNotExistError{
 			Repo:            args.Repo,
 			CloneInProgress: true,
 			CloneProgress:   cloneProgress,
 		}
-		eventWriter.Event("done", protocol.NewSearchEventDone(false, err))
-		return
 	}
 
 	if !conf.Get().DisableAutoGitUpdates {
@@ -1040,15 +1045,6 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 			}
 		}
 	}
-
-	var latencyOnce sync.Once
-	matchesBuf := streamhttp.NewJSONArrayBuf(8*1024, func(data []byte) error {
-		tr.LogFields(otlog.Int("flushing", len(data)))
-		latencyOnce.Do(func() {
-			searchLatency.Observe(time.Since(searchStart).Seconds())
-		})
-		return eventWriter.EventBytes("matches", data)
-	})
 
 	g, ctx := errgroup.WithContext(ctx)
 	ctx, cancel := context.WithCancel(ctx)
@@ -1081,7 +1077,6 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 	})
 
 	// Write matching commits to the stream, flushing occasionally
-	limitHit := false
 	g.Go(func() error {
 		defer cancel()
 		defer matchesBuf.Flush()
@@ -1117,11 +1112,7 @@ func (s *Server) search(w http.ResponseWriter, r *http.Request, args *protocol.S
 		}
 	})
 
-	searchErr = g.Wait()
-	doneEvent := protocol.NewSearchEventDone(limitHit, searchErr)
-	if err := eventWriter.Event("done", doneEvent); err != nil {
-		log15.Warn("failed to send done event", "error", err)
-	}
+	return limitHit, g.Wait()
 }
 
 // matchCount returns either:

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -971,7 +971,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if honey.Enabled() || traceLogs {
 		actor := r.Header.Get("X-Sourcegraph-Actor")
 		ev := honey.Event("gitserver-search")
-		ev.SampleRate = 1
+		ev.SampleRate = 16
 		ev.AddField("repo", args.Repo)
 		ev.AddField("revisions", args.Revisions)
 		ev.AddField("include_diff", args.IncludeDiff)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -960,7 +960,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// Run the search
-	limitHit, err := s.search(ctx, matchesBuf, &args)
+	limitHit, err := s.search(ctx, &args, matchesBuf)
 	eventWriter.Event("done", protocol.NewSearchEventDone(false, err))
 	tr.LogFields(otlog.Bool("limit_hit", limitHit))
 	tr.SetError(err)
@@ -995,7 +995,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) search(ctx context.Context, matchesBuf *streamhttp.JSONArrayBuf, args *protocol.SearchRequest) (limitHit bool, err error) {
+func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, matchesBuf *streamhttp.JSONArrayBuf) (limitHit bool, err error) {
 
 	args.Repo = protocol.NormalizeRepo(args.Repo)
 	if args.Limit == 0 {


### PR DESCRIPTION
This is a minor refactor stacked on #26887 that changes how errors are handled in the gitserver search path as well as where we handle instrumentation. Basically, the idea here is to move all instrumentation from `(*Server).search()` up into the `(*server).handleSearch()` method. This keeps the instrumentation cruft out of the search path, and allows us to more easily use the error value in instrumentation. It also has the benefit of better encapsulating the search code so it doesn't depend on a http writer or request. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
