### PR TITLE
codeintel: Fix ignored dumps

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
@@ -515,7 +515,7 @@ func (r *queryResolver) uploadIDsWithReferences(
 	}()
 
 	ignoreIDsMap := map[int]struct{}{}
-	for id := range ignoreIDs {
+	for _, id := range ignoreIDs {
 		ignoreIDsMap[id] = struct{}{}
 	}
 


### PR DESCRIPTION
There was a mistake in a `for` loop which prevented `ignoreIDs` from working as intended. Investigation prompted by https://github.com/sourcegraph/sourcegraph/pull/24854#discussion_r737579687