### PR TITLE
Disables "Go to definition" button when hovering at definition

### DIFF
--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -32,6 +32,9 @@ export interface ActionItemAction {
 
     /** Whether the action item is active in the given context */
     active: boolean
+
+    /** Whether the action item should be disabled in the given context */
+    disabledWhen?: boolean
 }
 
 export interface ActionItemComponentProps
@@ -181,6 +184,8 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
                 </>
             )
             tooltip = this.props.action.actionItem.description
+        } else if (this.props.disabledWhen) {
+            content = this.props.action.disabledTitle
         } else {
             content = (
                 <>
@@ -247,7 +252,8 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
                 disabled={
                     !this.props.active ||
                     ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
-                        this.state.actionOrError === LOADING)
+                        this.state.actionOrError === LOADING) ||
+                    this.props.disabledWhen
                 }
                 disabledClassName={this.props.inactiveClassName}
                 className={classNames(

--- a/client/shared/src/api/extension/api/contribution.ts
+++ b/client/shared/src/api/extension/api/contribution.ts
@@ -108,7 +108,11 @@ export function evaluateContributions<T>(context: Context<T>, contributions: Con
         menus:
             contributions.menus &&
             mapValues(contributions.menus, (menuItems): Evaluated<MenuItemContribution>[] | undefined =>
-                menuItems?.map(menuItem => ({ ...menuItem, when: menuItem.when && !!menuItem.when.exec(context) }))
+                menuItems?.map(menuItem => ({
+                    ...menuItem,
+                    when: menuItem.when && !!menuItem.when.exec(context),
+                    disabledWhen: menuItem.disabledWhen && !!menuItem.disabledWhen.exec(context),
+                }))
             ),
         actions: evaluateActionContributions<T>(context, contributions.actions),
     }
@@ -124,6 +128,7 @@ function evaluateActionContributions<T>(
     return actions?.map(action => ({
         ...action,
         title: action.title?.exec(context),
+        disabledTitle: action.disabledTitle?.exec(context),
         category: action.category?.exec(context),
         description: action.description?.exec(context),
         iconURL: action.iconURL?.exec(context),
@@ -153,6 +158,8 @@ export function parseContributionExpressions(contributions: Raw<Contributions>):
                 menuItems?.map(menuItem => ({
                     ...menuItem,
                     when: typeof menuItem.when === 'string' ? parse<boolean>(menuItem.when) : undefined,
+                    disabledWhen:
+                        typeof menuItem.disabledWhen === 'string' ? parse<boolean>(menuItem.disabledWhen) : undefined,
                 }))
             ),
         actions: contributions && parseActionContributionExpressions(contributions.actions),
@@ -169,6 +176,7 @@ function parseActionContributionExpressions(actions: Raw<Contributions['actions'
     return actions?.map(action => ({
         ...action,
         title: maybe(action.title, parseTemplate),
+        disabledTitle: maybe(action.disabledTitle, parseTemplate),
         category: maybe(action.category, parseTemplate),
         description: maybe(action.description, parseTemplate),
         iconURL: maybe(action.iconURL, parseTemplate),

--- a/client/shared/src/api/protocol/contribution.ts
+++ b/client/shared/src/api/protocol/contribution.ts
@@ -84,6 +84,9 @@ export interface ActionContribution {
     /** The title that succinctly describes what this action does. */
     title?: TemplateExpression
 
+    /** The title that succinctly describes what it is when the action is disabled. */
+    disabledTitle?: TemplateExpression
+
     /**
      * The category that describes the group of related actions of which this action is a member.
      *
@@ -270,6 +273,12 @@ export interface MenuItemContribution {
      * displayed. The expression may use values from the context in which the contribution would be displayed.
      */
     when?: Expression<boolean>
+
+    /**
+     * An expression that, if given, must evaluate to true (or a truthy value) for this contribution to be
+     * disabled. The expression may use values from the context in which the contribution would be displayed.
+     */
+    disabledWhen?: Expression<boolean>
 
     /**
      * The group in which this item is displayed. This defines the sort order of menu items. The group value is an

--- a/client/shared/src/api/protocol/contribution.ts
+++ b/client/shared/src/api/protocol/contribution.ts
@@ -84,7 +84,7 @@ export interface ActionContribution {
     /** The title that succinctly describes what this action does. */
     title?: TemplateExpression
 
-    /** The title that succinctly describes what it is when the action is disabled. */
+    /** The title that succinctly describes what this action is even though it's disabled. */
     disabledTitle?: TemplateExpression
 
     /**

--- a/client/shared/src/contributions/contributions.test.ts
+++ b/client/shared/src/contributions/contributions.test.ts
@@ -28,7 +28,13 @@ describe('getContributedActionItems', () => {
                 action: { id: 'b', command: 'b', title: 'tb', description: 'db' },
                 active: true,
                 altAction: { id: 'c', command: 'c', title: 'tc', description: 'dc' },
+                disabledWhen: false,
             },
-            { action: { id: 'a', command: 'a', title: 'ta', description: 'da' }, active: true, altAction: undefined },
+            {
+                action: { id: 'a', command: 'a', title: 'ta', description: 'da' },
+                active: true,
+                altAction: undefined,
+                disabledWhen: false,
+            },
         ] as ActionItemAction[]))
 })

--- a/client/shared/src/contributions/contributions.ts
+++ b/client/shared/src/contributions/contributions.ts
@@ -21,11 +21,14 @@ export function getContributedActionItems(
     const allItems: ActionItemAction[] = []
     const menuItems = contributions.menus?.[menu]
     if (menuItems) {
-        for (const { action: actionID, alt: altActionID, when } of sortBy(menuItems, MENU_ITEMS_PROP_SORT_ORDER)) {
+        for (const { action: actionID, alt: altActionID, when, disabledWhen } of sortBy(
+            menuItems,
+            MENU_ITEMS_PROP_SORT_ORDER
+        )) {
             const action = contributions.actions.find(a => a.id === actionID)
             const altAction = contributions.actions.find(a => a.id === altActionID)
             if (action) {
-                allItems.push({ action, altAction, active: when === undefined || !!when })
+                allItems.push({ action, altAction, active: when === undefined || !!when, disabledWhen: !!disabledWhen })
             }
         }
     }

--- a/client/shared/src/hover/actions.test.ts
+++ b/client/shared/src/hover/actions.test.ts
@@ -125,6 +125,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     // Show loader
                     l: {
@@ -134,6 +135,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     // Show find references button (same tick)
                     f: {
@@ -143,6 +145,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     // Show go to definition button, hide loader, show find references button
                     g: {
@@ -152,6 +155,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                 }))()
             )
@@ -188,6 +192,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     // Not found
                     n: {
@@ -197,6 +202,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     // Show loader
                     l: {
@@ -206,6 +212,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     // Show find references button (same tick)
                     f: {
@@ -215,6 +222,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     // Show go to definition button, hide loader, show find references button
                     g: {
@@ -224,6 +232,7 @@ describe('getHoverActionsContext', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                 }))()
             )
@@ -257,6 +266,7 @@ describe('getHoverActionsContext', () => {
                     'goToDefinition.error': false,
                     'findReferences.url': null,
                     hoverPosition: FIXTURE_PARAMS,
+                    hoveredOnDefinition: false,
                 },
                 // Go to definition
                 g: {
@@ -266,6 +276,7 @@ describe('getHoverActionsContext', () => {
                     'goToDefinition.error': false,
                     'findReferences.url': null,
                     hoverPosition: FIXTURE_PARAMS,
+                    hoveredOnDefinition: false,
                 },
                 // Find references
                 f: {
@@ -275,6 +286,7 @@ describe('getHoverActionsContext', () => {
                     'goToDefinition.error': false,
                     'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                     hoverPosition: FIXTURE_PARAMS,
+                    hoveredOnDefinition: false,
                 },
             } as {
                 [key: string]: HoverActionsContext
@@ -309,6 +321,7 @@ describe('getHoverActionsContext', () => {
                     'goToDefinition.error': false,
                     'findReferences.url': null,
                     hoverPosition: FIXTURE_PARAMS,
+                    hoveredOnDefinition: false,
                 },
                 // Go to definition
                 g: {
@@ -318,6 +331,7 @@ describe('getHoverActionsContext', () => {
                     'goToDefinition.error': false,
                     'findReferences.url': null,
                     hoverPosition: FIXTURE_PARAMS,
+                    hoveredOnDefinition: false,
                 },
                 // Find references button
                 f: {
@@ -327,6 +341,7 @@ describe('getHoverActionsContext', () => {
                     'goToDefinition.error': false,
                     'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                     hoverPosition: FIXTURE_PARAMS,
+                    hoveredOnDefinition: false,
                 },
             } as {
                 [key: string]: HoverActionsContext
@@ -541,6 +556,7 @@ describe('registerHoverContributions()', () => {
                 iconURL: undefined,
             },
             active: true,
+            disabledWhen: false,
             altAction: undefined,
         }
         const GO_TO_DEFINITION_PRELOADED_ACTION: ActionItemAction = {
@@ -549,8 +565,10 @@ describe('registerHoverContributions()', () => {
                 commandArguments: ['/r2@c2/-/blob/f2?L3:3'],
                 id: 'goToDefinition.preloaded',
                 title: 'Go to definition',
+                disabledTitle: 'You are at the definition',
             },
             active: true,
+            disabledWhen: false,
             altAction: undefined,
         }
         const FIND_REFERENCES_ACTION: ActionItemAction = {
@@ -561,6 +579,7 @@ describe('registerHoverContributions()', () => {
                 title: 'Find references',
             },
             active: true,
+            disabledWhen: false,
             altAction: undefined,
         }
 
@@ -574,6 +593,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()
@@ -589,6 +609,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': true,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()
@@ -604,6 +625,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()
@@ -619,6 +641,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': null,
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()
@@ -634,6 +657,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()
@@ -649,6 +673,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()
@@ -664,6 +689,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': true,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()
@@ -679,6 +705,7 @@ describe('registerHoverContributions()', () => {
                         'goToDefinition.error': false,
                         'findReferences.url': '/r@v/-/blob/f?L2:2#tab=references',
                         hoverPosition: FIXTURE_PARAMS,
+                        hoveredOnDefinition: false,
                     },
                     extensionHostAPI
                 ).toPromise()


### PR DESCRIPTION
Disables "Go to definition" button when already at definition



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
