### PR TITLE
Add UTM parameters to in product CTAs

### DIFF
--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
@@ -73,7 +73,7 @@ export const SelfHostedCta: React.FunctionComponent<SelfHostedCtaProps> = ({
                 <div>
                     <a
                         onClick={helpGettingStartedCTAOnClick}
-                        href="https://info.sourcegraph.com/talk-to-a-developer?_ga=2.257481099.1451692402.1630329056-789994471.1629391417"
+                        href=" https://info.sourcegraph.com/talk-to-a-developer?form_submission_source=inproduct?utm_campaign=inproduct-talktoadev&utm_medium=direct_traffic&utm_source=inproduct-talktoadev&utm_term=null&utm_content=talktoadevform"
                         {...linkProps}
                     >
                         Speak to an engineer

--- a/client/web/src/search/home/SelfHostInstructions.tsx
+++ b/client/web/src/search/home/SelfHostInstructions.tsx
@@ -86,7 +86,7 @@ export const SelfHostInstructions: React.FunctionComponent<TelemetryProps> = ({ 
                         <OpenInNewIcon aria-label="Open in new window" className="icon-inline" />
                     </a>
                     <a
-                        href="https://info.sourcegraph.com/talk-to-a-developer"
+                        href="https://info.sourcegraph.com/talk-to-a-developer?form_submission_source=inproduct?utm_campaign=inproduct-self-hosted-install&utm_medium=direct_traffic&utm_source=inproduct-self-hosted-install&utm_term=null&utm_content=self-hosted-install"
                         onClick={onTalkToEngineerClicked}
                         className="text-right flex-shrink-0"
                     >


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description
Augment links to the installation documentation and get help form. to contain utm parameters

## Ref
- [SG Issue](https://github.com/sourcegraph/sourcegraph/issues/26680)
- [Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-26680)

## Success Criteria
When testing the link to the talk to a developer form (items marked with the metric HelpGettingStartedCTA), submit the form using the name "Testing Talk to a Dev" and report back to this ticket when sent. We will verify a goal completion action for this event has been created in google analytics and that the lead submission is properly attributed to the product.