### PR TITLE
ci: ignore soft failures when uploading logs

### DIFF
--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -208,6 +208,12 @@ func (c *Client) ExportLogs(ctx context.Context, pipeline string, build int, opt
 			continue
 		}
 
+		if opts.State == "failed" && job.SoftFailed {
+			// Soft fails are not a state, but an attribute of failed jobs.
+			// Ignore them, so we don't count them as failures.
+			continue
+		}
+
 		l, _, err := c.bk.Jobs.GetJobLog(buildkiteOrg, pipeline, buildID, *job.ID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Soft failures are still considered as failed jobs by Buildkite. This totally makes sense CI wise, but it doesn't when it comes to uploading failures on Loki, as it prevents us to get accurate metrics.