### PR TITLE
authz: make SubRepoPermissionChecker only have Permissions

### DIFF
--- a/internal/authz/mock_sub_repo_perms.go
+++ b/internal/authz/mock_sub_repo_perms.go
@@ -11,9 +11,6 @@ import (
 // SubRepoPermissionChecker interface (from the package
 // github.com/sourcegraph/sourcegraph/internal/authz) used for unit testing.
 type MockSubRepoPermissionChecker struct {
-	// CurrentUserPermissionsFunc is an instance of a mock function object
-	// controlling the behavior of the method CurrentUserPermissions.
-	CurrentUserPermissionsFunc *SubRepoPermissionCheckerCurrentUserPermissionsFunc
 	// PermissionsFunc is an instance of a mock function object controlling
 	// the behavior of the method Permissions.
 	PermissionsFunc *SubRepoPermissionCheckerPermissionsFunc
@@ -24,11 +21,6 @@ type MockSubRepoPermissionChecker struct {
 // all results, unless overwritten.
 func NewMockSubRepoPermissionChecker() *MockSubRepoPermissionChecker {
 	return &MockSubRepoPermissionChecker{
-		CurrentUserPermissionsFunc: &SubRepoPermissionCheckerCurrentUserPermissionsFunc{
-			defaultHook: func(context.Context, RepoContent) (Perms, error) {
-				return 0, nil
-			},
-		},
 		PermissionsFunc: &SubRepoPermissionCheckerPermissionsFunc{
 			defaultHook: func(context.Context, int32, RepoContent) (Perms, error) {
 				return 0, nil
@@ -42,126 +34,10 @@ func NewMockSubRepoPermissionChecker() *MockSubRepoPermissionChecker {
 // implementation, unless overwritten.
 func NewMockSubRepoPermissionCheckerFrom(i SubRepoPermissionChecker) *MockSubRepoPermissionChecker {
 	return &MockSubRepoPermissionChecker{
-		CurrentUserPermissionsFunc: &SubRepoPermissionCheckerCurrentUserPermissionsFunc{
-			defaultHook: i.CurrentUserPermissions,
-		},
 		PermissionsFunc: &SubRepoPermissionCheckerPermissionsFunc{
 			defaultHook: i.Permissions,
 		},
 	}
-}
-
-// SubRepoPermissionCheckerCurrentUserPermissionsFunc describes the behavior
-// when the CurrentUserPermissions method of the parent
-// MockSubRepoPermissionChecker instance is invoked.
-type SubRepoPermissionCheckerCurrentUserPermissionsFunc struct {
-	defaultHook func(context.Context, RepoContent) (Perms, error)
-	hooks       []func(context.Context, RepoContent) (Perms, error)
-	history     []SubRepoPermissionCheckerCurrentUserPermissionsFuncCall
-	mutex       sync.Mutex
-}
-
-// CurrentUserPermissions delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockSubRepoPermissionChecker) CurrentUserPermissions(v0 context.Context, v1 RepoContent) (Perms, error) {
-	r0, r1 := m.CurrentUserPermissionsFunc.nextHook()(v0, v1)
-	m.CurrentUserPermissionsFunc.appendCall(SubRepoPermissionCheckerCurrentUserPermissionsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// CurrentUserPermissions method of the parent MockSubRepoPermissionChecker
-// instance is invoked and the hook queue is empty.
-func (f *SubRepoPermissionCheckerCurrentUserPermissionsFunc) SetDefaultHook(hook func(context.Context, RepoContent) (Perms, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// CurrentUserPermissions method of the parent MockSubRepoPermissionChecker
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *SubRepoPermissionCheckerCurrentUserPermissionsFunc) PushHook(hook func(context.Context, RepoContent) (Perms, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *SubRepoPermissionCheckerCurrentUserPermissionsFunc) SetDefaultReturn(r0 Perms, r1 error) {
-	f.SetDefaultHook(func(context.Context, RepoContent) (Perms, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *SubRepoPermissionCheckerCurrentUserPermissionsFunc) PushReturn(r0 Perms, r1 error) {
-	f.PushHook(func(context.Context, RepoContent) (Perms, error) {
-		return r0, r1
-	})
-}
-
-func (f *SubRepoPermissionCheckerCurrentUserPermissionsFunc) nextHook() func(context.Context, RepoContent) (Perms, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SubRepoPermissionCheckerCurrentUserPermissionsFunc) appendCall(r0 SubRepoPermissionCheckerCurrentUserPermissionsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// SubRepoPermissionCheckerCurrentUserPermissionsFuncCall objects describing
-// the invocations of this function.
-func (f *SubRepoPermissionCheckerCurrentUserPermissionsFunc) History() []SubRepoPermissionCheckerCurrentUserPermissionsFuncCall {
-	f.mutex.Lock()
-	history := make([]SubRepoPermissionCheckerCurrentUserPermissionsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SubRepoPermissionCheckerCurrentUserPermissionsFuncCall is an object that
-// describes an invocation of method CurrentUserPermissions on an instance
-// of MockSubRepoPermissionChecker.
-type SubRepoPermissionCheckerCurrentUserPermissionsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 RepoContent
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 Perms
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c SubRepoPermissionCheckerCurrentUserPermissionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c SubRepoPermissionCheckerCurrentUserPermissionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // SubRepoPermissionCheckerPermissionsFunc describes the behavior when the

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -25,12 +25,6 @@ type RepoContent struct {
 //
 //go:generate ../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/authz -i SubRepoPermissionChecker -o mock_sub_repo_perms.go
 type SubRepoPermissionChecker interface {
-	// CurrentUserPermissions returns the level of access the authenticated user within
-	// the provided context has for the requested content.
-	//
-	// If the context is unauthenticated, ErrUnauthenticated is returned.
-	CurrentUserPermissions(ctx context.Context, content RepoContent) (Perms, error)
-
 	// Permissions returns the level of access the provided user has for the requested
 	// content.
 	//
@@ -62,10 +56,6 @@ type SubRepoPermissionsSupportedChecker interface {
 type SubRepoPermsClient struct {
 	SupportedChecker  SubRepoPermissionsSupportedChecker
 	PermissionsGetter SubRepoPermissionsGetter
-}
-
-func (s *SubRepoPermsClient) CurrentUserPermissions(ctx context.Context, content RepoContent) (Perms, error) {
-	return s.Permissions(ctx, actor.FromContext(ctx).UID, content)
 }
 
 func (s *SubRepoPermsClient) Permissions(ctx context.Context, userID int32, content RepoContent) (Perms, error) {
@@ -142,4 +132,12 @@ func (s *SubRepoPermsClient) Permissions(ctx context.Context, userID int32, cont
 
 	// Return None if no rule matches to be safe
 	return None, nil
+}
+
+// CurrentUserPermissions returns the level of access the authenticated user within
+// the provided context has for the requested content.
+//
+// If the context is unauthenticated, ErrUnauthenticated is returned.
+func CurrentUserPermissions(ctx context.Context, s SubRepoPermissionChecker, content RepoContent) (Perms, error) {
+	return s.Permissions(ctx, actor.FromContext(ctx).UID, content)
 }

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -26,10 +26,16 @@ type RepoContent struct {
 //go:generate ../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/authz -i SubRepoPermissionChecker -o mock_sub_repo_perms.go
 type SubRepoPermissionChecker interface {
 	// CurrentUserPermissions returns the level of access the authenticated user within
-	// the provided context has.
+	// the provided context has for the requested content.
 	//
 	// If the context is unauthenticated, ErrUnauthenticated is returned.
 	CurrentUserPermissions(ctx context.Context, content RepoContent) (Perms, error)
+
+	// Permissions returns the level of access the provided user has for the requested
+	// content.
+	//
+	// If the userID represents an anonymous user, ErrUnauthenticated is returned.
+	Permissions(ctx context.Context, userID int32, content RepoContent) (Perms, error)
 }
 
 var _ SubRepoPermissionChecker = &SubRepoPermsClient{}
@@ -59,20 +65,19 @@ type SubRepoPermsClient struct {
 }
 
 func (s *SubRepoPermsClient) CurrentUserPermissions(ctx context.Context, content RepoContent) (Perms, error) {
+	return s.Permissions(ctx, actor.FromContext(ctx).UID, content)
+}
+
+func (s *SubRepoPermsClient) Permissions(ctx context.Context, userID int32, content RepoContent) (Perms, error) {
 	// Are sub-repo permissions enabled at the site level
 	if !conf.Get().ExperimentalFeatures.EnableSubRepoPermissions {
 		return Read, nil
 	}
 
-	a := actor.FromContext(ctx)
-	if !a.IsAuthenticated() {
+	if userID == 0 {
 		return None, &ErrUnauthenticated{}
 	}
 
-	return s.permissions(ctx, a.UID, content)
-}
-
-func (s *SubRepoPermsClient) permissions(ctx context.Context, userID int32, content RepoContent) (Perms, error) {
 	if s.SupportedChecker == nil {
 		return None, errors.New("SupportedChecker is nil")
 	}


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/27054, pulled from https://github.com/sourcegraph/sourcegraph/pull/27012
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
