### PR TITLE
Insights/api/default applied filters

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -316,7 +316,8 @@ type InsightViewPayloadResolver interface {
 }
 
 type InsightViewQueryArgs struct {
-	First *int32
-	After *string
-	Id    *graphql.ID
+	First   *int32
+	After   *string
+	Id      *graphql.ID
+	Filters *InsightViewFiltersInput
 }

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -195,7 +195,7 @@ extend type Query {
     """
     Return all insight views visible to the authenticated user.
     """
-    insightViews(first: Int, after: String, id: ID): InsightViewConnection!
+    insightViews(first: Int, after: String, id: ID, filters: InsightViewFiltersInput): InsightViewConnection!
 }
 
 extend type Mutation {

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -19,6 +19,8 @@ type insightSeriesResolver struct {
 	workerBaseStore *basestore.Store
 	series          types.InsightViewSeries
 	metadataStore   store.InsightMetadataStore
+
+	filters types.InsightViewFilters
 }
 
 func (r *insightSeriesResolver) SeriesId() string { return r.series.SeriesID }
@@ -42,13 +44,21 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 	if args.To != nil {
 		opts.To = &args.To.Time
 	}
+
+	// to preserve backwards compatibility, we are going to keep the arguments on this resolver for now. Ideally
+	// we would deprecate these in favor of passing arguments from a higher level resolver (insight view) to match
+	// the model of how we want default filters to work at the insight view level. That said, we will only inherit
+	// higher resolver filters if provided filter arguments are nil.
 	if args.IncludeRepoRegex != nil {
 		opts.IncludeRepoRegex = *args.IncludeRepoRegex
+	} else if r.filters.IncludeRepoRegex != nil {
+		opts.IncludeRepoRegex = *r.filters.IncludeRepoRegex
 	}
 	if args.ExcludeRepoRegex != nil {
 		opts.ExcludeRepoRegex = *args.ExcludeRepoRegex
+	} else if r.filters.ExcludeRepoRegex != nil {
+		opts.ExcludeRepoRegex = *r.filters.ExcludeRepoRegex
 	}
-	// TODO(slimsag): future: Pass through opts.Limit
 
 	points, err := r.insightsStore.SeriesPoints(ctx, opts)
 	if err != nil {

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -348,7 +348,14 @@ func (d *InsightViewQueryConnectionResolver) Nodes(ctx context.Context) ([]graph
 		return nil, err
 	}
 	for i := range views {
-		resolvers = append(resolvers, &insightViewResolver{view: &views[i], baseInsightResolver: d.baseInsightResolver})
+		resolver := &insightViewResolver{view: &views[i], baseInsightResolver: d.baseInsightResolver}
+		if d.args.Filters != nil {
+			resolver.overrideFilters = &types.InsightViewFilters{
+				IncludeRepoRegex: d.args.Filters.IncludeRepoRegex,
+				ExcludeRepoRegex: d.args.Filters.ExcludeRepoRegex,
+			}
+		}
+		resolvers = append(resolvers, resolver)
 	}
 	return resolvers, nil
 }

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -41,7 +41,8 @@ var _ graphqlbackend.InsightDataSeriesDefinition = &insightDataSeriesDefinitionU
 var _ graphqlbackend.InsightViewConnectionResolver = &InsightViewQueryConnectionResolver{}
 
 type insightViewResolver struct {
-	view *types.Insight
+	view            *types.Insight
+	overrideFilters *types.InsightViewFilters
 
 	baseInsightResolver
 }
@@ -53,33 +54,45 @@ func (i *insightViewResolver) ID() graphql.ID {
 }
 
 func (i *insightViewResolver) DefaultFilters(ctx context.Context) (graphqlbackend.InsightViewFiltersResolver, error) {
-	return &insightViewFiltersResolver{view: i.view}, nil
+	return &insightViewFiltersResolver{filters: &i.view.Filters}, nil
 }
 
 type insightViewFiltersResolver struct {
-	view *types.Insight
+	filters *types.InsightViewFilters
 }
 
 func (i *insightViewFiltersResolver) IncludeRepoRegex(ctx context.Context) (*string, error) {
-	return i.view.Filters.IncludeRepoRegex, nil
+	return i.filters.IncludeRepoRegex, nil
 }
 
 func (i *insightViewFiltersResolver) ExcludeRepoRegex(ctx context.Context) (*string, error) {
-	return i.view.Filters.ExcludeRepoRegex, nil
+	return i.filters.ExcludeRepoRegex, nil
 }
 
 func (i *insightViewResolver) AppliedFilters(ctx context.Context) (graphqlbackend.InsightViewFiltersResolver, error) {
-	panic("implement me")
+	if i.overrideFilters != nil {
+		return &insightViewFiltersResolver{filters: i.overrideFilters}, nil
+	}
+	return &insightViewFiltersResolver{filters: &i.view.Filters}, nil
 }
 
 func (i *insightViewResolver) DataSeries(ctx context.Context) ([]graphqlbackend.InsightSeriesResolver, error) {
 	var resolvers []graphqlbackend.InsightSeriesResolver
+
+	var filters *types.InsightViewFilters
+	if i.overrideFilters != nil {
+		filters = i.overrideFilters
+	} else {
+		filters = &i.view.Filters
+	}
+
 	for j := range i.view.Series {
 		resolvers = append(resolvers, &insightSeriesResolver{
 			insightsStore:   i.timeSeriesStore,
 			workerBaseStore: i.workerBaseStore,
 			series:          i.view.Series[j],
 			metadataStore:   i.insightStore,
+			filters:         *filters,
 		})
 	}
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/26388

Implements 
1. default filter logic into the time series resolver
2. GraphQL argument on `insightViews` query to override filters
3. return the `AppliedFilters` on the `InsightViewResolver` that are being applied

I made a change to the model of where these filters are applied in the resolver stack. Historically they were applied on the timeseries itself, and in the context of the very old prototype that made sense (it was the only resolver, really). As soon as we have the concept of a `view`, this model doesn't really work anymore. The premise is that a `view` is the entity that you can associate filters and aggregates, and they are applied across all of the series within the view.

This PR makes this change in the new API, and moves the filters argument to the `insightViews` query instead of the sub-resolver for the time series. We will not deprecate the old arguments for the time being to preserve backwards compatibility with the `insights` query.

This chart uses the old `insights` query for comparison
<img width="394" alt="CleanShot 2021-11-03 at 13 23 45@2x" src="https://user-images.githubusercontent.com/5090588/140191538-4cd288f3-885b-4bca-9e46-b406d6d8b53a.png">
d

This image is resolving the same view through the new API using default filters - the values match.
<img width="1071" alt="CleanShot 2021-11-03 at 13 24 13@2x" src="https://user-images.githubusercontent.com/5090588/140191566-0be417ec-862b-4b30-bb39-0075cfbee3a6.png">

This shows how we can override the filters at query time.
<img width="1071" alt="CleanShot 2021-11-03 at 13 49 08@2x" src="https://user-images.githubusercontent.com/5090588/140191626-7a7b90b9-11eb-4a85-908d-17369c0bd4b5.png">

