### PR TITLE
search contexts: fix repository resolving

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -550,11 +550,11 @@ type ReposListOptions struct {
 	IDs []api.RepoID
 
 	// UserID, if non zero, will limit the set of results to repositories added by the user
-	// through external services. Mutually exclusive with the ExternalServiceIDs option.
+	// through external services. Mutually exclusive with the ExternalServiceIDs and SearchContextID options.
 	UserID int32
 
 	// OrgID, if non zero, will limit the set of results to repositories owned by the organization
-	// through external services. Mutually exclusive with the ExternalServiceIDs option.
+	// through external services. Mutually exclusive with the ExternalServiceIDs and SearchContextID options.
 	OrgID int32
 
 	// SearchContextID, if non zero, will limit the set of results to repositories listed in
@@ -994,6 +994,10 @@ func (s *repoStore) listSQL(ctx context.Context, opt ReposListOptions) (*sqlf.Qu
 		return nil, errors.New("options ExternalServiceIDs, UserID and OrgID are mutually exclusive")
 	} else if len(opt.ExternalServiceIDs) != 0 {
 		where = append(where, sqlf.Sprintf("EXISTS (SELECT 1 FROM external_service_repos esr WHERE repo.id = esr.repo_id AND esr.external_service_id = ANY (%s))", pq.Array(opt.ExternalServiceIDs)))
+	} else if opt.SearchContextID != 0 {
+		// Joining on distinct search context repos to avoid returning duplicates
+		from = append(from, sqlf.Sprintf(`JOIN (SELECT DISTINCT repo_id, search_context_id FROM search_context_repos) dscr ON repo.id = dscr.repo_id`))
+		where = append(where, sqlf.Sprintf("dscr.search_context_id = %d", opt.SearchContextID))
 	} else if opt.UserID != 0 {
 		userReposCTE := sqlf.Sprintf(userReposQuery, opt.UserID)
 		if opt.IncludeUserPublicRepos {
@@ -1004,10 +1008,6 @@ func (s *repoStore) listSQL(ctx context.Context, opt ReposListOptions) (*sqlf.Qu
 	} else if opt.OrgID != 0 {
 		from = append(from, sqlf.Sprintf("INNER JOIN external_service_repos ON external_service_repos.repo_id = repo.id"))
 		where = append(where, sqlf.Sprintf("external_service_repos.org_id = %d", opt.OrgID))
-	} else if opt.SearchContextID != 0 {
-		// Joining on distinct search context repos to avoid returning duplicates
-		from = append(from, sqlf.Sprintf(`JOIN (SELECT DISTINCT repo_id, search_context_id FROM search_context_repos) dscr ON repo.id = dscr.repo_id`))
-		where = append(where, sqlf.Sprintf("dscr.search_context_id = %d", opt.SearchContextID))
 	}
 
 	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || !opt.MinLastChanged.IsZero() || opt.joinGitserverRepos {

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -682,8 +682,25 @@ func (s *SearchStreamClient) SearchAll(query string) ([]*AnyResult, error) {
 func (s *SearchStreamClient) OverwriteSettings(subjectID, contents string) error {
 	return s.Client.OverwriteSettings(subjectID, contents)
 }
+
 func (s *SearchStreamClient) AuthenticatedUserID() string {
 	return s.Client.AuthenticatedUserID()
+}
+
+func (s *SearchStreamClient) Repository(name string) (*Repository, error) {
+	return s.Client.Repository(name)
+}
+
+func (s *SearchStreamClient) CreateSearchContext(input CreateSearchContextInput, repositories []SearchContextRepositoryRevisionsInput) (string, error) {
+	return s.Client.CreateSearchContext(input, repositories)
+}
+
+func (s *SearchStreamClient) GetSearchContext(id string) (*GetSearchContextResult, error) {
+	return s.Client.GetSearchContext(id)
+}
+
+func (s *SearchStreamClient) DeleteSearchContext(id string) error {
+	return s.Client.DeleteSearchContext(id)
 }
 
 func (s *SearchStreamClient) search(query string, dec streamhttp.FrontendStreamDecoder) error {

--- a/internal/gqltestutil/search_context.go
+++ b/internal/gqltestutil/search_context.go
@@ -5,9 +5,10 @@ import (
 )
 
 type CreateSearchContextInput struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Public      bool   `json:"public"`
+	Name        string  `json:"name"`
+	Namespace   *string `json:"namespace"`
+	Description string  `json:"description"`
+	Public      bool    `json:"public"`
 }
 
 type UpdateSearchContextInput struct {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -121,7 +121,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 			SearchContextID:        searchContext.ID,
 			UserID:                 searchContext.NamespaceUserID,
 			OrgID:                  searchContext.NamespaceOrgID,
-			IncludeUserPublicRepos: searchContext.NamespaceUserID != 0,
+			IncludeUserPublicRepos: searchContext.ID == 0 && searchContext.NamespaceUserID != 0,
 		}
 
 		if op.Ranked {
@@ -308,7 +308,7 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 		SearchContextID:        searchContext.ID,
 		UserID:                 searchContext.NamespaceUserID,
 		OrgID:                  searchContext.NamespaceOrgID,
-		IncludeUserPublicRepos: searchContext.NamespaceUserID != 0,
+		IncludeUserPublicRepos: searchContext.ID == 0 && searchContext.NamespaceUserID != 0,
 	}
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Fix search contexts repository resolving by using SearchContextID if it's defined before UserID and OrgID.