### PR TITLE
push database.DB down from top of call tree

### DIFF
--- a/cmd/frontend/auth/non_public_test.go
+++ b/cmd/frontend/auth/non_public_test.go
@@ -11,13 +11,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestAllowAnonymousRequest(t *testing.T) {
-	db := new(dbtesting.MockDB)
-	ui.InitRouter(db, nil)
+	ui.InitRouter(dbmock.NewMockDB(), nil)
 	// Ensure auth.public is false (be robust against some other tests having side effects that
 	// change it, or changed defaults).
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthPublic: false, AuthProviders: []schema.AuthProviders{{Builtin: &schema.BuiltinAuthProvider{}}}}})
@@ -55,9 +54,7 @@ func TestAllowAnonymousRequest(t *testing.T) {
 }
 
 func TestNewUserRequiredAuthzMiddleware(t *testing.T) {
-	db := new(dbtesting.MockDB)
-
-	ui.InitRouter(db, nil)
+	ui.InitRouter(dbmock.NewMockDB(), nil)
 	// Ensure auth.public is false (be robust against some other tests having side effects that
 	// change it, or changed defaults).
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthPublic: false, AuthProviders: []schema.AuthProviders{{Builtin: &schema.BuiltinAuthProvider{}}}}})

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/database/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
@@ -37,9 +37,7 @@ func TestRedirects(t *testing.T) {
 	check := func(t *testing.T, path string, wantStatusCode int, wantRedirectLocation, userAgent string) {
 		t.Helper()
 
-		db := new(dbtesting.MockDB)
-
-		InitRouter(db, nil)
+		InitRouter(dbmock.NewMockDB(), nil)
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", path, nil)
 		if err != nil {

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/randstring"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -118,7 +117,7 @@ func Router() *mux.Router {
 // InitRouter create the router that serves pages for our web app
 // and assigns it to uirouter.Router.
 // The router can be accessed by calling Router().
-func InitRouter(db dbutil.DB, codeIntelResolver graphqlbackend.CodeIntelResolver) {
+func InitRouter(db database.DB, codeIntelResolver graphqlbackend.CodeIntelResolver) {
 	router := newRouter()
 	initRouter(db, router, codeIntelResolver)
 }
@@ -218,7 +217,7 @@ func brandNameSubtitle(titles ...string) string {
 	return strings.Join(append(titles, globals.Branding().BrandName), " - ")
 }
 
-func initRouter(db dbutil.DB, router *mux.Router, codeIntelResolver graphqlbackend.CodeIntelResolver) {
+func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbackend.CodeIntelResolver) {
 	uirouter.Router = router // make accessible to other packages
 
 	// basic pages with static titles

--- a/cmd/frontend/internal/app/ui/router_test.go
+++ b/cmd/frontend/internal/app/ui/router_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	uirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui/router"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -26,8 +26,7 @@ func init() {
 }
 
 func TestRouter(t *testing.T) {
-	db := new(dbtesting.MockDB)
-	InitRouter(db, nil)
+	InitRouter(dbmock.NewMockDB(), nil)
 	router := Router()
 	tests := []struct {
 		path      string
@@ -212,8 +211,7 @@ func TestRouter(t *testing.T) {
 }
 
 func TestRouter_RootPath(t *testing.T) {
-	db := new(dbtesting.MockDB)
-	InitRouter(db, nil)
+	InitRouter(dbmock.NewMockDB(), nil)
 	router := Router()
 
 	tests := []struct {

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/deviceid"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	tracepkg "github.com/sourcegraph/sourcegraph/internal/trace"
@@ -121,7 +120,7 @@ func healthCheckMiddleware(next http.Handler) http.Handler {
 
 // newInternalHTTPHandler creates and returns the HTTP handler for the internal API (accessible to
 // other internal services).
-func newInternalHTTPHandler(schema *graphql.Schema, db dbutil.DB, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimitWatcher graphqlbackend.LimitWatcher) http.Handler {
+func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimitWatcher graphqlbackend.LimitWatcher) http.Handler {
 	internalMux := http.NewServeMux()
 	internalMux.Handle("/.internal/", gziphandler.GzipHandler(
 		withInternalActor(

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -103,7 +103,7 @@ func NewHandler(db dbutil.DB, m *mux.Router, schema *graphql.Schema, githubWebho
 // 🚨 SECURITY: This handler should not be served on a publicly exposed port. 🚨
 // This handler is not guaranteed to provide the same authorization checks as
 // public API handlers.
-func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimitWatcher graphqlbackend.LimitWatcher) http.Handler {
+func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimitWatcher graphqlbackend.LimitWatcher) http.Handler {
 	if m == nil {
 		m = apirouter.New(nil)
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -41,7 +40,7 @@ func serveReposGetByName(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func servePhabricatorRepoCreate(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func servePhabricatorRepoCreate(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var repo api.PhabricatorRepoCreateRequest
 		err := json.NewDecoder(r.Body).Decode(&repo)
@@ -64,7 +63,7 @@ func servePhabricatorRepoCreate(db dbutil.DB) func(w http.ResponseWriter, r *htt
 
 // serveExternalServiceConfigs serves a JSON response that is an array of all
 // external service configs that match the requested kind.
-func serveExternalServiceConfigs(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveExternalServiceConfigs(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var req api.ExternalServiceConfigsRequest
 		err := json.NewDecoder(r.Body).Decode(&req)
@@ -114,7 +113,7 @@ func serveExternalServiceConfigs(db dbutil.DB) func(w http.ResponseWriter, r *ht
 
 // serveExternalServicesList serves a JSON response that is an array of all external services
 // of the given kind
-func serveExternalServicesList(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveExternalServicesList(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var req api.ExternalServicesListRequest
 		err := json.NewDecoder(r.Body).Decode(&req)
@@ -156,7 +155,7 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func serveReposListEnabled(db dbutil.DB) func(http.ResponseWriter, *http.Request) error {
+func serveReposListEnabled(db database.DB) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		names, err := database.Repos(db).ListEnabledNames(r.Context())
 		if err != nil {
@@ -166,7 +165,7 @@ func serveReposListEnabled(db dbutil.DB) func(http.ResponseWriter, *http.Request
 	}
 }
 
-func serveSavedQueriesListAll(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveSavedQueriesListAll(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		// List settings for all users, orgs, etc.
 		settings, err := database.SavedSearches(db).ListAll(r.Context())
@@ -197,7 +196,7 @@ func serveSavedQueriesListAll(db dbutil.DB) func(w http.ResponseWriter, r *http.
 	}
 }
 
-func serveSavedQueriesGetInfo(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveSavedQueriesGetInfo(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var query string
 		err := json.NewDecoder(r.Body).Decode(&query)
@@ -215,7 +214,7 @@ func serveSavedQueriesGetInfo(db dbutil.DB) func(w http.ResponseWriter, r *http.
 	}
 }
 
-func serveSavedQueriesSetInfo(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveSavedQueriesSetInfo(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var info *api.SavedQueryInfo
 		err := json.NewDecoder(r.Body).Decode(&info)
@@ -237,7 +236,7 @@ func serveSavedQueriesSetInfo(db dbutil.DB) func(w http.ResponseWriter, r *http.
 	}
 }
 
-func serveSavedQueriesDeleteInfo(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveSavedQueriesDeleteInfo(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var query string
 		err := json.NewDecoder(r.Body).Decode(&query)
@@ -254,7 +253,7 @@ func serveSavedQueriesDeleteInfo(db dbutil.DB) func(w http.ResponseWriter, r *ht
 	}
 }
 
-func serveSettingsGetForSubject(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveSettingsGetForSubject(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var subject api.SettingsSubject
 		if err := json.NewDecoder(r.Body).Decode(&subject); err != nil {
@@ -271,7 +270,7 @@ func serveSettingsGetForSubject(db dbutil.DB) func(w http.ResponseWriter, r *htt
 	}
 }
 
-func serveOrgsListUsers(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveOrgsListUsers(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var orgID int32
 		err := json.NewDecoder(r.Body).Decode(&orgID)
@@ -293,7 +292,7 @@ func serveOrgsListUsers(db dbutil.DB) func(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-func serveOrgsGetByName(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveOrgsGetByName(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var orgName string
 		err := json.NewDecoder(r.Body).Decode(&orgName)
@@ -311,7 +310,7 @@ func serveOrgsGetByName(db dbutil.DB) func(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-func serveUsersGetByUsername(db dbutil.DB) func(http.ResponseWriter, *http.Request) error {
+func serveUsersGetByUsername(db database.DB) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var username string
 		err := json.NewDecoder(r.Body).Decode(&username)
@@ -329,7 +328,7 @@ func serveUsersGetByUsername(db dbutil.DB) func(http.ResponseWriter, *http.Reque
 	}
 }
 
-func serveUserEmailsGetEmail(db dbutil.DB) func(http.ResponseWriter, *http.Request) error {
+func serveUserEmailsGetEmail(db database.DB) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var userID int32
 		err := json.NewDecoder(r.Body).Decode(&userID)
@@ -413,7 +412,7 @@ func serveGitTar(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func serveGitExec(db dbutil.DB) func(http.ResponseWriter, *http.Request) error {
+func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		defer r.Body.Close()
 		req := protocol.ExecRequest{}

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
@@ -16,7 +16,7 @@ func main() {
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})
 
-	shared.Main(func(db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
+	shared.Main(func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
 		return enterprise.DefaultServices()
 	})
 }

--- a/cmd/frontend/shared/frontend.go
+++ b/cmd/frontend/shared/frontend.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 
@@ -19,7 +19,7 @@ import (
 // It is exposed as function in a package so that it can be called by other
 // main package implementations such as Sourcegraph Enterprise, which import
 // proprietary/private code.
-func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) {
+func Main(enterpriseSetupHook func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) {
 	env.Lock()
 	err := cli.Main(enterpriseSetupHook)
 	if err != nil {

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
@@ -57,7 +58,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"searchcontexts": searchcontexts.Init,
 }
 
-func enterpriseSetupHook(db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
+func enterpriseSetupHook(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		log.Println("enterprise edition")


### PR DESCRIPTION
This puts database.DB at the very top of the call tree, from which we
can start propagating it downwards, meeting up with all the places I've
already started using it.

The goal here is to be able to inject a `database.DB` at the very top
level and pass that through the codebase from there. Right now, there
are still a number of references to `database.GlobalRepos` and
`dbconn.Global` which break this mockable chain, so in order to remove
the global db mocks completely, we'll need to get rid of those as well.
Unfortunately, getting rid of globals is difficult. Fortunately, I'm
feeling very motivated.

Stacked on #27104 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
