### PR TITLE
database: introduce Cursors

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -323,12 +323,9 @@ func (o *OrgResolver) Repositories(ctx context.Context, args *ListOrgRepositorie
 		if err != nil {
 			return nil, err
 		}
-		opt.CursorColumn = cursor.Column
-		opt.CursorValue = cursor.Value
-		opt.CursorDirection = cursor.Direction
+		opt.Cursors = append(opt.Cursors, cursor)
 	} else {
-		opt.CursorValue = ""
-		opt.CursorDirection = "next"
+		opt.Cursors = append(opt.Cursors, &database.Cursor{Direction: "next"})
 	}
 	if args.OrderBy == nil {
 		opt.OrderBy = database.RepoListOrderBy{{

--- a/cmd/frontend/graphqlbackend/repository_cursor.go
+++ b/cmd/frontend/graphqlbackend/repository_cursor.go
@@ -4,34 +4,27 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // This constant defines the cursor prefix, which disambiguates a repository
 // cursor from other types of cursors in the system.
 const repositoryCursorKind = "RepositoryCursor"
 
-// A repositoryCursor can be provided to a `repositories` query for efficient
-// cursor-based pagination (vs. LIMIT/OFFSET).
-type repositoryCursor struct {
-	Column    string
-	Value     string
-	Direction string
-}
-
 // marshalRepositoryCursor marshals a repository pagination cursor.
-func marshalRepositoryCursor(cursor *repositoryCursor) string {
+func marshalRepositoryCursor(cursor *database.Cursor) string {
 	return string(relay.MarshalID(repositoryCursorKind, cursor))
 }
 
 // unmarshalRepositoryCursor unmarshals a repository pagination cursor.
-func unmarshalRepositoryCursor(cursor *string) (*repositoryCursor, error) {
+func unmarshalRepositoryCursor(cursor *string) (*database.Cursor, error) {
 	if cursor == nil {
 		return nil, nil
 	}
 	if kind := relay.UnmarshalKind(graphql.ID(*cursor)); kind != repositoryCursorKind {
 		return nil, errors.Errorf("cannot unmarshal repository cursor type: %q", kind)
 	}
-	var spec *repositoryCursor
+	var spec *database.Cursor
 	if err := relay.UnmarshalSpec(graphql.ID(*cursor), &spec); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_cursor_test.go
+++ b/cmd/frontend/graphqlbackend/repository_cursor_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 var (
-	rawCursor    = repositoryCursor{Column: "foo", Value: "bar", Direction: "next"}
+	rawCursor    = database.Cursor{Column: "foo", Value: "bar", Direction: "next"}
 	opaqueCursor = "UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6ImZvbyIsIlZhbHVlIjoiYmFyIiwiRGlyZWN0aW9uIjoibmV4dCJ9"
 )
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -7,7 +7,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -386,12 +385,9 @@ func (r *UserResolver) Repositories(ctx context.Context, args *ListUserRepositor
 		if err != nil {
 			return nil, err
 		}
-		opt.CursorColumn = cursor.Column
-		opt.CursorValue = cursor.Value
-		opt.CursorDirection = cursor.Direction
+		opt.Cursors = append(opt.Cursors, cursor)
 	} else {
-		opt.CursorValue = ""
-		opt.CursorDirection = "next"
+		opt.Cursors = append(opt.Cursors, &database.Cursor{Direction: "next"})
 	}
 	if args.OrderBy == nil {
 		opt.OrderBy = database.RepoListOrderBy{{

--- a/internal/database/cursor.go
+++ b/internal/database/cursor.go
@@ -1,6 +1,7 @@
 package database
 
-// Cursors is a slice of Cursors
+// Cursors is a slice of Cursors which is needed when a single Cursor isn't specific
+// enough to paginate through unique records. Example: (repos.stars, repo.name)
 type Cursors []*Cursor
 
 // A Cursor for efficient index based pagination through large result sets.

--- a/internal/database/cursor.go
+++ b/internal/database/cursor.go
@@ -1,0 +1,14 @@
+package database
+
+// Cursors is a slice of Cursors
+type Cursors []*Cursor
+
+// A Cursor for efficient index based pagination through large result sets.
+type Cursor struct {
+	// Columns contains the relevant columns for cursor-based pagination (e.g. "name")
+	Column string
+	// Value contains the relevant value for cursor-based pagination (e.g. "Zaphod").
+	Value string
+	// Direction contains the comparison for cursor-based pagination, all possible values are: next, prev.
+	Direction string
+}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -614,14 +614,8 @@ type ReposListOptions struct {
 	// List of fields by which to order the return repositories.
 	OrderBy RepoListOrderBy
 
-	// CursorColumn contains the relevant column for cursor-based pagination (e.g. "name")
-	CursorColumn string
-
-	// CursorValue contains the relevant value for cursor-based pagination (e.g. "Zaphod").
-	CursorValue string
-
-	// CursorDirection contains the comparison for cursor-based pagination, all possible values are: next, prev.
-	CursorDirection string
+	// Cursors to efficiently paginate through large result sets.
+	Cursors Cursors
 
 	// UseOr decides between ANDing or ORing the predicates together.
 	UseOr bool
@@ -839,11 +833,13 @@ func (s *repoStore) listSQL(ctx context.Context, opt ReposListOptions) (*sqlf.Qu
 
 	// Cursor-based pagination requires parsing a handful of extra fields, which
 	// may result in additional query conditions.
-	cursorConds, err := parseCursorConds(opt)
-	if err != nil {
-		return nil, err
+	for _, c := range opt.Cursors {
+		cursorConds, err := parseCursorConds(c)
+		if err != nil {
+			return nil, err
+		}
+		where = append(where, cursorConds...)
 	}
-	where = append(where, cursorConds...)
 
 	if opt.Query != "" && (len(opt.IncludePatterns) > 0 || opt.ExcludePattern != "") {
 		return nil, errors.New("Repos.List: Query and IncludePatterns/ExcludePattern options are mutually exclusive")
@@ -1576,27 +1572,27 @@ func parsePattern(p string) ([]*sqlf.Query, error) {
 
 // parseCursorConds checks whether the query is using cursor-based pagination, and
 // if so performs the necessary transformations for it to be successful.
-func parseCursorConds(opt ReposListOptions) (conds []*sqlf.Query, err error) {
-	if opt.CursorColumn == "" || opt.CursorValue == "" {
+func parseCursorConds(c *Cursor) (conds []*sqlf.Query, err error) {
+	if c == nil || c.Column == "" || c.Value == "" {
 		return nil, nil
 	}
 	var direction string
-	switch opt.CursorDirection {
+	switch c.Direction {
 	case "next":
 		direction = ">="
 	case "prev":
 		direction = "<="
 	default:
-		return nil, errors.Errorf("missing or invalid cursor direction: %q", opt.CursorDirection)
+		return nil, errors.Errorf("missing or invalid cursor direction: %q", c.Direction)
 	}
 
-	switch opt.CursorColumn {
+	switch c.Column {
 	case string(RepoListName):
-		conds = append(conds, sqlf.Sprintf("name "+direction+" %s", opt.CursorValue))
+		conds = append(conds, sqlf.Sprintf("name "+direction+" %s", c.Value))
 	case string(RepoListCreatedAt):
-		conds = append(conds, sqlf.Sprintf("created_at "+direction+" %s", opt.CursorValue))
+		conds = append(conds, sqlf.Sprintf("created_at "+direction+" %s", c.Value))
 	default:
-		return nil, errors.Errorf("missing or invalid cursor: %q %q", opt.CursorColumn, opt.CursorValue)
+		return nil, errors.Errorf("missing or invalid cursor: %q %q", c.Column, c.Value)
 	}
 	return conds, nil
 }


### PR DESCRIPTION
This PR is the first in a series to introduce paginated repository
resolution in search. It introduces a `Cursor` and `Cursors` types,
which we will use to efficiently paginate through repos.

Having these types makes it easy to pass cursors around, which we will
need.

Part of #26995



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
