### PR TITLE
convert a bunch of dbutil.DB to database.DB

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 var builtinExtensions = map[string]bool{
@@ -51,7 +51,7 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/vhdl":       true,
 }
 
-func defaultSettings(db dbutil.DB) map[string]interface{} {
+func defaultSettings(db database.DB) map[string]interface{} {
 	extensionIDs := []string{}
 	for id := range builtinExtensions {
 		extensionIDs = append(extensionIDs, id)
@@ -71,7 +71,7 @@ func defaultSettings(db dbutil.DB) map[string]interface{} {
 const singletonDefaultSettingsGQLID = "DefaultSettings"
 
 type defaultSettingsResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	gqlID string
 }
 

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 var ErrExtensionsDisabled = errors.New("extensions are disabled in site configuration (contact the site admin to enable extensions)")
@@ -29,7 +29,7 @@ func (r *schemaResolver) ExtensionRegistry(ctx context.Context) (ExtensionRegist
 
 // ExtensionRegistry is the implementation of the GraphQL types ExtensionRegistry and
 // ExtensionRegistryMutation.
-var ExtensionRegistry func(db dbutil.DB) ExtensionRegistryResolver
+var ExtensionRegistry func(db database.DB) ExtensionRegistryResolver
 
 // ExtensionRegistryResolver is the interface for the GraphQL types ExtensionRegistry and
 // ExtensionRegistryMutation.
@@ -103,7 +103,7 @@ var NodeToRegistryExtension func(interface{}) (RegistryExtension, bool)
 
 // RegistryExtensionByID is called to look up values of GraphQL type RegistryExtension. It is
 // assigned at init time.
-var RegistryExtensionByID func(context.Context, dbutil.DB, graphql.ID) (RegistryExtension, error)
+var RegistryExtensionByID func(context.Context, database.DB, graphql.ID) (RegistryExtension, error)
 
 // RegistryExtension is the interface for the GraphQL type RegistryExtension.
 type RegistryExtension interface {

--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -14,7 +14,7 @@ type FileMatchResolver struct {
 	result.FileMatch
 
 	RepoResolver *RepositoryResolver
-	db           dbutil.DB
+	db           database.DB
 }
 
 // Equal provides custom comparison which is used by go-cmp

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
@@ -34,7 +33,7 @@ func (r *schemaResolver) gitCommitByID(ctx context.Context, id graphql.ID) (*Git
 }
 
 type GitCommitResolver struct {
-	db           dbutil.DB
+	db           database.DB
 	repoResolver *RepositoryResolver
 
 	// inputRev is the Git revspec that the user originally requested that resolved to this Git commit. It is used
@@ -58,7 +57,7 @@ type GitCommitResolver struct {
 
 // When set to nil, commit will be loaded lazily as needed by the resolver. Pass in a commit when you have batch loaded
 // a bunch of them and already have them at hand.
-func toGitCommitResolver(repo *RepositoryResolver, db dbutil.DB, id api.CommitID, commit *gitapi.Commit) *GitCommitResolver {
+func toGitCommitResolver(repo *RepositoryResolver, db database.DB, id api.CommitID, commit *gitapi.Commit) *GitCommitResolver {
 	return &GitCommitResolver{
 		db:              db,
 		repoResolver:    repo,

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestGitCommitResolver(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	commit := &gitapi.Commit{
 		ID:      "c1",

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -5,13 +5,13 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type gitCommitConnectionResolver struct {
-	db            dbutil.DB
+	db            database.DB
 	revisionRange string
 
 	first  *int32

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -37,7 +36,7 @@ var codeIntelRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 // GitTreeEntryResolver resolves an entry in a Git tree in a repository. The entry can be any Git
 // object type that is valid in a tree.
 type GitTreeEntryResolver struct {
-	db     dbutil.DB
+	db     database.DB
 	commit *GitCommitResolver
 
 	contentOnce sync.Once
@@ -52,7 +51,7 @@ type GitTreeEntryResolver struct {
 	isSingleChild *bool // whether this is the single entry in its parent. Only set by the (&GitTreeEntryResolver) entries.
 }
 
-func NewGitTreeEntryResolver(commit *GitCommitResolver, db dbutil.DB, stat fs.FileInfo) *GitTreeEntryResolver {
+func NewGitTreeEntryResolver(commit *GitCommitResolver, db database.DB, stat fs.FileInfo) *GitTreeEntryResolver {
 	return &GitTreeEntryResolver{db: db, commit: commit, stat: stat}
 }
 
@@ -188,7 +187,7 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 	return nil
 }
 
-func cloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL string) (string, error) {
+func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (string, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "cloneURLToRepoName")
 	defer span.Finish()
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -74,7 +74,7 @@ func TestRepository(t *testing.T) {
 }
 
 func TestResolverTo(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 	// This test exists purely to remove some non determinism in our tests
 	// run. The To* resolvers are stored in a map in our graphql
 	// implementation => the order we call them is non deterministic =>
@@ -84,7 +84,7 @@ func TestResolverTo(t *testing.T) {
 		&GitTreeEntryResolver{db: db},
 		&NamespaceResolver{},
 		&NodeResolver{},
-		&RepositoryResolver{db: database.NewDB(db)},
+		&RepositoryResolver{db: db},
 		&CommitSearchResultResolver{},
 		&gitRevSpec{},
 		&repositorySuggestionResolver{},

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -3,12 +3,12 @@ package graphqlbackend
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 type hunkResolver struct {
-	db   dbutil.DB
+	db   database.DB
 	repo *RepositoryResolver
 	hunk *git.Hunk
 }

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -51,11 +50,11 @@ func OrgByIDInt32(ctx context.Context, db database.DB, orgID int32) (*OrgResolve
 }
 
 type OrgResolver struct {
-	db  dbutil.DB
+	db  database.DB
 	org *types.Org
 }
 
-func NewOrg(db dbutil.DB, org *types.Org) *OrgResolver { return &OrgResolver{db: db, org: org} }
+func NewOrg(db database.DB, org *types.Org) *OrgResolver { return &OrgResolver{db: db, org: org} }
 
 func (o *OrgResolver) ID() graphql.ID { return MarshalOrgID(o.org.ID) }
 

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func (r *schemaResolver) Organizations(args *struct {
@@ -22,7 +21,7 @@ func (r *schemaResolver) Organizations(args *struct {
 }
 
 type orgConnectionResolver struct {
-	db  dbutil.DB
+	db  database.DB
 	opt database.OrgsListOptions
 }
 

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -6,13 +6,12 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type PersonResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	name  string
 	email string
 
@@ -25,7 +24,7 @@ type PersonResolver struct {
 	err  error
 }
 
-func NewPersonResolver(db dbutil.DB, name, email string, includeUserInfo bool) *PersonResolver {
+func NewPersonResolver(db database.DB, name, email string, includeUserInfo bool) *PersonResolver {
 	return &PersonResolver{
 		db:              db,
 		name:            name,

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sourcegraph/go-diff/diff"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 type PreviewRepositoryComparisonResolver interface {
@@ -17,7 +17,7 @@ type PreviewRepositoryComparisonResolver interface {
 }
 
 // NewPreviewRepositoryComparisonResolver is a convenience function to get a preview diff from a repo, given a base rev and the git patch.
-func NewPreviewRepositoryComparisonResolver(ctx context.Context, db dbutil.DB, repo *RepositoryResolver, baseRev, patch string) (*previewRepositoryComparisonResolver, error) {
+func NewPreviewRepositoryComparisonResolver(ctx context.Context, db database.DB, repo *RepositoryResolver, baseRev, patch string) (*previewRepositoryComparisonResolver, error) {
 	args := &RepositoryCommitArgs{Rev: baseRev}
 	commit, err := repo.Commit(ctx, args)
 	if err != nil {
@@ -32,7 +32,7 @@ func NewPreviewRepositoryComparisonResolver(ctx context.Context, db dbutil.DB, r
 }
 
 type previewRepositoryComparisonResolver struct {
-	db     dbutil.DB
+	db     database.DB
 	repo   *RepositoryResolver
 	commit *GitCommitResolver
 	patch  string
@@ -113,7 +113,7 @@ func fileDiffConnectionCompute(patch string) func(ctx context.Context, args *Fil
 	}
 }
 
-func previewNewFile(db dbutil.DB, r *FileDiffResolver) FileResolver {
+func previewNewFile(db database.DB, r *FileDiffResolver) FileResolver {
 	fileStat := CreateFileInfo(r.FileDiff.NewName, false)
 	return NewVirtualFileResolver(fileStat, fileDiffVirtualFileContent(r))
 }

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestPreviewRepositoryComparisonResolver(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	const testDiffFiles = 3
 	const testOldFile = `First

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -60,7 +60,7 @@ type FileDiff interface {
 	InternalID() string
 }
 
-func NewRepositoryComparison(ctx context.Context, db dbutil.DB, r *RepositoryResolver, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
+func NewRepositoryComparison(ctx context.Context, db database.DB, r *RepositoryResolver, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
 	var baseRevspec, headRevspec string
 	if args.Base == nil {
 		baseRevspec = "HEAD"
@@ -127,7 +127,7 @@ func (r *RepositoryResolver) Comparison(ctx context.Context, args *RepositoryCom
 }
 
 type RepositoryComparisonResolver struct {
-	db                       dbutil.DB
+	db                       database.DB
 	baseRevspec, headRevspec string
 	base, head               *GitCommitResolver
 	repo                     *RepositoryResolver
@@ -181,7 +181,7 @@ func (r *RepositoryComparisonResolver) FileDiffs(ctx context.Context, args *File
 
 // repositoryComparisonNewFile is the default NewFileFunc used by
 // RepositoryComparisonResolver to produce the new file in a FileDiffResolver.
-func repositoryComparisonNewFile(db dbutil.DB, r *FileDiffResolver) FileResolver {
+func repositoryComparisonNewFile(db database.DB, r *FileDiffResolver) FileResolver {
 	return &GitTreeEntryResolver{
 		db:     db,
 		commit: r.Head,
@@ -272,10 +272,10 @@ type ComputeDiffFunc func(ctx context.Context, args *FileDiffsConnectionArgs) ([
 
 // NewFileFunc is a function that returns the "new" file in a FileDiff as a
 // FileResolver.
-type NewFileFunc func(db dbutil.DB, r *FileDiffResolver) FileResolver
+type NewFileFunc func(db database.DB, r *FileDiffResolver) FileResolver
 
 func NewFileDiffConnectionResolver(
-	db dbutil.DB,
+	db database.DB,
 	base, head *GitCommitResolver,
 	args *FileDiffsConnectionArgs,
 	compute ComputeDiffFunc,
@@ -293,7 +293,7 @@ func NewFileDiffConnectionResolver(
 }
 
 type fileDiffConnectionResolver struct {
-	db      dbutil.DB
+	db      database.DB
 	base    *GitCommitResolver
 	head    *GitCommitResolver
 	first   *int32
@@ -383,7 +383,7 @@ type FileDiffResolver struct {
 	Base     *GitCommitResolver
 	Head     *GitCommitResolver
 
-	db      dbutil.DB
+	db      database.DB
 	newFile NewFileFunc
 }
 

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestRepositoryComparison(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	wantBaseRevision := "24f7ca7c1190835519e261d7eefa09df55ceea4f"
 	wantMergeBaseRevision := "a7985dde7f92ad3490ec513be78fa2b365c7534c"

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -1,9 +1,9 @@
 package graphqlbackend
 
-import "github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+import "github.com/sourcegraph/sourcegraph/internal/database"
 
 type repositoryContributorResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	name  string
 	email string
 	count int32

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -28,7 +28,7 @@ func (r *RepositoryResolver) Contributors(args *struct {
 }
 
 type repositoryContributorConnectionResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	args  repositoryContributorsArgs
 	first *int32
 

--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -9,13 +9,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type settingsResolver struct {
-	db       dbutil.DB
+	db       database.DB
 	subject  *settingsSubject
 	settings *api.Settings
 	user     *types.User
@@ -60,7 +59,7 @@ var globalSettingsAllowEdits, _ = strconv.ParseBool(env.Get("GLOBAL_SETTINGS_ALL
 
 // like database.Settings.CreateIfUpToDate, except it handles notifying the
 // query-runner if any saved queries have changed.
-func settingsCreateIfUpToDate(ctx context.Context, db dbutil.DB, subject *settingsSubject, lastID *int32, authorUserID int32, contents string) (latestSetting *api.Settings, err error) {
+func settingsCreateIfUpToDate(ctx context.Context, db database.DB, subject *settingsSubject, lastID *int32, authorUserID int32, contents string) (latestSetting *api.Settings, err error) {
 	if os.Getenv("GLOBAL_SETTINGS_FILE") != "" && subject.site != nil && !globalSettingsAllowEdits {
 		return nil, errors.New("Updating global settings not allowed when using GLOBAL_SETTINGS_FILE")
 	}

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -23,7 +22,7 @@ import (
 // - Organization settings
 // - Current user settings
 type settingsCascade struct {
-	db dbutil.DB
+	db database.DB
 	// At most 1 of these fields is set.
 	unauthenticatedActor bool
 	subject              *settingsSubject

--- a/cmd/frontend/graphqlbackend/settings_cascade_test.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -180,9 +180,8 @@ func TestMergeSettings(t *testing.T) {
 }
 
 func TestSubjects(t *testing.T) {
-	db := new(dbtesting.MockDB)
 	t.Run("Default settings are included", func(t *testing.T) {
-		cascade := &settingsCascade{db: db, unauthenticatedActor: true}
+		cascade := &settingsCascade{db: dbmock.NewMockDB(), unauthenticatedActor: true}
 		subjects, err := cascade.Subjects(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // Deprecated: The GraphQL type Configuration is deprecated.
@@ -38,7 +37,7 @@ type settingsMutationGroupInput struct {
 }
 
 type settingsMutation struct {
-	db      dbutil.DB
+	db      database.DB
 	input   *settingsMutationGroupInput
 	subject *settingsSubject
 }

--- a/cmd/frontend/graphqlbackend/signature.go
+++ b/cmd/frontend/graphqlbackend/signature.go
@@ -3,7 +3,7 @@ package graphqlbackend
 import (
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
@@ -20,7 +20,7 @@ func (r signatureResolver) Date() string {
 	return r.date.Format(time.RFC3339)
 }
 
-func toSignatureResolver(db dbutil.DB, sig *gitapi.Signature, includeUserInfo bool) *signatureResolver {
+func toSignatureResolver(db database.DB, sig *gitapi.Signature, includeUserInfo bool) *signatureResolver {
 	if sig == nil {
 		return nil
 	}

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -51,7 +51,7 @@ func (r *schemaResolver) Site() *siteResolver {
 }
 
 type siteResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	gqlID string // == singletonSiteGQLID, not the site ID
 }
 

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 )
@@ -50,7 +50,7 @@ func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*sy
 	}, nil
 }
 
-func symbolResultsToResolvers(db dbutil.DB, commit *GitCommitResolver, symbols []*result.SymbolMatch) []symbolResolver {
+func symbolResultsToResolvers(db database.DB, commit *GitCommitResolver, symbols []*result.SymbolMatch) []symbolResolver {
 	symbolResolvers := make([]symbolResolver, 0, len(symbols))
 	for _, symbol := range symbols {
 		symbolResolvers = append(symbolResolvers, toSymbolResolver(db, commit, symbol))
@@ -58,7 +58,7 @@ func symbolResultsToResolvers(db dbutil.DB, commit *GitCommitResolver, symbols [
 	return symbolResolvers
 }
 
-func toSymbolResolver(db dbutil.DB, commit *GitCommitResolver, sr *result.SymbolMatch) symbolResolver {
+func toSymbolResolver(db database.DB, commit *GitCommitResolver, sr *result.SymbolMatch) symbolResolver {
 	return symbolResolver{
 		db:          db,
 		commit:      commit,
@@ -91,7 +91,7 @@ func (r *symbolConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 }
 
 type symbolResolver struct {
-	db     dbutil.DB
+	db     database.DB
 	commit *GitCommitResolver
 	*result.SymbolMatch
 }

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
@@ -40,7 +39,7 @@ type UserConnectionResolver interface {
 var _ UserConnectionResolver = &userConnectionResolver{}
 
 type userConnectionResolver struct {
-	db           dbutil.DB
+	db           database.DB
 	opt          database.UsersListOptions
 	activePeriod *string
 
@@ -142,7 +141,7 @@ func (r *userConnectionResolver) useCache() bool {
 // staticUserConnectionResolver implements the GraphQL type UserConnection based on an underlying
 // list of users that is computed statically.
 type staticUserConnectionResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	users []*types.User
 }
 

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -55,7 +54,7 @@ func (r *schemaResolver) CreateUser(ctx context.Context, args *struct {
 //
 // 🚨 SECURITY: Only site admins should be able to instantiate this value.
 type createUserResult struct {
-	db   dbutil.DB
+	db   database.DB
 	user *types.User
 }
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -125,7 +125,7 @@ func InitDB() (*sql.DB, error) {
 }
 
 // Main is the main entrypoint for the frontend server program.
-func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) error {
+func Main(enterpriseSetupHook func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) error {
 	ctx := context.Background()
 
 	log.SetFlags(0)
@@ -199,7 +199,7 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 	}
 
 	// Run enterprise setup hook
-	enterprise := enterpriseSetupHook(db, outOfBandMigrationRunner)
+	enterprise := enterpriseSetupHook(database.NewDB(db), outOfBandMigrationRunner)
 
 	ui.InitRouter(db, enterprise.CodeIntelResolver)
 

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
@@ -16,7 +16,7 @@ func main() {
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})
 
-	shared.Main(func(db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
+	shared.Main(func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
 		return enterprise.DefaultServices()
 	})
 }

--- a/cmd/frontend/registry/api/extension_connection_graphql.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // makePrioritizeExtensionIDsSet returns a set whose values are the elements of
@@ -36,7 +36,7 @@ func (r *extensionRegistryResolver) Extensions(ctx context.Context, args *graphq
 type registryExtensionConnectionResolver struct {
 	args graphqlbackend.RegistryExtensionConnectionArgs
 
-	db                           dbutil.DB
+	db                           database.DB
 	listRemoteRegistryExtensions func(_ context.Context, query string) ([]*registry.Extension, error)
 
 	// cache results because they are used by multiple fields
@@ -48,12 +48,12 @@ type registryExtensionConnectionResolver struct {
 var (
 	// ListLocalRegistryExtensions lists and returns local registry extensions according to the args. If
 	// there is no local extension registry, it is not implemented.
-	ListLocalRegistryExtensions func(context.Context, dbutil.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error)
+	ListLocalRegistryExtensions func(context.Context, database.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error)
 
 	// CountLocalRegistryExtensions returns the count of local registry extensions according to the
 	// args. Pagination-related args are ignored. If there is no local extension registry, it is not
 	// implemented.
-	CountLocalRegistryExtensions func(context.Context, dbutil.DB, graphqlbackend.RegistryExtensionConnectionArgs) (int, error)
+	CountLocalRegistryExtensions func(context.Context, database.DB, graphqlbackend.RegistryExtensionConnectionArgs) (int, error)
 )
 
 func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]graphqlbackend.RegistryExtension, error) {

--- a/cmd/frontend/registry/api/extension_connection_graphql_test.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func TestRegistryExtensionConnectionResolver(t *testing.T) {
@@ -21,7 +21,7 @@ func TestRegistryExtensionConnectionResolver(t *testing.T) {
 		return ids
 	}
 
-	ListLocalRegistryExtensions = func(context.Context, dbutil.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
+	ListLocalRegistryExtensions = func(context.Context, database.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
 		return nil, nil
 	}
 	defer func() {

--- a/cmd/frontend/registry/api/extension_graphql.go
+++ b/cmd/frontend/registry/api/extension_graphql.go
@@ -8,7 +8,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func init() {
@@ -45,9 +45,9 @@ func UnmarshalRegistryExtensionID(id graphql.ID) (registryExtensionID RegistryEx
 // RegistryExtensionByIDInt32 looks up and returns the registry extension in the database with the
 // given ID. If no such extension exists, an error is returned. The func is nil when there is no
 // local registry.
-var RegistryExtensionByIDInt32 func(context.Context, dbutil.DB, int32) (graphqlbackend.RegistryExtension, error)
+var RegistryExtensionByIDInt32 func(context.Context, database.DB, int32) (graphqlbackend.RegistryExtension, error)
 
-func registryExtensionByID(ctx context.Context, db dbutil.DB, id graphql.ID) (graphqlbackend.RegistryExtension, error) {
+func registryExtensionByID(ctx context.Context, db database.DB, id graphql.ID) (graphqlbackend.RegistryExtension, error) {
 	registryExtensionID, err := UnmarshalRegistryExtensionID(id)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/registry/api/extensions.go
+++ b/cmd/frontend/registry/api/extensions.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 )
 
@@ -74,7 +74,7 @@ func ParseExtensionID(extensionID string) (prefix, extensionIDWithoutPrefix stri
 
 // GetLocalExtensionByExtensionID looks up and returns the registry extension in the local registry
 // with the given extension ID. If there is no local extension registry, it is not implemented.
-var GetLocalExtensionByExtensionID func(ctx context.Context, db dbutil.DB, extensionIDWithoutPrefix string) (local graphqlbackend.RegistryExtension, err error)
+var GetLocalExtensionByExtensionID func(ctx context.Context, db database.DB, extensionIDWithoutPrefix string) (local graphqlbackend.RegistryExtension, err error)
 
 // GetExtensionByExtensionID gets the extension with the given extension ID.
 //
@@ -84,7 +84,7 @@ var GetLocalExtensionByExtensionID func(ctx context.Context, db dbutil.DB, exten
 // to the remote registry specified in site configuration (usually sourcegraph.com). The host must
 // be specified to refer to a local extension on the current Sourcegraph site (e.g.,
 // sourcegraph.example.com/publisher/name).
-func GetExtensionByExtensionID(ctx context.Context, db dbutil.DB, extensionID string) (local graphqlbackend.RegistryExtension, remote *registry.Extension, err error) {
+func GetExtensionByExtensionID(ctx context.Context, db database.DB, extensionID string) (local graphqlbackend.RegistryExtension, remote *registry.Extension, err error) {
 	_, extensionIDWithoutPrefix, isLocal, err := ParseExtensionID(extensionID)
 	if err != nil {
 		return nil, nil, err
@@ -207,13 +207,13 @@ func listRemoteRegistryExtensions(ctx context.Context, query string) ([]*registr
 
 // GetLocalFeaturedExtensions looks up and returns the featured registry extensions in the local registry
 // If this is not sourcegraph.com, it is not implemented.
-var GetLocalFeaturedExtensions func(ctx context.Context, db dbutil.DB) ([]graphqlbackend.RegistryExtension, error)
+var GetLocalFeaturedExtensions func(ctx context.Context, db database.DB) ([]graphqlbackend.RegistryExtension, error)
 
 // GetFeaturedExtensions returns the set of featured extensions.
 //
 // If this is sourcegraph.com, these are local extensions. Otherwise, these are remote extensions
 // retrieved from sourcegraph.com.
-func GetFeaturedExtensions(ctx context.Context, db dbutil.DB) ([]graphqlbackend.RegistryExtension, error) {
+func GetFeaturedExtensions(ctx context.Context, db database.DB) ([]graphqlbackend.RegistryExtension, error) {
 	if envvar.SourcegraphDotComMode() && GetLocalFeaturedExtensions != nil {
 		return GetLocalFeaturedExtensions(ctx, db)
 	}

--- a/cmd/frontend/registry/api/extensions_test.go
+++ b/cmd/frontend/registry/api/extensions_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func TestSplitExtensionID(t *testing.T) {
@@ -101,14 +101,14 @@ type mockRegistryExtension struct {
 
 func TestGetExtensionByExtensionID(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Run("root", func(t *testing.T) {
 		mockLocalRegistryExtensionIDPrefix = &strnilptr
 		defer func() { mockLocalRegistryExtensionIDPrefix = nil }()
 
 		t.Run("2-part", func(t *testing.T) {
-			GetLocalExtensionByExtensionID = func(ctx context.Context, db dbutil.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
+			GetLocalExtensionByExtensionID = func(ctx context.Context, db database.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
 				if want := "a/b"; extensionID != want {
 					t.Errorf("got %q, want %q", extensionID, want)
 				}
@@ -162,7 +162,7 @@ func TestGetExtensionByExtensionID(t *testing.T) {
 		})
 
 		t.Run("3-part", func(t *testing.T) {
-			GetLocalExtensionByExtensionID = func(ctx context.Context, db dbutil.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
+			GetLocalExtensionByExtensionID = func(ctx context.Context, db database.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
 				if want := "b/c"; extensionID != want {
 					t.Errorf("got %q, want %q", extensionID, want)
 				}

--- a/cmd/frontend/registry/api/featured_extensions.go
+++ b/cmd/frontend/registry/api/featured_extensions.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 type featuredExtensionsResolver struct {
@@ -14,7 +14,7 @@ type featuredExtensionsResolver struct {
 
 	featuredExtensions []graphqlbackend.RegistryExtension
 	err                error
-	db                 dbutil.DB
+	db                 database.DB
 }
 
 func (r *extensionRegistryResolver) FeaturedExtensions(ctx context.Context) (graphqlbackend.FeaturedExtensionsConnection, error) {

--- a/cmd/frontend/shared/frontend.go
+++ b/cmd/frontend/shared/frontend.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 
@@ -19,7 +19,7 @@ import (
 // It is exposed as function in a package so that it can be called by other
 // main package implementations such as Sourcegraph Enterprise, which import
 // proprietary/private code.
-func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) {
+func Main(enterpriseSetupHook func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) {
 	env.Lock()
 	err := cli.Main(enterpriseSetupHook)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -32,7 +32,7 @@ import (
 
 var clock = timeutil.Now
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	database.ExternalServices = edb.NewExternalServicesStore
 	database.Authz = func(db dbutil.DB) database.AuthzStore {
 		return edb.NewAuthzStore(db, clock)

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -314,7 +314,7 @@ func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.Rep
 	}
 
 	return &userConnectionResolver{
-		db:    r.store.Handle().DB(),
+		db:    database.NewDB(r.store.Handle().DB()),
 		ids:   p.UserIDs,
 		first: args.First,
 		after: args.After,

--- a/enterprise/cmd/frontend/internal/authz/resolvers/users.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/users.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -21,7 +20,7 @@ var _ graphqlbackend.UserConnectionResolver = &userConnectionResolver{}
 // userConnectionResolver resolves a list of user from the roaring bitmap with pagination.
 type userConnectionResolver struct {
 	ids *roaring.Bitmap
-	db  dbutil.DB
+	db  database.DB
 
 	first int32
 	after *string

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/window"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
@@ -19,7 +19,7 @@ import (
 // Init initializes the given enterpriseServices to include the required
 // resolvers for Batch Changes and sets up webhook handlers for changeset
 // events.
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	// Validate site configuration.
 	conf.ContributeValidator(func(c conf.Unified) (problems conf.Problems) {
 		if _, err := window.NewConfiguration(c.BatchChangesRolloutWindows); err != nil {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
@@ -122,7 +123,7 @@ func (r *batchSpecWorkspaceStepResolver) DiffStat(ctx context.Context) (*graphql
 
 func (r *batchSpecWorkspaceStepResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
 	if r.stepInfo.Diff != nil {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DB(), r.repo, r.baseRev, *r.stepInfo.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, database.NewDB(r.store.DB()), r.repo, r.baseRev, *r.stepInfo.Diff)
 	}
 	return nil, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -247,7 +247,7 @@ func (r *changesetResolver) Author() (*graphqlbackend.PersonResolver, error) {
 	}
 
 	return graphqlbackend.NewPersonResolver(
-		r.store.DB(),
+		database.NewDB(r.store.DB()),
 		name,
 		email,
 		// Try to find the corresponding Sourcegraph user.
@@ -484,7 +484,7 @@ func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.Repository
 
 		return graphqlbackend.NewPreviewRepositoryComparisonResolver(
 			ctx,
-			r.store.DB(),
+			database.NewDB(r.store.DB()),
 			r.repoResolver,
 			desc.BaseRev,
 			diff,
@@ -519,7 +519,7 @@ func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.Repository
 		}
 	}
 
-	return graphqlbackend.NewRepositoryComparison(ctx, r.store.DB(), r.repoResolver, &graphqlbackend.RepositoryComparisonInput{
+	return graphqlbackend.NewRepositoryComparison(ctx, database.NewDB(r.store.DB()), r.repoResolver, &graphqlbackend.RepositoryComparisonInput{
 		Base:         &base,
 		Head:         &head,
 		FetchMissing: true,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -175,7 +175,7 @@ func (r *changesetDescriptionResolver) Diff(ctx context.Context) (graphqlbackend
 	if err != nil {
 		return nil, err
 	}
-	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DB(), r.repoResolver, r.desc.BaseRev, diff)
+	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, database.NewDB(r.store.DB()), r.repoResolver, r.desc.BaseRev, diff)
 }
 
 func (r *changesetDescriptionResolver) Commits() []graphqlbackend.GitCommitDescriptionResolver {
@@ -204,7 +204,7 @@ type gitCommitDescriptionResolver struct {
 
 func (r *gitCommitDescriptionResolver) Author() *graphqlbackend.PersonResolver {
 	return graphqlbackend.NewPersonResolver(
-		r.store.DB(),
+		database.NewDB(r.store.DB()),
 		r.authorName,
 		r.authorEmail,
 		// Try to find the corresponding Sourcegraph user.

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -11,12 +11,12 @@ import (
 	codeintelresolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	codeintelgqlresolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	if err := initServices(ctx, db); err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 	return nil
 }
 
-func newResolver(ctx context.Context, db dbutil.DB, observationContext *observation.Context) (gql.CodeIntelResolver, error) {
+func newResolver(ctx context.Context, db database.DB, observationContext *observation.Context) (gql.CodeIntelResolver, error) {
 	policyMatcher := policies.NewMatcher(
 		services.gitserverClient,
 		policies.NoopExtractor,
@@ -66,7 +66,7 @@ func newResolver(ctx context.Context, db dbutil.DB, observationContext *observat
 	return codeintelgqlresolvers.NewResolver(db, innerResolver), nil
 }
 
-func newUploadHandler(ctx context.Context, db dbutil.DB) (func(internal bool) http.Handler, error) {
+func newUploadHandler(ctx context.Context, db database.DB) (func(internal bool) http.Handler, error) {
 	internalHandler, err := NewCodeIntelUploadHandler(ctx, db, true)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -29,7 +28,7 @@ import (
 type CachedLocationResolver struct {
 	sync.RWMutex
 	children map[api.RepoID]*cachedRepositoryResolver
-	db       dbutil.DB
+	db       database.DB
 }
 
 type cachedRepositoryResolver struct {
@@ -45,7 +44,7 @@ type cachedCommitResolver struct {
 }
 
 // NewCachedLocationResolver creates a location resolver with an empty cache.
-func NewCachedLocationResolver(db dbutil.DB) *CachedLocationResolver {
+func NewCachedLocationResolver(db database.DB) *CachedLocationResolver {
 	return &CachedLocationResolver{
 		db:       db,
 		children: map[api.RepoID]*cachedRepositoryResolver{},

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
@@ -31,7 +31,7 @@ const numCommits = 10 // per repo
 const numPaths = 10   // per commit
 
 func TestCachedLocationResolver(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Cleanup(func() {
 		database.Mocks.Repos.Get = nil
@@ -170,7 +170,7 @@ func TestCachedLocationResolver(t *testing.T) {
 }
 
 func TestCachedLocationResolverUnknownRepository(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Cleanup(func() {
 		database.Mocks.Repos.Get = nil
@@ -200,7 +200,7 @@ func TestCachedLocationResolverUnknownRepository(t *testing.T) {
 }
 
 func TestCachedLocationResolverUnknownCommit(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Cleanup(func() {
 		database.Mocks.Repos.Get = nil
@@ -234,7 +234,7 @@ func TestCachedLocationResolverUnknownCommit(t *testing.T) {
 }
 
 func TestResolveLocations(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Cleanup(func() {
 		database.Mocks.Repos.Get = nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	resolvermocks "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
 func TestRanges(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))
@@ -35,7 +36,7 @@ func TestRanges(t *testing.T) {
 }
 
 func TestDefinitions(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))
@@ -57,7 +58,7 @@ func TestDefinitions(t *testing.T) {
 }
 
 func TestReferences(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))
@@ -96,7 +97,7 @@ func TestReferences(t *testing.T) {
 }
 
 func TestReferencesDefaultLimit(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))
@@ -122,7 +123,7 @@ func TestReferencesDefaultLimit(t *testing.T) {
 }
 
 func TestReferencesDefaultIllegalLimit(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))
@@ -142,7 +143,7 @@ func TestReferencesDefaultIllegalLimit(t *testing.T) {
 }
 
 func TestHover(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	mockResolver.HoverFunc.SetDefaultReturn("text", lsifstore.Range{}, true, nil)
@@ -165,7 +166,7 @@ func TestHover(t *testing.T) {
 }
 
 func TestDiagnostics(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))
@@ -188,7 +189,7 @@ func TestDiagnostics(t *testing.T) {
 }
 
 func TestDiagnosticsDefaultLimit(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))
@@ -210,7 +211,7 @@ func TestDiagnosticsDefaultLimit(t *testing.T) {
 }
 
 func TestDiagnosticsDefaultIllegalLimit(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db))

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 const (
@@ -37,7 +36,7 @@ type Resolver struct {
 }
 
 // NewResolver creates a new Resolver with the given resolver that defines all code intel-specific behavior.
-func NewResolver(db dbutil.DB, resolver resolvers.Resolver) gql.CodeIntelResolver {
+func NewResolver(db database.DB, resolver resolvers.Resolver) gql.CodeIntelResolver {
 	return &Resolver{
 		resolver:         resolver,
 		locationResolver: NewCachedLocationResolver(db),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func TestDeleteLSIFUpload(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Cleanup(func() {
 		database.Mocks.Users.GetByCurrentAuthUser = nil
@@ -49,7 +49,7 @@ func TestDeleteLSIFUpload(t *testing.T) {
 }
 
 func TestDeleteLSIFUploadUnauthenticated(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	id := graphql.ID(base64.StdEncoding.EncodeToString([]byte("LSIFUpload:42")))
 	mockResolver := resolvermocks.NewMockResolver()
@@ -60,7 +60,7 @@ func TestDeleteLSIFUploadUnauthenticated(t *testing.T) {
 }
 
 func TestDeleteLSIFIndex(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Cleanup(func() {
 		database.Mocks.Users.GetByCurrentAuthUser = nil
@@ -85,7 +85,7 @@ func TestDeleteLSIFIndex(t *testing.T) {
 }
 
 func TestDeleteLSIFIndexUnauthenticated(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	id := graphql.ID(base64.StdEncoding.EncodeToString([]byte("LSIFIndex:42")))
 	mockResolver := resolvermocks.NewMockResolver()

--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors/resolvers"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/dotcom/init.go
+++ b/enterprise/cmd/frontend/internal/dotcom/init.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/billing"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/productsubscription"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/stripeutil"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -39,7 +39,7 @@ func (d dotcomRootResolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFu
 
 var _ graphqlbackend.DotcomRootResolver = dotcomRootResolver{}
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	stripeEnabled := stripeutil.ValidateAndPublishConfig()
 	// Only enabled on Sourcegraph.com or when Stripe is configured correctly.
 	if envvar.SourcegraphDotComMode() || stripeEnabled {

--- a/enterprise/cmd/frontend/internal/executorqueue/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/init.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
@@ -17,7 +17,7 @@ import (
 )
 
 // Init initializes the executor endpoints required for use with the executor service.
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	accessToken := func() string {
 		if accessToken := conf.Get().ExecutorsAccessToken; accessToken != "" {
 			return accessToken

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
@@ -24,7 +23,7 @@ import (
 
 // TODO(efritz) - de-globalize assignments in this function
 // TODO(efritz) - refactor licensing packages - this is a huge mess!
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
 	database.BeforeCreateUser = enforcement.NewBeforeCreateUserHook()
@@ -118,7 +117,7 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 }
 
 type usersStore struct {
-	db dbutil.DB
+	db database.DB
 }
 
 func (u *usersStore) Count(ctx context.Context) (int, error) {

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func init() {
@@ -15,7 +15,7 @@ func init() {
 	registry.CountLocalRegistryExtensions = countLocalRegistryExtensions
 }
 
-func listLocalRegistryExtensions(ctx context.Context, db dbutil.DB, args graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
+func listLocalRegistryExtensions(ctx context.Context, db database.DB, args graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
 	if args.PrioritizeExtensionIDs != nil {
 		ids := filterStripLocalExtensionIDs(*args.PrioritizeExtensionIDs)
 		args.PrioritizeExtensionIDs = &ids
@@ -48,7 +48,7 @@ func listLocalRegistryExtensions(ctx context.Context, db dbutil.DB, args graphql
 	return ys, nil
 }
 
-func countLocalRegistryExtensions(ctx context.Context, db dbutil.DB, args graphqlbackend.RegistryExtensionConnectionArgs) (int, error) {
+func countLocalRegistryExtensions(ctx context.Context, db database.DB, args graphqlbackend.RegistryExtensionConnectionArgs) (int, error) {
 	opt, err := toDBExtensionsListOptions(args)
 	if err != nil {
 		return 0, err

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -12,12 +12,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // extensionDBResolver implements the GraphQL type RegistryExtension.
 type extensionDBResolver struct {
-	db dbutil.DB
+	db database.DB
 	v  *dbExtension
 
 	// Supplied as part of list endpoints, but

--- a/enterprise/cmd/frontend/internal/registry/extensions.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions.go
@@ -6,12 +6,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func init() {
 	conf.DefaultRemoteRegistry = "https://sourcegraph.com/.api/registry"
-	registry.GetLocalExtensionByExtensionID = func(ctx context.Context, db dbutil.DB, extensionIDWithoutPrefix string) (graphqlbackend.RegistryExtension, error) {
+	registry.GetLocalExtensionByExtensionID = func(ctx context.Context, db database.DB, extensionIDWithoutPrefix string) (graphqlbackend.RegistryExtension, error) {
 		x, err := dbExtensions{}.GetByExtensionID(ctx, extensionIDWithoutPrefix)
 		if err != nil {
 			return nil, err
@@ -22,7 +22,7 @@ func init() {
 		return &extensionDBResolver{db: db, v: x}, nil
 	}
 
-	registry.GetLocalFeaturedExtensions = func(ctx context.Context, db dbutil.DB) ([]graphqlbackend.RegistryExtension, error) {
+	registry.GetLocalFeaturedExtensions = func(ctx context.Context, db database.DB) ([]graphqlbackend.RegistryExtension, error) {
 		dbExtensions, err := dbExtensions{}.GetFeaturedExtensions(ctx)
 		if err != nil {
 			return nil, err

--- a/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
@@ -8,14 +8,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func init() {
 	frontendregistry.ExtensionRegistry.PublishersFunc = extensionRegistryPublishers
 }
 
-func extensionRegistryPublishers(ctx context.Context, db dbutil.DB, args *graphqlutil.ConnectionArgs) (graphqlbackend.RegistryPublisherConnection, error) {
+func extensionRegistryPublishers(ctx context.Context, db database.DB, args *graphqlutil.ConnectionArgs) (graphqlbackend.RegistryPublisherConnection, error) {
 	var opt dbPublishersListOptions
 	args.Set(&opt.LimitOffset)
 	return &registryPublisherConnection{opt: opt, db: db}, nil
@@ -29,7 +28,7 @@ type registryPublisherConnection struct {
 	once               sync.Once
 	registryPublishers []*dbPublisher
 	err                error
-	db                 dbutil.DB
+	db                 database.DB
 }
 
 func (r *registryPublisherConnection) compute(ctx context.Context) ([]*dbPublisher, error) {

--- a/enterprise/cmd/frontend/internal/registry/registry_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/registry_graphql.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
@@ -22,7 +22,7 @@ func init() {
 	frontendregistry.ExtensionRegistry.PublishExtensionFunc = extensionRegistryPublishExtension
 }
 
-func registryExtensionByIDInt32(ctx context.Context, db dbutil.DB, id int32) (graphqlbackend.RegistryExtension, error) {
+func registryExtensionByIDInt32(ctx context.Context, db database.DB, id int32) (graphqlbackend.RegistryExtension, error) {
 	if conf.Extensions() == nil {
 		return nil, graphqlbackend.ErrExtensionsDisabled
 	}
@@ -36,7 +36,7 @@ func registryExtensionByIDInt32(ctx context.Context, db dbutil.DB, id int32) (gr
 	return &extensionDBResolver{db: db, v: x}, nil
 }
 
-func extensionRegistryCreateExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryCreateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
+func extensionRegistryCreateExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryCreateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func extensionRegistryCreateExtension(ctx context.Context, db dbutil.DB, args *g
 	return &frontendregistry.ExtensionRegistryMutationResult{DB: db, ID: id}, nil
 }
 
-func viewerCanAdministerExtension(ctx context.Context, db dbutil.DB, id frontendregistry.RegistryExtensionID) error {
+func viewerCanAdministerExtension(ctx context.Context, db database.DB, id frontendregistry.RegistryExtensionID) error {
 	if id.LocalID == 0 {
 		return errors.New("unable to administer extension on remote registry")
 	}
@@ -69,7 +69,7 @@ func viewerCanAdministerExtension(ctx context.Context, db dbutil.DB, id frontend
 	return toRegistryPublisherID(extension).viewerCanAdminister(ctx, db)
 }
 
-func extensionRegistryUpdateExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryUpdateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
+func extensionRegistryUpdateExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryUpdateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	id, err := frontendregistry.UnmarshalRegistryExtensionID(args.Extension)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func extensionRegistryUpdateExtension(ctx context.Context, db dbutil.DB, args *g
 	return &frontendregistry.ExtensionRegistryMutationResult{DB: db, ID: id.LocalID}, nil
 }
 
-func extensionRegistryDeleteExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryDeleteExtensionArgs) (*graphqlbackend.EmptyResponse, error) {
+func extensionRegistryDeleteExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryDeleteExtensionArgs) (*graphqlbackend.EmptyResponse, error) {
 	id, err := frontendregistry.UnmarshalRegistryExtensionID(args.Extension)
 	if err != nil {
 		return nil, err
@@ -103,7 +103,7 @@ func extensionRegistryDeleteExtension(ctx context.Context, db dbutil.DB, args *g
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
-func extensionRegistryPublishExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryPublishExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
+func extensionRegistryPublishExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryPublishExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/searchcontexts/init.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/init.go
@@ -6,12 +6,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.SearchContextsResolver = resolvers.NewResolver(database.NewDB(db))
 	return nil
 }

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -29,7 +29,7 @@ import (
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -43,7 +43,7 @@ func init() {
 	oobmigration.ReturnEnterpriseMigrations = true
 }
 
-type EnterpriseInitializer = func(context.Context, dbutil.DB, *oobmigration.Runner, *enterprise.Services, *observation.Context) error
+type EnterpriseInitializer = func(context.Context, database.DB, *oobmigration.Runner, *enterprise.Services, *observation.Context) error
 
 var initFunctions = map[string]EnterpriseInitializer{
 	"authz":          authz.Init,
@@ -57,7 +57,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"searchcontexts": searchcontexts.Init,
 }
 
-func enterpriseSetupHook(db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
+func enterpriseSetupHook(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		log.Println("enterprise edition")

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -12,8 +12,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -37,7 +37,7 @@ func IsEnabled() bool {
 }
 
 // Init initializes the given enterpriseServices to include the required resolvers for insights.
-func Init(ctx context.Context, postgres dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, postgres database.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	if !IsEnabled() {
 		if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
 			enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver("backend-run code insights are not available on single-container deployments")


### PR DESCRIPTION
Now that all the stores have mockable interface versions, we can start
using them. I've already begun the process in order to nail down the
pattern, but in order to allow mocking across the entire codebase, we
need to replace usage of dbutil.DB with database.DB so mocks can be
propagated.

Progresses #26113 

This commit just updates one of our graphql resolvers to use database.DB
instead of dbutil.DB, then fixes the type errors. Pretty amazing how
interconnected it all is.

This is a very mechanical change. The process was just:
1) Update a resolver to use `database.DB` instead of `dbutil.DB`
2) Fix any type errors by changing the input type to `database.DB`, or if there is no input type, wrap the object with `database.NewDB()`
3) Repeat 2

There will be more like this, but given that these changes hit a huge portion
of the code base, keeping them smaller will hopefully help with merge conflicts.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
