### PR TITLE
clean up some unnecessary uses of dbtest.NewDB

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -132,7 +132,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 		if strings.HasPrefix(url, "../") {
 			url = path.Join(r.Repository().Name(), url)
 		}
-		repoName, err := cloneURLToRepoName(ctx, r.db, url)
+		repoName, err := cloneURLToRepoName(ctx, database.NewDB(r.db), url)
 		if err != nil {
 			log15.Error("Failed to resolve submodule repository name from clone URL", "cloneURL", submodule.URL(), "err", err)
 			return "", nil
@@ -188,7 +188,7 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 	return nil
 }
 
-func cloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL string) (string, error) {
+func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (string, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "cloneURLToRepoName")
 	defer span.Finish()
 

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cloneurls"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -122,7 +123,7 @@ func (r *editorRequest) searchRedirect(ctx context.Context) (string, error) {
 	var repoFilter string
 	if s.remoteURL != "" {
 		// Search in this repository.
-		repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, r.db, s.remoteURL)
+		repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, database.NewDB(r.db), s.remoteURL)
 		if err != nil {
 			return "", err
 		}
@@ -174,7 +175,7 @@ func (r *editorRequest) searchRedirect(ctx context.Context) (string, error) {
 func (r *editorRequest) openFileRedirect(ctx context.Context) (string, error) {
 	of := r.openFileRequest
 	// Determine the repo name and branch.
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, r.db, of.remoteURL)
+	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, database.NewDB(r.db), of.remoteURL)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/frontend/internal/auth/override.go
+++ b/cmd/frontend/internal/auth/override.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
@@ -27,7 +26,7 @@ const (
 //
 // It is used to enable our e2e tests to authenticate to https://sourcegraph.sgdev.org without
 // needing to give them Google Workspace access.
-func OverrideAuthMiddleware(db dbutil.DB, next http.Handler) http.Handler {
+func OverrideAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		secret := envOverrideAuthSecret
 		// Accept both old header (X-Oidc-Override, deprecated) and new overrideSecretHeader for now.
@@ -37,7 +36,7 @@ func OverrideAuthMiddleware(db dbutil.DB, next http.Handler) http.Handler {
 				username = defaultUsername
 			}
 
-			userID, safeErrMsg, err := auth.GetAndSaveUser(r.Context(), database.NewDB(db), auth.GetAndSaveUserOp{
+			userID, safeErrMsg, err := auth.GetAndSaveUser(r.Context(), db, auth.GetAndSaveUserOp{
 				UserProps: database.NewUser{
 					Username:        username,
 					Email:           username + "+override@example.com",
@@ -57,13 +56,13 @@ func OverrideAuthMiddleware(db dbutil.DB, next http.Handler) http.Handler {
 
 			// Make the user a site admin because that is more useful for e2e tests and local dev
 			// scripting (which are the use cases of this override auth provider).
-			if err := database.Users(db).SetIsSiteAdmin(r.Context(), userID, true); err != nil {
+			if err := db.Users().SetIsSiteAdmin(r.Context(), userID, true); err != nil {
 				log15.Error("Error setting auth-override user as site admin.", "error", err)
 				http.Error(w, "", http.StatusInternalServerError)
 				return
 			}
 
-			user, err := database.Users(db).GetByID(r.Context(), userID)
+			user, err := db.Users().GetByID(r.Context(), userID)
 			if err != nil {
 				log15.Error("Error retrieving user from database.", "error", err)
 				http.Error(w, "", http.StatusInternalServerError)

--- a/cmd/frontend/internal/auth/override_test.go
+++ b/cmd/frontend/internal/auth/override_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -22,22 +22,23 @@ func TestOverrideAuthMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
 
-	db := dbtest.NewDB(t)
-
-	handler := OverrideAuthMiddleware(db, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		actor := actor.FromContext(r.Context())
-		if actor.IsAuthenticated() {
-			fmt.Fprintf(w, "user %v", actor.UID)
-		} else {
-			fmt.Fprint(w, "no user")
-		}
-	}))
+	newHandler := func(db database.DB) http.Handler {
+		return OverrideAuthMiddleware(db, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			actor := actor.FromContext(r.Context())
+			if actor.IsAuthenticated() {
+				fmt.Fprintf(w, "user %v", actor.UID)
+			} else {
+				fmt.Fprint(w, "no user")
+			}
+		}))
+	}
 
 	const overrideSecret = "s"
 
 	t.Run("disabled, not sent", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
+		handler := newHandler(dbmock.NewMockDB())
 		handler.ServeHTTP(rr, req)
 		if got, want := rr.Body.String(), "no user"; got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -49,6 +50,7 @@ func TestOverrideAuthMiddleware(t *testing.T) {
 		defer func() { envOverrideAuthSecret = "" }()
 		rr := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
+		handler := newHandler(dbmock.NewMockDB())
 		handler.ServeHTTP(rr, req)
 		if got, want := rr.Body.String(), "no user"; got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -61,6 +63,7 @@ func TestOverrideAuthMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
 		req = req.WithContext(actor.WithActor(context.Background(), &actor.Actor{UID: 2}))
+		handler := newHandler(dbmock.NewMockDB())
 		handler.ServeHTTP(rr, req)
 		if got, want := rr.Body.String(), "user 2"; got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -82,11 +85,16 @@ func TestOverrideAuthMiddleware(t *testing.T) {
 			return 1, "", nil
 		}
 		defer func() { auth.MockGetAndSaveUser = nil }()
-		database.Mocks.Users.SetIsSiteAdmin = func(int32, bool) error { return nil }
-		database.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+
+		users := dbmock.NewMockUserStore()
+		users.SetIsSiteAdminFunc.SetDefaultReturn(nil)
+		users.GetByIDFunc.SetDefaultHook(func(_ context.Context, id int32) (*types.User, error) {
 			return &types.User{ID: id, CreatedAt: time.Now()}, nil
-		}
-		defer func() { database.Mocks = database.MockStores{} }()
+		})
+		db := dbmock.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		handler := newHandler(db)
 		handler.ServeHTTP(rr, req)
 		if got, want := rr.Body.String(), "user 1"; got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -112,11 +120,16 @@ func TestOverrideAuthMiddleware(t *testing.T) {
 			return 0, "safeErr", errors.New("x")
 		}
 		defer func() { auth.MockGetAndSaveUser = nil }()
-		database.Mocks.Users.SetIsSiteAdmin = func(int32, bool) error { return nil }
-		database.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+
+		users := dbmock.NewMockUserStore()
+		users.SetIsSiteAdminFunc.SetDefaultReturn(nil)
+		users.GetByIDFunc.SetDefaultHook(func(_ context.Context, id int32) (*types.User, error) {
 			return &types.User{ID: id, CreatedAt: time.Now()}, nil
-		}
-		defer func() { database.Mocks = database.MockStores{} }()
+		})
+		db := dbmock.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		handler := newHandler(db)
 		handler.ServeHTTP(rr, req)
 		if got, want := rr.Body.String(), "user 1"; got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -132,6 +145,7 @@ func TestOverrideAuthMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set(overrideSecretHeader, "bad")
+		handler := newHandler(dbmock.NewMockDB())
 		handler.ServeHTTP(rr, req)
 		if got, want := rr.Body.String(), "no user"; got != want {
 			t.Errorf("got %q, want %q", got, want)

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -64,8 +64,8 @@ func HandleSiteInit(db database.DB) http.HandlerFunc {
 
 // checkEmailAbuse performs abuse prevention checks to prevent email abuse, i.e. users using emails
 // of other people whom they want to annoy.
-func checkEmailAbuse(ctx context.Context, db dbutil.DB, addr string) (abused bool, reason string, err error) {
-	email, err := database.UserEmails(db).GetLatestVerificationSentEmail(ctx, addr)
+func checkEmailAbuse(ctx context.Context, db database.DB, addr string) (abused bool, reason string, err error) {
+	email, err := db.UserEmails().GetLatestVerificationSentEmail(ctx, addr)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return false, "", nil

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -6,12 +6,10 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 )
 
 func TestCheckEmailAbuse(t *testing.T) {
-	ctx := context.Background()
-
 	now := time.Now()
 	yesterday := now.AddDate(0, 0, -1)
 	farFuture := now.AddDate(100, 0, 0)
@@ -57,15 +55,12 @@ func TestCheckEmailAbuse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db := dbtest.NewDB(t)
-			database.Mocks.UserEmails.GetLatestVerificationSentEmail = func(context.Context, string) (*database.UserEmail, error) {
-				return test.mockEmail, test.mockErr
-			}
-			defer func() {
-				database.Mocks.UserEmails.GetLatestVerificationSentEmail = nil
-			}()
+			userEmails := dbmock.NewMockUserEmailsStore()
+			userEmails.GetLatestVerificationSentEmailFunc.SetDefaultReturn(test.mockEmail, test.mockErr)
+			db := dbmock.NewMockDB()
+			db.UserEmailsFunc.SetDefaultReturn(userEmails)
 
-			abused, reason, err := checkEmailAbuse(ctx, db, "fake@localhost")
+			abused, reason, err := checkEmailAbuse(context.Background(), db, "fake@localhost")
 			if test.expErr != err {
 				t.Fatalf("err: want %v but got %v", test.expErr, err)
 			} else if test.expAbused != abused {

--- a/cmd/frontend/internal/cloneurls/clone_urls.go
+++ b/cmd/frontend/internal/cloneurls/clone_urls.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -24,7 +23,7 @@ import (
 // configuration for github.com, even if one is not explicitly specified. Returns the empty string and nil
 // error if a matching code host could not be found. This function does not actually check the code
 // host to see if the repository actually exists.
-func ReposourceCloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL string) (repoName api.RepoName, err error) {
+func ReposourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (repoName api.RepoName, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "ReposourceCloneURLToRepoName")
 	defer span.Finish()
 
@@ -33,7 +32,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL st
 	}
 
 	// Fast path for repos we already have in our database
-	name, err := database.Repos(db).GetFirstRepoNamesByCloneURL(ctx, cloneURL)
+	name, err := db.Repos().GetFirstRepoNamesByCloneURL(ctx, cloneURL)
 	if err != nil {
 		return "", err
 	}
@@ -64,7 +63,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, db dbutil.DB, cloneURL st
 	}
 
 	for {
-		svcs, err := database.ExternalServices(db).List(ctx, opt)
+		svcs, err := db.ExternalServices().List(ctx, opt)
 		if err != nil {
 			return "", errors.Wrap(err, "list")
 		}


### PR DESCRIPTION
There are a significant number of uses of `dbtest.NewDB()` in tests
that mock out all interactions with the database. When we don't
actually need a database, it's considerably more performant to use
a mock database since it doesn't need to copy the schema to
create the database. 

This PR targets a few of these tests and converts them to the new
mock database style. As a bonus to having more isolated tests, this
also significantly speeds up these tests. Think like 2s -> .02s for tests
in packages that no longer need to call `dbtest.NewDB()`. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
