### PR TITLE
ci: remove Github token workaround and update LOKI_URL

### DIFF
--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -6,8 +6,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../../"
 SG_ROOT=$(pwd)
 set -ex
 
-GITHU
-
 # Setup single-server instance and run tests
 # backend integration tests requires a Github Enterprise Token
 GITHUB_TOKEN=$GHE_GITHUB_TOKEN

--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -6,5 +6,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../../"
 SG_ROOT=$(pwd)
 set -ex
 
+GITHU
+
 # Setup single-server instance and run tests
-./dev/ci/run-integration.sh "${SG_ROOT}/dev/ci/backend-integration-against-server.sh"
+# backend integration tests requires a Github Enterprise Token
+GITHUB_TOKEN=$GHE_GITHUB_TOKEN
+GITHUB_TOKEN=$GITHUB_TOKEN ./dev/ci/run-integration.sh "${SG_ROOT}/dev/ci/backend-integration-against-server.sh"

--- a/dev/ci/test/code-intel/test.sh
+++ b/dev/ci/test/code-intel/test.sh
@@ -9,10 +9,5 @@ set -ex
 # Use candidate image built by main pipeline
 export IMAGE="us.gcr.io/sourcegraph-dev/server:${CANDIDATE_VERSION}"
 
-# TODO(JH) Remove that before merging the PR
-if [[ -n "$DUP_GITHUB_TOKEN" ]]; then
-  GITHUB_TOKEN=$DUP_GITHUB_TOKEN
-fi
-
 # Setup single-server instance and run tests
-GITHUB_TOKEN=$GITHUB_TOKEN ./dev/ci/run-integration.sh "${SG_ROOT}/dev/ci/test/code-intel/test-against-server.sh"
+./dev/ci/run-integration.sh "${SG_ROOT}/dev/ci/test/code-intel/test-against-server.sh"

--- a/enterprise/dev/upload-build-logs.sh
+++ b/enterprise/dev/upload-build-logs.sh
@@ -30,4 +30,4 @@ echo "--- :go: Building sg"
 )
 
 echo "--- :arrow_up: Uploading logs (if build failed)"
-./ci_sg ci logs --out="$LOKI_URL" --state="failed" --branch="$BUILDKITE_BRANCH"
+./ci_sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="failed" --branch="$BUILDKITE_BRANCH"


### PR DESCRIPTION
Fixes sourcegraph/sourcegraph#26738 and clean `GITHUB_TOKEN` along the way.

- _Backend Integration tests_ requires a Github Enterprise token: available under `GHE_GITHUB_TOKEN` and assigned to `GITHUB_TOKEN` within the shell script running those.
- `GITHUB_TOKEN` is now by default a standard Github token unless overridden (see above).

