### PR TITLE
insights: migrate langstats insights

### DIFF
--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -438,13 +438,11 @@ func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore
 		UniqueID:       from.ID,
 		OtherThreshold: from.OtherThreshold,
 	}
-
 	series := types.InsightSeries{
 		SeriesID:           ksuid.New().String(),
 		Repositories:       []string{from.Repository},
 		SampleIntervalUnit: string(types.Month),
 	}
-
 	var grants []store.InsightViewGrant
 	if from.UserID != nil {
 		grants = []store.InsightViewGrant{store.UserGrant(int(*from.UserID))}
@@ -458,12 +456,10 @@ func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore
 	if err != nil {
 		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
 	}
-
 	series, err = tx.CreateSeries(ctx, series)
 	if err != nil {
 		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
 	}
-
 	err = tx.AttachSeriesToView(ctx, series, view, types.InsightViewSeriesMetadata{})
 	if err != nil {
 		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -162,11 +162,19 @@ func (m *settingMigrator) migrate(ctx context.Context) error {
 		return errors.Wrap(err, "failed to fetch just-in-time insights from all settings")
 	}
 
+	langStatsInsights, err := insights.GetLangStatsInsights(ctx, m.base, insights.All)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch lang stats insights from all settings")
+	}
+
 	log15.Info("insights migration: migrating backend insights")
 	m.migrateInsights(ctx, discovered, backend)
 
-	log15.Info("insights migration: migrating frontend insights")
+	log15.Info("insights migration: migrating frontend search insights")
 	m.migrateInsights(ctx, justInTimeInsights, frontend)
+
+	log15.Info("insights migration: migrating frontend lang stats insights")
+	m.migrateLangStatsInsights(ctx, langStatsInsights)
 
 	log15.Info("insights migration: migrating dashboards")
 	dashboards, err := loader.LoadDashboards(ctx)
@@ -226,6 +234,40 @@ func (m *settingMigrator) migrateInsights(ctx context.Context, toMigrate []insig
 	}
 	log15.Info("insights settings migration batch complete", "batch", batch, "count", count, "skipped", skipped, "errors", errorCount)
 
+}
+
+func (m *settingMigrator) migrateLangStatsInsights(ctx context.Context, toMigrate []insights.LangStatsInsight) {
+	insightStore := store.NewInsightStore(m.insights)
+	tx, err := insightStore.Transact(ctx)
+	if err != nil {
+		log15.Info("insights migration: problem connecting to store, aborting lang stats migration")
+		return
+	}
+	defer func() { err = tx.Store.Done(err) }()
+
+	var count, skipped, errorCount int
+	for _, d := range toMigrate {
+		if d.ID == "" {
+			// we need a unique ID, and if for some reason this insight doesn't have one, it can't be migrated.
+			skipped++
+			continue
+		}
+		err := insightStore.DeleteViewByUniqueID(ctx, d.ID)
+		log15.Info("insights migration: deleting insight view", "unique_id", d.ID)
+		if err != nil {
+			// if we fail here there isn't much we can do in this migration, so continue
+			skipped++
+			continue
+		}
+		err = migrateLangStatSeries(ctx, insightStore, d)
+		if err != nil {
+			// we can't do anything about errors, so we will just skip it and log it
+			errorCount++
+			log15.Error("insights migration: error while migrating insight", "error", err)
+		}
+		count++
+	}
+	log15.Info("insights settings migration batch complete", "batch", "langStats", "count", count, "skipped", skipped, "errors", errorCount)
 }
 
 func migrateDashboard(ctx context.Context, dashboardStore *store.DBDashboardStore, from insights.SettingDashboard) (err error) {
@@ -379,6 +421,54 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 			return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
 		}
 	}
+	return nil
+}
+
+func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore, from insights.LangStatsInsight) (err error) {
+	tx, err := insightStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Store.Done(err) }()
+
+	log15.Info("insights migration: attempting to migrate insight", "unique_id", from.ID)
+
+	view := types.InsightView{
+		Title:          from.Title,
+		UniqueID:       from.ID,
+		OtherThreshold: from.OtherThreshold,
+	}
+
+	series := types.InsightSeries{
+		SeriesID:           ksuid.New().String(),
+		Repositories:       []string{from.Repository},
+		SampleIntervalUnit: string(types.Month),
+	}
+
+	var grants []store.InsightViewGrant
+	if from.UserID != nil {
+		grants = []store.InsightViewGrant{store.UserGrant(int(*from.UserID))}
+	} else if from.OrgID != nil {
+		grants = []store.InsightViewGrant{store.OrgGrant(int(*from.OrgID))}
+	} else {
+		grants = []store.InsightViewGrant{store.GlobalGrant()}
+	}
+
+	view, err = tx.CreateView(ctx, view, grants)
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+
+	series, err = tx.CreateSeries(ctx, series)
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+
+	err = tx.AttachSeriesToView(ctx, series, view, types.InsightViewSeriesMetadata{})
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+
 	return nil
 }
 

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -410,6 +410,7 @@ func (s *InsightStore) CreateView(ctx context.Context, view types.InsightView, g
 		view.UniqueID,
 		view.Filters.IncludeRepoRegex,
 		view.Filters.ExcludeRepoRegex,
+		view.OtherThreshold,
 	))
 	if row.Err() != nil {
 		return types.InsightView{}, row.Err()
@@ -626,8 +627,8 @@ VALUES (%s, %s, %s, %s);
 
 const createInsightViewSql = `
 -- source: enterprise/internal/insights/store/insight_store.go:CreateView
-INSERT INTO insight_view (title, description, unique_id, default_filter_include_repo_regex, default_filter_exclude_repo_regex)
-VALUES (%s, %s, %s, %s, %s)
+INSERT INTO insight_view (title, description, unique_id, default_filter_include_repo_regex, default_filter_exclude_repo_regex, other_threshold)
+VALUES (%s, %s, %s, %s, %s, %s)
 returning id;`
 
 const updateInsightViewSql = `

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -50,11 +50,12 @@ type InsightViewSeriesMetadata struct {
 
 // InsightView is a single insight view that may or may not have any associated series.
 type InsightView struct {
-	ID          int
-	Title       string
-	Description string
-	UniqueID    string
-	Filters     InsightViewFilters
+	ID             int
+	Title          string
+	Description    string
+	UniqueID       string
+	Filters        InsightViewFilters
+	OtherThreshold float32
 }
 
 // InsightSeries is a single data series for a Code Insight. This contains some metadata about the data series, as well

--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -130,6 +130,8 @@ func GetLangStatsInsights(ctx context.Context, db dbutil.DB, filter SettingFilte
 		if err != nil {
 			return []LangStatsInsight{}, err
 		}
+		userId := settings[i].Subject.User
+		orgId := settings[i].Subject.Org
 
 		for id, body := range raw {
 			var temp LangStatsInsight
@@ -138,6 +140,9 @@ func GetLangStatsInsights(ctx context.Context, db dbutil.DB, filter SettingFilte
 				// a deprecated schema collides with this field name, so skip any deserialization errors
 				continue
 			}
+			temp.UserID = userId
+			temp.OrgID = orgId
+
 			results = append(results, temp)
 		}
 	}
@@ -272,6 +277,8 @@ type LangStatsInsight struct {
 	Title          string
 	Repository     string
 	OtherThreshold float32
+	OrgID          *int32
+	UserID         *int32
 }
 
 type DefaultFilters struct {

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -272,12 +272,14 @@ func TestGetLangStatsInsights(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	orgId := int32(1)
 	want := []insights.LangStatsInsight{
 		{
 			ID:             "codeStatsInsights.insight.global.lang1",
 			Title:          "my insight",
 			Repository:     "github.com/sourcegraph/sourcegraph",
 			OtherThreshold: float32(0),
+			OrgID:          &orgId,
 		},
 	}
 

--- a/migrations/codeinsights/1000000019_other_threshold.down.sql
+++ b/migrations/codeinsights/1000000019_other_threshold.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE insight_view
+DROP COLUMN IF EXISTS other_threshold;
+
+COMMIT;

--- a/migrations/codeinsights/1000000019_other_threshold.up.sql
+++ b/migrations/codeinsights/1000000019_other_threshold.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE insight_view
+    ADD COLUMN IF NOT EXISTS other_threshold FLOAT4;
+
+COMMENT ON COLUMN insight_view.other_threshold IS 'Percent threshold for grouping series under "other"';
+
+COMMIT;


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/26676

## Description

This PR migrates langstats insights into the db along with the search insights. A few things to call out:
- I added an `other_threshold` column to `insight_view`. I know we talked about also adding a `type` column, but I'd prefer to add that along with the next issue, https://github.com/sourcegraph/sourcegraph/issues/26675, because that's where it will be used. Just to make sure it fits the need once I dig in there.
- I think some of this could probably be refactored to make better use of existing code, but since it's all going to get ripped out soon I didn't think it was worth refactoring.
- I think there's a bug where frontend search insights are not storing the right permissions. I will double check this tomorrow and open an issue if so. (It looked like the backend insights were getting the permissions in a different way than I did it here, so I need a little more time to look into it.)

## Testing Steps

I ran this with a few different langStats insights I created through the UI, (with different permissions to test that piece,) and verified that they looked as I expected in the database. I also ran an `insightViews` query via the API and saw that they showed up there. There's no way for the frontend to tell yet that these are different, but that will be next!