### PR TITLE
lsifstore: add API docs tests

### DIFF
--- a/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation_test.go
@@ -121,11 +121,11 @@ func TestWriteDocumentationPathInfo(t *testing.T) {
 
 	// Query the path info and snapshot it.
 	t.Run("query path info", func(t *testing.T) {
-		gotPage, err := store.DocumentationPathInfo(ctx, testBundleID, pathInfo.PathID)
+		got, err := store.DocumentationPathInfo(ctx, testBundleID, pathInfo.PathID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Equal(t, gotPage)
+		autogold.Equal(t, got)
 	})
 }
 

--- a/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation_test.go
@@ -1,0 +1,170 @@
+package lsifstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/hexops/valast"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// Note: You can `go test ./pkg -update` to update the expected `want` values in these tests.
+// See https://github.com/hexops/autogold for more information.
+
+func TestWriteDocumentationUpload(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := context.Background()
+
+	// Enable API docs search, so WriteDocumentationSearch is tested.
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				ApidocsSearchIndexing: "enabled",
+			},
+		},
+	})
+	defer conf.Mock(nil)
+
+	// Get a documentation page we can use to test writes to the DB.
+	tmpStore := populateTestStore(t)
+	page, err := tmpStore.DocumentationPage(ctx, testBundleID, "/github.com/sourcegraph/lsif-go/internal/index")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock the actual upload.
+	repo := &types.Repo{
+		Name:    "github.com/sourcegraph/lsif-go",
+		ID:      443, // arbitrary
+		Private: false,
+	}
+	upload := dbstore.Upload{
+		ID:             testBundleID,
+		RepositoryName: string(repo.Name),
+		RepositoryID:   int(repo.ID),
+		Indexer:        "lsif-go",
+	}
+	isDefaultBranch := true
+
+	db := dbtest.NewDB(t)
+	store := NewStore(db, &observation.TestContext)
+
+	{
+		tx, err := store.Transact(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Write the page.
+		repositoryNameID, languageNameID, err := tx.WriteDocumentationSearchPrework(ctx, upload, repo, isDefaultBranch)
+		if err != nil {
+			t.Fatal(err)
+		}
+		documentationPages := make(chan *precise.DocumentationPageData, 1)
+		documentationPages <- page
+		close(documentationPages)
+		err = tx.WriteDocumentationPages(ctx, upload, repo, isDefaultBranch, documentationPages, repositoryNameID, languageNameID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = tx.Done(err); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Query the page and snapshot it.
+	t.Run("query the page", func(t *testing.T) {
+		gotPage, err := store.DocumentationPage(ctx, testBundleID, page.Tree.PathID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		autogold.Equal(t, gotPage)
+	})
+}
+
+func TestWriteDocumentationPathInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := context.Background()
+
+	db := dbtest.NewDB(t)
+	store := NewStore(db, &observation.TestContext)
+
+	pathInfo := &precise.DocumentationPathInfoData{
+		PathID:  "/github.com/sourcegraph/lsif-go/internal",
+		IsIndex: true,
+		Children: []string{
+			"/github.com/sourcegraph/lsif-go/internal/gomod",
+			"/github.com/sourcegraph/lsif-go/internal/index",
+		},
+	}
+
+	// Write documentation path info.
+	documentationPathInfo := make(chan *precise.DocumentationPathInfoData, 1)
+	documentationPathInfo <- pathInfo
+	close(documentationPathInfo)
+	err := store.WriteDocumentationPathInfo(ctx, testBundleID, documentationPathInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Query the path info and snapshot it.
+	t.Run("query path info", func(t *testing.T) {
+		gotPage, err := store.DocumentationPathInfo(ctx, testBundleID, pathInfo.PathID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		autogold.Equal(t, gotPage)
+	})
+}
+
+func TestWriteDocumentationMappings(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := context.Background()
+
+	db := dbtest.NewDB(t)
+	store := NewStore(db, &observation.TestContext)
+
+	filePath := "internal/index/indexer.go"
+	mapping := precise.DocumentationMapping{
+		ResultID: 1337, // arbitrary for sake of testing
+		PathID:   "/github.com/sourcegraph/lsif-go/internal/index#NewIndexer",
+		FilePath: &filePath,
+	}
+
+	// Write documentation mapping.
+	documentationMappings := make(chan precise.DocumentationMapping, 1)
+	documentationMappings <- mapping
+	close(documentationMappings)
+	err := store.WriteDocumentationMappings(ctx, testBundleID, documentationMappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm lookup from PathID -> result ID works
+	gotID, err := store.documentationPathIDToID(ctx, testBundleID, mapping.PathID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	autogold.Want("ID", precise.ID("1337")).Equal(t, gotID)
+
+	// Confirm lookup from PathID -> filepath works
+	gotFilePath, err := store.documentationPathIDToFilePath(ctx, testBundleID, mapping.PathID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	autogold.Want("FilePath", valast.Addr("internal/index/indexer.go").(*string)).Equal(t, gotFilePath)
+}

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation_test.go
@@ -1,0 +1,138 @@
+package lsifstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
+)
+
+// Note: You can `go test ./pkg -update` to update the expected `want` values in these tests.
+// See https://github.com/hexops/autogold for more information.
+
+func TestDocumentationPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	store := populateTestStore(t)
+
+	got, err := store.DocumentationPage(context.Background(), testBundleID, "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Just a snapshot of the output so we know when anything changes.
+	autogold.Equal(t, got)
+}
+
+func TestDocumentationPathInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	store := populateTestStore(t)
+
+	testCases := []struct {
+		pathID string
+		want   autogold.Value
+	}{
+		{"/github.com/sourcegraph/lsif-go", autogold.Want("/github.com/sourcegraph/lsif-go", &precise.DocumentationPathInfoData{
+			PathID:  "/github.com/sourcegraph/lsif-go",
+			IsIndex: true,
+			Children: []string{
+				"/github.com/sourcegraph/lsif-go/cmd",
+				"/github.com/sourcegraph/lsif-go/internal",
+			},
+		})},
+		{"/github.com/sourcegraph/lsif-go/cmd", autogold.Want("/github.com/sourcegraph/lsif-go/cmd", &precise.DocumentationPathInfoData{
+			PathID:  "/github.com/sourcegraph/lsif-go/cmd",
+			IsIndex: true,
+			Children: []string{
+				"/github.com/sourcegraph/lsif-go/cmd/lsif-go",
+			},
+		})},
+		{"/github.com/sourcegraph/lsif-go/internal", autogold.Want("/github.com/sourcegraph/lsif-go/internal", &precise.DocumentationPathInfoData{
+			PathID:  "/github.com/sourcegraph/lsif-go/internal",
+			IsIndex: true,
+			Children: []string{
+				"/github.com/sourcegraph/lsif-go/internal/gomod",
+				"/github.com/sourcegraph/lsif-go/internal/index",
+			},
+		})},
+		{"/github.com/sourcegraph/lsif-go/internal/index", autogold.Want("/github.com/sourcegraph/lsif-go/internal/index", &precise.DocumentationPathInfoData{
+			PathID:   "/github.com/sourcegraph/lsif-go/internal/index",
+			Children: []string{},
+		})},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			got, err := store.DocumentationPathInfo(context.Background(), testBundleID, tc.pathID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.want.Equal(t, got)
+		})
+	}
+}
+
+func TestDocumentationDefinitions(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	store := populateTestStore(t)
+
+	testCases := []autogold.Value{
+		autogold.Want("/github.com/sourcegraph/lsif-go/internal/index#NewIndexer", []Location{Location{
+			DumpID: 1,
+			Path:   "internal/index/indexer.go",
+			Range: Range{
+				Start: Position{
+					Line:      62,
+					Character: 5,
+				},
+				End: Position{
+					Line:      62,
+					Character: 15,
+				},
+			},
+		}}),
+		autogold.Want("/github.com/sourcegraph/lsif-go/internal/gomod#versionPattern", []Location{Location{
+			DumpID: 1,
+			Path:   "internal/gomod/module.go",
+			Range: Range{
+				Start: Position{
+					Line:      84,
+					Character: 4,
+				},
+				End: Position{
+					Line:      84,
+					Character: 18,
+				},
+			},
+		}}),
+		autogold.Want("/github.com/sourcegraph/lsif-go/cmd/lsif-go#main", []Location{Location{
+			DumpID: 1,
+			Path:   "cmd/lsif-go/main.go",
+			Range: Range{
+				Start: Position{
+					Line:      26,
+					Character: 5,
+				},
+				End: Position{
+					Line:      26,
+					Character: 9,
+				},
+			},
+		}}),
+	}
+	for _, want := range testCases {
+		t.Run(want.Name(), func(t *testing.T) {
+			pathID := want.Name()
+			got, _, err := store.DocumentationDefinitions(context.Background(), testBundleID, pathID, 10, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want.Equal(t, got)
+		})
+	}
+}

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation_test.go
@@ -82,7 +82,7 @@ func TestDocumentationDefinitions(t *testing.T) {
 	store := populateTestStore(t)
 
 	testCases := []autogold.Value{
-		autogold.Want("/github.com/sourcegraph/lsif-go/internal/index#NewIndexer", []Location{Location{
+		autogold.Want("/github.com/sourcegraph/lsif-go/internal/index#NewIndexer", []Location{{
 			DumpID: 1,
 			Path:   "internal/index/indexer.go",
 			Range: Range{
@@ -96,7 +96,7 @@ func TestDocumentationDefinitions(t *testing.T) {
 				},
 			},
 		}}),
-		autogold.Want("/github.com/sourcegraph/lsif-go/internal/gomod#versionPattern", []Location{Location{
+		autogold.Want("/github.com/sourcegraph/lsif-go/internal/gomod#versionPattern", []Location{{
 			DumpID: 1,
 			Path:   "internal/gomod/module.go",
 			Range: Range{
@@ -110,7 +110,7 @@ func TestDocumentationDefinitions(t *testing.T) {
 				},
 			},
 		}}),
-		autogold.Want("/github.com/sourcegraph/lsif-go/cmd/lsif-go#main", []Location{Location{
+		autogold.Want("/github.com/sourcegraph/lsif-go/cmd/lsif-go#main", []Location{{
 			DumpID: 1,
 			Path:   "cmd/lsif-go/main.go",
 			Range: Range{

--- a/enterprise/internal/codeintel/stores/lsifstore/testdata/TestDocumentationPage.golden
+++ b/enterprise/internal/codeintel/stores/lsifstore/testdata/TestDocumentationPage.golden
@@ -1,0 +1,2267 @@
+&precise.DocumentationPageData{Tree: &precise.DocumentationNode{
+	PathID: "/",
+	Documentation: protocol.Documentation{
+		Identifier: "protocol",
+		NewPage:    true,
+		Tags: []protocol.Tag{
+			protocol.Tag("package"),
+		},
+	},
+	Label: protocol.MarkupContent{
+		Kind:  protocol.MarkupKind("plaintext"),
+		Value: "Package protocol",
+	},
+	Detail: protocol.MarkupContent{Kind: protocol.MarkupKind("markdown")},
+	Children: []precise.DocumentationNodeChild{
+		precise.DocumentationNodeChild{PathID: "/github.com"},
+		precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+			PathID: "/#const",
+			Documentation: protocol.Documentation{
+				Identifier: "const",
+				Tags:       []protocol.Tag{},
+			},
+			Label: protocol.MarkupContent{
+				Kind:  protocol.MarkupKind("plaintext"),
+				Value: "Constants",
+			},
+			Detail: protocol.MarkupContent{Kind: protocol.MarkupKind("plaintext")},
+			Children: []precise.DocumentationNodeChild{
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeContains",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeContains",
+						SearchKey:  "protocol.EdgeContains",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeContains",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeContains EdgeLabel = \"contains\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeItem",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeItem",
+						SearchKey:  "protocol.EdgeItem",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeItem",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeItem EdgeLabel = \"item\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeMoniker",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeMoniker",
+						SearchKey:  "protocol.EdgeMoniker",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeMoniker",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeMoniker EdgeLabel = \"moniker\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeNext",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeNext",
+						SearchKey:  "protocol.EdgeNext",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeNext",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeNext EdgeLabel = \"next\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeNextMoniker",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeNextMoniker",
+						SearchKey:  "protocol.EdgeNextMoniker",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeNextMoniker",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeNextMoniker EdgeLabel = \"nextMoniker\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgePackageInformation",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgePackageInformation",
+						SearchKey:  "protocol.EdgePackageInformation",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgePackageInformation",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgePackageInformation EdgeLabel = \"packageInformation\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentDeclaration",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentDeclaration",
+						SearchKey:  "protocol.EdgeTextDocumentDeclaration",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentDeclaration",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentDeclaration EdgeLabel = \"textDocument/declaration\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentDefinition",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentDefinition",
+						SearchKey:  "protocol.EdgeTextDocumentDefinition",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentDefinition",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentDefinition EdgeLabel = \"textDocument/definition\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentDiagnostic",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentDiagnostic",
+						SearchKey:  "protocol.EdgeTextDocumentDiagnostic",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentDiagnostic",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentDiagnostic EdgeLabel = \"textDocument/diagnostic\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentDocumentLink",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentDocumentLink",
+						SearchKey:  "protocol.EdgeTextDocumentDocumentLink",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentDocumentLink",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentDocumentLink EdgeLabel = \"textDocument/documentLink\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentDocumentSymbol",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentDocumentSymbol",
+						SearchKey:  "protocol.EdgeTextDocumentDocumentSymbol",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentDocumentSymbol",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentDocumentSymbol EdgeLabel = \"textDocument/documentSymbol\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentFoldingRange",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentFoldingRange",
+						SearchKey:  "protocol.EdgeTextDocumentFoldingRange",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentFoldingRange",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentFoldingRange EdgeLabel = \"textDocument/foldingRange\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentHover",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentHover",
+						SearchKey:  "protocol.EdgeTextDocumentHover",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentHover",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentHover EdgeLabel = \"textDocument/hover\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentImplementation",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentImplementation",
+						SearchKey:  "protocol.EdgeTextDocumentImplementation",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentImplementation",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentImplementation EdgeLabel = \"textDocument/implementation\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentReferences",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentReferences",
+						SearchKey:  "protocol.EdgeTextDocumentReferences",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentReferences",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentReferences EdgeLabel = \"textDocument/references\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeTextDocumentTypeDefinition",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeTextDocumentTypeDefinition",
+						SearchKey:  "protocol.EdgeTextDocumentTypeDefinition",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const EdgeTextDocumentTypeDefinition",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst EdgeTextDocumentTypeDefinition EdgeLabel = \"textDocument/typeDefinition\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#ElementEdge",
+					Documentation: protocol.Documentation{
+						Identifier: "ElementEdge",
+						SearchKey:  "protocol.ElementEdge",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const ElementEdge",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst ElementEdge ElementType = \"edge\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#ElementVertex",
+					Documentation: protocol.Documentation{
+						Identifier: "ElementVertex",
+						SearchKey:  "protocol.ElementVertex",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const ElementVertex",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst ElementVertex ElementType = \"vertex\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#PositionEncoding",
+					Documentation: protocol.Documentation{
+						Identifier: "PositionEncoding",
+						SearchKey:  "protocol.PositionEncoding",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const PositionEncoding",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst PositionEncoding = \"utf-16\"\n```\n\nPositionEncoding is the encoding used to compute line and character values in positions and ranges. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Version",
+					Documentation: protocol.Documentation{
+						Identifier: "Version",
+						SearchKey:  "protocol.Version",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const Version",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst Version = \"0.4.3\"\n```\n\nVersion represnets the current LSIF version of implementation. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexDeclarationResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexDeclarationResult",
+						SearchKey:  "protocol.VertexDeclarationResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexDeclarationResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexDeclarationResult VertexLabel = \"declarationResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexDefinitionResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexDefinitionResult",
+						SearchKey:  "protocol.VertexDefinitionResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexDefinitionResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexDefinitionResult VertexLabel = \"definitionResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexDianosticResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexDianosticResult",
+						SearchKey:  "protocol.VertexDianosticResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexDianosticResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexDianosticResult VertexLabel = \"diagnosticResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexDocument",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexDocument",
+						SearchKey:  "protocol.VertexDocument",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexDocument",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexDocument VertexLabel = \"document\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexDocumentLinkResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexDocumentLinkResult",
+						SearchKey:  "protocol.VertexDocumentLinkResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexDocumentLinkResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexDocumentLinkResult VertexLabel = \"documentLinkResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexDocumentSymbolResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexDocumentSymbolResult",
+						SearchKey:  "protocol.VertexDocumentSymbolResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexDocumentSymbolResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexDocumentSymbolResult VertexLabel = \"documentSymbolResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexEvent",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexEvent",
+						SearchKey:  "protocol.VertexEvent",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexEvent",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexEvent VertexLabel = \"$event\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexFoldingRangeResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexFoldingRangeResult",
+						SearchKey:  "protocol.VertexFoldingRangeResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexFoldingRangeResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexFoldingRangeResult VertexLabel = \"foldingRangeResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexHoverResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexHoverResult",
+						SearchKey:  "protocol.VertexHoverResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexHoverResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexHoverResult VertexLabel = \"hoverResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexImplementationResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexImplementationResult",
+						SearchKey:  "protocol.VertexImplementationResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexImplementationResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexImplementationResult VertexLabel = \"implementationResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexLocation",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexLocation",
+						SearchKey:  "protocol.VertexLocation",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexLocation",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexLocation VertexLabel = \"location\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexMetaData",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexMetaData",
+						SearchKey:  "protocol.VertexMetaData",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexMetaData",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexMetaData VertexLabel = \"metaData\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexMoniker",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexMoniker",
+						SearchKey:  "protocol.VertexMoniker",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexMoniker",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexMoniker VertexLabel = \"moniker\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexPackageInformation",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexPackageInformation",
+						SearchKey:  "protocol.VertexPackageInformation",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexPackageInformation",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexPackageInformation VertexLabel = \"packageInformation\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexProject",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexProject",
+						SearchKey:  "protocol.VertexProject",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexProject",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexProject VertexLabel = \"project\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexRange",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexRange",
+						SearchKey:  "protocol.VertexRange",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexRange",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexRange VertexLabel = \"range\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexReferenceResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexReferenceResult",
+						SearchKey:  "protocol.VertexReferenceResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexReferenceResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexReferenceResult VertexLabel = \"referenceResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexResultSet",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexResultSet",
+						SearchKey:  "protocol.VertexResultSet",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexResultSet",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexResultSet VertexLabel = \"resultSet\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexTypeDefinitionResult",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexTypeDefinitionResult",
+						SearchKey:  "protocol.VertexTypeDefinitionResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("constant"),
+							protocol.Tag("string"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "const VertexTypeDefinitionResult",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nconst VertexTypeDefinitionResult VertexLabel = \"typeDefinitionResult\"\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+			},
+		}},
+		precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+			PathID: "/#type",
+			Documentation: protocol.Documentation{
+				Identifier: "type",
+				Tags:       []protocol.Tag{},
+			},
+			Label: protocol.MarkupContent{
+				Kind:  protocol.MarkupKind("plaintext"),
+				Value: "Types",
+			},
+			Detail: protocol.MarkupContent{Kind: protocol.MarkupKind("plaintext")},
+			Children: []precise.DocumentationNodeChild{
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Contains",
+					Documentation: protocol.Documentation{
+						Identifier: "Contains",
+						SearchKey:  "protocol.Contains",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Contains struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Contains struct {\n\tEdge\n\tOutV string   `json:\"outV\"`\n\tInVs []string `json:\"inVs\"`\n}\n```\n\nContains is an edge object that represents 1:n \"contains\" relation. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewContains",
+						Documentation: protocol.Documentation{
+							Identifier: "NewContains",
+							SearchKey:  "protocol.NewContains",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewContains(id, outV string, inVs []string) *Contains",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewContains(id, outV string, inVs []string) *Contains\n```\n\nNewContains returns a new Contains object with given ID and vertices information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#DefinitionResult",
+					Documentation: protocol.Documentation{
+						Identifier: "DefinitionResult",
+						SearchKey:  "protocol.DefinitionResult",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type DefinitionResult struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype DefinitionResult struct {\n\tVertex\n}\n```\n\nDefinitionResult connects a definition that is spread over multiple ranges or multiple documents. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewDefinitionResult",
+						Documentation: protocol.Documentation{
+							Identifier: "NewDefinitionResult",
+							SearchKey:  "protocol.NewDefinitionResult",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewDefinitionResult(id string) *DefinitionResult",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewDefinitionResult(id string) *DefinitionResult\n```\n\nNewDefinitionResult returns a new DefinitionResult object with given ID. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Document",
+					Documentation: protocol.Documentation{
+						Identifier: "Document",
+						SearchKey:  "protocol.Document",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Document struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Document struct {\n\tVertex\n\t// The URI indicates the location of the document.\n\tURI string `json:\"uri\"`\n\t// The language identifier of the document.\n\tLanguageID string `json:\"languageId\"`\n\t// The contents of the the document.\n\tContents string `json:\"contents,omitempty\"`\n}\n```\n\nDocument is a vertex of document in the project. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewDocument",
+						Documentation: protocol.Documentation{
+							Identifier: "NewDocument",
+							SearchKey:  "protocol.NewDocument",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewDocument(id, languageID, uri string, contents []byte) *Document",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewDocument(id, languageID, uri string, contents []byte) *Document\n```\n\nNewDocument returns a new Document object with given ID, URI and contents. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Edge",
+					Documentation: protocol.Documentation{
+						Identifier: "Edge",
+						SearchKey:  "protocol.Edge",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Edge struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Edge struct {\n\tElement\n\t// The kind of edge in the graph.\n\tLabel EdgeLabel `json:\"label\"`\n}\n```\n\nEdge contains information of an edge in the graph. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#EdgeLabel",
+					Documentation: protocol.Documentation{
+						Identifier: "EdgeLabel",
+						SearchKey:  "protocol.EdgeLabel",
+						Tags:       []protocol.Tag{protocol.Tag("string")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type EdgeLabel string",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype EdgeLabel string\n```\n\nEdgeLabel represents the purpose of an edge. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Element",
+					Documentation: protocol.Documentation{
+						Identifier: "Element",
+						SearchKey:  "protocol.Element",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Element struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Element struct {\n\t// The unique identifier of this element within the scope of project.\n\tID string `json:\"id\"`\n\t// The kind of element in the graph.\n\tType ElementType `json:\"type\"`\n}\n```\n\nElement contains basic information of an element in the graph. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#ElementType",
+					Documentation: protocol.Documentation{
+						Identifier: "ElementType",
+						SearchKey:  "protocol.ElementType",
+						Tags:       []protocol.Tag{protocol.Tag("string")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type ElementType string",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype ElementType string\n```\n\nElementType represents the kind of element. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Event",
+					Documentation: protocol.Documentation{
+						Identifier: "Event",
+						SearchKey:  "protocol.Event",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Event struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Event struct {\n\tVertex\n\t// The kind of event (begin or end).\n\tKind string `json:\"kind\"`\n\t// The type of element this event describes (project or document).\n\tScope string `json:\"scope\"`\n\t// The identifier of the data beginning or ending.\n\tData string `json:\"data\"`\n}\n```\n\nEvent is optional metadata emitted to give hints to consumers about the beginning and ending of new \"socpes\" (e.g. a project or document). \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewEvent",
+						Documentation: protocol.Documentation{
+							Identifier: "NewEvent",
+							SearchKey:  "protocol.NewEvent",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewEvent(id, kind, scope, data string) *Event",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewEvent(id, kind, scope, data string) *Event\n```\n\nNewEvent returns a new Event object with the given ID, kind, scope, and data information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#HoverResult",
+					Documentation: protocol.Documentation{
+						Identifier: "HoverResult",
+						SearchKey:  "protocol.HoverResult",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type HoverResult struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype HoverResult struct {\n\tVertex\n\t// The result contents as the hover information.\n\tResult hoverResult `json:\"result\"`\n}\n```\n\nHoverResult connects a hover that is spread over multiple ranges or multiple documents. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewHoverResult",
+						Documentation: protocol.Documentation{
+							Identifier: "NewHoverResult",
+							SearchKey:  "protocol.NewHoverResult",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewHoverResult(id string, contents []MarkedString) *HoverResult",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewHoverResult(id string, contents []MarkedString) *HoverResult\n```\n\nNewHoverResult returns a new HoverResult object with given ID, signature and extra contents. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Item",
+					Documentation: protocol.Documentation{
+						Identifier: "Item",
+						SearchKey:  "protocol.Item",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Item struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Item struct {\n\tEdge\n\tOutV string   `json:\"outV\"`\n\tInVs []string `json:\"inVs\"`\n\t// The document the item belongs to.\n\tDocument string `json:\"document\"`\n\t// The relationship property of the item.\n\tProperty string `json:\"property,omitempty\"`\n}\n```\n\nItem is an edge object that represents \"item\" relation. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewItem",
+							Documentation: protocol.Documentation{
+								Identifier: "NewItem",
+								SearchKey:  "protocol.NewItem",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewItem(id, outV string, inVs []string, document string) *Item",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewItem(id, outV string, inVs []string, document string) *Item\n```\n\nNewItem returns a new Item object with given ID and vertices information. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewItemOfDefinitions",
+							Documentation: protocol.Documentation{
+								Identifier: "NewItemOfDefinitions",
+								SearchKey:  "protocol.NewItemOfDefinitions",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewItemOfDefinitions(id, outV string, inVs []string, document string) *Item",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewItemOfDefinitions(id, outV string, inVs []string, document string) *Item\n```\n\nNewItemOfDefinitions returns a new Item object with given ID, vertices and document informationand in \"definitions\" relationship. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewItemOfReferences",
+							Documentation: protocol.Documentation{
+								Identifier: "NewItemOfReferences",
+								SearchKey:  "protocol.NewItemOfReferences",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewItemOfReferences(id, outV string, inVs []string, document string) *Item",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewItemOfReferences(id, outV string, inVs []string, document string) *Item\n```\n\nNewItemOfReferences returns a new Item object with given ID, vertices and document informationand in \"references\" relationship. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewItemWithProperty",
+							Documentation: protocol.Documentation{
+								Identifier: "NewItemWithProperty",
+								SearchKey:  "protocol.NewItemWithProperty",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewItemWithProperty(id, outV string, inVs []string, document, property string) *Item",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewItemWithProperty(id, outV string, inVs []string, document, property string) *Item\n```\n\nNewItemWithProperty returns a new Item object with given ID, vertices, document and property information. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+					},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#MarkedString",
+					Documentation: protocol.Documentation{
+						Identifier: "MarkedString",
+						SearchKey:  "protocol.MarkedString",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type MarkedString protocol.markedString",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype MarkedString markedString\n```\n\nMarkedString is the object to describe marked string. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewMarkedString",
+							Documentation: protocol.Documentation{
+								Identifier: "NewMarkedString",
+								SearchKey:  "protocol.NewMarkedString",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewMarkedString(s, languageID string) MarkedString",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewMarkedString(s, languageID string) MarkedString\n```\n\nNewMarkedString returns a MarkedString with given string in language \"go\". \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#RawMarkedString",
+							Documentation: protocol.Documentation{
+								Identifier: "RawMarkedString",
+								SearchKey:  "protocol.RawMarkedString",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func RawMarkedString(s string) MarkedString",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc RawMarkedString(s string) MarkedString\n```\n\nRawMarkedString returns a MarkedString consisting of only a raw string (i.e., \"foo\" instead of {\"value\":\"foo\", \"language\":\"bar\"}). \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#MarkedString.MarshalJSON",
+							Documentation: protocol.Documentation{
+								Identifier: "MarkedString.MarshalJSON",
+								SearchKey:  "protocol.MarkedString.MarshalJSON",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (m MarkedString) MarshalJSON() ([]byte, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (m MarkedString) MarshalJSON() ([]byte, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#MarkedString.UnmarshalJSON",
+							Documentation: protocol.Documentation{
+								Identifier: "MarkedString.UnmarshalJSON",
+								SearchKey:  "protocol.MarkedString.UnmarshalJSON",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (m *MarkedString) UnmarshalJSON(data []byte) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (m *MarkedString) UnmarshalJSON(data []byte) error\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+					},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#MetaData",
+					Documentation: protocol.Documentation{
+						Identifier: "MetaData",
+						SearchKey:  "protocol.MetaData",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type MetaData struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype MetaData struct {\n\tVertex\n\t// The version of the LSIF format using semver notation.\n\tVersion string `json:\"version\"`\n\t// The project root (in form of an URI) used to compute this dump.\n\tProjectRoot string `json:\"projectRoot\"`\n\t// The string encoding used to compute line and character values in\n\t// positions and ranges. Currently only 'utf-16' is support due to the\n\t// limitations in LSP.\n\tPositionEncoding string `json:\"positionEncoding\"`\n\t// The information about the tool that created the dump.\n\tToolInfo ToolInfo `json:\"toolInfo\"`\n}\n```\n\nMetaData contains basic information about the dump. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewMetaData",
+						Documentation: protocol.Documentation{
+							Identifier: "NewMetaData",
+							SearchKey:  "protocol.NewMetaData",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewMetaData(id, root string, info ToolInfo) *MetaData",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewMetaData(id, root string, info ToolInfo) *MetaData\n```\n\nNewMetaData returns a new MetaData object with given ID, project root and tool information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Moniker",
+					Documentation: protocol.Documentation{
+						Identifier: "Moniker",
+						SearchKey:  "protocol.Moniker",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Moniker struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Moniker struct {\n\tVertex\n\t// The kind of moniker (e.g. local, export, import).\n\tKind string `json:\"kind\"`\n\t// The kind of moniker, usually a language or package manager.\n\tScheme string `json:\"scheme\"`\n\t// The unique moniker identifier.\n\tIdentifier string `json:\"identifier\"`\n}\n```\n\nMoniker describes a unique name for a result set or range. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewMoniker",
+						Documentation: protocol.Documentation{
+							Identifier: "NewMoniker",
+							SearchKey:  "protocol.NewMoniker",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewMoniker(id, kind, scheme, identifier string) *Moniker",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewMoniker(id, kind, scheme, identifier string) *Moniker\n```\n\nNewMoniker returns a new Moniker wtih the given ID, kind, scheme, and identifier. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#MonikerEdge",
+					Documentation: protocol.Documentation{
+						Identifier: "MonikerEdge",
+						SearchKey:  "protocol.MonikerEdge",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type MonikerEdge struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype MonikerEdge struct {\n\tEdge\n\tOutV string `json:\"outV\"`\n\tInV  string `json:\"inV\"`\n}\n```\n\nMonikerEdge connects a moniker to a range or result set. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewMonikerEdge",
+						Documentation: protocol.Documentation{
+							Identifier: "NewMonikerEdge",
+							SearchKey:  "protocol.NewMonikerEdge",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewMonikerEdge(id, outV, inV string) *MonikerEdge",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewMonikerEdge(id, outV, inV string) *MonikerEdge\n```\n\nNewMonikerEdge returns a new MonikerEdge with the given ID and vertices. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Next",
+					Documentation: protocol.Documentation{
+						Identifier: "Next",
+						SearchKey:  "protocol.Next",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Next struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Next struct {\n\tEdge\n\tOutV string `json:\"outV\"`\n\tInV  string `json:\"inV\"`\n}\n```\n\nNext is an edge object that represents \"next\" relation. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewNext",
+						Documentation: protocol.Documentation{
+							Identifier: "NewNext",
+							SearchKey:  "protocol.NewNext",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewNext(id, outV, inV string) *Next",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewNext(id, outV, inV string) *Next\n```\n\nNewNext returns a new Next object with given ID and vertices information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#NextMonikerEdge",
+					Documentation: protocol.Documentation{
+						Identifier: "NextMonikerEdge",
+						SearchKey:  "protocol.NextMonikerEdge",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type NextMonikerEdge struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype NextMonikerEdge struct {\n\tEdge\n\tOutV string `json:\"outV\"`\n\tInV  string `json:\"inV\"`\n}\n```\n\nNextMonikerEdge connects a moniker to another moniker. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewNextMonikerEdge",
+						Documentation: protocol.Documentation{
+							Identifier: "NewNextMonikerEdge",
+							SearchKey:  "protocol.NewNextMonikerEdge",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewNextMonikerEdge(id, outV, inV string) *NextMonikerEdge",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewNextMonikerEdge(id, outV, inV string) *NextMonikerEdge\n```\n\nNewNextMonikerEdge returns a new NextMonikerEdge with the given ID and vertices. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#PackageInformation",
+					Documentation: protocol.Documentation{
+						Identifier: "PackageInformation",
+						SearchKey:  "protocol.PackageInformation",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type PackageInformation struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype PackageInformation struct {\n\tVertex\n\t// The name of the package.\n\tName string `json:\"name\"`\n\t// The package manager.\n\tManager string `json:\"manager\"`\n\t// The version of the package.\n\tVersion string `json:\"version\"`\n}\n```\n\nPackageInformation describes a package for a moniker. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewPackageInformation",
+						Documentation: protocol.Documentation{
+							Identifier: "NewPackageInformation",
+							SearchKey:  "protocol.NewPackageInformation",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewPackageInformation(id, name, manager, version string) *PackageInformation",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewPackageInformation(id, name, manager, version string) *PackageInformation\n```\n\nNewPackageInformation returns a new PackageInformation with the given ID, name, manager, and version. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#PackageInformationEdge",
+					Documentation: protocol.Documentation{
+						Identifier: "PackageInformationEdge",
+						SearchKey:  "protocol.PackageInformationEdge",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type PackageInformationEdge struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype PackageInformationEdge struct {\n\tEdge\n\tOutV string `json:\"outV\"`\n\tInV  string `json:\"inV\"`\n}\n```\n\nPackageInformationEdge connects a moniker and a package information vertex. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewPackageInformationEdge",
+						Documentation: protocol.Documentation{
+							Identifier: "NewPackageInformationEdge",
+							SearchKey:  "protocol.NewPackageInformationEdge",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewPackageInformationEdge(id, outV, inV string) *PackageInformationEdge",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewPackageInformationEdge(id, outV, inV string) *PackageInformationEdge\n```\n\nNewPackageInformationEdge returns a new PackageInformationEdge with the given ID and vertices. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Pos",
+					Documentation: protocol.Documentation{
+						Identifier: "Pos",
+						SearchKey:  "protocol.Pos",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Pos struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Pos struct {\n\t// The line number (0-based index)\n\tLine int `json:\"line\"`\n\t// The column of the character (0-based index)\n\tCharacter int `json:\"character\"`\n}\n```\n\nPos contains the precise position information. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Project",
+					Documentation: protocol.Documentation{
+						Identifier: "Project",
+						SearchKey:  "protocol.Project",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Project struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Project struct {\n\tVertex\n\t// The kind of language of the dump.\n\tKind string `json:\"kind\"`\n}\n```\n\nProject declares the language of the dump. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewProject",
+						Documentation: protocol.Documentation{
+							Identifier: "NewProject",
+							SearchKey:  "protocol.NewProject",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewProject(id string, languageID string) *Project",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewProject(id string, languageID string) *Project\n```\n\nNewProject returns a new Project object with given ID. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Range",
+					Documentation: protocol.Documentation{
+						Identifier: "Range",
+						SearchKey:  "protocol.Range",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Range struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Range struct {\n\tVertex\n\t// The start position of the range.\n\tStart Pos `json:\"start\"`\n\t// The end position of the range.\n\tEnd Pos `json:\"end\"`\n}\n```\n\nRange contains range information of a vertex object. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewRange",
+						Documentation: protocol.Documentation{
+							Identifier: "NewRange",
+							SearchKey:  "protocol.NewRange",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewRange(id string, start, end Pos) *Range",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewRange(id string, start, end Pos) *Range\n```\n\nNewRange returns a new Range object with given ID and position information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#ReferenceResult",
+					Documentation: protocol.Documentation{
+						Identifier: "ReferenceResult",
+						SearchKey:  "protocol.ReferenceResult",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type ReferenceResult struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype ReferenceResult struct {\n\tVertex\n}\n```\n\nReferenceResult acts as a hub to be able to store reference information common to a set of ranges. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#ResultSet",
+					Documentation: protocol.Documentation{
+						Identifier: "ResultSet",
+						SearchKey:  "protocol.ResultSet",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type ResultSet struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype ResultSet struct {\n\tVertex\n}\n```\n\nResultSet acts as a hub to be able to store information common to a set of ranges. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewReferenceResult",
+							Documentation: protocol.Documentation{
+								Identifier: "NewReferenceResult",
+								SearchKey:  "protocol.NewReferenceResult",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewReferenceResult(id string) *ResultSet",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewReferenceResult(id string) *ResultSet\n```\n\nNewReferenceResult returns a new ReferenceResult object with given ID. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewResultSet",
+							Documentation: protocol.Documentation{
+								Identifier: "NewResultSet",
+								SearchKey:  "protocol.NewResultSet",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewResultSet(id string) *ResultSet",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewResultSet(id string) *ResultSet\n```\n\nNewResultSet returns a new ResultSet object with given ID. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+					},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#TextDocumentDefinition",
+					Documentation: protocol.Documentation{
+						Identifier: "TextDocumentDefinition",
+						SearchKey:  "protocol.TextDocumentDefinition",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type TextDocumentDefinition struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype TextDocumentDefinition struct {\n\tEdge\n\tOutV string `json:\"outV\"`\n\tInV  string `json:\"inV\"`\n}\n```\n\nTextDocumentDefinition is an edge object that represents \"textDocument/definition\" relation. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewTextDocumentDefinition",
+						Documentation: protocol.Documentation{
+							Identifier: "NewTextDocumentDefinition",
+							SearchKey:  "protocol.NewTextDocumentDefinition",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewTextDocumentDefinition(id, outV, inV string) *TextDocumentDefinition",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewTextDocumentDefinition(id, outV, inV string) *TextDocumentDefinition\n```\n\nNewTextDocumentDefinition returns a new TextDocumentDefinition object with given ID and vertices information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#TextDocumentHover",
+					Documentation: protocol.Documentation{
+						Identifier: "TextDocumentHover",
+						SearchKey:  "protocol.TextDocumentHover",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type TextDocumentHover struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype TextDocumentHover struct {\n\tEdge\n\tOutV string `json:\"outV\"`\n\tInV  string `json:\"inV\"`\n}\n```\n\nTextDocumentHover is an edge object that represents \"textDocument/hover\" relation. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewTextDocumentHover",
+						Documentation: protocol.Documentation{
+							Identifier: "NewTextDocumentHover",
+							SearchKey:  "protocol.NewTextDocumentHover",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewTextDocumentHover(id, outV, inV string) *TextDocumentHover",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewTextDocumentHover(id, outV, inV string) *TextDocumentHover\n```\n\nNewTextDocumentHover returns a new TextDocumentHover object with given ID and vertices information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#TextDocumentReferences",
+					Documentation: protocol.Documentation{
+						Identifier: "TextDocumentReferences",
+						SearchKey:  "protocol.TextDocumentReferences",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type TextDocumentReferences struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype TextDocumentReferences struct {\n\tEdge\n\tOutV string `json:\"outV\"`\n\tInV  string `json:\"inV\"`\n}\n```\n\nTextDocumentReferences is an edge object that represents \"textDocument/references\" relation. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/#NewTextDocumentReferences",
+						Documentation: protocol.Documentation{
+							Identifier: "NewTextDocumentReferences",
+							SearchKey:  "protocol.NewTextDocumentReferences",
+							Tags:       []protocol.Tag{protocol.Tag("function")},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewTextDocumentReferences(id, outV, inV string) *TextDocumentReferences",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewTextDocumentReferences(id, outV, inV string) *TextDocumentReferences\n```\n\nNewTextDocumentReferences returns a new TextDocumentReferences object with given ID and vertices information. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#ToolInfo",
+					Documentation: protocol.Documentation{
+						Identifier: "ToolInfo",
+						SearchKey:  "protocol.ToolInfo",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type ToolInfo struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype ToolInfo struct {\n\t// The name of the tool.\n\tName string `json:\"name\"`\n\t// The version of the tool.\n\tVersion string `json:\"version,omitempty\"`\n\t// The arguments passed to the tool.\n\tArgs []string `json:\"args,omitempty\"`\n}\n```\n\nToolInfo contains information about the tool that created the dump. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Vertex",
+					Documentation: protocol.Documentation{
+						Identifier: "Vertex",
+						SearchKey:  "protocol.Vertex",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Vertex struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Vertex struct {\n\tElement\n\t// The kind of vertex in the graph.\n\tLabel VertexLabel `json:\"label\"`\n}\n```\n\nVertex contains information of a vertex in the graph. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#VertexLabel",
+					Documentation: protocol.Documentation{
+						Identifier: "VertexLabel",
+						SearchKey:  "protocol.VertexLabel",
+						Tags:       []protocol.Tag{protocol.Tag("string")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type VertexLabel string",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype VertexLabel string\n```\n\nVertexLabel represents the purpose of vertex. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#Writer",
+					Documentation: protocol.Documentation{
+						Identifier: "Writer",
+						SearchKey:  "protocol.Writer",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Writer struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Writer struct {\n\tw           io.Writer\n\taddContents bool\n\tid          int\n\tnumElements int\n}\n```\n\nWriter emits vertices and edges to the underlying writer. This struct will guarantee that unique identifiers are generated for each element. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#NewWriter",
+							Documentation: protocol.Documentation{
+								Identifier: "NewWriter",
+								SearchKey:  "protocol.NewWriter",
+								Tags:       []protocol.Tag{protocol.Tag("function")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func NewWriter(w io.Writer, addContents bool) *Writer",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc NewWriter(w io.Writer, addContents bool) *Writer\n```\n\nNewWriter creates a new Writer. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitBeginEvent",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitBeginEvent",
+								SearchKey:  "protocol.Writer.EmitBeginEvent",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitBeginEvent(scope string, data string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitBeginEvent(scope string, data string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitContains",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitContains",
+								SearchKey:  "protocol.Writer.EmitContains",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitContains(outV string, inVs []string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitContains(outV string, inVs []string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitDefinitionResult",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitDefinitionResult",
+								SearchKey:  "protocol.Writer.EmitDefinitionResult",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitDefinitionResult() (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitDefinitionResult() (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitDocument",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitDocument",
+								SearchKey:  "protocol.Writer.EmitDocument",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitDocument(languageID, path string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitDocument(languageID, path string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitEndEvent",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitEndEvent",
+								SearchKey:  "protocol.Writer.EmitEndEvent",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitEndEvent(scope string, data string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitEndEvent(scope string, data string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitHoverResult",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitHoverResult",
+								SearchKey:  "protocol.Writer.EmitHoverResult",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitHoverResult(contents []MarkedString) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitHoverResult(contents []MarkedString) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitItem",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitItem",
+								SearchKey:  "protocol.Writer.EmitItem",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitItem(outV string, inVs []string, docID string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitItem(outV string, inVs []string, docID string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitItemOfDefinitions",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitItemOfDefinitions",
+								SearchKey:  "protocol.Writer.EmitItemOfDefinitions",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitItemOfDefinitions(outV string, inVs []string, docID string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitItemOfDefinitions(outV string, inVs []string, docID string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitItemOfReferences",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitItemOfReferences",
+								SearchKey:  "protocol.Writer.EmitItemOfReferences",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitItemOfReferences(outV string, inVs []string, docID string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitItemOfReferences(outV string, inVs []string, docID string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitMetaData",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitMetaData",
+								SearchKey:  "protocol.Writer.EmitMetaData",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitMetaData(root string, info ToolInfo) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitMetaData(root string, info ToolInfo) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitMoniker",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitMoniker",
+								SearchKey:  "protocol.Writer.EmitMoniker",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitMoniker(kind, scheme, identifier string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitMoniker(kind, scheme, identifier string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitMonikerEdge",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitMonikerEdge",
+								SearchKey:  "protocol.Writer.EmitMonikerEdge",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitMonikerEdge(outV, inV string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitMonikerEdge(outV, inV string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitNext",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitNext",
+								SearchKey:  "protocol.Writer.EmitNext",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitNext(outV, inV string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitNext(outV, inV string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitPackageInformation",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitPackageInformation",
+								SearchKey:  "protocol.Writer.EmitPackageInformation",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitPackageInformation(packageName, scheme, version string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitPackageInformation(packageName, scheme, version string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitPackageInformationEdge",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitPackageInformationEdge",
+								SearchKey:  "protocol.Writer.EmitPackageInformationEdge",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitPackageInformationEdge(outV, inV string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitPackageInformationEdge(outV, inV string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitProject",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitProject",
+								SearchKey:  "protocol.Writer.EmitProject",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitProject(languageID string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitProject(languageID string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitRange",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitRange",
+								SearchKey:  "protocol.Writer.EmitRange",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitRange(start, end Pos) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitRange(start, end Pos) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitReferenceResult",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitReferenceResult",
+								SearchKey:  "protocol.Writer.EmitReferenceResult",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitReferenceResult() (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitReferenceResult() (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitResultSet",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitResultSet",
+								SearchKey:  "protocol.Writer.EmitResultSet",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitResultSet() (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitResultSet() (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitTextDocumentDefinition",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitTextDocumentDefinition",
+								SearchKey:  "protocol.Writer.EmitTextDocumentDefinition",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitTextDocumentDefinition(outV, inV string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitTextDocumentDefinition(outV, inV string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitTextDocumentHover",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitTextDocumentHover",
+								SearchKey:  "protocol.Writer.EmitTextDocumentHover",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitTextDocumentHover(outV, inV string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitTextDocumentHover(outV, inV string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.EmitTextDocumentReferences",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.EmitTextDocumentReferences",
+								SearchKey:  "protocol.Writer.EmitTextDocumentReferences",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) EmitTextDocumentReferences(outV, inV string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) EmitTextDocumentReferences(outV, inV string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.NextID",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.NextID",
+								SearchKey:  "protocol.Writer.NextID",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) NextID() string",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) NextID() string\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.NumElements",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.NumElements",
+								SearchKey:  "protocol.Writer.NumElements",
+								Tags:       []protocol.Tag{protocol.Tag("method")},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) NumElements() int",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) NumElements() int\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/#Writer.emit",
+							Documentation: protocol.Documentation{
+								Identifier: "Writer.emit",
+								SearchKey:  "protocol.Writer.emit",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (w *Writer) emit(v interface{}) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (w *Writer) emit(v interface{}) error\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+					},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#hoverResult",
+					Documentation: protocol.Documentation{
+						Identifier: "hoverResult",
+						SearchKey:  "protocol.hoverResult",
+						Tags: []protocol.Tag{
+							protocol.Tag("struct"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type hoverResult struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype hoverResult struct {\n\tContents []MarkedString `json:\"contents\"`\n}\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/#markedString",
+					Documentation: protocol.Documentation{
+						Identifier: "markedString",
+						SearchKey:  "protocol.markedString",
+						Tags: []protocol.Tag{
+							protocol.Tag("struct"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type markedString struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype markedString struct {\n\t// The language of the marked string.\n\tLanguage string `json:\"language\"`\n\t// The value of the marked string.\n\tValue string `json:\"value\"`\n\t// Indicates whether to marshal JSON as raw string.\n\tisRawString bool\n}\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+			},
+		}},
+	},
+}}

--- a/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationMappings/query_path_info.golden
+++ b/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationMappings/query_path_info.golden
@@ -1,1 +1,0 @@
-(*precise.DocumentationPathInfoData)(nil)

--- a/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationMappings/query_path_info.golden
+++ b/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationMappings/query_path_info.golden
@@ -1,0 +1,1 @@
+(*precise.DocumentationPathInfoData)(nil)

--- a/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationPathInfo/query_path_info.golden
+++ b/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationPathInfo/query_path_info.golden
@@ -1,0 +1,8 @@
+&precise.DocumentationPathInfoData{
+	PathID:  "/github.com/sourcegraph/lsif-go/internal",
+	IsIndex: true,
+	Children: []string{
+		"/github.com/sourcegraph/lsif-go/internal/gomod",
+		"/github.com/sourcegraph/lsif-go/internal/index",
+	},
+}

--- a/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationUpload/query_the_page.golden
+++ b/enterprise/internal/codeintel/stores/lsifstore/testdata/TestWriteDocumentationUpload/query_the_page.golden
@@ -1,0 +1,739 @@
+&precise.DocumentationPageData{Tree: &precise.DocumentationNode{
+	PathID: "/github.com/sourcegraph/lsif-go/internal/index",
+	Documentation: protocol.Documentation{
+		Identifier: "index",
+		NewPage:    true,
+		SearchKey:  "github.com/sourcegraph/lsif-go/internal/index",
+		Tags: []protocol.Tag{
+			protocol.Tag("private"),
+			protocol.Tag("package"),
+		},
+	},
+	Label: protocol.MarkupContent{
+		Kind:  protocol.MarkupKind("plaintext"),
+		Value: "Package index",
+	},
+	Detail: protocol.MarkupContent{
+		Kind: protocol.MarkupKind("markdown"),
+		Value: `Package index is used to generate an LSIF dump for a workspace.
+
+`,
+	},
+	Children: []precise.DocumentationNodeChild{
+		precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+			PathID: "/github.com/sourcegraph/lsif-go/internal/index#const",
+			Documentation: protocol.Documentation{
+				Identifier: "const",
+				Tags: []protocol.Tag{
+					protocol.Tag("private"),
+				},
+			},
+			Label: protocol.MarkupContent{
+				Kind:  protocol.MarkupKind("plaintext"),
+				Value: "Constants",
+			},
+			Detail: protocol.MarkupContent{Kind: protocol.MarkupKind("plaintext")},
+			Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+				PathID: "/github.com/sourcegraph/lsif-go/internal/index#LanguageGo",
+				Documentation: protocol.Documentation{
+					Identifier: "LanguageGo",
+					SearchKey:  "index.LanguageGo",
+					Tags: []protocol.Tag{
+						protocol.Tag("constant"),
+						protocol.Tag("string"),
+					},
+				},
+				Label: protocol.MarkupContent{
+					Kind:  protocol.MarkupKind("plaintext"),
+					Value: "const LanguageGo",
+				},
+				Detail: protocol.MarkupContent{
+					Kind:  protocol.MarkupKind("markdown"),
+					Value: "```Go\nconst LanguageGo = \"go\"\n```\n\n",
+				},
+				Children: []precise.DocumentationNodeChild{},
+			}}},
+		}},
+		precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+			PathID: "/github.com/sourcegraph/lsif-go/internal/index#type",
+			Documentation: protocol.Documentation{
+				Identifier: "type",
+				Tags:       []protocol.Tag{protocol.Tag("private")},
+			},
+			Label: protocol.MarkupContent{
+				Kind:  protocol.MarkupKind("plaintext"),
+				Value: "Types",
+			},
+			Detail: protocol.MarkupContent{Kind: protocol.MarkupKind("plaintext")},
+			Children: []precise.DocumentationNodeChild{
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#Indexer",
+					Documentation: protocol.Documentation{
+						Identifier: "Indexer",
+						SearchKey:  "index.Indexer",
+						Tags:       []protocol.Tag{protocol.Tag("interface")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Indexer interface",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Indexer interface {\n\tIndex() (*Stats, error)\n}\n```\n\nIndexer reads source files and outputs LSIF data. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+						PathID: "/github.com/sourcegraph/lsif-go/internal/index#NewIndexer",
+						Documentation: protocol.Documentation{
+							Identifier: "NewIndexer",
+							SearchKey:  "index.NewIndexer",
+							Tags: []protocol.Tag{
+								protocol.Tag("function"),
+							},
+						},
+						Label: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("plaintext"),
+							Value: "func NewIndexer(projectRoot string,...",
+						},
+						Detail: protocol.MarkupContent{
+							Kind:  protocol.MarkupKind("markdown"),
+							Value: "```Go\nfunc NewIndexer(\n\tprojectRoot string,\n\trepositoryRoot string,\n\tmoduleName string,\n\tmoduleVersion string,\n\tdependencies map[string]string,\n\taddContents bool,\n\ttoolInfo protocol.ToolInfo,\n\tw io.Writer,\n) Indexer\n```\n\nNewIndexer creates a new Indexer. \n\n",
+						},
+						Children: []precise.DocumentationNodeChild{},
+					}}},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#Stats",
+					Documentation: protocol.Documentation{
+						Identifier: "Stats",
+						SearchKey:  "index.Stats",
+						Tags:       []protocol.Tag{protocol.Tag("struct")},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type Stats struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype Stats struct {\n\tNumPkgs     int\n\tNumFiles    int\n\tNumDefs     int\n\tNumElements int\n}\n```\n\nStats contains statistics of data processed during index. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#defInfo",
+					Documentation: protocol.Documentation{
+						Identifier: "defInfo",
+						SearchKey:  "index.defInfo",
+						Tags: []protocol.Tag{
+							protocol.Tag("struct"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type defInfo struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype defInfo struct {\n\t// The identifier of the containing document. This is necessary\n\t// to track when emitting item edges as we need to store the\n\t// document to which it belongs (not where it is referenced).\n\tdocID string\n\t// The vertex ID of the range that represents the definition.\n\trangeID string\n\t// The vertex ID of the resultSet that represents the definition.\n\tresultSetID string\n\t// The lazily initialized definition result ID upon first use found.\n\tdefResultID string\n}\n```\n\ndefInfo contains LSIF information of a definition. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#fileInfo",
+					Documentation: protocol.Documentation{
+						Identifier: "fileInfo",
+						SearchKey:  "index.fileInfo",
+						Tags: []protocol.Tag{
+							protocol.Tag("struct"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type fileInfo struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype fileInfo struct {\n\t// The vertex ID of the document that represents the file.\n\tdocID string\n\t// The vertices ID of ranges that represents the definition.\n\t// This information is collected to emit \"contains\" edge.\n\tdefRangeIDs []string\n\t// The vertices ID of ranges that represents the definition use cases.\n\t// This information is collected to emit \"contains\" edge.\n\tuseRangeIDs []string\n}\n```\n\nfileInfo contains LSIF information of a file. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer",
+					Documentation: protocol.Documentation{
+						Identifier: "indexer",
+						SearchKey:  "index.indexer",
+						Tags: []protocol.Tag{
+							protocol.Tag("struct"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type indexer struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype indexer struct {\n\tprojectRoot    string\n\trepositoryRoot string\n\ttoolInfo       protocol.ToolInfo\n\tw              *protocol.Writer\n\n\t// De-duplication\n\tdefsIndexed      map[string]bool\n\tusesIndexed      map[string]bool\n\tranges           map[string]map[int]string // filename -> offset -> rangeID\n\thoverResultCache map[string]string\n\n\t// Type correlation\n\tfiles   map[string]*fileInfo      // Keys: filename\n\timports map[token.Pos]*defInfo    // Keys: definition position\n\tfuncs   map[string]*defInfo       // Keys: full name (with receiver for methods)\n\tconsts  map[token.Pos]*defInfo    // Keys: definition position\n\tvars    map[token.Pos]*defInfo    // Keys: definition position\n\ttypes   map[string]*defInfo       // Keys: type name\n\tlabels  map[token.Pos]*defInfo    // Keys: definition position\n\trefs    map[string]*refResultInfo // Keys: definition range ID\n\n\t// Monikers\n\tmoduleName            string\n\tmoduleVersion         string\n\tdependencies          map[string]string\n\tpackageInformationIDs map[string]string\n}\n```\n\nindexer keeps track of all information needed to generate an LSIF dump. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.Index",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.Index",
+								SearchKey:  "index.indexer.Index",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) Index() (*Stats, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) Index() (*Stats, error)\n```\n\nIndex generates an LSIF dump from a workspace by traversing through source files and writing the LSIF equivalent to the output source that implements io.Writer. It is caller's responsibility to close the output source if applicable. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.addImports",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.addImports",
+								SearchKey:  "index.indexer.addImports",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) addImports(p *packages.Package, f *ast.File, fi *fileInfo) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) addImports(p *packages.Package, f *ast.File, fi *fileInfo) error\n```\n\naddImports constructs *ast.Ident and types.Object out of *ImportSpec and inserts them into packages defs map to be indexed within a unified process. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.addMonikers",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.addMonikers",
+								SearchKey:  "index.indexer.addMonikers",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) addMonikers(kind string, identifier string, sourceID, packageID string) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) addMonikers(kind string, identifier string, sourceID, packageID string) error\n```\n\naddMonikers outputs a \"gomod\" moniker vertex, attaches the given package vertex identifier to it, and attaches the new moniker to the source moniker vertex. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.emitExportMoniker",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.emitExportMoniker",
+								SearchKey:  "index.indexer.emitExportMoniker",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) emitExportMoniker(sourceID, identifier string) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) emitExportMoniker(sourceID, identifier string) error\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.emitImportMoniker",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.emitImportMoniker",
+								SearchKey:  "index.indexer.emitImportMoniker",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) emitImportMoniker(sourceID, identifier string) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) emitImportMoniker(sourceID, identifier string) error\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.ensurePackageInformation",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.ensurePackageInformation",
+								SearchKey:  "index.indexer.ensurePackageInformation",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) ensurePackageInformation(packageName, version string) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) ensurePackageInformation(packageName, version string) (string, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.index",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.index",
+								SearchKey:  "index.indexer.index",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) index(pkgs []*packages.Package) (*Stats, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) index(pkgs []*packages.Package) (*Stats, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.indexDefs",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.indexDefs",
+								SearchKey:  "index.indexer.indexDefs",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) indexDefs(pkgs []*packages.Package, p *packages.Package, f *ast.File, fi *fileInfo, proID, filename string) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) indexDefs(pkgs []*packages.Package, p *packages.Package, f *ast.File, fi *fileInfo, proID, filename string) error\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.indexPkgDefs",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.indexPkgDefs",
+								SearchKey:  "index.indexer.indexPkgDefs",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) indexPkgDefs(pkgs []*packages.Package, p *packages.Package, proID string) (err error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) indexPkgDefs(pkgs []*packages.Package, p *packages.Package, proID string) (err error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.indexPkgDocs",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.indexPkgDocs",
+								SearchKey:  "index.indexer.indexPkgDocs",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) indexPkgDocs(p *packages.Package, proID string) (err error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) indexPkgDocs(p *packages.Package, proID string) (err error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.indexPkgUses",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.indexPkgUses",
+								SearchKey:  "index.indexer.indexPkgUses",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) indexPkgUses(pkgs []*packages.Package, p *packages.Package, proID string) (err error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) indexPkgUses(pkgs []*packages.Package, p *packages.Package, proID string) (err error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.indexUses",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.indexUses",
+								SearchKey:  "index.indexer.indexUses",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) indexUses(pkgs []*packages.Package, p *packages.Package, fi *fileInfo, filename string) error",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) indexUses(pkgs []*packages.Package, p *packages.Package, fi *fileInfo, filename string) error\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.makeCachedExternalHoverResult",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.makeCachedExternalHoverResult",
+								SearchKey:  "index.indexer.makeCachedExternalHoverResult",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) makeCachedExternalHoverResult(pkgs []*packages.Package, p *packages.Package, obj types.Object, pkg *types.Package) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) makeCachedExternalHoverResult(pkgs []*packages.Package, p *packages.Package, obj types.Object, pkg *types.Package) (string, error)\n```\n\nmakeCachedExternalHoverResult creates a hover result vertex and returns its ID. This method should be called for objects defined externally with a resolvable package. This method will only make a new vertex if the path and object-position pair has not been seen before. Because some methods in an external package are likely to be used more than once in a project, this can save many copies of the same text. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.makeCachedHoverResult",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.makeCachedHoverResult",
+								SearchKey:  "index.indexer.makeCachedHoverResult",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) makeCachedHoverResult(pkgs []*packages.Package, p *packages.Package, f *ast.File, obj types.Object) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) makeCachedHoverResult(pkgs []*packages.Package, p *packages.Package, f *ast.File, obj types.Object) (string, error)\n```\n\nmakeCachedHoverResult creates a hover result vertex and returns its iD. This method should be called for each definition in the set of indexed files. This method will not create a new vertex for a pkgName object that has been seen before. Because package text is likely to be large, and repeated at each import and each use in the file (over many multiple files), this can save many copies of the same text. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.makeHoverResult",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.makeHoverResult",
+								SearchKey:  "index.indexer.makeHoverResult",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) makeHoverResult(pkgs []*packages.Package, p *packages.Package, f *ast.File, obj types.Object) (string, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) makeHoverResult(pkgs []*packages.Package, p *packages.Package, f *ast.File, obj types.Object) (string, error)\n```\n\nmakeHoverResult create a hover result vertex and returns its ID. This method should be called for each definition in the set of indexed files. \n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+						precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+							PathID: "/github.com/sourcegraph/lsif-go/internal/index#indexer.packages",
+							Documentation: protocol.Documentation{
+								Identifier: "indexer.packages",
+								SearchKey:  "index.indexer.packages",
+								Tags: []protocol.Tag{
+									protocol.Tag("method"),
+									protocol.Tag("private"),
+								},
+							},
+							Label: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("plaintext"),
+								Value: "func (i *indexer) packages() ([]*packages.Package, error)",
+							},
+							Detail: protocol.MarkupContent{
+								Kind:  protocol.MarkupKind("markdown"),
+								Value: "```Go\nfunc (i *indexer) packages() ([]*packages.Package, error)\n```\n\n",
+							},
+							Children: []precise.DocumentationNodeChild{},
+						}},
+					},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#refResultInfo",
+					Documentation: protocol.Documentation{
+						Identifier: "refResultInfo",
+						SearchKey:  "index.refResultInfo",
+						Tags: []protocol.Tag{
+							protocol.Tag("struct"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "type refResultInfo struct",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\ntype refResultInfo struct {\n\t// The vertex ID of the resultSet that represents the referenceResult.\n\tresultSetID string\n\t// The vertices ID of definition ranges that are referenced by the referenceResult.\n\t// This is a map from the document ID to the set of range IDs contained within it.\n\t// This information is collected to emit `{\"label\":\"item\", \"property\":\"definitions\"}` edge.\n\tdefRangeIDs map[string][]string\n\t// The vertices ID of reference ranges that are represented by the referenceResult.\n\t// This is a map from the document ID to the set of range IDs contained within it.\n\t// This information is collected to emit `{\"label\":\"item\", \"property\":\"references\"}` edge.\n\trefRangeIDs map[string][]string\n}\n```\n\nrefResultInfo contains LSIF information of a reference result. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+			},
+		}},
+		precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+			PathID: "/github.com/sourcegraph/lsif-go/internal/index#func",
+			Documentation: protocol.Documentation{
+				Identifier: "func",
+				Tags:       []protocol.Tag{protocol.Tag("private")},
+			},
+			Label: protocol.MarkupContent{
+				Kind:  protocol.MarkupKind("plaintext"),
+				Value: "Functions",
+			},
+			Detail: protocol.MarkupContent{Kind: protocol.MarkupKind("plaintext")},
+			Children: []precise.DocumentationNodeChild{
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#constructMarkedString",
+					Documentation: protocol.Documentation{
+						Identifier: "constructMarkedString",
+						SearchKey:  "index.constructMarkedString",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func constructMarkedString(s, comments, extra string) ([]protocol.MarkedString, error)",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc constructMarkedString(s, comments, extra string) ([]protocol.MarkedString, error)\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#externalHoverContents",
+					Documentation: protocol.Documentation{
+						Identifier: "externalHoverContents",
+						SearchKey:  "index.externalHoverContents",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func externalHoverContents(pkgs []*packages.Package, p *packages.Package, obj types.Object, pkg *types.Package) ([]protocol.MarkedString, error)",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc externalHoverContents(pkgs []*packages.Package, p *packages.Package, obj types.Object, pkg *types.Package) ([]protocol.MarkedString, error)\n```\n\nexternalHoverContents returns contents used as hover info for objects that are not defined in any of the (directly) analyzed source files. This will attempt to find the definition in the AST of the dependency and pull the hover text from that. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#findComments",
+					Documentation: protocol.Documentation{
+						Identifier: "findComments",
+						SearchKey:  "index.findComments",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func findComments(pkgs []*packages.Package, p *packages.Package, f *ast.File, o types.Object) (string, error)",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc findComments(pkgs []*packages.Package, p *packages.Package, f *ast.File, o types.Object) (string, error)\n```\n\nfindComments traverses the paths found within enclosing interval of the object to collect comments. \n\nThis function is modified from [https://sourcegraph.com/github.com/sourcegraph/go-langserver](https://sourcegraph.com/github.com/sourcegraph/go-langserver)@02f4198/-/blob/langserver/hover.go#L106 \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#findContents",
+					Documentation: protocol.Documentation{
+						Identifier: "findContents",
+						SearchKey:  "index.findContents",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func findContents(pkgs []*packages.Package, p *packages.Package, f *ast.File, obj types.Object) ([]protocol.MarkedString, error)",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc findContents(pkgs []*packages.Package, p *packages.Package, f *ast.File, obj types.Object) ([]protocol.MarkedString, error)\n```\n\nfindContents returns contents used as hover info for given object. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#getPackageComment",
+					Documentation: protocol.Documentation{
+						Identifier: "getPackageComment",
+						SearchKey:  "index.getPackageComment",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func getPackageComment(dependencyPackage *packages.Package, pkgPath string) string",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc getPackageComment(dependencyPackage *packages.Package, pkgPath string) string\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#joinCommentGroups",
+					Documentation: protocol.Documentation{
+						Identifier: "joinCommentGroups",
+						SearchKey:  "index.joinCommentGroups",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func joinCommentGroups(a, b *ast.CommentGroup) string",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc joinCommentGroups(a, b *ast.CommentGroup) string\n```\n\njoinCommentGroups joins the resultant non-empty comment text from two CommentGroups with a newline. \n\nThis function is copied from [https://sourcegraph.com/github.com/sourcegraph/go-langserver](https://sourcegraph.com/github.com/sourcegraph/go-langserver)@02f4198/-/blob/langserver/hover.go#L190 \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#lspRange",
+					Documentation: protocol.Documentation{
+						Identifier: "lspRange",
+						SearchKey:  "index.lspRange",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func lspRange(pos token.Position, name string, isQuotedPkgName bool) (start protocol.Pos, end protocol.Pos)",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc lspRange(pos token.Position, name string, isQuotedPkgName bool) (start protocol.Pos, end protocol.Pos)\n```\n\nlspRange transforms go/token.Position (1-based) to LSP start and end ranges (0-based) which takes in consideration of identifier's name length. If the token is a quoted package name, we'll create a range that covers only the string contents, not the quotes. \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#packagePrefixes",
+					Documentation: protocol.Documentation{
+						Identifier: "packagePrefixes",
+						SearchKey:  "index.packagePrefixes",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func packagePrefixes(packageName string) []string",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc packagePrefixes(packageName string) []string\n```\n\npackagePrefixes returns all prefixes of the go package path. For example, the package `foo/bar/baz` will return \n\n```\n- `foo/bar/baz`\n- `foo/bar`\n- `foo`\n\n```\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#prettyPrintTypesString",
+					Documentation: protocol.Documentation{
+						Identifier: "prettyPrintTypesString",
+						SearchKey:  "index.prettyPrintTypesString",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func prettyPrintTypesString(s string) string",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc prettyPrintTypesString(s string) string\n```\n\nprettyPrintTypesString is pretty printing specific to the output of types.*String. Instead of re-implementing the printer, we can just transform its output. \n\nThis function is copied from [https://sourcegraph.com/github.com/sourcegraph/go-langserver](https://sourcegraph.com/github.com/sourcegraph/go-langserver)@02f4198/-/blob/langserver/hover.go#L332 \n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+				precise.DocumentationNodeChild{Node: &precise.DocumentationNode{
+					PathID: "/github.com/sourcegraph/lsif-go/internal/index#typeString",
+					Documentation: protocol.Documentation{
+						Identifier: "typeString",
+						SearchKey:  "index.typeString",
+						Tags: []protocol.Tag{
+							protocol.Tag("function"),
+							protocol.Tag("private"),
+						},
+					},
+					Label: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("plaintext"),
+						Value: "func typeString(obj types.Object) (string, string)",
+					},
+					Detail: protocol.MarkupContent{
+						Kind:  protocol.MarkupKind("markdown"),
+						Value: "```Go\nfunc typeString(obj types.Object) (string, string)\n```\n\n",
+					},
+					Children: []precise.DocumentationNodeChild{},
+				}},
+			},
+		}},
+	},
+}}


### PR DESCRIPTION
After this change, we have decent test coverage for:

* `WriteDocumentationSearchPrework`
* `WriteDocumentationPages`
* `WriteDocumentationSearch`
* `WriteDocumentationPathInfo`
* `WriteDocumentationMappings`
* `documentationPathIDToID`
* `documentationPathIDToFilePath`
* `DocumentationPage`
* `DocumentationPathInfo`
* `DocumentationDefinitions`

It's not perfect - more could be done to improve these, make them more legible, etc. But it's a start, and decent coverage.

Helps #20567

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>