### PR TITLE
Extract createChangesetSpecs from src-cli

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1410,6 +1410,8 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -1431,6 +1433,8 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=

--- a/lib/batches/batch_spec_test.go
+++ b/lib/batches/batch_spec_test.go
@@ -164,7 +164,6 @@ changesetTemplate:
 				t.Fatal(err)
 			}
 
-			fmt.Printf("len(batchSpec.Steps)=%d", len(batchSpec.Steps))
 			if batchSpec.Steps[0].IfCondition() != tt.want {
 				t.Fatalf("wrong IfCondition. want=%q, got=%q", tt.want, batchSpec.Steps[0].IfCondition())
 			}

--- a/lib/batches/changeset_specs.go
+++ b/lib/batches/changeset_specs.go
@@ -1,0 +1,287 @@
+package batches
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sourcegraph/go-diff/diff"
+
+	"github.com/sourcegraph/sourcegraph/lib/batches/git"
+	"github.com/sourcegraph/sourcegraph/lib/batches/template"
+)
+
+var errOptionalPublishedUnsupported = NewValidationError(errors.New(`This Sourcegraph version requires the "published" field to be specified in the batch spec; upgrade to version 3.30.0 or later to be able to omit the published field and control publication from the UI.`))
+
+type ChangesetSpecRepository struct {
+	Name        string
+	FileMatches []string
+
+	BaseRef string
+	BaseRev string
+}
+type ChangesetSpecInput struct {
+	// This is the old graphql.Repository
+	BaseRepositoryID string
+	HeadRepositoryID string
+
+	// This is just a thin wrapper
+	Repository ChangesetSpecRepository
+
+	// These were on Task
+	BatchChangeAttributes *template.BatchChangeAttributes `json:"-"`
+	Template              *ChangesetTemplate              `json:"-"`
+	TransformChanges      *TransformChanges               `json:"-"`
+
+	// These were on executionResult
+
+	// Diff is the produced by executing all steps.
+	Diff string `json:"diff"`
+	// ChangedFiles are files that have been changed by all steps.
+	ChangedFiles *git.Changes `json:"changedFiles"`
+	// Outputs are the outputs produced by all steps.
+	Outputs map[string]interface{} `json:"outputs"`
+	// Path relative to the repository's root directory in which the steps
+	// have been executed.
+	// No leading slashes. Root directory is blank string.
+	Path string
+}
+
+type ChangesetSpecFeatureFlags struct {
+	IncludeAutoAuthorDetails bool
+	AllowOptionalPublished   bool
+}
+
+func BuildChangesetSpecs(input *ChangesetSpecInput, features ChangesetSpecFeatureFlags) ([]*ChangesetSpec, error) {
+	tmplCtx := &template.ChangesetTemplateContext{
+		BatchChangeAttributes: *input.BatchChangeAttributes,
+		Steps: template.StepsContext{
+			Changes: input.ChangedFiles,
+			Path:    input.Path,
+		},
+		Outputs: input.Outputs,
+		Repository: template.Repository{
+			Name:        input.Repository.Name,
+			FileMatches: input.Repository.FileMatches,
+		},
+	}
+
+	var authorName string
+	var authorEmail string
+
+	if input.Template.Commit.Author == nil {
+		if features.IncludeAutoAuthorDetails {
+			// user did not provide author info, so use defaults
+			authorName = "Sourcegraph"
+			authorEmail = "batch-changes@sourcegraph.com"
+		}
+	} else {
+		var err error
+		authorName, err = template.RenderChangesetTemplateField("authorName", input.Template.Commit.Author.Name, tmplCtx)
+		if err != nil {
+			return nil, err
+		}
+		authorEmail, err = template.RenderChangesetTemplateField("authorEmail", input.Template.Commit.Author.Email, tmplCtx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	title, err := template.RenderChangesetTemplateField("title", input.Template.Title, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := template.RenderChangesetTemplateField("body", input.Template.Body, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := template.RenderChangesetTemplateField("message", input.Template.Commit.Message, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: As a next step, we should extend the ChangesetTemplateContext to also include
+	// TransformChanges.Group and then change validateGroups and groupFileDiffs to, for each group,
+	// render the branch name *before* grouping the diffs.
+	defaultBranch, err := template.RenderChangesetTemplateField("branch", input.Template.Branch, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	newSpec := func(branch, diff string) (*ChangesetSpec, error) {
+		var published interface{} = nil
+		if input.Template.Published != nil {
+			published = input.Template.Published.ValueWithSuffix(input.Repository.Name, branch)
+
+			// Backward compatibility: before optional published fields were
+			// allowed, ValueWithSuffix() would fall back to false, not nil. We
+			// need to replicate this behaviour here.
+			if published == nil && !features.AllowOptionalPublished {
+				published = false
+			}
+		} else if !features.AllowOptionalPublished {
+			return nil, errOptionalPublishedUnsupported
+		}
+
+		return &ChangesetSpec{
+			BaseRepository: input.BaseRepositoryID,
+			HeadRepository: input.HeadRepositoryID,
+			BaseRef:        input.Repository.BaseRef,
+			BaseRev:        input.Repository.BaseRev,
+
+			HeadRef: ensureRefPrefix(branch),
+			Title:   title,
+			Body:    body,
+			Commits: []GitCommitDescription{
+				{
+					Message:     message,
+					AuthorName:  authorName,
+					AuthorEmail: authorEmail,
+					Diff:        diff,
+				},
+			},
+			Published: PublishedValue{Val: published},
+		}, nil
+	}
+
+	var specs []*ChangesetSpec
+
+	groups := groupsForRepository(input.Repository.Name, input.TransformChanges)
+	if len(groups) != 0 {
+		err := validateGroups(input.Repository.Name, input.Template.Branch, groups)
+		if err != nil {
+			return specs, err
+		}
+
+		// TODO: Regarding 'defaultBranch', see comment above
+		diffsByBranch, err := groupFileDiffs(input.Diff, defaultBranch, groups)
+		if err != nil {
+			return specs, errors.Wrap(err, "grouping diffs failed")
+		}
+
+		for branch, diff := range diffsByBranch {
+			spec, err := newSpec(branch, diff)
+			if err != nil {
+				return nil, err
+			}
+			specs = append(specs, spec)
+		}
+	} else {
+		spec, err := newSpec(defaultBranch, input.Diff)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, spec)
+	}
+
+	return specs, nil
+}
+
+func groupsForRepository(repoName string, transform *TransformChanges) []Group {
+	groups := []Group{}
+
+	if transform == nil {
+		return groups
+	}
+
+	for _, g := range transform.Group {
+		if g.Repository != "" {
+			if g.Repository == repoName {
+				groups = append(groups, g)
+			}
+		} else {
+			groups = append(groups, g)
+		}
+	}
+
+	return groups
+}
+
+func validateGroups(repoName, defaultBranch string, groups []Group) error {
+	uniqueBranches := make(map[string]struct{}, len(groups))
+
+	for _, g := range groups {
+		if _, ok := uniqueBranches[g.Branch]; ok {
+			return NewValidationError(fmt.Errorf("transformChanges would lead to multiple changesets in repository %s to have the same branch %q", repoName, g.Branch))
+		} else {
+			uniqueBranches[g.Branch] = struct{}{}
+		}
+
+		if g.Branch == defaultBranch {
+			return NewValidationError(fmt.Errorf("transformChanges group branch for repository %s is the same as branch %q in changesetTemplate", repoName, defaultBranch))
+		}
+	}
+
+	return nil
+}
+
+func groupFileDiffs(completeDiff, defaultBranch string, groups []Group) (map[string]string, error) {
+	fileDiffs, err := diff.ParseMultiFileDiff([]byte(completeDiff))
+	if err != nil {
+		return nil, err
+	}
+
+	// Housekeeping: we setup these two datastructures so we can
+	// - access the group.Branch by the directory for which they should be used
+	// - check against the given directories, in order.
+	branchesByDirectory := make(map[string]string, len(groups))
+	dirs := make([]string, len(branchesByDirectory))
+	for _, g := range groups {
+		branchesByDirectory[g.Directory] = g.Branch
+		dirs = append(dirs, g.Directory)
+	}
+
+	byBranch := make(map[string][]*diff.FileDiff, len(groups))
+	byBranch[defaultBranch] = []*diff.FileDiff{}
+
+	// For each file diff...
+	for _, f := range fileDiffs {
+		name := f.NewName
+		if name == "/dev/null" {
+			name = f.OrigName
+		}
+
+		// .. we check whether it matches one of the given directories in the
+		// group transformations, with the last match winning:
+		var matchingDir string
+		for _, d := range dirs {
+			if strings.Contains(name, d) {
+				matchingDir = d
+			}
+		}
+
+		// If the diff didn't match a rule, it goes into the default branch and
+		// the default changeset.
+		if matchingDir == "" {
+			byBranch[defaultBranch] = append(byBranch[defaultBranch], f)
+			continue
+		}
+
+		// If it *did* match a directory, we look up which branch we should use:
+		branch, ok := branchesByDirectory[matchingDir]
+		if !ok {
+			panic("this should not happen: " + matchingDir)
+		}
+
+		byBranch[branch] = append(byBranch[branch], f)
+	}
+
+	finalDiffsByBranch := make(map[string]string, len(byBranch))
+	for branch, diffs := range byBranch {
+		printed, err := diff.PrintMultiFileDiff(diffs)
+		if err != nil {
+			return nil, errors.Wrap(err, "printing multi file diff failed")
+		}
+		finalDiffsByBranch[branch] = string(printed)
+	}
+	return finalDiffsByBranch, nil
+}
+
+func ensureRefPrefix(ref string) string {
+	if strings.HasPrefix(ref, "refs/heads/") {
+		return ref
+	}
+	return "refs/heads/" + ref
+}

--- a/lib/batches/changeset_specs_test.go
+++ b/lib/batches/changeset_specs_test.go
@@ -1,0 +1,373 @@
+package batches
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/copystructure"
+
+	"github.com/sourcegraph/sourcegraph/lib/batches/git"
+	"github.com/sourcegraph/sourcegraph/lib/batches/overridable"
+	"github.com/sourcegraph/sourcegraph/lib/batches/template"
+)
+
+func TestCreateChangesetSpecs(t *testing.T) {
+	defaultChangesetSpec := &ChangesetSpec{
+		BaseRepository: "base-repo-id",
+		BaseRef:        "refs/heads/my-cool-base-ref",
+		BaseRev:        "f00b4r",
+		HeadRepository: "head-repo-id",
+		HeadRef:        "refs/heads/my-branch",
+
+		Title: "The title",
+		Body:  "The body",
+		Commits: []GitCommitDescription{
+			{
+				Message:     "git commit message",
+				Diff:        "cool diff",
+				AuthorName:  "Sourcegraph",
+				AuthorEmail: "batch-changes@sourcegraph.com",
+			},
+		},
+		Published: PublishedValue{Val: false},
+	}
+
+	specWith := func(s *ChangesetSpec, f func(s *ChangesetSpec)) *ChangesetSpec {
+		copy, err := copystructure.Copy(s)
+		if err != nil {
+			t.Fatalf("deep copying spec: %+v", err)
+		}
+
+		s = copy.(*ChangesetSpec)
+		f(s)
+		return s
+	}
+
+	defaultInput := &ChangesetSpecInput{
+		Repository: ChangesetSpecRepository{
+			Name:        "github.com/sourcegraph/src-cli",
+			FileMatches: []string{"go.mod", "README"},
+			BaseRef:     "refs/heads/my-cool-base-ref",
+			BaseRev:     "f00b4r",
+		},
+
+		BaseRepositoryID: "base-repo-id",
+		HeadRepositoryID: "head-repo-id",
+
+		BatchChangeAttributes: &template.BatchChangeAttributes{
+			Name:        "the name",
+			Description: "The description",
+		},
+
+		Template: &ChangesetTemplate{
+			Title:  "The title",
+			Body:   "The body",
+			Branch: "my-branch",
+			Commit: ExpandedGitCommitDescription{
+				Message: "git commit message",
+			},
+			Published: parsePublishedFieldString(t, "false"),
+		},
+
+		Diff: "cool diff",
+		ChangedFiles: &git.Changes{
+			Modified: []string{"README.md"},
+		},
+		Outputs: map[string]interface{}{},
+	}
+
+	inputWith := func(task *ChangesetSpecInput, f func(task *ChangesetSpecInput)) *ChangesetSpecInput {
+		copy, err := copystructure.Copy(task)
+		if err != nil {
+			t.Fatalf("deep copying task: %+v", err)
+		}
+
+		task = copy.(*ChangesetSpecInput)
+		f(task)
+		return task
+	}
+
+	featuresAllEnabled := ChangesetSpecFeatureFlags{
+		IncludeAutoAuthorDetails: true,
+		AllowOptionalPublished:   true,
+	}
+	featuresWithoutOptionalPublished := ChangesetSpecFeatureFlags{
+		IncludeAutoAuthorDetails: true,
+		AllowOptionalPublished:   false,
+	}
+
+	tests := []struct {
+		name string
+
+		input    *ChangesetSpecInput
+		features ChangesetSpecFeatureFlags
+
+		want    []*ChangesetSpec
+		wantErr string
+	}{
+		{
+			name:     "success",
+			input:    defaultInput,
+			features: featuresAllEnabled,
+			want: []*ChangesetSpec{
+				defaultChangesetSpec,
+			},
+			wantErr: "",
+		},
+		{
+			name: "publish by branch",
+			input: inputWith(defaultInput, func(input *ChangesetSpecInput) {
+				published := `[{"github.com/sourcegraph/*@my-branch": true}]`
+				input.Template.Published = parsePublishedFieldString(t, published)
+			}),
+			features: featuresAllEnabled,
+			want: []*ChangesetSpec{
+				specWith(defaultChangesetSpec, func(s *ChangesetSpec) {
+					s.Published = PublishedValue{Val: true}
+				}),
+			},
+			wantErr: "",
+		},
+		{
+			name: "publish by branch not matching",
+			input: inputWith(defaultInput, func(input *ChangesetSpecInput) {
+				published := `[{"github.com/sourcegraph/*@another-branch-name": true}]`
+				input.Template.Published = parsePublishedFieldString(t, published)
+			}),
+			features: featuresAllEnabled,
+			want: []*ChangesetSpec{
+				specWith(defaultChangesetSpec, func(s *ChangesetSpec) {
+					s.Published = PublishedValue{Val: nil}
+				}),
+			},
+			wantErr: "",
+		},
+		{
+			name: "publish by branch not matching on an old Sourcegraph version",
+			input: inputWith(defaultInput, func(input *ChangesetSpecInput) {
+				published := `[{"github.com/sourcegraph/*@another-branch-name": true}]`
+				input.Template.Published = parsePublishedFieldString(t, published)
+			}),
+			features: featuresWithoutOptionalPublished,
+			want: []*ChangesetSpec{
+				specWith(defaultChangesetSpec, func(s *ChangesetSpec) {
+					s.Published = PublishedValue{Val: false}
+				}),
+			},
+			wantErr: "",
+		},
+		{
+			name: "publish in UI on a supported version",
+			input: inputWith(defaultInput, func(input *ChangesetSpecInput) {
+				input.Template.Published = nil
+			}),
+			features: featuresAllEnabled,
+			want: []*ChangesetSpec{
+				specWith(defaultChangesetSpec, func(s *ChangesetSpec) {
+					s.Published = PublishedValue{Val: nil}
+				}),
+			},
+			wantErr: "",
+		},
+		{
+			name: "publish in UI on an unsupported version",
+			input: inputWith(defaultInput, func(input *ChangesetSpecInput) {
+				input.Template.Published = nil
+			}),
+			features: featuresWithoutOptionalPublished,
+			want:     nil,
+			wantErr:  errOptionalPublishedUnsupported.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			have, err := BuildChangesetSpecs(tt.input, tt.features)
+			if err != nil {
+				if tt.wantErr != "" {
+					if err.Error() != tt.wantErr {
+						t.Fatalf("wrong error. want=%q, got=%q", tt.wantErr, err.Error())
+					}
+					return
+				} else {
+					t.Fatalf("unexpected error: %s", err)
+				}
+			}
+
+			if !cmp.Equal(tt.want, have) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tt.want, have))
+			}
+		})
+	}
+}
+
+func TestGroupFileDiffs(t *testing.T) {
+	diff1 := `diff --git 1/1.txt 1/1.txt
+new file mode 100644
+index 0000000..19d6416
+--- /dev/null
++++ 1/1.txt
+@@ -0,0 +1,1 @@
++this is 1
+`
+	diff2 := `diff --git 1/2/2.txt 1/2/2.txt
+new file mode 100644
+index 0000000..c825d65
+--- /dev/null
++++ 1/2/2.txt
+@@ -0,0 +1,1 @@
++this is 2
+`
+	diff3 := `diff --git 1/2/3/3.txt 1/2/3/3.txt
+new file mode 100644
+index 0000000..1bd79fb
+--- /dev/null
++++ 1/2/3/3.txt
+@@ -0,0 +1,1 @@
++this is 3
+`
+
+	defaultBranch := "my-default-branch"
+	allDiffs := diff1 + diff2 + diff3
+
+	tests := []struct {
+		diff          string
+		defaultBranch string
+		groups        []Group
+		want          map[string]string
+	}{
+		{
+			diff: allDiffs,
+			groups: []Group{
+				{Directory: "1/2/3", Branch: "everything-in-3"},
+			},
+			want: map[string]string{
+				"my-default-branch": diff1 + diff2,
+				"everything-in-3":   diff3,
+			},
+		},
+		{
+			diff: allDiffs,
+			groups: []Group{
+				{Directory: "1/2", Branch: "everything-in-2-and-3"},
+			},
+			want: map[string]string{
+				"my-default-branch":     diff1,
+				"everything-in-2-and-3": diff2 + diff3,
+			},
+		},
+		{
+			diff: allDiffs,
+			groups: []Group{
+				{Directory: "1", Branch: "everything-in-1-and-2-and-3"},
+			},
+			want: map[string]string{
+				"my-default-branch":           "",
+				"everything-in-1-and-2-and-3": diff1 + diff2 + diff3,
+			},
+		},
+		{
+			diff: allDiffs,
+			groups: []Group{
+				// Each diff is matched against each directory, last match wins
+				{Directory: "1", Branch: "only-in-1"},
+				{Directory: "1/2", Branch: "only-in-2"},
+				{Directory: "1/2/3", Branch: "only-in-3"},
+			},
+			want: map[string]string{
+				"my-default-branch": "",
+				"only-in-3":         diff3,
+				"only-in-2":         diff2,
+				"only-in-1":         diff1,
+			},
+		},
+		{
+			diff: allDiffs,
+			groups: []Group{
+				// Last one wins here, because it matches every diff
+				{Directory: "1/2/3", Branch: "only-in-3"},
+				{Directory: "1/2", Branch: "only-in-2"},
+				{Directory: "1", Branch: "only-in-1"},
+			},
+			want: map[string]string{
+				"my-default-branch": "",
+				"only-in-1":         diff1 + diff2 + diff3,
+			},
+		},
+		{
+			diff: allDiffs,
+			groups: []Group{
+				{Directory: "", Branch: "everything"},
+			},
+			want: map[string]string{
+				"my-default-branch": diff1 + diff2 + diff3,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		have, err := groupFileDiffs(tc.diff, defaultBranch, tc.groups)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !cmp.Equal(tc.want, have) {
+			t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tc.want, have))
+		}
+	}
+}
+
+func TestValidateGroups(t *testing.T) {
+	repoName := "github.com/sourcegraph/src-cli"
+	defaultBranch := "my-batch-change"
+
+	tests := []struct {
+		defaultBranch string
+		groups        []Group
+		wantErr       string
+	}{
+		{
+			groups: []Group{
+				{Directory: "a", Branch: "my-batch-change-a"},
+				{Directory: "b", Branch: "my-batch-change-b"},
+			},
+			wantErr: "",
+		},
+		{
+			groups: []Group{
+				{Directory: "a", Branch: "my-batch-change-SAME"},
+				{Directory: "b", Branch: "my-batch-change-SAME"},
+			},
+			wantErr: "transformChanges would lead to multiple changesets in repository github.com/sourcegraph/src-cli to have the same branch \"my-batch-change-SAME\"",
+		},
+		{
+			groups: []Group{
+				{Directory: "a", Branch: "my-batch-change-SAME"},
+				{Directory: "b", Branch: defaultBranch},
+			},
+			wantErr: "transformChanges group branch for repository github.com/sourcegraph/src-cli is the same as branch \"my-batch-change\" in changesetTemplate",
+		},
+	}
+
+	for _, tc := range tests {
+		err := validateGroups(repoName, defaultBranch, tc.groups)
+		var haveErr string
+		if err != nil {
+			haveErr = err.Error()
+		}
+
+		if haveErr != tc.wantErr {
+			t.Fatalf("wrong error:\nwant=%q\nhave=%q", tc.wantErr, haveErr)
+		}
+	}
+}
+
+func parsePublishedFieldString(t *testing.T, input string) *overridable.BoolOrString {
+	t.Helper()
+
+	var result overridable.BoolOrString
+	if err := json.Unmarshal([]byte(input), &result); err != nil {
+		t.Fatalf("failed to parse %q as overridable.BoolOrString: %s", input, err)
+	}
+	return &result
+}

--- a/lib/batches/changeset_specs_test.go
+++ b/lib/batches/changeset_specs_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/copystructure"
 
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 	"github.com/sourcegraph/sourcegraph/lib/batches/overridable"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
@@ -70,11 +71,13 @@ func TestCreateChangesetSpecs(t *testing.T) {
 			Published: parsePublishedFieldString(t, "false"),
 		},
 
-		Diff: "cool diff",
-		ChangedFiles: &git.Changes{
-			Modified: []string{"README.md"},
+		Result: execution.Result{
+			Diff: "cool diff",
+			ChangedFiles: &git.Changes{
+				Modified: []string{"README.md"},
+			},
+			Outputs: map[string]interface{}{},
 		},
-		Outputs: map[string]interface{}{},
 	}
 
 	inputWith := func(task *ChangesetSpecInput, f func(task *ChangesetSpecInput)) *ChangesetSpecInput {

--- a/lib/batches/execution/results.go
+++ b/lib/batches/execution/results.go
@@ -1,0 +1,80 @@
+package execution
+
+import (
+	"bytes"
+
+	"github.com/sourcegraph/sourcegraph/lib/batches/git"
+)
+
+// StepResult represents the result of a single, previously executed step.
+type StepResult struct {
+	// Files are the changes made to Files by the step.
+	Files *git.Changes
+	// Stdout is the output produced by the step on standard out.
+	Stdout *bytes.Buffer
+	// Stderr is the output produced by the step on standard error.
+	Stderr *bytes.Buffer
+}
+
+// ModifiedFiles returns the files modified by a step.
+func (r StepResult) ModifiedFiles() []string {
+	if r.Files != nil {
+		return r.Files.Modified
+	}
+	return []string{}
+}
+
+// AddedFiles returns the files added by a step.
+func (r StepResult) AddedFiles() []string {
+	if r.Files != nil {
+		return r.Files.Added
+	}
+	return []string{}
+}
+
+// DeletedFiles returns the files deleted by a step.
+func (r StepResult) DeletedFiles() []string {
+	if r.Files != nil {
+		return r.Files.Deleted
+	}
+	return []string{}
+}
+
+// RenamedFiles returns the new name of files that have been renamed by a step.
+func (r StepResult) RenamedFiles() []string {
+	if r.Files != nil {
+		return r.Files.Renamed
+	}
+	return []string{}
+}
+
+// AfterStepResult is the ExecutionResult after executing a Step with the given
+// index in Steps.
+type AfterStepResult struct {
+	// StepIndex is the index of the step in the list of steps.
+	StepIndex int `json:"stepIndex"`
+	// Diff is the cumulative `git diff` after executing the Step.
+	Diff []byte `json:"diff"`
+	// Outputs is a copy of the Outputs after executing the Step.
+	Outputs map[string]interface{} `json:"outputs"`
+	// PreviousStepResult is the StepResult of the step before Step, if Step !=
+	// 0.
+	PreviousStepResult StepResult `json:"previousStepResult"`
+}
+
+// Result is the result of executing all executable steps in a workspace.
+type Result struct {
+	// Diff is the produced by executing all steps.
+	Diff string `json:"diff"`
+
+	// ChangedFiles are files that have been changed by all steps.
+	ChangedFiles *git.Changes `json:"changedFiles"`
+
+	// Outputs are the outputs produced by all steps.
+	Outputs map[string]interface{} `json:"outputs"`
+
+	// Path relative to the repository's root directory in which the steps
+	// have been executed.
+	// No leading slashes. Root directory is blank string.
+	Path string
+}

--- a/lib/batches/git/refs.go
+++ b/lib/batches/git/refs.go
@@ -1,0 +1,10 @@
+package git
+
+import "strings"
+
+func EnsureRefPrefix(ref string) string {
+	if strings.HasPrefix(ref, "refs/heads/") {
+		return ref
+	}
+	return "refs/heads/" + ref
+}

--- a/lib/batches/template/templating.go
+++ b/lib/batches/template/templating.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/gobwas/glob"
 
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 )
 
@@ -109,13 +110,13 @@ type StepContext struct {
 	Outputs map[string]interface{}
 	// Step is the result of the current step. Empty when evaluating the "run" field
 	// but filled when evaluating the "outputs" field.
-	Step StepResult
+	Step execution.StepResult
 	// Steps contains the path in which the steps are being executed and the
 	// changes made by all steps that were executed up until the current step.
 	Steps StepsContext
 	// PreviousStep is the result of the previous step. Empty when there is no
 	// previous step.
-	PreviousStep StepResult
+	PreviousStep execution.StepResult
 	// Repository is the Sourcegraph repository in which the steps are executed.
 	Repository Repository
 }
@@ -123,7 +124,7 @@ type StepContext struct {
 // ToFuncMap returns a template.FuncMap to access fields on the StepContext in a
 // text/template.
 func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
-	newStepResult := func(res *StepResult) map[string]interface{} {
+	newStepResult := func(res *execution.StepResult) map[string]interface{} {
 		m := map[string]interface{}{
 			"modified_files": "",
 			"added_files":    "",
@@ -160,7 +161,7 @@ func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
 			return newStepResult(&stepCtx.Step)
 		},
 		"steps": func() map[string]interface{} {
-			res := newStepResult(&StepResult{Files: stepCtx.Steps.Changes})
+			res := newStepResult(&execution.StepResult{Files: stepCtx.Steps.Changes})
 			res["path"] = stepCtx.Steps.Path
 			return res
 		},
@@ -180,49 +181,6 @@ func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
 			}
 		},
 	}
-}
-
-// StepResult represents the result of a previously executed step.
-type StepResult struct {
-	// Files are the changes made to Files by the step.
-	Files *git.Changes
-
-	// Stdout is the output produced by the step on standard out.
-	Stdout *bytes.Buffer
-	// Stderr is the output produced by the step on standard error.
-	Stderr *bytes.Buffer
-}
-
-// ModifiedFiles returns the files modified by a step.
-func (r StepResult) ModifiedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Modified
-	}
-	return []string{}
-}
-
-// AddedFiles returns the files added by a step.
-func (r StepResult) AddedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Added
-	}
-	return []string{}
-}
-
-// DeletedFiles returns the files deleted by a step.
-func (r StepResult) DeletedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Deleted
-	}
-	return []string{}
-}
-
-// RenamedFiles returns the new name of files that have been renamed by a step.
-func (r StepResult) RenamedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Renamed
-	}
-	return []string{}
 }
 
 type StepsContext struct {
@@ -270,9 +228,9 @@ func (tmplCtx *ChangesetTemplateContext) ToFuncMap() template.FuncMap {
 			return tmplCtx.Outputs
 		},
 		"steps": func() map[string]interface{} {
-			// Wrap the *StepChanges in a StepResult so we can use nil-safe
+			// Wrap the *StepChanges in a execution.StepResult so we can use nil-safe
 			// methods.
-			res := StepResult{Files: tmplCtx.Steps.Changes}
+			res := execution.StepResult{Files: tmplCtx.Steps.Changes}
 
 			return map[string]interface{}{
 				"modified_files": res.ModifiedFiles(),

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
 
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 )
 
@@ -23,7 +24,7 @@ func TestEvalStepCondition(t *testing.T) {
 			Name:        "test-batch-change",
 			Description: "This batch change is just an experiment",
 		},
-		PreviousStep: StepResult{
+		PreviousStep: execution.StepResult{
 			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
@@ -88,7 +89,7 @@ func TestRenderStepTemplate(t *testing.T) {
 			Name:        "test-batch-change",
 			Description: "This batch change is just an experiment",
 		},
-		PreviousStep: StepResult{
+		PreviousStep: execution.StepResult{
 			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
@@ -97,7 +98,7 @@ func TestRenderStepTemplate(t *testing.T) {
 			"lastLine": "lastLine is this",
 			"project":  parsedYaml,
 		},
-		Step: StepResult{
+		Step: execution.StepResult{
 			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is current step's stdout"),
 			Stderr: bytes.NewBufferString("this is current step's stderr"),
@@ -232,7 +233,7 @@ ${{ steps.path }}
 
 func TestRenderStepMap(t *testing.T) {
 	stepCtx := &StepContext{
-		PreviousStep: StepResult{
+		PreviousStep: execution.StepResult{
 			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-runewidth v0.0.12
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/sourcegraph/go-diff v0.6.1

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -193,10 +193,14 @@ github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpe
 github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.mod h1:dSsfyI2zABAdhcbvkXqgxOxrCsbYeHCPgrZkku60dSg=
 github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/26929 and extracts the `createChangesetSpecs` method from src-cli into the `lib/batches` package.

I'm not too happy with the `ChangesetSpecInput` struct, but I also don't know how to improve it -- yet. But I figured that will come once I use it on the server-side and the src-cli side.

So, if you don't have any ideas on how to improve the input: how about we wait a few days?