### PR TITLE
external_services: adjust the behavior of `ExcludeNamespaceUser` option

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -190,11 +190,11 @@ type ExternalServicesListOptions struct {
 	// When specified, only include external services with the given IDs.
 	IDs []int64
 	// When true, only include external services not under any namespace (i.e. owned
-	// by all site admins), and values of NamespaceUserID, NamespaceOrgID and
-	// ExcludeNamespaceUser are ignored.
+	// by all site admins), and values of ExcludeNamespaceUser, NamespaceUserID and
+	// NamespaceOrgID are ignored.
 	NoNamespace bool
-	// When true, will exclude external services under any user namespace, and
-	// values of NamespaceUserID and NamespaceOrgID are ignored.
+	// When true, will exclude external services under any user namespace, and the
+	// value of NamespaceUserID is ignored.
 	ExcludeNamespaceUser bool
 	// When specified, only include external services under given user namespace.
 	NamespaceUserID int32
@@ -230,14 +230,19 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 		}
 		conds = append(conds, sqlf.Sprintf("id IN (%s)", sqlf.Join(ids, ",")))
 	}
+
 	if o.NoNamespace {
 		conds = append(conds, sqlf.Sprintf(`namespace_user_id IS NULL AND namespace_org_id IS NULL`))
-	} else if o.ExcludeNamespaceUser {
-		conds = append(conds, sqlf.Sprintf(`namespace_user_id IS NULL`))
-	} else if o.NamespaceUserID > 0 {
-		conds = append(conds, sqlf.Sprintf(`namespace_user_id = %d`, o.NamespaceUserID))
-	} else if o.NamespaceOrgID > 0 {
-		conds = append(conds, sqlf.Sprintf(`namespace_org_id = %d`, o.NamespaceOrgID))
+	} else {
+		if o.ExcludeNamespaceUser {
+			conds = append(conds, sqlf.Sprintf(`namespace_user_id IS NULL`))
+		} else if o.NamespaceUserID > 0 {
+			conds = append(conds, sqlf.Sprintf(`namespace_user_id = %d`, o.NamespaceUserID))
+		}
+
+		if o.NamespaceOrgID > 0 {
+			conds = append(conds, sqlf.Sprintf(`namespace_org_id = %d`, o.NamespaceOrgID))
+		}
 	}
 	if len(o.Kinds) > 0 {
 		kinds := make([]*sqlf.Query, 0, len(o.Kinds))


### PR DESCRIPTION
Followup of https://github.com/sourcegraph/sourcegraph/pull/26828#discussion_r740933700.

Namely,

1. `NoNamespace` -> any namespace is ignored
2. `ExcludeNamespaceUser` -> only user namespace is ignored. If we supply `NamespaceOrgID`, it is still applied
3. `NamespaceUserID`, `NamespaceOrgID` are mutually exclusive

The 3. is not precisely reflected in code because if we stop restricting conditions because of conflict, more rows would be returned (and could cause unauthorized access to external services). i.e. having `deleted_at IS NULL AND namespace_user_id = 1 AND namespace_org_id = 2` would return nothing in practice, but no result is safer than not restricting namespace at all (`deleted_at IS NULL`), and ended up returning external services from other namespaces from the query.