### PR TITLE
perf: Faster global settings lookup

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1895,6 +1895,7 @@ Contains security-relevant events with a long time horizon for storage.
  author_user_id | integer                  |           |          | 
 Indexes:
     "settings_pkey" PRIMARY KEY, btree (id)
+    "settings_global_id" btree (id DESC) WHERE user_id IS NULL AND org_id IS NULL
     "settings_org_id_idx" btree (org_id)
     "settings_user_id_idx" btree (user_id)
 Foreign-key constraints:

--- a/migrations/frontend/1528395925_settings_global_index.down.sql
+++ b/migrations/frontend/1528395925_settings_global_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS settings_global_id;
+
+COMMIT;

--- a/migrations/frontend/1528395925_settings_global_index.up.sql
+++ b/migrations/frontend/1528395925_settings_global_index.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS settings_global_id ON settings (id DESC) WHERE user_id IS NULL AND org_id IS NULL;
+
+COMMIT;


### PR DESCRIPTION
Saw this be "rather slow", so I spent 10 minutes investigating. Outcome: We now save around 2ms on reading global settings. Given this query is run pretty often, I think it's worth the additional very small index.

Before

```
                                                                      QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.58..6.92 rows=1 width=485) (actual time=1.907..1.908 rows=1 loops=1)
   ->  Nested Loop Left Join  (cost=0.58..11307.08 rows=1785 width=485) (actual time=1.906..1.906 rows=1 loops=1)
         ->  Index Scan Backward using settings_pkey on settings s  (cost=0.29..9517.39 rows=1785 width=485) (actual time=1.899..1.899 rows=1 loops=1)
               Filter: ((user_id IS NULL) AND (org_id IS NULL))
               Rows Removed by Filter: 3705
         ->  Index Scan using users_pkey on users  (cost=0.29..1.00 rows=1 width=12) (actual time=0.002..0.002 rows=0 loops=1)
               Index Cond: (id = s.author_user_id)
 Planning Time: 0.287 ms
 Execution Time: 1.932 ms
```

After

```
                                                                     QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.56..1.70 rows=1 width=485) (actual time=0.014..0.014 rows=1 loops=1)
   ->  Nested Loop Left Join  (cost=0.56..2032.29 rows=1785 width=485) (actual time=0.013..0.013 rows=1 loops=1)
         ->  Index Scan using erik_test_settings on settings s  (cost=0.28..242.61 rows=1785 width=485) (actual time=0.010..0.010 rows=1 loops=1)
         ->  Index Scan using users_pkey on users  (cost=0.29..1.00 rows=1 width=12) (actual time=0.001..0.001 rows=0 loops=1)
               Index Cond: (id = s.author_user_id)
 Planning Time: 0.283 ms
 Execution Time: 0.033 ms
(7 rows)
```