### PR TITLE
remove global mocks for FeatureFlagStore

### DIFF
--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
@@ -18,8 +17,8 @@ var ErrNotAuthenticated = errors.New("not authenticated")
 //
 // It is used when an action on a user can be performed by site admins and the
 // organization's members, but nobody else.
-func CheckOrgAccessOrSiteAdmin(ctx context.Context, db dbutil.DB, orgID int32) error {
-	return checkOrgAccess(ctx, database.NewDB(db), orgID, true)
+func CheckOrgAccessOrSiteAdmin(ctx context.Context, db database.DB, orgID int32) error {
+	return checkOrgAccess(ctx, db, orgID, true)
 }
 
 // CheckOrgAccess returns an error if the user is not a member of the

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -41,11 +42,9 @@ func TestOrganization(t *testing.T) {
 }
 
 func TestOrganizationRepositories(t *testing.T) {
-	db := database.NewDB(nil)
-	resetMocks()
-	database.Mocks.Orgs.GetByName = func(context.Context, string) (*types.Org, error) {
-		return &types.Org{ID: 1, Name: "acme"}, nil
-	}
+	orgs := dbmock.NewMockOrgStore()
+	orgs.GetByNameFunc.SetDefaultReturn(&types.Org{ID: 1, Name: "acme"}, nil)
+
 	database.Mocks.Repos.List = func(context.Context, database.ReposListOptions) (repos []*types.Repo, err error) {
 		return []*types.Repo{
 			{
@@ -53,24 +52,23 @@ func TestOrganizationRepositories(t *testing.T) {
 			},
 		}, nil
 	}
-	database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-		return &types.User{ID: 1}, nil
-	}
-	database.Mocks.OrgMembers.GetByOrgIDAndUserID = func(ctx context.Context, orgID, userID int32) (*types.OrgMembership, error) {
-		return &types.OrgMembership{
-			OrgID:  1,
-			UserID: 1,
-		}, nil
-	}
-	database.Mocks.FeatureFlags.GetOrgFeatureFlag = func(ctx context.Context, orgID int32, flagName string) (bool, error) {
-		return true, nil
-	}
+
+	users := dbmock.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+
+	orgMembers := dbmock.NewMockOrgMemberStore()
+	orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(&types.OrgMembership{OrgID: 1, UserID: 1}, nil)
+
+	featureFlags := dbmock.NewMockFeatureFlagStore()
+	featureFlags.GetOrgFeatureFlagFunc.SetDefaultReturn(true, nil)
+
+	db := dbmock.NewMockDB()
+	db.OrgsFunc.SetDefaultReturn(orgs)
+	db.UsersFunc.SetDefaultReturn(users)
+	db.OrgMembersFunc.SetDefaultReturn(orgMembers)
+	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-
-	defer func() {
-		resetMocks()
-	}()
 
 	RunTests(t, []*Test{
 		{

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -40,7 +40,7 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 	var l []*OrgResolver
 	for _, org := range orgs {
 		l = append(l, &OrgResolver{
-			db:  r.db,
+			db:  database.NewDB(r.db),
 			org: org,
 		})
 	}

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -60,7 +60,7 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 		})
 		// Apply the user's orgs' settings.
 		for _, org := range orgs {
-			subjects = append(subjects, &settingsSubject{org: &OrgResolver{db: r.db, org: org}})
+			subjects = append(subjects, &settingsSubject{org: &OrgResolver{db: database.NewDB(r.db), org: org}})
 		}
 		// Apply the user's own settings last (it has highest priority).
 		subjects = append(subjects, r.subject)

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -432,7 +432,7 @@ func (r *Resolver) isAllowedToCreate(ctx context.Context, owner graphql.ID) erro
 	case "User":
 		return backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(r.store.Handle().DB()), ownerInt32)
 	case "Org":
-		return backend.CheckOrgAccessOrSiteAdmin(ctx, r.store.Handle().DB(), ownerInt32)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, database.NewDB(r.store.Handle().DB()), ownerInt32)
 	default:
 		return errors.Errorf("provided ID is not a namespace")
 	}

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -38,7 +38,7 @@ func extensionRegistryViewerPublishers(ctx context.Context, db dbutil.DB) ([]gra
 		return nil, err
 	}
 	for _, org := range orgs {
-		publishers = append(publishers, &registryPublisher{org: graphqlbackend.NewOrg(db, org)})
+		publishers = append(publishers, &registryPublisher{org: graphqlbackend.NewOrg(database.NewDB(db), org)})
 	}
 	return publishers, nil
 }
@@ -142,7 +142,7 @@ func (p *registryPublisherID) viewerCanAdminister(ctx context.Context, db dbutil
 		return backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(db), p.userID)
 	case p.orgID != 0:
 		// 🚨 SECURITY: Check that the current user is a member of the publisher org.
-		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, p.orgID)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, database.NewDB(db), p.orgID)
 	default:
 		return errRegistryUnknownPublisher
 	}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -888,7 +888,7 @@ func (s *Service) CheckNamespaceAccess(ctx context.Context, namespaceUserID, nam
 
 func (s *Service) checkNamespaceAccessWithDB(ctx context.Context, db dbutil.DB, namespaceUserID, namespaceOrgID int32) (err error) {
 	if namespaceOrgID != 0 {
-		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, namespaceOrgID)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, database.NewDB(db), namespaceOrgID)
 	} else if namespaceUserID != 0 {
 		return backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(db), namespaceUserID)
 	} else {

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -558,10 +558,6 @@ func (f *featureFlagStore) GetGlobalFeatureFlags(ctx context.Context) (map[strin
 
 // GetOrgFeatureFlag returns the calculated flag value for the given organization, taking potential override into account
 func (f *featureFlagStore) GetOrgFeatureFlag(ctx context.Context, orgID int32, flagName string) (bool, error) {
-	if Mocks.FeatureFlags.GetOrgFeatureFlag != nil {
-		return Mocks.FeatureFlags.GetOrgFeatureFlag(ctx, orgID, flagName)
-	}
-
 	g, ctx := errgroup.WithContext(ctx)
 
 	var override *ff.Override

--- a/internal/database/feature_flags_mock.go
+++ b/internal/database/feature_flags_mock.go
@@ -1,9 +1,0 @@
-package database
-
-import (
-	"context"
-)
-
-type MockFeatureFlags struct {
-	GetOrgFeatureFlag func(ctx context.Context, orgID int32, flagName string) (bool, error)
-}

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -24,6 +24,4 @@ type MockStores struct {
 	ExternalServices MockExternalServices
 
 	Authz MockAuthz
-
-	FeatureFlags MockFeatureFlags
 }


### PR DESCRIPTION
Replaces remaining references to MockFeatureFlagStore with injected
mocks, and removes the global mocked store.

Stacked on #26970 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
