### PR TITLE
ci: add timestamps in bare metal agents

### DIFF
--- a/dev/ci/test/Vagrantfile
+++ b/dev/ci/test/Vagrantfile
@@ -86,6 +86,8 @@ export BITBUCKET_SERVER_TOKEN=#{ENV['BITBUCKET_SERVER_TOKEN']}
 export BITBUCKET_SERVER_USERNAME=#{ENV['BITBUCKET_SERVER_USERNAME']}
 export SGDEV_OVERRIDE_AUTH_SECRET=#{ENV['SGDEV_OVERRIDE_AUTH_SECRET']}
 export VAGRANT_RUN_ENV=#{ENV['VAGRANT_RUN_ENV']}
+# Log output must have timestamps for sg ci logs --output to work
+export BUILDKITE_TIMESTAMP_LINES=true
 
 # Env vars required by the QA tests - see:
 # https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/mn37wmu5dzhll6qxcnpmutvlq4


### PR DESCRIPTION
Fixes #26891

This is a crude fix, a better one would be to update the configuration (see this PR https://github.com/sourcegraph/infrastructure/pull/2867) but I'm not entirely sure this won't mess up with Vagrant logs in some way. I'll check with @davejrt. 

In the meantime, this PR fixes the problem.  