### PR TITLE
database: Add RepoSupported to SubRepoPermsStore

### DIFF
--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -42,7 +42,7 @@ type SubRepoPermissionsGetter interface {
 // SubRepoPermissionsSupportedChecker should be used to quickly check whether
 // sub-repo permissions are supported for the given repo.
 type SubRepoPermissionsSupportedChecker interface {
-	Supported(ctx context.Context, repo api.RepoName) (bool, error)
+	RepoSupported(ctx context.Context, repo api.RepoName) (bool, error)
 }
 
 // SubRepoPermsClient is responsible for checking whether a user has access to
@@ -80,7 +80,7 @@ func (s *SubRepoPermsClient) permissions(ctx context.Context, userID int32, cont
 		return None, errors.New("PermissionsGetter is nil")
 	}
 
-	if supported, err := s.SupportedChecker.Supported(ctx, content.Repo); err != nil {
+	if supported, err := s.SupportedChecker.RepoSupported(ctx, content.Repo); err != nil {
 		return None, errors.Wrap(err, "checking for sub-repo permissions support")
 	} else if !supported {
 		// We assume that repo level access has already been granted

--- a/internal/database/dbmock/subrepopermsstore_mock.go
+++ b/internal/database/dbmock/subrepopermsstore_mock.go
@@ -26,6 +26,9 @@ type MockSubRepoPermsStore struct {
 	// GetByUserFunc is an instance of a mock function object controlling
 	// the behavior of the method GetByUser.
 	GetByUserFunc *SubRepoPermsStoreGetByUserFunc
+	// RepoSupportedFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoSupported.
+	RepoSupportedFunc *SubRepoPermsStoreRepoSupportedFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *SubRepoPermsStoreTransactFunc
@@ -58,6 +61,11 @@ func NewMockSubRepoPermsStore() *MockSubRepoPermsStore {
 		GetByUserFunc: &SubRepoPermsStoreGetByUserFunc{
 			defaultHook: func(context.Context, int32) (map[api.RepoName]authz.SubRepoPermissions, error) {
 				return nil, nil
+			},
+		},
+		RepoSupportedFunc: &SubRepoPermsStoreRepoSupportedFunc{
+			defaultHook: func(context.Context, api.RepoName) (bool, error) {
+				return false, nil
 			},
 		},
 		TransactFunc: &SubRepoPermsStoreTransactFunc{
@@ -96,6 +104,9 @@ func NewMockSubRepoPermsStoreFrom(i database.SubRepoPermsStore) *MockSubRepoPerm
 		},
 		GetByUserFunc: &SubRepoPermsStoreGetByUserFunc{
 			defaultHook: i.GetByUser,
+		},
+		RepoSupportedFunc: &SubRepoPermsStoreRepoSupportedFunc{
+			defaultHook: i.RepoSupported,
 		},
 		TransactFunc: &SubRepoPermsStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -433,6 +444,117 @@ func (c SubRepoPermsStoreGetByUserFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SubRepoPermsStoreGetByUserFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// SubRepoPermsStoreRepoSupportedFunc describes the behavior when the
+// RepoSupported method of the parent MockSubRepoPermsStore instance is
+// invoked.
+type SubRepoPermsStoreRepoSupportedFunc struct {
+	defaultHook func(context.Context, api.RepoName) (bool, error)
+	hooks       []func(context.Context, api.RepoName) (bool, error)
+	history     []SubRepoPermsStoreRepoSupportedFuncCall
+	mutex       sync.Mutex
+}
+
+// RepoSupported delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockSubRepoPermsStore) RepoSupported(v0 context.Context, v1 api.RepoName) (bool, error) {
+	r0, r1 := m.RepoSupportedFunc.nextHook()(v0, v1)
+	m.RepoSupportedFunc.appendCall(SubRepoPermsStoreRepoSupportedFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RepoSupported method
+// of the parent MockSubRepoPermsStore instance is invoked and the hook
+// queue is empty.
+func (f *SubRepoPermsStoreRepoSupportedFunc) SetDefaultHook(hook func(context.Context, api.RepoName) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RepoSupported method of the parent MockSubRepoPermsStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *SubRepoPermsStoreRepoSupportedFunc) PushHook(hook func(context.Context, api.RepoName) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *SubRepoPermsStoreRepoSupportedFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *SubRepoPermsStoreRepoSupportedFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, api.RepoName) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *SubRepoPermsStoreRepoSupportedFunc) nextHook() func(context.Context, api.RepoName) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SubRepoPermsStoreRepoSupportedFunc) appendCall(r0 SubRepoPermsStoreRepoSupportedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of SubRepoPermsStoreRepoSupportedFuncCall
+// objects describing the invocations of this function.
+func (f *SubRepoPermsStoreRepoSupportedFunc) History() []SubRepoPermsStoreRepoSupportedFuncCall {
+	f.mutex.Lock()
+	history := make([]SubRepoPermsStoreRepoSupportedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SubRepoPermsStoreRepoSupportedFuncCall is an object that describes an
+// invocation of method RepoSupported on an instance of
+// MockSubRepoPermsStore.
+type SubRepoPermsStoreRepoSupportedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoName
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SubRepoPermsStoreRepoSupportedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SubRepoPermsStoreRepoSupportedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -181,7 +181,7 @@ func (s *subRepoPermsStore) RepoSupported(ctx context.Context, repo api.RepoName
 SELECT EXISTS(
   SELECT
   FROM external_services
-    JOIN external_service_repos esr on external_services.id = esr.external_service_id
+    JOIN external_service_repos esr ON external_services.id = esr.external_service_id
     JOIN repo r ON esr.repo_id = r.id
   WHERE r.name = %s
   AND kind IN ('PERFORCE')


### PR DESCRIPTION
This will allow us to quickly check if a repo supports sub-repo
permissions. The intention is for the result to be cached but the query
itself should be quick.

When testing in production in returns in 0.3ms and only requires index
scans.

Closes https://github.com/sourcegraph/sourcegraph/issues/27055