### PR TITLE
search: remove backend.ListSearchable

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -6,14 +6,12 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -179,42 +177,6 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, e
 
 	trueP := true
 	return s.store.ListMinimalRepos(ctx, database.ReposListOptions{Index: &trueP})
-}
-
-// ListSearchable calls database.IndexableRepos.ListPublic, with tracing.
-// It lists all public indexable repos and also any private repos added by the
-// current user. Only used on sourcegraph.com where we don't have every repo indexed.
-func (s *repos) ListSearchable(ctx context.Context) (repos []types.MinimalRepo, err error) {
-	ctx, done := trace(ctx, "Repos", "ListSearchable", nil, &err)
-	defer func() {
-		if err == nil {
-			span := opentracing.SpanFromContext(ctx)
-			span.LogFields(otlog.Int("result.len", len(repos)))
-		}
-		done()
-	}()
-
-	span := opentracing.SpanFromContext(ctx)
-	repos, err = s.cache.ListPublic(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "listing default public repos")
-	}
-	span.LogFields(otlog.Int("public.len", len(repos)))
-
-	// For authenticated users we also want to include any private repos they may have added
-	if a := actor.FromContext(ctx); a.IsAuthenticated() {
-		privateRepos, err := s.store.ListMinimalRepos(ctx, database.ReposListOptions{
-			UserID:      a.UID,
-			OnlyPrivate: true,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "getting user private repos")
-		}
-		span.LogFields(otlog.Int("private.len", len(privateRepos)))
-		repos = append(repos, privateRepos...)
-	}
-
-	return repos, nil
 }
 
 func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api.CommitID, forceEnhancedLanguageDetection bool) (res *inventory.Inventory, err error) {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/zoekt"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -297,10 +296,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, options search
 	tr.LazyPrintf("resolveRepositories - start")
 	defer tr.LazyPrintf("resolveRepositories - done")
 
-	repositoryResolver := &searchrepos.Resolver{
-		DB:                  r.db,
-		SearchableReposFunc: backend.Repos.ListSearchable,
-	}
+	repositoryResolver := &searchrepos.Resolver{DB: r.db}
 
 	return repositoryResolver.Resolve(ctx, options)
 }

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -111,10 +111,7 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 // query does not contain any repos to search.
 func (r *searchResolver) reposExist(ctx context.Context, options search.RepoOptions) bool {
 	options.UserSettings = r.UserSettings
-	repositoryResolver := &searchrepos.Resolver{
-		DB:                  r.db,
-		SearchableReposFunc: backend.Repos.ListSearchable,
-	}
+	repositoryResolver := &searchrepos.Resolver{DB: r.db}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0
 }


### PR DESCRIPTION
This PR is part of series to introduce paginated repo resolution in
search.

We remove `backend.ListSearchable` and its use in repository resolution
because global searches on Sourcegraph.com no longer depend on it. This
in turn simplifies the code in preparation for cursor based pagination.

Part of #26995



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
