### PR TITLE
authz: Locally cache whether sub-repo perms enabled

### DIFF
--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"path"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gobwas/glob"
@@ -11,6 +12,27 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 )
+
+var (
+	subRepoPermsEnabledFlag int32
+)
+
+func init() {
+	// We need to check whether sub-repo permissions are enabled often so we cache
+	// the config value locally and only update it when it changes.
+	//
+	// This will be removed once sub-repo perms are no longer experimental.
+	go conf.Watch(func() {
+		c := conf.Get()
+		if c.ExperimentalFeatures != nil && c.ExperimentalFeatures.EnableSubRepoPermissions {
+			atomic.StoreInt32(&subRepoPermsEnabledFlag, 1)
+		}
+	})
+}
+
+func subRepoPermsEnabled() bool {
+	return atomic.LoadInt32(&subRepoPermsEnabledFlag) == 1
+}
 
 // RepoContent specifies data existing in a repo. It currently only supports
 // paths but will be extended in future to support other pieces of metadata, for
@@ -60,7 +82,7 @@ type SubRepoPermsClient struct {
 
 func (s *SubRepoPermsClient) Permissions(ctx context.Context, userID int32, content RepoContent) (Perms, error) {
 	// Are sub-repo permissions enabled at the site level
-	if !conf.Get().ExperimentalFeatures.EnableSubRepoPermissions {
+	if !subRepoPermsEnabled() {
 		return Read, nil
 	}
 
@@ -148,7 +170,7 @@ func CurrentUserPermissions(ctx context.Context, s SubRepoPermissionChecker, con
 func ActorPermissions(ctx context.Context, s SubRepoPermissionChecker, a *actor.Actor, content RepoContent) (Perms, error) {
 	// Check config here, despite checking again in the s.Permissions implementation,
 	// because we also make some permissions decisions here.
-	if !conf.Get().ExperimentalFeatures.EnableSubRepoPermissions {
+	if !subRepoPermsEnabled() {
 		return Read, nil
 	}
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -26,6 +26,8 @@ func init() {
 		c := conf.Get()
 		if c.ExperimentalFeatures != nil && c.ExperimentalFeatures.EnableSubRepoPermissions {
 			atomic.StoreInt32(&subRepoPermsEnabledFlag, 1)
+		} else {
+			atomic.StoreInt32(&subRepoPermsEnabledFlag, 0)
 		}
 	})
 }


### PR DESCRIPTION
This change use conf.Watch to subscribe to config changes and locally
caches whether sub-repo perms are enabled at the package level.

This change is mostly needed since we don't trust the performance
implications of constantly calling conf.Get() in tight loops. In theory
it's cached, but we're unsure of how this behaves when a change occurs.

An alternative to https://github.com/sourcegraph/sourcegraph/pull/27087