### PR TITLE
search: introduce ConfigFingerprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.9
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/microcosm-cc/bluemonday v1.0.16
+	github.com/mitchellh/hashstructure v1.1.0
 	github.com/montanaflynn/stats v0.6.6
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c

--- a/go.sum
+++ b/go.sum
@@ -1421,6 +1421,8 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
+github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/internal/search/backend/config.go
+++ b/internal/search/backend/config.go
@@ -1,0 +1,102 @@
+package backend
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/mitchellh/hashstructure"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// ConfigFingerprint represents a point in time that indexed search
+// configuration was generated. It is an opaque identifier sent to clients to
+// allow efficient calculation of what has changed since the last request.
+type ConfigFingerprint struct {
+	ts   time.Time
+	hash uint64
+}
+
+// NewConfigFingerprint returns a ConfigFingerprint for the current time and sc.
+func NewConfigFingerprint(sc *schema.SiteConfiguration) (*ConfigFingerprint, error) {
+	hash, err := hashstructure.Hash(sc, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigFingerprint{
+		ts:   time.Now(),
+		hash: hash,
+	}, nil
+}
+
+// Marshal returns an opaque string for c to send to clients.
+func (c *ConfigFingerprint) Marshal() string {
+	ts := c.ts.UTC().Truncate(time.Second)
+	return fmt.Sprintf("search-config-fingerprint 1 %s %x", ts.Format(time.RFC3339), c.hash)
+}
+
+// Unmarshal s into c. This is the inverse of Marshal.
+func (c *ConfigFingerprint) Unmarshal(s string) (err error) {
+	parts := strings.Fields(s)
+
+	// We support no cursor.
+	if len(parts) == 0 {
+		return nil
+	}
+
+	if len(parts) < 2 || parts[0] != "search-config-fingerprint" {
+		return errors.Errorf("malformed search-config-fingerprint: %q", s)
+	}
+	if parts[1] != "1" {
+		// Unknown version, treat as if not specified
+		return nil
+	}
+
+	// Use consistent error wrapping from this point since we know it is a
+	// version 1 search-config-fingerprint.
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "malformed search-config-fingerprint 1: %q", s)
+		}
+	}()
+
+	if len(parts) != 4 {
+		return errors.New("expected 4 fields")
+	}
+
+	c.ts, err = time.Parse(time.RFC3339, parts[2])
+	if err != nil {
+		return errors.Wrapf(err, "malformed search-config-fingerprint 1: %q", s)
+	}
+
+	c.hash, err = strconv.ParseUint(parts[3], 16, 64)
+	if err != nil {
+		return errors.Wrapf(err, "malformed search-config-fingerprint 1: %q", s)
+	}
+
+	return nil
+}
+
+// Since returns the time to return changes since. Note: It does not return
+// the exact time the fingerprint was generated, but instead some time in the
+// past to allow for time skew and races.
+func (c *ConfigFingerprint) Since() time.Time {
+	if c.ts.IsZero() {
+		return c.ts
+	}
+	// 90s is the same value recommended by the TOTP spec.
+	return c.ts.Add(-90 * time.Second)
+}
+
+// SameConfig returns true if c2 was generated with the same site
+// configuration.
+func (c *ConfigFingerprint) SameConfig(c2 *ConfigFingerprint) bool {
+	// ts being zero indicates a missing cursor or non-fatal unmarshalling of
+	// the cursor.
+	if c.ts.IsZero() || c2.ts.IsZero() {
+		return false
+	}
+	return c.hash == c2.hash
+}

--- a/internal/search/backend/config_test.go
+++ b/internal/search/backend/config_test.go
@@ -1,0 +1,98 @@
+package backend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestConfigFingerprint(t *testing.T) {
+	sc1 := &schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			SearchIndexBranches: map[string][]string{
+				"foo": {"dev"},
+			},
+		},
+	}
+	sc2 := &schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			SearchIndexBranches: map[string][]string{
+				"foo": {"dev", "qa"},
+			},
+		},
+	}
+
+	var seq time.Duration
+	mk := func(sc *schema.SiteConfiguration) *ConfigFingerprint {
+		t.Helper()
+		cf, err := NewConfigFingerprint(sc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Each consecutive call we adjust the time significantly to ensure
+		// when comparing config we don't take into account time.
+		cf.ts = cf.ts.Add(seq * time.Hour)
+		seq++
+
+		testMarshal(t, cf)
+		return cf
+	}
+
+	cfA := mk(sc1)
+	cfB := mk(sc1)
+	cfC := mk(sc2)
+
+	if !cfA.SameConfig(cfB) {
+		t.Fatal("expected same config for A and B")
+	}
+	if cfA.SameConfig(cfC) {
+		t.Fatal("expected different config for A and C")
+	}
+}
+
+func TestConfigFingerprint_Marshal(t *testing.T) {
+	// Use a fixed time for this test case
+	now, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cf := ConfigFingerprint{
+		ts:   now,
+		hash: 123,
+	}
+
+	got := cf.Marshal()
+	want := "search-config-fingerprint 1 2006-01-02T15:04:05Z 7b"
+	if got != want {
+		t.Errorf("unexpected marshal value:\ngot:  %s\nwant: %s", got, want)
+	}
+
+	testMarshal(t, &cf)
+}
+
+func testMarshal(t *testing.T, cf *ConfigFingerprint) {
+	t.Helper()
+
+	v := cf.Marshal()
+	t.Log(v)
+
+	var got ConfigFingerprint
+	if err := got.Unmarshal(v); err != nil {
+		t.Fatal(err)
+	}
+
+	if !cf.SameConfig(&got) {
+		t.Error("expected same config")
+	}
+
+	since := got.Since()
+	if since.After(cf.ts) {
+		t.Error("since should not be after ts")
+	}
+	if since.Before(cf.ts.Add(-time.Hour)) {
+		t.Error("since should not be before ts - hour")
+	}
+}


### PR DESCRIPTION
This is the opaque structure used by Sourcegraph to minimize the amount
of work done when zoekt polls for repository options. It is a timestamp
and a hash of the configuration. Using these two bits of information, we
can heuristically calculate what has changed since the fingerprint.

We version the fingerprint format since we expect changes in the future
as the requirements of inputs to IndexOptions changes.

Note: this only introduces the structure, but does not use it yet.