### PR TITLE
database: add Stars field to RepoName

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -395,6 +395,13 @@ const getSourcesByRepoQueryStr = `
 )
 `
 
+var minimalRepoColumns = []string{
+	"repo.id",
+	"repo.name",
+	"repo.private",
+	"repo.stars",
+}
+
 var repoColumns = []string{
 	"repo.id",
 	"repo.name",
@@ -413,11 +420,6 @@ var repoColumns = []string{
 	"repo.metadata",
 	"repo.blocked",
 	getSourcesByRepoQueryStr,
-}
-
-// id, name, private
-func minimalColumns(columns []string) []string {
-	return columns[:3]
 }
 
 func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
@@ -738,7 +740,7 @@ func (s *repoStore) StreamRepoNames(ctx context.Context, opt ReposListOptions, c
 	}()
 	s.ensureStore()
 
-	opt.Select = minimalColumns(repoColumns)
+	opt.Select = minimalRepoColumns
 	if len(opt.OrderBy) == 0 {
 		opt.OrderBy = append(opt.OrderBy, RepoListSort{Field: RepoListID})
 	}
@@ -748,7 +750,7 @@ func (s *repoStore) StreamRepoNames(ctx context.Context, opt ReposListOptions, c
 	err = s.list(ctx, tr, opt, func(rows *sql.Rows) error {
 		var r types.RepoName
 		var private bool
-		err := rows.Scan(&r.ID, &r.Name, &private)
+		err := rows.Scan(&r.ID, &r.Name, &private, &dbutil.NullInt{N: &r.Stars})
 		if err != nil {
 			return err
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -389,16 +389,18 @@ func (rs Repos) Filter(pred func(*Repo) bool) (fs Repos) {
 	return fs
 }
 
-// RepoName represents a source code repository name and its ID.
+// RepoName represents a source code repository name, its ID and number of stars.
 type RepoName struct {
-	ID   api.RepoID
-	Name api.RepoName
+	ID    api.RepoID
+	Name  api.RepoName
+	Stars int
 }
 
 func (r *RepoName) ToRepo() *Repo {
 	return &Repo{
-		ID:   r.ID,
-		Name: r.Name,
+		ID:    r.ID,
+		Name:  r.Name,
+		Stars: r.Stars,
 	}
 }
 


### PR DESCRIPTION
This PR is part of a series to migrate search to paginated repository
resolution.

This change is needed so that we can read the `Stars` value of the last
`types.RepoName` in a page of repos that is sorted by star count. That
value will then be put in a `database.Cursors` type which will be passed
around to a `searchrepos.Pager`.

Part of #26995



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
