### PR TITLE
move migrators into oobmigration package

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -179,13 +179,13 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 	outOfBandMigrationRunner := newOutOfBandMigrationRunner(ctx, db)
 
 	// Run a background job to handle encryption of external service configuration.
-	extsvcMigrator := database.NewExternalServiceConfigMigratorWithDB(db)
+	extsvcMigrator := oobmigration.NewExternalServiceConfigMigratorWithDB(db)
 	extsvcMigrator.AllowDecrypt = os.Getenv("ALLOW_DECRYPT_MIGRATION") == "true"
 	if err := outOfBandMigrationRunner.Register(extsvcMigrator.ID(), extsvcMigrator, oobmigration.MigratorOptions{Interval: 3 * time.Second}); err != nil {
 		log.Fatalf("failed to run external service encryption job: %v", err)
 	}
 	// Run a background job to handle encryption of external service configuration.
-	extAccMigrator := database.NewExternalAccountsMigratorWithDB(db)
+	extAccMigrator := oobmigration.NewExternalAccountsMigratorWithDB(db)
 	extAccMigrator.AllowDecrypt = os.Getenv("ALLOW_DECRYPT_MIGRATION") == "true"
 	if err := outOfBandMigrationRunner.Register(extAccMigrator.ID(), extAccMigrator, oobmigration.MigratorOptions{Interval: 3 * time.Second}); err != nil {
 		log.Fatalf("failed to run user external account encryption job: %v", err)
@@ -193,7 +193,7 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 
 	// Run a background job to calculate the has_webhooks field on external
 	// service records.
-	webhookMigrator := database.NewExternalServiceWebhookMigratorWithDB(db)
+	webhookMigrator := oobmigration.NewExternalServiceWebhookMigratorWithDB(db)
 	if err := outOfBandMigrationRunner.Register(webhookMigrator.ID(), webhookMigrator, oobmigration.MigratorOptions{Interval: 3 * time.Second}); err != nil {
 		log.Fatalf("failed to run external service webhook job: %v", err)
 	}

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -215,10 +215,10 @@ type ExternalServicesListOptions struct {
 
 	// When true, only external services without has_webhooks set will be
 	// returned. For use by ExternalServiceWebhookMigrator only.
-	noCachedWebhooks bool
+	NoCachedWebhooks bool
 	// When true, records will be locked. For use by
 	// ExternalServiceWebhookMigrator only.
-	forUpdate bool
+	ForUpdate bool
 }
 
 func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
@@ -257,7 +257,7 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 	if o.OnlyCloudDefault {
 		conds = append(conds, sqlf.Sprintf("cloud_default = true"))
 	}
-	if o.noCachedWebhooks {
+	if o.NoCachedWebhooks {
 		conds = append(conds, sqlf.Sprintf("has_webhooks IS NULL"))
 	}
 	return conds
@@ -1275,7 +1275,7 @@ func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesLis
 	}
 
 	var forUpdate *sqlf.Query
-	if opt.forUpdate {
+	if opt.ForUpdate {
 		forUpdate = sqlf.Sprintf("FOR UPDATE SKIP LOCKED")
 	} else {
 		forUpdate = sqlf.Sprintf("")

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -111,7 +111,7 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 				Kinds:                test.kinds,
 				AfterID:              test.afterID,
 				OnlyCloudDefault:     test.onlyCloudDefault,
-				noCachedWebhooks:     test.noCachedWebhooks,
+				NoCachedWebhooks:     test.noCachedWebhooks,
 			}
 			q := sqlf.Join(opts.sqlConditions(), "AND")
 			if diff := cmp.Diff(test.wantQuery, q.Query(sqlf.PostgresBindVar)); diff != "" {

--- a/internal/oobmigration/migrators_test.go
+++ b/internal/oobmigration/migrators_test.go
@@ -1,4 +1,4 @@
-package database
+package oobmigration
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -70,7 +71,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -132,7 +133,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -200,7 +201,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -261,7 +262,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -292,7 +293,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -394,7 +395,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 				AuthData: &authData,
 				Data:     &data,
 			}
-			_, err := ExternalAccounts(db).CreateUserAndSave(ctx, NewUser{Username: fmt.Sprintf("u-%d", i)}, spec, accData)
+			_, err := database.ExternalAccounts(db).CreateUserAndSave(ctx, database.NewUser{Username: fmt.Sprintf("u-%d", i)}, spec, accData)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -675,7 +676,7 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 		t.Helper()
 		var svcs []*types.ExternalService
 
-		es := ExternalServices(db)
+		es := database.ExternalServices(db)
 		basestore := basestore.NewWithDB(db, sql.TxOptions{})
 
 		// Create a trivial external service of each kind, as well as duplicate
@@ -830,7 +831,7 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 	t.Run("Up", func(t *testing.T) {
 		db := dbtest.NewDB(t)
 		initSvcs := createExternalServices(t, ctx, db)
-		es := ExternalServices(db)
+		es := database.ExternalServices(db)
 
 		m := NewExternalServiceWebhookMigratorWithDB(db)
 		// Ensure that we have to run two Ups.
@@ -846,16 +847,16 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 		assert.Nil(t, m.Up(ctx))
 
 		// Do we really have one external service left?
-		after, err := es.List(ctx, ExternalServicesListOptions{
-			noCachedWebhooks: true,
+		after, err := es.List(ctx, database.ExternalServicesListOptions{
+			NoCachedWebhooks: true,
 		})
 		assert.Nil(t, err)
 		assert.EqualValues(t, 1, len(after))
 
 		// Now we'll do the last one.
 		assert.Nil(t, m.Up(ctx))
-		after, err = es.List(ctx, ExternalServicesListOptions{
-			noCachedWebhooks: true,
+		after, err = es.List(ctx, database.ExternalServicesListOptions{
+			NoCachedWebhooks: true,
 		})
 		assert.Nil(t, err)
 		assert.EqualValues(t, 0, len(after))
@@ -863,7 +864,7 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 		// Finally, let's make sure we have the expected number of each: we
 		// should have three records with has_webhooks = true, and the rest
 		// should be has_webhooks = false.
-		svcs, err := es.List(ctx, ExternalServicesListOptions{})
+		svcs, err := es.List(ctx, database.ExternalServicesListOptions{})
 		assert.Nil(t, err)
 
 		hasWebhooks := 0


### PR DESCRIPTION
Importing internal/oobmigration into internal/database is problematic
from a cyclical import perspective. Since `database` is imported all
over the codebase, we should keep the import footprint of that package
as small as possible. This moves internal/database/oob_migration.go to
internal/oobmigraiton/migrators.go to avoid this issue.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
