### PR TITLE
monitoring: Set time period for repo-updater error rate to 15m

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3095,7 +3095,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 5m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 15m0s
 
 **Possible solutions**
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -207,7 +207,7 @@ func RepoUpdater() *monitoring.Container {
 							Name:              "sched_error",
 							Description:       "repositories schedule error rate",
 							Query:             `max(rate(src_repoupdater_sched_error[1m]))`,
-							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(5 * time.Minute),
+							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(15 * time.Minute),
 							Panel:             monitoring.Panel().Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: "Check repo-updater logs for errors",


### PR DESCRIPTION
We've noticed that gitserver rolling out takes around 15 minutes at
the moment. And since it also causes this alert to get triggered,
setting the time window to 15m should help us avoid false positives.

![image](https://user-images.githubusercontent.com/2682729/140055108-6d3b00c3-f937-4371-a99f-ac134f41f0d6.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
