### PR TITLE
search: extract excluded repos counting from repo resolution

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -20,7 +20,6 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -664,7 +663,6 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 					OnMissingRepoRevs: zoektutil.MissingRepoRevStatus(r.stream),
 				})
 			}
-
 		}
 
 		if r.PatternType == query.SearchTypeStructural && p.Pattern != "" {
@@ -1649,14 +1647,32 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		tr.LazyPrintf("adding error for missing repo revs - done")
 	}
 
-	agg.Send(streaming.SearchEvent{
-		Stats: streaming.Stats{
-			Repos:            resolved.RepoSet,
-			ExcludedForks:    resolved.ExcludedRepos.Forks,
-			ExcludedArchived: resolved.ExcludedRepos.Archived,
-		},
-	})
-	tr.LazyPrintf("sending first stats (repos %d, excluded repos %+v) - done", len(resolved.RepoSet), resolved.ExcludedRepos)
+	agg.Send(streaming.SearchEvent{Stats: streaming.Stats{Repos: resolved.RepoSet}})
+	tr.LazyPrintf("sending first stats (repos %d) - done", len(resolved.RepoSet))
+
+	{
+		wg := waitGroup(true)
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+
+			repositoryResolver := searchrepos.Resolver{DB: r.db}
+			excluded, err := repositoryResolver.Excluded(ctx, args.RepoOptions)
+			if err != nil {
+				agg.Error(err)
+				return
+			}
+
+			agg.Send(streaming.SearchEvent{
+				Stats: streaming.Stats{
+					ExcludedArchived: excluded.Archived,
+					ExcludedForks:    excluded.Forks,
+				},
+			})
+
+			tr.LazyPrintf("sent excluded stats %#v", excluded)
+		})
+	}
 
 	if args.ResultTypes.Has(result.TypeRepo) {
 		wg := waitGroup(true)
@@ -1665,7 +1681,6 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			defer wg.Done()
 			_ = agg.DoRepoSearch(ctx, args, int32(limit))
 		})
-
 	}
 
 	if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -133,7 +133,6 @@ func TestSearchResults(t *testing.T) {
 				t.Error("!calledReposListRepoNames")
 			}
 		}
-
 	})
 
 	t.Run("multiple terms regexp", func(t *testing.T) {
@@ -508,7 +507,8 @@ func TestSearchResultsHydration(t *testing.T) {
 			ID:          repoName,
 			ServiceType: extsvc.TypeGitHub,
 			ServiceID:   "https://github.com",
-		}}
+		},
+	}
 
 	hydratedRepo := &types.Repo{
 
@@ -1051,7 +1051,6 @@ func TestIsGlobalSearch(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -441,7 +441,6 @@ func TestResolveRepositoriesWithUserSearchContext(t *testing.T) {
 	}
 
 	repos := dbmock.NewMockRepoStore()
-	repos.CountFunc.SetDefaultReturn(6, nil)
 	repos.ListRepoNamesFunc.SetDefaultHook(func(ctx context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
 		if op.UserID != wantUserID {
 			t.Fatalf("got %q, want %q", op.UserID, wantUserID)
@@ -515,7 +514,6 @@ func TestResolveRepositoriesWithUserSearchContext(t *testing.T) {
 	}
 
 	mockrequire.Called(t, ns.GetByNameFunc)
-	mockrequire.Called(t, repos.CountFunc)
 	mockrequire.Called(t, repos.ListRepoNamesFunc)
 }
 
@@ -541,7 +539,6 @@ func TestResolveRepositoriesWithSearchContext(t *testing.T) {
 	}
 
 	repos := dbmock.NewMockRepoStore()
-	repos.CountFunc.SetDefaultReturn(2, nil)
 	repos.ListRepoNamesFunc.SetDefaultHook(func(ctx context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
 		if op.SearchContextID != searchContext.ID {
 			t.Fatalf("got %q, want %q", op.SearchContextID, searchContext.ID)


### PR DESCRIPTION
This PR is a part of series to bring paginated repo resolution to
search.

It extracts the excluded repos counting step from repo resolution into
its own method, which is then called concurrently with other searches in
`doResults`.

This is needed because this counting doesn't make sense to do when
resolving repos in a paginated fashion.

Part of #26995



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
