### PR TITLE
search: deprecate GraphQL suggestions

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1647,7 +1647,9 @@ type Search {
     The suggestions.
     """
     suggestions(first: Int): [SearchSuggestion!]!
-        @deprecated(reason: "Suggestions now done with streaming search. This field is deprecated and will be removed in a future release.")
+        @deprecated(
+            reason: "Suggestions now done with streaming search. This field is deprecated and will be removed in a future release."
+        )
 
     """
     A subset of results (excluding actual search results) which are heavily

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1647,6 +1647,8 @@ type Search {
     The suggestions.
     """
     suggestions(first: Int): [SearchSuggestion!]!
+        @deprecated(reason: "Suggestions now done with streaming search. This field is deprecated and will be removed in a future release.")
+
     """
     A subset of results (excluding actual search results) which are heavily
     cached and thus quicker to query. Useful for e.g. querying sparkline


### PR DESCRIPTION
They are now done with streaming search. We'll be able to remove the resolvers in the next release.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
