### PR TITLE
ci: run slow go tests concurrently

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -1,6 +1,31 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
+
+function usage {
+  cat <<EOF
+Usage: go-test.sh [only|exclude package-path-1 package-path-2 ...]
+
+Run go tests, optionally restricting which ones based on the only and exclude coommands.
+
+EOF
+}
+
+if [ "$1" == "-h" ]; then
+  usage
+  exit 1
+fi
+
+if [ -n "$1" ]; then
+  FILTER_ACTION=$1
+  shift
+  FILTER_TARGETS=$*
+fi
+
+# Display to the user what kind of filtering is happening here
+if [ -n "$FILTER_ACTION" ]; then
+  echo -e "--- :information_source: \033[0;34mFiltering go tests: $FILTER_ACTION $FILTER_TARGETS\033[0m"
+fi
 
 # For searcher
 echo "--- comby install"
@@ -19,8 +44,35 @@ find . -name go.mod -exec dirname '{}' \; | while read -r d; do
   echo "--- $d go mod download"
   go mod download
 
-  echo "--- $d go test"
-  go test -timeout 10m -coverprofile=coverage.txt -covermode=atomic -race ./...
+  patterns="${FILTER_TARGETS[*]// /\\|}" # replace spaces with \| to have multiple patterns being matched
+  case "$FILTER_ACTION" in
+    exclude)
+      TEST_PACKAGES=$(go list ./... | { grep -v "$patterns" || true; }) # -v to reject
+      if [ -n "$TEST_PACKAGES" ]; then
+        echo "--- $d go test"
+        # shellcheck disable=SC2086
+        go test -timeout 10m -coverprofile=coverage.txt -covermode=atomic -race $TEST_PACKAGES
+      else
+        echo "--- $d go test (skipping)"
+      fi
+      ;;
+    only)
+      TEST_PACKAGES=$(go list ./... | { grep "$patterns" || true; }) # select only what we need
+      if [ -n "$TEST_PACKAGES" ]; then
+        echo "--- $d go test"
+        # shellcheck disable=SC2086
+        go test -timeout 10m -coverprofile=coverage.txt -covermode=atomic -race $TEST_PACKAGES
+      else
+        echo "--- $d go test (skipping)"
+      fi
+      ;;
+    *)
+      TEST_PACKAGES="./..."
+      echo "--- $d go test"
+      # shellcheck disable=SC2086
+      go test -timeout 10m -coverprofile=coverage.txt -covermode=atomic -race $TEST_PACKAGES
+      ;;
+  esac
 
   popd >/dev/null
 done


### PR DESCRIPTION
_Context: this is a quick win to improve Go devs QoL regarding their PRs, that we hacked with @asdine this afternoon._ 

On Go only PRs, the `go test` step is definitely the longest one, often reaching the 7 minutes mark. By running the slowest tests concurrently, we can bring that number down around 4 minutes and eventually lower. 

- Before: 7m15s
- After: 3m50s (and we can probably get this number lower) 

The coverage will not be impacted as per [Codecov's doc](https://docs.codecov.com/docs/merging-reports). 

Regarding the implementation, this is very much a bandage solution as this adds more obscure shell lines. 