### PR TITLE
database: exclude deleted services when calculating webhook status

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -210,8 +210,6 @@ type ExternalServicesListOptions struct {
 	// When true, will only return services that have the cloud_default flag set to
 	// true.
 	OnlyCloudDefault bool
-	// When true, deleted external services are included.
-	IncludeDeleted bool
 
 	*LimitOffset
 
@@ -224,12 +222,7 @@ type ExternalServicesListOptions struct {
 }
 
 func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
-	conds := []*sqlf.Query{}
-	if o.IncludeDeleted {
-		conds = append(conds, sqlf.Sprintf("TRUE"))
-	} else {
-		conds = append(conds, sqlf.Sprintf("deleted_at IS NULL"))
-	}
+	conds := []*sqlf.Query{sqlf.Sprintf("deleted_at IS NULL")}
 	if len(o.IDs) > 0 {
 		ids := make([]*sqlf.Query, 0, len(o.IDs))
 		for _, id := range o.IDs {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -39,7 +39,6 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 		afterID              int64
 		wantQuery            string
 		onlyCloudDefault     bool
-		includeDeleted       bool
 		noCachedWebhooks     bool
 		wantArgs             []interface{}
 	}{
@@ -95,11 +94,6 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 			wantQuery:        "deleted_at IS NULL AND cloud_default = true",
 		},
 		{
-			name:           "has IncludeDeleted",
-			includeDeleted: true,
-			wantQuery:      "TRUE",
-		},
-		{
 			name:             "has noCachedWebhooks",
 			noCachedWebhooks: true,
 			wantQuery:        "deleted_at IS NULL AND has_webhooks IS NULL",
@@ -115,7 +109,6 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 				Kinds:                test.kinds,
 				AfterID:              test.afterID,
 				OnlyCloudDefault:     test.onlyCloudDefault,
-				IncludeDeleted:       test.includeDeleted,
 				noCachedWebhooks:     test.noCachedWebhooks,
 			}
 			q := sqlf.Join(opts.sqlConditions(), "AND")

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -405,7 +405,6 @@ func (m *ExternalServiceWebhookMigrator) Up(ctx context.Context) (err error) {
 
 	svcs, err := store.List(ctx, ExternalServicesListOptions{
 		OrderByDirection: "ASC",
-		IncludeDeleted:   true,
 		LimitOffset:      &LimitOffset{Limit: m.BatchSize},
 		noCachedWebhooks: true,
 		forUpdate:        true,

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -386,8 +386,8 @@ func (m *ExternalServiceWebhookMigrator) Progress(ctx context.Context) (float64,
 				CAST(c1.count AS float) / CAST(c2.count AS float)
 			END
 		FROM
-			(SELECT COUNT(*) AS count FROM external_services WHERE has_webhooks IS NOT NULL) c1,
-			(SELECT COUNT(*) AS count FROM external_services) c2
+			(SELECT COUNT(*) AS count FROM external_services WHERE deleted_at IS NULL AND has_webhooks IS NOT NULL) c1,
+			(SELECT COUNT(*) AS count FROM external_services WHERE deleted_at IS NULL) c2
 	`)))
 	return progress, err
 }

--- a/internal/database/oob_migrate_test.go
+++ b/internal/database/oob_migrate_test.go
@@ -770,6 +770,29 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 		}
 		svcs = append(svcs, svc)
 
+		// We'll also add another external service that is deleted, and
+		// shouldn't count.
+		if err := basestore.Exec(
+			ctx,
+			sqlf.Sprintf(`
+				INSERT INTO
+					external_services
+					(
+						kind,
+						display_name,
+						config,
+						deleted_at
+					)
+					VALUES (%s, %s, %s, NOW())
+				`,
+				extsvc.KindOther,
+				"deleted",
+				"{}",
+			),
+		); err != nil {
+			t.Fatal(err)
+		}
+
 		return svcs
 	}
 


### PR DESCRIPTION
I included deleted external services in the webhook OOB migrator for completeness, but there's really no point now I understand the cases where we access external services better. Let's just exclude them (and, as a bonus, quiet some warnings on prod).

Since this was the only use of the `IncludeDeleted` list option, I've removed the option once more.

cc: @daxmc99 