### PR TITLE
insights: allow empty repository array for global series

### DIFF
--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -310,7 +310,7 @@ func (s *InsightStore) GetDataSeries(ctx context.Context, args GetDataSeriesArgs
 		preds = append(preds, sqlf.Sprintf("series_id = %s", args.SeriesID))
 	}
 	if args.GlobalOnly {
-		preds = append(preds, sqlf.Sprintf("repositories is null"))
+		preds = append(preds, sqlf.Sprintf("repositories IS NULL OR CARDINALITY(repositories) = 0"))
 	}
 
 	q := sqlf.Sprintf(getInsightDataSeriesSql, sqlf.Join(preds, "\n AND"))


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27032

Allow empty or null repositories as a global scope.