### PR TITLE
db: Don't log security event twice

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -151,10 +151,6 @@ func (s *repoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err 
 	}
 
 	repo := repos[0]
-	if repo.Private {
-		counterAccessGranted.Inc()
-		logPrivateRepoAccessGranted(ctx, s.Handle().DB(), []api.RepoID{repo.ID})
-	}
 
 	return repo, repo.IsBlocked()
 }


### PR DESCRIPTION
In (*database.RepoStore).Get we logged a security event, but the underlying listRepos method already does that, so this event is duplicative.
