### PR TITLE
remove global NamespaceStore mocks

### DIFF
--- a/cmd/frontend/graphqlbackend/access_token.go
+++ b/cmd/frontend/graphqlbackend/access_token.go
@@ -51,7 +51,7 @@ func unmarshalAccessTokenID(id graphql.ID) (accessTokenID int64, err error) {
 func (r *accessTokenResolver) ID() graphql.ID { return marshalAccessTokenID(r.accessToken.ID) }
 
 func (r *accessTokenResolver) Subject(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, r.db, r.accessToken.SubjectUserID)
+	return UserByIDInt32(ctx, database.NewDB(r.db), r.accessToken.SubjectUserID)
 }
 
 func (r *accessTokenResolver) Scopes() []string { return r.accessToken.Scopes }
@@ -59,7 +59,7 @@ func (r *accessTokenResolver) Scopes() []string { return r.accessToken.Scopes }
 func (r *accessTokenResolver) Note() string { return r.accessToken.Note }
 
 func (r *accessTokenResolver) Creator(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, r.db, r.accessToken.CreatorUserID)
+	return UserByIDInt32(ctx, database.NewDB(r.db), r.accessToken.CreatorUserID)
 }
 
 func (r *accessTokenResolver) CreatedAt() DateTime { return DateTime{Time: r.accessToken.CreatedAt} }

--- a/cmd/frontend/graphqlbackend/event_log.go
+++ b/cmd/frontend/graphqlbackend/event_log.go
@@ -16,7 +16,7 @@ type userEventLogResolver struct {
 
 func (s *userEventLogResolver) User(ctx context.Context) (*UserResolver, error) {
 	if s.event.UserID != nil {
-		user, err := UserByIDInt32(ctx, s.db, *s.event.UserID)
+		user, err := UserByIDInt32(ctx, database.NewDB(s.db), *s.event.UserID)
 		if err != nil && errcode.IsNotFound(err) {
 			// Don't throw an error if a user has been deleted.
 			return nil, nil

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -45,7 +45,7 @@ func unmarshalExternalAccountID(id graphql.ID) (externalAccountID int32, err err
 
 func (r *externalAccountResolver) ID() graphql.ID { return marshalExternalAccountID(r.account.ID) }
 func (r *externalAccountResolver) User(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, r.db, r.account.UserID)
+	return UserByIDInt32(ctx, database.NewDB(r.db), r.account.UserID)
 }
 func (r *externalAccountResolver) ServiceType() string { return r.account.ServiceType }
 func (r *externalAccountResolver) ServiceID() string   { return r.account.ServiceID }

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -95,7 +95,7 @@ func (r *externalServiceResolver) Namespace(ctx context.Context) (*NamespaceReso
 		return nil, nil
 	}
 	userID := MarshalUserID(r.externalService.NamespaceUserID)
-	n, err := NamespaceByID(ctx, r.db, userID)
+	n, err := NamespaceByID(ctx, database.NewDB(r.db), userID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -1160,7 +1160,7 @@ func TestExternalServices_PageInfo(t *testing.T) {
 			}()
 
 			r := &externalServiceConnectionResolver{
-				db:  db,
+				db:  database.NewDB(db),
 				opt: test.opt,
 			}
 			pageInfo, err := r.PageInfo(context.Background())

--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
 type FeatureFlagResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	inner *featureflag.FeatureFlag
 }
 
@@ -33,7 +32,7 @@ func (f *FeatureFlagResolver) ToFeatureFlagRollout() (*FeatureFlagRolloutResolve
 }
 
 type FeatureFlagBooleanResolver struct {
-	db dbutil.DB
+	db database.DB
 	// Invariant: inner.Bool is non-nil
 	inner *featureflag.FeatureFlag
 }
@@ -49,7 +48,7 @@ func (f *FeatureFlagBooleanResolver) Overrides(ctx context.Context) ([]*FeatureF
 }
 
 type FeatureFlagRolloutResolver struct {
-	db dbutil.DB
+	db database.DB
 	// Invariant: inner.Rollout is non-nil
 	inner *featureflag.FeatureFlag
 }
@@ -64,7 +63,7 @@ func (f *FeatureFlagRolloutResolver) Overrides(ctx context.Context) ([]*FeatureF
 	return overridesToResolvers(f.db, overrides), nil
 }
 
-func overridesToResolvers(db dbutil.DB, input []*featureflag.Override) []*FeatureFlagOverrideResolver {
+func overridesToResolvers(db database.DB, input []*featureflag.Override) []*FeatureFlagOverrideResolver {
 	res := make([]*FeatureFlagOverrideResolver, 0, len(input))
 	for _, flag := range input {
 		res = append(res, &FeatureFlagOverrideResolver{db, flag})
@@ -73,7 +72,7 @@ func overridesToResolvers(db dbutil.DB, input []*featureflag.Override) []*Featur
 }
 
 type FeatureFlagOverrideResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	inner *featureflag.Override
 }
 
@@ -171,7 +170,7 @@ func (r *schemaResolver) FeatureFlags(ctx context.Context) ([]*FeatureFlagResolv
 	return flagsToResolvers(r.db, flags), nil
 }
 
-func flagsToResolvers(db dbutil.DB, flags []*featureflag.FeatureFlag) []*FeatureFlagResolver {
+func flagsToResolvers(db database.DB, flags []*featureflag.FeatureFlag) []*FeatureFlagResolver {
 	res := make([]*FeatureFlagResolver, 0, len(flags))
 	for _, flag := range flags {
 		res = append(res, &FeatureFlagResolver{db, flag})

--- a/cmd/frontend/graphqlbackend/namespaces.go
+++ b/cmd/frontend/graphqlbackend/namespaces.go
@@ -8,7 +8,6 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // Namespace is the interface for the GraphQL Namespace interface.
@@ -35,7 +34,7 @@ func (e InvalidNamespaceIDErr) Error() string {
 }
 
 // NamespaceByID looks up a GraphQL value of type Namespace by ID.
-func NamespaceByID(ctx context.Context, db dbutil.DB, id graphql.ID) (Namespace, error) {
+func NamespaceByID(ctx context.Context, db database.DB, id graphql.ID) (Namespace, error) {
 	switch relay.UnmarshalKind(id) {
 	case "User":
 		return UserByID(ctx, db, id)
@@ -59,7 +58,7 @@ func UnmarshalNamespaceID(id graphql.ID, userID *int32, orgID *int32) (err error
 }
 
 func (r *schemaResolver) NamespaceByName(ctx context.Context, args *struct{ Name string }) (*NamespaceResolver, error) {
-	namespace, err := database.Namespaces(r.db).GetByName(ctx, args.Name)
+	namespace, err := r.db.Namespaces().GetByName(ctx, args.Name)
 	if err == database.ErrNamespaceNotFound {
 		return nil, nil
 	}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -34,7 +34,7 @@ func (r *schemaResolver) Org(ctx context.Context, args *struct {
 	return OrgByID(ctx, r.db, args.ID)
 }
 
-func OrgByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*OrgResolver, error) {
+func OrgByID(ctx context.Context, db database.DB, id graphql.ID) (*OrgResolver, error) {
 	orgID, err := UnmarshalOrgID(id)
 	if err != nil {
 		return nil, err
@@ -42,8 +42,8 @@ func OrgByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*OrgResolver, er
 	return OrgByIDInt32(ctx, db, orgID)
 }
 
-func OrgByIDInt32(ctx context.Context, db dbutil.DB, orgID int32) (*OrgResolver, error) {
-	org, err := database.Orgs(db).GetByID(ctx, orgID)
+func OrgByIDInt32(ctx context.Context, db database.DB, orgID int32) (*OrgResolver, error) {
+	org, err := db.Orgs().GetByID(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -44,15 +44,15 @@ func unmarshalOrgInvitationID(id graphql.ID) (orgInvitationID int64, err error) 
 }
 
 func (r *organizationInvitationResolver) Organization(ctx context.Context) (*OrgResolver, error) {
-	return OrgByIDInt32(ctx, r.db, r.v.OrgID)
+	return OrgByIDInt32(ctx, database.NewDB(r.db), r.v.OrgID)
 }
 
 func (r *organizationInvitationResolver) Sender(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, r.db, r.v.SenderUserID)
+	return UserByIDInt32(ctx, database.NewDB(r.db), r.v.SenderUserID)
 }
 
 func (r *organizationInvitationResolver) Recipient(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, r.db, r.v.RecipientUserID)
+	return UserByIDInt32(ctx, database.NewDB(r.db), r.v.RecipientUserID)
 }
 func (r *organizationInvitationResolver) CreatedAt() DateTime { return DateTime{Time: r.v.CreatedAt} }
 func (r *organizationInvitationResolver) NotifiedAt() *DateTime {

--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -45,11 +45,11 @@ type organizationMembershipResolver struct {
 }
 
 func (r *organizationMembershipResolver) Organization(ctx context.Context) (*OrgResolver, error) {
-	return OrgByIDInt32(ctx, r.db, r.membership.OrgID)
+	return OrgByIDInt32(ctx, database.NewDB(r.db), r.membership.OrgID)
 }
 
 func (r *organizationMembershipResolver) User(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, r.db, r.membership.UserID)
+	return UserByIDInt32(ctx, database.NewDB(r.db), r.membership.UserID)
 }
 
 func (r *organizationMembershipResolver) CreatedAt() DateTime {

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -91,14 +91,14 @@ func (r savedSearchResolver) Query() string { return r.s.Query }
 
 func (r savedSearchResolver) Namespace(ctx context.Context) (*NamespaceResolver, error) {
 	if r.s.OrgID != nil {
-		n, err := NamespaceByID(ctx, r.db, MarshalOrgID(*r.s.OrgID))
+		n, err := NamespaceByID(ctx, database.NewDB(r.db), MarshalOrgID(*r.s.OrgID))
 		if err != nil {
 			return nil, err
 		}
 		return &NamespaceResolver{n}, nil
 	}
 	if r.s.UserID != nil {
-		n, err := NamespaceByID(ctx, r.db, MarshalUserID(*r.s.UserID))
+		n, err := NamespaceByID(ctx, database.NewDB(r.db), MarshalUserID(*r.s.UserID))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -36,7 +36,7 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 		return mockSettingsCascadeSubjects()
 	}
 
-	subjects := []*settingsSubject{{defaultSettings: &defaultSettingsResolver{db: r.db, gqlID: singletonDefaultSettingsGQLID}}, {site: &siteResolver{db: r.db, gqlID: singletonSiteGQLID}}}
+	subjects := []*settingsSubject{{defaultSettings: &defaultSettingsResolver{db: r.db, gqlID: singletonDefaultSettingsGQLID}}, {site: &siteResolver{db: database.NewDB(r.db), gqlID: singletonSiteGQLID}}}
 
 	if r.unauthenticatedActor {
 		return subjects, nil

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -31,7 +31,7 @@ func marshalSurveyResponseID(id int32) graphql.ID { return relay.MarshalID("Surv
 
 func (s *surveyResponseResolver) User(ctx context.Context) (*UserResolver, error) {
 	if s.surveyResponse.UserID != nil {
-		user, err := UserByIDInt32(ctx, s.db, *s.surveyResponse.UserID)
+		user, err := UserByIDInt32(ctx, database.NewDB(s.db), *s.surveyResponse.UserID)
 		if err != nil && errcode.IsNotFound(err) {
 			// This can happen if the user has been deleted, see issue #4888 and #6454
 			return nil, nil

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -71,7 +71,7 @@ func NewUserResolver(db dbutil.DB, user *types.User) *UserResolver {
 
 // UserByID looks up and returns the user with the given GraphQL ID. If no such user exists, it returns a
 // non-nil error.
-func UserByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*UserResolver, error) {
+func UserByID(ctx context.Context, db database.DB, id graphql.ID) (*UserResolver, error) {
 	userID, err := UnmarshalUserID(id)
 	if err != nil {
 		return nil, err
@@ -81,8 +81,8 @@ func UserByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*UserResolver, 
 
 // UserByIDInt32 looks up and returns the user with the given database ID. If no such user exists,
 // it returns a non-nil error.
-func UserByIDInt32(ctx context.Context, db dbutil.DB, id int32) (*UserResolver, error) {
-	user, err := database.Users(db).GetByID(ctx, id)
+func UserByIDInt32(ctx context.Context, db database.DB, id int32) (*UserResolver, error) {
+	user, err := db.Users().GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/state"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
@@ -59,7 +60,7 @@ func (r *batchChangeResolver) Description() *string {
 }
 
 func (r *batchChangeResolver) InitialApplier(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.batchChange.InitialApplierID)
+	user, err := graphqlbackend.UserByIDInt32(ctx, database.NewDB(r.store.DB()), r.batchChange.InitialApplierID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
 	}
@@ -67,7 +68,7 @@ func (r *batchChangeResolver) InitialApplier(ctx context.Context) (*graphqlbacke
 }
 
 func (r *batchChangeResolver) LastApplier(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.batchChange.LastApplierID)
+	user, err := graphqlbackend.UserByIDInt32(ctx, database.NewDB(r.store.DB()), r.batchChange.LastApplierID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
 	}
@@ -85,7 +86,7 @@ func (r *batchChangeResolver) SpecCreator(ctx context.Context) (*graphqlbackend.
 	if err != nil {
 		return nil, err
 	}
-	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DB(), spec.UserID)
+	user, err := graphqlbackend.UserByIDInt32(ctx, database.NewDB(r.store.DB()), spec.UserID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
 	}
@@ -113,13 +114,13 @@ func (r *batchChangeResolver) computeNamespace(ctx context.Context) (graphqlback
 		if r.batchChange.NamespaceUserID != 0 {
 			r.namespace.Namespace, r.namespaceErr = graphqlbackend.UserByIDInt32(
 				ctx,
-				r.store.DB(),
+				database.NewDB(r.store.DB()),
 				r.batchChange.NamespaceUserID,
 			)
 		} else {
 			r.namespace.Namespace, r.namespaceErr = graphqlbackend.OrgByIDInt32(
 				ctx,
-				r.store.DB(),
+				database.NewDB(r.store.DB()),
 				r.batchChange.NamespaceOrgID,
 			)
 		}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -159,7 +159,7 @@ func (r *batchSpecResolver) Description() graphqlbackend.BatchChangeDescriptionR
 }
 
 func (r *batchSpecResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.batchSpec.UserID)
+	user, err := graphqlbackend.UserByIDInt32(ctx, database.NewDB(r.store.DB()), r.batchSpec.UserID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
 	}
@@ -525,9 +525,9 @@ func (r *batchSpecResolver) computeNamespace(ctx context.Context) (*graphqlbacke
 		)
 
 		if r.batchSpec.NamespaceUserID != 0 {
-			n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.batchSpec.NamespaceUserID)
+			n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, database.NewDB(r.store.DB()), r.batchSpec.NamespaceUserID)
 		} else {
-			n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, r.store.DB(), r.batchSpec.NamespaceOrgID)
+			n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, database.NewDB(r.store.DB()), r.batchSpec.NamespaceOrgID)
 		}
 
 		if errcode.IsNotFound(err) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -89,7 +90,7 @@ func (r *bulkOperationResolver) Errors(ctx context.Context) ([]graphqlbackend.Ch
 }
 
 func (r *bulkOperationResolver) Initiator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	return graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.bulkOperation.UserID)
+	return graphqlbackend.UserByIDInt32(ctx, database.NewDB(r.store.DB()), r.bulkOperation.UserID)
 }
 
 func (r *bulkOperationResolver) ChangesetCount() int32 {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	cm "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/email"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -535,7 +536,7 @@ func (m *monitor) ID() graphql.ID {
 }
 
 func (m *monitor) CreatedBy(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	return graphqlbackend.UserByIDInt32(ctx, m.store.Handle().DB(), m.Monitor.CreatedBy)
+	return graphqlbackend.UserByIDInt32(ctx, database.NewDB(m.store.Handle().DB()), m.Monitor.CreatedBy)
 }
 
 func (m *monitor) CreatedAt() graphqlbackend.DateTime {
@@ -552,9 +553,9 @@ func (m *monitor) Enabled() bool {
 
 func (m *monitor) Owner(ctx context.Context) (n graphqlbackend.NamespaceResolver, err error) {
 	if m.NamespaceOrgID == nil {
-		n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, m.store.Handle().DB(), *m.NamespaceUserID)
+		n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, database.NewDB(m.store.Handle().DB()), *m.NamespaceUserID)
 	} else {
-		n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, m.store.Handle().DB(), *m.NamespaceOrgID)
+		n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, database.NewDB(m.store.Handle().DB()), *m.NamespaceOrgID)
 	}
 	return n, err
 }
@@ -780,9 +781,9 @@ func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.List
 	for _, r := range ms {
 		n := graphqlbackend.NamespaceResolver{}
 		if r.NamespaceOrgID == nil {
-			n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, m.store.Handle().DB(), *r.NamespaceUserID)
+			n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, database.NewDB(m.store.Handle().DB()), *r.NamespaceUserID)
 		} else {
-			n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, m.store.Handle().DB(), *r.NamespaceOrgID)
+			n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, database.NewDB(m.store.Handle().DB()), *r.NamespaceOrgID)
 		}
 		if err != nil {
 			return nil, err

--- a/enterprise/cmd/frontend/internal/dotcom/billing/customers.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/customers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stripe/stripe-go/customer"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
@@ -126,7 +127,7 @@ func createCustomerID(ctx context.Context, db dbutil.DB, userID int32) (string, 
 		return mockCreateCustomerID(userID)
 	}
 
-	user, err := graphqlbackend.UserByIDInt32(ctx, db, userID)
+	user, err := graphqlbackend.UserByIDInt32(ctx, database.NewDB(db), userID)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/invoices_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/invoices_graphql.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/billing"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 type productSubscriptionPreviewInvoice struct {
@@ -61,7 +62,7 @@ func (r ProductSubscriptionLicensingResolver) PreviewProductSubscriptionInvoice(
 	var accountUserID *int32
 	if args.Account != nil {
 		// There is a customer ID given.
-		accountUser, err := graphqlbackend.UserByID(ctx, r.DB, *args.Account)
+		accountUser, err := graphqlbackend.UserByID(ctx, database.NewDB(r.DB), *args.Account)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/billing"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/stripeutil"
-	db_ "github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -86,7 +86,7 @@ func (r *productSubscription) Name() string {
 }
 
 func (r *productSubscription) Account(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	return graphqlbackend.UserByIDInt32(ctx, r.db, r.v.UserID)
+	return graphqlbackend.UserByIDInt32(ctx, database.NewDB(r.db), r.v.UserID)
 }
 
 func (r *productSubscription) Events(ctx context.Context) ([]graphqlbackend.ProductSubscriptionEvent, error) {
@@ -118,7 +118,7 @@ func (r *productSubscription) ActiveLicense(ctx context.Context) (graphqlbackend
 	// Return newest license.
 	licenses, err := dbLicenses{db: r.db}.List(ctx, dbLicensesListOptions{
 		ProductSubscriptionID: r.v.ID,
-		LimitOffset:           &db_.LimitOffset{Limit: 1},
+		LimitOffset:           &database.LimitOffset{Limit: 1},
 	})
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (r ProductSubscriptionLicensingResolver) CreateProductSubscription(ctx cont
 		return nil, err
 	}
 
-	user, err := graphqlbackend.UserByID(ctx, r.DB, args.AccountID)
+	user, err := graphqlbackend.UserByID(ctx, database.NewDB(r.DB), args.AccountID)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (r ProductSubscriptionLicensingResolver) SetProductSubscriptionBilling(ctx 
 }
 
 func (r ProductSubscriptionLicensingResolver) CreatePaidProductSubscription(ctx context.Context, args *graphqlbackend.CreatePaidProductSubscriptionArgs) (*graphqlbackend.CreatePaidProductSubscriptionResult, error) {
-	user, err := graphqlbackend.UserByID(ctx, r.DB, args.AccountID)
+	user, err := graphqlbackend.UserByID(ctx, database.NewDB(r.DB), args.AccountID)
 	if err != nil {
 		return nil, err
 	}
@@ -463,7 +463,7 @@ func (r ProductSubscriptionLicensingResolver) ProductSubscriptions(ctx context.C
 	var accountUser *graphqlbackend.UserResolver
 	if args.Account != nil {
 		var err error
-		accountUser, err = graphqlbackend.UserByID(ctx, r.DB, *args.Account)
+		accountUser, err = graphqlbackend.UserByID(ctx, database.NewDB(r.DB), *args.Account)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -38,7 +39,7 @@ func (r *extensionDBResolver) ExtensionIDWithoutRegistry() string {
 }
 
 func (r *extensionDBResolver) Publisher(ctx context.Context) (graphqlbackend.RegistryPublisher, error) {
-	return getRegistryPublisher(ctx, r.db, r.v.Publisher)
+	return getRegistryPublisher(ctx, database.NewDB(r.db), r.v.Publisher)
 }
 
 func (r *extensionDBResolver) Name() string { return r.v.Name }

--- a/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -53,7 +54,7 @@ func (r *registryPublisherConnection) Nodes(ctx context.Context) ([]graphqlbacke
 
 	var l []graphqlbackend.RegistryPublisher
 	for _, publisher := range publishers {
-		p, err := getRegistryPublisher(ctx, r.db, *publisher)
+		p, err := getRegistryPublisher(ctx, database.NewDB(r.db), *publisher)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -78,7 +78,7 @@ func (r *registryPublisher) RegistryExtensionConnectionURL() (*string, error) {
 
 var errRegistryUnknownPublisher = errors.New("unknown registry extension publisher")
 
-func getRegistryPublisher(ctx context.Context, db dbutil.DB, publisher dbPublisher) (*registryPublisher, error) {
+func getRegistryPublisher(ctx context.Context, db database.DB, publisher dbPublisher) (*registryPublisher, error) {
 	switch {
 	case publisher.UserID != 0:
 		user, err := graphqlbackend.UserByIDInt32(ctx, db, publisher.UserID)

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -12,7 +12,6 @@ type MockStores struct {
 	AccessTokens MockAccessTokens
 
 	Repos           MockRepos
-	Namespaces      MockNamespaces
 	Orgs            MockOrgs
 	OrgMembers      MockOrgMembers
 	SavedSearches   MockSavedSearches

--- a/internal/database/namespaces.go
+++ b/internal/database/namespaces.go
@@ -71,10 +71,6 @@ func (s *namespaceStore) GetByID(
 	ctx context.Context,
 	orgID, userID int32,
 ) (*Namespace, error) {
-	if Mocks.Namespaces.GetByID != nil {
-		return Mocks.Namespaces.GetByID(ctx, orgID, userID)
-	}
-
 	preds := []*sqlf.Query{}
 	if orgID != 0 && userID != 0 {
 		return nil, ErrNamespaceMultipleIDs
@@ -102,10 +98,6 @@ func (s *namespaceStore) GetByName(
 	ctx context.Context,
 	name string,
 ) (*Namespace, error) {
-	if Mocks.Namespaces.GetByName != nil {
-		return Mocks.Namespaces.GetByName(ctx, name)
-	}
-
 	var n Namespace
 	if err := s.getNamespace(ctx, &n, []*sqlf.Query{
 		sqlf.Sprintf("name = %s", name),

--- a/internal/database/namespaces_mock.go
+++ b/internal/database/namespaces_mock.go
@@ -1,8 +1,0 @@
-package database
-
-import "context"
-
-type MockNamespaces struct {
-	GetByID   func(ctx context.Context, orgID, userID int32) (*Namespace, error)
-	GetByName func(ctx context.Context, name string) (*Namespace, error)
-}


### PR DESCRIPTION
This removes all references to MockNamespaceStore and replaces them with
injected mocks.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
