### PR TITLE
ci: avoid diffing svg in go-generate.sh

### DIFF
--- a/dev/check/go-generate.sh
+++ b/dev/check/go-generate.sh
@@ -16,7 +16,7 @@ main() {
   # Runs generate.sh and ensures no files changed. This relies on the go
   # generation that ran are idempotent.
   ./dev/generate.sh
-  git diff --exit-code -- . ':!go.sum'
+  git diff --exit-code -- . ':!go.sum' ':!*.svg'
 }
 
 main "$@"


### PR DESCRIPTION
So, it seems that https://github.com/sourcegraph/sourcegraph/pull/26285 introduced a flake, that can be observed here: https://buildkite.com/sourcegraph/sourcegraph/builds?branch=jh%2Ffix-go-generate-svg 

The fix does not address the root cause, which I could not identify in a reasonable amount of time. Running the step either locally or on the agents did not lead to failures. 

Therefore, I fixed by excluding the `svg` files from the failing step (`dev/check/go-generate.sh`). 

I QA'ed the fix by running it 50 times in a row and we're good. 

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/10151/140510621-c16900c2-03c7-467d-81ce-4fb5bb02dbc3.png">

cc @umpox 