### PR TITLE
ci: only upload logs for main builds

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -239,10 +239,12 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 				wait, // wait for all steps to pass
 				triggerUpdaterPipeline)
 		}
-	}
 
-	// Collect all build failures (if any) and upload them on Grafana Cloud.
-	ops.Append(uploadBuildLogs())
+		// Collect all build failures (if any) and upload them on Grafana Cloud.
+		if c.RunType.Is(MainBranch) {
+			ops.Append(uploadBuildLogs())
+		}
+	}
 
 	// Construct pipeline
 	pipeline := &bk.Pipeline{


### PR DESCRIPTION
I think the original plan in https://github.com/sourcegraph/sourcegraph/issues/25768 was just to have `main` builds here - I don't think there's a `branch` label yet, so for now let's just have `main`