### PR TITLE
search: remove support for names in configuration endpoint

### DIFF
--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -82,9 +82,9 @@ type RepoIndexOptions struct {
 // sourcegraph-zoekt-indexserver. It is for repos based on site settings c.
 func GetIndexOptions(
 	c *schema.SiteConfiguration,
-	getRepoIndexOptions func(repo string) (*RepoIndexOptions, error),
+	getRepoIndexOptions func(repoID int32) (*RepoIndexOptions, error),
 	getSearchContextRevisions func(repoID int32) ([]string, error),
-	repos ...string,
+	repos ...int32,
 ) []byte {
 	// Limit concurrency to 32 to avoid too many active network requests and
 	// strain on gitserver (as ported from zoekt-sourcegraph-indexserver). In
@@ -110,11 +110,11 @@ func GetIndexOptions(
 
 func getIndexOptions(
 	c *schema.SiteConfiguration,
-	repoName string,
-	getRepoIndexOptions func(repo string) (*RepoIndexOptions, error),
-	getSearchContextRevisions func(repo int32) ([]string, error),
+	repoID int32,
+	getRepoIndexOptions func(repoID int32) (*RepoIndexOptions, error),
+	getSearchContextRevisions func(repoID int32) ([]string, error),
 ) []byte {
-	opts, err := getRepoIndexOptions(repoName)
+	opts, err := getRepoIndexOptions(repoID)
 	if err != nil {
 		return marshal(&zoektIndexOptions{Error: err.Error()})
 	}
@@ -135,7 +135,7 @@ func getIndexOptions(
 
 	// Add all branches that are referenced by version contexts
 	if c.ExperimentalFeatures != nil {
-		for _, rev := range c.ExperimentalFeatures.SearchIndexBranches[repoName] {
+		for _, rev := range c.ExperimentalFeatures.SearchIndexBranches[opts.Name] {
 			branches[rev] = struct{}{}
 		}
 	}

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -15,11 +14,29 @@ import (
 )
 
 func TestGetIndexOptions(t *testing.T) {
-	withBranches := func(c schema.SiteConfiguration, b map[string][]string) schema.SiteConfiguration {
+	const (
+		REPO = int32(iota + 1)
+		FOO
+		NOT_IN_VERSION_CONTEXT
+		PRIORITY
+		PUBLIC
+		FORK
+		ARCHIVED
+	)
+
+	name := func(repo int32) string {
+		return fmt.Sprintf("repo-%.2d", repo)
+	}
+
+	withBranches := func(c schema.SiteConfiguration, repo int32, branches ...string) schema.SiteConfiguration {
 		if c.ExperimentalFeatures == nil {
 			c.ExperimentalFeatures = &schema.ExperimentalFeatures{}
 		}
-		c.ExperimentalFeatures.SearchIndexBranches = b
+		if c.ExperimentalFeatures.SearchIndexBranches == nil {
+			c.ExperimentalFeatures.SearchIndexBranches = map[string][]string{}
+		}
+		b := c.ExperimentalFeatures.SearchIndexBranches
+		b[name(repo)] = append(b[name(repo)], branches...)
 		return c
 	}
 
@@ -27,16 +44,17 @@ func TestGetIndexOptions(t *testing.T) {
 		name              string
 		conf              schema.SiteConfiguration
 		searchContextRevs []string
-		repo              string
+		repo              int32
 		want              zoektIndexOptions
 	}
 
 	cases := []caseT{{
 		name: "default",
 		conf: schema.SiteConfiguration{},
-		repo: "repo",
+		repo: REPO,
 		want: zoektIndexOptions{
 			RepoID:  1,
+			Name:    "repo-01",
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -45,9 +63,10 @@ func TestGetIndexOptions(t *testing.T) {
 	}, {
 		name: "public",
 		conf: schema.SiteConfiguration{},
-		repo: "public",
+		repo: PUBLIC,
 		want: zoektIndexOptions{
 			RepoID:  5,
+			Name:    "repo-05",
 			Public:  true,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
@@ -57,9 +76,10 @@ func TestGetIndexOptions(t *testing.T) {
 	}, {
 		name: "fork",
 		conf: schema.SiteConfiguration{},
-		repo: "fork",
+		repo: FORK,
 		want: zoektIndexOptions{
 			RepoID:  6,
+			Name:    "repo-06",
 			Fork:    true,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
@@ -69,9 +89,10 @@ func TestGetIndexOptions(t *testing.T) {
 	}, {
 		name: "archived",
 		conf: schema.SiteConfiguration{},
-		repo: "archived",
+		repo: ARCHIVED,
 		want: zoektIndexOptions{
 			RepoID:   7,
+			Name:     "repo-07",
 			Archived: true,
 			Symbols:  true,
 			Branches: []zoekt.RepositoryBranch{
@@ -82,9 +103,10 @@ func TestGetIndexOptions(t *testing.T) {
 		name: "nosymbols",
 		conf: schema.SiteConfiguration{
 			SearchIndexSymbolsEnabled: boolPtr(false)},
-		repo: "repo",
+		repo: REPO,
 		want: zoektIndexOptions{
 			RepoID: 1,
+			Name:   "repo-01",
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
 			},
@@ -94,9 +116,10 @@ func TestGetIndexOptions(t *testing.T) {
 		conf: schema.SiteConfiguration{
 			SearchLargeFiles: []string{"**/*.jar", "*.bin"},
 		},
-		repo: "repo",
+		repo: REPO,
 		want: zoektIndexOptions{
 			RepoID:     1,
+			Name:       "repo-01",
 			Symbols:    true,
 			LargeFiles: []string{"**/*.jar", "*.bin"},
 			Branches: []zoekt.RepositoryBranch{
@@ -105,10 +128,11 @@ func TestGetIndexOptions(t *testing.T) {
 		},
 	}, {
 		name: "conf index branches",
-		conf: withBranches(schema.SiteConfiguration{}, map[string][]string{"repo": {"a"}}),
-		repo: "repo",
+		conf: withBranches(schema.SiteConfiguration{}, REPO, "a"),
+		repo: REPO,
 		want: zoektIndexOptions{
 			RepoID:  1,
+			Name:    "repo-01",
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -118,10 +142,11 @@ func TestGetIndexOptions(t *testing.T) {
 	}, {
 		name:              "with search context revisions",
 		conf:              schema.SiteConfiguration{},
-		repo:              "repo",
+		repo:              REPO,
 		searchContextRevs: []string{"rev1", "rev2"},
 		want: zoektIndexOptions{
 			RepoID:  1,
+			Name:    "repo-01",
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -132,9 +157,10 @@ func TestGetIndexOptions(t *testing.T) {
 	}, {
 		name: "with a priority value",
 		conf: schema.SiteConfiguration{},
-		repo: "priority",
+		repo: PRIORITY,
 		want: zoektIndexOptions{
 			RepoID:  4,
+			Name:    "repo-04",
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -158,33 +184,28 @@ func TestGetIndexOptions(t *testing.T) {
 		}
 		cases = append(cases, caseT{
 			name: "limit branches",
-			conf: withBranches(schema.SiteConfiguration{}, map[string][]string{"repo": branches}),
-			repo: "repo",
+			conf: withBranches(schema.SiteConfiguration{}, REPO, branches...),
+			repo: REPO,
 			want: zoektIndexOptions{
 				RepoID:   1,
+				Name:     "repo-01",
 				Symbols:  true,
 				Branches: want,
 			},
 		})
 	}
 
-	getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
-		repoID := int32(1)
-		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority", "public", "fork", "archived"} {
-			if r == repo {
-				break
-			}
-			repoID++
-		}
+	getRepoIndexOptions := func(repo int32) (*RepoIndexOptions, error) {
 		var priority float64
-		if repo == "priority" {
+		if repo == PRIORITY {
 			priority = 10
 		}
 		return &RepoIndexOptions{
-			RepoID:   repoID,
-			Public:   repo == "public",
-			Fork:     repo == "fork",
-			Archived: repo == "archived",
+			RepoID:   repo,
+			Name:     name(repo),
+			Public:   repo == PUBLIC,
+			Fork:     repo == FORK,
+			Archived: repo == ARCHIVED,
 			Priority: priority,
 			GetVersion: func(branch string) (string, error) {
 				return "!" + branch, nil
@@ -262,13 +283,13 @@ func TestGetIndexOptions_getVersion(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
+			getRepoIndexOptions := func(repo int32) (*RepoIndexOptions, error) {
 				return &RepoIndexOptions{
 					GetVersion: tc.f,
 				}, nil
 			}
 
-			b := GetIndexOptions(&conf, getRepoIndexOptions, getSearchContextRevs, "repo")
+			b := GetIndexOptions(&conf, getRepoIndexOptions, getSearchContextRevs, 1)
 
 			var got zoektIndexOptions
 			if err := json.Unmarshal(b, &got); err != nil {
@@ -290,32 +311,33 @@ func TestGetIndexOptions_getVersion(t *testing.T) {
 }
 
 func TestGetIndexOptions_batch(t *testing.T) {
+	isError := func(repo int32) bool {
+		return repo%20 == 0
+	}
 	var (
-		repos []string
+		repos []int32
 		want  []zoektIndexOptions
 	)
-	for i := 0; i < 100; i++ {
-		if i%20 == 0 {
-			repos = append(repos, fmt.Sprintf("error-%02d", i))
+	for repo := int32(1); repo < 100; repo++ {
+		repos = append(repos, repo)
+		if isError(repo) {
 			want = append(want, zoektIndexOptions{Error: "error"})
 		} else {
-			repo := fmt.Sprintf("repo-%02d", i)
-			repos = append(repos, repo)
 			want = append(want, zoektIndexOptions{
 				Symbols: true,
 				Branches: []zoekt.RepositoryBranch{
-					{Name: "HEAD", Version: "!HEAD-" + repo},
+					{Name: "HEAD", Version: fmt.Sprintf("!HEAD-%d", repo)},
 				},
 			})
 		}
 	}
-	getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
+	getRepoIndexOptions := func(repo int32) (*RepoIndexOptions, error) {
 		return &RepoIndexOptions{
 			GetVersion: func(branch string) (string, error) {
-				if strings.HasPrefix(repo, "error") {
+				if isError(repo) {
 					return "", errors.New("error")
 				}
-				return fmt.Sprintf("!%s-%s", branch, repo), nil
+				return fmt.Sprintf("!%s-%d", branch, repo), nil
 			},
 		}, nil
 	}


### PR DESCRIPTION
Zoekt only sends repository IDs. This allows us to simplify the code and make it purely based around repository IDs. I was tempted to update types further here since it is a little clunky to be using int32 in the backend code. However, there are some nicer refactors to do first before I do that so that will come later.
