### PR TITLE
search: fix race condition in doResults

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1758,6 +1758,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 
 	// Start all specific search jobs, if any.
 	for _, job := range jobs {
+		job := job
 		wg := wgForJob(job)
 		wg.Add(1)
 		goroutine.Go(func() {


### PR DESCRIPTION
While working on paginated repository resolution, I ran into a weird
race in tests. I tracked it down to this classic race bug of closing
over a shared loop variable in a go-routine.

Part of #26995



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
