### PR TITLE
Implement retryBatchSpecWorkspaces

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1540,8 +1540,28 @@ func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *g
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DB()); err != nil {
 		return nil, err
 	}
-	// TODO(ssbc): not implemented
-	return nil, errors.New("not implemented yet")
+
+	var workspaceIDs []int64
+	for _, raw := range args.BatchSpecWorkspaces {
+		id, err := unmarshalBatchSpecWorkspaceID(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		if id == 0 {
+			return nil, ErrIDIsZero{}
+		}
+
+		workspaceIDs = append(workspaceIDs, id)
+	}
+
+	svc := service.New(r.store)
+	err := svc.RetryBatchSpecWorkspaces(ctx, workspaceIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &graphqlbackend.EmptyResponse{}, nil
 }
 
 func (r *Resolver) RetryBatchSpecExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecExecutionArgs) (*graphqlbackend.EmptyResponse, error) {

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -1182,8 +1182,11 @@ func (s *Service) RetryBatchSpecWorkspaces(ctx context.Context, workspaceIDs []i
 
 	// Check that batch spec is not applied
 	_, err = tx.GetBatchChange(ctx, store.GetBatchChangeOpts{BatchSpecID: batchSpecID})
-	if err != store.ErrNoResults {
-		return errors.Wrap(err, "batch spec has already been applied")
+	if err != nil && err != store.ErrNoResults {
+		return errors.Wrap(err, "checking whether batch spec has been applied")
+	}
+	if err == nil {
+		return errors.New("batch spec already applied")
 	}
 
 	// Load jobs and check their state

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1733,6 +1733,166 @@ func TestService(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("RetryBatchSpecWorkspaces", func(t *testing.T) {
+		failureMessage := "this failed"
+
+		t.Run("success", func(t *testing.T) {
+			spec := testBatchSpec(admin.ID)
+			if err := s.CreateBatchSpec(ctx, spec); err != nil {
+				t.Fatal(err)
+			}
+
+			changesetSpec1 := ct.CreateChangesetSpec(t, ctx, s, ct.TestSpecOpts{
+				Repo:      rs[2].ID,
+				BatchSpec: spec.ID,
+				HeadRef:   "refs/heads/my-spec",
+			})
+
+			changesetSpec2 := ct.CreateChangesetSpec(t, ctx, s, ct.TestSpecOpts{
+				Repo:      rs[2].ID,
+				BatchSpec: spec.ID,
+				HeadRef:   "refs/heads/my-spec-2",
+			})
+
+			var workspaceIDs []int64
+			for i, repo := range rs {
+				ws := &btypes.BatchSpecWorkspace{
+					BatchSpecID: spec.ID,
+					RepoID:      repo.ID,
+					Steps: []batcheslib.Step{
+						{Run: "echo hello", Container: "alpine:3"},
+					},
+				}
+				// This workspace has the completed job and resulted in 2 changesetspecs
+				if i == 2 {
+					ws.ChangesetSpecIDs = append(ws.ChangesetSpecIDs, changesetSpec1.ID, changesetSpec2.ID)
+				}
+
+				if err := s.CreateBatchSpecWorkspace(ctx, ws); err != nil {
+					t.Fatal(err)
+				}
+				workspaceIDs = append(workspaceIDs, ws.ID)
+			}
+
+			failedJob := &btypes.BatchSpecWorkspaceExecutionJob{
+				BatchSpecWorkspaceID: workspaceIDs[0],
+				State:                btypes.BatchSpecWorkspaceExecutionJobStateFailed,
+				StartedAt:            time.Now(),
+				FinishedAt:           time.Now(),
+				FailureMessage:       &failureMessage,
+			}
+			createJob(t, s, failedJob)
+
+			erroredJob := &btypes.BatchSpecWorkspaceExecutionJob{
+				BatchSpecWorkspaceID: workspaceIDs[1],
+				State:                btypes.BatchSpecWorkspaceExecutionJobStateErrored,
+				StartedAt:            time.Now(),
+				FinishedAt:           time.Now(),
+				FailureMessage:       &failureMessage,
+			}
+			createJob(t, s, erroredJob)
+
+			completedJob := &btypes.BatchSpecWorkspaceExecutionJob{
+				BatchSpecWorkspaceID: workspaceIDs[2],
+				State:                btypes.BatchSpecWorkspaceExecutionJobStateCompleted,
+				StartedAt:            time.Now(),
+				FinishedAt:           time.Now(),
+			}
+			createJob(t, s, completedJob)
+
+			jobs := []*btypes.BatchSpecWorkspaceExecutionJob{
+				failedJob, erroredJob, completedJob,
+			}
+
+			// RETRY
+			if err := svc.RetryBatchSpecWorkspaces(ctx, workspaceIDs); err != nil {
+				t.Fatal(err)
+			}
+
+			assertJobsDeleted(t, s, jobs)
+			assertChangesetSpecsDeleted(t, s, []*btypes.ChangesetSpec{changesetSpec1, changesetSpec2})
+			assertJobsCreatedFor(t, s, []int64{workspaceIDs[0], workspaceIDs[1], workspaceIDs[2]})
+		})
+	})
+}
+
+func createJob(t *testing.T, s *store.Store, job *btypes.BatchSpecWorkspaceExecutionJob) {
+	t.Helper()
+
+	clone := *job
+
+	if err := ct.CreateBatchSpecWorkspaceExecutionJob(context.Background(), s, store.ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
+		t.Fatal(err)
+	}
+
+	job.State = clone.State
+	job.Cancel = clone.Cancel
+	job.WorkerHostname = clone.WorkerHostname
+	job.StartedAt = clone.StartedAt
+	job.FinishedAt = clone.FinishedAt
+	job.FailureMessage = clone.FailureMessage
+
+	ct.UpdateJobState(t, context.Background(), s, job)
+}
+
+func assertJobsDeleted(t *testing.T, s *store.Store, jobs []*btypes.BatchSpecWorkspaceExecutionJob) {
+	t.Helper()
+
+	jobIDs := make([]int64, len(jobs))
+	for i, j := range jobs {
+		jobIDs[i] = j.ID
+	}
+	old, err := s.ListBatchSpecWorkspaceExecutionJobs(context.Background(), store.ListBatchSpecWorkspaceExecutionJobsOpts{
+		IDs: jobIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(old) != 0 {
+		t.Fatal("old jobs not deleted")
+	}
+}
+
+func assertJobsCreatedFor(t *testing.T, s *store.Store, workspaceIDs []int64) {
+	t.Helper()
+
+	idMap := make(map[int64]struct{}, len(workspaceIDs))
+	for _, id := range workspaceIDs {
+		idMap[id] = struct{}{}
+	}
+	jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(context.Background(), store.ListBatchSpecWorkspaceExecutionJobsOpts{
+		BatchSpecWorkspaceIDs: workspaceIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != len(workspaceIDs) {
+		t.Fatal("jobs not created")
+	}
+	for _, job := range jobs {
+		if _, ok := idMap[job.BatchSpecWorkspaceID]; !ok {
+			t.Fatalf("job created for wrong workspace")
+		}
+	}
+}
+
+func assertChangesetSpecsDeleted(t *testing.T, s *store.Store, specs []*btypes.ChangesetSpec) {
+	t.Helper()
+
+	ids := make([]int64, len(specs))
+	for i, j := range specs {
+		ids[i] = j.ID
+	}
+	old, _, err := s.ListChangesetSpecs(context.Background(), store.ListChangesetSpecsOpts{
+		IDs: ids,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(old) != 0 {
+		t.Fatal("specs not deleted")
+	}
 }
 
 func testBatchChange(user int32, spec *btypes.BatchSpec) *btypes.BatchChange {

--- a/enterprise/internal/batches/store/batch_spec_workspace.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace.go
@@ -196,6 +196,7 @@ type ListBatchSpecWorkspacesOpts struct {
 	LimitOpts
 	Cursor      int64
 	BatchSpecID int64
+	IDs         []int64
 }
 
 // ListBatchSpecWorkspaces lists batch changes with the given filters.
@@ -234,6 +235,10 @@ ORDER BY id ASC
 func listBatchSpecWorkspacesQuery(opts ListBatchSpecWorkspacesOpts) *sqlf.Query {
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("repo.deleted_at IS NULL"),
+	}
+
+	if len(opts.IDs) != 0 {
+		preds = append(preds, sqlf.Sprintf("batch_spec_workspaces.id = ANY(%s)", pq.Array(opts.IDs)))
 	}
 
 	if opts.BatchSpecID != 0 {

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -104,6 +105,52 @@ func (s *Store) CreateBatchSpecWorkspaceExecutionJobs(ctx context.Context, batch
 	cond := sqlf.Sprintf(executableWorkspaceJobsConditionFmtstr)
 	q := sqlf.Sprintf(createBatchSpecWorkspaceExecutionJobsQueryFmtstr, batchSpecID, cond)
 	return s.Exec(ctx, q)
+}
+
+const createBatchSpecWorkspaceExecutionJobsForWorkspacesQueryFmtstr = `
+-- source: enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go:CreateBatchSpecWorkspaceExecutionJobsForWorkspaces
+INSERT INTO
+	batch_spec_workspace_execution_jobs (batch_spec_workspace_id)
+SELECT
+	batch_spec_workspaces.id
+FROM
+	batch_spec_workspaces
+WHERE
+	batch_spec_workspaces.id = ANY (%s)
+`
+
+// CreateBatchSpecWorkspaceExecutionJobsForWorkspaces creates the batch spec workspace jobs for the given workspaces.
+func (s *Store) CreateBatchSpecWorkspaceExecutionJobsForWorkspaces(ctx context.Context, workspaceIDs []int64) (err error) {
+	ctx, endObservation := s.operations.createBatchSpecWorkspaceExecutionJobsForWorkspaces.With(ctx, &err, observation.Args{LogFields: []log.Field{}})
+	defer endObservation(1, observation.Args{})
+
+	q := sqlf.Sprintf(createBatchSpecWorkspaceExecutionJobsForWorkspacesQueryFmtstr, pq.Array(workspaceIDs))
+	return s.Exec(ctx, q)
+}
+
+const deleteBatchSpecWorkspaceExecutionJobsQueryFmtstr = `
+-- source: enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go:DeleteBatchSpecWorkspaceExecutionJobs
+DELETE FROM
+	batch_spec_workspace_execution_jobs
+WHERE
+	id = ANY (%s)
+RETURNING id
+`
+
+// DeleteBatchSpecWorkspaceExecutionJobs
+func (s *Store) DeleteBatchSpecWorkspaceExecutionJobs(ctx context.Context, ids []int64) (err error) {
+	ctx, endObservation := s.operations.deleteBatchSpecWorkspaceExecutionJobs.With(ctx, &err, observation.Args{LogFields: []log.Field{}})
+	defer endObservation(1, observation.Args{})
+
+	q := sqlf.Sprintf(deleteBatchSpecWorkspaceExecutionJobsQueryFmtstr, pq.Array(ids))
+	deleted, err := basestore.ScanInts(s.Query(ctx, q))
+	if err != nil {
+		return err
+	}
+	if len(deleted) != len(ids) {
+		return errors.Newf("wrong number of jobs deleted: %d instead of %d", len(deleted), len(ids))
+	}
+	return nil
 }
 
 // GetBatchSpecWorkspaceExecutionJobOpts captures the query options needed for getting a BatchSpecWorkspaceExecutionJob
@@ -379,6 +426,60 @@ SET
 	access_token_id = %s
 WHERE
 	id = %s
+`
+
+// RetryBatchSpecWorkspaceExecutionJobs retrys the matching
+// BatchSpecWorkspaceExecutionJobs.
+//
+// The returned list of records may not match the list of the given IDs, if
+// some of the records were not completed, failed or errored.
+func (s *Store) RetryBatchSpecWorkspaceExecutionJobs(ctx context.Context, ids []int64) (err error) {
+	ctx, endObservation := s.operations.retryBatchSpecWorkspaceExecutionJobs.With(ctx, &err, observation.Args{LogFields: []log.Field{}})
+	defer endObservation(1, observation.Args{})
+
+	if len(ids) == 0 {
+		return errors.New("no IDs given")
+	}
+
+	q := sqlf.Sprintf(
+		retryBatchSpecWorkspaceExecutionJobsQueryFmtstr,
+		// IDs
+		pq.Array(ids),
+		// Retryable states
+		btypes.BatchSpecWorkspaceExecutionJobStateCompleted,
+		btypes.BatchSpecWorkspaceExecutionJobStateErrored,
+		btypes.BatchSpecWorkspaceExecutionJobStateFailed,
+		// New state
+		btypes.BatchSpecWorkspaceExecutionJobStateQueued,
+		s.now(),
+		sqlf.Join(BatchSpecWorkspaceExecutionJobColumns.ToSqlf(), ", "),
+	)
+
+	return s.Exec(ctx, q)
+}
+
+var retryBatchSpecWorkspaceExecutionJobsQueryFmtstr = `
+-- source: enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go:RetryBatchSpecWorkspaceExecutionJobs
+WITH candidates AS (
+	SELECT
+		batch_spec_workspace_execution_jobs.id
+	FROM
+		batch_spec_workspace_execution_jobs
+	WHERE
+		batch_spec_workspace_execution_jobs.id = ANY (%s) -- ids
+		AND
+		batch_spec_workspace_execution_jobs.state IN (%s, %s, %s)
+	ORDER BY id
+	FOR UPDATE
+)
+UPDATE
+	batch_spec_workspace_execution_jobs
+SET
+	cancel = false,
+	state = %s,
+	updated_at = %s
+WHERE
+	id IN (SELECT id FROM candidates)
 `
 
 func ScanBatchSpecWorkspaceExecutionJob(wj *btypes.BatchSpecWorkspaceExecutionJob, s dbutil.Scanner) error {

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -524,4 +524,137 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			createJobsAndAssert(t, batchSpec, []int64{normalWorkspace.ID, ignoredWorkspace.ID, unsupportedWorkspace.ID})
 		})
 	})
+
+	t.Run("CreateBatchSpecWorkspaceExecutionJobsForWorkspaces", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			workspaces := createWorkspaces(t, ctx, s)
+			ids := workspacesIDs(t, workspaces)
+
+			err := s.CreateBatchSpecWorkspaceExecutionJobsForWorkspaces(ctx, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
+				BatchSpecWorkspaceIDs: ids,
+			})
+
+			if have, want := len(jobs), len(workspaces); have != want {
+				t.Fatalf("wrong number of jobs created. want=%d, have=%d", want, have)
+			}
+		})
+	})
+
+	t.Run("DeleteBatchSpecWorkspaceExecutionJobs", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			workspaces := createWorkspaces(t, ctx, s)
+			ids := workspacesIDs(t, workspaces)
+
+			err := s.CreateBatchSpecWorkspaceExecutionJobsForWorkspaces(ctx, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
+				BatchSpecWorkspaceIDs: ids,
+			})
+			if have, want := len(jobs), len(workspaces); have != want {
+				t.Fatalf("wrong number of jobs created. want=%d, have=%d", want, have)
+			}
+
+			jobIDs := make([]int64, len(jobs))
+			for i, j := range jobs {
+				jobIDs[i] = j.ID
+			}
+
+			if err := s.DeleteBatchSpecWorkspaceExecutionJobs(ctx, jobIDs); err != nil {
+				t.Fatal(err)
+			}
+
+			jobs, err = s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
+				IDs: jobIDs,
+			})
+			if have, want := len(jobs), 0; have != want {
+				t.Fatalf("wrong number of jobs still exists. want=%d, have=%d", want, have)
+			}
+		})
+
+		t.Run("with wrong IDs", func(t *testing.T) {
+			workspaces := createWorkspaces(t, ctx, s)
+			ids := workspacesIDs(t, workspaces)
+
+			err := s.CreateBatchSpecWorkspaceExecutionJobsForWorkspaces(ctx, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
+				BatchSpecWorkspaceIDs: ids,
+			})
+			if have, want := len(jobs), len(workspaces); have != want {
+				t.Fatalf("wrong number of jobs created. want=%d, have=%d", want, have)
+			}
+
+			jobIDs := make([]int64, len(jobs))
+			for i, j := range jobs {
+				jobIDs[i] = j.ID
+			}
+
+			jobIDs = append(jobIDs, 999, 888, 777)
+
+			err = s.DeleteBatchSpecWorkspaceExecutionJobs(ctx, jobIDs)
+			if err == nil {
+				t.Fatal("error is nil")
+			}
+
+			want := fmt.Sprintf("wrong number of jobs deleted: %d instead of %d", len(workspaces), len(workspaces)+3)
+			if err.Error() != want {
+				t.Fatalf("wrong error message. want=%q, have=%q", want, err.Error())
+			}
+
+			jobs, err = s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
+				IDs: jobIDs,
+			})
+			if have, want := len(jobs), 0; have != want {
+				t.Fatalf("wrong number of jobs still exists. want=%d, have=%d", want, have)
+			}
+		})
+	})
+}
+
+func createWorkspaces(t *testing.T, ctx context.Context, s *Store) []*btypes.BatchSpecWorkspace {
+	t.Helper()
+
+	batchSpec := &btypes.BatchSpec{NamespaceUserID: 1}
+	if err := s.CreateBatchSpec(ctx, batchSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	singleStep := []batches.Step{{Run: "echo lol", Container: "alpine:3"}}
+	workspaces := []*btypes.BatchSpecWorkspace{
+		{Steps: singleStep},
+		{Steps: singleStep, Ignored: true},
+		{Steps: singleStep, Unsupported: true},
+		{Steps: []batches.Step{}},
+	}
+	for i, workspace := range workspaces {
+		workspace.BatchSpecID = batchSpec.ID
+		workspace.RepoID = 1
+		workspace.Branch = fmt.Sprintf("refs/heads/main-%d", i)
+		workspace.Commit = fmt.Sprintf("commit-%d", i)
+	}
+
+	if err := s.CreateBatchSpecWorkspace(ctx, workspaces...); err != nil {
+		t.Fatal(err)
+	}
+
+	return workspaces
+}
+
+func workspacesIDs(t *testing.T, workspaces []*btypes.BatchSpecWorkspace) []int64 {
+	ids := make([]int64, len(workspaces))
+	for i, w := range workspaces {
+		ids[i] = w.ID
+	}
+	return ids
 }

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -600,6 +600,9 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
 				BatchSpecWorkspaceIDs: ids,
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if have, want := len(jobs), len(workspaces); have != want {
 				t.Fatalf("wrong number of jobs created. want=%d, have=%d", want, have)
 			}

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -538,6 +538,9 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
 				BatchSpecWorkspaceIDs: ids,
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if have, want := len(jobs), len(workspaces); have != want {
 				t.Fatalf("wrong number of jobs created. want=%d, have=%d", want, have)
@@ -558,6 +561,9 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
 				BatchSpecWorkspaceIDs: ids,
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if have, want := len(jobs), len(workspaces); have != want {
 				t.Fatalf("wrong number of jobs created. want=%d, have=%d", want, have)
 			}
@@ -574,6 +580,9 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			jobs, err = s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
 				IDs: jobIDs,
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if have, want := len(jobs), 0; have != want {
 				t.Fatalf("wrong number of jobs still exists. want=%d, have=%d", want, have)
 			}
@@ -615,6 +624,9 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			jobs, err = s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
 				IDs: jobIDs,
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if have, want := len(jobs), 0; have != want {
 				t.Fatalf("wrong number of jobs still exists. want=%d, have=%d", want, have)
 			}

--- a/enterprise/internal/batches/store/batch_spec_workspace_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_test.go
@@ -162,6 +162,32 @@ func testStoreBatchSpecWorkspaces(t *testing.T, ctx context.Context, s *Store, c
 				}
 			}
 		})
+
+		t.Run("ByID", func(t *testing.T) {
+			for _, ws := range workspaces {
+				have, _, err := s.ListBatchSpecWorkspaces(ctx, ListBatchSpecWorkspacesOpts{
+					IDs: []int64{ws.ID},
+				})
+
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if ws.RepoID == deletedRepo.ID {
+					if len(have) != 0 {
+						t.Fatalf("expected zero results, but got: %d", len(have))
+					}
+					return
+				}
+				if len(have) != 1 {
+					t.Fatalf("wrong number of results. have=%d", len(have))
+				}
+
+				if diff := cmp.Diff(have, []*btypes.BatchSpecWorkspace{ws}); diff != "" {
+					t.Fatalf("invalid jobs returned: %s", diff)
+				}
+			}
+		})
 	})
 
 	t.Run("MarkSkippedBatchSpecWorkspaces", func(t *testing.T) {

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -399,6 +399,30 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 				}
 			}
 		})
+
+		t.Run("ByID", func(t *testing.T) {
+			for i := 0; i < 3; i++ {
+				spec := &btypes.ChangesetSpec{
+					BatchSpecID: int64(i + 1),
+					RepoID:      repo.ID,
+				}
+				err := s.CreateChangesetSpec(ctx, spec)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := s.DeleteChangesetSpecs(ctx, DeleteChangesetSpecsOpts{
+					IDs: []int64{spec.ID},
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				_, err = s.GetChangesetSpec(ctx, GetChangesetSpecOpts{ID: spec.ID})
+				if err != ErrNoResults {
+					t.Fatal("changeset spec not deleted")
+				}
+			}
+		})
 	})
 
 	t.Run("DeleteExpiredChangesetSpecs", func(t *testing.T) {

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -237,10 +237,13 @@ type operations struct {
 	listBatchSpecWorkspaces        *observation.Operation
 	markSkippedBatchSpecWorkspaces *observation.Operation
 
-	createBatchSpecWorkspaceExecutionJobs *observation.Operation
-	getBatchSpecWorkspaceExecutionJob     *observation.Operation
-	listBatchSpecWorkspaceExecutionJobs   *observation.Operation
-	cancelBatchSpecWorkspaceExecutionJobs *observation.Operation
+	createBatchSpecWorkspaceExecutionJobs              *observation.Operation
+	createBatchSpecWorkspaceExecutionJobsForWorkspaces *observation.Operation
+	getBatchSpecWorkspaceExecutionJob                  *observation.Operation
+	listBatchSpecWorkspaceExecutionJobs                *observation.Operation
+	deleteBatchSpecWorkspaceExecutionJobs              *observation.Operation
+	cancelBatchSpecWorkspaceExecutionJobs              *observation.Operation
+	retryBatchSpecWorkspaceExecutionJobs               *observation.Operation
 
 	createBatchSpecResolutionJob *observation.Operation
 	getBatchSpecResolutionJob    *observation.Operation
@@ -361,10 +364,13 @@ func newOperations(observationContext *observation.Context) *operations {
 			listBatchSpecWorkspaces:        op("ListBatchSpecWorkspaces"),
 			markSkippedBatchSpecWorkspaces: op("MarkSkippedBatchSpecWorkspaces"),
 
-			createBatchSpecWorkspaceExecutionJobs: op("CreateBatchSpecWorkspaceExecutionJobs"),
-			getBatchSpecWorkspaceExecutionJob:     op("GetBatchSpecWorkspaceExecutionJob"),
-			listBatchSpecWorkspaceExecutionJobs:   op("ListBatchSpecWorkspaceExecutionJobs"),
-			cancelBatchSpecWorkspaceExecutionJobs: op("CancelBatchSpecWorkspaceExecutionJobs"),
+			createBatchSpecWorkspaceExecutionJobs:              op("CreateBatchSpecWorkspaceExecutionJobs"),
+			createBatchSpecWorkspaceExecutionJobsForWorkspaces: op("CreateBatchSpecWorkspaceExecutionJobsForWorkspaces"),
+			getBatchSpecWorkspaceExecutionJob:                  op("GetBatchSpecWorkspaceExecutionJob"),
+			listBatchSpecWorkspaceExecutionJobs:                op("ListBatchSpecWorkspaceExecutionJobs"),
+			deleteBatchSpecWorkspaceExecutionJobs:              op("DeleteBatchSpecWorkspaceExecutionJobs"),
+			cancelBatchSpecWorkspaceExecutionJobs:              op("CancelBatchSpecWorkspaceExecutionJobs"),
+			retryBatchSpecWorkspaceExecutionJobs:               op("RetryBatchSpecWorkspaceExecutionJobs"),
 
 			createBatchSpecResolutionJob: op("CreateBatchSpecResolutionJob"),
 			getBatchSpecResolutionJob:    op("GetBatchSpecResolutionJob"),

--- a/enterprise/internal/batches/types/batch_spec_workspace_execution_job.go
+++ b/enterprise/internal/batches/types/batch_spec_workspace_execution_job.go
@@ -14,9 +14,12 @@ type BatchSpecWorkspaceExecutionJobState string
 const (
 	BatchSpecWorkspaceExecutionJobStateQueued     BatchSpecWorkspaceExecutionJobState = "queued"
 	BatchSpecWorkspaceExecutionJobStateProcessing BatchSpecWorkspaceExecutionJobState = "processing"
-	BatchSpecWorkspaceExecutionJobStateErrored    BatchSpecWorkspaceExecutionJobState = "errored"
 	BatchSpecWorkspaceExecutionJobStateFailed     BatchSpecWorkspaceExecutionJobState = "failed"
 	BatchSpecWorkspaceExecutionJobStateCompleted  BatchSpecWorkspaceExecutionJobState = "completed"
+
+	// There is no Errored state because automatic-retry of
+	// BatchSpecWorkspaceExecutionJobs is disabled. If a job fails, it's
+	// "failed" and needs to be retried manually.
 )
 
 // Valid returns true if the given BatchSpecWorkspaceExecutionJobState is valid.
@@ -24,7 +27,6 @@ func (s BatchSpecWorkspaceExecutionJobState) Valid() bool {
 	switch s {
 	case BatchSpecWorkspaceExecutionJobStateQueued,
 		BatchSpecWorkspaceExecutionJobStateProcessing,
-		BatchSpecWorkspaceExecutionJobStateErrored,
 		BatchSpecWorkspaceExecutionJobStateFailed,
 		BatchSpecWorkspaceExecutionJobStateCompleted:
 		return true

--- a/enterprise/internal/batches/types/batch_spec_workspace_execution_job.go
+++ b/enterprise/internal/batches/types/batch_spec_workspace_execution_job.go
@@ -38,8 +38,7 @@ func (s BatchSpecWorkspaceExecutionJobState) ToGraphQL() string { return strings
 
 // Retryable returns whether the state is retryable.
 func (s BatchSpecWorkspaceExecutionJobState) Retryable() bool {
-	return s == BatchSpecWorkspaceExecutionJobStateErrored ||
-		s == BatchSpecWorkspaceExecutionJobStateFailed ||
+	return s == BatchSpecWorkspaceExecutionJobStateFailed ||
 		s == BatchSpecWorkspaceExecutionJobStateCompleted
 }
 

--- a/enterprise/internal/batches/types/batch_spec_workspace_execution_job.go
+++ b/enterprise/internal/batches/types/batch_spec_workspace_execution_job.go
@@ -36,6 +36,13 @@ func (s BatchSpecWorkspaceExecutionJobState) Valid() bool {
 // ToGraphQL returns the GraphQL representation of the worker state.
 func (s BatchSpecWorkspaceExecutionJobState) ToGraphQL() string { return strings.ToUpper(string(s)) }
 
+// Retryable returns whether the state is retryable.
+func (s BatchSpecWorkspaceExecutionJobState) Retryable() bool {
+	return s == BatchSpecWorkspaceExecutionJobStateErrored ||
+		s == BatchSpecWorkspaceExecutionJobStateFailed ||
+		s == BatchSpecWorkspaceExecutionJobStateCompleted
+}
+
 type BatchSpecWorkspaceExecutionJob struct {
 	ID int64
 


### PR DESCRIPTION
This implements the `retryBatchSpecWorkspaces` mutation for #26142. There's some store tests missing for the new predicates I introduced and some details, but I think it's already ready for review while I sleep tonight.