### PR TITLE
Update label-notify for search teams

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -14,7 +14,9 @@ jobs:
                   team/extensibility=@joelkw @muratsu
                   team/frontend-platform=@umpox @valerybugakov @5h1ru @pdubroy @taylorsperry
                   team/cloud=@RafLeszczynski
-                  team/search=@lguychard
+                  team/search-product=@benvenker @lguychard
+                  team/search-core=@jjeffwarner
+                  [deprecated]team/search=@lguychard
                   team/code-intelligence=@macraig
                   team/code-insights=@joelkw @felixfbecker @vovakulikov @unclejustin
                   team/distribution=@dan-mckean


### PR DESCRIPTION
- Added appropriate notification recipients for `team/search-product`, `team/search-core`
- The `team/search` catch-all label is now `[deprecated]team/search`. It notifies all search PM/EMs so that we can triage issues that still end up tagged with it.
