### PR TITLE
db: Add missing `star` column to ListIndexableRepos

### DIFF
--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -82,20 +82,24 @@ func TestListIndexableRepos(t *testing.T) {
 			}
 			want := []types.MinimalRepo{
 				{
-					ID:   api.RepoID(11),
-					Name: "github.com/foo/bar11",
+					ID:    api.RepoID(11),
+					Name:  "github.com/foo/bar11",
+					Stars: 25,
 				},
 				{
-					ID:   api.RepoID(10),
-					Name: "github.com/foo/bar10",
+					ID:    api.RepoID(10),
+					Name:  "github.com/foo/bar10",
+					Stars: 5,
 				},
 				{
-					ID:   api.RepoID(14),
-					Name: "github.com/foo/bar14",
+					ID:    api.RepoID(14),
+					Name:  "github.com/foo/bar14",
+					Stars: 2,
 				},
 				{
-					ID:   api.RepoID(15),
-					Name: "github.com/foo/bar15",
+					ID:    api.RepoID(15),
+					Name:  "github.com/foo/bar15",
+					Stars: 0,
 				},
 			}
 			if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {
@@ -110,16 +114,19 @@ func TestListIndexableRepos(t *testing.T) {
 			}
 			want := []types.MinimalRepo{
 				{
-					ID:   api.RepoID(11),
-					Name: "github.com/foo/bar11",
+					ID:    api.RepoID(11),
+					Name:  "github.com/foo/bar11",
+					Stars: 25,
 				},
 				{
-					ID:   api.RepoID(10),
-					Name: "github.com/foo/bar10",
+					ID:    api.RepoID(10),
+					Name:  "github.com/foo/bar10",
+					Stars: 5,
 				},
 				{
-					ID:   api.RepoID(14),
-					Name: "github.com/foo/bar14",
+					ID:    api.RepoID(14),
+					Name:  "github.com/foo/bar14",
+					Stars: 2,
 				},
 			}
 			if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1105,7 +1105,7 @@ func (s *repoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableRe
 
 	for rows.Next() {
 		var r types.MinimalRepo
-		if err := rows.Scan(&r.ID, &r.Name); err != nil {
+		if err := rows.Scan(&r.ID, &r.Name, &dbutil.NullInt{N: &r.Stars}); err != nil {
 			return nil, errors.Wrap(err, "scanning indexable repos")
 		}
 		results = append(results, r)
@@ -1120,7 +1120,7 @@ func (s *repoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableRe
 const listIndexableReposQuery = `
 -- source: internal/database/repos.go:ListIndexableRepos
 SELECT
-	repo.id, repo.name
+	repo.id, repo.name, repo.stars
 FROM repo
 %s
 WHERE


### PR DESCRIPTION
This function is used so deeply in code it's hard to tell if this causes problems today, but this definitely feels safer to me.
