### PR TITLE
sg: add a check for go version and docker-compose

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -714,6 +714,21 @@ checks:
     cmd: docker version
     failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
 
+  docker-compose:
+    cmd: docker-compose version
+    failMessage: "Failed to run 'docker-compose version'. Please make sure Docker is running."
+
+  go:
+    cmd: go version
+    failMessage: 'Failed to run go'
+
+  go-version:
+    cmd: |
+      go_version=#$(go version | cut -d' ' -f 3 | sed 's/go//')
+      tools_version=$(cat .tool-versions | grep golang | sed 's/golang //')
+      [ "$go_version" = "$tools_version" ] || (echo "➡️ Need go version $tools_version, but got $go_version instead" && exit 1)
+    failMessage: 'Incorrect go version'
+
   redis:
     cmd: (command -v redis-cli && redis-cli -p 6379 PING) || docker-compose -f dev/redis-postgres.yml exec -T redis redis-cli PING
     failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -719,7 +719,7 @@ checks:
     failMessage: "Failed to run 'docker-compose version'. Please make sure Docker is running."
 
   go:
-    cmd: go version
+    cmd: go version || (echo "➡️ Install Go or make it sure it is in the \$PATH" && exit 1)
     failMessage: 'Failed to run go'
 
   go-version:


### PR DESCRIPTION
This checks in pure bash that go version matches the one in `.tools-version` so we can spot obvious issues early on when diagnosing issues. 

```
$ sg doctor
# (...)
❌ Check "go-version" failed: 'bash -c go_version="1.16"
tools_version=$(cat .tool-versions | grep golang | sed 's/golang //')
[ "$go_versi...
Incorrect go version
Check produced the following output:
--------------------------------------------------------------------------------
➡️ Need go version 1.17.1, but got 1.16 instead
# (...)
❌ Check "go" failed: 'bash -c go versiowfpn || (echo "➡️ Install Go or make it sure it is in the \$PATH" && exit 1)' failed: go versiowfp...
Failed to run go
Check produced the following output:
--------------------------------------------------------------------------------
go versiowfpn: unknown command
Run 'go help' for usage.
➡️ Install Go or make it sure it is in the $PATH
```
