### PR TITLE
fix transactions with database.DB type

### DIFF
--- a/internal/database/basestore/handle.go
+++ b/internal/database/basestore/handle.go
@@ -33,7 +33,7 @@ func (h *TransactableHandle) InTransaction() bool {
 	db := h.db
 	if unwrapper, ok := db.(dbutil.Unwrapper); ok {
 		// Unwrap in case the dbutil.DB is a database.db instead of *sql.DB or
-		// *sql.Tx.  This is needed because below, we attempt to cast the db as
+		// *sql.Tx. This is needed because below, we attempt to cast the db as
 		// a dbutil.Tx, which is not implemented by database.db. This should
 		// eventually be removed once dbutil.DB is subsumed by database.DB
 		db = unwrapper.Unwrap()

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"context"
 	"database/sql"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -15,7 +14,6 @@ import (
 // and remove dbutil.DB altogether.
 type DB interface {
 	dbutil.DB
-	dbutil.TxBeginner
 	AccessTokens() AccessTokenStore
 	EventLogs() EventLogStore
 	ExternalServices() ExternalServiceStore
@@ -48,14 +46,6 @@ type db struct {
 }
 
 var _ DB = (*db)(nil)
-
-func (d *db) BeginTx(ctx context.Context, o *sql.TxOptions) (*sql.Tx, error) {
-	tb, ok := d.DB.(dbutil.TxBeginner)
-	if !ok {
-		return nil, basestore.ErrNotTransactable
-	}
-	return tb.BeginTx(ctx, o)
-}
 
 func (d *db) AccessTokens() AccessTokenStore {
 	return AccessTokens(d.DB)
@@ -131,4 +121,12 @@ func (d *db) UserPublicRepos() UserPublicRepoStore {
 
 func (d *db) Users() UserStore {
 	return Users(d.DB)
+}
+
+func (d *db) Unwrap() dbutil.DB {
+	// Recursively unwrap in case we ever call `database.NewDB()` with a `database.DB`
+	if unwrapper, ok := d.DB.(dbutil.Unwrapper); ok {
+		return unwrapper.Unwrap()
+	}
+	return d.DB
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,0 +1,252 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestDBTransactions(t *testing.T) {
+	ctx := context.Background()
+	t.Run("no transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(t)
+		db := NewDB(sqlDB)
+
+		err := db.Repos().Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+		require.NoError(t, err)
+
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("basic transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(t)
+		db := NewDB(sqlDB)
+
+		// Lifetime of tx
+		{
+			tx, err := db.Repos().Transact(ctx)
+			require.NoError(t, err)
+
+			err = tx.Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := tx.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			tx.Done(nil)
+		}
+
+		// After committing the transaction, the repo should be visible
+		// outisde the transaction
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("rolled back transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(t)
+		db := NewDB(sqlDB)
+
+		// Lifetime of tx
+		{
+			tx, err := db.Repos().Transact(ctx)
+			require.NoError(t, err)
+
+			err = tx.Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := tx.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			tx.Done(errors.New("force a rollback"))
+		}
+
+		// After rolling back the transaction, the repo should not be visible
+		// outside the transaction
+		_, err := db.Repos().Get(ctx, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("nested transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(t)
+		db := NewDB(sqlDB)
+
+		// Lifetime of tx1
+		{
+			tx1, err := db.Repos().Transact(ctx)
+			require.NoError(t, err)
+
+			err = tx1.Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := tx1.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			// Lifetime of tx2
+			{
+				tx2, err := db.Repos().Transact(ctx)
+				require.NoError(t, err)
+
+				err = tx2.Create(ctx, &types.Repo{ID: 2, Name: "test2"})
+				require.NoError(t, err)
+
+				// Get inside the transaction should work
+				r, err := tx2.Get(ctx, 2)
+				require.NoError(t, err)
+				require.Equal(t, api.RepoName("test2"), r.Name)
+
+				// Before committing the transaction, repo 2 should not be visible
+				// outside the transaction
+				_, err = db.Repos().Get(ctx, 2)
+				require.Error(t, err)
+				_, err = tx1.Get(ctx, 2)
+				require.Error(t, err)
+
+				tx2.Done(nil)
+			}
+
+			// After committing the transaction, repo 2 should be visible
+			// outside the transaction
+			r, err = db.Repos().Get(ctx, 2)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test2"), r.Name)
+			r, err = tx1.Get(ctx, 2)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test2"), r.Name)
+
+			tx1.Done(nil)
+		}
+
+		// After committing the transaction, repo 1 should be visible
+		// outisde the transaction
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("nested transaction rollback works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(t)
+		db := NewDB(sqlDB)
+
+		// Lifetime of tx1
+		{
+			tx1, err := db.Repos().Transact(ctx)
+			require.NoError(t, err)
+
+			err = tx1.Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := tx1.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			// Lifetime of tx2
+			{
+				tx2, err := db.Repos().Transact(ctx)
+				require.NoError(t, err)
+
+				err = tx2.Create(ctx, &types.Repo{ID: 2, Name: "test2"})
+				require.NoError(t, err)
+
+				// Get inside the transaction should work
+				r, err := tx2.Get(ctx, 2)
+				require.NoError(t, err)
+				require.Equal(t, api.RepoName("test2"), r.Name)
+
+				// Before committing the transaction, repo 2 should not be visible
+				// outside the transaction
+				_, err = db.Repos().Get(ctx, 2)
+				require.Error(t, err)
+				_, err = tx1.Get(ctx, 2)
+				require.Error(t, err)
+
+				tx2.Done(errors.New("force rollback"))
+			}
+
+			// After rolling back the transaction, repo 2 should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 2)
+			require.Error(t, err)
+			_, err = tx1.Get(ctx, 2)
+			require.Error(t, err)
+
+			tx1.Done(nil)
+		}
+
+		// After committing the transaction, repo 1 should be visible
+		// outisde the transaction
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("basic transaction works with nested database.DB", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(t)
+		db := NewDB(sqlDB)
+		// this ill-advised, but possible, so make sure we can handle it.
+		// In the future, this ideally not be possible by typing this more strictly.
+		db = NewDB(db)
+
+		// Lifetime of tx
+		{
+			tx, err := db.Repos().Transact(ctx)
+			require.NoError(t, err)
+
+			err = tx.Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := tx.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			tx.Done(nil)
+		}
+
+		// After committing the transaction, the repo should be visible
+		// outisde the transaction
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+}

--- a/internal/database/dbmock/db_mock.go
+++ b/internal/database/dbmock/db_mock.go
@@ -18,9 +18,6 @@ type MockDB struct {
 	// AccessTokensFunc is an instance of a mock function object controlling
 	// the behavior of the method AccessTokens.
 	AccessTokensFunc *DBAccessTokensFunc
-	// BeginTxFunc is an instance of a mock function object controlling the
-	// behavior of the method BeginTx.
-	BeginTxFunc *DBBeginTxFunc
 	// EventLogsFunc is an instance of a mock function object controlling
 	// the behavior of the method EventLogs.
 	EventLogsFunc *DBEventLogsFunc
@@ -93,11 +90,6 @@ func NewMockDB() *MockDB {
 		AccessTokensFunc: &DBAccessTokensFunc{
 			defaultHook: func() database.AccessTokenStore {
 				return nil
-			},
-		},
-		BeginTxFunc: &DBBeginTxFunc{
-			defaultHook: func(context.Context, *sql.TxOptions) (*sql.Tx, error) {
-				return nil, nil
 			},
 		},
 		EventLogsFunc: &DBEventLogsFunc{
@@ -214,9 +206,6 @@ func NewMockDBFrom(i database.DB) *MockDB {
 	return &MockDB{
 		AccessTokensFunc: &DBAccessTokensFunc{
 			defaultHook: i.AccessTokens,
-		},
-		BeginTxFunc: &DBBeginTxFunc{
-			defaultHook: i.BeginTx,
 		},
 		EventLogsFunc: &DBEventLogsFunc{
 			defaultHook: i.EventLogs,
@@ -381,114 +370,6 @@ func (c DBAccessTokensFuncCall) Args() []interface{} {
 // invocation.
 func (c DBAccessTokensFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// DBBeginTxFunc describes the behavior when the BeginTx method of the
-// parent MockDB instance is invoked.
-type DBBeginTxFunc struct {
-	defaultHook func(context.Context, *sql.TxOptions) (*sql.Tx, error)
-	hooks       []func(context.Context, *sql.TxOptions) (*sql.Tx, error)
-	history     []DBBeginTxFuncCall
-	mutex       sync.Mutex
-}
-
-// BeginTx delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockDB) BeginTx(v0 context.Context, v1 *sql.TxOptions) (*sql.Tx, error) {
-	r0, r1 := m.BeginTxFunc.nextHook()(v0, v1)
-	m.BeginTxFunc.appendCall(DBBeginTxFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the BeginTx method of
-// the parent MockDB instance is invoked and the hook queue is empty.
-func (f *DBBeginTxFunc) SetDefaultHook(hook func(context.Context, *sql.TxOptions) (*sql.Tx, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// BeginTx method of the parent MockDB instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *DBBeginTxFunc) PushHook(hook func(context.Context, *sql.TxOptions) (*sql.Tx, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *DBBeginTxFunc) SetDefaultReturn(r0 *sql.Tx, r1 error) {
-	f.SetDefaultHook(func(context.Context, *sql.TxOptions) (*sql.Tx, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *DBBeginTxFunc) PushReturn(r0 *sql.Tx, r1 error) {
-	f.PushHook(func(context.Context, *sql.TxOptions) (*sql.Tx, error) {
-		return r0, r1
-	})
-}
-
-func (f *DBBeginTxFunc) nextHook() func(context.Context, *sql.TxOptions) (*sql.Tx, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *DBBeginTxFunc) appendCall(r0 DBBeginTxFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of DBBeginTxFuncCall objects describing the
-// invocations of this function.
-func (f *DBBeginTxFunc) History() []DBBeginTxFuncCall {
-	f.mutex.Lock()
-	history := make([]DBBeginTxFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// DBBeginTxFuncCall is an object that describes an invocation of method
-// BeginTx on an instance of MockDB.
-type DBBeginTxFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 *sql.TxOptions
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *sql.Tx
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c DBBeginTxFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c DBBeginTxFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // DBEventLogsFunc describes the behavior when the EventLogs method of the

--- a/internal/database/dbmock/repostore_mock.go
+++ b/internal/database/dbmock/repostore_mock.go
@@ -27,6 +27,9 @@ type MockRepoStore struct {
 	// DeleteFunc is an instance of a mock function object controlling the
 	// behavior of the method Delete.
 	DeleteFunc *RepoStoreDeleteFunc
+	// DoneFunc is an instance of a mock function object controlling the
+	// behavior of the method Done.
+	DoneFunc *RepoStoreDoneFunc
 	// ExternalServicesFunc is an instance of a mock function object
 	// controlling the behavior of the method ExternalServices.
 	ExternalServicesFunc *RepoStoreExternalServicesFunc
@@ -94,6 +97,11 @@ func NewMockRepoStore() *MockRepoStore {
 		},
 		DeleteFunc: &RepoStoreDeleteFunc{
 			defaultHook: func(context.Context, ...api.RepoID) error {
+				return nil
+			},
+		},
+		DoneFunc: &RepoStoreDoneFunc{
+			defaultHook: func(error) error {
 				return nil
 			},
 		},
@@ -192,6 +200,9 @@ func NewMockRepoStoreFrom(i database.RepoStore) *MockRepoStore {
 		},
 		DeleteFunc: &RepoStoreDeleteFunc{
 			defaultHook: i.Delete,
+		},
+		DoneFunc: &RepoStoreDoneFunc{
+			defaultHook: i.Done,
 		},
 		ExternalServicesFunc: &RepoStoreExternalServicesFunc{
 			defaultHook: i.ExternalServices,
@@ -573,6 +584,108 @@ func (c RepoStoreDeleteFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RepoStoreDeleteFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RepoStoreDoneFunc describes the behavior when the Done method of the
+// parent MockRepoStore instance is invoked.
+type RepoStoreDoneFunc struct {
+	defaultHook func(error) error
+	hooks       []func(error) error
+	history     []RepoStoreDoneFuncCall
+	mutex       sync.Mutex
+}
+
+// Done delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockRepoStore) Done(v0 error) error {
+	r0 := m.DoneFunc.nextHook()(v0)
+	m.DoneFunc.appendCall(RepoStoreDoneFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Done method of the
+// parent MockRepoStore instance is invoked and the hook queue is empty.
+func (f *RepoStoreDoneFunc) SetDefaultHook(hook func(error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Done method of the parent MockRepoStore instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *RepoStoreDoneFunc) PushHook(hook func(error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *RepoStoreDoneFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *RepoStoreDoneFunc) PushReturn(r0 error) {
+	f.PushHook(func(error) error {
+		return r0
+	})
+}
+
+func (f *RepoStoreDoneFunc) nextHook() func(error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoStoreDoneFunc) appendCall(r0 RepoStoreDoneFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of RepoStoreDoneFuncCall objects describing
+// the invocations of this function.
+func (f *RepoStoreDoneFunc) History() []RepoStoreDoneFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoStoreDoneFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoStoreDoneFuncCall is an object that describes an invocation of method
+// Done on an instance of MockRepoStore.
+type RepoStoreDoneFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoStoreDoneFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoStoreDoneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -64,6 +64,12 @@ type TxBeginner interface {
 	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
 }
 
+// An Unwrapper unwraps itself into its nested DB.
+// This is currently necessary because
+type Unwrapper interface {
+	Unwrap() DB
+}
+
 func IsPostgresError(err error, codename string) bool {
 	var e *pgconn.PgError
 	return errors.As(err, &e) && e.Code == codename

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -65,8 +65,11 @@ type TxBeginner interface {
 }
 
 // An Unwrapper unwraps itself into its nested DB.
-// This is currently necessary because
+// This is necessary because the concrete type of a dbutil.DB
+// is used to assert interfaces like `Tx` and `TxBeginner`, so
+// wrapping a dbutil.DB breaks those interface assertions.
 type Unwrapper interface {
+	// Unwrap returns the inner DB. If defined, it must return a valid DB (never nil).
 	Unwrap() DB
 }
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -66,6 +66,7 @@ type RepoStore interface {
 	Transact(context.Context) (RepoStore, error)
 	With(basestore.ShareableStore) RepoStore
 	Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error)
+	Done(error) error
 
 	Count(context.Context, ReposListOptions) (int, error)
 	Create(context.Context, ...*types.Repo) error


### PR DESCRIPTION
This fixes an issue that caused long-running transactions in production.
The problem was that, when creating a transaction, we make interface
assertions against the concrete type of `dbutil.DB`, which work fine
when `dbutil.DB` is always a `*sql.DB` or `*sql.Tx`. However, with the
new `database.DB` type, it embeds a `dbutil.DB`, so the transaction
methods aren't exposed, making these interface assertions fail.

This commit adds an `Unwrap() dbutil.DB` method to `database.DB` so
that, when determining what the underlying type is for transactions, we
can unwrap a `database.DB` to expose those methods.

This is not ideal, and I have some ideas for making it better, but they
require being further along in the refactoring process to be viable. For
now, I think this is a reasonable band-aid that allows the process to
continue.

Also, I added a few tests to make sure this behavior doesn't regress,
and that will catch issues like the one from this morning.

Addresses the issue that caused to revert in #26946



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
