### PR TITLE
all: rename types.RepoName to types.MinimalRepo

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -163,7 +163,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 
 // ListIndexable calls database.IndexableRepos.List, with tracing. It lists ALL
 // indexable repos which could include private user added repos.
-func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err error) {
+func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, err error) {
 	ctx, done := trace(ctx, "Repos", "ListIndexable", nil, &err)
 	defer func() {
 		if err == nil {
@@ -178,13 +178,13 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err 
 	}
 
 	trueP := true
-	return s.store.ListRepoNames(ctx, database.ReposListOptions{Index: &trueP})
+	return s.store.ListMinimalRepos(ctx, database.ReposListOptions{Index: &trueP})
 }
 
 // ListSearchable calls database.IndexableRepos.ListPublic, with tracing.
 // It lists all public indexable repos and also any private repos added by the
 // current user. Only used on sourcegraph.com where we don't have every repo indexed.
-func (s *repos) ListSearchable(ctx context.Context) (repos []types.RepoName, err error) {
+func (s *repos) ListSearchable(ctx context.Context) (repos []types.MinimalRepo, err error) {
 	ctx, done := trace(ctx, "Repos", "ListSearchable", nil, &err)
 	defer func() {
 		if err == nil {
@@ -203,7 +203,7 @@ func (s *repos) ListSearchable(ctx context.Context) (repos []types.RepoName, err
 
 	// For authenticated users we also want to include any private repos they may have added
 	if a := actor.FromContext(ctx); a.IsAuthenticated() {
-		privateRepos, err := s.store.ListRepoNames(ctx, database.ReposListOptions{
+		privateRepos, err := s.store.ListMinimalRepos(ctx, database.ReposListOptions{
 			UserID:      a.UID,
 			OnlyPrivate: true,
 		})

--- a/cmd/frontend/graphqlbackend/compute.go
+++ b/cmd/frontend/graphqlbackend/compute.go
@@ -182,11 +182,11 @@ func toComputeResultResolver(fm *result.FileMatch, result compute.Result, repoRe
 
 func toResultResolverList(ctx context.Context, cmd compute.Command, matches []result.Match, db dbutil.DB) ([]*computeResultResolver, error) {
 	type repoKey struct {
-		Name types.RepoName
+		Name types.MinimalRepo
 		Rev  string
 	}
 	repoResolvers := make(map[repoKey]*RepositoryResolver, 10)
-	getRepoResolver := func(repoName types.RepoName, rev string) *RepositoryResolver {
+	getRepoResolver := func(repoName types.MinimalRepo, rev string) *RepositoryResolver {
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
 		}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -236,7 +236,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 		j := 0
 		for i := range repoRevs {
 			repoRevs[i] = &search.RepositoryRevisions{
-				Repo: types.RepoName{
+				Repo: types.MinimalRepo{
 					ID:   api.RepoID(i),
 					Name: api.RepoName(chars[j] + "/repoName" + strconv.Itoa(i)),
 				},

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -136,11 +136,11 @@ func (sr *SearchResultsResolver) Results() []SearchResultResolver {
 
 func matchesToResolvers(db database.DB, matches []result.Match) []SearchResultResolver {
 	type repoKey struct {
-		Name types.RepoName
+		Name types.MinimalRepo
 		Rev  string
 	}
 	repoResolvers := make(map[repoKey]*RepositoryResolver, 10)
-	getRepoResolver := func(repoName types.RepoName, rev string) *RepositoryResolver {
+	getRepoResolver := func(repoName types.MinimalRepo, rev string) *RepositoryResolver {
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
 		}
@@ -1569,7 +1569,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		// Get all private repos for the the current actor. On sourcegraph.com, those are
 		// only the repos directly added by the user. Otherwise it's all repos the user has
 		// access to on all connected code hosts / external services.
-		userPrivateRepos, err := database.Repos(r.db).ListRepoNames(ctx, database.ReposListOptions{
+		userPrivateRepos, err := database.Repos(r.db).ListMinimalRepos(ctx, database.ReposListOptions{
 			UserID:       userID, // Zero valued when not in sourcegraph.com mode
 			OnlyPrivate:  true,
 			LimitOffset:  &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -66,7 +66,7 @@ func searchResultsStatsLanguages(ctx context.Context, matches []result.Match) ([
 	}
 
 	var (
-		repos    = map[api.RepoID]types.RepoName{}
+		repos    = map[api.RepoID]types.MinimalRepo{}
 		filesMap = map[repoCommit]*fileStatsWork{}
 
 		run = parallel.NewRun(16)
@@ -76,7 +76,7 @@ func searchResultsStatsLanguages(ctx context.Context, matches []result.Match) ([
 	)
 
 	// Track the mapping of repo ID -> repo object as we iterate.
-	sawRepo := func(repo types.RepoName) {
+	sawRepo := func(repo types.MinimalRepo) {
 		if _, ok := repos[repo.ID]; !ok {
 			repos[repo.ID] = repo
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -62,7 +62,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	defer gitserver.ResetClientMocks()
 
 	mkResult := func(path string, lineNumbers ...int32) *result.FileMatch {
-		rn := types.RepoName{
+		rn := types.MinimalRepo{
 			Name: "r",
 		}
 		fm := mkFileMatch(rn, path, lineNumbers...)

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -367,7 +367,7 @@ func TestQuoteSuggestions(t *testing.T) {
 	})
 }
 
-func mkFileMatch(repo types.RepoName, path string, lineNumbers ...int32) *result.FileMatch {
+func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int32) *result.FileMatch {
 	var lines []*result.LineMatch
 	for _, n := range lineNumbers {
 		lines = append(lines, &result.LineMatch{LineNumber: n})
@@ -394,7 +394,7 @@ func BenchmarkSearchResults(b *testing.B) {
 
 	ctx := context.Background()
 
-	database.Mocks.Repos.ListRepoNames = func(_ context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
+	database.Mocks.Repos.ListMinimalRepos = func(_ context.Context, op database.ReposListOptions) ([]types.MinimalRepo, error) {
 		return minimalRepos, nil
 	}
 	database.Mocks.Repos.Count = func(ctx context.Context, opt database.ReposListOptions) (int, error) {
@@ -431,14 +431,14 @@ func BenchmarkSearchResults(b *testing.B) {
 	}
 }
 
-func generateRepos(count int) ([]types.RepoName, []*zoekt.RepoListEntry) {
-	repos := make([]types.RepoName, 0, count)
+func generateRepos(count int) ([]types.MinimalRepo, []*zoekt.RepoListEntry) {
+	repos := make([]types.MinimalRepo, 0, count)
 	zoektRepos := make([]*zoekt.RepoListEntry, 0, count)
 
 	for i := 1; i <= count; i++ {
 		name := fmt.Sprintf("repo-%d", i)
 
-		repoWithIDs := types.RepoName{
+		repoWithIDs := types.MinimalRepo{
 			ID:   api.RepoID(i),
 			Name: api.RepoName(name),
 		}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -246,7 +246,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, indexed boo
 
 			if symbolMatch, _ := symbol.GetMatchAtLineCharacter(
 				ctx,
-				types.RepoName{ID: common.Repo.ID, Name: common.Repo.Name},
+				types.MinimalRepo{ID: common.Repo.ID, Name: common.Repo.Name},
 				common.CommitID,
 				strings.TrimLeft(blobPath, "/"),
 				lineRange.StartLine-1,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -116,7 +116,7 @@ func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, new
 	reposStore := database.Repos(db)
 	reposList := &reposListServer{
 		ListIndexable:   backend.Repos.ListIndexable,
-		StreamRepoNames: reposStore.StreamRepoNames,
+		StreamMinimalRepos: reposStore.StreamMinimalRepos,
 		Indexers:        search.Indexers(),
 	}
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -115,9 +115,9 @@ func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, new
 
 	reposStore := database.Repos(db)
 	reposList := &reposListServer{
-		ListIndexable:   backend.Repos.ListIndexable,
+		ListIndexable:      backend.Repos.ListIndexable,
 		StreamMinimalRepos: reposStore.StreamMinimalRepos,
-		Indexers:        search.Indexers(),
+		Indexers:           search.Indexers(),
 	}
 
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(reposList.serveIndex)))

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -142,9 +142,9 @@ func serveSearchConfiguration(db dbutil.DB) func(http.ResponseWriter, *http.Requ
 
 type reposListServer struct {
 	// ListIndexable returns the repositories to index.
-	ListIndexable func(context.Context) ([]types.RepoName, error)
+	ListIndexable func(context.Context) ([]types.MinimalRepo, error)
 
-	StreamRepoNames func(context.Context, database.ReposListOptions, func(*types.RepoName)) error
+	StreamMinimalRepos func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error
 
 	// Indexers is the subset of searchbackend.Indexers methods we
 	// use. reposListServer is used by indexed-search to get the list of
@@ -154,7 +154,7 @@ type reposListServer struct {
 	Indexers interface {
 		// ReposSubset returns the subset of repoNames that hostname should
 		// index.
-		ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.RepoName) ([]types.RepoName, error)
+		ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.MinimalRepo) ([]types.MinimalRepo, error)
 		// Enabled is true if horizontal indexed search is enabled.
 		Enabled() bool
 	}
@@ -189,10 +189,10 @@ func (h *reposListServer) serveIndex(w http.ResponseWriter, r *http.Request) err
 
 	if h.Indexers.Enabled() {
 		indexed := make(map[uint32]*zoekt.MinimalRepoListEntry, max(len(opt.Indexed), len(opt.IndexedIDs)))
-		err = h.StreamRepoNames(r.Context(), database.ReposListOptions{
+		err = h.StreamMinimalRepos(r.Context(), database.ReposListOptions{
 			IDs:   opt.IndexedIDs,
 			Names: opt.Indexed,
-		}, func(r *types.RepoName) { indexed[uint32(r.ID)] = nil })
+		}, func(r *types.MinimalRepo) { indexed[uint32(r.ID)] = nil })
 
 		if err != nil {
 			return err

--- a/cmd/frontend/internal/httpapi/search_test.go
+++ b/cmd/frontend/internal/httpapi/search_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestReposIndex(t *testing.T) {
-	allRepos := []types.RepoName{
+	allRepos := []types.MinimalRepo{
 		{ID: 1, Name: "github.com/popular/foo"},
 		{ID: 2, Name: "github.com/popular/bar"},
 		{ID: 3, Name: "github.com/alice/foo"},
@@ -32,7 +32,7 @@ func TestReposIndex(t *testing.T) {
 
 	cases := []struct {
 		name      string
-		indexable []types.RepoName
+		indexable []types.MinimalRepo
 		body      string
 		want      []string
 	}{{
@@ -76,7 +76,7 @@ func TestReposIndex(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			srv := &reposListServer{
 				ListIndexable:   fakeListIndexable(tc.indexable),
-				StreamRepoNames: fakeStreamRepoNames(allRepos),
+				StreamMinimalRepos: fakeStreamMinimalRepos(allRepos),
 				Indexers:        suffixIndexers(true),
 			}
 
@@ -121,14 +121,14 @@ func TestReposIndex(t *testing.T) {
 	}
 }
 
-func fakeListIndexable(indexable []types.RepoName) func(context.Context) ([]types.RepoName, error) {
-	return func(context.Context) ([]types.RepoName, error) {
+func fakeListIndexable(indexable []types.MinimalRepo) func(context.Context) ([]types.MinimalRepo, error) {
+	return func(context.Context) ([]types.MinimalRepo, error) {
 		return indexable, nil
 	}
 }
 
-func fakeStreamRepoNames(repos []types.RepoName) func(context.Context, database.ReposListOptions, func(*types.RepoName)) error {
-	return func(ctx context.Context, opt database.ReposListOptions, cb func(*types.RepoName)) error {
+func fakeStreamMinimalRepos(repos []types.MinimalRepo) func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error {
+	return func(ctx context.Context, opt database.ReposListOptions, cb func(*types.MinimalRepo)) error {
 		names := make(map[string]bool, len(opt.Names))
 		for _, name := range opt.Names {
 			names[name] = true
@@ -154,7 +154,7 @@ func fakeStreamRepoNames(repos []types.RepoName) func(context.Context, database.
 // the suffix of hostname.
 type suffixIndexers bool
 
-func (b suffixIndexers) ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.RepoName) ([]types.RepoName, error) {
+func (b suffixIndexers) ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.MinimalRepo) ([]types.MinimalRepo, error) {
 	if !b.Enabled() {
 		return nil, errors.New("indexers disabled")
 	}
@@ -162,7 +162,7 @@ func (b suffixIndexers) ReposSubset(ctx context.Context, hostname string, indexe
 		return nil, errors.New("empty hostname")
 	}
 
-	var filter []types.RepoName
+	var filter []types.MinimalRepo
 	for _, r := range indexable {
 		if strings.HasSuffix(string(r.Name), hostname) {
 			filter = append(filter, r)

--- a/cmd/frontend/internal/httpapi/search_test.go
+++ b/cmd/frontend/internal/httpapi/search_test.go
@@ -75,9 +75,9 @@ func TestReposIndex(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			srv := &reposListServer{
-				ListIndexable:   fakeListIndexable(tc.indexable),
+				ListIndexable:      fakeListIndexable(tc.indexable),
 				StreamMinimalRepos: fakeStreamMinimalRepos(allRepos),
-				Indexers:        suffixIndexers(true),
+				Indexers:           suffixIndexers(true),
 			}
 
 			req := httptest.NewRequest("POST", "/", bytes.NewReader([]byte(tc.body)))

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -354,7 +354,7 @@ type scheduler interface {
 	ListRepos() []string
 
 	// EnsureScheduled ensures that all the repos provided are known to the scheduler.
-	EnsureScheduled([]types.RepoName)
+	EnsureScheduled([]types.MinimalRepo)
 }
 
 type permsSyncer interface {
@@ -445,7 +445,7 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 		// of the queue
 		managed := sched.ListRepos()
 
-		uncloned, err := baseRepoStore.ListRepoNames(ctx, database.ReposListOptions{Names: managed, NoCloned: true})
+		uncloned, err := baseRepoStore.ListMinimalRepos(ctx, database.ReposListOptions{Names: managed, NoCloned: true})
 		if err != nil {
 			log15.Warn("failed to fetch list of uncloned repositories", "error", err)
 			return

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -58,7 +58,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 		}
 
 		// TODO(asdine): GetByIDs now returns the complete repo information rather that only a subset.
-		// Ensure this doesn't have an impact on performance and switch to using ListRepoNames if needed.
+		// Ensure this doesn't have an impact on performance and switch to using ListMinimalRepos if needed.
 		r.repos, r.err = database.Repos(r.db).GetByIDs(ctx, repoIDs...)
 		if r.err != nil {
 			return

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -159,7 +159,7 @@ func (r *Resolver) repositoryRevisionsFromInputArgs(ctx context.Context, args []
 			return nil, errors.Errorf("cannot find repo with id: %q", repository.RepositoryID)
 		}
 		repositoryRevisions = append(repositoryRevisions, &types.SearchContextRepositoryRevisions{
-			Repo:      types.RepoName{ID: repo.ID, Name: repo.Name},
+			Repo:      types.MinimalRepo{ID: repo.ID, Name: repo.Name},
 			Revisions: repository.Revisions,
 		})
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -184,9 +184,9 @@ func (s *PermsSyncer) providersByURNs() map[string]authz.Provider {
 // elements at a time to workaround Postgres' limit of 65535 bind parameters
 // using exact name matching. This method only includes private repository names
 // and does not do deduplication on the returned list.
-func (s *PermsSyncer) listPrivateRepoNamesBySpecs(ctx context.Context, repoSpecs []api.ExternalRepoSpec) ([]types.RepoName, error) {
+func (s *PermsSyncer) listPrivateRepoNamesBySpecs(ctx context.Context, repoSpecs []api.ExternalRepoSpec) ([]types.MinimalRepo, error) {
 	if len(repoSpecs) == 0 {
-		return []types.RepoName{}, nil
+		return []types.MinimalRepo{}, nil
 	}
 
 	remaining := repoSpecs
@@ -195,9 +195,9 @@ func (s *PermsSyncer) listPrivateRepoNamesBySpecs(ctx context.Context, repoSpecs
 		nextCut = len(remaining)
 	}
 
-	repoNames := make([]types.RepoName, 0, len(repoSpecs))
+	repoNames := make([]types.MinimalRepo, 0, len(repoSpecs))
 	for nextCut > 0 {
-		rs, err := s.reposStore.RepoStore.ListRepoNames(ctx,
+		rs, err := s.reposStore.RepoStore.ListMinimalRepos(ctx,
 			database.ReposListOptions{
 				ExternalRepos: remaining[:nextCut],
 				OnlyPrivate:   true,
@@ -401,7 +401,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 	// Exclusions are relative to inclusions, so if there is no inclusion, exclusion
 	// are meaningless and no need to trigger a DB query.
 	if len(includeContainsSpecs) > 0 {
-		rs, err := s.reposStore.RepoStore.ListRepoNames(ctx,
+		rs, err := s.reposStore.RepoStore.ListMinimalRepos(ctx,
 			database.ReposListOptions{
 				ExternalRepoIncludeContains: includeContainsSpecs,
 				ExternalRepoExcludeContains: excludeContainsSpecs,
@@ -545,7 +545,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, use
 	// Exclusions are relative to inclusions, so if there is no inclusion, exclusion
 	// are meaningless and no need to trigger a DB query.
 	if len(includeContainsSpecs) > 0 {
-		rs, err := s.reposStore.RepoStore.ListRepoNames(ctx,
+		rs, err := s.reposStore.RepoStore.ListMinimalRepos(ctx,
 			database.ReposListOptions{
 				ExternalRepoIncludeContains: includeContainsSpecs,
 				ExternalRepoExcludeContains: excludeContainsSpecs,

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -138,15 +138,15 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
 		return true, nil
 	}
-	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
+	database.Mocks.Repos.ListMinimalRepos = func(v0 context.Context, args database.ReposListOptions) ([]types.MinimalRepo, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
 		}
 
-		names := make([]types.RepoName, 0, len(args.ExternalRepos))
+		names := make([]types.MinimalRepo, 0, len(args.ExternalRepos))
 		for _, r := range args.ExternalRepos {
 			id, _ := strconv.Atoi(r.ID)
-			names = append(names, types.RepoName{ID: api.RepoID(id)})
+			names = append(names, types.MinimalRepo{ID: api.RepoID(id)})
 		}
 		return names, nil
 	}
@@ -230,11 +230,11 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
 		return true, nil
 	}
-	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
+	database.Mocks.Repos.ListMinimalRepos = func(v0 context.Context, args database.ReposListOptions) ([]types.MinimalRepo, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
 		}
-		return []types.RepoName{{ID: 1}}, nil
+		return []types.MinimalRepo{{ID: 1}}, nil
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
@@ -324,11 +324,11 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
 		return true, nil
 	}
-	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
+	database.Mocks.Repos.ListMinimalRepos = func(v0 context.Context, args database.ReposListOptions) ([]types.MinimalRepo, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
 		}
-		return []types.RepoName{{ID: 1}}, nil
+		return []types.MinimalRepo{{ID: 1}}, nil
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
@@ -445,7 +445,7 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
 		return true, nil
 	}
-	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
+	database.Mocks.Repos.ListMinimalRepos = func(v0 context.Context, args database.ReposListOptions) ([]types.MinimalRepo, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
 		} else if len(args.ExternalRepoIncludeContains) == 0 {
@@ -453,7 +453,7 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 		} else if len(args.ExternalRepoExcludeContains) == 0 {
 			return nil, errors.New("ExternalRepoExcludeContains want non-zero but got zero")
 		}
-		return []types.RepoName{{ID: 1}}, nil
+		return []types.MinimalRepo{{ID: 1}}, nil
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil
@@ -515,7 +515,7 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	edb.Mocks.Perms.UserIsMemberOfOrgHasCodeHostConnection = func(context.Context, int32) (bool, error) {
 		return false, nil
 	}
-	database.Mocks.Repos.ListRepoNames = func(v0 context.Context, args database.ReposListOptions) ([]types.RepoName, error) {
+	database.Mocks.Repos.ListMinimalRepos = func(v0 context.Context, args database.ReposListOptions) ([]types.MinimalRepo, error) {
 		if !args.OnlyPrivate {
 			return nil, errors.New("OnlyPrivate want true but got false")
 		} else if len(args.ExternalRepoIncludeContains) == 0 {
@@ -523,7 +523,7 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 		} else if len(args.ExternalRepoExcludeContains) == 0 {
 			return nil, errors.New("ExternalRepoExcludeContains want non-zero but got zero")
 		}
-		return []types.RepoName{{ID: 1}}, nil
+		return []types.MinimalRepo{{ID: 1}}, nil
 	}
 	database.Mocks.UserEmails.ListByUser = func(ctx context.Context, opt database.UserEmailsListOptions) ([]*database.UserEmail, error) {
 		return nil, nil

--- a/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
@@ -37,8 +37,8 @@ type IndexingSettingStore interface {
 }
 
 type IndexingRepoStore interface {
-	ListRepoNames(ctx context.Context, opt database.ReposListOptions) (results []types.RepoName, err error)
-	ListIndexableRepos(ctx context.Context, opts database.ListIndexableReposOptions) (results []types.RepoName, err error)
+	ListMinimalRepos(ctx context.Context, opt database.ReposListOptions) (results []types.MinimalRepo, err error)
+	ListIndexableRepos(ctx context.Context, opts database.ListIndexableReposOptions) (results []types.MinimalRepo, err error)
 }
 
 func (s *DBStoreShim) With(other basestore.ShareableStore) DBStore {

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
@@ -2506,25 +2506,26 @@ type IndexingRepoStoreListMinimalReposFunc struct {
 	mutex       sync.Mutex
 }
 
-// ListMinimalRepos delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
+// ListMinimalRepos delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
 func (m *MockIndexingRepoStore) ListMinimalRepos(v0 context.Context, v1 database.ReposListOptions) ([]types.MinimalRepo, error) {
 	r0, r1 := m.ListMinimalReposFunc.nextHook()(v0, v1)
 	m.ListMinimalReposFunc.appendCall(IndexingRepoStoreListMinimalReposFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the ListMinimalRepos method
-// of the parent MockIndexingRepoStore instance is invoked and the hook
-// queue is empty.
+// SetDefaultHook sets function that is called when the ListMinimalRepos
+// method of the parent MockIndexingRepoStore instance is invoked and the
+// hook queue is empty.
 func (f *IndexingRepoStoreListMinimalReposFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// ListMinimalRepos method of the parent MockIndexingRepoStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
+// ListMinimalRepos method of the parent MockIndexingRepoStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
 func (f *IndexingRepoStoreListMinimalReposFunc) PushHook(hook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
@@ -2347,9 +2347,9 @@ type MockIndexingRepoStore struct {
 	// ListIndexableReposFunc is an instance of a mock function object
 	// controlling the behavior of the method ListIndexableRepos.
 	ListIndexableReposFunc *IndexingRepoStoreListIndexableReposFunc
-	// ListRepoNamesFunc is an instance of a mock function object
-	// controlling the behavior of the method ListRepoNames.
-	ListRepoNamesFunc *IndexingRepoStoreListRepoNamesFunc
+	// ListMinimalReposFunc is an instance of a mock function object
+	// controlling the behavior of the method ListMinimalRepos.
+	ListMinimalReposFunc *IndexingRepoStoreListMinimalReposFunc
 }
 
 // NewMockIndexingRepoStore creates a new mock of the IndexingRepoStore
@@ -2358,12 +2358,12 @@ type MockIndexingRepoStore struct {
 func NewMockIndexingRepoStore() *MockIndexingRepoStore {
 	return &MockIndexingRepoStore{
 		ListIndexableReposFunc: &IndexingRepoStoreListIndexableReposFunc{
-			defaultHook: func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+			defaultHook: func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 				return nil, nil
 			},
 		},
-		ListRepoNamesFunc: &IndexingRepoStoreListRepoNamesFunc{
-			defaultHook: func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+		ListMinimalReposFunc: &IndexingRepoStoreListMinimalReposFunc{
+			defaultHook: func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 				return nil, nil
 			},
 		},
@@ -2378,8 +2378,8 @@ func NewMockIndexingRepoStoreFrom(i IndexingRepoStore) *MockIndexingRepoStore {
 		ListIndexableReposFunc: &IndexingRepoStoreListIndexableReposFunc{
 			defaultHook: i.ListIndexableRepos,
 		},
-		ListRepoNamesFunc: &IndexingRepoStoreListRepoNamesFunc{
-			defaultHook: i.ListRepoNames,
+		ListMinimalReposFunc: &IndexingRepoStoreListMinimalReposFunc{
+			defaultHook: i.ListMinimalRepos,
 		},
 	}
 }
@@ -2388,15 +2388,15 @@ func NewMockIndexingRepoStoreFrom(i IndexingRepoStore) *MockIndexingRepoStore {
 // ListIndexableRepos method of the parent MockIndexingRepoStore instance is
 // invoked.
 type IndexingRepoStoreListIndexableReposFunc struct {
-	defaultHook func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)
-	hooks       []func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)
+	defaultHook func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)
+	hooks       []func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)
 	history     []IndexingRepoStoreListIndexableReposFuncCall
 	mutex       sync.Mutex
 }
 
 // ListIndexableRepos delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockIndexingRepoStore) ListIndexableRepos(v0 context.Context, v1 database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (m *MockIndexingRepoStore) ListIndexableRepos(v0 context.Context, v1 database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 	r0, r1 := m.ListIndexableReposFunc.nextHook()(v0, v1)
 	m.ListIndexableReposFunc.appendCall(IndexingRepoStoreListIndexableReposFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -2405,7 +2405,7 @@ func (m *MockIndexingRepoStore) ListIndexableRepos(v0 context.Context, v1 databa
 // SetDefaultHook sets function that is called when the ListIndexableRepos
 // method of the parent MockIndexingRepoStore instance is invoked and the
 // hook queue is empty.
-func (f *IndexingRepoStoreListIndexableReposFunc) SetDefaultHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)) {
+func (f *IndexingRepoStoreListIndexableReposFunc) SetDefaultHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)) {
 	f.defaultHook = hook
 }
 
@@ -2414,7 +2414,7 @@ func (f *IndexingRepoStoreListIndexableReposFunc) SetDefaultHook(hook func(conte
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *IndexingRepoStoreListIndexableReposFunc) PushHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)) {
+func (f *IndexingRepoStoreListIndexableReposFunc) PushHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2422,21 +2422,21 @@ func (f *IndexingRepoStoreListIndexableReposFunc) PushHook(hook func(context.Con
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *IndexingRepoStoreListIndexableReposFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (f *IndexingRepoStoreListIndexableReposFunc) SetDefaultReturn(r0 []types.MinimalRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *IndexingRepoStoreListIndexableReposFunc) PushReturn(r0 []types.RepoName, r1 error) {
-	f.PushHook(func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (f *IndexingRepoStoreListIndexableReposFunc) PushReturn(r0 []types.MinimalRepo, r1 error) {
+	f.PushHook(func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
-func (f *IndexingRepoStoreListIndexableReposFunc) nextHook() func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (f *IndexingRepoStoreListIndexableReposFunc) nextHook() func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2478,7 +2478,7 @@ type IndexingRepoStoreListIndexableReposFuncCall struct {
 	Arg1 database.ListIndexableReposOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.RepoName
+	Result0 []types.MinimalRepo
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2496,36 +2496,36 @@ func (c IndexingRepoStoreListIndexableReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// IndexingRepoStoreListRepoNamesFunc describes the behavior when the
-// ListRepoNames method of the parent MockIndexingRepoStore instance is
+// IndexingRepoStoreListMinimalReposFunc describes the behavior when the
+// ListMinimalRepos method of the parent MockIndexingRepoStore instance is
 // invoked.
-type IndexingRepoStoreListRepoNamesFunc struct {
-	defaultHook func(context.Context, database.ReposListOptions) ([]types.RepoName, error)
-	hooks       []func(context.Context, database.ReposListOptions) ([]types.RepoName, error)
-	history     []IndexingRepoStoreListRepoNamesFuncCall
+type IndexingRepoStoreListMinimalReposFunc struct {
+	defaultHook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)
+	hooks       []func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)
+	history     []IndexingRepoStoreListMinimalReposFuncCall
 	mutex       sync.Mutex
 }
 
-// ListRepoNames delegates to the next hook function in the queue and stores
+// ListMinimalRepos delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockIndexingRepoStore) ListRepoNames(v0 context.Context, v1 database.ReposListOptions) ([]types.RepoName, error) {
-	r0, r1 := m.ListRepoNamesFunc.nextHook()(v0, v1)
-	m.ListRepoNamesFunc.appendCall(IndexingRepoStoreListRepoNamesFuncCall{v0, v1, r0, r1})
+func (m *MockIndexingRepoStore) ListMinimalRepos(v0 context.Context, v1 database.ReposListOptions) ([]types.MinimalRepo, error) {
+	r0, r1 := m.ListMinimalReposFunc.nextHook()(v0, v1)
+	m.ListMinimalReposFunc.appendCall(IndexingRepoStoreListMinimalReposFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the ListRepoNames method
+// SetDefaultHook sets function that is called when the ListMinimalRepos method
 // of the parent MockIndexingRepoStore instance is invoked and the hook
 // queue is empty.
-func (f *IndexingRepoStoreListRepoNamesFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions) ([]types.RepoName, error)) {
+func (f *IndexingRepoStoreListMinimalReposFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// ListRepoNames method of the parent MockIndexingRepoStore instance invokes
+// ListMinimalRepos method of the parent MockIndexingRepoStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *IndexingRepoStoreListRepoNamesFunc) PushHook(hook func(context.Context, database.ReposListOptions) ([]types.RepoName, error)) {
+func (f *IndexingRepoStoreListMinimalReposFunc) PushHook(hook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2533,21 +2533,21 @@ func (f *IndexingRepoStoreListRepoNamesFunc) PushHook(hook func(context.Context,
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *IndexingRepoStoreListRepoNamesFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+func (f *IndexingRepoStoreListMinimalReposFunc) SetDefaultReturn(r0 []types.MinimalRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *IndexingRepoStoreListRepoNamesFunc) PushReturn(r0 []types.RepoName, r1 error) {
-	f.PushHook(func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+func (f *IndexingRepoStoreListMinimalReposFunc) PushReturn(r0 []types.MinimalRepo, r1 error) {
+	f.PushHook(func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
-func (f *IndexingRepoStoreListRepoNamesFunc) nextHook() func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+func (f *IndexingRepoStoreListMinimalReposFunc) nextHook() func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2560,27 +2560,27 @@ func (f *IndexingRepoStoreListRepoNamesFunc) nextHook() func(context.Context, da
 	return hook
 }
 
-func (f *IndexingRepoStoreListRepoNamesFunc) appendCall(r0 IndexingRepoStoreListRepoNamesFuncCall) {
+func (f *IndexingRepoStoreListMinimalReposFunc) appendCall(r0 IndexingRepoStoreListMinimalReposFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of IndexingRepoStoreListRepoNamesFuncCall
+// History returns a sequence of IndexingRepoStoreListMinimalReposFuncCall
 // objects describing the invocations of this function.
-func (f *IndexingRepoStoreListRepoNamesFunc) History() []IndexingRepoStoreListRepoNamesFuncCall {
+func (f *IndexingRepoStoreListMinimalReposFunc) History() []IndexingRepoStoreListMinimalReposFuncCall {
 	f.mutex.Lock()
-	history := make([]IndexingRepoStoreListRepoNamesFuncCall, len(f.history))
+	history := make([]IndexingRepoStoreListMinimalReposFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// IndexingRepoStoreListRepoNamesFuncCall is an object that describes an
-// invocation of method ListRepoNames on an instance of
+// IndexingRepoStoreListMinimalReposFuncCall is an object that describes an
+// invocation of method ListMinimalRepos on an instance of
 // MockIndexingRepoStore.
-type IndexingRepoStoreListRepoNamesFuncCall struct {
+type IndexingRepoStoreListMinimalReposFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2589,7 +2589,7 @@ type IndexingRepoStoreListRepoNamesFuncCall struct {
 	Arg1 database.ReposListOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.RepoName
+	Result0 []types.MinimalRepo
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2597,13 +2597,13 @@ type IndexingRepoStoreListRepoNamesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexingRepoStoreListRepoNamesFuncCall) Args() []interface{} {
+func (c IndexingRepoStoreListMinimalReposFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexingRepoStoreListRepoNamesFuncCall) Results() []interface{} {
+func (c IndexingRepoStoreListMinimalReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/authz/perforce/protects.go
+++ b/enterprise/internal/authz/perforce/protects.go
@@ -258,7 +258,7 @@ func repoIncludesExcludesScanner(perms *authz.ExternalUserPermissions) *protects
 			line.match = strings.TrimRight(line.match, ".")
 
 			// NOTE: Manipulations made to `depotContains` will affect the behaviour of
-			// `(*RepoStore).ListRepoNames` - make sure to test new changes there as well.
+			// `(*RepoStore).ListMinimalRepos` - make sure to test new changes there as well.
 			depotContains := convertToPostgresMatch(line.match)
 
 			if !line.isExclusion {

--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -18,7 +18,7 @@ import (
 
 // IndexableReposLister is a subset of the API exposed by the backend.ListIndexable.
 type IndexableReposLister interface {
-	List(ctx context.Context) ([]types.RepoName, error)
+	List(ctx context.Context) ([]types.MinimalRepo, error)
 }
 
 // RepoStore is a subset of the API exposed by the database.Repos() store.

--- a/enterprise/internal/insights/discovery/all_repos_iterator_test.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator_test.go
@@ -164,12 +164,12 @@ func TestAllReposIterator_DotCom(t *testing.T) {
 		indexableReposListCall int // There is no pagination with this store! We'll probably want that, eventually.
 		nextRepoID             api.RepoID
 	)
-	indexableReposLister.ListFunc.SetDefaultHook(func(ctx context.Context) ([]types.RepoName, error) {
+	indexableReposLister.ListFunc.SetDefaultHook(func(ctx context.Context) ([]types.MinimalRepo, error) {
 		indexableReposListCall++
-		var result []types.RepoName
+		var result []types.MinimalRepo
 		for i := 0; i < 9; i++ {
 			nextRepoID++
-			result = append(result, types.RepoName{ID: nextRepoID, Name: api.RepoName(fmt.Sprint(nextRepoID))})
+			result = append(result, types.MinimalRepo{ID: nextRepoID, Name: api.RepoName(fmt.Sprint(nextRepoID))})
 		}
 		return result, nil
 	})

--- a/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
+++ b/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
@@ -25,7 +25,7 @@ type MockIndexableReposLister struct {
 func NewMockIndexableReposLister() *MockIndexableReposLister {
 	return &MockIndexableReposLister{
 		ListFunc: &IndexableReposListerListFunc{
-			defaultHook: func(context.Context) ([]types.RepoName, error) {
+			defaultHook: func(context.Context) ([]types.MinimalRepo, error) {
 				return nil, nil
 			},
 		},
@@ -46,15 +46,15 @@ func NewMockIndexableReposListerFrom(i IndexableReposLister) *MockIndexableRepos
 // IndexableReposListerListFunc describes the behavior when the List method
 // of the parent MockIndexableReposLister instance is invoked.
 type IndexableReposListerListFunc struct {
-	defaultHook func(context.Context) ([]types.RepoName, error)
-	hooks       []func(context.Context) ([]types.RepoName, error)
+	defaultHook func(context.Context) ([]types.MinimalRepo, error)
+	hooks       []func(context.Context) ([]types.MinimalRepo, error)
 	history     []IndexableReposListerListFuncCall
 	mutex       sync.Mutex
 }
 
 // List delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockIndexableReposLister) List(v0 context.Context) ([]types.RepoName, error) {
+func (m *MockIndexableReposLister) List(v0 context.Context) ([]types.MinimalRepo, error) {
 	r0, r1 := m.ListFunc.nextHook()(v0)
 	m.ListFunc.appendCall(IndexableReposListerListFuncCall{v0, r0, r1})
 	return r0, r1
@@ -63,7 +63,7 @@ func (m *MockIndexableReposLister) List(v0 context.Context) ([]types.RepoName, e
 // SetDefaultHook sets function that is called when the List method of the
 // parent MockIndexableReposLister instance is invoked and the hook queue is
 // empty.
-func (f *IndexableReposListerListFunc) SetDefaultHook(hook func(context.Context) ([]types.RepoName, error)) {
+func (f *IndexableReposListerListFunc) SetDefaultHook(hook func(context.Context) ([]types.MinimalRepo, error)) {
 	f.defaultHook = hook
 }
 
@@ -71,7 +71,7 @@ func (f *IndexableReposListerListFunc) SetDefaultHook(hook func(context.Context)
 // List method of the parent MockIndexableReposLister instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *IndexableReposListerListFunc) PushHook(hook func(context.Context) ([]types.RepoName, error)) {
+func (f *IndexableReposListerListFunc) PushHook(hook func(context.Context) ([]types.MinimalRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -79,21 +79,21 @@ func (f *IndexableReposListerListFunc) PushHook(hook func(context.Context) ([]ty
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *IndexableReposListerListFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]types.RepoName, error) {
+func (f *IndexableReposListerListFunc) SetDefaultReturn(r0 []types.MinimalRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *IndexableReposListerListFunc) PushReturn(r0 []types.RepoName, r1 error) {
-	f.PushHook(func(context.Context) ([]types.RepoName, error) {
+func (f *IndexableReposListerListFunc) PushReturn(r0 []types.MinimalRepo, r1 error) {
+	f.PushHook(func(context.Context) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
-func (f *IndexableReposListerListFunc) nextHook() func(context.Context) ([]types.RepoName, error) {
+func (f *IndexableReposListerListFunc) nextHook() func(context.Context) ([]types.MinimalRepo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -131,7 +131,7 @@ type IndexableReposListerListFuncCall struct {
 	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.RepoName
+	Result0 []types.MinimalRepo
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/database/dbcache/cached_indexable_repos.go
+++ b/internal/database/dbcache/cached_indexable_repos.go
@@ -18,20 +18,20 @@ import (
 const indexableReposMaxAge = time.Minute
 
 type cachedRepos struct {
-	repos   []types.RepoName
+	repos   []types.MinimalRepo
 	fetched time.Time
 }
 
 // Repos returns the current cached repos and boolean value indicating
 // whether an update is required
-func (c *cachedRepos) Repos() ([]types.RepoName, bool) {
+func (c *cachedRepos) Repos() ([]types.MinimalRepo, bool) {
 	if c == nil {
 		return nil, true
 	}
 	if c.repos == nil {
 		return nil, true
 	}
-	return append([]types.RepoName{}, c.repos...), time.Since(c.fetched) > indexableReposMaxAge
+	return append([]types.MinimalRepo{}, c.repos...), time.Since(c.fetched) > indexableReposMaxAge
 }
 
 func NewIndexableReposLister(store database.RepoStore) *IndexableReposLister {
@@ -56,16 +56,16 @@ type IndexableReposLister struct {
 //
 // The values are cached for up to indexableReposMaxAge. If the cache has expired, we return
 // stale data and start a background refresh.
-func (s *IndexableReposLister) List(ctx context.Context) (results []types.RepoName, err error) {
+func (s *IndexableReposLister) List(ctx context.Context) (results []types.MinimalRepo, err error) {
 	return s.list(ctx, false)
 }
 
 // ListPublic is similar to List except that it only includes public repos.
-func (s *IndexableReposLister) ListPublic(ctx context.Context) (results []types.RepoName, err error) {
+func (s *IndexableReposLister) ListPublic(ctx context.Context) (results []types.MinimalRepo, err error) {
 	return s.list(ctx, true)
 }
 
-func (s *IndexableReposLister) list(ctx context.Context, onlyPublic bool) (results []types.RepoName, err error) {
+func (s *IndexableReposLister) list(ctx context.Context, onlyPublic bool) (results []types.MinimalRepo, err error) {
 	cache := &(s.cacheAllRepos)
 	if onlyPublic {
 		cache = &(s.cachePublicRepos)
@@ -95,7 +95,7 @@ func (s *IndexableReposLister) list(ctx context.Context, onlyPublic bool) (resul
 	return repos, nil
 }
 
-func (s *IndexableReposLister) refreshCache(ctx context.Context, onlyPublic bool) ([]types.RepoName, error) {
+func (s *IndexableReposLister) refreshCache(ctx context.Context, onlyPublic bool) ([]types.MinimalRepo, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -122,7 +122,7 @@ func (s *IndexableReposLister) refreshCache(ctx context.Context, onlyPublic bool
 
 	cache.Store(&cachedRepos{
 		// Copy since repos will be mutated by the caller
-		repos:   append([]types.RepoName{}, repos...),
+		repos:   append([]types.MinimalRepo{}, repos...),
 		fetched: time.Now(),
 	})
 

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -80,7 +80,7 @@ func TestListIndexableRepos(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []types.RepoName{
+			want := []types.MinimalRepo{
 				{
 					ID:   api.RepoID(11),
 					Name: "github.com/foo/bar11",
@@ -108,7 +108,7 @@ func TestListIndexableRepos(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []types.RepoName{
+			want := []types.MinimalRepo{
 				{
 					ID:   api.RepoID(11),
 					Name: "github.com/foo/bar11",

--- a/internal/database/dbmock/repostore_mock.go
+++ b/internal/database/dbmock/repostore_mock.go
@@ -61,18 +61,18 @@ type MockRepoStore struct {
 	// ListIndexableReposFunc is an instance of a mock function object
 	// controlling the behavior of the method ListIndexableRepos.
 	ListIndexableReposFunc *RepoStoreListIndexableReposFunc
-	// ListRepoNamesFunc is an instance of a mock function object
-	// controlling the behavior of the method ListRepoNames.
-	ListRepoNamesFunc *RepoStoreListRepoNamesFunc
+	// ListMinimalReposFunc is an instance of a mock function object
+	// controlling the behavior of the method ListMinimalRepos.
+	ListMinimalReposFunc *RepoStoreListMinimalReposFunc
 	// MetadataFunc is an instance of a mock function object controlling the
 	// behavior of the method Metadata.
 	MetadataFunc *RepoStoreMetadataFunc
 	// QueryFunc is an instance of a mock function object controlling the
 	// behavior of the method Query.
 	QueryFunc *RepoStoreQueryFunc
-	// StreamRepoNamesFunc is an instance of a mock function object
-	// controlling the behavior of the method StreamRepoNames.
-	StreamRepoNamesFunc *RepoStoreStreamRepoNamesFunc
+	// StreamMinimalReposFunc is an instance of a mock function object
+	// controlling the behavior of the method StreamMinimalRepos.
+	StreamMinimalReposFunc *RepoStoreStreamMinimalReposFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *RepoStoreTransactFunc
@@ -151,12 +151,12 @@ func NewMockRepoStore() *MockRepoStore {
 			},
 		},
 		ListIndexableReposFunc: &RepoStoreListIndexableReposFunc{
-			defaultHook: func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+			defaultHook: func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 				return nil, nil
 			},
 		},
-		ListRepoNamesFunc: &RepoStoreListRepoNamesFunc{
-			defaultHook: func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+		ListMinimalReposFunc: &RepoStoreListMinimalReposFunc{
+			defaultHook: func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 				return nil, nil
 			},
 		},
@@ -170,8 +170,8 @@ func NewMockRepoStore() *MockRepoStore {
 				return nil, nil
 			},
 		},
-		StreamRepoNamesFunc: &RepoStoreStreamRepoNamesFunc{
-			defaultHook: func(context.Context, database.ReposListOptions, func(*types.RepoName)) error {
+		StreamMinimalReposFunc: &RepoStoreStreamMinimalReposFunc{
+			defaultHook: func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error {
 				return nil
 			},
 		},
@@ -234,8 +234,8 @@ func NewMockRepoStoreFrom(i database.RepoStore) *MockRepoStore {
 		ListIndexableReposFunc: &RepoStoreListIndexableReposFunc{
 			defaultHook: i.ListIndexableRepos,
 		},
-		ListRepoNamesFunc: &RepoStoreListRepoNamesFunc{
-			defaultHook: i.ListRepoNames,
+		ListMinimalReposFunc: &RepoStoreListMinimalReposFunc{
+			defaultHook: i.ListMinimalRepos,
 		},
 		MetadataFunc: &RepoStoreMetadataFunc{
 			defaultHook: i.Metadata,
@@ -243,8 +243,8 @@ func NewMockRepoStoreFrom(i database.RepoStore) *MockRepoStore {
 		QueryFunc: &RepoStoreQueryFunc{
 			defaultHook: i.Query,
 		},
-		StreamRepoNamesFunc: &RepoStoreStreamRepoNamesFunc{
-			defaultHook: i.StreamRepoNames,
+		StreamMinimalReposFunc: &RepoStoreStreamMinimalReposFunc{
+			defaultHook: i.StreamMinimalRepos,
 		},
 		TransactFunc: &RepoStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -1675,15 +1675,15 @@ func (c RepoStoreListEnabledNamesFuncCall) Results() []interface{} {
 // ListIndexableRepos method of the parent MockRepoStore instance is
 // invoked.
 type RepoStoreListIndexableReposFunc struct {
-	defaultHook func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)
-	hooks       []func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)
+	defaultHook func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)
+	hooks       []func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)
 	history     []RepoStoreListIndexableReposFuncCall
 	mutex       sync.Mutex
 }
 
 // ListIndexableRepos delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockRepoStore) ListIndexableRepos(v0 context.Context, v1 database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (m *MockRepoStore) ListIndexableRepos(v0 context.Context, v1 database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 	r0, r1 := m.ListIndexableReposFunc.nextHook()(v0, v1)
 	m.ListIndexableReposFunc.appendCall(RepoStoreListIndexableReposFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -1692,7 +1692,7 @@ func (m *MockRepoStore) ListIndexableRepos(v0 context.Context, v1 database.ListI
 // SetDefaultHook sets function that is called when the ListIndexableRepos
 // method of the parent MockRepoStore instance is invoked and the hook queue
 // is empty.
-func (f *RepoStoreListIndexableReposFunc) SetDefaultHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)) {
+func (f *RepoStoreListIndexableReposFunc) SetDefaultHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)) {
 	f.defaultHook = hook
 }
 
@@ -1700,7 +1700,7 @@ func (f *RepoStoreListIndexableReposFunc) SetDefaultHook(hook func(context.Conte
 // ListIndexableRepos method of the parent MockRepoStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *RepoStoreListIndexableReposFunc) PushHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error)) {
+func (f *RepoStoreListIndexableReposFunc) PushHook(hook func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1708,21 +1708,21 @@ func (f *RepoStoreListIndexableReposFunc) PushHook(hook func(context.Context, da
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *RepoStoreListIndexableReposFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (f *RepoStoreListIndexableReposFunc) SetDefaultReturn(r0 []types.MinimalRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *RepoStoreListIndexableReposFunc) PushReturn(r0 []types.RepoName, r1 error) {
-	f.PushHook(func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (f *RepoStoreListIndexableReposFunc) PushReturn(r0 []types.MinimalRepo, r1 error) {
+	f.PushHook(func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
-func (f *RepoStoreListIndexableReposFunc) nextHook() func(context.Context, database.ListIndexableReposOptions) ([]types.RepoName, error) {
+func (f *RepoStoreListIndexableReposFunc) nextHook() func(context.Context, database.ListIndexableReposOptions) ([]types.MinimalRepo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1763,7 +1763,7 @@ type RepoStoreListIndexableReposFuncCall struct {
 	Arg1 database.ListIndexableReposOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.RepoName
+	Result0 []types.MinimalRepo
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -1781,35 +1781,35 @@ func (c RepoStoreListIndexableReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// RepoStoreListRepoNamesFunc describes the behavior when the ListRepoNames
+// RepoStoreListMinimalReposFunc describes the behavior when the ListMinimalRepos
 // method of the parent MockRepoStore instance is invoked.
-type RepoStoreListRepoNamesFunc struct {
-	defaultHook func(context.Context, database.ReposListOptions) ([]types.RepoName, error)
-	hooks       []func(context.Context, database.ReposListOptions) ([]types.RepoName, error)
-	history     []RepoStoreListRepoNamesFuncCall
+type RepoStoreListMinimalReposFunc struct {
+	defaultHook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)
+	hooks       []func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)
+	history     []RepoStoreListMinimalReposFuncCall
 	mutex       sync.Mutex
 }
 
-// ListRepoNames delegates to the next hook function in the queue and stores
+// ListMinimalRepos delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockRepoStore) ListRepoNames(v0 context.Context, v1 database.ReposListOptions) ([]types.RepoName, error) {
-	r0, r1 := m.ListRepoNamesFunc.nextHook()(v0, v1)
-	m.ListRepoNamesFunc.appendCall(RepoStoreListRepoNamesFuncCall{v0, v1, r0, r1})
+func (m *MockRepoStore) ListMinimalRepos(v0 context.Context, v1 database.ReposListOptions) ([]types.MinimalRepo, error) {
+	r0, r1 := m.ListMinimalReposFunc.nextHook()(v0, v1)
+	m.ListMinimalReposFunc.appendCall(RepoStoreListMinimalReposFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the ListRepoNames method
+// SetDefaultHook sets function that is called when the ListMinimalRepos method
 // of the parent MockRepoStore instance is invoked and the hook queue is
 // empty.
-func (f *RepoStoreListRepoNamesFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions) ([]types.RepoName, error)) {
+func (f *RepoStoreListMinimalReposFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// ListRepoNames method of the parent MockRepoStore instance invokes the
+// ListMinimalRepos method of the parent MockRepoStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *RepoStoreListRepoNamesFunc) PushHook(hook func(context.Context, database.ReposListOptions) ([]types.RepoName, error)) {
+func (f *RepoStoreListMinimalReposFunc) PushHook(hook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1817,21 +1817,21 @@ func (f *RepoStoreListRepoNamesFunc) PushHook(hook func(context.Context, databas
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *RepoStoreListRepoNamesFunc) SetDefaultReturn(r0 []types.RepoName, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+func (f *RepoStoreListMinimalReposFunc) SetDefaultReturn(r0 []types.MinimalRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *RepoStoreListRepoNamesFunc) PushReturn(r0 []types.RepoName, r1 error) {
-	f.PushHook(func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+func (f *RepoStoreListMinimalReposFunc) PushReturn(r0 []types.MinimalRepo, r1 error) {
+	f.PushHook(func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 		return r0, r1
 	})
 }
 
-func (f *RepoStoreListRepoNamesFunc) nextHook() func(context.Context, database.ReposListOptions) ([]types.RepoName, error) {
+func (f *RepoStoreListMinimalReposFunc) nextHook() func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1844,26 +1844,26 @@ func (f *RepoStoreListRepoNamesFunc) nextHook() func(context.Context, database.R
 	return hook
 }
 
-func (f *RepoStoreListRepoNamesFunc) appendCall(r0 RepoStoreListRepoNamesFuncCall) {
+func (f *RepoStoreListMinimalReposFunc) appendCall(r0 RepoStoreListMinimalReposFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of RepoStoreListRepoNamesFuncCall objects
+// History returns a sequence of RepoStoreListMinimalReposFuncCall objects
 // describing the invocations of this function.
-func (f *RepoStoreListRepoNamesFunc) History() []RepoStoreListRepoNamesFuncCall {
+func (f *RepoStoreListMinimalReposFunc) History() []RepoStoreListMinimalReposFuncCall {
 	f.mutex.Lock()
-	history := make([]RepoStoreListRepoNamesFuncCall, len(f.history))
+	history := make([]RepoStoreListMinimalReposFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// RepoStoreListRepoNamesFuncCall is an object that describes an invocation
-// of method ListRepoNames on an instance of MockRepoStore.
-type RepoStoreListRepoNamesFuncCall struct {
+// RepoStoreListMinimalReposFuncCall is an object that describes an invocation
+// of method ListMinimalRepos on an instance of MockRepoStore.
+type RepoStoreListMinimalReposFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1872,7 +1872,7 @@ type RepoStoreListRepoNamesFuncCall struct {
 	Arg1 database.ReposListOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.RepoName
+	Result0 []types.MinimalRepo
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -1880,13 +1880,13 @@ type RepoStoreListRepoNamesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RepoStoreListRepoNamesFuncCall) Args() []interface{} {
+func (c RepoStoreListMinimalReposFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RepoStoreListRepoNamesFuncCall) Results() []interface{} {
+func (c RepoStoreListMinimalReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -2113,35 +2113,35 @@ func (c RepoStoreQueryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// RepoStoreStreamRepoNamesFunc describes the behavior when the
-// StreamRepoNames method of the parent MockRepoStore instance is invoked.
-type RepoStoreStreamRepoNamesFunc struct {
-	defaultHook func(context.Context, database.ReposListOptions, func(*types.RepoName)) error
-	hooks       []func(context.Context, database.ReposListOptions, func(*types.RepoName)) error
-	history     []RepoStoreStreamRepoNamesFuncCall
+// RepoStoreStreamMinimalReposFunc describes the behavior when the
+// StreamMinimalRepos method of the parent MockRepoStore instance is invoked.
+type RepoStoreStreamMinimalReposFunc struct {
+	defaultHook func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error
+	hooks       []func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error
+	history     []RepoStoreStreamMinimalReposFuncCall
 	mutex       sync.Mutex
 }
 
-// StreamRepoNames delegates to the next hook function in the queue and
+// StreamMinimalRepos delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockRepoStore) StreamRepoNames(v0 context.Context, v1 database.ReposListOptions, v2 func(*types.RepoName)) error {
-	r0 := m.StreamRepoNamesFunc.nextHook()(v0, v1, v2)
-	m.StreamRepoNamesFunc.appendCall(RepoStoreStreamRepoNamesFuncCall{v0, v1, v2, r0})
+func (m *MockRepoStore) StreamMinimalRepos(v0 context.Context, v1 database.ReposListOptions, v2 func(*types.MinimalRepo)) error {
+	r0 := m.StreamMinimalReposFunc.nextHook()(v0, v1, v2)
+	m.StreamMinimalReposFunc.appendCall(RepoStoreStreamMinimalReposFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the StreamRepoNames
+// SetDefaultHook sets function that is called when the StreamMinimalRepos
 // method of the parent MockRepoStore instance is invoked and the hook queue
 // is empty.
-func (f *RepoStoreStreamRepoNamesFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions, func(*types.RepoName)) error) {
+func (f *RepoStoreStreamMinimalReposFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// StreamRepoNames method of the parent MockRepoStore instance invokes the
+// StreamMinimalRepos method of the parent MockRepoStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *RepoStoreStreamRepoNamesFunc) PushHook(hook func(context.Context, database.ReposListOptions, func(*types.RepoName)) error) {
+func (f *RepoStoreStreamMinimalReposFunc) PushHook(hook func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2149,21 +2149,21 @@ func (f *RepoStoreStreamRepoNamesFunc) PushHook(hook func(context.Context, datab
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *RepoStoreStreamRepoNamesFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, database.ReposListOptions, func(*types.RepoName)) error {
+func (f *RepoStoreStreamMinimalReposFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *RepoStoreStreamRepoNamesFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, database.ReposListOptions, func(*types.RepoName)) error {
+func (f *RepoStoreStreamMinimalReposFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error {
 		return r0
 	})
 }
 
-func (f *RepoStoreStreamRepoNamesFunc) nextHook() func(context.Context, database.ReposListOptions, func(*types.RepoName)) error {
+func (f *RepoStoreStreamMinimalReposFunc) nextHook() func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2176,26 +2176,26 @@ func (f *RepoStoreStreamRepoNamesFunc) nextHook() func(context.Context, database
 	return hook
 }
 
-func (f *RepoStoreStreamRepoNamesFunc) appendCall(r0 RepoStoreStreamRepoNamesFuncCall) {
+func (f *RepoStoreStreamMinimalReposFunc) appendCall(r0 RepoStoreStreamMinimalReposFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of RepoStoreStreamRepoNamesFuncCall objects
+// History returns a sequence of RepoStoreStreamMinimalReposFuncCall objects
 // describing the invocations of this function.
-func (f *RepoStoreStreamRepoNamesFunc) History() []RepoStoreStreamRepoNamesFuncCall {
+func (f *RepoStoreStreamMinimalReposFunc) History() []RepoStoreStreamMinimalReposFuncCall {
 	f.mutex.Lock()
-	history := make([]RepoStoreStreamRepoNamesFuncCall, len(f.history))
+	history := make([]RepoStoreStreamMinimalReposFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// RepoStoreStreamRepoNamesFuncCall is an object that describes an
-// invocation of method StreamRepoNames on an instance of MockRepoStore.
-type RepoStoreStreamRepoNamesFuncCall struct {
+// RepoStoreStreamMinimalReposFuncCall is an object that describes an
+// invocation of method StreamMinimalRepos on an instance of MockRepoStore.
+type RepoStoreStreamMinimalReposFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2204,7 +2204,7 @@ type RepoStoreStreamRepoNamesFuncCall struct {
 	Arg1 database.ReposListOptions
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 func(*types.RepoName)
+	Arg2 func(*types.MinimalRepo)
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -2212,13 +2212,13 @@ type RepoStoreStreamRepoNamesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RepoStoreStreamRepoNamesFuncCall) Args() []interface{} {
+func (c RepoStoreStreamMinimalReposFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RepoStoreStreamRepoNamesFuncCall) Results() []interface{} {
+func (c RepoStoreStreamMinimalReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/dbmock/repostore_mock.go
+++ b/internal/database/dbmock/repostore_mock.go
@@ -1781,8 +1781,8 @@ func (c RepoStoreListIndexableReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// RepoStoreListMinimalReposFunc describes the behavior when the ListMinimalRepos
-// method of the parent MockRepoStore instance is invoked.
+// RepoStoreListMinimalReposFunc describes the behavior when the
+// ListMinimalRepos method of the parent MockRepoStore instance is invoked.
 type RepoStoreListMinimalReposFunc struct {
 	defaultHook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)
 	hooks       []func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)
@@ -1790,17 +1790,17 @@ type RepoStoreListMinimalReposFunc struct {
 	mutex       sync.Mutex
 }
 
-// ListMinimalRepos delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
+// ListMinimalRepos delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
 func (m *MockRepoStore) ListMinimalRepos(v0 context.Context, v1 database.ReposListOptions) ([]types.MinimalRepo, error) {
 	r0, r1 := m.ListMinimalReposFunc.nextHook()(v0, v1)
 	m.ListMinimalReposFunc.appendCall(RepoStoreListMinimalReposFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the ListMinimalRepos method
-// of the parent MockRepoStore instance is invoked and the hook queue is
-// empty.
+// SetDefaultHook sets function that is called when the ListMinimalRepos
+// method of the parent MockRepoStore instance is invoked and the hook queue
+// is empty.
 func (f *RepoStoreListMinimalReposFunc) SetDefaultHook(hook func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)) {
 	f.defaultHook = hook
 }
@@ -1861,8 +1861,8 @@ func (f *RepoStoreListMinimalReposFunc) History() []RepoStoreListMinimalReposFun
 	return history
 }
 
-// RepoStoreListMinimalReposFuncCall is an object that describes an invocation
-// of method ListMinimalRepos on an instance of MockRepoStore.
+// RepoStoreListMinimalReposFuncCall is an object that describes an
+// invocation of method ListMinimalRepos on an instance of MockRepoStore.
 type RepoStoreListMinimalReposFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
@@ -2114,7 +2114,8 @@ func (c RepoStoreQueryFuncCall) Results() []interface{} {
 }
 
 // RepoStoreStreamMinimalReposFunc describes the behavior when the
-// StreamMinimalRepos method of the parent MockRepoStore instance is invoked.
+// StreamMinimalRepos method of the parent MockRepoStore instance is
+// invoked.
 type RepoStoreStreamMinimalReposFunc struct {
 	defaultHook func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error
 	hooks       []func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error
@@ -2138,9 +2139,9 @@ func (f *RepoStoreStreamMinimalReposFunc) SetDefaultHook(hook func(context.Conte
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// StreamMinimalRepos method of the parent MockRepoStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
+// StreamMinimalRepos method of the parent MockRepoStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
 func (f *RepoStoreStreamMinimalReposFunc) PushHook(hook func(context.Context, database.ReposListOptions, func(*types.MinimalRepo)) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -91,16 +91,16 @@ func mustCreateGitserverRepo(ctx context.Context, t *testing.T, db *sql.DB, repo
 	return createdRepos
 }
 
-func repoNamesFromRepos(repos []*types.Repo) []types.RepoName {
-	rnames := make([]types.RepoName, 0, len(repos))
+func repoNamesFromRepos(repos []*types.Repo) []types.MinimalRepo {
+	rnames := make([]types.MinimalRepo, 0, len(repos))
 	for _, repo := range repos {
-		rnames = append(rnames, types.RepoName{ID: repo.ID, Name: repo.Name})
+		rnames = append(rnames, types.MinimalRepo{ID: repo.ID, Name: repo.Name})
 	}
 
 	return rnames
 }
 
-func reposFromRepoNames(names []types.RepoName) []*types.Repo {
+func reposFromRepoNames(names []types.MinimalRepo) []*types.Repo {
 	repos := make([]*types.Repo, 0, len(names))
 	for _, name := range names {
 		repos = append(repos, &types.Repo{ID: name.ID, Name: name.Name})
@@ -367,7 +367,7 @@ func TestRepos_List(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_userID(t *testing.T) {
+func TestRepos_ListMinimalRepos_userID(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -436,11 +436,11 @@ func TestRepos_ListRepoNames_userID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []types.RepoName{
+	want := []types.MinimalRepo{
 		{ID: repo.ID, Name: repo.Name},
 	}
 
-	have, err := Repos(db).ListRepoNames(ctx, ReposListOptions{UserID: user.ID})
+	have, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{UserID: user.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,7 +450,7 @@ func TestRepos_ListRepoNames_userID(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_orgID(t *testing.T) {
+func TestRepos_ListMinimalRepos_orgID(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -512,11 +512,11 @@ func TestRepos_ListRepoNames_orgID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []types.RepoName{
+	want := []types.MinimalRepo{
 		{ID: repo.ID, Name: repo.Name},
 	}
 
-	have, err := Repos(db).ListRepoNames(ctx, ReposListOptions{OrgID: org.ID})
+	have, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{OrgID: org.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1316,7 +1316,7 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames(t *testing.T) {
+func TestRepos_ListMinimalRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1348,9 +1348,9 @@ func TestRepos_ListRepoNames(t *testing.T) {
 	repo := mustCreate(ctx, t, db, &types.Repo{
 		Name: "name",
 	})
-	want := []types.RepoName{{ID: repo[0].ID, Name: repo[0].Name}}
+	want := []types.MinimalRepo{{ID: repo[0].ID, Name: repo[0].Name}}
 
-	repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{})
+	repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1359,7 +1359,7 @@ func TestRepos_ListRepoNames(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_fork(t *testing.T) {
+func TestRepos_ListMinimalRepos_fork(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1372,36 +1372,36 @@ func TestRepos_ListRepoNames_fork(t *testing.T) {
 	yours := repoNamesFromRepos(mustCreate(ctx, t, db, &types.Repo{Name: "b/r", Fork: true}))
 
 	{
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{OnlyForks: true})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, yours, repos)
 	}
 	{
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{NoForks: true})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{NoForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, mine, repos)
 	}
 	{
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{NoForks: true, OnlyForks: true})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{NoForks: true, OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, nil, repos)
 	}
 	{
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		assertJSONEqual(t, append(append([]types.RepoName(nil), mine...), yours...), repos)
+		assertJSONEqual(t, append(append([]types.MinimalRepo(nil), mine...), yours...), repos)
 	}
 }
 
-func TestRepos_ListRepoNames_cloned(t *testing.T) {
+func TestRepos_ListMinimalRepos_cloned(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1416,17 +1416,17 @@ func TestRepos_ListRepoNames_cloned(t *testing.T) {
 	tests := []struct {
 		name string
 		opt  ReposListOptions
-		want []types.RepoName
+		want []types.MinimalRepo
 	}{
 		{"OnlyCloned", ReposListOptions{OnlyCloned: true}, yours},
 		{"NoCloned", ReposListOptions{NoCloned: true}, mine},
 		{"NoCloned && OnlyCloned", ReposListOptions{NoCloned: true, OnlyCloned: true}, nil},
-		{"Default", ReposListOptions{}, append(append([]types.RepoName(nil), mine...), yours...)},
+		{"Default", ReposListOptions{}, append(append([]types.MinimalRepo(nil), mine...), yours...)},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos(db).ListRepoNames(ctx, test.opt)
+			repos, err := Repos(db).ListMinimalRepos(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1435,7 +1435,7 @@ func TestRepos_ListRepoNames_cloned(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_ids(t *testing.T) {
+func TestRepos_ListMinimalRepos_ids(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1453,7 +1453,7 @@ func TestRepos_ListRepoNames_ids(t *testing.T) {
 	tests := []struct {
 		name string
 		opt  ReposListOptions
-		want []types.RepoName
+		want []types.MinimalRepo
 	}{
 		{"Subset", ReposListOptions{IDs: mine.IDs()}, repoNamesFromRepos(mine)},
 		{"All", ReposListOptions{IDs: all.IDs()}, repoNamesFromRepos(all)},
@@ -1462,7 +1462,7 @@ func TestRepos_ListRepoNames_ids(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos(db).ListRepoNames(ctx, test.opt)
+			repos, err := Repos(db).ListMinimalRepos(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1471,7 +1471,7 @@ func TestRepos_ListRepoNames_ids(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_serviceTypes(t *testing.T) {
+func TestRepos_ListMinimalRepos_serviceTypes(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1489,7 +1489,7 @@ func TestRepos_ListRepoNames_serviceTypes(t *testing.T) {
 	tests := []struct {
 		name string
 		opt  ReposListOptions
-		want []types.RepoName
+		want []types.MinimalRepo
 	}{
 		{"OnlyGithub", ReposListOptions{ServiceTypes: []string{extsvc.TypeGitHub}}, repoNamesFromRepos(mine)},
 		{"OnlyGitlab", ReposListOptions{ServiceTypes: []string{extsvc.TypeGitLab}}, repoNamesFromRepos(yours)},
@@ -1499,7 +1499,7 @@ func TestRepos_ListRepoNames_serviceTypes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos(db).ListRepoNames(ctx, test.opt)
+			repos, err := Repos(db).ListMinimalRepos(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1508,7 +1508,7 @@ func TestRepos_ListRepoNames_serviceTypes(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_pagination(t *testing.T) {
+func TestRepos_ListMinimalRepos_pagination(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1543,7 +1543,7 @@ func TestRepos_ListRepoNames_pagination(t *testing.T) {
 		{limit: 4, offset: 4, exp: nil},
 	}
 	for _, test := range tests {
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1553,10 +1553,10 @@ func TestRepos_ListRepoNames_pagination(t *testing.T) {
 	}
 }
 
-// TestRepos_ListRepoNames_query tests the behavior of Repos.ListRepoNames when called with
+// TestRepos_ListMinimalRepos_query tests the behavior of Repos.ListMinimalRepos when called with
 // a query.
 // Test batch 1 (correct filtering)
-func TestRepos_ListRepoNames_correctFiltering(t *testing.T) {
+func TestRepos_ListMinimalRepos_correctFiltering(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1584,7 +1584,7 @@ func TestRepos_ListRepoNames_correctFiltering(t *testing.T) {
 		{"mno/p", []api.RepoName{"jkl/mno/pqr"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{Query: test.query})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1595,7 +1595,7 @@ func TestRepos_ListRepoNames_correctFiltering(t *testing.T) {
 }
 
 // Test batch 2 (correct ranking)
-func TestRepos_ListRepoNames_query2(t *testing.T) {
+func TestRepos_ListMinimalRepos_query2(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1626,7 +1626,7 @@ func TestRepos_ListRepoNames_query2(t *testing.T) {
 		{"def/m", []api.RepoName{"def/mno"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{Query: test.query})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1637,7 +1637,7 @@ func TestRepos_ListRepoNames_query2(t *testing.T) {
 }
 
 // Test sort
-func TestRepos_ListRepoNames_sort(t *testing.T) {
+func TestRepos_ListMinimalRepos_sort(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1695,7 +1695,7 @@ func TestRepos_ListRepoNames_sort(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy})
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1705,9 +1705,9 @@ func TestRepos_ListRepoNames_sort(t *testing.T) {
 	}
 }
 
-// TestRepos_ListRepoNames_patterns tests the behavior of Repos.List when called with
+// TestRepos_ListMinimalRepos_patterns tests the behavior of Repos.List when called with
 // IncludePatterns and ExcludePattern.
-func TestRepos_ListRepoNames_patterns(t *testing.T) {
+func TestRepos_ListMinimalRepos_patterns(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1749,7 +1749,7 @@ func TestRepos_ListRepoNames_patterns(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{
 			IncludePatterns: test.includePatterns,
 			ExcludePattern:  test.excludePattern,
 		})
@@ -1762,9 +1762,9 @@ func TestRepos_ListRepoNames_patterns(t *testing.T) {
 	}
 }
 
-// TestRepos_ListRepoNames_patterns tests the behavior of Repos.List when called with
+// TestRepos_ListMinimalRepos_patterns tests the behavior of Repos.List when called with
 // a QueryPattern.
-func TestRepos_ListRepoNames_queryPattern(t *testing.T) {
+func TestRepos_ListMinimalRepos_queryPattern(t *testing.T) {
 	t.Parallel()
 	db := dbtest.NewDB(t)
 	ctx := actor.WithInternalActor(context.Background())
@@ -1783,7 +1783,7 @@ func TestRepos_ListRepoNames_queryPattern(t *testing.T) {
 		want []api.RepoName
 		err  string
 	}{
-		// These are the same tests as TestRepos_ListRepoNames_patterns, but in an
+		// These are the same tests as TestRepos_ListMinimalRepos_patterns, but in an
 		// expression form.
 		{
 			q:    "(a|c)",
@@ -1870,7 +1870,7 @@ func TestRepos_ListRepoNames_queryPattern(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos(db).ListRepoNames(ctx, ReposListOptions{
+		repos, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{
 			PatternQuery: test.q,
 		})
 		if err != nil {
@@ -1892,40 +1892,40 @@ func TestRepos_ListRepoNames_queryPattern(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_queryAndPatternsMutuallyExclusive(t *testing.T) {
+func TestRepos_ListMinimalRepos_queryAndPatternsMutuallyExclusive(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	wantErr := "Query and IncludePatterns/ExcludePattern options are mutually exclusive"
 
 	t.Parallel()
 	db := dbtest.NewDB(t)
 	t.Run("Query and IncludePatterns", func(t *testing.T) {
-		_, err := Repos(db).ListRepoNames(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
+		_, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}
 	})
 
 	t.Run("Query and ExcludePattern", func(t *testing.T) {
-		_, err := Repos(db).ListRepoNames(ctx, ReposListOptions{Query: "x", ExcludePattern: "y"})
+		_, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{Query: "x", ExcludePattern: "y"})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}
 	})
 }
 
-func TestRepos_ListRepoNames_UserIDAndExternalServiceIDsMutuallyExclusive(t *testing.T) {
+func TestRepos_ListMinimalRepos_UserIDAndExternalServiceIDsMutuallyExclusive(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	wantErr := "options ExternalServiceIDs, UserID and OrgID are mutually exclusive"
 
 	t.Parallel()
 	db := dbtest.NewDB(t)
-	_, err := Repos(db).ListRepoNames(ctx, ReposListOptions{UserID: 1, ExternalServiceIDs: []int64{2}})
+	_, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{UserID: 1, ExternalServiceIDs: []int64{2}})
 	if err == nil || !strings.Contains(err.Error(), wantErr) {
 		t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 	}
 }
 
-func TestRepos_ListRepoNames_useOr(t *testing.T) {
+func TestRepos_ListMinimalRepos_useOr(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -1949,7 +1949,7 @@ func TestRepos_ListRepoNames_useOr(t *testing.T) {
 	tests := []struct {
 		name string
 		opt  ReposListOptions
-		want []types.RepoName
+		want []types.MinimalRepo
 	}{
 		{"Archived or Forks", ReposListOptions{OnlyArchived: true, OnlyForks: true, UseOr: true}, repoNamesFromRepos(archivedAndForks)},
 		{"Archived or Forks Or Cloned", ReposListOptions{OnlyArchived: true, OnlyForks: true, OnlyCloned: true, UseOr: true}, repoNamesFromRepos(all)},
@@ -1957,7 +1957,7 @@ func TestRepos_ListRepoNames_useOr(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos(db).ListRepoNames(ctx, test.opt)
+			repos, err := Repos(db).ListMinimalRepos(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1966,7 +1966,7 @@ func TestRepos_ListRepoNames_useOr(t *testing.T) {
 	}
 }
 
-func TestRepos_ListRepoNames_externalServiceID(t *testing.T) {
+func TestRepos_ListMinimalRepos_externalServiceID(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -2002,7 +2002,7 @@ func TestRepos_ListRepoNames_externalServiceID(t *testing.T) {
 	tests := []struct {
 		name string
 		opt  ReposListOptions
-		want []types.RepoName
+		want []types.MinimalRepo
 	}{
 		{"Some", ReposListOptions{ExternalServiceIDs: []int64{service1.ID}}, repoNamesFromRepos(mine)},
 		{"Default", ReposListOptions{}, repoNamesFromRepos(append(mine, yours...))},
@@ -2011,7 +2011,7 @@ func TestRepos_ListRepoNames_externalServiceID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos(db).ListRepoNames(ctx, test.opt)
+			repos, err := Repos(db).ListMinimalRepos(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2022,7 +2022,7 @@ func TestRepos_ListRepoNames_externalServiceID(t *testing.T) {
 
 // This function tests for both individual uses of ExternalRepoIncludeContains,
 // ExternalRepoExcludeContains as well as combination of these two options.
-func TestRepos_ListRepoNames_externalRepoContains(t *testing.T) {
+func TestRepos_ListMinimalRepos_externalRepoContains(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -2119,7 +2119,7 @@ func TestRepos_ListRepoNames_externalRepoContains(t *testing.T) {
 	tests := []struct {
 		name string
 		opt  ReposListOptions
-		want []types.RepoName
+		want []types.MinimalRepo
 	}{
 		{
 			name: "only apply ExternalRepoIncludeContains",
@@ -2338,7 +2338,7 @@ func TestRepos_ListRepoNames_externalRepoContains(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos(db).ListRepoNames(ctx, test.opt)
+			repos, err := Repos(db).ListMinimalRepos(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2382,11 +2382,11 @@ func TestRepos_ListRepos_UserPublicRepos(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []types.RepoName{
+	want := []types.MinimalRepo{
 		{ID: repo.ID, Name: repo.Name},
 	}
 
-	have, err := Repos(db).ListRepoNames(ctx, ReposListOptions{UserID: user.ID})
+	have, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{UserID: user.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2395,12 +2395,12 @@ func TestRepos_ListRepos_UserPublicRepos(t *testing.T) {
 		t.Fatalf(diff)
 	}
 
-	want = []types.RepoName{
+	want = []types.MinimalRepo{
 		{ID: repo.ID, Name: repo.Name},
 		{ID: otherRepo.ID, Name: otherRepo.Name},
 	}
 
-	have, err = Repos(db).ListRepoNames(ctx, ReposListOptions{UserID: user.ID, IncludeUserPublicRepos: true})
+	have, err = Repos(db).ListMinimalRepos(ctx, ReposListOptions{UserID: user.ID, IncludeUserPublicRepos: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -14,7 +14,7 @@ type MockRepos struct {
 	GetByName                   func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
 	GetByIDs                    func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
 	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
-	ListMinimalRepos               func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
+	ListMinimalRepos            func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
 	Metadata                    func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
 	Create                      func(ctx context.Context, repos ...*types.Repo) (err error)
 	Count                       func(ctx context.Context, opt ReposListOptions) (int, error)

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -14,7 +14,7 @@ type MockRepos struct {
 	GetByName                   func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
 	GetByIDs                    func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
 	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
-	ListRepoNames               func(v0 context.Context, v1 ReposListOptions) ([]types.RepoName, error)
+	ListMinimalRepos               func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
 	Metadata                    func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
 	Create                      func(ctx context.Context, repos ...*types.Repo) (err error)
 	Count                       func(ctx context.Context, opt ReposListOptions) (int, error)
@@ -77,13 +77,13 @@ func (s *MockRepos) MockList(t testing.TB, wantRepos ...api.RepoName) (called *b
 	return
 }
 
-func (s *MockRepos) MockListRepoNames(t testing.TB, wantRepos ...api.RepoName) (called *bool) {
+func (s *MockRepos) MockListMinimalRepos(t testing.TB, wantRepos ...api.RepoName) (called *bool) {
 	called = new(bool)
-	s.ListRepoNames = func(ctx context.Context, opt ReposListOptions) ([]types.RepoName, error) {
+	s.ListMinimalRepos = func(ctx context.Context, opt ReposListOptions) ([]types.MinimalRepo, error) {
 		*called = true
-		repos := make([]types.RepoName, len(wantRepos))
+		repos := make([]types.MinimalRepo, len(wantRepos))
 		for i, repo := range wantRepos {
-			repos[i] = types.RepoName{Name: repo}
+			repos[i] = types.MinimalRepo{Name: repo}
 		}
 		return repos, nil
 	}

--- a/internal/database/search_contexts.go
+++ b/internal/database/search_contexts.go
@@ -504,7 +504,7 @@ func (s *searchContextsStore) GetSearchContextRepositoryRevisions(ctx context.Co
 		sort.Strings(revisions)
 
 		out = append(out, &types.SearchContextRepositoryRevisions{
-			Repo: types.RepoName{
+			Repo: types.MinimalRepo{
 				ID:   api.RepoID(repoID),
 				Name: api.RepoName(repositoryIDsToName[repoID]),
 			},

--- a/internal/database/search_contexts_test.go
+++ b/internal/database/search_contexts_test.go
@@ -377,8 +377,8 @@ func TestSearchContexts_CreateAndSetRepositoryRevisions(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	repoAName := types.RepoName{ID: repoA.ID, Name: repoA.Name}
-	repoBName := types.RepoName{ID: repoB.ID, Name: repoB.Name}
+	repoAName := types.MinimalRepo{ID: repoA.ID, Name: repoA.Name}
+	repoBName := types.MinimalRepo{ID: repoB.ID, Name: repoB.Name}
 
 	// Create a search context with initial repository revisions
 	initialRepositoryRevisions := []*types.SearchContextRepositoryRevisions{
@@ -812,7 +812,7 @@ func TestSearchContexts_GetAllRevisionsForRepos(t *testing.T) {
 		searchContexts[idx], err = sc.CreateSearchContextWithRepositoryRevisions(
 			internalCtx,
 			searchContext,
-			[]*types.SearchContextRepositoryRevisions{{Repo: types.RepoName{ID: repos[idx].ID, Name: repos[idx].Name}, Revisions: []string{testRevision}}},
+			[]*types.SearchContextRepositoryRevisions{{Repo: types.MinimalRepo{ID: repos[idx].ID, Name: repos[idx].Name}, Revisions: []string{testRevision}}},
 		)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -306,7 +306,7 @@ func (s *updateScheduler) PrioritiseUncloned(names []string) {
 }
 
 // EnsureScheduled ensures that all repos in repos exist in the scheduler.
-func (s *updateScheduler) EnsureScheduled(repos []types.RepoName) {
+func (s *updateScheduler) EnsureScheduled(repos []types.MinimalRepo) {
 	s.schedule.insertNew(repos)
 }
 
@@ -724,7 +724,7 @@ func (s *schedule) prioritiseUncloned(names []string) {
 }
 
 // insertNew will insert repos only if they are not known to the scheduler
-func (s *schedule) insertNew(repos []types.RepoName) {
+func (s *schedule) insertNew(repos []types.MinimalRepo) {
 	required := make(map[string]struct{}, len(repos))
 	for _, n := range repos {
 		required[strings.ToLower(string(n.Name))] = struct{}{}

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -837,8 +837,8 @@ func TestUpdateQueue_PrioritiseUncloned(t *testing.T) {
 }
 
 func TestScheduleInsertNew(t *testing.T) {
-	repo1 := types.RepoName{ID: 1, Name: "repo1"}
-	repo2 := types.RepoName{ID: 2, Name: "repo2"}
+	repo1 := types.MinimalRepo{ID: 1, Name: "repo1"}
+	repo2 := types.MinimalRepo{ID: 2, Name: "repo2"}
 
 	_, stop := startRecording()
 	defer stop()
@@ -855,12 +855,12 @@ func TestScheduleInsertNew(t *testing.T) {
 
 	// add everything to the scheduler for the distant future.
 	mockTime(defaultTime.Add(time.Hour))
-	s.schedule.insertNew([]types.RepoName{repo1})
+	s.schedule.insertNew([]types.MinimalRepo{repo1})
 	assertFront(repo1.Name)
 
 	// Add including old
 	mockTime(defaultTime)
-	s.schedule.insertNew([]types.RepoName{repo1, repo2})
+	s.schedule.insertNew([]types.MinimalRepo{repo1, repo2})
 	assertFront(repo2.Name)
 }
 

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -67,7 +67,7 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 			Limit: 1,
 		},
 	}
-	notCloned, err := database.Repos(db).ListRepoNames(ctx, opts)
+	notCloned, err := database.Repos(db).ListMinimalRepos(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing not-cloned repos")
 	}
@@ -87,7 +87,7 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 			Limit: 1,
 		},
 	}
-	failedSync, err := database.Repos(db).ListRepoNames(ctx, opts)
+	failedSync, err := database.Repos(db).ListMinimalRepos(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "counting repo sync failures")
 	}

--- a/internal/search/backend/indexers.go
+++ b/internal/search/backend/indexers.go
@@ -37,7 +37,7 @@ type Indexers struct {
 // indexed is the set of repositories currently indexed by hostname.
 //
 // An error is returned if hostname is not part of the Indexers endpoints.
-func (c *Indexers) ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, repos []types.RepoName) ([]types.RepoName, error) {
+func (c *Indexers) ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, repos []types.MinimalRepo) ([]types.MinimalRepo, error) {
 	if !c.Enabled() {
 		return repos, nil
 	}
@@ -56,7 +56,7 @@ func (c *Indexers) ReposSubset(ctx context.Context, hostname string, indexed map
 	// it should drop. We will only drop them if the assigned endpoint has
 	// indexed it. This is to prevent dropping a computed index until
 	// rebalancing is finished.
-	other := map[string][]types.RepoName{}
+	other := map[string][]types.MinimalRepo{}
 
 	subset := repos[:0]
 	for _, r := range repos {

--- a/internal/search/backend/indexers_test.go
+++ b/internal/search/backend/indexers_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestReposSubset(t *testing.T) {
-	var indexed map[string][]types.RepoName
+	var indexed map[string][]types.MinimalRepo
 	index := &Indexers{
 		Map: prefixMap([]string{"foo", "bar", "baz.fully.qualified:80"}),
 		Indexed: func(ctx context.Context, k string) map[uint32]*zoekt.MinimalRepoListEntry {
@@ -29,12 +29,12 @@ func TestReposSubset(t *testing.T) {
 		},
 	}
 
-	repos := make(map[string]types.RepoName)
-	getRepos := func(names ...string) (rs []types.RepoName) {
+	repos := make(map[string]types.MinimalRepo)
+	getRepos := func(names ...string) (rs []types.MinimalRepo) {
 		for _, name := range names {
 			r, ok := repos[name]
 			if !ok {
-				r = types.RepoName{
+				r = types.MinimalRepo{
 					ID:   api.RepoID(rand.Int31()),
 					Name: api.RepoName(name),
 				}
@@ -48,9 +48,9 @@ func TestReposSubset(t *testing.T) {
 	cases := []struct {
 		name     string
 		hostname string
-		indexed  map[string][]types.RepoName
-		repos    []types.RepoName
-		want     []types.RepoName
+		indexed  map[string][]types.MinimalRepo
+		repos    []types.MinimalRepo
+		want     []types.MinimalRepo
 		errS     string
 	}{{
 		name:     "bad hostname",
@@ -65,7 +65,7 @@ func TestReposSubset(t *testing.T) {
 		name:     "none",
 		hostname: "bar",
 		repos:    getRepos("foo-1", "foo-2", "foo-3"),
-		want:     []types.RepoName{},
+		want:     []types.MinimalRepo{},
 	}, {
 		name:     "subset",
 		hostname: "foo",
@@ -84,7 +84,7 @@ func TestReposSubset(t *testing.T) {
 	}, {
 		name:     "drop",
 		hostname: "foo",
-		indexed: map[string][]types.RepoName{
+		indexed: map[string][]types.MinimalRepo{
 			"foo": getRepos("foo-1", "foo-drop", "bar-drop", "bar-keep"),
 			"bar": getRepos("foo-1", "bar-drop"),
 		},

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -293,7 +293,7 @@ func orderedFuzzyRegexp(pieces []string) string {
 	return "(" + strings.Join(pieces, ").*?(") + ")"
 }
 
-func logCommitSearchResultsToMatches(op *search.CommitParameters, repoName types.RepoName, rawResults []*git.LogCommitSearchResult) []*result.CommitMatch {
+func logCommitSearchResultsToMatches(op *search.CommitParameters, repoName types.MinimalRepo, rawResults []*git.LogCommitSearchResult) []*result.CommitMatch {
 	if len(rawResults) == 0 {
 		return nil
 	}

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -233,7 +233,7 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	return newPred
 }
 
-func protocolMatchToCommitMatch(repo types.RepoName, diff bool, in protocol.CommitMatch) *result.CommitMatch {
+func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.CommitMatch) *result.CommitMatch {
 	var (
 		matchBody       string
 		matchHighlights []result.HighlightedRange

--- a/internal/search/commit/commit_new_test.go
+++ b/internal/search/commit/commit_new_test.go
@@ -67,7 +67,7 @@ func TestCheckSearchLimits(t *testing.T) {
 		repoRevs := make([]*search.RepositoryRevisions, test.numRepoRevs)
 		for i := range repoRevs {
 			repoRevs[i] = &search.RepositoryRevisions{
-				Repo: types.RepoName{ID: api.RepoID(i)},
+				Repo: types.MinimalRepo{ID: api.RepoID(i)},
 			}
 		}
 

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -60,7 +60,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 	repoRevs := &search.RepositoryRevisions{
-		Repo: types.RepoName{ID: 1, Name: "repo"},
+		Repo: types.MinimalRepo{ID: 1, Name: "repo"},
 		Revs: []search.RevisionSpecifier{{RevSpec: "rev"}},
 	}
 	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, db, search.CommitParameters{
@@ -75,7 +75,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 
 	want := []*result.CommitMatch{{
 		Commit:      gitapi.Commit{ID: "c1", Author: gitSignatureWithDate},
-		Repo:        types.RepoName{ID: 1, Name: "repo"},
+		Repo:        types.MinimalRepo{ID: 1, Name: "repo"},
 		DiffPreview: &result.HighlightedString{Value: "x", Highlights: []result.HighlightedRange{}},
 		Body:        result.HighlightedString{Value: "```diff\nx```", Highlights: []result.HighlightedRange{}},
 	}}

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -56,7 +56,7 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
-	Repo types.RepoName
+	Repo types.MinimalRepo
 	Revs []RevisionSpecifier
 
 	// resolveOnce protects resolvedRevs

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -14,7 +14,7 @@ import (
 
 type CommitMatch struct {
 	Commit     gitapi.Commit
-	Repo       types.RepoName
+	Repo       types.MinimalRepo
 	Refs       []string
 	SourceRefs []string
 	// MessagePreview and DiffPreview are mutually exclusive. Only one should be set
@@ -37,7 +37,7 @@ func (r *CommitMatch) ResultCount() int {
 	return 1
 }
 
-func (r *CommitMatch) RepoName() types.RepoName {
+func (r *CommitMatch) RepoName() types.MinimalRepo {
 	return r.Repo
 }
 

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -13,7 +13,7 @@ import (
 func TestDeduper(t *testing.T) {
 	commit := func(repo, id string) *CommitMatch {
 		return &CommitMatch{
-			Repo: types.RepoName{
+			Repo: types.MinimalRepo{
 				Name: api.RepoName(repo),
 			},
 			Commit: gitapi.Commit{
@@ -24,7 +24,7 @@ func TestDeduper(t *testing.T) {
 
 	diff := func(repo, id string) *CommitMatch {
 		return &CommitMatch{
-			Repo: types.RepoName{
+			Repo: types.MinimalRepo{
 				Name: api.RepoName(repo),
 			},
 			Commit: gitapi.Commit{
@@ -44,7 +44,7 @@ func TestDeduper(t *testing.T) {
 	file := func(repo, commit, path string, lines []*LineMatch) *FileMatch {
 		return &FileMatch{
 			File: File{
-				Repo: types.RepoName{
+				Repo: types.MinimalRepo{
 					Name: api.RepoName(repo),
 				},
 				CommitID: api.CommitID(commit),

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -17,7 +17,7 @@ type File struct {
 	// preserve the original revision specifier from the user instead of navigating them to the
 	// absolute commit ID when they select a result.
 	InputRev *string        `json:"-"`
-	Repo     types.RepoName `json:"-"`
+	Repo     types.MinimalRepo `json:"-"`
 	CommitID api.CommitID   `json:"-"`
 	Path     string
 }
@@ -49,7 +49,7 @@ type FileMatch struct {
 	LimitHit bool
 }
 
-func (fm *FileMatch) RepoName() types.RepoName {
+func (fm *FileMatch) RepoName() types.MinimalRepo {
 	return fm.File.Repo
 }
 

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -16,9 +16,9 @@ type File struct {
 	// InputRev is the Git revspec that the user originally requested to search. It is used to
 	// preserve the original revision specifier from the user instead of navigating them to the
 	// absolute commit ID when they select a result.
-	InputRev *string        `json:"-"`
+	InputRev *string           `json:"-"`
 	Repo     types.MinimalRepo `json:"-"`
-	CommitID api.CommitID   `json:"-"`
+	CommitID api.CommitID      `json:"-"`
 	Path     string
 }
 

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -12,7 +12,7 @@ type Match interface {
 	ResultCount() int
 	Limit(int) int
 	Select(filter.SelectPath) Match
-	RepoName() types.RepoName
+	RepoName() types.MinimalRepo
 
 	// Key returns a key which uniquely identifies this match.
 	Key() Key

--- a/internal/search/result/merge_test.go
+++ b/internal/search/result/merge_test.go
@@ -13,7 +13,7 @@ import (
 
 func commitResult(repo, commit string) *CommitMatch {
 	return &CommitMatch{
-		Repo: types.RepoName{Name: api.RepoName(repo)},
+		Repo: types.MinimalRepo{Name: api.RepoName(repo)},
 		Commit: gitapi.Commit{
 			ID: api.CommitID(commit),
 		},
@@ -23,7 +23,7 @@ func commitResult(repo, commit string) *CommitMatch {
 func diffResult(repo, commit string) *CommitMatch {
 	return &CommitMatch{
 		DiffPreview: &HighlightedString{},
-		Repo:        types.RepoName{Name: api.RepoName(repo)},
+		Repo:        types.MinimalRepo{Name: api.RepoName(repo)},
 		Commit: gitapi.Commit{
 			ID: api.CommitID(commit),
 		},
@@ -39,7 +39,7 @@ func repoResult(name string) *RepoMatch {
 func fileResult(repo string, lineMatches []*LineMatch, symbolMatches []*SymbolMatch) *FileMatch {
 	return &FileMatch{
 		File: File{
-			Repo: types.RepoName{Name: api.RepoName(repo)},
+			Repo: types.MinimalRepo{Name: api.RepoName(repo)},
 		},
 		Symbols:     symbolMatches,
 		LineMatches: lineMatches,

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -16,8 +16,8 @@ type RepoMatch struct {
 	Rev string
 }
 
-func (r RepoMatch) RepoName() types.RepoName {
-	return types.RepoName{
+func (r RepoMatch) RepoName() types.MinimalRepo {
+	return types.MinimalRepo{
 		Name: r.Name,
 		ID:   r.ID,
 	}

--- a/internal/search/result/symbol_test.go
+++ b/internal/search/result/symbol_test.go
@@ -23,7 +23,7 @@ func TestSymbolRange(t *testing.T) {
 }
 
 func TestSymbolURL(t *testing.T) {
-	repoA := types.RepoName{Name: "repo/A", ID: 1}
+	repoA := types.MinimalRepo{Name: "repo/A", ID: 1}
 	fileAA := File{Repo: repoA, Path: "A"}
 
 	rev := "testrev"

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -33,9 +33,9 @@ func TestSearchRepositories(t *testing.T) {
 		t.Skip("TestSeachRepositories only works in local dev and is not reliable in CI")
 	}
 	repositories := []*search.RepositoryRevisions{
-		{Repo: types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
-		{Repo: types.RepoName{ID: 456, Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
-		{Repo: types.RepoName{ID: 789, Name: "bar/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: types.MinimalRepo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: types.MinimalRepo{ID: 456, Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: types.MinimalRepo{ID: 789, Name: "bar/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
 	}
 
 	zoekt := &searchbackend.FakeSearcher{}
@@ -47,7 +47,7 @@ func TestSearchRepositories(t *testing.T) {
 		case "foo/one":
 			return []result.Match{&result.FileMatch{
 				File: result.File{
-					Repo:     types.RepoName{ID: 123, Name: repoName},
+					Repo:     types.MinimalRepo{ID: 123, Name: repoName},
 					InputRev: &rev,
 					Path:     "f.go",
 				},
@@ -55,7 +55,7 @@ func TestSearchRepositories(t *testing.T) {
 		case "bar/one":
 			return []result.Match{&result.FileMatch{
 				File: result.File{
-					Repo:     types.RepoName{ID: 789, Name: repoName},
+					Repo:     types.MinimalRepo{ID: 789, Name: repoName},
 					InputRev: &rev,
 					Path:     "f.go",
 				},
@@ -142,12 +142,12 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	zoekt := &searchbackend.FakeSearcher{}
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		unindexed.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
 			rev := "1a2b3c"
 			return []result.Match{&result.FileMatch{
 				File: result.File{
-					Repo:     types.RepoName{ID: 123, Name: repo.Repo.Name},
+					Repo:     types.MinimalRepo{ID: 123, Name: repo.Repo.Name},
 					InputRev: &rev,
 					Path:     "foo.go",
 				},
@@ -172,7 +172,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	})
 
 	t.Run("repo shouldn't be included in results, query has repoHasFile filter ", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		unindexed.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
 			return nil, &streaming.Stats{}, nil
 		}
@@ -195,12 +195,12 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	})
 
 	t.Run("repo shouldn't be included in results, query has -repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		unindexed.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
 			rev := "1a2b3c"
 			return []result.Match{&result.FileMatch{
 				File: result.File{
-					Repo:     types.RepoName{ID: 123, Name: repo.Repo.Name},
+					Repo:     types.MinimalRepo{ID: 123, Name: repo.Repo.Name},
 					InputRev: &rev,
 					Path:     "foo.go",
 				},
@@ -225,7 +225,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	})
 
 	t.Run("repo should be included in results, query has -repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		unindexed.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
 			return nil, &streaming.Stats{}, nil
 		}
@@ -296,7 +296,7 @@ func BenchmarkSearchRepositories(b *testing.B) {
 	n := 200 * 1000
 	repos := make([]*search.RepositoryRevisions, n)
 	for i := 0; i < n; i++ {
-		repo := types.RepoName{Name: api.RepoName("github.com/org/repo" + strconv.Itoa(i))}
+		repo := types.MinimalRepo{Name: api.RepoName("github.com/org/repo" + strconv.Itoa(i))}
 		repos[i] = &search.RepositoryRevisions{Repo: repo, Revs: []search.RevisionSpecifier{{}}}
 	}
 	q, _ := query.ParseLiteral("context.WithValue")
@@ -328,8 +328,8 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 	return r
 }
 
-func mkRepos(names ...string) []types.RepoName {
-	var repos []types.RepoName
+func mkRepos(names ...string) []types.MinimalRepo {
+	var repos []types.MinimalRepo
 	for _, name := range names {
 		sum := md5.Sum([]byte(name))
 		id := api.RepoID(binary.BigEndian.Uint64(sum[:]))
@@ -339,7 +339,7 @@ func mkRepos(names ...string) []types.RepoName {
 		if id == 0 {
 			id++
 		}
-		repos = append(repos, types.RepoName{ID: id, Name: api.RepoName(name)})
+		repos = append(repos, types.MinimalRepo{ID: id, Name: api.RepoName(name)})
 	}
 	return repos
 }

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -141,7 +141,7 @@ func TestConstructingSearchContextSpecs(t *testing.T) {
 	}
 }
 
-func createRepos(ctx context.Context, repoStore database.RepoStore) ([]types.RepoName, error) {
+func createRepos(ctx context.Context, repoStore database.RepoStore) ([]types.MinimalRepo, error) {
 	err := repoStore.Create(ctx, &types.Repo{Name: "github.com/example/a"}, &types.Repo{Name: "github.com/example/b"})
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func createRepos(ctx context.Context, repoStore database.RepoStore) ([]types.Rep
 	if err != nil {
 		return nil, err
 	}
-	return []types.RepoName{{ID: repoA.ID, Name: repoA.Name}, {ID: repoB.ID, Name: repoB.Name}}, nil
+	return []types.MinimalRepo{{ID: repoA.ID, Name: repoA.Name}, {ID: repoB.ID, Name: repoB.Name}}, nil
 }
 
 func TestResolvingSearchContextRepoNames(t *testing.T) {
@@ -187,7 +187,7 @@ func TestResolvingSearchContextRepoNames(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	gotRepos, err := r.ListRepoNames(ctx, database.ReposListOptions{SearchContextID: searchContext.ID})
+	gotRepos, err := r.ListMinimalRepos(ctx, database.ReposListOptions{SearchContextID: searchContext.ID})
 	if err != nil {
 		t.Fatalf("Expected no error, got %s", err)
 	}

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -18,7 +18,7 @@ type Stats struct {
 
 	// Repos that were matched by the repo-related filters. This should only
 	// be set once by search, when we have resolved Repos.
-	Repos map[api.RepoID]types.RepoName
+	Repos map[api.RepoID]types.MinimalRepo
 
 	// Status is a RepoStatusMap of repository search statuses.
 	Status search.RepoStatusMap
@@ -46,7 +46,7 @@ func (c *Stats) Update(other *Stats) {
 	c.IsIndexUnavailable = c.IsIndexUnavailable || other.IsIndexUnavailable
 
 	if c.Repos == nil && len(other.Repos) > 0 {
-		c.Repos = make(map[api.RepoID]types.RepoName, len(other.Repos))
+		c.Repos = make(map[api.RepoID]types.MinimalRepo, len(other.Repos))
 	}
 	for id, r := range other.Repos {
 		c.Repos[id] = r

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSearchFiltersUpdate(t *testing.T) {
-	repo := types.RepoName{
+	repo := types.MinimalRepo{
 		Name: "foo",
 	}
 

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -205,7 +205,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 // indexedSymbols checks to see if Zoekt has indexed symbols information for a
 // repository at a specific commit. If it has it returns the branch name (for
 // use when querying zoekt). Otherwise an empty string is returned.
-func indexedSymbolsBranch(ctx context.Context, repo *types.RepoName, commit string) string {
+func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit string) string {
 	z := search.Indexed()
 	if z == nil {
 		return ""
@@ -232,7 +232,7 @@ func indexedSymbolsBranch(ctx context.Context, repo *types.RepoName, commit stri
 	return ""
 }
 
-func searchZoekt(ctx context.Context, repoName types.RepoName, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
+func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
 	raw := *queryString
 	if raw == "" {
 		raw = ".*"
@@ -322,7 +322,7 @@ func searchZoekt(ctx context.Context, repoName types.RepoName, commitID api.Comm
 	return
 }
 
-func Compute(ctx context.Context, repoName types.RepoName, commitID api.CommitID, inputRev *string, query *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
+func Compute(ctx context.Context, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, query *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
 	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
 	// and remove indexedSymbolsBranch.
 	if branch := indexedSymbolsBranch(ctx, &repoName, string(commitID)); branch != "" {
@@ -377,7 +377,7 @@ func Compute(ctx context.Context, repoName types.RepoName, commitID api.CommitID
 
 // GetMatchAtLineCharacter retrieves the shortest matching symbol (if exists) defined
 // at a specific line number and character offset in the provided file.
-func GetMatchAtLineCharacter(ctx context.Context, repo types.RepoName, commitID api.CommitID, filePath string, line int, character int) (*result.SymbolMatch, error) {
+func GetMatchAtLineCharacter(ctx context.Context, repo types.MinimalRepo, commitID api.CommitID, filePath string, line int, character int) (*result.SymbolMatch, error) {
 	// Should be large enough to include all symbols from a single file
 	first := int32(999999)
 	emptyString := ""

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -176,7 +176,7 @@ type TextParameters struct {
 	Repos []*RepositoryRevisions
 
 	// perf: For global queries, we only resolve private repos.
-	UserPrivateRepos []types.RepoName
+	UserPrivateRepos []types.MinimalRepo
 	Mode             GlobalSearchMode
 
 	// Query is the parsed query from the user. You should be using Pattern

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -77,9 +77,9 @@ func SearchFilesInReposBatch(ctx context.Context, zoektArgs zoektutil.IndexedSea
 	return fms, stats, err
 }
 
-var mockSearchFilesInRepo func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error)
+var mockSearchFilesInRepo func(ctx context.Context, repo types.MinimalRepo, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error)
 
-func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo types.RepoName, gitserverRepo api.RepoName, rev string, index bool, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (bool, error) {
+func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo types.MinimalRepo, gitserverRepo api.RepoName, rev string, index bool, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (bool, error) {
 	if mockSearchFilesInRepo != nil {
 		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout, stream)
 	}
@@ -120,7 +120,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 }
 
 // newToMatches returns a closure that converts []*protocol.FileMatch to []result.Match.
-func newToMatches(repo types.RepoName, commit api.CommitID, rev *string) func([]*protocol.FileMatch) []result.Match {
+func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func([]*protocol.FileMatch) []result.Match {
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
@@ -154,7 +154,7 @@ func newToMatches(repo types.RepoName, commit api.CommitID, rev *string) func([]
 
 // repoShouldBeSearched determines whether a repository should be searched in, based on whether the repository
 // fits in the subset of repositories specified in the query's `repohasfile` and `-repohasfile` flags if they exist.
-func repoShouldBeSearched(ctx context.Context, searcherURLs *endpoint.Map, searchPattern *search.TextPatternInfo, repo types.RepoName, commit api.CommitID, fetchTimeout time.Duration) (shouldBeSearched bool, err error) {
+func repoShouldBeSearched(ctx context.Context, searcherURLs *endpoint.Map, searchPattern *search.TextPatternInfo, repo types.MinimalRepo, commit api.CommitID, fetchTimeout time.Duration) (shouldBeSearched bool, err error) {
 	shouldBeSearched = true
 	flagInQuery := len(searchPattern.FilePatternsReposMustInclude) > 0
 	if flagInQuery {
@@ -175,7 +175,7 @@ func repoShouldBeSearched(ctx context.Context, searcherURLs *endpoint.Map, searc
 
 // repoHasFilesWithNamesMatching searches in a repository for matches for the patterns in the `repohasfile` or `-repohasfile` flags, and returns
 // whether or not the repoShouldBeSearched in or not, based on whether matches were returned.
-func repoHasFilesWithNamesMatching(ctx context.Context, searcherURLs *endpoint.Map, include bool, repoHasFileFlag []string, repo types.RepoName, commit api.CommitID, fetchTimeout time.Duration) (bool, error) {
+func repoHasFilesWithNamesMatching(ctx context.Context, searcherURLs *endpoint.Map, include bool, repoHasFileFlag []string, repo types.MinimalRepo, commit api.CommitID, fetchTimeout time.Duration) (bool, error) {
 	for _, pattern := range repoHasFileFlag {
 		foundMatches := false
 		onMatches := func(matches []*protocol.FileMatch) {

--- a/internal/search/unindexed/unindexed_test.go
+++ b/internal/search/unindexed/unindexed_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestSearchFilesInRepos(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.MinimalRepo, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
@@ -156,7 +156,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 }
 
 func TestSearchFilesInReposStream(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.MinimalRepo, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
@@ -251,7 +251,7 @@ func assertReposStatus(t *testing.T, repoNames map[api.RepoID]string, got search
 }
 
 func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.MinimalRepo, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
@@ -350,7 +350,7 @@ func TestRepoShouldBeSearched(t *testing.T) {
 		FilePatternsReposMustInclude: []string{"main"},
 	}
 
-	shouldBeSearched, err := repoShouldBeSearched(context.Background(), nil, info, types.RepoName{Name: "foo/one", ID: 1}, "1a2b3c", time.Minute)
+	shouldBeSearched, err := repoShouldBeSearched(context.Background(), nil, info, types.MinimalRepo{Name: "foo/one", ID: 1}, "1a2b3c", time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +358,7 @@ func TestRepoShouldBeSearched(t *testing.T) {
 		t.Errorf("expected repo to be searched, got shouldn't be searched")
 	}
 
-	shouldBeSearched, err = repoShouldBeSearched(context.Background(), nil, info, types.RepoName{Name: "foo/no-filematch", ID: 2}, "1a2b3c", time.Minute)
+	shouldBeSearched, err = repoShouldBeSearched(context.Background(), nil, info, types.MinimalRepo{Name: "foo/no-filematch", ID: 2}, "1a2b3c", time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,8 +380,8 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 	return r
 }
 
-func mkRepos(names ...string) []types.RepoName {
-	var repos []types.RepoName
+func mkRepos(names ...string) []types.MinimalRepo {
+	var repos []types.MinimalRepo
 	for _, name := range names {
 		sum := md5.Sum([]byte(name))
 		id := api.RepoID(binary.BigEndian.Uint64(sum[:]))
@@ -391,7 +391,7 @@ func mkRepos(names ...string) []types.RepoName {
 		if id == 0 {
 			id++
 		}
-		repos = append(repos, types.RepoName{ID: id, Name: api.RepoName(name)})
+		repos = append(repos, types.MinimalRepo{ID: id, Name: api.RepoName(name)})
 	}
 	return repos
 }

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -500,7 +500,7 @@ func TestZoektResultCountFactor(t *testing.T) {
 func TestZoektIndexedRepos_single(t *testing.T) {
 	repoRev := func(revSpec string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
-			Repo: types.RepoName{ID: api.RepoID(1), Name: "test/repo"},
+			Repo: types.MinimalRepo{ID: api.RepoID(1), Name: "test/repo"},
 			Revs: []search.RevisionSpecifier{
 				{RevSpec: revSpec},
 			},
@@ -626,7 +626,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		}},
 	}
 
-	results := zoektFileMatchToSymbolResults(types.RepoName{Name: "foo"}, "master", file)
+	results := zoektFileMatchToSymbolResults(types.MinimalRepo{Name: "foo"}, "master", file)
 	var symbols []result.Symbol
 	for _, res := range results {
 		symbols = append(symbols, res.Symbol)
@@ -675,7 +675,7 @@ func TestZoektGlobalQueryScope(t *testing.T) {
 	cases := []struct {
 		name    string
 		opts    search.RepoOptions
-		priv    []types.RepoName
+		priv    []types.MinimalRepo
 		want    string
 		wantErr string
 	}{{
@@ -691,14 +691,14 @@ func TestZoektGlobalQueryScope(t *testing.T) {
 			NoArchived: true,
 			NoForks:    true,
 		},
-		priv: []types.RepoName{{ID: 1}, {ID: 2}},
+		priv: []types.MinimalRepo{{ID: 1}, {ID: 2}},
 		want: `(or (and branch="HEAD" rawConfig:RcOnlyPublic|RcNoForks|RcNoArchived) (branchesrepos HEAD:2))`,
 	}, {
 		name: "private",
 		opts: search.RepoOptions{
 			Visibility: query.Private,
 		},
-		priv: []types.RepoName{{ID: 1}, {ID: 2}},
+		priv: []types.MinimalRepo{{ID: 1}, {ID: 2}},
 		want: `(branchesrepos HEAD:2)`,
 	}, {
 		name: "minusrepofilter",
@@ -796,8 +796,8 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 	return r
 }
 
-func mkRepos(names ...string) []types.RepoName {
-	var repos []types.RepoName
+func mkRepos(names ...string) []types.MinimalRepo {
+	var repos []types.MinimalRepo
 	for _, name := range names {
 		sum := md5.Sum([]byte(name))
 		id := api.RepoID(binary.BigEndian.Uint64(sum[:]))
@@ -807,7 +807,7 @@ func mkRepos(names ...string) []types.RepoName {
 		if id == 0 {
 			id++
 		}
-		repos = append(repos, types.RepoName{ID: id, Name: api.RepoName(name)})
+		repos = append(repos, types.MinimalRepo{ID: id, Name: api.RepoName(name)})
 	}
 	return repos
 }

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -123,4 +123,4 @@ func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k
 
 // repoRevFunc is a function which maps repository names returned from Zoekt
 // into the Sourcegraph's resolved repository revisions for the search.
-type repoRevFunc func(file *zoekt.FileMatch) (repo types.RepoName, revs []string)
+type repoRevFunc func(file *zoekt.FileMatch) (repo types.MinimalRepo, revs []string)

--- a/internal/search/zoekt/zoekt_global.go
+++ b/internal/search/zoekt/zoekt_global.go
@@ -70,7 +70,7 @@ func NewGlobalZoektQuery(query zoektquery.Q, scope zoektquery.Q, includePrivate 
 // method only adds a set of private repositories to the scope, if the
 // construction of a GlobalZoektQuery was permitted to includePrivate
 // repositories.
-func (q *GlobalZoektQuery) ApplyPrivateFilter(userPrivateRepos []types.RepoName) {
+func (q *GlobalZoektQuery) ApplyPrivateFilter(userPrivateRepos []types.MinimalRepo) {
 	if q.includePrivate && len(userPrivateRepos) > 0 {
 		ids := make([]uint32, 0, len(userPrivateRepos))
 		for _, r := range userPrivateRepos {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -389,14 +389,14 @@ func (rs Repos) Filter(pred func(*Repo) bool) (fs Repos) {
 	return fs
 }
 
-// RepoName represents a source code repository name, its ID and number of stars.
-type RepoName struct {
+// MinimalRepo represents a source code repository name, its ID and number of stars.
+type MinimalRepo struct {
 	ID    api.RepoID
 	Name  api.RepoName
 	Stars int
 }
 
-func (r *RepoName) ToRepo() *Repo {
+func (r *MinimalRepo) ToRepo() *Repo {
 	return &Repo{
 		ID:    r.ID,
 		Name:  r.Name,
@@ -404,12 +404,12 @@ func (r *RepoName) ToRepo() *Repo {
 	}
 }
 
-// RepoNames is an utility type with convenience methods for operating on lists of repo names
-type RepoNames []RepoName
+// MinimalRepos is an utility type with convenience methods for operating on lists of repo names
+type MinimalRepos []MinimalRepo
 
-func (rs RepoNames) Len() int           { return len(rs) }
-func (rs RepoNames) Less(i, j int) bool { return rs[i].ID < rs[j].ID }
-func (rs RepoNames) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
+func (rs MinimalRepos) Len() int           { return len(rs) }
+func (rs MinimalRepos) Less(i, j int) bool { return rs[i].ID < rs[j].ID }
+func (rs MinimalRepos) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
 
 type CodeHostRepository struct {
 	Name       string
@@ -1212,6 +1212,6 @@ type SearchContext struct {
 // converted when needed. We could use search.RepositoryRevisions directly instead, but it
 // introduces an import cycle with `internal/vcs/git` package when used in `internal/database/search_contexts.go`.
 type SearchContextRepositoryRevisions struct {
-	Repo      RepoName
+	Repo      MinimalRepo
 	Revisions []string
 }


### PR DESCRIPTION
This is big search and replace to rename our types.RepoName to
types.MinimalRepo, now that it contains a few different fields.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
