### PR TITLE
vcs/git: Make LStat private

### DIFF
--- a/internal/vcs/git/file_info.go
+++ b/internal/vcs/git/file_info.go
@@ -15,7 +15,7 @@ import (
 const ModeSubmodule = 0160000 | os.ModeDevice
 
 // Submodule holds information about a Git submodule and is
-// returned in the FileInfo's Sys field by Stat/Lstat/ReadDir calls.
+// returned in the FileInfo's Sys field by Stat/ReadDir calls.
 type Submodule struct {
 	// URL is the submodule repository clone URL.
 	URL string
@@ -29,7 +29,7 @@ type Submodule struct {
 }
 
 // ObjectInfo holds information about a Git object and is returned in (fs.FileInfo).Sys for blobs
-// and trees from Stat/Lstat/ReadDir calls.
+// and trees from Stat/ReadDir calls.
 type ObjectInfo interface {
 	OID() gitdomain.OID
 }

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -64,9 +64,9 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 
 	// Check symlinks are links
 	for _, symlink := range symlinks {
-		fi, err := Lstat(ctx, repo, commitID, symlink)
+		fi, err := lStat(ctx, repo, commitID, symlink)
 		if err != nil {
-			t.Fatalf("fs.Lstat(%s): %s", symlink, err)
+			t.Fatalf("fs.lStat(%s): %s", symlink, err)
 		}
 		if runtime.GOOS != "windows" {
 			// TODO(alexsaveliev) make it work on Windows too
@@ -75,7 +75,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	}
 
 	// Also check the FileInfo returned by ReadDir to ensure it's
-	// consistent with the FileInfo returned by Lstat.
+	// consistent with the FileInfo returned by lStat.
 	entries, err := ReadDir(ctx, repo, commitID, ".", false)
 	if err != nil {
 		t.Fatalf("fs.ReadDir(.): %s", err)


### PR DESCRIPTION
It's only used from within the package.
