### PR TITLE
web: highlight selected line in blobs

### DIFF
--- a/client/web/src/repo/blob/Blob.module.scss
+++ b/client/web/src/repo/blob/Blob.module.scss
@@ -39,7 +39,8 @@
 
     tr {
         transition: background 200ms ease-out;
-        &.selected {
+
+        &:global(.selected) {
             background: var(--code-selection-bg);
         }
     }


### PR DESCRIPTION
## Context

The selected line selector changed [today](https://github.com/sourcegraph/sourcegraph/issues/26565) because of the migration to the CSS module. Since this class is not scoped, it should be used with the `:global()` keyword, to avoid hashing it. Without this keyword, it's scoped and the selector looks like this `& .Blob_module_selected_[hash_here]`.