### PR TITLE
db: Break dependency of RepoStore on ExternalServiceStore

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_external.go
+++ b/cmd/frontend/graphqlbackend/repository_external.go
@@ -69,7 +69,7 @@ func (r *RepositoryResolver) ExternalServices(ctx context.Context, args *struct 
 		OrderByDirection: "ASC",
 	}
 
-	svcs, err := database.ExternalServices(r.db).List(ctx, opts)
+	svcs, err := r.db.ExternalServices().List(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_external.go
+++ b/cmd/frontend/graphqlbackend/repository_external.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func (r *RepositoryResolver) ExternalRepository() *externalRepositoryResolver {
@@ -49,7 +50,26 @@ func (r *RepositoryResolver) ExternalServices(ctx context.Context, args *struct 
 		return nil, err
 	}
 
-	svcs, err := database.Repos(r.db).ExternalServices(ctx, r.IDInt32())
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	svcIDs := repo.ExternalServiceIDs()
+	if len(svcIDs) == 0 {
+		return &computedExternalServiceConnectionResolver{
+			db:               r.db,
+			args:             args.ConnectionArgs,
+			externalServices: []*types.ExternalService{},
+		}, nil
+	}
+
+	opts := database.ExternalServicesListOptions{
+		IDs:              svcIDs,
+		OrderByDirection: "ASC",
+	}
+
+	svcs, err := database.ExternalServices(r.db).List(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/dbmock/repostore_mock.go
+++ b/internal/database/dbmock/repostore_mock.go
@@ -30,9 +30,6 @@ type MockRepoStore struct {
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *RepoStoreDoneFunc
-	// ExternalServicesFunc is an instance of a mock function object
-	// controlling the behavior of the method ExternalServices.
-	ExternalServicesFunc *RepoStoreExternalServicesFunc
 	// GetFunc is an instance of a mock function object controlling the
 	// behavior of the method Get.
 	GetFunc *RepoStoreGetFunc
@@ -103,11 +100,6 @@ func NewMockRepoStore() *MockRepoStore {
 		DoneFunc: &RepoStoreDoneFunc{
 			defaultHook: func(error) error {
 				return nil
-			},
-		},
-		ExternalServicesFunc: &RepoStoreExternalServicesFunc{
-			defaultHook: func(context.Context, api.RepoID) ([]*types.ExternalService, error) {
-				return nil, nil
 			},
 		},
 		GetFunc: &RepoStoreGetFunc{
@@ -203,9 +195,6 @@ func NewMockRepoStoreFrom(i database.RepoStore) *MockRepoStore {
 		},
 		DoneFunc: &RepoStoreDoneFunc{
 			defaultHook: i.Done,
-		},
-		ExternalServicesFunc: &RepoStoreExternalServicesFunc{
-			defaultHook: i.ExternalServices,
 		},
 		GetFunc: &RepoStoreGetFunc{
 			defaultHook: i.Get,
@@ -687,115 +676,6 @@ func (c RepoStoreDoneFuncCall) Args() []interface{} {
 // invocation.
 func (c RepoStoreDoneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// RepoStoreExternalServicesFunc describes the behavior when the
-// ExternalServices method of the parent MockRepoStore instance is invoked.
-type RepoStoreExternalServicesFunc struct {
-	defaultHook func(context.Context, api.RepoID) ([]*types.ExternalService, error)
-	hooks       []func(context.Context, api.RepoID) ([]*types.ExternalService, error)
-	history     []RepoStoreExternalServicesFuncCall
-	mutex       sync.Mutex
-}
-
-// ExternalServices delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockRepoStore) ExternalServices(v0 context.Context, v1 api.RepoID) ([]*types.ExternalService, error) {
-	r0, r1 := m.ExternalServicesFunc.nextHook()(v0, v1)
-	m.ExternalServicesFunc.appendCall(RepoStoreExternalServicesFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ExternalServices
-// method of the parent MockRepoStore instance is invoked and the hook queue
-// is empty.
-func (f *RepoStoreExternalServicesFunc) SetDefaultHook(hook func(context.Context, api.RepoID) ([]*types.ExternalService, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ExternalServices method of the parent MockRepoStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *RepoStoreExternalServicesFunc) PushHook(hook func(context.Context, api.RepoID) ([]*types.ExternalService, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *RepoStoreExternalServicesFunc) SetDefaultReturn(r0 []*types.ExternalService, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoID) ([]*types.ExternalService, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *RepoStoreExternalServicesFunc) PushReturn(r0 []*types.ExternalService, r1 error) {
-	f.PushHook(func(context.Context, api.RepoID) ([]*types.ExternalService, error) {
-		return r0, r1
-	})
-}
-
-func (f *RepoStoreExternalServicesFunc) nextHook() func(context.Context, api.RepoID) ([]*types.ExternalService, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *RepoStoreExternalServicesFunc) appendCall(r0 RepoStoreExternalServicesFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of RepoStoreExternalServicesFuncCall objects
-// describing the invocations of this function.
-func (f *RepoStoreExternalServicesFunc) History() []RepoStoreExternalServicesFuncCall {
-	f.mutex.Lock()
-	history := make([]RepoStoreExternalServicesFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// RepoStoreExternalServicesFuncCall is an object that describes an
-// invocation of method ExternalServices on an instance of MockRepoStore.
-type RepoStoreExternalServicesFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoID
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*types.ExternalService
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c RepoStoreExternalServicesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c RepoStoreExternalServicesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // RepoStoreGetFunc describes the behavior when the Get method of the parent

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -2149,53 +2149,6 @@ func TestRepos_ListRepos_UserPublicRepos(t *testing.T) {
 	}
 }
 
-func TestRepos_RepoExternalServices(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
-	t.Parallel()
-	db := dbtest.NewDB(t)
-	ctx := actor.WithInternalActor(context.Background())
-
-	confGet := func() *conf.Unified {
-		return &conf.Unified{}
-	}
-
-	services := types.MakeExternalServices()
-	service1 := services[0]
-	service2 := services[1]
-	if err := ExternalServices(db).Create(ctx, confGet, service1); err != nil {
-		t.Fatal(err)
-	}
-	if err := ExternalServices(db).Create(ctx, confGet, service2); err != nil {
-		t.Fatal(err)
-	}
-
-	repo1 := types.MakeGithubRepo(service1)
-	if err := Repos(db).Create(ctx, repo1); err != nil {
-		t.Fatal(err)
-	}
-
-	repo2 := types.MakeGitlabRepo(service2)
-	if err := Repos(db).Create(ctx, repo2); err != nil {
-		t.Fatal(err)
-	}
-
-	assertServices := func(repoID api.RepoID, want []*types.ExternalService) {
-		services, err := Repos(db).ExternalServices(ctx, repoID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(want, services); diff != "" {
-			t.Fatal(diff)
-		}
-	}
-
-	assertServices(repo1.ID, []*types.ExternalService{service1})
-	assertServices(repo2.ID, []*types.ExternalService{service2})
-}
-
 func TestGetFirstRepoNamesByCloneURL(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
This bothered me. Also it makes it so we don't need to re-fetch the repo in most cases in the resolver.