### PR TITLE
authz: disable p4 repo-centric sync with sub-repo perms

### DIFF
--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -182,7 +182,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 // FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
 // token.
 func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, errors.New("not implemented")
+	return nil, &authz.ErrUnimplemented{Feature: "perforce.FetchUserPermsByToken"}
 }
 
 // getAllUserEmails returns a set of username <-> email pairs of all users in the Perforce server.
@@ -284,6 +284,11 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {
 		return nil, errors.Errorf("not a code host of the repository: want %q but have %q",
 			repo.ServiceID, p.codeHost.ServiceID)
+	}
+
+	// Disable FetchRepoPerms until we implement sub-repo permissions for it.
+	if len(p.depots) > 0 {
+		return nil, &authz.ErrUnimplemented{Feature: "perforce.FetchRepoPerms for sub-repo permissions"}
 	}
 
 	// -a : Displays protection lines for all users. This option requires super

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -4,6 +4,7 @@ package authz
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -57,7 +58,8 @@ type ExternalUserPermissions struct {
 	ExcludeContains []extsvc.RepoID
 
 	// SubRepoPermissions denotes sub-repository content access control rules where
-	// relevant.
+	// relevant. If no corresponding entry for an Exacts repo exists in SubRepoPermissions,
+	// it can be safely assumed that access to the entire repo is available.
 	SubRepoPermissions map[extsvc.RepoID]*SubRepoPermissions
 }
 
@@ -141,4 +143,22 @@ type ErrUnauthenticated struct{}
 
 func (e ErrUnauthenticated) Error() string {
 	return "request is unauthenticated"
+}
+
+func (e ErrUnauthenticated) Unauthenticated() bool { return true }
+
+// ErrUnimplemented indicates sync is unimplemented and its data should not be used.
+type ErrUnimplemented struct {
+	Feature string
+}
+
+func (e ErrUnimplemented) Error() string {
+	return fmt.Sprintf("%s is unimplemented", e.Feature)
+}
+
+func (e ErrUnimplemented) Unimplemented() bool { return true }
+
+func (e ErrUnimplemented) Is(err error) bool {
+	_, ok := err.(*ErrUnimplemented)
+	return ok
 }

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -148,7 +148,10 @@ func (e ErrUnauthenticated) Error() string {
 func (e ErrUnauthenticated) Unauthenticated() bool { return true }
 
 // ErrUnimplemented indicates sync is unimplemented and its data should not be used.
+//
+// When returning this error, provide a pointer.
 type ErrUnimplemented struct {
+	// Feature indicates the unimplemented functionality.
 	Feature string
 }
 

--- a/internal/authz/iface_test.go
+++ b/internal/authz/iface_test.go
@@ -1,0 +1,19 @@
+package authz
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrUnimplementedIs(t *testing.T) {
+	err := &ErrUnimplemented{Feature: "some feature"}
+
+	assert.True(t, err.Is(&ErrUnimplemented{}),
+		"err.Is(err) should match")
+	assert.True(t, errors.Is(err, &ErrUnimplemented{}),
+		"errors.Is(e1, e2) should match")
+
+	assert.False(t, err.Is(errors.New("different error")))
+}

--- a/internal/authz/iface_test.go
+++ b/internal/authz/iface_test.go
@@ -1,9 +1,9 @@
 package authz
 
 import (
-	"errors"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This allows us to safely assume that we will not accidentally grant access to a repo before sub-repo permissions are sync'd via user-centric sync.

In the long term we might want to implement sub-repo perms for repo-centric sync, but for now this is more straight-forward.

Related to #26644 