### PR TITLE
worker: refactor packages to allow for OSS usage

### DIFF
--- a/cmd/worker/job/job.go
+++ b/cmd/worker/job/job.go
@@ -1,0 +1,32 @@
+package job
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+// Job creates configuration struct and background routine instances to be run
+// as part of the worker process.
+type Job interface {
+	// Config returns a set of configuration struct pointers that should be loaded
+	// and validated as part of application startup.
+	//
+	// If called multiple times, the same pointers should be returned.
+	//
+	// Note that the Load function of every config object is invoked even if the
+	// job is not enabled. It is assumed safe to call this method with an invalid
+	// configuration (and all configuration errors should be surfaced via Validate).
+	Config() []env.Config
+
+	// Routines constructs and returns the set of background routines that
+	// should run as part of the worker process. Service initialization should
+	// be shared between setup hooks when possible (e.g. sync.Once initialization).
+	//
+	// Note that the given context is meant to be used _only_ for setup. A context
+	// passed to a periodic routine should be a fresh context unattached to this,
+	// as the argument to this function will be canceled after all Routine invocations
+	// have exited after application startup.
+	Routines(ctx context.Context) ([]goroutine.BackgroundRoutine, error)
+}

--- a/cmd/worker/memo/memo.go
+++ b/cmd/worker/memo/memo.go
@@ -1,4 +1,4 @@
-package shared
+package memo
 
 import "sync"
 

--- a/cmd/worker/shared/job.go
+++ b/cmd/worker/shared/job.go
@@ -1,36 +1,9 @@
 package shared
 
 import (
-	"context"
-
-	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 )
 
-// Job creates configuration struct and background routine instances to be run
-// as part of the worker process.
-type Job interface {
-	// Config returns a set of configuration struct pointers that should be loaded
-	// and validated as part of application startup.
-	//
-	// If called multiple times, the same pointers should be returned.
-	//
-	// Note that the Load function of every config object is invoked even if the
-	// job is not enabled. It is assumed safe to call this method with an invalid
-	// configuration (and all configuration errors should be surfaced via Validate).
-	Config() []env.Config
-
-	// Routines constructs and returns the set of background routines that
-	// should run as part of the worker process. Service initialization should
-	// be shared between setup hooks when possible (e.g. sync.Once initialization).
-	//
-	// Note that the given context is meant to be used _only_ for setup. A context
-	// passed to a periodic routine should be a fresh context unattached to this,
-	// as the argument to this function will be canceled after all Routine invocations
-	// have exited after application startup.
-	Routines(ctx context.Context) ([]goroutine.BackgroundRoutine, error)
-}
-
-var builtins = map[string]Job{
+var builtins = map[string]job.Job{
 	// Empty for now
 }

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
@@ -29,8 +30,8 @@ import (
 const addr = ":3189"
 
 // Start runs the worker. This method does not return.
-func Start(additionalJobs map[string]Job) {
-	jobs := map[string]Job{}
+func Start(additionalJobs map[string]job.Job) {
+	jobs := map[string]job.Job{}
 	for name, job := range builtins {
 		jobs[name] = job
 	}
@@ -91,7 +92,7 @@ func Start(additionalJobs map[string]Job) {
 // loadConfigs calls Load on the configs of each of the jobs registered in this binary.
 // All configs will be loaded regardless if they would later be validated - this is the
 // best place we have to manipulate the environment before the call to env.Lock.
-func loadConfigs(jobs map[string]Job) {
+func loadConfigs(jobs map[string]job.Job) {
 	// Load the worker config
 	config.names = jobNames(jobs)
 	config.Load()
@@ -107,7 +108,7 @@ func loadConfigs(jobs map[string]Job) {
 // mustValidateConfigs calls Validate on the configs of each of the jobs that will be run
 // by this instance of the worker. If any config has a validation error, a fatal log message
 // will be emitted.
-func mustValidateConfigs(jobs map[string]Job) {
+func mustValidateConfigs(jobs map[string]job.Job) {
 	validationErrors := map[string][]error{}
 	if err := config.Validate(); err != nil {
 		log.Fatalf("Failed to load configuration: %s", err)
@@ -147,7 +148,7 @@ func mustValidateConfigs(jobs map[string]Job) {
 // the jobs that will be run by this instance of the worker. Since these metrics are summed
 // over all instances (and we don't change the jobs that are registered to a running worker),
 // we only need to emit an initial count once.
-func emitJobCountMetrics(jobs map[string]Job) {
+func emitJobCountMetrics(jobs map[string]job.Job) {
 	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "src_worker_jobs",
 		Help: "Total number of jobs running in the worker.",
@@ -167,7 +168,7 @@ func emitJobCountMetrics(jobs map[string]Job) {
 // mustCreateBackgroundRoutines runs the Routines function of each of the given jobs concurrently.
 // If an error occurs from any of them, a fatal log message will be emitted. Otherwise, the set
 // of background routines from each job will be returned.
-func mustCreateBackgroundRoutines(jobs map[string]Job) []goroutine.BackgroundRoutine {
+func mustCreateBackgroundRoutines(jobs map[string]job.Job) []goroutine.BackgroundRoutine {
 	var (
 		allRoutines  []goroutine.BackgroundRoutine
 		descriptions []string
@@ -198,7 +199,7 @@ type routinesResult struct {
 // runRoutinesConcurrently returns a channel that will be populated with the return value of
 // the Routines function from each given job. Each function is called concurrently. If an
 // error occurs in one function, the context passed to all its siblings will be canceled.
-func runRoutinesConcurrently(jobs map[string]Job) chan routinesResult {
+func runRoutinesConcurrently(jobs map[string]job.Job) chan routinesResult {
 	results := make(chan routinesResult, len(jobs))
 	defer close(results)
 
@@ -236,7 +237,7 @@ func runRoutinesConcurrently(jobs map[string]Job) chan routinesResult {
 }
 
 // jobNames returns an ordered slice of keys from the given map.
-func jobNames(jobs map[string]Job) []string {
+func jobNames(jobs map[string]job.Job) []string {
 	names := make([]string, 0, len(jobs))
 	for name := range jobs {
 		names = append(names, name)

--- a/cmd/worker/workerdb/db.go
+++ b/cmd/worker/workerdb/db.go
@@ -1,16 +1,17 @@
-package shared
+package workerdb
 
 import (
 	"database/sql"
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )
 
-// InitDatabase initializes and returns a connection to the frontend database.
-func InitDatabase() (*sql.DB, error) {
+// Init initializes and returns a connection to the frontend database.
+func Init() (*sql.DB, error) {
 	conn, err := initDatabaseMemo.Init()
 	if err != nil {
 		return nil, err
@@ -19,7 +20,7 @@ func InitDatabase() (*sql.DB, error) {
 	return conn.(*sql.DB), nil
 }
 
-var initDatabaseMemo = NewMemoizedConstructor(func() (interface{}, error) {
+var initDatabaseMemo = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	postgresDSN := WatchServiceConnectionValue(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})

--- a/cmd/worker/workerdb/service_connections.go
+++ b/cmd/worker/workerdb/service_connections.go
@@ -1,4 +1,4 @@
-package shared
+package workerdb
 
 import (
 	"log"

--- a/enterprise/cmd/worker/internal/batches/janitor_job.go
+++ b/enterprise/cmd/worker/internal/batches/janitor_job.go
@@ -8,7 +8,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/executorqueue"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/background"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -20,7 +21,7 @@ import (
 
 type janitorJob struct{}
 
-func NewJanitorJob() shared.Job {
+func NewJanitorJob() job.Job {
 	return &janitorJob{}
 }
 
@@ -35,7 +36,7 @@ func (j *janitorJob) Routines(ctx context.Context) ([]goroutine.BackgroundRoutin
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	db, err := shared.InitDatabase()
+	db, err := workerdb.Init()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
+++ b/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )
@@ -20,8 +21,8 @@ func InitCodeIntelDatabase() (*sql.DB, error) {
 	return conn.(*sql.DB), err
 }
 
-var initCodeIntelDatabaseMemo = shared.NewMemoizedConstructor(func() (interface{}, error) {
-	postgresDSN := shared.WatchServiceConnectionValue(func(serviceConnections conftypes.ServiceConnections) string {
+var initCodeIntelDatabaseMemo = memo.NewMemoizedConstructor(func() (interface{}, error) {
+	postgresDSN := workerdb.WatchServiceConnectionValue(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
 

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph_job.go
@@ -7,7 +7,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/commitgraph"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -18,7 +19,7 @@ import (
 
 type commitGraphJob struct{}
 
-func NewCommitGraphJob() shared.Job {
+func NewCommitGraphJob() job.Job {
 	return &commitGraphJob{}
 }
 
@@ -33,7 +34,7 @@ func (j *commitGraphJob) Routines(ctx context.Context) ([]goroutine.BackgroundRo
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	db, err := shared.InitDatabase()
+	db, err := workerdb.Init()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/worker/internal/codeintel/dbstore.go
+++ b/enterprise/cmd/worker/internal/codeintel/dbstore.go
@@ -5,7 +5,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -22,14 +23,14 @@ func InitDBStore() (*dbstore.Store, error) {
 	return conn.(*dbstore.Store), nil
 }
 
-var initDBStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initDBStore = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	db, err := shared.InitDatabase()
+	db, err := workerdb.Init()
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +48,7 @@ func InitDependencySyncingStore() (dbworkerstore.Store, error) {
 	return store.(dbworkerstore.Store), nil
 }
 
-var initDependencySyncStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initDependencySyncStore = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
@@ -71,7 +72,7 @@ func InitDependencyIndexingStore() (dbworkerstore.Store, error) {
 	return store.(dbworkerstore.Store), nil
 }
 
-var initDependenyIndexStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initDependenyIndexStore = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/enterprise/cmd/worker/internal/codeintel/gitserver.go
+++ b/enterprise/cmd/worker/internal/codeintel/gitserver.go
@@ -5,7 +5,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -21,7 +21,7 @@ func InitGitserverClient() (*gitserver.Client, error) {
 	return conn.(*gitserver.Client), err
 }
 
-var initGitserverClient = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initGitserverClient = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/enterprise/cmd/worker/internal/codeintel/indexing_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing_job.go
@@ -7,7 +7,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/indexing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/enqueuer"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
@@ -22,7 +23,7 @@ import (
 
 type indexingJob struct{}
 
-func NewIndexingJob() shared.Job {
+func NewIndexingJob() job.Job {
 	return &indexingJob{}
 }
 
@@ -37,7 +38,7 @@ func (j *indexingJob) Routines(ctx context.Context) ([]goroutine.BackgroundRouti
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	db, err := shared.InitDatabase()
+	db, err := workerdb.Init()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/worker/internal/codeintel/janitor_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_job.go
@@ -7,7 +7,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/janitor"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/executorqueue"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
@@ -20,7 +20,7 @@ import (
 
 type janitorJob struct{}
 
-func NewJanitorJob() shared.Job {
+func NewJanitorJob() job.Job {
 	return &janitorJob{}
 }
 

--- a/enterprise/cmd/worker/internal/codeintel/lsifstore.go
+++ b/enterprise/cmd/worker/internal/codeintel/lsifstore.go
@@ -5,7 +5,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -21,7 +21,7 @@ func InitLSIFStore() (*lsifstore.Store, error) {
 	return conn.(*lsifstore.Store), err
 }
 
-var initLSFIStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initLSFIStore = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/enterprise/cmd/worker/internal/executorqueue/config.go
+++ b/enterprise/cmd/worker/internal/executorqueue/config.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
@@ -19,7 +19,7 @@ func InitMetricsConfig() *Config {
 	return res.(*Config)
 }
 
-var initMetricsConfig = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initMetricsConfig = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	return &Config{}, nil
 })
 

--- a/enterprise/cmd/worker/internal/insights/job.go
+++ b/enterprise/cmd/worker/internal/insights/job.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/inconshreveable/log15"
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -38,7 +40,7 @@ func (s *insightsJob) Routines(ctx context.Context) ([]goroutine.BackgroundRouti
 	}
 	log15.Info("Code Insights Enabled.")
 
-	mainAppDb, err := shared.InitDatabase()
+	mainAppDb, err := workerdb.Init()
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +52,6 @@ func (s *insightsJob) Routines(ctx context.Context) ([]goroutine.BackgroundRouti
 	return background.GetBackgroundJobs(context.Background(), mainAppDb, insightsDB), nil
 }
 
-func NewInsightsJob() shared.Job {
+func NewInsightsJob() job.Job {
 	return &insightsJob{}
 }

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/insights"
 
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/batches"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel"
 	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
@@ -27,7 +29,7 @@ func main() {
 
 	go setAuthzProviders()
 
-	shared.Start(map[string]shared.Job{
+	shared.Start(map[string]job.Job{
 		"codeintel-commitgraph":    codeintel.NewCommitGraphJob(),
 		"codeintel-janitor":        codeintel.NewJanitorJob(),
 		"codeintel-auto-indexing":  codeintel.NewIndexingJob(),
@@ -43,7 +45,7 @@ func main() {
 // the jobs configured in this service. This also enables repository update operations to fetch
 // permissions from code hosts.
 func setAuthzProviders() {
-	db, err := shared.InitDatabase()
+	db, err := workerdb.Init()
 	if err != nil {
 		return
 	}

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -7,7 +7,8 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -20,7 +21,7 @@ import (
 
 const syncInterval = 24 * time.Hour
 
-func NewSyncingJob() shared.Job {
+func NewSyncingJob() job.Job {
 	return &syncingJob{}
 }
 
@@ -36,7 +37,7 @@ func (j *syncingJob) Routines(_ context.Context) ([]goroutine.BackgroundRoutine,
 		return nil, nil
 	}
 
-	db, err := shared.InitDatabase()
+	db, err := workerdb.Init()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Defining workers outside of the enterprise package is theoretically supported right now: you can add your worker to the `builtin` global variable, and then it will be loaded regardless of which enterprise workers are configured.

In practice, though, this is infeasible, for two reasons:

1. Workers that access the database first do so by invoking `shared.InitDatabase()`, which is going to result in a circular dependency, as `shared.builtin` has to import the package defining the worker. You end up with something like `shared.builtin -> awesome.Worker -> shared.InitDatabase`, and Go rightly complains.
2. Most workers are going to want to validate that the job they're returning is valid: the pattern used in enterprise workers is to have their constructor return `shared.Job` instead of the concrete struct type, which may well not even be exported. Again, this will result in a circular import loop for similar reasons to the above.

Instead, we can move the genuinely reusable bits of code — the database handling, the memoisation helper, and the `Job` interface — out of the main `shared` package. This means that the imports become acyclic: now the example above looks like `shared.builtin -> awesome.Worker -> workerdb.Init`.

All that said, I don't particularly love the new structure of `cmd/worker`: it leaves `cmd/worker/shared` as a bit of a dumping ground, albeit a slightly more focused one than before.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
