### PR TITLE
remove global mocks for OrgInvitationStore

### DIFF
--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 var ErrNoAccessExternalService = errors.New("the authenticated user does not have access to this external service")
 
 // CheckExternalServiceAccess checks whether the current user is allowed to
 // access the supplied external service.
-func CheckExternalServiceAccess(ctx context.Context, db dbutil.DB, namespaceUserID, namespaceOrgID int32) error {
+func CheckExternalServiceAccess(ctx context.Context, db database.DB, namespaceUserID, namespaceOrgID int32) error {
 	// Fast path that doesn't need to hit DB as we can get id from context
 	a := actor.FromContext(ctx)
 	if namespaceUserID > 0 && a.IsAuthenticated() && namespaceUserID == a.UID {
@@ -26,7 +25,7 @@ func CheckExternalServiceAccess(ctx context.Context, db dbutil.DB, namespaceUser
 	}
 
 	// Special case when external service has no owner
-	if namespaceUserID == 0 && namespaceOrgID == 0 && CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(db)) == nil {
+	if namespaceUserID == 0 && namespaceOrgID == 0 && CheckCurrentUserIsSiteAdmin(ctx, db) == nil {
 		return nil
 	}
 
@@ -35,8 +34,8 @@ func CheckExternalServiceAccess(ctx context.Context, db dbutil.DB, namespaceUser
 
 // CheckOrgExternalServices checks if the feature organization can own external services
 // is allowed or not
-func CheckOrgExternalServices(ctx context.Context, db dbutil.DB, orgID int32) error {
-	enabled, err := database.FeatureFlags(db).GetOrgFeatureFlag(ctx, orgID, "org-code")
+func CheckOrgExternalServices(ctx context.Context, db database.DB, orgID int32) error {
+	enabled, err := db.FeatureFlags().GetOrgFeatureFlag(ctx, orgID, "org-code")
 	if err != nil {
 		return err
 	} else if enabled {

--- a/cmd/frontend/backend/external_services_test.go
+++ b/cmd/frontend/backend/external_services_test.go
@@ -5,15 +5,13 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestCheckExternalServiceAccess(t *testing.T) {
 	ctx := testContext()
 	nonAuthContext := actor.WithActor(ctx, &actor.Actor{UID: 0})
-	db := new(dbtesting.MockDB)
 
 	mockSiteAdmin := func(isSiteAdmin bool) *types.User {
 		return &types.User{ID: 1, SiteAdmin: isSiteAdmin}
@@ -103,16 +101,15 @@ func TestCheckExternalServiceAccess(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-				return test.mockCurrentUser, nil
-			}
-			database.Mocks.OrgMembers.GetByOrgIDAndUserID = func(ctx context.Context, orgID, userID int32) (*types.OrgMembership, error) {
-				return test.mockOrgMember, nil
-			}
-			defer func() {
-				database.Mocks.Users = database.MockUsers{}
-				database.Mocks.OrgMembers = database.MockOrgMembers{}
-			}()
+			users := dbmock.NewMockUserStore()
+			users.GetByCurrentAuthUserFunc.SetDefaultReturn(test.mockCurrentUser, nil)
+
+			orgMembers := dbmock.NewMockOrgMemberStore()
+			orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(test.mockOrgMember, nil)
+
+			db := dbmock.NewMockDB()
+			db.UsersFunc.SetDefaultReturn(users)
+			db.OrgMembersFunc.SetDefaultReturn(orgMembers)
 
 			result := CheckExternalServiceAccess(test.ctx, db, test.namespaceUserID, test.namespaceOrgID)
 

--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -19,7 +19,7 @@ var ErrNotAuthenticated = errors.New("not authenticated")
 // It is used when an action on a user can be performed by site admins and the
 // organization's members, but nobody else.
 func CheckOrgAccessOrSiteAdmin(ctx context.Context, db dbutil.DB, orgID int32) error {
-	return checkOrgAccess(ctx, db, orgID, true)
+	return checkOrgAccess(ctx, database.NewDB(db), orgID, true)
 }
 
 // CheckOrgAccess returns an error if the user is not a member of the
@@ -27,17 +27,17 @@ func CheckOrgAccessOrSiteAdmin(ctx context.Context, db dbutil.DB, orgID int32) e
 //
 // It is used when an action on a user can be performed by the organization's
 // members, but nobody else.
-func CheckOrgAccess(ctx context.Context, db dbutil.DB, orgID int32) error {
+func CheckOrgAccess(ctx context.Context, db database.DB, orgID int32) error {
 	return checkOrgAccess(ctx, db, orgID, false)
 }
 
 // checkOrgAccess is a helper method used above which allows optionally allowing
 // site admins to access all organisations.
-func checkOrgAccess(ctx context.Context, db dbutil.DB, orgID int32, allowAdmin bool) error {
+func checkOrgAccess(ctx context.Context, db database.DB, orgID int32, allowAdmin bool) error {
 	if actor.FromContext(ctx).IsInternal() {
 		return nil
 	}
-	currentUser, err := CurrentUser(ctx, database.NewDB(db))
+	currentUser, err := CurrentUser(ctx, db)
 	if err != nil {
 		return err
 	}
@@ -52,8 +52,8 @@ func checkOrgAccess(ctx context.Context, db dbutil.DB, orgID int32, allowAdmin b
 
 var ErrNotAnOrgMember = errors.New("current user is not an org member")
 
-func checkUserIsOrgMember(ctx context.Context, db dbutil.DB, userID, orgID int32) error {
-	resp, err := database.OrgMembers(db).GetByOrgIDAndUserID(ctx, orgID, userID)
+func checkUserIsOrgMember(ctx context.Context, db database.DB, userID, orgID int32) error {
+	resp, err := db.OrgMembers().GetByOrgIDAndUserID(ctx, orgID, userID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return ErrNotAnOrgMember

--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -58,7 +58,7 @@ func (a *affiliatedRepositoriesConnection) Nodes(ctx context.Context) ([]*codeHo
 				return
 			}
 			// 🚨 SECURITY: check if user can access external service
-			err = backend.CheckExternalServiceAccess(ctx, a.db, svc.NamespaceUserID, svc.NamespaceOrgID)
+			err = backend.CheckExternalServiceAccess(ctx, database.NewDB(a.db), svc.NamespaceUserID, svc.NamespaceOrgID)
 			if err != nil {
 				a.err = err
 				return
@@ -170,7 +170,7 @@ func (r *codeHostRepositoryResolver) Private() bool {
 
 func (r *codeHostRepositoryResolver) CodeHost(ctx context.Context) *externalServiceResolver {
 	return &externalServiceResolver{
-		db:              r.db,
+		db:              database.NewDB(r.db),
 		externalService: r.codeHost,
 	}
 }

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -58,7 +58,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		}
 
 		if namespaceUserID > 0 {
-			allowUserExternalServices, err := database.Users(r.db).CurrentUserAllowedExternalServices(ctx)
+			allowUserExternalServices, err := r.db.Users().CurrentUserAllowedExternalServices(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -94,7 +94,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		externalService.NamespaceOrgID = namespaceOrgID
 	}
 
-	if err := database.ExternalServices(r.db).Create(ctx, conf.Get, externalService); err != nil {
+	if err := r.db.ExternalServices().Create(ctx, conf.Get, externalService); err != nil {
 		return nil, err
 	}
 
@@ -314,7 +314,7 @@ func (r *externalServiceConnectionResolver) Nodes(ctx context.Context) ([]*exter
 	}
 	resolvers := make([]*externalServiceResolver, 0, len(externalServices))
 	for _, externalService := range externalServices {
-		resolvers = append(resolvers, &externalServiceResolver{db: r.db, externalService: externalService})
+		resolvers = append(resolvers, &externalServiceResolver{db: database.NewDB(r.db), externalService: externalService})
 	}
 	return resolvers, nil
 }
@@ -371,7 +371,7 @@ func (r *computedExternalServiceConnectionResolver) Nodes(ctx context.Context) [
 	}
 	resolvers := make([]*externalServiceResolver, 0, len(svcs))
 	for _, svc := range svcs {
-		resolvers = append(resolvers, &externalServiceResolver{db: r.db, externalService: svc})
+		resolvers = append(resolvers, &externalServiceResolver{db: database.NewDB(r.db), externalService: svc})
 	}
 	return resolvers
 }

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -300,11 +300,11 @@ type ListOrgRepositoriesArgs struct {
 }
 
 func (o *OrgResolver) Repositories(ctx context.Context, args *ListOrgRepositoriesArgs) (RepositoryConnectionResolver, error) {
-	if err := backend.CheckOrgExternalServices(ctx, o.db, o.org.ID); err != nil {
+	if err := backend.CheckOrgExternalServices(ctx, database.NewDB(o.db), o.org.ID); err != nil {
 		return nil, err
 	}
 	// 🚨 SECURITY: Only org members can list the org repositories.
-	if err := backend.CheckOrgAccess(ctx, o.db, o.org.ID); err != nil {
+	if err := backend.CheckOrgAccess(ctx, database.NewDB(o.db), o.org.ID); err != nil {
 		if err == backend.ErrNotAnOrgMember {
 			return nil, errors.New("must be a member of this organization to view its repositories")
 		}

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -222,7 +222,7 @@ func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *Tot
 			return nil, err
 		}
 	} else if r.opt.OrgID != 0 {
-		if err := backend.CheckOrgAccess(ctx, r.db, r.opt.OrgID); err != nil {
+		if err := backend.CheckOrgAccess(ctx, database.NewDB(r.db), r.opt.OrgID); err != nil {
 			return nil, err
 		}
 	} else {

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -83,5 +83,5 @@ func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalS
 		return nil, err
 	}
 
-	return &externalServiceResolver{db: r.db, externalService: externalService}, nil
+	return &externalServiceResolver{db: database.NewDB(r.db), externalService: externalService}, nil
 }

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -21,8 +21,6 @@ type MockStores struct {
 
 	ExternalAccounts MockExternalAccounts
 
-	OrgInvitations MockOrgInvitations
-
 	ExternalServices MockExternalServices
 
 	Authz MockAuthz

--- a/internal/database/org_invitations.go
+++ b/internal/database/org_invitations.go
@@ -83,10 +83,6 @@ func (err OrgInvitationNotFoundError) Error() string {
 }
 
 func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, recipientUserID int32) (*OrgInvitation, error) {
-	if Mocks.OrgInvitations.Create != nil {
-		return Mocks.OrgInvitations.Create(orgID, senderUserID, recipientUserID)
-	}
-
 	t := &OrgInvitation{
 		OrgID:           orgID,
 		SenderUserID:    senderUserID,
@@ -110,10 +106,6 @@ func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, re
 //
 // 🚨 SECURITY: The caller must ensure that the actor is permitted to view this org invitation.
 func (s *orgInvitationStore) GetByID(ctx context.Context, id int64) (*OrgInvitation, error) {
-	if Mocks.OrgInvitations.GetByID != nil {
-		return Mocks.OrgInvitations.GetByID(id)
-	}
-
 	results, err := s.list(ctx, []*sqlf.Query{sqlf.Sprintf("id=%d", id)}, nil)
 	if err != nil {
 		return nil, err
@@ -241,10 +233,6 @@ func (s *orgInvitationStore) Respond(ctx context.Context, id int64, recipientUse
 // Revoke marks an org invitation as revoked. The recipient is forbidden from responding to it after
 // it has been revoked.
 func (s *orgInvitationStore) Revoke(ctx context.Context, id int64) error {
-	if Mocks.OrgInvitations.Revoke != nil {
-		return Mocks.OrgInvitations.Revoke(id)
-	}
-
 	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE org_invitations SET revoked_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL", id)
 	if err != nil {
 		return err
@@ -257,11 +245,4 @@ func (s *orgInvitationStore) Revoke(ctx context.Context, id int64) error {
 		return OrgInvitationNotFoundError{[]interface{}{id}}
 	}
 	return nil
-}
-
-// MockOrgInvitations mocks the org invitations store.
-type MockOrgInvitations struct {
-	Create  func(orgID, senderUserID, recipientUserID int32) (*OrgInvitation, error)
-	GetByID func(id int64) (*OrgInvitation, error)
-	Revoke  func(id int64) error
 }


### PR DESCRIPTION
This converts tests that use MockOrgInvitationStore to use
the new generated mocks, and removes MockOrgInvitationStore.

Stacked on #26966 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
