### PR TITLE
graphqlbackend: fix tests what are not printing the actual error

### DIFF
--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -135,23 +136,17 @@ func TestNode_Org(t *testing.T) {
 
 func TestUnmarshalOrgID(t *testing.T) {
 	t.Run("Valid org ID is parsed correctly", func(t *testing.T) {
-		const id = 1
+		const id = int32(1)
 		namespaceOrgID := relay.MarshalID("Org", id)
-		org, err := UnmarshalOrgID(namespaceOrgID)
-		if err != nil {
-			t.Fatal("Error when unmarshalling valid org id: #{err}")
-		}
-		if id != org {
-			t.Fatal("ID mismatch: want #{id} but got #{org}")
-		}
+		orgID, err := UnmarshalOrgID(namespaceOrgID)
+		assert.NoError(t, err)
+		assert.Equal(t, id, orgID)
 	})
 
 	t.Run("Returns error for invalid org ID", func(t *testing.T) {
 		const id = 1
 		namespaceOrgID := relay.MarshalID("User", id)
 		_, err := UnmarshalOrgID(namespaceOrgID)
-		if err == nil {
-			t.Fatal("Expecting error, got: #{org}, #{err}")
-		}
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
Followup of https://github.com/sourcegraph/sourcegraph/pull/26507#discussion_r735614592.

`#{err}` is a static string in Go, it does not infer the value of `err` variable.