### PR TITLE
code-intel: fix multiple fetch and re-indexing per open modal

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -14,6 +14,8 @@ const DEFAULT_MAX_RESULTS = 100
 export interface FuzzyFinderProps {
     setIsVisible: Dispatch<SetStateAction<boolean>>
 
+    isVisible: boolean
+
     /**
      * The maximum number of files a repo can have to use case-insensitive fuzzy finding.
      *
@@ -31,6 +33,10 @@ export const FuzzyFinder: React.FunctionComponent<FuzzyFinderProps> = props => {
     const [fsm, setFsm] = useState<FuzzyFSM>({ key: 'empty' })
     const { repoName = '', commitID = '' } = parseBrowserRepoURL(location.pathname + location.search + location.hash)
     const { downloadFilename, isLoadingFilename, filenameError } = useFilename(repoName, commitID)
+
+    if (!props.isVisible) {
+        return null
+    }
 
     return (
         <FuzzyModal

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -118,10 +118,11 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
                     input?.select()
                 }}
             />
-            {isFuzzyFinderVisible && props.isRepositoryRelatedPage && fuzzyFinder && (
+            {props.isRepositoryRelatedPage && fuzzyFinder && (
                 <FuzzyFinder
                     caseInsensitiveFileCountThreshold={fuzzyFinderCaseInsensitiveFileCountThreshold}
                     setIsVisible={bool => setIsFuzzyFinderVisible(bool)}
+                    isVisible={isFuzzyFinderVisible}
                 />
             )}
         </Form>


### PR DESCRIPTION
## 🤔  Description
<!--- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR fixes Fuzzy finder issues where filenames are slow to re-download and re-index within a single SPA session.

## 🔖  Relevant tickets
<!--- _Add the tickets that it resolves._ -->

Fixes #26576 

## 🚀  GIF
_What gif best describes this PR or how it makes you feel?_

![shortcut](https://media.giphy.com/media/FgiHOQyKUJmwg/giphy.gif)