### PR TITLE
Remove `acceptSearchSuggestionOnEnter` experimental feature

### DIFF
--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -21,7 +21,6 @@ export interface Settings {
     extensions?: { [extensionID: string]: boolean }
     experimentalFeatures?: {
         enableFastResultLoading?: boolean
-        acceptSearchSuggestionOnEnter?: boolean
         batchChangesExecution?: boolean
         showSearchContext?: boolean
         showSearchContextManagement?: boolean

--- a/client/web/src/search/input/MonacoQueryInput.story.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.story.tsx
@@ -24,7 +24,6 @@ const defaultProps: MonacoQueryInputProps = {
     selectedSearchContextSpec: 'global',
     onChange: () => {},
     onSubmit: () => {},
-    settingsCascade: { final: null, subjects: null },
     onHandleFuzzyFinder: () => {},
 }
 

--- a/client/web/src/search/input/SearchBox.tsx
+++ b/client/web/src/search/input/SearchBox.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames'
 import React from 'react'
 
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
@@ -20,8 +19,7 @@ export interface SearchBoxProps
     extends Omit<TogglesProps, 'navbarSearchQuery' | 'submitSearch'>,
         ThemeProps,
         SearchContextInputProps,
-        TelemetryProps,
-        SettingsCascadeProps {
+        TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean // significant for query suggestions
     queryState: QueryState

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1446,8 +1446,6 @@ type Settings struct {
 
 // SettingsExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 type SettingsExperimentalFeatures struct {
-	// AcceptSearchSuggestionOnEnter description: Whether the search bar should select completion suggestions when pressing enter
-	AcceptSearchSuggestionOnEnter *bool `json:"acceptSearchSuggestionOnEnter,omitempty"`
 	// ApiDocs description: Enables API documentation.
 	ApiDocs *bool `json:"apiDocs,omitempty"`
 	// BatchChangesExecution description: Enables/disables the Batch Changes server side execution feature.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -181,14 +181,6 @@
             "pointer": true
           }
         },
-        "acceptSearchSuggestionOnEnter": {
-          "description": "Whether the search bar should select completion suggestions when pressing enter",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
         "batchChangesExecution": {
           "description": "Enables/disables the Batch Changes server side execution feature.",
           "type": "boolean",


### PR DESCRIPTION
This feature didn't work out because dynamically loaded completion
suggestions (files, symbols) make it easy to accidentally pick a
completion when you want to trigger a search.

Related discussions https://docs.google.com/document/d/1PmREUZzUXuPgZTBnIOGwN5BNbp9OZpQYjwFbil9rbWo/edit#


Reverts https://github.com/sourcegraph/sourcegraph/pull/21962 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
