### PR TITLE
[CLOUD-78] external_services: upsert "authorization" field in `Upsert` method

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -457,7 +457,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, use
 		}
 		if provider == nil {
 			// NOTE: User code host connection can only be added on sourcegraph.com, and
-			//  authorization is enforced everything, it does not make sense that we cannot
+			//  authorization is enforced for everything, it does not make sense that we cannot
 			//  derive an `authz.Provider` from it.
 			log15.Warn("PermsSyncer.fetchUserPermsViaExternalServices.noAuthzProvider",
 				"userID", userID,

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -456,7 +456,13 @@ func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, use
 			return nil, errors.Wrapf(err, "new provider from external service %d", svc.ID)
 		}
 		if provider == nil {
-			// We have no authz provider configured for this external service
+			// NOTE: User code host connection can only be added on sourcegraph.com, and
+			//  authorization is enforced everything, it does not make sense that we cannot
+			//  derive an `authz.Provider` from it.
+			log15.Warn("PermsSyncer.fetchUserPermsViaExternalServices.noAuthzProvider",
+				"userID", userID,
+				"id", svc.ID,
+			)
 			continue
 		}
 

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -689,6 +689,16 @@ func (e *ExternalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 	e.ensureStore()
 
 	for _, s := range svcs {
+		// 🚨 SECURITY: For all GitHub and GitLab code host connections on Sourcegraph
+		// Cloud, we always want to enforce repository permissions using OAuth to
+		// prevent unexpected resource leaking.
+		if envvar.SourcegraphDotComMode() {
+			s.Config, err = upsertAuthorizationToExternalService(s.Kind, s.Config)
+			if err != nil {
+				return err
+			}
+		}
+
 		if err := e.recalculateFields(s, s.Config); err != nil {
 			return err
 		}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/keegancsmith/sqlf"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -717,6 +719,65 @@ func TestUpsertAuthorizationToExternalService(t *testing.T) {
 			}
 		})
 	}
+}
+
+// This test ensures under Sourcegraph.com mode, every call of `Create`,
+// `Upsert` and `Update` has the "authorization" field presented in the external
+// service config automatically.
+func TestExternalServicesStore_upsertAuthorizationToExternalService(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	db := dbtest.NewDB(t)
+	ctx := context.Background()
+
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
+
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	externalServices := ExternalServices(db)
+
+	// Test Create method
+	es := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := externalServices.Create(ctx, confGet, es)
+	require.NoError(t, err)
+
+	got, err := externalServices.GetByID(ctx, es.ID)
+	require.NoError(t, err)
+	exists := gjson.Get(got.Config, "authorization").Exists()
+	assert.True(t, exists, `"authorization" field exists`)
+
+	// Reset Config field and test Upsert method
+	es.Config = `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`
+	err = externalServices.Upsert(ctx, es)
+	require.NoError(t, err)
+
+	got, err = externalServices.GetByID(ctx, es.ID)
+	require.NoError(t, err)
+	exists = gjson.Get(got.Config, "authorization").Exists()
+	assert.True(t, exists, `"authorization" field exists`)
+
+	// Reset Config field and test Update method
+	es.Config = `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`
+	err = externalServices.Update(ctx,
+		conf.Get().AuthProviders,
+		es.ID,
+		&ExternalServiceUpdate{
+			Config: &es.Config,
+		},
+	)
+	require.NoError(t, err)
+
+	got, err = externalServices.GetByID(ctx, es.ID)
+	require.NoError(t, err)
+	exists = gjson.Get(got.Config, "authorization").Exists()
+	assert.True(t, exists, `"authorization" field exists`)
 }
 
 func TestCountRepoCount(t *testing.T) {


### PR DESCRIPTION
Upon finishing the implementation of CLOUD-78, we couldn't get private repositories being added the user's organization to show up in the user's search results (the user also has access to the repository on the code host).

After the investigation, we discovered that we overlooked `ExternalServicesStore.Upsert` method where we call [`upsertAuthorizationToExternalService`](https://github.com/sourcegraph/sourcegraph/blob/d5ac81bc118795a0b1b759d5d63838d755d4e651/internal/database/external_services.go#L575) in both [`ExternalServicesStore.Create`](https://github.com/sourcegraph/sourcegraph/blob/d5ac81bc118795a0b1b759d5d63838d755d4e651/internal/database/external_services.go#L630-L631) and [`ExternalServicesStore.Update`](https://github.com/sourcegraph/sourcegraph/blob/d5ac81bc118795a0b1b759d5d63838d755d4e651/internal/database/external_services.go#L961-L962), to make sure the special `"authorization"` field exists in every external service config.

The outcome of missing this field caused our permissions syncer to believe that [it does not need to fetch permissions from the code host](https://github.com/sourcegraph/sourcegraph/blob/d5ac81bc118795a0b1b759d5d63838d755d4e651/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go#L458-L460) for the user (because [we do not derive an `authz.Provider` from external services that are not having the `"authorization"` field in their config](https://github.com/sourcegraph/sourcegraph/blob/d5ac81bc118795a0b1b759d5d63838d755d4e651/enterprise/internal/authz/github/authz.go?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L86-L89)).

### Security impact

We're totally safe and no private data had leaked thanks to the philosophy that [we never skip authz on dotcom](https://github.com/sourcegraph/sourcegraph/blob/d5ac81bc118795a0b1b759d5d63838d755d4e651/internal/database/external_services.go#L1454).

### Followup

With this discovery, our prod database is in "dirty" state that all external services do not have the "authorization" field. This is fine as-is because we're always on the conservative side and assume no access on dotcom by default.

Technically, we need an out-of-band migration to upsert `"authorization"` field to all existing external services, but given the fact (that I believe) our repo syncing process continuously call `Upsert` method between 2 minutes and 8 hours for all external services, after this PR landed on prod for 8 hours, we will fix the "dirty" state. cc @sourcegraph/repo-management to confirm the "fact" :D

I also added a warning log in this PR for user-added external services that we cannot derive an `authz.Provider` for us to monitoring from logs (and also useful as a general warning).

---

Jira: CLOUD-78