### PR TITLE
web: lazy-load `@sentry/browser`

### DIFF
--- a/client/shared/dev/mockSentryBrowser.ts
+++ b/client/shared/dev/mockSentryBrowser.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/browser'
+
+// eslint-disable-next-line no-var
+declare var window: Window & typeof globalThis & { Sentry: typeof Sentry }
+
+if ('Sentry' in window === false) {
+    window.Sentry = Sentry
+}

--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -126,7 +126,7 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
 
 function shouldErrorBeReported(error: unknown): boolean {
     // Report errors only in production environment.
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
         return false
     }
 

--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,3 @@
-import * as sentry from '@sentry/browser'
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import ReloadIcon from 'mdi-react/ReloadIcon'
@@ -52,11 +51,11 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
 
     public componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
         if (shouldErrorBeReported(error)) {
-            sentry.withScope(scope => {
+            Sentry.withScope(scope => {
                 for (const [key, value] of Object.entries(errorInfo)) {
                     scope.setExtra(key, value)
                 }
-                sentry.captureException(error)
+                Sentry.captureException(error)
             })
         }
     }
@@ -126,6 +125,11 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
 }
 
 function shouldErrorBeReported(error: unknown): boolean {
+    // Report errors only in production environment.
+    if (process.env.NODE_ENV !== 'production') {
+        return false
+    }
+
     if (error instanceof HTTPStatusError) {
         // Ignore Server error responses (5xx)
         return error.status < 500

--- a/client/web/src/sentry.ts
+++ b/client/web/src/sentry.ts
@@ -19,11 +19,13 @@ window.addEventListener('error', error => {
     }
 })
 
+export type SentrySDK = Hub & {
+    init: typeof init
+    onLoad: typeof onLoad
+}
+
 declare global {
-    const Sentry: Hub & {
-        init: typeof init
-        onLoad: typeof onLoad
-    }
+    const Sentry: SentrySDK
 }
 
 if (typeof Sentry !== 'undefined') {

--- a/client/web/src/sentry.ts
+++ b/client/web/src/sentry.ts
@@ -1,4 +1,5 @@
-import * as sentry from '@sentry/browser'
+// Import only types to avoid including @sentry/browser into the main chunk.
+import type { Hub, init, onLoad } from '@sentry/browser'
 
 import { authenticatedUser } from './auth'
 
@@ -18,18 +19,33 @@ window.addEventListener('error', error => {
     }
 })
 
-if (window.context.sentryDSN) {
-    sentry.init({
-        dsn: window.context.sentryDSN,
-        release: 'frontend@' + window.context.version,
-    })
-    // Sentry is never un-initialized
-    // eslint-disable-next-line rxjs/no-ignored-subscription
-    authenticatedUser.subscribe(user => {
-        sentry.configureScope(scope => {
-            if (user) {
-                scope.setUser({ id: user.id })
-            }
-        })
+declare global {
+    const Sentry: Hub & {
+        init: typeof init
+        onLoad: typeof onLoad
+    }
+}
+
+if (typeof Sentry !== 'undefined') {
+    // Wait for Sentry to lazy-load from the script tag defined in the app.html.
+    // https://sentry-docs-git-patch-1.sentry.dev/platforms/javascript/guides/react/install/lazy-load-sentry/
+    Sentry.onLoad(() => {
+        // This check is required to please the Typescript compiler 🙂.
+        if (window.context.sentryDSN) {
+            Sentry.init({
+                dsn: window.context.sentryDSN,
+                release: 'frontend@' + window.context.version,
+            })
+
+            // Sentry is never un-initialized.
+            // eslint-disable-next-line rxjs/no-ignored-subscription
+            authenticatedUser.subscribe(user => {
+                Sentry.configureScope(scope => {
+                    if (user) {
+                        scope.setUser({ id: user.id })
+                    }
+                })
+            })
+        }
     })
 }

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -39,6 +39,7 @@
 	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 	})(window,document,'script','dataLayer','GTM-TB4NLS7');</script>
 	<!-- End Google Tag Manager -->
+	<script src='https://js.sentry-cdn.com/ae2f74442b154faf90b5ff0f7cd1c618.min.js' crossorigin="anonymous"></script>
 	{{ end }}
 	<script ignore-csp>
 		window.context = {{.Context }}

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -59,6 +59,7 @@ const config = {
     path.join(__dirname, 'client/shared/dev/setLinkComponentForTest.ts'),
     path.join(__dirname, 'client/shared/dev/mockResizeObserver.ts'),
     path.join(__dirname, 'client/shared/dev/mockUniqueId.ts'),
+    path.join(__dirname, 'client/shared/dev/mockSentryBrowser.ts'),
     // Enzyme setup file
     path.join(__dirname, 'client/shared/dev/enzymeSetup.js'),
   ],


### PR DESCRIPTION
## Context

To make our bundle smaller and reduce the initial loading time of the web application, we can lazy-load heavy dependencies like `@sentry/browser`.

## Changes

- Added script tag to the [app.html](https://github.com/sourcegraph/sourcegraph/blob/main/cmd/frontend/internal/app/ui/app.html) that lazy-loads Sentry SDK.
- Removed `@sentry/browser` imports (apart from TS types) from the `web` package.

## Results

The main bundle is **4.04%** smaller.

<img width="1372" alt="Screenshot 2021-11-01 at 15 42 57" src="https://user-images.githubusercontent.com/3846380/140024087-f3476de8-00be-4e0c-9514-9e2276c49955.png">

## Notes

Ad-blocking or script-blocking extensions may [prevent](https://github.com/easylist/easylist/issues/6963) Sentry SDK from being fetched and initialized correctly. The solution here would be to use a server-side pass-through for event reporting and our CDN for serving the init script. Created an issue to investigate further: https://github.com/sourcegraph/sourcegraph/issues/26981.

Closes https://github.com/sourcegraph/sourcegraph/issues/26840
