### PR TITLE
dbtesting: detect pkg name

### DIFF
--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "backendtestdb"
-}
-
 func TestGetFirstServiceVersion(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 

--- a/cmd/frontend/graphqlbackend/db_test.go
+++ b/cmd/frontend/graphqlbackend/db_test.go
@@ -1,7 +1,0 @@
-package graphqlbackend
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "graphqlbackenddb"
-}

--- a/cmd/frontend/internal/app/ping_test.go
+++ b/cmd/frontend/internal/app/ping_test.go
@@ -11,13 +11,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "app"
-}
 
 func TestLatestPingHandler(t *testing.T) {
 	t.Parallel()

--- a/cmd/frontend/internal/app/usage_stats_test.go
+++ b/cmd/frontend/internal/app/usage_stats_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "app"
-}
-
 func TestUsageStatsArchiveHandler(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/cmd/frontend/internal/bg/db_test.go
+++ b/cmd/frontend/internal/bg/db_test.go
@@ -1,9 +1,0 @@
-package bg
-
-import (
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-)
-
-func init() {
-	dbtesting.DBNameSuffix = "bgdb"
-}

--- a/cmd/frontend/internal/confdb/db_test.go
+++ b/cmd/frontend/internal/confdb/db_test.go
@@ -1,7 +1,0 @@
-package confdb
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "confdb"
-}

--- a/cmd/frontend/internal/httpapi/db_test.go
+++ b/cmd/frontend/internal/httpapi/db_test.go
@@ -6,12 +6,10 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	dbtesting.DBNameSuffix = "httpapidb"
 	if !testing.Verbose() {
 		log15.Root().SetHandler(log15.DiscardHandler())
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "codemonitorsdb"
-}
-
 func TestCreateCodeMonitor(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/enterprise/cmd/frontend/internal/dotcom/billing/db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/db_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "billing"
-}
-
 func TestDBUsersBillingCustomerID(t *testing.T) {
 	db := dbtesting.GetDB(t)
 	ctx := context.Background()

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/db_test.go
@@ -1,7 +1,0 @@
-package productsubscription
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "productsubscription"
-}

--- a/enterprise/cmd/frontend/internal/registry/db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/db_test.go
@@ -1,7 +1,0 @@
-package registry
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "registry"
-}

--- a/enterprise/internal/codeintel/stores/dbstore/migration/migration_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/migration_test.go
@@ -1,7 +1,0 @@
-package migration
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "dbstore.migration"
-}

--- a/enterprise/internal/codeintel/stores/dbstore/store_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/store_test.go
@@ -1,14 +1,9 @@
 package dbstore
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "enterprise-codeintel"
-}
 
 func testStore(db dbutil.DB) *Store {
 	return NewWithDB(db, &observation.TestContext)

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migration_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migration_test.go
@@ -1,7 +1,0 @@
-package migration
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "lsifstore.migration"
-}

--- a/enterprise/internal/codeintel/stores/lsifstore/store_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/store_test.go
@@ -1,7 +1,0 @@
-package lsifstore
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "lsifstore"
-}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "codemonitorsbackground"
-}
-
 func TestActionRunner(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/enterprise/internal/codemonitors/main_test.go
+++ b/enterprise/internal/codemonitors/main_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "codemonitorsstoredb"
-}
-
 const (
 	testQuery       = "repo:github\\.com/sourcegraph/sourcegraph func type:diff patternType:literal"
 	testDescription = "test description"

--- a/enterprise/internal/codemonitors/storetest/monitor_creator.go
+++ b/enterprise/internal/codemonitors/storetest/monitor_creator.go
@@ -17,10 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "codemonitorsstoredb"
-}
-
 const (
 	testQuery       = "repo:github\\.com/sourcegraph/sourcegraph func type:diff patternType:literal"
 	testDescription = "test description"

--- a/enterprise/internal/database/db_test.go
+++ b/enterprise/internal/database/db_test.go
@@ -4,13 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "enterprisedb"
-}
 
 func equal(t testing.TB, name string, want, have interface{}) {
 	t.Helper()

--- a/enterprise/internal/insights/background/queryrunner/worker_test.go
+++ b/enterprise/internal/insights/background/queryrunner/worker_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "codeinsightsbackendqueryrunner"
-}
-
 // TestJobQueue tests that EnqueueJob and dequeueJob work mutually to transfer jobs to/from the
 // database.
 func TestJobQueue(t *testing.T) {

--- a/enterprise/internal/insights/resolvers/resolver_test.go
+++ b/enterprise/internal/insights/resolvers/resolver_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "insightsresolvers"
-}
-
 // TestResolver_Insights just checks that root resolver setup and getting an insights connection
 // does not result in any errors. It is a pretty minimal test.
 func TestResolver_Insights(t *testing.T) {

--- a/internal/codeintel/stores/dbstore/store_test.go
+++ b/internal/codeintel/stores/dbstore/store_test.go
@@ -1,14 +1,9 @@
 package dbstore
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "oss-codeintel"
-}
 
 func testStore(db dbutil.DB) *Store {
 	return NewWithDB(db, &observation.TestContext, nil)

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "base-store"
-}
-
 func TestTransaction(t *testing.T) {
 	db := dbtesting.GetDB(t)
 	setupStoreTest(t, db)

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "batch"
-}
-
 func TestBatchInserter(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/database/dbcache/main_test.go
+++ b/internal/database/dbcache/main_test.go
@@ -1,9 +1,0 @@
-package dbcache
-
-import (
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-)
-
-func init() {
-	dbtesting.DBNameSuffix = "internal-database-cache"
-}

--- a/internal/database/dbtesting/dbtesting.go
+++ b/internal/database/dbtesting/dbtesting.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"hash/crc32"
 	"hash/fnv"
 	"io"
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -56,11 +58,6 @@ var (
 
 // SetupGlobalTestDB creates a temporary test DB handle, sets
 // `dbconn.Global` to it and setups other test configuration.
-//
-// Callers (other than github.com/sourcegraph/sourcegraph/internal/database) must
-// set a name in this package's DBNameSuffix var that is unique among all other
-// test packages that call SetupGlobalTestDB, so that each package's
-// tests run in separate DBs and do not conflict.
 func SetupGlobalTestDB(t testing.TB) {
 	useFastPasswordMocks()
 
@@ -69,7 +66,7 @@ func SetupGlobalTestDB(t testing.TB) {
 	}
 
 	connectOnce.Do(func() {
-		connectErr = initTest(DBNameSuffix)
+		connectErr = initTest()
 	})
 	if connectErr != nil {
 		// only ignore connection errors if not on CI
@@ -133,12 +130,14 @@ func emptyDBPreserveSchema(t testing.TB, d *sql.DB) {
 	}
 }
 
-// initTest creates a test database, named with the given suffix
-// (dropping it if it already exists), and configures this package to use it.
-// It is called by integration tests (in a package init func) that need to use
-// a real database.
-func initTest(nameSuffix string) error {
-	dbname := "sourcegraph-test-" + nameSuffix
+// initTest creates a test database (dropping it if it already exists), and
+// configures this package to use it.  It is called by integration tests (in a
+// package init func) that need to use a real database.
+func initTest() error {
+	dbname, err := dbName()
+	if err != nil {
+		return err
+	}
 
 	if os.Getenv("TEST_SKIP_DROP_DB_BEFORE_TESTS") == "" {
 		// When running the database-backcompat.sh tests, we need to *keep* the DB around because it has
@@ -175,6 +174,67 @@ func initTest(nameSuffix string) error {
 	}
 
 	return nil
+}
+
+// dbName generates a unique name for the package currently being tested.
+func dbName() (string, error) {
+	pkg := testPkgName()
+	if pkg == "" {
+		return "", errors.New("dbtesting: could not detect test package")
+	}
+
+	// Postgres identifier limit is 64. Conservatively shorten name if bigger
+	// than 32.
+	if len(pkg) > 32 {
+		pkg = fmt.Sprintf("%X-%s", crc32.ChecksumIEEE([]byte(pkg)), pkg[len(pkg)-32:])
+	}
+
+	return "sourcegraph-test-" + strings.ReplaceAll(pkg, "/", "-"), nil
+}
+
+// testPkgName finds the relative name of the sourcegraph package being tested
+// by inspecting the call stack. If it fails, it returns an empty string.
+func testPkgName() string {
+	pc := make([]uintptr, 20)
+	n := runtime.Callers(1, pc)
+	if n == 0 {
+		return ""
+	}
+
+	pc = pc[:n]
+	frames := runtime.CallersFrames(pc)
+
+	modulePrefix := "github.com/sourcegraph/sourcegraph/"
+	pkg := ""
+
+	var (
+		frame runtime.Frame
+		more  = true
+	)
+
+	// Look for last function name that looks like a sourcegraph test
+	for more {
+		frame, more = frames.Next()
+
+		// Example name of a function we are looking for and the example pkg
+		//
+		//  github.com/sourcegraph/sourcegraph/cmd/frontend/backend.TestGetFirstServiceVersion
+		//  =>
+		//  cmd/frontend/backend
+
+		testNameIdx := strings.Index(frame.Function, ".Test")
+		if testNameIdx < 0 {
+			continue
+		}
+
+		if !strings.HasPrefix(frame.Function, modulePrefix) {
+			continue
+		}
+
+		pkg = frame.Function[len(modulePrefix):testNameIdx]
+	}
+
+	return pkg
 }
 
 // MockDB implements the dbutil.DB interface and is intended to be used

--- a/internal/database/dbtesting/dbtesting.go
+++ b/internal/database/dbtesting/dbtesting.go
@@ -46,11 +46,6 @@ func useFastPasswordMocks() {
 // BeforeTest functions are called before each test is run (by SetupGlobalTestDB).
 var BeforeTest []func()
 
-// DBNameSuffix must be set by DB test packages at init time to a value that is unique among all
-// other such values used by other DB test packages. This is necessary to ensure the tests do not
-// concurrently use the same DB (which would cause test failures).
-var DBNameSuffix = "database"
-
 var (
 	connectOnce sync.Once
 	connectErr  error

--- a/internal/database/dbtesting/dbtesting_test.go
+++ b/internal/database/dbtesting/dbtesting_test.go
@@ -1,0 +1,14 @@
+package dbtesting
+
+import "testing"
+
+func TestDBName(t *testing.T) {
+	want := "sourcegraph-test-internal-database-dbtesting"
+	got, err := dbName()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("unexpected dbname\ngot:  %q\nwant: %q", got, want)
+	}
+}

--- a/internal/database/globalstatedb/db_test.go
+++ b/internal/database/globalstatedb/db_test.go
@@ -1,7 +1,0 @@
-package globalstatedb
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "globalstatedb"
-}

--- a/internal/database/main_test.go
+++ b/internal/database/main_test.go
@@ -6,13 +6,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
-
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "internal-database"
-}
 
 func TestMain(m *testing.M) {
 	flag.Parse()

--- a/internal/insights/insights_test.go
+++ b/internal/insights/insights_test.go
@@ -18,10 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "insights"
-}
-
 func TestGetSearchInsights(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/oobmigration/store_test.go
+++ b/internal/oobmigration/store_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "oobmigration"
-}
-
 func TestList(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -16,13 +16,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "searchcontexts"
-}
 
 func TestResolvingValidSearchContextSpecs(t *testing.T) {
 	t.Parallel()

--- a/internal/usagestats/main_test.go
+++ b/internal/usagestats/main_test.go
@@ -6,13 +6,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
-
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "usagestats"
-}
 
 func TestMain(m *testing.M) {
 	flag.Parse()

--- a/internal/workerutil/dbworker/store/main_test.go
+++ b/internal/workerutil/dbworker/store/main_test.go
@@ -1,7 +1,0 @@
-package store
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "workerutil"
-}

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/migrations"
 )
 
-func init() {
-	dbtesting.DBNameSuffix = "migrations"
-}
-
 func TestIDConstraints(t *testing.T) {
 	cases := []struct {
 		Name string


### PR DESCRIPTION
Using dbtesting is not how new code is written, so direct uses of this should fade away over time. However, it still frustrates me to see its tentacles all over our codebase via the init calls that set DBNameSuffix global.

This is some fun code which eliminates the need to set DBNameSuffix by detecting the package under test and generating the DBNameSuffix based on that.

The first commit contains the meat of the change. The second commit is larger and is a mechanical removal of DBNameSuffix since it is no longer read.